### PR TITLE
[V1] Fast decode prepare path for prepare_inputs logic

### DIFF
--- a/examples/offline_inference/basic/basic.py
+++ b/examples/offline_inference/basic/basic.py
@@ -10,12 +10,12 @@ prompts = [
     "The future of AI is",
 ]
 # Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=10)
 
 
 def main():
     # Create an LLM.
-    llm = LLM(model="facebook/opt-125m")
+    llm = LLM(model="facebook/opt-125m", disable_cascade_attn=True)
     # Generate texts from the prompts.
     # The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_MOE_PADDING: bool = True
     VLLM_ROCM_CUSTOM_PAGED_ATTN: bool = True
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
+    VLLM_ENABLE_V1_ADVANCE_STEP: bool = False
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
     Q_SCALE_CONSTANT: int = 200
@@ -600,6 +601,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
+    "VLLM_ENABLE_V1_ADVANCE_STEP":
+    lambda: bool(int(os.getenv("VLLM_ENABLE_V1_ADVANCE_STEP", "0"))),
 
     # If set, vllm will run in development mode, which will enable
     # some additional endpoints for developing and debugging,


### PR DESCRIPTION
This PR implements a fast-path "advance_decode_prepare" for prepare_inputs logic. The fast-path is applied when we have repeating decodes of the same requests, which is beneficial for low latency cases. Initial results on llama 3.2 1B show around ~10% improvement for TPOT in serving mode.

Without fast-path decode:
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  108.51    
Total input tokens:                      50000     
Total generated tokens:                  5000      
Request throughput (req/s):              0.92      
Output token throughput (tok/s):         46.08     
Total Token throughput (tok/s):          506.85    
---------------Time to First Token----------------
Mean TTFT (ms):                          21.47     
Median TTFT (ms):                        21.00     
P99 TTFT (ms):                           29.99     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.73      
Median TPOT (ms):                        2.64      
P99 TPOT (ms):                           3.24      
---------------Inter-token Latency----------------
Mean ITL (ms):                           2.73      
Median ITL (ms):                         2.61      
P99 ITL (ms):                            4.08      
==================================================

```
With fast-path decode:
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  108.50    
Total input tokens:                      50000     
Total generated tokens:                  5000      
Request throughput (req/s):              0.92      
Output token throughput (tok/s):         46.08     
Total Token throughput (tok/s):          506.93    
---------------Time to First Token----------------
Mean TTFT (ms):                          20.63     
Median TTFT (ms):                        20.39     
P99 TTFT (ms):                           31.10     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.48      
Median TPOT (ms):                        2.42      
P99 TPOT (ms):                           3.18      
---------------Inter-token Latency----------------
Mean ITL (ms):                           2.49      
Median ITL (ms):                         2.38      
P99 ITL (ms):                            3.96      
==================================================
```

TODOs:
1. Add measurements with full cuda graphs PR
2. Enable cascade attn
3. Support flashinfer