### PR TITLE
[Frontend]: always try to load lora adapter from reslover

### DIFF
--- a/tests/entrypoints/openai/test_serving_models.py
+++ b/tests/entrypoints/openai/test_serving_models.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
 
+import vllm.envs as envs
 from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.openai.protocol import (ErrorResponse,
@@ -13,6 +15,7 @@ from vllm.entrypoints.openai.protocol import (ErrorResponse,
 from vllm.entrypoints.openai.serving_models import (BaseModelPath,
                                                     OpenAIServingModels)
 from vllm.lora.request import LoRARequest
+from vllm.lora.resolver import LoRAResolver
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 BASE_MODEL_PATHS = [BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME)]
@@ -20,6 +23,20 @@ LORA_LOADING_SUCCESS_MESSAGE = (
     "Success: LoRA adapter '{lora_name}' added successfully.")
 LORA_UNLOADING_SUCCESS_MESSAGE = (
     "Success: LoRA adapter '{lora_name}' removed successfully.")
+
+
+class DummyLoRAResolver(LoRAResolver):
+    """A dummy LoRA resolver for testing."""
+
+    async def resolve_lora(self, base_model_name: str,
+                           lora_name: str) -> Optional[LoRARequest]:
+        if lora_name == "test_lora":
+            return LoRARequest(
+                lora_name=lora_name,
+                lora_path=f"/dummy/path/{lora_name}",
+                lora_int_id=abs(hash(lora_name)),
+            )
+        return None
 
 
 async def _async_serving_models_init() -> OpenAIServingModels:
@@ -121,3 +138,52 @@ async def test_unload_lora_adapter_not_found():
     assert isinstance(response, ErrorResponse)
     assert response.type == "NotFoundError"
     assert response.code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_load_lora_adapter_with_resolver_success():
+    serving_models = await _async_serving_models_init()
+    serving_models.lora_resolvers.append(DummyLoRAResolver())
+    envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING = True
+    request = LoadLoRAAdapterRequest(lora_name="test_lora", lora_path="")
+    response = await serving_models.load_lora_adapter(request)
+    assert isinstance(response, str)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(
+        lora_name="test_lora")
+
+
+@pytest.mark.asyncio
+async def test_load_lora_adapter_with_resolver_fallback_fails():
+    serving_models = await _async_serving_models_init()
+    serving_models.lora_resolvers.append(DummyLoRAResolver())
+    envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING = True
+    request = LoadLoRAAdapterRequest(lora_name="no_test_lora", lora_path="")
+    response = await serving_models.load_lora_adapter(request)
+    assert isinstance(response, ErrorResponse)
+    assert response.type == "InvalidUserInput"
+    assert response.code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_load_lora_adapter_with_resolver_fallback_success():
+    serving_models = await _async_serving_models_init()
+    serving_models.lora_resolvers.append(DummyLoRAResolver())
+    envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING = True
+    request = LoadLoRAAdapterRequest(lora_name="no_test_lora",
+                                     lora_path="/dummy/path/no_test_lora")
+    response = await serving_models.load_lora_adapter(request)
+    assert isinstance(response, str)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(
+        lora_name="no_test_lora")
+
+
+@pytest.mark.asyncio
+async def test_load_lora_adapter_with_resolver_disabled_fails():
+    serving_models = await _async_serving_models_init()
+    serving_models.lora_resolvers.append(DummyLoRAResolver())
+    envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING = False
+    request = LoadLoRAAdapterRequest(lora_name="test_lora", lora_path="")
+    response = await serving_models.load_lora_adapter(request)
+    assert isinstance(response, ErrorResponse)
+    assert response.type == "InvalidUserInput"
+    assert response.code == HTTPStatus.BAD_REQUEST

--- a/vllm/entrypoints/openai/serving_models.py
+++ b/vllm/entrypoints/openai/serving_models.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Optional, Union
 
+import vllm.envs as envs
 from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.openai.protocol import (ErrorResponse,
@@ -154,15 +155,30 @@ class OpenAIServingModels:
             request: LoadLoRAAdapterRequest,
             base_model_name: Optional[str] = None
     ) -> Union[ErrorResponse, str]:
-        error_check_ret = await self._check_load_lora_adapter_request(request)
-        if error_check_ret is not None:
-            return error_check_ret
+        lora_request = None
+        # Try to resolve the lora adapter using available resolvers
+        # First attempt to resolve using registered resolvers
+        if envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING:
+            lora_request = await self.resolve_lora(request.lora_name)
 
-        lora_name, lora_path = request.lora_name, request.lora_path
-        unique_id = self.lora_id_counter.inc(1)
-        lora_request = LoRARequest(lora_name=lora_name,
-                                   lora_int_id=unique_id,
-                                   lora_path=lora_path)
+        if not isinstance(lora_request, LoRARequest):
+            # Failed to resolve, fallback to direct loading
+            logger.warning(
+                "Failed to resolve LoRA adapter '%s', "
+                "falling back to direct loading",
+                request.lora_name,
+            )
+            error_check_ret = await self._check_load_lora_adapter_request(
+                request)
+            if error_check_ret is not None:
+                return error_check_ret
+
+            unique_id = self.lora_id_counter.inc(1)
+            lora_request = LoRARequest(
+                lora_name=request.lora_name,
+                lora_int_id=unique_id,
+                lora_path=request.lora_path,
+            )
         if base_model_name is not None and self.is_base_model(base_model_name):
             lora_request.base_model_name = base_model_name
 
@@ -182,6 +198,7 @@ class OpenAIServingModels:
                                          status_code=status_code)
 
         self.lora_requests.append(lora_request)
+        lora_name, lora_path = lora_request.lora_name, lora_request.lora_path
         logger.info("Loaded new LoRA adapter: name '%s', path '%s'", lora_name,
                     lora_path)
         return f"Success: LoRA adapter '{lora_name}' added successfully."


### PR DESCRIPTION
Enable loading lora adapter from reslover in entrypoint: "/v1/load_lora_adapter"

## Changes

- ```vllm/entrypoints/openai/serving_models.py```: Updated load_lora_adapter to first attempt loading LoRA adapters via the resolve_lora method if VLLM_ALLOW_RUNTIME_LORA_UPDATING is enabled.Includes fallback to the direct loading method if resolution fails or is disabled.

- ```tests/entrypoints/openai/test_serving_models.py```: add related ut