### PR TITLE
Handle error when `str` passed to `/v1/audio/transcriptions`

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -5,10 +5,11 @@
 import json
 import re
 import time
+from http import HTTPStatus
 from typing import Annotated, Any, ClassVar, Literal, Optional, Union
 
 import torch
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 from pydantic import (BaseModel, ConfigDict, Field, TypeAdapter,
                       ValidationInfo, field_validator, model_validator)
 from typing_extensions import TypeAlias
@@ -1727,7 +1728,14 @@ class TranscriptionRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_stream_options(cls, data):
+    def validate_transcription_request(cls, data):
+        if isinstance(data.get("file"), str):
+            raise HTTPException(
+                status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                detail=("Unsupported type for 'file'. Audio file should be a "
+                        "'fastapi.UploadFile' object, not 'str'.")
+            )
+
         stream_opts = ["stream_include_usage", "stream_continuous_usage_stats"]
         stream = data.get("stream", False)
         if any(bool(data.get(so, False)) for so in stream_opts) and not stream:

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1732,8 +1732,7 @@ class TranscriptionRequest(OpenAIBaseModel):
         if isinstance(data.get("file"), str):
             raise HTTPException(
                 status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-                detail=("Unsupported type for 'file'. Audio file should be a "
-                        "'fastapi.UploadFile' object, not 'str'.")
+                detail="Expected 'file' to be a file-like object, not 'str'.",
             )
 
         stream_opts = ["stream_include_usage", "stream_continuous_usage_stats"]


### PR DESCRIPTION
Solves part of https://github.com/vllm-project/vllm/issues/17038

Server side:

```console
INFO:     127.0.0.1:42508 - "POST /v1/audio/transcriptions HTTP/1.1" 422 Unprocessable Entity
```

Client side:

```console
$ curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' -d file=b%27%27 --insecure http://127.0.0.1:8000/v1/audio/transcriptions
{"detail":"Unsupported type for 'file'. Audio file should be a 'fastapi.UploadFile' object, not 'str'."}
```