### PR TITLE
[V1] Add minItems, maxItems support with xgrammar

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -22,7 +22,7 @@ lm-format-enforcer >= 0.10.11, < 0.11
 llguidance >= 0.7.9, < 0.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64"
 outlines == 0.1.11
 lark == 1.2.2
-xgrammar == 0.1.18; platform_machine == "x86_64" or platform_machine == "aarch64"
+xgrammar == 0.1.19; platform_machine == "x86_64" or platform_machine == "aarch64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/tests/v1/entrypoints/conftest.py
+++ b/tests/v1/entrypoints/conftest.py
@@ -73,7 +73,9 @@ def sample_json_schema():
                         }
                     },
                     "required": ["company", "duration", "position"]
-                }
+                },
+                "minItems": 1,
+                "maxItems": 3
             }
         },
         "required":

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -215,9 +215,8 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
 
         # Check for array unsupported keywords
         if obj.get("type") == "array" and any(
-                key in obj
-                for key in ("uniqueItems", "contains", "minContains",
-                            "maxContains", "minItems", "maxItems")):
+                key in obj for key in ("uniqueItems", "contains",
+                                       "minContains", "maxContains")):
             return True
 
         # Unsupported keywords for strings


### PR DESCRIPTION
xgrammar 0.1.19 supports the `minItems` and `maxItems` of JSON arrays.
Upgrade the dependency and allow JSON schemas with those properties
set.

xgrammar PR: https://github.com/mlc-ai/xgrammar/pull/296

Closes #16880

Signed-off-by: Russell Bryant <rbryant@redhat.com>
