### PR TITLE
[BUG] [ROCm] [MLA] Fix variable name bug due to change in variable name in PR #17483

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -98,17 +98,17 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             paged_kv_last_page_len,
         )
 
-    def _build_decode(self, block_table: torch.Tensor,
+    def _build_decode(self, block_table_tensor: torch.Tensor,
                       seq_lens: torch.Tensor) -> AiterMLADecodeMetadata:
 
         (
             paged_kv_indices,
             paged_kv_indptr,
             paged_last_page_len,
-        ) = self._get_paged_kv_tensors(block_table, seq_lens)
+        ) = self._get_paged_kv_tensors(block_table_tensor, seq_lens)
 
         attn_metadata = AiterMLADecodeMetadata(
-            block_table=block_table,
+            block_table=block_table_tensor,
             seq_lens=seq_lens,
             paged_kv_indptr=paged_kv_indptr,
             paged_kv_indices=paged_kv_indices,


### PR DESCRIPTION
This is to fix the error due to change of name introduced by PR https://github.com/vllm-project/vllm/pull/17483

the rename of the `block_table` to `block_table_tensor` in `_build_decode` function had broken `AiterMLAMetadataBuilder._build_decode`

<!--- pyml disable-next-line no-emphasis-as-heading -->
