### PR TITLE
Fix `top_k` being disabled when `generation_config.json` contains `top_k: 50`

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1235,7 +1235,7 @@ class ModelConfig:
         # If config.top_k is the Transformers default, to_diff_dict() will
         # remove it. vLLM default is different, so we need to add it back.
         if config.top_k == GenerationConfig().top_k:
-            diff_dict["top_k"] = config.top_l
+            diff_dict["top_k"] = config.top_k
 
         return diff_dict
 


### PR DESCRIPTION
Discovered in https://github.com/vllm-project/vllm/issues/17553#issuecomment-2858141072