### PR TITLE
[doc] add download/list/delete HF model CLI usage

### DIFF
--- a/docs/source/models/supported_models.md
+++ b/docs/source/models/supported_models.md
@@ -170,7 +170,7 @@ Alternatively, you can [open an issue on GitHub](https://github.com/vllm-project
 
 #### Download a model
 
-Use the Hugging Face CLI to [download a model](https://huggingface.co/docs/huggingface_hub/guides/cli#huggingface-cli-download) or specific files from a model repository:
+If you prefer, you can use the Hugging Face CLI to [download a model](https://huggingface.co/docs/huggingface_hub/guides/cli#huggingface-cli-download) or specific files from a model repository:
 
 ```console
 # Download a model

--- a/docs/source/models/supported_models.md
+++ b/docs/source/models/supported_models.md
@@ -168,6 +168,66 @@ If vLLM successfully returns text (for generative models) or hidden states (for 
 Otherwise, please refer to [Adding a New Model](#new-model) for instructions on how to implement your model in vLLM.
 Alternatively, you can [open an issue on GitHub](https://github.com/vllm-project/vllm/issues/new/choose) to request vLLM support.
 
+#### Download a model
+
+Use the Hugging Face CLI to [download a model](https://huggingface.co/docs/huggingface_hub/guides/cli#huggingface-cli-download) or specific files from a model repository:
+
+```console
+# Download a model
+huggingface-cli download HuggingFaceH4/zephyr-7b-beta
+
+# Specify a custom cache directory
+huggingface-cli download HuggingFaceH4/zephyr-7b-beta --cache-dir ./path/to/cache
+
+# Download a specific file from a model repo
+huggingface-cli download HuggingFaceH4/zephyr-7b-beta eval_results.json
+```
+
+#### List the downloaded models
+
+Use the Hugging Face CLI to [manage models](https://huggingface.co/docs/huggingface_hub/guides/manage-cache#scan-your-cache) stored in local cache:
+
+```console
+# List cached models
+huggingface-cli scan-cache
+
+# Show detailed (verbose) output
+huggingface-cli scan-cache -v
+
+# Specify a custom cache directory
+huggingface-cli scan-cache --dir ~/.cache/huggingface/hub
+```
+
+#### Delete a cached model
+
+Use the Hugging Face CLI to interactively [delete downloaded model](https://huggingface.co/docs/huggingface_hub/guides/manage-cache#clean-your-cache) from the cache:
+
+```console
+# The `delete-cache` command requires extra dependencies to work with the TUI.
+# Please run `pip install huggingface_hub[cli]` to install them.
+
+# Launch the interactive TUI to select models to delete
+$ huggingface-cli delete-cache
+? Select revisions to delete: 1 revisions selected counting for 438.9M.
+  ○ None of the following (if selected, nothing will be deleted).
+Model BAAI/bge-base-en-v1.5 (438.9M, used 1 week ago)
+❯ ◉ a5beb1e3: main # modified 1 week ago
+
+Model BAAI/bge-large-en-v1.5 (1.3G, used 1 week ago)
+  ○ d4aa6901: main # modified 1 week ago
+
+Model BAAI/bge-reranker-base (1.1G, used 4 weeks ago)
+  ○ 2cfc18c9: main # modified 4 weeks ago
+
+Press <space> to select, <enter> to validate and <ctrl+c> to quit without modification.
+
+# Need to confirm after selected
+? Select revisions to delete: 1 revision(s) selected.
+? 1 revisions selected counting for 438.9M. Confirm deletion ? Yes
+Start deletion.
+Done. Deleted 1 repo(s) and 0 revision(s) for a total of 438.9M.
+```
+
 #### Using a proxy
 
 Here are some tips for loading/downloading models from Hugging Face using a proxy:


### PR DESCRIPTION
```
$ huggingface-cli scan-cache --help
usage: huggingface-cli <command> [<args>] scan-cache [-h] [--dir DIR] [-v]

options:
  -h, --help     show this help message and exit
  --dir DIR      cache directory to scan (optional). Default to the default HuggingFace cache.
  -v, --verbose  show a more verbose output

$ huggingface-cli scan-cache
REPO ID                                                         REPO TYPE REVISION                                 SIZE ON DISK NB FILES LAST_MODIFIED REFS       LOCAL PATH
--------------------------------------------------------------- --------- ---------------------------------------- ------------ -------- ------------- ---------- -------------------------------------------------------------------------------------------------------------------------------------------------------------
unsloth/Llama-3.2-1B-Instruct                                   model     9b58d4a36161a1e49ecf0a69d20b2736fef8e438         2.5G        6 3 weeks ago   main       /home/xx/.cache/huggingface/hub/models--unsloth--Llama-3.2-1B-Instruct/snapshots/9b58d4a36161a1e49ecf0a69d20b2736fef8e438
unsloth/tinyllama-bnb-4bit                                      model     c6cc31241054c2fe9b4c804f398faffe1254728f       764.8M        7 5 weeks ago   main       /home/xx/.cache/huggingface/hub/models--unsloth--tinyllama-bnb-4bit/snapshots/c6cc31241054c2fe9b4c804f398faffe1254728f
yard1/llama-2-7b-sql-lora-test                                  model     0dfa347e8877a4d4ed19ee56c140fa518470028c        43.6M        9 5 weeks ago   main       /home/xx/.cache/huggingface/hub/models--yard1--llama-2-7b-sql-lora-test/snapshots/0dfa347e8877a4d4ed19ee56c140fa518470028c
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
