### PR TITLE
[BugFix] [ROCm]: Bugfix and handle addition case of input for `rocm_aiter_rms_norm`

### DIFF
--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -28,6 +28,7 @@ AITER_MODEL_LIST = [
     "Qwen/Qwen-7B-Chat",
     "Qwen/Qwen2.5-0.5B-Instruct",
     "TitanML/tiny-mixtral",
+    "Qwen/Qwen3-8B",
 ]
 
 
@@ -77,6 +78,9 @@ AITER_MODEL_LIST = [
         pytest.param(
             "Qwen/Qwen2.5-0.5B-Instruct",  # qwen2
             marks=[pytest.mark.core_model],
+        ),
+        pytest.param(
+            "Qwen/Qwen3-8B",  # qwen (text-only)
         ),
         pytest.param("stabilityai/stablelm-3b-4e1t"),  # stablelm
         pytest.param("bigcode/starcoder2-3b"),  # starcoder2


### PR DESCRIPTION
After this PR (https://github.com/vllm-project/vllm/pull/17735) , a new case to be handled in `rocm_aiter_rms_norm`.

`x` could be a 3-dimensional tensor. `x` is reshaped to 2-dimensional tensors before calling `aiter.rms_norm`

# lm_eval
Dataset: GSM8K
Engine: V0

## Qwen/Qwen3-235B-A22B-FP8 without AITER
vllm (pretrained=Qwen/Qwen3-235B-A22B-FP8,tensor_parallel_size=4,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8726|±  |0.0092|
|     |       |strict-match    |     5|exact_match|↑  |0.8567|±  |0.0097|

## Qwen/Qwen3-235B-A22B-FP8 with AITER RMS Norm
vllm (pretrained=Qwen/Qwen3-235B-A22B-FP8,tensor_parallel_size=4,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8734|±  |0.0092|
|     |       |strict-match    |     5|exact_match|↑  |0.8506|±  |0.0098|

## Qwen/Qwen3-32B without AITER
vllm (pretrained=Qwen/Qwen3-32B,tensor_parallel_size=1,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6255|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7369|±  |0.0121|

## Qwen/Qwen3-32B with AITER RMS Norm
vllm (pretrained=Qwen/Qwen3-32B,tensor_parallel_size=4,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6209|±  |0.0134|
|     |       |strict-match    |     5|exact_match|↑  |0.7453|±  |0.0120|


## Add Qwen3 dense to the list of `test_common.py`
Passed:  `tests/models/language/generation/test_common.py`


<!--- pyml disable-next-line no-emphasis-as-heading -->
