### PR TITLE
[Bugfix][V1] Only get input embeddings w/ multi-modal models if first PP

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1114,7 +1114,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         else:
             mm_embeds = []
 
-        if self.is_multimodal_model:
+        if self.is_multimodal_model and get_pp_group().is_first_rank:
             # NOTE(woosuk): To unify token ids and soft tokens (vision
             # embeddings), we always use embeddings (rather than token ids)
             # as input to the multimodal model, even when the input is text.


### PR DESCRIPTION
This PR fixes multi-modal model using PP on V1 by only calling `model.get_input_embeddings` for the first PP rank. Prior to this fix, all PP ranks would attempt to invoke `model.get_input_embeddings` in which the layer does not exist on the other ranks, resulting in the following stack trace:

```
ERROR 04-29 20:23:15 [core.py:400] EngineCore hit an exception: Traceback (most recent call last):
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/core.py", line 393, in run_engine_core
ERROR 04-29 20:23:15 [core.py:400]     engine_core.run_busy_loop()
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/core.py", line 415, in run_busy_loop
ERROR 04-29 20:23:15 [core.py:400]     self._process_engine_step()
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/core.py", line 444, in _process_engine_step
ERROR 04-29 20:23:15 [core.py:400]     outputs = self.step_fn()
ERROR 04-29 20:23:15 [core.py:400]               ^^^^^^^^^^^^^^
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/core.py", line 260, in step_with_batch_queue
ERROR 04-29 20:23:15 [core.py:400]     model_output = future.result()
ERROR 04-29 20:23:15 [core.py:400]                    ^^^^^^^^^^^^^^^
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/executor/ray_distributed_executor.py", line 24, in result
ERROR 04-29 20:23:15 [core.py:400]     return self.ref.get()
ERROR 04-29 20:23:15 [core.py:400]            ^^^^^^^^^^^^^^
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/ray/experimental/compiled_dag_ref.py", line 150, in get
ERROR 04-29 20:23:15 [core.py:400]     return _process_return_vals(return_vals, True)
ERROR 04-29 20:23:15 [core.py:400]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/ray/experimental/compiled_dag_ref.py", line 27, in _process_return_vals
ERROR 04-29 20:23:15 [core.py:400]     raise val.as_instanceof_cause()
ERROR 04-29 20:23:15 [core.py:400] ray.exceptions.RayTaskError(RuntimeError): ray::RayWorkerWrapper.__ray_call__() (pid=39293, ip=172.20.0.3)
ERROR 04-29 20:23:15 [core.py:400]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/vllm/executor/ray_utils.py", line 136, in execute_model_ray
ERROR 04-29 20:23:15 [core.py:400]     output = self.worker.model_runner.execute_model(
ERROR 04-29 20:23:15 [core.py:400]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 04-29 20:23:15 [core.py:400]     return func(*args, **kwargs)
ERROR 04-29 20:23:15 [core.py:400]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 04-29 20:23:15 [core.py:400]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 1033, in execute_model
ERROR 04-29 20:23:15 [core.py:400]     self.inputs_embeds[:num_scheduled_tokens].copy_(inputs_embeds)
ERROR 04-29 20:23:15 [core.py:400] RuntimeError: The size of tensor a (5120) must match the size of tensor b (7) at non-singleton dimension 1
```
