### PR TITLE
[CI] Fix test_collective_rpc

### DIFF
--- a/tests/entrypoints/llm/test_collective_rpc.py
+++ b/tests/entrypoints/llm/test_collective_rpc.py
@@ -10,7 +10,7 @@ from ...utils import create_new_process_for_each_test
 @pytest.mark.parametrize("tp_size", [1, 2])
 @pytest.mark.parametrize("backend", ["mp", "ray"])
 @create_new_process_for_each_test()
-def test_collective_rpc(tp_size, backend):
+def test_collective_rpc(tp_size, backend, monkeypatch):
     if tp_size == 1 and backend == "ray":
         pytest.skip("Skip duplicate test case")
     if tp_size == 1:
@@ -21,6 +21,7 @@ def test_collective_rpc(tp_size, backend):
     def echo_rank(self):
         return self.rank
 
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
     llm = LLM(model="meta-llama/Llama-3.2-1B-Instruct",
               enforce_eager=True,
               load_format="dummy",


### PR DESCRIPTION
This change is related to #17490. This test didn't run on that PR, so
the failure was missed. This code currently relies on the pickle
fallback, so pickle support must be enabled to use it for now.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
