### PR TITLE
[V1] Enable float32 for V1 backends that support it (e.g., Triton)

### DIFF
--- a/tests/kernels/test_triton_unified_attention.py
+++ b/tests/kernels/test_triton_unified_attention.py
@@ -12,7 +12,7 @@ NUM_HEADS = [(4, 4), (8, 2), (16, 2)]
 HEAD_SIZES = [128, 256]
 BLOCK_SIZES = [16, 32]
 
-DTYPES = [torch.float16, torch.bfloat16]
+DTYPES = [torch.float16, torch.bfloat16, torch.float32]
 QDTYPES = [None, torch.float8_e4m3fn]
 # one value large enough to test overflow in index calculation.
 # one value small enough to test the schema op check


### PR DESCRIPTION
Right now we fall back to V0 if the user asks for `dtype=float32`. This is based on the outdated assumption that V1 only supports FA which in turn doesn't support float32. The V1 Triton backend, and potentially others, do support float32 so we should let the user configure that if they want. 

float32 is quite often useful for correctness testing. 

Also adds explicit unit tests for float32 to the `triton_unified_attention` kernel to cover this case. 

