### PR TITLE
[Misc] remove --model from vllm serve usage

### DIFF
--- a/examples/online_serving/openai_chat_completion_client_with_tools.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools.py
@@ -7,12 +7,12 @@ IMPORTANT: for mistral, you must use one of the provided mistral tool call
 templates, or your own - the model default doesn't work for tool calls with vLLM
 See the vLLM docs on OpenAI server & tool calling for more details.
 
-vllm serve --model mistralai/Mistral-7B-Instruct-v0.3 \
+vllm serve mistralai/Mistral-7B-Instruct-v0.3 \
             --chat-template examples/tool_chat_template_mistral.jinja \
             --enable-auto-tool-choice --tool-call-parser mistral
 
 OR
-vllm serve --model NousResearch/Hermes-2-Pro-Llama-3-8B \
+vllm serve NousResearch/Hermes-2-Pro-Llama-3-8B \
             --chat-template examples/tool_chat_template_hermes.jinja \
             --enable-auto-tool-choice --tool-call-parser hermes
 """


### PR DESCRIPTION

if use  model as a positional argument by default.
```
$ vllm serve --model mistralai/Mistral-7B-Instruct-v0.3
Traceback (most recent call last):
  File "/home/xx/miniconda3/envs/vllm/bin/vllm", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/xx/github/vllm/vllm/entrypoints/cli/main.py", line 48, in main
    args = parser.parse_args()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/xx/github/vllm/vllm/utils.py", line 1391, in parse_args
    raise ValueError(
ValueError: With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option.
```