### PR TITLE
[Bugfix] Fix Video IO error for short video

### DIFF
--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -26,6 +26,11 @@ TEST_IMAGE_URLS = [
     "https://upload.wikimedia.org/wikipedia/commons/0/0b/RGBA_comp.png",
 ]
 
+TEST_VIDEO_URLS = [
+    "https://www.bogotobogo.com/python/OpenCV_Python/images/mean_shift_tracking/slow_traffic_small.mp4",
+    "https://opencv.org/wp-content/uploads/2025/02/Example-Video.mp4",
+]
+
 
 @pytest.fixture(scope="module")
 def url_images() -> dict[str, Image.Image]:
@@ -132,6 +137,17 @@ async def test_fetch_image_local_files(image_url: str):
         with pytest.raises(RuntimeError, match="Cannot load local files"):
             connector.fetch_image(
                 f"file://{temp_dir}/../{os.path.basename(image_url)}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("video_url", TEST_VIDEO_URLS)
+@pytest.mark.parametrize("num_frames", [-1, 32, 1800])
+async def test_fetch_video_http(video_url: str, num_frames: int):
+    connector = MediaConnector()
+
+    video_sync = connector.fetch_video(video_url, num_frames)
+    video_async = await connector.fetch_video_async(video_url, num_frames)
+    assert np.array_equal(video_sync, video_async)
 
 
 # Used for the next two tests related to `merge_and_sort_multimodal_metadata`.

--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -28,6 +28,7 @@ TEST_IMAGE_URLS = [
 
 TEST_VIDEO_URLS = [
     "https://www.bogotobogo.com/python/OpenCV_Python/images/mean_shift_tracking/slow_traffic_small.mp4",
+    "https://filesamples.com/samples/video/avi/sample_640x360.avi",
 ]
 
 
@@ -144,8 +145,8 @@ async def test_fetch_image_local_files(image_url: str):
 async def test_fetch_video_http(video_url: str, num_frames: int):
     connector = MediaConnector()
 
-    video_sync = connector.fetch_video(video_url, num_frames)
-    video_async = await connector.fetch_video_async(video_url, num_frames)
+    video_sync = connector.fetch_video(video_url, num_frames=num_frames)
+    video_async = await connector.fetch_video_async(video_url, num_frames=num_frames)
     assert np.array_equal(video_sync, video_async)
 
 

--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -146,7 +146,8 @@ async def test_fetch_video_http(video_url: str, num_frames: int):
     connector = MediaConnector()
 
     video_sync = connector.fetch_video(video_url, num_frames=num_frames)
-    video_async = await connector.fetch_video_async(video_url, num_frames=num_frames)
+    video_async = await connector.fetch_video_async(video_url,
+                                                    num_frames=num_frames)
     assert np.array_equal(video_sync, video_async)
 
 

--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -28,7 +28,6 @@ TEST_IMAGE_URLS = [
 
 TEST_VIDEO_URLS = [
     "https://www.bogotobogo.com/python/OpenCV_Python/images/mean_shift_tracking/slow_traffic_small.mp4",
-    "https://opencv.org/wp-content/uploads/2025/02/Example-Video.mp4",
 ]
 
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -105,7 +105,8 @@ class OpenCVVideoBackend(VideoLoader):
                     frames[i] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                     i += 1
         # we expect all frames loaded
-        assert i == num_frames
+        assert i == num_frames, (f"Expected reading {num_frames} frames, "
+                                 f"but only loaded {i} frames from video.")
         return frames
 
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -81,7 +81,8 @@ class OpenCVVideoBackend(VideoLoader):
         total_frames_num = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         full_read = num_frames == -1 or total_frames_num < num_frames
         if full_read:
-            frame_idx = list(range(0, total_frames_num))
+            num_frames = total_frames_num
+            frame_idx = list(range(0, num_frames))
         else:
             uniform_sampled_frames = np.linspace(0,
                                                  total_frames_num - 1,


### PR DESCRIPTION

FIX #17775 (*link existing issues this PR will resolve*)
- Fix missing `num_frames` update for OpenCV video IO backend
- Add video tests for media IO.

<!--- pyml disable-next-line no-emphasis-as-heading -->
