### PR TITLE
[BugFix] Correct max_model_len derivation from config.json for Mistral format 

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -188,8 +188,9 @@ def test_flash_attn(monkeypatch: pytest.MonkeyPatch):
         m.setenv(STR_BACKEND_ENV_VAR, STR_FLASH_ATTN_VAL)
 
         # Unsupported CUDA arch
-        monkeypatch.setattr(torch.cuda, "get_device_capability", lambda:
-                            (7, 5))
+        monkeypatch.setattr(torch.cuda,
+                            "get_device_capability",
+                            lambda _=None: (7, 5))
         backend = get_attn_backend(16, torch.float16, None, 16, False)
         assert backend.get_name() != STR_FLASH_ATTN_VAL
 

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -188,9 +188,8 @@ def test_flash_attn(monkeypatch: pytest.MonkeyPatch):
         m.setenv(STR_BACKEND_ENV_VAR, STR_FLASH_ATTN_VAL)
 
         # Unsupported CUDA arch
-        monkeypatch.setattr(torch.cuda,
-                            "get_device_capability",
-                            lambda _=None: (7, 5))
+        monkeypatch.setattr(torch.cuda, "get_device_capability", lambda:
+                            (7, 5))
         backend = get_attn_backend(16, torch.float16, None, 16, False)
         assert backend.get_name() != STR_FLASH_ATTN_VAL
 

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -691,11 +691,10 @@ def load_params_config(model: Union[str, Path], revision: Optional[str],
         max_position_embeddings = 128_000
         try:
             trust_remote_code_val = kwargs.get("trust_remote_code", False)
-            hf_config = get_config(
-                model=model,
-                trust_remote_code=trust_remote_code_val,
-                revision=revision,
-                config_format=ConfigFormat.HF)
+            hf_config = get_config(model=model,
+                                   trust_remote_code=trust_remote_code_val,
+                                   revision=revision,
+                                   config_format=ConfigFormat.HF)
             if hf_value := hf_config.get_text_config().max_position_embeddings:
                 max_position_embeddings = hf_value
         except Exception as e:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -691,12 +691,11 @@ def load_params_config(model: Union[str, Path], revision: Optional[str],
         max_position_embeddings = 128_000
         try:
             trust_remote_code_val = kwargs.get("trust_remote_code", False)
-            token_val = kwargs.get("token")
-            hf_config = AutoConfig.from_pretrained(
-                model,
-                revision=revision,
+            hf_config = get_config(
+                model=model,
                 trust_remote_code=trust_remote_code_val,
-                token=token_val)
+                revision=revision,
+                config_format=ConfigFormat.HF)
             if hf_value := hf_config.get_text_config().max_position_embeddings:
                 max_position_embeddings = hf_value
         except Exception as e:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -699,11 +699,12 @@ def load_params_config(model: Union[str, Path], revision: Optional[str],
                 token=token_val)
             if hf_value := hf_config.get_text_config().max_position_embeddings:
                 max_position_embeddings = hf_value
-        except Exception:
-            warning_message = ("Could not read 'max_position_embeddings' "
-                               "from the config for model: "
-                               "'{model}'.\n").format(model=model)
-            logger.warning(warning_message)
+        except Exception as e:
+            logger.warning(
+                "The params.json file is missing 'max_position_embeddings'"
+                " and could not get a value from the HF config."
+                " Defaulting to 128000",
+                exc_info=e)
         config_dict["max_position_embeddings"] = max_position_embeddings
 
     if config_dict.get("quantization") is not None:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -686,9 +686,54 @@ def load_params_config(model: Union[str, Path], revision: Optional[str],
     config_dict["hidden_act"] = config_dict.get("activation", "silu")
     config_dict["tie_word_embeddings"] = config_dict.get(
         "tie_embeddings", False)
-    config_dict["max_seq_len"] = config_dict.get("max_seq_len", 128_000)
-    config_dict["max_position_embeddings"] = config_dict.get(
-        "max_position_embeddings", 128_000)
+    # Check if max_position_embeddings is in params.json
+    mpe_from_params = config_dict.get("max_position_embeddings")
+    final_mpe_to_set = mpe_from_params
+
+    if final_mpe_to_set is None:
+        # Not found in params.json, try to get from standard HF AutoConfig
+        hf_config_for_defaults = None
+        try:
+            trust_remote_code_val = kwargs.get("trust_remote_code", False)
+            token_val = kwargs.get("token")  # Passed from get_config
+
+            hf_config_for_defaults = AutoConfig.from_pretrained(
+                model,
+                revision=revision,
+                trust_remote_code=trust_remote_code_val,
+                token=token_val)
+        except Exception as e:
+            error_message = (
+                "Invalid repository ID or local directory specified:"
+                " '{model}'.\nPlease verify the following requirements:\n"
+                "1. Provide a valid Hugging Face repository ID.\n"
+                "2. Specify a local directory that contains a recognized "
+                "configuration file.\n").format(model=model)
+
+            raise ValueError(error_message) from e
+
+        if hf_config_for_defaults:
+            # Try to get from text_config first, then top-level
+            mpe_from_hf_config = None
+            text_config_obj = getattr(hf_config_for_defaults, "text_config",
+                                      None)
+            if text_config_obj and hasattr(text_config_obj,
+                                           "max_position_embeddings"):
+                mpe_from_hf_config = getattr(text_config_obj,
+                                             "max_position_embeddings", None)
+
+            if mpe_from_hf_config is None and hasattr(
+                    hf_config_for_defaults, "max_position_embeddings"):
+                mpe_from_hf_config = getattr(hf_config_for_defaults,
+                                             "max_position_embeddings", None)
+
+            if mpe_from_hf_config is not None:
+                final_mpe_to_set = mpe_from_hf_config
+
+        if final_mpe_to_set is None:  # Still not found, use ultimate fallback
+            final_mpe_to_set = 128_000
+
+    config_dict["max_position_embeddings"] = final_mpe_to_set
 
     if config_dict.get("quantization") is not None:
         quantization = config_dict.get("quantization", {})


### PR DESCRIPTION
FIX #17747 

@tjohnson31415 

Thank you for your patience and suggestions.

- I've reverted the code to its original version first before applying modifications.

- I have removed all logic related to max_seq_len.

- The subsequent logic (to fetch from standard Hugging Face config) will only be triggered if max_position_embeddings cannot be obtained from params.json.

- I am referencing the configuration loaded from config.json as it's done for ConfigFormat.HF (i.e., using AutoConfig.from_pretrained).

- Something went wrong, and I accidentally caused issues in the original branch, so I've opened a new PR to merge the code.