### PR TITLE
Don't default construct `ModelConfig` when default constructing `VllmConfig`

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3954,7 +3954,9 @@ class VllmConfig:
     simplifies passing around the distinct configurations in the codebase.
     """
 
-    model_config: ModelConfig = field(default_factory=ModelConfig)
+    # TODO: use default_factory once default constructing ModelConfig doesn't
+    # try to download a model
+    model_config: ModelConfig = None  # type: ignore
     """Model configuration."""
     cache_config: CacheConfig = field(default_factory=CacheConfig)
     """Cache configuration."""


### PR DESCRIPTION
Solves issue from https://github.com/vllm-project/vllm/pull/17562#issuecomment-2868654911