### PR TITLE
Remove noisy warnings from `SchedulerConfig`

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2016,15 +2016,9 @@ class SchedulerConfig:
     def __post_init__(self) -> None:
         if self.max_model_len is None:
             self.max_model_len = 8192
-            logger.warning_once(
-                "max_model_len was is not set. Defaulting to arbitrary value "
-                "of %d.", self.max_model_len)
 
         if self.max_num_seqs is None:
             self.max_num_seqs = 128
-            logger.warning_once(
-                "max_num_seqs was is not set. Defaulting to arbitrary value "
-                "of %d.", self.max_num_seqs)
 
         if self.max_num_batched_tokens is None:
             if self.enable_chunked_prefill:


### PR DESCRIPTION
Removes noisy warnings that appear when `SchedulerConfig` is default constructed (it is default constructed by `get_kwargs` when building the CLI args).

They could mislead the user into thinking that they have not set `max_model_len` in `ModelConfig` correctly. And `max_num_seqs` is a magic number depending on if you're using V0 or V1.