### PR TITLE
[Doc] Fix output message explaining TPOT.

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -494,7 +494,7 @@ async def benchmark(
 
     process_one_metric("ttft", "TTFT", "Time to First Token")
     process_one_metric("tpot", "TPOT",
-                       "Time per Output Token (excl. 1st token)")
+                       "Time per Output Token (incl. 1st token)")
     process_one_metric("itl", "ITL", "Inter-token Latency")
     process_one_metric("e2el", "E2EL", "End-to-end Latency")
 


### PR DESCRIPTION
As far as I understand, the difference between TPOT and ITL is that TPOT *includes* the time for the first token. E.g.,:
```
TPOT = (TTFT + (N-1)*ITL)/N
```
However, the output from the serving benchmark suggests that TPOT *excludes* the first token, which I find very confusing. 