### PR TITLE
FIX: import TypedDict from typing_extensions for python<3.12

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -2,12 +2,18 @@
 
 import json
 import time
+import sys
 from collections.abc import (AsyncGenerator, Iterable, Iterator, Mapping,
                              Sequence)
 from concurrent.futures.thread import ThreadPoolExecutor
 from http import HTTPStatus
 from typing import (Annotated, Any, Callable, ClassVar, Generic, Optional,
-                    TypedDict, TypeVar, Union)
+                    TypeVar, Union)
+
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 from fastapi import Request
 from pydantic import BaseModel, ConfigDict, Field


### PR DESCRIPTION
Launching openai serving engine will face the issue: 
```
pydantic.errors.PydanticUserError: Please use typing_extensions.TypedDict instead of typing.TypedDict on Python < 3.12.

For further information visit https://errors.pydantic.dev/2.11/u/typed-dict-version
```
I am using Python 3.10.16, and it causes the issue above.

FIX #17966

<!--- pyml disable-next-line no-emphasis-as-heading -->
