### PR TITLE
[P/D][v1] Allow registering external kv connector from args

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3470,7 +3470,17 @@ class KVTransferConfig:
     """The KV connector port, used to build distributed connection."""
 
     kv_connector_external_registration_args: Optional[dict[str, Any]] = None
-    """Extra args for external kv connector registration."""
+    """Extra args for external kv connector registration.
+       Example Usages:
+          kv_transfer_config=KVTransferConfig(
+                kv_connector="ExternalConnector",
+                kv_connector_external_registration_args={
+                    "name": "ExternalConnector",
+                    "module_path": "external_lib.path.external_kv_connector",
+                    "class_name": "ExternalConnector",
+                },
+          )
+    """
 
     kv_connector_extra_config: dict[str, Any] = field(default_factory=dict)
     """any extra config that the connector may need."""

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3469,6 +3469,9 @@ class KVTransferConfig:
     kv_port: int = 14579
     """The KV connector port, used to build distributed connection."""
 
+    kv_connector_external_registration_args: Optional[dict[str, Any]] = None
+    """Extra args for external kv connector registration."""
+
     kv_connector_extra_config: dict[str, Any] = field(default_factory=dict)
     """any extra config that the connector may need."""
 

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -59,6 +59,10 @@ class KVConnectorFactory:
                              f"but found {envs.VLLM_USE_V1=}")
 
         connector_name = config.kv_transfer_config.kv_connector
+        if (config.kv_transfer_config.kv_connector_external_registration_args
+                is not None and connector_name not in cls._registry):
+            cls.register_connector(**config.kv_transfer_config.
+                                   kv_connector_external_registration_args)
         connector_cls = cls._registry[connector_name]()
         assert issubclass(connector_cls, KVConnectorBase_V1)
         logger.info("Creating v1 connector with name: %s", connector_name)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -161,6 +161,7 @@ class Worker(WorkerBase):
             context = nullcontext()
         with context:
             self.model_runner.load_model()
+            ensure_kv_transfer_initialized(self.vllm_config)
 
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
@@ -342,8 +343,6 @@ def init_worker_distributed_environment(
 
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size)
-
-    ensure_kv_transfer_initialized(vllm_config)
 
 
 def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):


### PR DESCRIPTION
KVConnectorBase_V1 API is introduced in (https://github.com/vllm-project/vllm/pull/15960), however, due to the multi-process nature, it's hard to register a customized kv connector implementations from outside context. 

This change will make the kv connector registration more flexible as it allows for external dependency injection.
Example Usage:
```
kv_connector_registry_args={
  "name": "CustomConnector",
  "module_path": "external.module.path",
  "class_name": "CustomConnector",
},
```

This will allow external developers to register customized kv connectors without keep adding a boilerplate & updating the factory.py.

The third commit moves the kv connector init after model loading, allowing `vllm_config`  to be populated with all attention layers info. 

