### PR TITLE
[Bugfix][TPU] Use np array when updating cache slot_mapping

### DIFF
--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -531,7 +531,7 @@ class TPUModelRunner(LoRAModelRunnerMixin):
         np.add(block_numbers * self.block_size,
                block_offsets,
                out=self.input_batch.block_table.
-               slot_mapping_cpu[:total_num_scheduled_tokens])
+               slot_mapping_np[:total_num_scheduled_tokens])
 
         # Prepare the attention metadata.
         self.query_start_loc_np[0] = 0


### PR DESCRIPTION
Fix a typo in https://github.com/vllm-project/vllm/pull/17483

The in-place `np.add` will throw an error if the output placeholder is not np array.

cc @heheda12345 @WoosukKwon @mgoin 
