### PR TITLE
[Bugfix] When use set rope_scaling should replace it

### DIFF
--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -659,6 +659,9 @@ class NomicBertEmbeddingModel(BertEmbeddingModel):
                 "factor": config.rotary_scaling_factor
             }
         }
+        # if use set rope_scaling, need to update
+        if config.rope_scaling is not None:
+            rotary_kwargs["rope_scaling"] = config.rope_scaling
 
         return BertModel(vllm_config=vllm_config,
                          prefix=prefix,


### PR DESCRIPTION

FIX https://github.com/vllm-project/vllm/issues/17949

Test code:
```python
import logging
from vllm.engine.arg_utils import AsyncEngineArgs
from vllm.engine.async_llm_engine import AsyncLLMEngine
from vllm.usage.usage_lib import UsageContext

logger = logging.getLogger()

embedding_engine_args = AsyncEngineArgs(
    model="nomic-ai/CodeRankEmbed",
    tensor_parallel_size=1,
    enforce_eager=True,
    rope_scaling={"rope_type":"dynamic","factor":2.0},  # even with explicit RoPE scaling configuration
    trust_remote_code=True,
    task="embed",  # Task type for embedding models
)
logger.info("Configured embedding engine arguments")

embedding_engine = AsyncLLMEngine.from_engine_args(
    embedding_engine_args, usage_context=UsageContext.OPENAI_API_SERVER
)
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
