### PR TITLE
Fix NoFreeBlocksError

### DIFF
--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -129,9 +129,11 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
                 block_size=self.block_size,
             )
 
-        if self.max_block_sliding_window is not None:
-            num_required_blocks = min(num_required_blocks,
-                                      self.max_block_sliding_window)
+        # FIXME: Ideally self.max_block_sliding_window blocks should be
+        # sufficient, but this does not hold at the prefill stage.
+        # if self.max_block_sliding_window is not None:
+        #     num_required_blocks = min(num_required_blocks,
+        #                               self.max_block_sliding_window)
 
         num_free_gpu_blocks = self.block_allocator.get_num_free_blocks(
             device=Device.GPU)


### PR DESCRIPTION
`NoFreeBlocksError` may occur due to a mismatch between the `can_allocate` and `allocate` logic in the block manager. Specifically, `can_allocate` incorrectly takes `sliding_window_size` into account, even though sliding window is not well supported during the prefill stage.

To reproduce:
1. Prepare a model that uses sliding window, such as Mistral.
2. Send multiple requests to allocate most of the memory blocks, leaving only a small number of free blocks but more than `max_block_sliding_window`.
3. Send a long request that requires more blocks than the total number of remaining free blocks.

FIX https://github.com/vllm-project/vllm/issues/11168
