### PR TITLE
[Misc][RFC] Add automated profiling sweep and heatmap visualization tools

### DIFF
--- a/tools/profiler/plot_heatmap_from_traces.py
+++ b/tools/profiler/plot_heatmap_from_traces.py
@@ -80,7 +80,13 @@ def plot_heatmap(data, title, filename, fmt=".1f", cmap="viridis"):
         for j in range(len(prompt_lens)):
             val = data[i, j]
             if not np.isnan(val):
-                ax.text(j, i, format(val, fmt), ha="center", va="center", fontsize=6, color="white")
+                ax.text(
+                    j, i, format(val, fmt),
+                    ha="center",
+                    va="center",
+                    fontsize=6,
+                    color="white"
+                )
 
     plt.colorbar(im, ax=ax)
     plt.tight_layout()

--- a/tools/profiler/plot_heatmap_from_traces.py
+++ b/tools/profiler/plot_heatmap_from_traces.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import json
-import numpy as np
+import os
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 from vllm.profiler.layerwise_profile import SummaryStatsEntry
 
 # === Configuration ===
@@ -11,12 +13,14 @@ OUTPUT_DIR = "./outputs"
 FIGURE_OUTPUT_DIR = "./heatmap_figures"
 os.makedirs(FIGURE_OUTPUT_DIR, exist_ok=True)
 
+
 # === Parse filename like profiling_bs16_pl2048.json ===
 def parse_filename(fname):
     parts = fname.replace(".json", "").split("_")
     bs = int(parts[1][2:])
     pl = int(parts[2][2:])
     return bs, pl
+
 
 # === Extract root-level CUDA time from summary_stats ===
 def extract_cuda_time(json_file, phase):
@@ -29,6 +33,7 @@ def extract_cuda_time(json_file, phase):
         return None
     root_entry = SummaryStatsEntry(**entries[0]["entry"])
     return root_entry.cuda_time_us / 1000.0  # ms
+
 
 # === Load all times into dict {(bs, pl): time} ===
 def load_profile_times(directory, phase):
@@ -43,6 +48,7 @@ def load_profile_times(directory, phase):
             time_map[(bs, pl)] = t
     return time_map
 
+
 # === Collect times ===
 prefill_times = load_profile_times(OUTPUT_DIR, "prefill")
 decode_times = load_profile_times(OUTPUT_DIR, "decode_1")
@@ -50,6 +56,7 @@ decode_times = load_profile_times(OUTPUT_DIR, "decode_1")
 # === Batch sizes and prompt lengths ===
 batch_sizes = sorted({k[0] for k in prefill_times})
 prompt_lens = sorted({k[1] for k in prefill_times})
+
 
 # === Create heatmap matrix ===
 def build_heatmap(time_data):
@@ -61,8 +68,10 @@ def build_heatmap(time_data):
                 t_mat[i, j] = time_data[key]
     return t_mat
 
+
 prefill_mat = build_heatmap(prefill_times)
 decode_mat = build_heatmap(decode_times)
+
 
 # === Plot heatmaps ===
 def plot_heatmap(data, title, filename, fmt=".1f", cmap="viridis"):
@@ -80,18 +89,19 @@ def plot_heatmap(data, title, filename, fmt=".1f", cmap="viridis"):
         for j in range(len(prompt_lens)):
             val = data[i, j]
             if not np.isnan(val):
-                ax.text(
-                    j, i, format(val, fmt),
-                    ha="center",
-                    va="center",
-                    fontsize=6,
-                    color="white"
-                )
+                ax.text(j,
+                        i,
+                        format(val, fmt),
+                        ha="center",
+                        va="center",
+                        fontsize=6,
+                        color="white")
 
     plt.colorbar(im, ax=ax)
     plt.tight_layout()
     plt.savefig(os.path.join(FIGURE_OUTPUT_DIR, filename))
     plt.close()
+
 
 # === Save ===
 plot_heatmap(prefill_mat, "Prefill - Time (ms)", "prefill_time.png")

--- a/tools/profiler/plot_heatmap_from_traces.py
+++ b/tools/profiler/plot_heatmap_from_traces.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import json
+import numpy as np
+import matplotlib.pyplot as plt
+from vllm.profiler.layerwise_profile import SummaryStatsEntry
+
+# === Configuration ===
+OUTPUT_DIR = "./outputs"
+FIGURE_OUTPUT_DIR = "./heatmap_figures"
+os.makedirs(FIGURE_OUTPUT_DIR, exist_ok=True)
+
+# === Parse filename like profiling_bs16_pl2048.json ===
+def parse_filename(fname):
+    parts = fname.replace(".json", "").split("_")
+    bs = int(parts[1][2:])
+    pl = int(parts[2][2:])
+    return bs, pl
+
+# === Extract root-level CUDA time from summary_stats ===
+def extract_cuda_time(json_file, phase):
+    with open(json_file) as f:
+        data = json.load(f)
+    if phase not in data:
+        return None
+    entries = data[phase]["summary_stats"]
+    if not entries:
+        return None
+    root_entry = SummaryStatsEntry(**entries[0]["entry"])
+    return root_entry.cuda_time_us / 1000.0  # ms
+
+# === Load all times into dict {(bs, pl): time} ===
+def load_profile_times(directory, phase):
+    time_map = {}
+    for fname in os.listdir(directory):
+        if not fname.endswith(".json"):
+            continue
+        bs, pl = parse_filename(fname)
+        json_file = os.path.join(directory, fname)
+        t = extract_cuda_time(json_file, phase)
+        if t is not None:
+            time_map[(bs, pl)] = t
+    return time_map
+
+# === Collect times ===
+prefill_times = load_profile_times(OUTPUT_DIR, "prefill")
+decode_times = load_profile_times(OUTPUT_DIR, "decode_1")
+
+# === Batch sizes and prompt lengths ===
+batch_sizes = sorted({k[0] for k in prefill_times})
+prompt_lens = sorted({k[1] for k in prefill_times})
+
+# === Create heatmap matrix ===
+def build_heatmap(time_data):
+    t_mat = np.full((len(batch_sizes), len(prompt_lens)), np.nan)
+    for i, bs in enumerate(batch_sizes):
+        for j, pl in enumerate(prompt_lens):
+            key = (bs, pl)
+            if key in time_data:
+                t_mat[i, j] = time_data[key]
+    return t_mat
+
+prefill_mat = build_heatmap(prefill_times)
+decode_mat = build_heatmap(decode_times)
+
+# === Plot heatmaps ===
+def plot_heatmap(data, title, filename, fmt=".1f", cmap="viridis"):
+    fig, ax = plt.subplots(figsize=(12, 6))
+    im = ax.imshow(data, cmap=cmap, aspect="auto")
+    ax.set_xticks(np.arange(len(prompt_lens)))
+    ax.set_xticklabels(prompt_lens, rotation=45)
+    ax.set_yticks(np.arange(len(batch_sizes)))
+    ax.set_yticklabels(batch_sizes)
+    ax.set_xlabel("Prompt Length")
+    ax.set_ylabel("Batch Size")
+    ax.set_title(title)
+
+    for i in range(len(batch_sizes)):
+        for j in range(len(prompt_lens)):
+            val = data[i, j]
+            if not np.isnan(val):
+                ax.text(j, i, format(val, fmt), ha="center", va="center", fontsize=6, color="white")
+
+    plt.colorbar(im, ax=ax)
+    plt.tight_layout()
+    plt.savefig(os.path.join(FIGURE_OUTPUT_DIR, filename))
+    plt.close()
+
+# === Save ===
+plot_heatmap(prefill_mat, "Prefill - Time (ms)", "prefill_time.png")
+plot_heatmap(decode_mat, "Decode - Time (ms)", "decode_time.png")

--- a/tools/profiler/profiling.py
+++ b/tools/profiler/profiling.py
@@ -189,7 +189,9 @@ def run_profile(context: ProfileContext,
 
     # Create LLM
     engine_args_dict = asdict(context.engine_args)
-    engine_args_dict['max_model_len'] = engine_args_dict['max_num_batched_tokens']
+    engine_args_dict["max_model_len"] = (
+        engine_args_dict["max_num_batched_tokens"]
+    )
     llm = LLM(**engine_args_dict)
 
     batch_size = context.batch_size
@@ -201,9 +203,14 @@ def run_profile(context: ProfileContext,
     max_num_seqs = scheduler_config.max_num_seqs
 
 
-    # We will run the script with batch sizes. We assume that we will fail at some particular
+    # We will run the script with batch sizes. 
+    # We assume that we will fail at some particular
     # prompt_len, bc batch_size x prompt_lens will give OOM error.
-    prompt_lens = [128, 256, 512, 1024, 1536, 2048, 4096, 8192, 16384, 32768, 65536]
+    prompt_lens = [
+        128, 256, 512, 1024, 1536, 2048,
+        4096, 8192, 16384, 32768, 65536
+    ]
+
     for prompt_len in prompt_lens:
         output_folder = f"./outputs/"
         json_filename = f"profiling_bs{batch_size}_pl{prompt_len}.json"
@@ -211,8 +218,9 @@ def run_profile(context: ProfileContext,
 
         if batch_size * prompt_len > max_num_batched_tokens:
             print(f"ERROR: chosen batch_size * prompt_len "
-                f"({batch_size} * {prompt_len} = {batch_size * prompt_len}) is  "
-                f"larger than max_num_batched_tokens ({max_num_batched_tokens}) "
+                f"({batch_size} * {prompt_len} = {batch_size * prompt_len}) "
+                f"is larger than max_num_batched_tokens "
+                f"({max_num_batched_tokens}) "
                 f"and therefore cannot be run in a single profile step, please "
                 f"choose a smaller batch size or prompt length, or increase "
                 f"--max-num-batched-tokens")
@@ -220,12 +228,16 @@ def run_profile(context: ProfileContext,
         if batch_size > max_num_seqs:
             print(
                 f"ERROR: chosen batch_size ({batch_size}) is larger than "
-                f"max_num_seqs ({max_num_seqs}) and therefore cannot be run in a "
+                f"max_num_seqs ({max_num_seqs}) "
+                f"and therefore cannot be run in a "
                 f"single profile step, please choose a smaller batch size")
             sys.exit(-1)
         print("llm.llm_engine.model_config.max_model_len: ",
             llm.llm_engine.model_config.max_model_len)
-        if prompt_len + max_output_len > llm.llm_engine.model_config.max_model_len:
+        if (
+            prompt_len + max_output_len
+            > llm.llm_engine.model_config.max_model_len
+        ):
             print(f"ERROR: chosen prompt_len + max_output_len ({prompt_len} + "
                 f"{max_output_len} = {prompt_len + max_output_len}) is larger "
                 f"than the model's max_model_len ({max_model_len}), please "
@@ -233,7 +245,7 @@ def run_profile(context: ProfileContext,
                 f"--max-model-len")
             sys.exit(-1)
 
-        def add_requests():
+        def add_requests(prompt_len=prompt_len):
 
             def get_output_len_generator() -> Generator[int, Any, Any]:
                 for output_len, num_reqs in ol_nr.items():
@@ -310,7 +322,9 @@ def run_profile(context: ProfileContext,
                 context.save_chrome_traces_folder + "/prefill.json")
             for idx, decode_prof in enumerate(decode_profs):
                 decode_prof.profiler.export_chrome_trace(
-                    context.save_chrome_traces_folder + f"/decode_{idx + 1}.json")
+                    context.save_chrome_traces_folder
+                    + f"/decode_{idx + 1}.json"
+                )
             print("Traces saved as prefill.json and decode_1.json, etc."
                 f" in folder {context.save_chrome_traces_folder}")
 

--- a/tools/profiler/profiling.py
+++ b/tools/profiler/profiling.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+import json
+import os
+import sys
+from argparse import RawTextHelpFormatter
+from collections.abc import Generator
+from dataclasses import asdict, dataclass
+from typing import Any, Optional, TypeAlias
+
+import torch
+import tqdm
+
+from vllm import LLM, SamplingParams
+from vllm.engine.arg_utils import EngineArgs
+from vllm.profiler import layerwise_profile
+from vllm.utils import FlexibleArgumentParser
+
+BATCH_SIZE_DEFAULT = 1
+PROMPT_LEN_DEFAULT = 256
+
+
+@dataclass
+class ProfileContext:
+    engine_args: EngineArgs
+    prompt_len: int
+    batch_size: int
+
+    # The profiler can run in 2 modes,
+    # 1. Run profiler for user specified num_steps
+    num_steps: Optional[int] = None
+    # 2. Run profiler until all requests complete
+    complete_num_requests_per_step: Optional[int] = None
+
+    save_chrome_traces_folder: Optional[str] = None
+
+
+def get_dtype(dtype: str):
+    if dtype == "torch.float":
+        return torch.float
+    else:
+        return dtype
+
+
+OutputLen_NumReqs_Map: TypeAlias = dict[int, int]
+def compute_request_output_lengths(batch_size: int, step_requests: list[int]) \
+      -> OutputLen_NumReqs_Map:
+    """
+    Given the number of requests, batch_size, and the number of requests
+    that each engine-step should process, step_requests, determine the
+    output lengths of the requests such that step_request is honoured.
+
+    Example: 
+    if batch size = 128 and step_request = [128, 128, 96, 64, 32, 1]
+    then return,
+    {2 : 32, 3 : 32, 4 : 32, 5 : 31, 6 : 1}, meaning,
+    32 requests should have output length 2,
+    32 requests should have output length 3,
+    32 requests should have output length 4,
+    31 requests should have output length 5,
+    1 request should have output length 6.
+
+    Args:
+        batch_size (int): Number of requests submitted for profile. This is
+            args.batch_size.
+        step_requests (list[int]): step_requests[i] is the number of requests
+            that the ith engine step should process.
+
+    Returns:
+        OutputLen_NumReqs_Map : A dictionary with output-length as keys and the
+            number of requests required to have that output-length as values.
+    """
+    ol_nr: OutputLen_NumReqs_Map = {}
+
+    # Number of request that are assigned an output-length
+    num_reqs_assigned: int = 0
+    num_steps: int = len(step_requests)
+
+    # sanity check. The first step (prefill-step), must process all requests.
+    assert step_requests[0] == batch_size
+
+    # Begin assignments from the last step.
+    output_length: int = num_steps
+    for num_requests_at_step in reversed(step_requests):
+        if num_reqs_assigned == batch_size:
+            break
+
+        assert num_reqs_assigned < batch_size
+
+        # Remove the number of requests that have been determined
+        # to participate in this step and beyond.
+        num_reqs_unassigned_at_step = num_requests_at_step - num_reqs_assigned
+        assert num_reqs_unassigned_at_step >= 0
+
+        if num_reqs_unassigned_at_step > 0:
+            ol_nr[output_length] = num_reqs_unassigned_at_step
+            num_reqs_assigned += num_reqs_unassigned_at_step
+
+        output_length -= 1
+
+    # sanity checks.
+    assert sum(ol_nr.values()) == batch_size, \
+            ("Number of requests in output-length assignment does not match "
+             f"batch-size.\n batch size {batch_size} - "
+             f"step requests {step_requests} - assignments {ol_nr}")
+
+    # Check that the output-length is in [1, num-steps]. Output length must be
+    # at least 1 as all requests must participate in the prefill-step.
+    assert all(ol >= 1 and ol <= num_steps for ol in ol_nr), \
+            ("Output lengths of requests should be in range "
+             f"[1, num-engine-steps].\n batch size {batch_size} - "
+             f"step requests {step_requests} - assignments {ol_nr}")
+
+    return ol_nr
+
+
+def determine_requests_per_step(context: ProfileContext) -> list[int]:
+    """
+    Determine number of requests each engine step should process.
+    If context.num_steps is set, then all engine steps process the
+    same number of requests and the output list is of length
+    context.num_steps.
+
+    If context.complete_num_requests_per_step is set, then each decode step
+    processes fewer and fewer requests until there are no requests to process.
+    In this case, the output list is as big as the number of steps
+    required to process all requests.
+
+    Args:
+        context: ProfileContext object.
+
+    Returns:
+        list[int]: Number of requests to process for all engine-steps. 
+         output[i], contains the number of requests that the ith step
+         should process.
+    """
+    if context.num_steps:
+        # All requests must run until num_engine_steps. This implies
+        # that their output lengths must be equal to num_engine_steps.
+        return [context.batch_size] * context.num_steps
+
+    assert context.complete_num_requests_per_step and \
+                context.complete_num_requests_per_step > 0, \
+        (f"Expected a positive complete_num_requests_per_step argument."
+         f"Instead got {context.complete_num_requests_per_step}")
+
+    # We start dropping after the first decode step.
+    step_requests = [
+        context.batch_size,  # prefill
+        context.batch_size,  # decode
+    ]
+
+    num_running_requests = context.batch_size
+    num_running_requests -= context.complete_num_requests_per_step
+    while num_running_requests > 0:
+        step_requests.append(num_running_requests)
+        num_running_requests -= context.complete_num_requests_per_step
+
+    if step_requests[-1] != 1:
+        # have 1 request running at the last step. This is often
+        # useful
+        step_requests.append(1)
+
+    return step_requests
+
+
+def run_profile(context: ProfileContext, 
+                json_output: Optional[str]):
+    print("Run profile with:")
+    for key, value in asdict(context).items():
+        print(f"  {key} = {value}")
+
+    requests_per_step: list[int] = determine_requests_per_step(context)
+
+    ol_nr: OutputLen_NumReqs_Map = compute_request_output_lengths(
+        context.batch_size, requests_per_step)
+
+    num_steps_to_profile: int = len(requests_per_step)
+    max_output_len: int = max(ol_nr.keys())
+    assert max_output_len >= 1
+
+    # Create sampling params
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        # max_tokens is set on a per-request basis.
+        max_tokens=None,
+        ignore_eos=True)
+
+    # Create LLM
+    engine_args_dict = asdict(context.engine_args)
+    engine_args_dict['max_model_len'] = engine_args_dict['max_num_batched_tokens']
+    llm = LLM(**engine_args_dict)
+
+    batch_size = context.batch_size
+    prompt_len = context.prompt_len
+
+    scheduler_config = llm.llm_engine.scheduler_config
+    max_model_len = llm.llm_engine.model_config.max_model_len
+    max_num_batched_tokens = scheduler_config.max_num_batched_tokens
+    max_num_seqs = scheduler_config.max_num_seqs
+
+
+    # We will run the script with batch sizes. We assume that we will fail at some particular
+    # prompt_len, bc batch_size x prompt_lens will give OOM error.
+    prompt_lens = [128, 256, 512, 1024, 1536, 2048, 4096, 8192, 16384, 32768, 65536]
+    for prompt_len in prompt_lens:
+        output_folder = f"./outputs/"
+        json_filename = f"profiling_bs{batch_size}_pl{prompt_len}.json"
+        json_filename = output_folder + json_filename
+
+        if batch_size * prompt_len > max_num_batched_tokens:
+            print(f"ERROR: chosen batch_size * prompt_len "
+                f"({batch_size} * {prompt_len} = {batch_size * prompt_len}) is  "
+                f"larger than max_num_batched_tokens ({max_num_batched_tokens}) "
+                f"and therefore cannot be run in a single profile step, please "
+                f"choose a smaller batch size or prompt length, or increase "
+                f"--max-num-batched-tokens")
+            sys.exit(-1)
+        if batch_size > max_num_seqs:
+            print(
+                f"ERROR: chosen batch_size ({batch_size}) is larger than "
+                f"max_num_seqs ({max_num_seqs}) and therefore cannot be run in a "
+                f"single profile step, please choose a smaller batch size")
+            sys.exit(-1)
+        print("llm.llm_engine.model_config.max_model_len: ",
+            llm.llm_engine.model_config.max_model_len)
+        if prompt_len + max_output_len > llm.llm_engine.model_config.max_model_len:
+            print(f"ERROR: chosen prompt_len + max_output_len ({prompt_len} + "
+                f"{max_output_len} = {prompt_len + max_output_len}) is larger "
+                f"than the model's max_model_len ({max_model_len}), please "
+                f"choose a smaller prompt_len or max_output_len, or increase "
+                f"--max-model-len")
+            sys.exit(-1)
+
+        def add_requests():
+
+            def get_output_len_generator() -> Generator[int, Any, Any]:
+                for output_len, num_reqs in ol_nr.items():
+                    for _ in range(num_reqs):
+                        yield output_len
+
+            output_len_generator = get_output_len_generator()
+            for i in range(batch_size):
+                sampling_params.max_tokens = next(output_len_generator)
+                assert isinstance(sampling_params.max_tokens, int)
+
+                prompt_token_ids = torch.randint(llm.get_tokenizer().vocab_size,
+                                                size=(prompt_len, )).tolist()
+
+                llm.llm_engine.add_request(
+                    request_id=f"seq{i}",
+                    prompt={'prompt_token_ids': prompt_token_ids},
+                    params=sampling_params)
+
+        def abort_requests():
+            for i in range(batch_size):
+                llm.llm_engine.abort_request(f"seq{i}")
+
+        # Warm up run
+        print("Warm up run ...")
+        add_requests()
+        llm.llm_engine.step()  # Prefill
+        llm.llm_engine.step()  # Decode
+        abort_requests()
+
+        print("Profile run ...")
+        add_requests()
+
+        with layerwise_profile() as prefill_prof:
+            llm.llm_engine.step()  # First step is prefill
+
+        decode_profs = []
+        for _ in tqdm.tqdm(range(num_steps_to_profile - 1)):
+            num_running_seqs = llm.llm_engine.scheduler[
+                0].get_num_unfinished_seq_groups()
+            with layerwise_profile(
+                    num_running_seqs=num_running_seqs) as decode_prof:
+                llm.llm_engine.step()
+            decode_profs.append(decode_prof)
+
+        decode_results_list = [prof.results for prof in decode_profs]
+        prefill_results = prefill_prof.results
+        has_decode = len(decode_results_list) > 0
+
+        # Always dumps the result to a json
+        
+        if json_output:
+
+            json_dict = {
+                "context": {
+                    "python_version": f"{sys.version}",
+                    "torch_version": f"{torch.__version__}",
+                    **asdict(context)
+                },
+                "prefill": prefill_results.convert_stats_to_dict(),
+            }
+
+            if has_decode:
+                for idx, dr in enumerate(decode_results_list):
+                    json_dict[f"decode_{idx + 1}"] = dr.convert_stats_to_dict()
+
+            with open(json_filename, "w+") as f:
+                json.dump(json_dict, f, indent=2)
+            pass
+
+        if context.save_chrome_traces_folder is not None:
+            os.makedirs(context.save_chrome_traces_folder, exist_ok=True)
+            prefill_prof.profiler.export_chrome_trace(
+                context.save_chrome_traces_folder + "/prefill.json")
+            for idx, decode_prof in enumerate(decode_profs):
+                decode_prof.profiler.export_chrome_trace(
+                    context.save_chrome_traces_folder + f"/decode_{idx + 1}.json")
+            print("Traces saved as prefill.json and decode_1.json, etc."
+                f" in folder {context.save_chrome_traces_folder}")
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(description="""
+Profile a model
+
+    example:
+    ```
+    python examples/offline_inference/profiling.py \\
+        --model neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8 --batch-size 4 \\
+        --prompt-len 512 --max-num-batched-tokens 8196 --json Llama31-8b-FP8 \\
+        --enforce-eager run_num_steps -n 2
+    ```
+
+    then you can use various tools to analyze the json output
+    terminal ascii tables:
+        ```
+        python tools/profiler/print_layerwise_table.py \\
+            --json-trace Llama31-8b-FP8.json --phase prefill --table summary
+        ```
+    or create matplotlib stacked bar charts:
+        ```
+        python tools/profiler/visualize_layerwise_profile.py \\
+            --json-trace Llama31-8b-FP8.json \\
+            --output-directory profile_breakdown --plot-metric pct_cuda_time
+        ```
+""",
+                                    formatter_class=RawTextHelpFormatter)
+    parser.add_argument(
+        "--json",
+        type=str,
+        default=None,
+        help="Export the results as a json file. This should be the filename")
+    parser.add_argument(
+        "--prompt-len",
+        type=int,
+        default=PROMPT_LEN_DEFAULT,
+        help=f"Length of the random prompt to use when profiling, all batched "
+        f"requests use the same prompt_len, default={PROMPT_LEN_DEFAULT}")
+    parser.add_argument("--batch-size",
+                        type=int,
+                        default=BATCH_SIZE_DEFAULT,
+                        help=f"Number of requests to run as a single batch, "
+                        f"default={BATCH_SIZE_DEFAULT}")
+    parser.add_argument("--save-chrome-traces-folder",
+                        type=str,
+                        help="Save chrome traces for the prefill and decode "
+                        "will save traces as prefill.json and decode_1.json, "
+                        "etc. inside this folder")
+
+    subparsers = parser.add_subparsers(dest="cmd")
+
+    run_num_steps_parser = subparsers.add_parser(
+        "run_num_steps",
+        help="This variation profiles n engine.step() invocations.")
+    run_num_steps_parser.add_argument(
+        '-n',
+        '--num-steps',
+        type=int,
+        help="Number of engine steps to profile.\n"
+        "Setting it to 1, profiles only the prefill step.\n"
+        "Setting it to 2, profiles the prefill and first decode step\n"
+        "Setting it to 3, profiles the prefill, 1st and 2nd decode steps\n"
+        "and so on ...")
+
+    run_to_completion_parser = subparsers.add_parser(
+        "run_to_completion",
+        help="This variation profiles all the engine.step() invocations"
+        "until the engine exhausts all submitted requests.")
+    run_to_completion_parser.add_argument(
+        '-n',
+        '--complete-num-requests-per-step',
+        type=int,
+        help=
+        "Complete complete_num_requests_per_step requests every decode step."
+        "For e.g., with batch_size 128 and complete_num_requests_per_step 32,"
+        "the profiler is run for 6 engine steps, with the steps processing, "
+        "128, 128, 96, 64, 32, 1 requests respectively.\n"
+        "Note that we tack-on a one-request step at the end as it is often "
+        "useful.")
+
+    EngineArgs.add_cli_args(parser)
+
+    args = parser.parse_args()
+    context = ProfileContext(
+        engine_args=EngineArgs.from_cli_args(args),
+        **{
+            k: v
+            for k, v in vars(args).items()
+            if k in inspect.signature(ProfileContext).parameters
+        })
+
+    if not os.path.exists("outputs"):
+        os.makedirs("outputs")
+
+    run_profile(context, json_output=args.json)

--- a/tools/profiler/profiling.py
+++ b/tools/profiler/profiling.py
@@ -165,8 +165,7 @@ def determine_requests_per_step(context: ProfileContext) -> list[int]:
     return step_requests
 
 
-def run_profile(context: ProfileContext, 
-                json_output: Optional[str]):
+def run_profile(context: ProfileContext, json_output: Optional[str]):
     print("Run profile with:")
     for key, value in asdict(context).items():
         print(f"  {key} = {value}")
@@ -190,8 +189,7 @@ def run_profile(context: ProfileContext,
     # Create LLM
     engine_args_dict = asdict(context.engine_args)
     engine_args_dict["max_model_len"] = (
-        engine_args_dict["max_num_batched_tokens"]
-    )
+        engine_args_dict["max_num_batched_tokens"])
     llm = LLM(**engine_args_dict)
 
     batch_size = context.batch_size
@@ -202,22 +200,21 @@ def run_profile(context: ProfileContext,
     max_num_batched_tokens = scheduler_config.max_num_batched_tokens
     max_num_seqs = scheduler_config.max_num_seqs
 
-
-    # We will run the script with batch sizes. 
+    # We will run the script with batch sizes.
     # We assume that we will fail at some particular
     # prompt_len, bc batch_size x prompt_lens will give OOM error.
     prompt_lens = [
-        128, 256, 512, 1024, 1536, 2048,
-        4096, 8192, 16384, 32768, 65536
+        128, 256, 512, 1024, 1536, 2048, 4096, 8192, 16384, 32768, 65536
     ]
 
     for prompt_len in prompt_lens:
-        output_folder = f"./outputs/"
+        output_folder = "./outputs/"
         json_filename = f"profiling_bs{batch_size}_pl{prompt_len}.json"
         json_filename = output_folder + json_filename
 
         if batch_size * prompt_len > max_num_batched_tokens:
-            print(f"ERROR: chosen batch_size * prompt_len "
+            print(
+                f"ERROR: chosen batch_size * prompt_len "
                 f"({batch_size} * {prompt_len} = {batch_size * prompt_len}) "
                 f"is larger than max_num_batched_tokens "
                 f"({max_num_batched_tokens}) "
@@ -226,19 +223,17 @@ def run_profile(context: ProfileContext,
                 f"--max-num-batched-tokens")
             sys.exit(-1)
         if batch_size > max_num_seqs:
-            print(
-                f"ERROR: chosen batch_size ({batch_size}) is larger than "
-                f"max_num_seqs ({max_num_seqs}) "
-                f"and therefore cannot be run in a "
-                f"single profile step, please choose a smaller batch size")
+            print(f"ERROR: chosen batch_size ({batch_size}) is larger than "
+                  f"max_num_seqs ({max_num_seqs}) "
+                  f"and therefore cannot be run in a "
+                  f"single profile step, please choose a smaller batch size")
             sys.exit(-1)
         print("llm.llm_engine.model_config.max_model_len: ",
-            llm.llm_engine.model_config.max_model_len)
-        if (
-            prompt_len + max_output_len
-            > llm.llm_engine.model_config.max_model_len
-        ):
-            print(f"ERROR: chosen prompt_len + max_output_len ({prompt_len} + "
+              llm.llm_engine.model_config.max_model_len)
+        if (prompt_len + max_output_len
+                > llm.llm_engine.model_config.max_model_len):
+            print(
+                f"ERROR: chosen prompt_len + max_output_len ({prompt_len} + "
                 f"{max_output_len} = {prompt_len + max_output_len}) is larger "
                 f"than the model's max_model_len ({max_model_len}), please "
                 f"choose a smaller prompt_len or max_output_len, or increase "
@@ -257,8 +252,9 @@ def run_profile(context: ProfileContext,
                 sampling_params.max_tokens = next(output_len_generator)
                 assert isinstance(sampling_params.max_tokens, int)
 
-                prompt_token_ids = torch.randint(llm.get_tokenizer().vocab_size,
-                                                size=(prompt_len, )).tolist()
+                prompt_token_ids = torch.randint(
+                    llm.get_tokenizer().vocab_size,
+                    size=(prompt_len, )).tolist()
 
                 llm.llm_engine.add_request(
                     request_id=f"seq{i}",
@@ -296,7 +292,7 @@ def run_profile(context: ProfileContext,
         has_decode = len(decode_results_list) > 0
 
         # Always dumps the result to a json
-        
+
         if json_output:
 
             json_dict = {
@@ -322,11 +318,10 @@ def run_profile(context: ProfileContext,
                 context.save_chrome_traces_folder + "/prefill.json")
             for idx, decode_prof in enumerate(decode_profs):
                 decode_prof.profiler.export_chrome_trace(
-                    context.save_chrome_traces_folder
-                    + f"/decode_{idx + 1}.json"
-                )
+                    context.save_chrome_traces_folder +
+                    f"/decode_{idx + 1}.json")
             print("Traces saved as prefill.json and decode_1.json, etc."
-                f" in folder {context.save_chrome_traces_folder}")
+                  f" in folder {context.save_chrome_traces_folder}")
 
 
 if __name__ == "__main__":

--- a/tools/profiler/sweep_profiling.py
+++ b/tools/profiler/sweep_profiling.py
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
-import time
 import argparse
-from datetime import timedelta
 import os
 import signal
+import subprocess
+import time
+from datetime import timedelta
+
 # Create the argument parser
 parser = argparse.ArgumentParser(
-    description="Run vLLM profiling with different batch sizes"
-)
+    description="Run vLLM profiling with different batch sizes")
 parser.add_argument(
-    '--model', type=str, default="meta-llama/Llama-3.2-3B",
+    '--model',
+    type=str,
+    default="meta-llama/Llama-3.2-3B",
     help='Model name to use for profiling',
 )
 parser.add_argument(
@@ -24,10 +26,8 @@ parser.add_argument(
     '--tensor-parallel-size',
     type=int,
     default=1,
-    help=(
-        'Tensor parallelism degree '
-        '(number of GPUs to split model across)'
-    ),
+    help=('Tensor parallelism degree '
+          '(number of GPUs to split model across)'),
 )
 
 args = parser.parse_args()
@@ -36,41 +36,47 @@ MAX_NUM_BATCHED_TOKENS_GPU = args.max_tokens
 TENSOR_PARALLEL_SIZE = args.tensor_parallel_size
 batch_sizes = [1, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32]
 start_time = time.time()
-print(
-    "Note that --prompt-len and --json are DUMMY flags in this file, "
-    "the inputs are handled in profiling.py."
-)
-print(
-    f"WARNING: MAX_NUM_BATCHED_TOKENS_GPU is "
-    f"set to {MAX_NUM_BATCHED_TOKENS_GPU}. "
-    f"This may not fit on a smaller GPU!"
-)
+print("Note that --prompt-len and --json are DUMMY flags in this file, "
+      "the inputs are handled in profiling.py.")
+print(f"WARNING: MAX_NUM_BATCHED_TOKENS_GPU is "
+      f"set to {MAX_NUM_BATCHED_TOKENS_GPU}. "
+      f"This may not fit on a smaller GPU!")
 print(f"INFO: The model being used is {model_name}")
 print(f"INFO: Using tensor parallel size of {TENSOR_PARALLEL_SIZE}")
 # Process each batch size
 for batch_size in batch_sizes:
     print(f"\n=== Starting profiling for batch_size = {batch_size} ===")
     max_num_batched_tokens = MAX_NUM_BATCHED_TOKENS_GPU
-    
+
     command = [
-        "VLLM_USE_V1=0", 
-        "python", "profiling.py", 
-        "--model", model_name,
-        "--batch-size", str(batch_size),
-        "--prompt-len", str(0), # dummy value, handled in profiling.py
-        "--max-num-batched-tokens", str(max_num_batched_tokens),
-        "--json", "DUMMY_ARG.json", # dummy, handled inside profiling.py
-        "--load-format", "dummy",
+        "VLLM_USE_V1=0",
+        "python",
+        "profiling.py",
+        "--model",
+        model_name,
+        "--batch-size",
+        str(batch_size),
+        "--prompt-len",
+        str(0),  # dummy value, handled in profiling.py
+        "--max-num-batched-tokens",
+        str(max_num_batched_tokens),
+        "--json",
+        "DUMMY_ARG.json",  # dummy, handled inside profiling.py
+        "--load-format",
+        "dummy",
         "--enforce-eager",
-        "--tensor-parallel-size", str(TENSOR_PARALLEL_SIZE),
-        "run_num_steps", "-n", "2"
+        "--tensor-parallel-size",
+        str(TENSOR_PARALLEL_SIZE),
+        "run_num_steps",
+        "-n",
+        "2"
     ]
-    
+
     cmd_string = " ".join(command)
     print(f"\nRunning: {cmd_string}")
-    
+
     try:
-        # Start the process with shell=True 
+        # Start the process with shell=True
         # since we're using environment variables
         process = subprocess.Popen(cmd_string, shell=True)
         return_code = process.wait()
@@ -78,19 +84,17 @@ for batch_size in batch_sizes:
             print(f"Successfully completed: batch_size={batch_size}")
         else:
             print(f"Command failed with exit code {return_code}")
-            print(f"Encountered an error. Moving to next batch size.")
+            print("Encountered an error. Moving to next batch size.")
     except Exception as e:
         print(f"Exception occurred: {str(e)}")
         import traceback
         error_details = traceback.format_exc()
         print(f"Detailed error traceback:\n{error_details}")
         with open('profiling_errors.log', 'a') as log_file:
-            log_file.write(
-                f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] "
-                f"Error with batch_size={batch_size}: {str(e)}\n"
-            )
+            log_file.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] "
+                           f"Error with batch_size={batch_size}: {str(e)}\n")
             log_file.write(f"Traceback:\n{error_details}\n\n")
-        print(f"Encountered an exception. Moving to next batch size.")
+        print("Encountered an exception. Moving to next batch size.")
     finally:
         if process and process.poll() is None:
             try:

--- a/tools/profiler/sweep_profiling.py
+++ b/tools/profiler/sweep_profiling.py
@@ -7,21 +7,44 @@ from datetime import timedelta
 import os
 import signal
 # Create the argument parser
-parser = argparse.ArgumentParser(description='Run vLLM profiling with different batch sizes')
-parser.add_argument('--model', type=str, default="meta-llama/Llama-3.2-3B",
-                    help='Model name to use for profiling')
-parser.add_argument('--max-tokens', type=int, default=int(1e5),
-                    help='Maximum number of batched tokens for GPU (default: 100000)')
-parser.add_argument('--tensor-parallel-size', type=int, default=1,
-                    help='Tensor parallelism degree (number of GPUs to split model across)')
+parser = argparse.ArgumentParser(
+    description="Run vLLM profiling with different batch sizes"
+)
+parser.add_argument(
+    '--model', type=str, default="meta-llama/Llama-3.2-3B",
+    help='Model name to use for profiling',
+)
+parser.add_argument(
+    '--max-tokens',
+    type=int,
+    default=int(1e5),
+    help='Maximum number of batched tokens for GPU (default: 100000)',
+)
+parser.add_argument(
+    '--tensor-parallel-size',
+    type=int,
+    default=1,
+    help=(
+        'Tensor parallelism degree '
+        '(number of GPUs to split model across)'
+    ),
+)
+
 args = parser.parse_args()
 model_name = args.model
 MAX_NUM_BATCHED_TOKENS_GPU = args.max_tokens
 TENSOR_PARALLEL_SIZE = args.tensor_parallel_size
 batch_sizes = [1, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32]
 start_time = time.time()
-print("Note that --prompt-len and --json are DUMMY flags in this file, the inputs are handled in profiling.py. We will clean this up later.")
-print(f"WARNING: MAX_NUM_BATCHED_TOKENS_GPU is set to {MAX_NUM_BATCHED_TOKENS_GPU}. This may not fit on a smaller GPU!")
+print(
+    "Note that --prompt-len and --json are DUMMY flags in this file, "
+    "the inputs are handled in profiling.py."
+)
+print(
+    f"WARNING: MAX_NUM_BATCHED_TOKENS_GPU is "
+    f"set to {MAX_NUM_BATCHED_TOKENS_GPU}. "
+    f"This may not fit on a smaller GPU!"
+)
 print(f"INFO: The model being used is {model_name}")
 print(f"INFO: Using tensor parallel size of {TENSOR_PARALLEL_SIZE}")
 # Process each batch size
@@ -34,9 +57,9 @@ for batch_size in batch_sizes:
         "python", "profiling.py", 
         "--model", model_name,
         "--batch-size", str(batch_size),
-        "--prompt-len", str(0), # This is a dummy value, prompt lens are handled in the profiling.py file
+        "--prompt-len", str(0), # dummy value, handled in profiling.py
         "--max-num-batched-tokens", str(max_num_batched_tokens),
-        "--json", "DUMMY_ARG.json", # another dummy arg, this is handled inside profiling.py
+        "--json", "DUMMY_ARG.json", # dummy, handled inside profiling.py
         "--load-format", "dummy",
         "--enforce-eager",
         "--tensor-parallel-size", str(TENSOR_PARALLEL_SIZE),
@@ -47,7 +70,8 @@ for batch_size in batch_sizes:
     print(f"\nRunning: {cmd_string}")
     
     try:
-        # Start the process with shell=True since we're using environment variables
+        # Start the process with shell=True 
+        # since we're using environment variables
         process = subprocess.Popen(cmd_string, shell=True)
         return_code = process.wait()
         if return_code == 0:
@@ -61,7 +85,10 @@ for batch_size in batch_sizes:
         error_details = traceback.format_exc()
         print(f"Detailed error traceback:\n{error_details}")
         with open('profiling_errors.log', 'a') as log_file:
-            log_file.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Error with batch_size={batch_size}: {str(e)}\n")
+            log_file.write(
+                f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] "
+                f"Error with batch_size={batch_size}: {str(e)}\n"
+            )
             log_file.write(f"Traceback:\n{error_details}\n\n")
         print(f"Encountered an exception. Moving to next batch size.")
     finally:

--- a/tools/profiler/sweep_profiling.py
+++ b/tools/profiler/sweep_profiling.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import time
+import argparse
+from datetime import timedelta
+import os
+import signal
+# Create the argument parser
+parser = argparse.ArgumentParser(description='Run vLLM profiling with different batch sizes')
+parser.add_argument('--model', type=str, default="meta-llama/Llama-3.2-3B",
+                    help='Model name to use for profiling')
+parser.add_argument('--max-tokens', type=int, default=int(1e5),
+                    help='Maximum number of batched tokens for GPU (default: 100000)')
+parser.add_argument('--tensor-parallel-size', type=int, default=1,
+                    help='Tensor parallelism degree (number of GPUs to split model across)')
+args = parser.parse_args()
+model_name = args.model
+MAX_NUM_BATCHED_TOKENS_GPU = args.max_tokens
+TENSOR_PARALLEL_SIZE = args.tensor_parallel_size
+batch_sizes = [1, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32]
+start_time = time.time()
+print("Note that --prompt-len and --json are DUMMY flags in this file, the inputs are handled in profiling.py. We will clean this up later.")
+print(f"WARNING: MAX_NUM_BATCHED_TOKENS_GPU is set to {MAX_NUM_BATCHED_TOKENS_GPU}. This may not fit on a smaller GPU!")
+print(f"INFO: The model being used is {model_name}")
+print(f"INFO: Using tensor parallel size of {TENSOR_PARALLEL_SIZE}")
+# Process each batch size
+for batch_size in batch_sizes:
+    print(f"\n=== Starting profiling for batch_size = {batch_size} ===")
+    max_num_batched_tokens = MAX_NUM_BATCHED_TOKENS_GPU
+    
+    command = [
+        "VLLM_USE_V1=0", 
+        "python", "profiling.py", 
+        "--model", model_name,
+        "--batch-size", str(batch_size),
+        "--prompt-len", str(0), # This is a dummy value, prompt lens are handled in the profiling.py file
+        "--max-num-batched-tokens", str(max_num_batched_tokens),
+        "--json", "DUMMY_ARG.json", # another dummy arg, this is handled inside profiling.py
+        "--load-format", "dummy",
+        "--enforce-eager",
+        "--tensor-parallel-size", str(TENSOR_PARALLEL_SIZE),
+        "run_num_steps", "-n", "2"
+    ]
+    
+    cmd_string = " ".join(command)
+    print(f"\nRunning: {cmd_string}")
+    
+    try:
+        # Start the process with shell=True since we're using environment variables
+        process = subprocess.Popen(cmd_string, shell=True)
+        return_code = process.wait()
+        if return_code == 0:
+            print(f"Successfully completed: batch_size={batch_size}")
+        else:
+            print(f"Command failed with exit code {return_code}")
+            print(f"Encountered an error. Moving to next batch size.")
+    except Exception as e:
+        print(f"Exception occurred: {str(e)}")
+        import traceback
+        error_details = traceback.format_exc()
+        print(f"Detailed error traceback:\n{error_details}")
+        with open('profiling_errors.log', 'a') as log_file:
+            log_file.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Error with batch_size={batch_size}: {str(e)}\n")
+            log_file.write(f"Traceback:\n{error_details}\n\n")
+        print(f"Encountered an exception. Moving to next batch size.")
+    finally:
+        if process and process.poll() is None:
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                time.sleep(0.5)
+                if process.poll() is None:
+                    os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except OSError as e:
+                print(f"Warning when terminating process: {e}")
+
+end_time = time.time()
+total_time = end_time - start_time
+formatted_time = str(timedelta(seconds=int(total_time)))
+print("\n=== Profiling Complete ===")
+print(f"Total execution time: {formatted_time}")


### PR DESCRIPTION
### Summary

This PR introduces a lightweight and automated profiling suite for vLLM, enabling kernel-level benchmarking across multiple batch sizes and prompt lengths, and visualizing the results as heatmaps.

It includes:

1. `sweep_profiling.py`: Automates profiling runs with varied batch and prompt configurations. In addition to the overall model runner time, we also generate the profiling result for operator breakdown.
2. `plot_heatmap_from_traces.py`: Parses JSON trace outputs and generates latency heatmaps.
3. `profiling.py`: A self-contained adaptation of `examples/offline_inference/profiling.py`, modified for sweepability and output compatibility.

For more detailed description for this RFC and PR, please see #17823 .

### Usage

Example:
```bash
python sweep_profiling.py --model "deepseek-ai/DeepSeek-R1-Distill-Llama-8B" --max-tokens 80000 --tensor-parallel-size 2
```

This will generate multiple trace files like:
```
profiling_bs8_pl128.json
profiling_bs16_pl512.json
...
```

To visualize results:
```bash
python plot_heatmap_from_traces.py
```


### Files Added
```
tools/profiler/
├── profiling.py                    # Adapted from examples/offline_inference/profiling.py
├── sweep_profiling.py              # Automates profiling.py across batch × prompt
├── plot_heatmap_from_traces.py     # Visualizes JSON traces as heatmaps
```

### Notes

- Currently targets vLLM V0 only

### Related Issue

FIX #17823 

### CC List

@GindaChen @JJMN22 

<!--- pyml disable-next-line no-emphasis-as-heading -->
