### PR TITLE
[Misc]Added span attribute gen_ai.system to identify spans from vLLM

### DIFF
--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -123,6 +123,7 @@ def test_traces(
 
         attributes = decode_attributes(
             request.resource_spans[0].scope_spans[0].spans[0].attributes)
+        assert attributes.get(SpanAttributes.GEN_AI_SYSTEM) == "vLLM"
         assert attributes.get(SpanAttributes.GEN_AI_RESPONSE_MODEL) == model
         assert attributes.get(
             SpanAttributes.GEN_AI_REQUEST_ID) == outputs[0].request_id

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1951,8 +1951,7 @@ class LLMEngine:
             metrics = seq_group.metrics
             ttft = metrics.first_token_time - metrics.arrival_time
             e2e_time = metrics.finished_time - metrics.arrival_time
-            seq_span.set_attribute(SpanAttributes.GEN_AI_SYSTEM,
-                                   "vLLM")
+            seq_span.set_attribute(SpanAttributes.GEN_AI_SYSTEM, "vLLM")
             seq_span.set_attribute(SpanAttributes.GEN_AI_RESPONSE_MODEL,
                                    self.model_config.model)
             seq_span.set_attribute(SpanAttributes.GEN_AI_REQUEST_ID,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1951,6 +1951,8 @@ class LLMEngine:
             metrics = seq_group.metrics
             ttft = metrics.first_token_time - metrics.arrival_time
             e2e_time = metrics.finished_time - metrics.arrival_time
+            seq_span.set_attribute(SpanAttributes.GEN_AI_SYSTEM,
+                                   "vLLM")
             seq_span.set_attribute(SpanAttributes.GEN_AI_RESPONSE_MODEL,
                                    self.model_config.model)
             seq_span.set_attribute(SpanAttributes.GEN_AI_REQUEST_ID,

--- a/vllm/tracing.py
+++ b/vllm/tracing.py
@@ -97,6 +97,7 @@ def extract_trace_headers(headers: Mapping[str, str]) -> Mapping[str, str]:
 class SpanAttributes:
     # Attribute names copied from here to avoid version conflicts:
     # https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md
+    GEN_AI_SYSTEM = "gen_ai.system"
     GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
     GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
     GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"


### PR DESCRIPTION
A span attribute `gen_ai.system` has been set to `vLLM` to identify spans originating from vLLM.
<!--- pyml disable-next-line no-emphasis-as-heading -->
