### PR TITLE
[V1] [Spec Decode] llama4 lm_head and bugfix

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -472,12 +472,14 @@ steps:
 
 - label: Language Models Test (Standard)
   mirror_hardwares: [amdexperimental]
+  torch_nightly: true
   source_file_dependencies:
   - vllm/
   - tests/models/language
   commands:
     # Install causal-conv1d for plamo2 models here, as it is not compatible with pip-compile.
     - pip install 'git+https://github.com/Dao-AILab/causal-conv1d@v1.5.0.post8'
+    - pip freeze | grep -E 'torch'
     - pytest -v -s models/language -m core_model
 
 - label: Language Models Test (Extended)
@@ -493,11 +495,13 @@ steps:
 
 - label: Multi-Modal Models Test (Standard)
   mirror_hardwares: [amdexperimental]
+  torch_nightly: true
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
   commands:
     - pip install git+https://github.com/TIGER-AI-Lab/Mantis.git
+    - pip freeze | grep -E 'torch'
     - pytest -v -s models/multimodal/processing
     - pytest -v -s --ignore models/multimodal/generation/test_whisper.py models/multimodal -m core_model
     - cd .. && pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model  # Otherwise, mp_method="spawn" doesn't work

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,9 +14,7 @@ aiohttp==3.10.11
     #   fsspec
     #   lm-eval
 aiosignal==1.3.1
-    # via
-    #   aiohttp
-    #   ray
+    # via aiohttp
 annotated-types==0.7.0
     # via pydantic
 anyio==4.6.2.post1
@@ -85,7 +83,7 @@ contourpy==1.3.0
     # via matplotlib
 cramjam==2.9.0
     # via fastparquet
-cupy-cuda12x==13.3.0
+cupy-cuda12x==13.4.1
     # via ray
 cycler==0.12.1
     # via matplotlib
@@ -150,7 +148,6 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-    #   ray
 fsspec==2024.9.0
     # via
     #   datasets
@@ -542,7 +539,7 @@ pyyaml==6.0.2
     #   vocos
 rapidfuzz==3.12.1
     # via jiwer
-ray==2.43.0
+ray==2.46.0
     # via -r requirements/test.in
 redis==5.2.0
     # via tensorizer

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,9 @@ aiohttp==3.10.11
     #   fsspec
     #   lm-eval
 aiosignal==1.3.1
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   ray
 annotated-types==0.7.0
     # via pydantic
 anyio==4.6.2.post1
@@ -83,7 +85,7 @@ contourpy==1.3.0
     # via matplotlib
 cramjam==2.9.0
     # via fastparquet
-cupy-cuda12x==13.4.1
+cupy-cuda12x==13.3.0
     # via ray
 cycler==0.12.1
     # via matplotlib
@@ -148,6 +150,7 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
+    #   ray
 fsspec==2024.9.0
     # via
     #   datasets
@@ -539,7 +542,7 @@ pyyaml==6.0.2
     #   vocos
 rapidfuzz==3.12.1
     # via jiwer
-ray==2.46.0
+ray==2.43.0
     # via -r requirements/test.in
 redis==5.2.0
     # via tensorizer

--- a/tests/v1/entrypoints/conftest.py
+++ b/tests/v1/entrypoints/conftest.py
@@ -72,12 +72,14 @@ def sample_json_schema():
                             "type": "string"
                         }
                     },
-                    "required": ["company", "duration", "position"]
+                    "required": ["company", "duration", "position"],
+                    "additionalProperties": False
                 }
             }
         },
         "required":
-        ["name", "age", "skills", "grade", "email", "work_history"]
+        ["name", "age", "skills", "grade", "email", "work_history"],
+        "additionalProperties": False
     }
 
 
@@ -100,7 +102,8 @@ def unsupported_json_schema():
                 }
             }
         },
-        "required": ["score", "tags"]
+        "required": ["score", "tags"],
+        "additionalProperties": False
     }
 
 
@@ -139,7 +142,8 @@ def sample_definition_json_schema():
         },
         'required': ['steps', 'final_answer'],
         'title': 'MathReasoning',
-        'type': 'object'
+        'type': 'object',
+        "additionalProperties": False
     }
 
 

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -68,7 +68,6 @@ class EAGLEConfig(PretrainedConfig):
 
         if self.model is not None:
             for k, v in self.model.to_dict().items():
-                if not hasattr(self, k):
                     setattr(self, k, v)
 
     @classmethod

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -9,7 +9,7 @@ from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.model_loader.utils import set_default_torch_dtype
-from vllm.model_executor.models import ModelRegistry
+from vllm.model_executor.models import ModelRegistry, supports_multimodal
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
@@ -309,7 +309,10 @@ class EagleProposer:
                 self.model.model.embed_tokens = target_model.model.embed_tokens
         else:
             logger.info("Loading EAGLE LM head weights from the target model.")
-            self.model.lm_head = target_model.lm_head
+            if supports_multimodal(target_model) or hasattr(target_model, 'get_language_model'):
+                self.model.lm_head = target_model.get_language_model().lm_head
+            else:
+                self.model.lm_head = target_model.lm_head
 
     @torch.inference_mode()
     def dummy_run(


### PR DESCRIPTION
The change in `vllm/v1/spec_decode/eagle.py` is to point to the correct lm head when using a multimodal model.

I believe the change in `vllm/transformers_utils/configs/eagle.py` is needed because the call to `EagleConfig` from SpeculativeConfig’s `__post_init__` doesn’t pass in any kwargs (found in `vllm/config.py`). Thus, the call to `super().__init__(**kwargs)` will result in the keys of self always being set to their default values; for example,  `tie_word_embeddings` will always be `True`, which is undesired. Thus, I removed the `if not hasattr`. This makes it so self is being set to the configuration represented with `self.model` (which is our actual config). Please correct me if I am wrong, thanks!

<!--- pyml disable-next-line no-emphasis-as-heading -->
