### PR TITLE
[CI/Build] Add audio+video docker tag to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -348,3 +348,15 @@ FROM vllm-openai-base AS vllm-openai
 
 ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 #################### OPENAI API SERVER ####################
+
+#################### OPENAI API SERVER (W/ AUDIO+VIDEO) ####################
+FROM vllm-openai-base AS vllm-openai-av
+
+# Install the optional multimodal extras.
+# They only pull in pure-Python libs (librosa, soundfile, decord), so
+# there's no heavy GPU build step and the core wheel stays unchanged.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system "vllm[audio,video]"
+
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+#################### OPENAI API SERVER (W/ AUDIO+VIDEO) ####################


### PR DESCRIPTION
Creates a separate image for audio and video to be used in CICD to enable easy access to those features from just `docker pull`.

Fixes [#13940](https://github.com/vllm-project/vllm/issues/13940) 

