### PR TITLE
[Bugfix] fix check kv cache memory log info

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -544,7 +544,7 @@ def check_enough_kv_cache_memory(vllm_config: VllmConfig,
                                                    available_memory)
         estimated_msg = ""
         if estimated_max_len > 0:
-            estimated_msg = " Based on the available memory,"
+            estimated_msg = " Based on the available memory," \
             f" the estimated maximum model length is {estimated_max_len}."
 
         raise ValueError(


### PR DESCRIPTION
The estimated_msg variable was not correctly concatenated and assigned, resulting in incomplete error messages. This issue occurred in the following code block:
```python
if estimated_max_len > 0:
    estimated_msg = " Based on the available memory,"
    f" the estimated maximum model length is {estimated_max_len}."
````
I merged the string concatenation into a single line to ensure the estimated_msg variable is correctly assigned the concatenated message. The updated code is as follows:
```python
if estimated_max_len > 0:
    estimated_msg = " Based on the available memory," \
                    f" the estimated maximum model length is {estimated_max_len}."
```
No other functionality is impacted by this change.