### PR TITLE
cmake: Get rid of VLLM_PYTHON_EXECUTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
 # Suppress potential warnings about unused manually-specified variables
 set(ignoreMe "${VLLM_PYTHON_PATH}")
 
-#
-# Supported python versions.  These versions will be searched in order, the
-# first match will be selected.  These should be kept in sync with setup.py.
-#
-set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12")
 
 # Supported NVIDIA architectures.
 set(CUDA_SUPPORTED_ARCHS "7.0;7.2;7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;12.0")
@@ -49,16 +44,16 @@ set(TORCH_SUPPORTED_VERSION_CUDA "2.7.0")
 set(TORCH_SUPPORTED_VERSION_ROCM "2.7.0")
 
 #
-# Try to find python package with an executable that exactly matches
-# `VLLM_PYTHON_EXECUTABLE` and is one of the supported versions.
+# Set Python find strategy and support versions
 #
-if (VLLM_PYTHON_EXECUTABLE)
-  find_python_from_executable(${VLLM_PYTHON_EXECUTABLE} "${PYTHON_SUPPORTED_VERSIONS}")
-else()
-  message(FATAL_ERROR
-    "Please set VLLM_PYTHON_EXECUTABLE to the path of the desired python version"
-    " before running cmake configure.")
-endif()
+set(Python_FIND_VIRTUALENV FIRST)
+set(Python_Supported_Versions "3.9" "3.10" "3.11" "3.12")
+
+#
+# Find Python + components, check if it's within the versions we support
+#
+find_package(Python COMPONENTS Interpreter Development.Module Development.SABIModule REQUIRED)
+check_python_version(${Python_Supported_Versions})
 
 #
 # Update cmake's `CMAKE_PREFIX_PATH` with torch location.

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -2,13 +2,7 @@
 # Attempt to find the python package that uses the same python executable as
 # `EXECUTABLE` and is one of the `SUPPORTED_VERSIONS`.
 #
-macro (find_python_from_executable EXECUTABLE SUPPORTED_VERSIONS)
-  file(REAL_PATH ${EXECUTABLE} EXECUTABLE)
-  set(Python_EXECUTABLE ${EXECUTABLE})
-  find_package(Python COMPONENTS Interpreter Development.Module Development.SABIModule)
-  if (NOT Python_FOUND)
-    message(FATAL_ERROR "Unable to find python matching: ${EXECUTABLE}.")
-  endif()
+macro (check_python_version SUPPORTED_VERSIONS)
   set(_VER "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
   set(_SUPPORTED_VERSIONS_LIST ${SUPPORTED_VERSIONS} ${ARGN})
   if (NOT _VER IN_LIST _SUPPORTED_VERSIONS_LIST)
@@ -16,7 +10,6 @@ macro (find_python_from_executable EXECUTABLE SUPPORTED_VERSIONS)
       "Python version (${_VER}) is not one of the supported versions: "
       "${_SUPPORTED_VERSIONS_LIST}.")
   endif()
-  message(STATUS "Found python matching: ${EXECUTABLE}.")
 endmacro()
 
 #

--- a/setup.py
+++ b/setup.py
@@ -168,10 +168,6 @@ class cmake_build_ext(build_ext):
                 '-DCMAKE_HIP_COMPILER_LAUNCHER=ccache',
             ]
 
-        # Pass the python executable to cmake so it can find an exact
-        # match.
-        cmake_args += ['-DVLLM_PYTHON_EXECUTABLE={}'.format(sys.executable)]
-
         # Pass the python path to cmake so it can reuse the build dependencies
         # on subsequent calls to python.
         cmake_args += ['-DVLLM_PYTHON_PATH={}'.format(":".join(sys.path))]


### PR DESCRIPTION
Use the default built in stuff for finding Python, makes it so that you can actually run just to invoke the cmake.

```bash
mkdir build && cd build
cmake ../
```

Initially I went with using a range in the FindPython call but turns out that leads to unexpected behavior for venvs where it finds the wrong version.

Now this should work with virtual environments pretty well.

<!--- pyml disable-next-line no-emphasis-as-heading -->
