### PR TITLE
Fix ReadTheDocs CI

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,6 +7,7 @@ sphinx-togglebutton==0.3.2
 myst-parser==3.0.1  # `myst-parser==4.0.1` breaks inline code in titles
 msgspec
 commonmark # Required by sphinx-argparse when using :markdownhelp:
+snowballstemmer>=2.0.0,<3.0.0 # Pinning to avoid bug in 3.0 release. See https://github.com/snowballstem/snowball/issues/229
 
 # Custom autodoc2 is necessary for faster docstring processing
 # see: https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/33#issuecomment-2856386035


### PR DESCRIPTION
CI is failing due to a bug in a recently (2h ago) released version of snowballstemmer. This PR pins the version to the 2.x release to avoid the bug. See https://github.com/snowballstem/snowball/issues/229 for more information.

<!--- pyml disable-next-line no-emphasis-as-heading -->
