### PR TITLE
[bugfix] fix the wrong parser

### DIFF
--- a/vllm/entrypoints/cli/collect_env.py
+++ b/vllm/entrypoints/cli/collect_env.py
@@ -8,7 +8,7 @@ from vllm.utils import FlexibleArgumentParser
 
 
 class CollectEnvSubcommand(CLISubcommand):
-    """The `serve` subcommand for the vLLM CLI. """
+    """The `collect-env` subcommand for the vLLM CLI. """
 
     def __init__(self):
         self.name = "collect-env"
@@ -22,12 +22,12 @@ class CollectEnvSubcommand(CLISubcommand):
     def subparser_init(
             self,
             subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
-        serve_parser = subparsers.add_parser(
+        collect_env_parser = subparsers.add_parser(
             "collect-env",
             help="Start collecting environment information.",
             description="Start collecting environment information.",
             usage="vllm collect-env")
-        return serve_parser
+        return collect_env_parser
 
 
 def cmd_init() -> list[CLISubcommand]:

--- a/vllm/entrypoints/cli/collect_env.py
+++ b/vllm/entrypoints/cli/collect_env.py
@@ -4,7 +4,6 @@ import argparse
 
 from vllm.collect_env import main as collect_env_main
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils import FlexibleArgumentParser
 
 
@@ -28,7 +27,7 @@ class CollectEnvSubcommand(CLISubcommand):
             help="Start collecting environment information.",
             description="Start collecting environment information.",
             usage="vllm collect-env")
-        return make_arg_parser(serve_parser)
+        return serve_parser
 
 
 def cmd_init() -> list[CLISubcommand]:


### PR DESCRIPTION
As I understand correctly(pls correct me if am wrong), there is no arg for `collect_env`, but it will show lots of args from `--help`, seems returen the wrong `parser`:
```
vllm collect-env --help
usage: vllm collect-env

Start collecting environment information.

options:
  --allow-credentials   Allow credentials. (default: False)
  --allowed-headers ALLOWED_HEADERS
                        Allowed headers. (default: ['*'])
  --allowed-methods ALLOWED_METHODS
                        Allowed methods. (default: ['*'])
  --allowed-origins ALLOWED_ORIGINS
                        Allowed origins. (default: ['*'])
  --api-key API_KEY     If provided, the server will require this key to be presented in the
                        header. (default: None)
  --chat-template CHAT_TEMPLATE
...
```
So it should simply return `serve_parser`, it may not show args in help.
```
 vllm collect-env --help
usage: vllm collect-env

Start collecting environment information.

options:
  -h, --help  show this help message and exit
```
