### PR TITLE
[Bugfix] Fix FBGEMM integration

### DIFF
--- a/vllm/model_executor/layers/quantization/fbgemm_fp8.py
+++ b/vllm/model_executor/layers/quantization/fbgemm_fp8.py
@@ -63,7 +63,9 @@ class FBGEMMFp8Config(QuantizationConfig):
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> Optional["QuantizeMethodBase"]:
         if isinstance(layer, LinearBase):
-            if is_layer_skipped(prefix, self.ignore_list):
+            if is_layer_skipped(prefix=prefix,
+                                ignored_layers=self.ignore_list,
+                                fused_mapping=self.packed_modules_mapping):
                 return UnquantizedLinearMethod()
             return FBGEMMFp8LinearMethod(self)
         return None


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/pull/16850#issuecomment-2873016121

Addresses issues with both the FP8 W8A8 and FP8 Marlin path. 

Marlin needed to allow for the layer to not have weight_block_sizes present, and both paths needed to update their ignored modules check to work with fused modules.

Manually verified evals:

FP8 W8A8
```
WARNING 05-12 16:46:30 [marlin_utils_fp8.py:81] Your GPU does not have native support for FP8 computation but FP8 quantization is being used. Weight-only FP8 compression will be used leveraging the Marlin kernel. This may degrade performance for compute-heavy workloads.
vllm (pretrained=nm-testing/Meta-Llama-3-8B-Instruct-FBGEMM-nonuniform,enforce_eager=True,max_model_len=2048,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7513|±  |0.0119|
|     |       |strict-match    |     5|exact_match|↑  |0.7536|±  |0.0119|
```

FP8 Marlin
```
vllm (pretrained=nm-testing/Meta-Llama-3-8B-Instruct-FBGEMM-nonuniform,enforce_eager=True,max_model_len=2048,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7559|±  |0.0118|
|     |       |strict-match    |     5|exact_match|↑  |0.7574|±  |0.0118|
```


====

Original failure found in CI: https://buildkite.com/vllm/ci/builds/19754#0196bd80-d18b-4c8a-bf76-50e9a53c5a6c/43-353

```
ERROR 05-10 22:15:39 [multiproc_executor.py:487]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/fbgemm_fp8.py", line 144, in process_weights_after_loading
ERROR 05-10 22:15:39 [multiproc_executor.py:487]     prepare_fp8_layer_for_marlin(layer)
ERROR 05-10 22:15:39 [multiproc_executor.py:487]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py", line 122, in prepare_fp8_layer_for_marlin
ERROR 05-10 22:15:39 [multiproc_executor.py:487]     if layer.weight_block_size is None:
ERROR 05-10 22:15:39 [multiproc_executor.py:487]        ^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-10 22:15:39 [multiproc_executor.py:487]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1940, in __getattr__
ERROR 05-10 22:15:39 [multiproc_executor.py:487]     raise AttributeError(
ERROR 05-10 22:15:39 [multiproc_executor.py:487] AttributeError: 'QKVParallelLinear' object has no attribute 'weight_block_size'
```