### PR TITLE
[Bugfix] Fix QKVCrossParallelLinear::sync_weight_attrs for PyTorch compile

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1425,8 +1425,8 @@ class QKVCrossParallelLinear(LinearBase):
     ):
         missing_attrs_dict = {
             k: getattr(src_param, k)
-            for k in (set(src_param.__dict__.keys()) -
-                      set(tgt_param.__dict__.keys()))
+            for k in (set(vars(src_param).keys()) -
+                      set(vars(tgt_param).keys()))
         }
         # TODO(Isotr0py): handle bitsandbytes 8bit
         use_bitsandbytes_4bit = getattr(src_param, "use_bitsandbytes_4bit",


### PR DESCRIPTION
It fixes issue with compilation in Dynamo. Original version failed with:

torch._dynamo.exc.InternalTorchDynamoError: AttributeError: 'dict' object has no attribute 'node'
...
    from user code:
..
         File "./vllm/model_executor/layers/linear.py", line 1469, in sync_weight_attrs
           for k in (set(src_param.__dict__.keys()) -