### PR TITLE
Don't load generation config if generation_config=vllm

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1215,12 +1215,14 @@ class ModelConfig:
         return self.multimodal_config
 
     def try_get_generation_config(self) -> dict[str, Any]:
-        if self.generation_config in ("auto", "vllm"):
+        if self.generation_config == "auto":
             config = try_get_generation_config(
                 self.hf_config_path or self.model,
                 trust_remote_code=self.trust_remote_code,
                 revision=self.revision,
             )
+        elif self.generation_config == "vllm":
+            config = None
         else:
             config = try_get_generation_config(
                 self.generation_config,


### PR DESCRIPTION
Based on the doc
> --generation-config
The folder path to the generation config. Defaults to "auto", the generation config will be loaded from model path. If set to "vllm", no generation config is loaded, vLLM defaults will be used. If set to a folder path, the generation config will be loaded from the specified folder path. If max_new_tokens is specified in generation config, then it sets a server-wide limit on the number of output tokens for all requests.

we should not attempt to load config when `generation-config == "vllm"`. 

<!--- pyml disable-next-line no-emphasis-as-heading -->
