### PR TITLE
[Fix] check to make sure processor has chat templates

### DIFF
--- a/tests/compile/test_pass_manager.py
+++ b/tests/compile/test_pass_manager.py
@@ -22,7 +22,7 @@ def test_bad_callable():
     pass_manager.configure(config)
 
     with pytest.raises(AssertionError):
-        pass_manager.add(simple_callable)  # noqa, type wrong on purpose
+        pass_manager.add(simple_callable)
 
 
 # Pass that inherits from InductorPass

--- a/vllm/compilation/inductor_pass.py
+++ b/vllm/compilation/inductor_pass.py
@@ -16,7 +16,7 @@ if is_torch_equal_or_newer("2.6"):
     from torch._inductor.custom_graph_pass import CustomGraphPass
 else:
     # CustomGraphPass is not present in 2.5 or lower, import our version
-    from .torch25_custom_graph_pass import (  # noqa: yapf
+    from .torch25_custom_graph_pass import (  # noqa: E501
         Torch25CustomGraphPass as CustomGraphPass)
 
 _pass_context = None

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -345,7 +345,7 @@ def resolve_hf_chat_template(
                 trust_remote_code=trust_remote_code,
             )
             if isinstance(processor, ProcessorMixin) and \
-                processor.chat_template is not None:
+                hasattr(processor, 'chat_template') and processor.chat_template is not None:
                 return processor.chat_template
         except Exception:
             logger.debug("Failed to load AutoProcessor chat template for %s",

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -345,11 +345,11 @@ def resolve_hf_chat_template(
                 trust_remote_code=trust_remote_code,
             )
             if isinstance(processor, ProcessorMixin) and \
-                hasattr(processor, 'chat_template') and processor.chat_template is not None:
+                hasattr(processor, 'chat_template') and \
+                processor.chat_template is not None:
                 return processor.chat_template
         except Exception:
-            logger.debug("Failed to load AutoProcessor chat template for %s",
-                        tokenizer.name_or_path, exc_info=True)
+            logger.debug("Failed to load AutoProcessor chat template for %s", tokenizer.name_or_path, exc_info=True)  # noqa: E501
 
     # 3rd priority: AutoTokenizer chat template
     try:


### PR DESCRIPTION
This PR address a small chore check to make sure that the processor has the chat_template attributes
before accessing check for None. This problem arises with models such as `microsoft/Phi-3.5-vision-instruct`
with `trust_remote_code=True` and there are no chat_template in the processor class here.

```log
DEBUG 05-13 03:32:38 [chat_utils.py:355] Failed to load AutoProcessor chat template for microsoft/Phi-3.5-vision-instruct
DEBUG 05-13 03:32:38 [chat_utils.py:355] Traceback (most recent call last):
DEBUG 05-13 03:32:38 [chat_utils.py:355]   File "/home/ubuntu/workspace/vllm/vllm/entrypoints/chat_utils.py", line 352, in resolve_hf_chat_template
DEBUG 05-13 03:32:38 [chat_utils.py:355]     processor.chat_template is not None:
DEBUG 05-13 03:32:38 [chat_utils.py:355]     ^^^^^^^^^^^^^^^^^^^^^^^
DEBUG 05-13 03:32:38 [chat_utils.py:355] AttributeError: 'Phi3VProcessor' object has no attribute 'chat_template'
INFO 05-13 03:32:38 [chat_utils.py:413] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
DEBUG 05-13 03:32:38 [chat_utils.py:355] Failed to load AutoProcessor chat template for microsoft/Phi-3.5-vision-instruct
DEBUG 05-13 03:32:38 [chat_utils.py:355] Traceback (most recent call last):
DEBUG 05-13 03:32:38 [chat_utils.py:355]   File "/home/ubuntu/workspace/vllm/vllm/entrypoints/chat_utils.py", line 352, in resolve_hf_chat_template
DEBUG 05-13 03:32:38 [chat_utils.py:355]     processor.chat_template is not None:
DEBUG 05-13 03:32:38 [chat_utils.py:355]     ^^^^^^^^^^^^^^^^^^^^^^^
DEBUG 05-13 03:32:38 [chat_utils.py:355] AttributeError: 'Phi3VProcessor' object has no attribute 'chat_template'
```

Given that we only log the debug, probably good to propagate this exception upwards once we have a better way to handle
exception on engine without crashing them

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
