### PR TITLE
[Bugfix] Fixes for new marlin moe usage

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -57,9 +57,10 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
             "input_activations")
 
         if quant_config._is_wNa16_group_channel(weight_quant, input_quant):
+            # group_size=None means channelwise
+            group_size = weight_quant.group_size or -1
             # Prefer to use the MarlinMoE kernel when it is supported.
-            if not check_moe_marlin_supports_layer(layer,
-                                                   weight_quant.group_size):
+            if not check_moe_marlin_supports_layer(layer, group_size):
                 if (weight_quant.strategy in QuantizationStrategy.GROUP and
                         weight_quant.actorder in (ActivationOrdering.GROUP,
                                                   ActivationOrdering.DYNAMIC)):

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -610,9 +610,9 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         activation: str = "silu",
     ) -> torch.Tensor:
         assert activation == "silu", "Only SiLU activation is supported."
-        if apply_router_weight_on_input is not None:
+        if apply_router_weight_on_input:
             raise NotImplementedError(
-                "Apply router weight on input is not supported for"
+                "Apply router weight on input is not supported for "
                 "fused Marlin MoE method.")
 
         topk_weights, topk_ids = FusedMoE.select_experts(


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/pull/16850#issuecomment-2873016121

Found using failing tests in "Weight Loading Multiple GPU Test - Large Models" on buildkite: https://buildkite.com/vllm/ci/builds/19754/steps?jid=0196bd80-d187-4367-af2f-a8fada079333#/43-1306

Minimal reproductions

Issue: Passing in `group_size=None` for channelwise models in compressed-tensors format
```
vllm serve nm-testing/Mixtral-8x7B-Instruct-v0.1-W4A16-channel-quantized -tp 2 --load-format dummy
...
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]   File "/home/mgoin/code/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 498, in __init__
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]     self.quant_method = quant_config.get_quant_method(self, prefix)
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]   File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py", line 101, in get_quant_method
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]     return CompressedTensorsMoEMethod.get_moe_method(self, layer)
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]   File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py", line 62, in get_moe_method
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]     if not check_moe_marlin_supports_layer(layer,
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]   File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/utils/marlin_utils.py", line 179, in check_moe_marlin_supports_layer
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]     intermediate_size_per_partition % max(64, group_size) == 0 and \
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487]                                       ^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=1 pid=2902434) ERROR 05-12 18:46:04 [multiproc_executor.py:487] TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

Issue: The check for `apply_router_weight_on_input` in `GPTQMarlinMoEMethod` did not check boolean value
```
vllm serve TheBloke/Mixtral-8x7B-v0.1-GPTQ -tp 2 --load-format dummy --enforce-eager
...
(VllmWorker rank=0 pid=2933636) ERROR 05-12 19:06:21 [multiproc_executor.py:522]   File "/home/mgoin/code/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 875, in forward_impl
(VllmWorker rank=0 pid=2933636) ERROR 05-12 19:06:21 [multiproc_executor.py:522]     final_hidden_states = self.quant_method.apply(
(VllmWorker rank=0 pid=2933636) ERROR 05-12 19:06:21 [multiproc_executor.py:522]                           ^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=0 pid=2933636) ERROR 05-12 19:06:21 [multiproc_executor.py:522]   File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/gptq_marlin.py", line 614, in apply
(VllmWorker rank=0 pid=2933636) ERROR 05-12 19:06:21 [multiproc_executor.py:522]     raise NotImplementedError(
(VllmWorker rank=0 pid=2933636) ERROR 05-12 19:06:21 [multiproc_executor.py:522] NotImplementedError: Apply router weight on input is not supported forfused Marlin MoE method.
```