### PR TITLE
[Fix] Fix spec decoding tests

### DIFF
--- a/tests/spec_decode/test_memory_usage.py
+++ b/tests/spec_decode/test_memory_usage.py
@@ -44,8 +44,10 @@ def test_memory_usage_no_spec():
     previous_memory_allocated = None
     llm = vllm.LLM(
         model=MAIN_MODEL,
-        speculative_model=SPEC_MODEL,
-        num_speculative_tokens=3,
+        speculative_config={
+            'model': SPEC_MODEL,
+            'num_speculative_tokens': 3,
+        },
         speculative_disable_by_batch_size=SPEC_DISABLE_BATCH_SIZE,
     )
 


### PR DESCRIPTION
This fixes the bug introduced in #15506 - the spec decoding interface changed before the PR landed.

<!--- pyml disable-next-line no-emphasis-as-heading -->
