### PR TITLE
[Bugfix][Example] make lmcache v0 work.

### DIFF
--- a/examples/lmcache/cpu_offload_lmcache.py
+++ b/examples/lmcache/cpu_offload_lmcache.py
@@ -34,7 +34,7 @@ from vllm.config import KVTransferConfig
 from vllm.engine.arg_utils import EngineArgs
 
 
-def setup_environment_variables():
+def setup_environment_variables(vllm_version: str):
     # LMCache-related environment variables
     # Use experimental features in LMCache
     os.environ["LMCACHE_USE_EXPERIMENTAL"] = "True"
@@ -44,6 +44,8 @@ def setup_environment_variables():
     os.environ["LMCACHE_LOCAL_CPU"] = "True"
     # Set local CPU memory limit to 5.0 GB
     os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = "5.0"
+    if vllm_version == "v0":
+        os.environ["VLLM_USE_V1"] = "0"
 
 
 @contextlib.contextmanager
@@ -120,7 +122,7 @@ def main():
         lmcache_connector = "LMCacheConnectorV1"
         model = "meta-llama/Meta-Llama-3.1-8B-Instruct"
 
-    setup_environment_variables()
+    setup_environment_variables(args.version)
 
     with build_llm_with_lmcache(lmcache_connector, model, args.version) as llm:
 


### PR DESCRIPTION
when run " python3 cpu_offload_lmcache.py -v v0" met the following errors:
ERROR 05-13 06:24:35 [core.py:396] EngineCore failed to start.
ERROR 05-13 06:24:35 [core.py:396] Traceback (most recent call last):
ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 387, in run_engine_core
ERROR 05-13 06:24:35 [core.py:396]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 329, in __init__
ERROR 05-13 06:24:35 [core.py:396]     super().__init__(vllm_config, executor_class, log_stats,
ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 64, in __init__
ERROR 05-13 06:24:35 [core.py:396]     self.model_executor = executor_class(vllm_config)
ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/executor_base.py", line 52, in __init__                                                                                                                              ERROR 05-13 06:24:35 [core.py:396]     self._init_executor()                                                                       ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/uniproc_executor.py", line 46, in _init_executor                                                                                                                     ERROR 05-13 06:24:35 [core.py:396]     self.collective_rpc("init_device")                                                          ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/uniproc_executor.py", line 56, in collective_rpc                                                                                                                     ERROR 05-13 06:24:35 [core.py:396]     answer = run_method(self.driver_worker, method, args, kwargs)                               ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/utils.py", line 2456, in run_method        ERROR 05-13 06:24:35 [core.py:396]     return func(*args, **kwargs)                                                                ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker_base.py", line 604, in init_device                                                                                                                              ERROR 05-13 06:24:35 [core.py:396]     self.worker.init_device()  # type: ignore
ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/worker/gpu_worker.py", line 135, in init_device                                                                                                                            ERROR 05-13 06:24:35 [core.py:396]     init_worker_distributed_environment(self.vllm_config, self.rank,                            ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/worker/gpu_worker.py", line 329, in init_worker_distributed_environment                                                                                                    ERROR 05-13 06:24:35 [core.py:396]     ensure_kv_transfer_initialized(vllm_config)                                                 ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/distributed/kv_transfer/kv_transfer_state.py", line 64, in ensure_kv_transfer_initialized                                                                                     ERROR 05-13 06:24:35 [core.py:396]     _KV_CONNECTOR_AGENT = KVConnectorFactory.create_connector_v1(                               ERROR 05-13 06:24:35 [core.py:396]   File "/usr/local/lib/python3.10/dist-packages/vllm/distributed/kv_transfer/kv_connector/factory.py", line 63, in create_connector_v1                                                                                             ERROR 05-13 06:24:35 [core.py:396]     assert issubclass(connector_cls, KVConnectorBase_V1)                                        ERROR 05-13 06:24:35 [core.py:396] AssertionError              

So, for lmcache==v0, it must run vllm=v0.
