### PR TITLE
[Doc] Update pip install instruction for testing dependencies

### DIFF
--- a/docs/source/contributing/overview.md
+++ b/docs/source/contributing/overview.md
@@ -32,7 +32,7 @@ Check out the [building from source](#build-from-source) documentation for detai
 ## Testing
 
 ```bash
-pip install -r requirements/dev.txt
+pip install -r requirements/dev.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
 # Linting, formatting and static type checking
 pre-commit install --hook-type pre-commit --hook-type commit-msg

--- a/docs/source/contributing/overview.md
+++ b/docs/source/contributing/overview.md
@@ -32,6 +32,8 @@ Check out the [building from source](#build-from-source) documentation for detai
 ## Testing
 
 ```bash
+# The following command assumes CUDA 12.8. For CPU-only, other CUDA versions, 
+# or ROCm, etc., adjust the torch installation as needed.
 pip install -r requirements/dev.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
 # Linting, formatting and static type checking


### PR DESCRIPTION

Update the pip install dev requirements instruction in the doc, following up on https://github.com/vllm-project/vllm/pull/17576.
Running `pip install -r requirements/dev.txt` will give error:
```
ERROR: Could not find a version that satisfies the requirement torch==2.7.0+cu128 (from versions: 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.5.0, 2.5.1, 2.6.0, 2.7.0)
ERROR: No matching distribution found for torch==2.7.0+cu128
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
