### PR TITLE
[BugFix] Avoid secondary missing `MultiprocExecutor.workers` error

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -258,9 +258,10 @@ class MultiprocExecutor(Executor):
                 self.io_thread_pool.shutdown(wait=False, cancel_futures=True)
                 self.io_thread_pool = None
 
-            for w in self.workers:
-                w.worker_response_mq = None
-            self._ensure_worker_termination([w.proc for w in self.workers])
+            if workers := getattr(self, 'workers', None):
+                for w in workers:
+                    w.worker_response_mq = None
+                self._ensure_worker_termination([w.proc for w in workers])
 
         self.rpc_broadcast_mq = None
 


### PR DESCRIPTION
If V1 `MultiprocExecutor` fails during startup before the workers field has been set it will result in secondary confusing exception: `AttributeError: 'MultiprocExecutor' object has no attribute 'workers'`.

As reported in https://github.com/vllm-project/vllm/issues/17756 and https://github.com/vllm-project/vllm/issues/17533.
