### PR TITLE
fix: convert slot_mapping tensor to array in tpu_model_runner

### DIFF
--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -531,7 +531,7 @@ class TPUModelRunner(LoRAModelRunnerMixin):
         np.add(block_numbers * self.block_size,
                block_offsets,
                out=self.input_batch.block_table.
-               slot_mapping_cpu[:total_num_scheduled_tokens])
+               slot_mapping_cpu[:total_num_scheduled_tokens].numpy())
 
         # Prepare the attention metadata.
         self.query_start_loc_np[0] = 0


### PR DESCRIPTION
fix: convert slot_mapping tensor to ndarray in tpu_model_runner

The slot_mapping tensor of the scheduled_tokens should be converted to an array. The issue was caused by #17483.

FIX #17969 

<!--- pyml disable-next-line no-emphasis-as-heading -->
