### PR TITLE
[Misc] Add torch.int16 to TORCH_DTYPE_TO_NUMPY_DTYPE conversion map

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -176,6 +176,7 @@ TORCH_DTYPE_TO_NUMPY_DTYPE = {
     torch.float32: np.float32,
     torch.float64: np.float64,
     torch.uint8: np.uint8,
+    torch.int16: np.int16,
     torch.int32: np.int32,
     torch.int64: np.int64,
 }


### PR DESCRIPTION
This PR adds missing support for torch.int16 in the TORCH_DTYPE_TO_NUMPY_DTYPE dictionary, enabling correct mapping to np.int16.

Previously, torch.int16 was not handled, which could lead to runtime errors or fallback behavior in dtype conversion logic involving NumPy interoperability.