### PR TITLE
[V1][Structured Output] Update llguidance (`>= 0.7.11`) to avoid AttributeError (no `StructTag`) 

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,7 +19,7 @@ pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.11, < 0.11
-llguidance >= 0.7.9, < 0.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64"
+llguidance >= 0.7.11, < 0.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64"
 outlines == 0.1.11
 lark == 1.2.2
 xgrammar == 0.1.18; platform_machine == "x86_64" or platform_machine == "aarch64"


### PR DESCRIPTION
Update llguidance (`>= 0.7.11`) to avoid AttributeError (no `StructTag`) .

When I tested `tests/v1/entrypoints/llm/test_struct_output_generate.py` with `llguidance=0.7.10`, I get the error shown below:

```bash
AttributeError: module 'llguidance' has no attribute 'StructTag'
```

Then, I find that only `llguidance >= 0.7.11` has the `StructTag` attribute, find more details [here](https://github.com/guidance-ai/llguidance/blob/v0.7.11/python/llguidance/__init__.py#L25).

Thus, I have updated the version of `llguidance` in `requirements/common.txt`.
