### PR TITLE
[doc] update lora doc

### DIFF
--- a/docs/source/features/lora.md
+++ b/docs/source/features/lora.md
@@ -66,7 +66,7 @@ The commit ID `0dfa347e8877a4d4ed19ee56c140fa518470028c` may change over time. P
 
 The server entrypoint accepts all other LoRA configuration parameters (`max_loras`, `max_lora_rank`, `max_cpu_loras`,
 etc.), which will apply to all forthcoming requests. Upon querying the `/models` endpoint, we should see our LoRA along
-with its base model:
+with its base model (if `jq` is not installed, you can follow [this guide](https://jqlang.org/download/) to install it.):
 
 ```bash
 curl localhost:8000/v1/models | jq .
@@ -134,13 +134,15 @@ curl -X POST http://localhost:8000/v1/load_lora_adapter \
 }'
 ```
 
-Upon a successful request, the API will respond with a 200 OK status code. If an error occurs, such as if the adapter
+Upon a successful request, the API will respond with a `200 OK` status code from `vllm serve`, and `curl` returns the response body: `Success: LoRA adapter 'sql_adapter' added successfully`. If an error occurs, such as if the adapter
 cannot be found or loaded, an appropriate error message will be returned.
 
 Unloading a LoRA Adapter:
 
 To unload a LoRA adapter that has been previously loaded, send a POST request to the `/v1/unload_lora_adapter` endpoint
 with the name or ID of the adapter to be unloaded.
+
+Upon a successful request, the API responds with a `200 OK` status code from `vllm serve`, and `curl` returns the response body: `Success: LoRA adapter 'sql_adapter' removed successfully`.
 
 Example request to unload a LoRA adapter:
 


### PR DESCRIPTION

update the lora doc for jq install tips, and API response description.
```
vllm serve meta-llama/Llama-2-7b-hf --enable-lora --lora-modules sql-lora=/home/xx/sql-lora/
INFO 05-10 10:46:14 [serving_models.py:185] Loaded new LoRA adapter: name 'sql_adapter', path '/home/xx/sql-lora'
INFO:     127.0.0.1:55020 - "POST /v1/load_lora_adapter HTTP/1.1" 200 OK
INFO 05-10 10:56:49 [serving_models.py:202] Removed LoRA adapter: name 'sql_adapter'
INFO:     127.0.0.1:54752 - "POST /v1/unload_lora_adapter HTTP/1.1" 200 OK


$ curl -X POST http://localhost:8000/v1/load_lora_adapter -H "Content-Type: application/json" -d '{
    "lora_name": "sql_adapter",
    "lora_path": "/home/xx/sql-lora"
}'
Success: LoRA adapter 'sql_adapter' added successfully.

$ curl -X POST http://localhost:8000/v1/unload_lora_adapter \
> -H "Content-Type: application/json" \
> -d '{
>     "lora_name": "sql_adapter"
> }'
Success: LoRA adapter 'sql_adapter' removed successfully.
```

