### PR TITLE
[Frontend] Add -d/--detach option for vllm serve

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -4,7 +4,10 @@
 import argparse
 import os
 import signal
+import subprocess
 import sys
+import time
+import uuid
 
 import uvloop
 import zmq
@@ -46,7 +49,9 @@ class ServeSubcommand(CLISubcommand):
         if hasattr(args, 'model_tag') and args.model_tag is not None:
             args.model = args.model_tag
 
-        if args.headless or args.api_server_count < 1:
+        if getattr(args, "detach", False):
+            run_detached(args)
+        elif args.headless or args.api_server_count < 1:
             run_headless(args)
         elif args.api_server_count > 1:
             run_multi_api_server(args)
@@ -95,6 +100,30 @@ class ServeSubcommand(CLISubcommand):
             help="Read CLI options from a config file. "
             "Must be a YAML with the following options: "
             "https://docs.vllm.ai/en/latest/configuration/serve_args.html")
+        serve_parser.add_argument(
+            "-d",
+            "--detach",
+            action="store_true",
+            help="Run the vLLM server in detached mode (background).")
+        serve_parser.add_argument(
+            "-t",
+            "--timeout",
+            type=int,
+            default=60,
+            help="Timeout (in seconds) to wait for server "
+            "startup when using --detach.")
+        serve_parser.add_argument(
+            "--log-dir",
+            type=str,
+            default="/var/log/vllm",
+            help="Directory to store vLLM log files (only with -d). "
+            "Fallback to ~/.vllm/logs if no permission.")
+        serve_parser.add_argument(
+            "--pid-dir",
+            type=str,
+            default="/var/run/vllm",
+            help="Directory to store PID files (only with -d). "
+            "Fallback to ~/.vllm/pids if no permission.")
 
         serve_parser = make_arg_parser(serve_parser)
         show_filtered_argument_or_group_from_help(serve_parser, "serve")
@@ -322,3 +351,116 @@ def run_api_server_worker_proc(listen_address,
     uvloop.run(
         run_server_worker(listen_address, sock, args, client_config,
                           **uvicorn_kwargs))
+
+
+def wait_until_server_ready(log_path: str, timeout: int):
+    success_line = "Application startup complete"
+    start_time = time.time()
+
+    try:
+        with open(log_path) as log_fp:
+            while time.time() - start_time < timeout:
+                line = log_fp.readline()
+                if line:
+                    if success_line in line:
+                        print("[✔] Server startup confirmed.")
+                        return True
+                else:
+                    time.sleep(0.1)
+    except FileNotFoundError:
+        return False
+
+    return False
+
+
+def ensure_writable_dir(preferred_path: str, fallback_path: str):
+    try:
+        os.makedirs(preferred_path, exist_ok=True)
+        testfile = os.path.join(preferred_path, ".write_test")
+        with open(testfile, "w") as f:
+            f.write("ok")
+        os.remove(testfile)
+        return preferred_path
+    except (PermissionError, OSError):
+        print(f"[!] Cannot write to {preferred_path}. "
+              f"Falling back to {fallback_path}")
+        os.makedirs(fallback_path, exist_ok=True)
+        return fallback_path
+
+
+def run_detached(args: argparse.Namespace):
+    fallback_base = os.path.expanduser("~/.vllm")
+    log_dir = ensure_writable_dir(args.log_dir,
+                                  os.path.join(fallback_base, "logs"))
+    pid_dir = ensure_writable_dir(args.pid_dir,
+                                  os.path.join(fallback_base, "pids"))
+    registry_dir = fallback_base
+
+    os.makedirs(registry_dir, exist_ok=True)
+
+    instance_id = str(uuid.uuid4())[:8]
+
+    # Build command
+    cmd = ["vllm", "serve"]
+    filtered_args = [
+        arg for arg in sys.argv[2:] if arg not in ("-d", "--detach")
+    ]
+    cmd += filtered_args
+    full_cmd_str = " ".join(cmd)
+
+    log_file = os.path.join(log_dir, f"{instance_id}.log")
+    pid_file = os.path.join(pid_dir, f"{instance_id}.pid")
+
+    # Start process
+    with open(log_file, "w") as log:
+        process = subprocess.Popen(
+            cmd,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            bufsize=1,  # Line-buffered for real-time output
+        )
+
+    # Wait for confirmation
+    print("Waiting for vLLM server to start...")
+    ready = wait_until_server_ready(log_file, timeout=args.timeout)
+
+    if process.poll() is not None:
+        print(
+            "[✗] vLLM process exited unexpectedly before confirming startup.")
+        return
+
+    pid = process.pid
+    if not ready:
+        if process.poll() is None:
+            # Process still alive, but server not ready: auto-terminate
+            print("[✗] Server not ready within timeout. "
+                  "Terminating the process...")
+
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+                print("Process terminated with SIGTERM.")
+            except subprocess.TimeoutExpired:
+                print("Process did not terminate. Sending SIGKILL...")
+                process.kill()
+                print("Process killed with SIGKILL.")
+
+            print(f"Log file: {log_file}")
+            print("Hint: Try increasing --timeout "
+                  "if the model takes long to load.")
+            return
+        else:
+            # Process already exited, no need to kill
+            print("[✗] vLLM process exited before confirming startup.")
+            print(f"Log file: {log_file}")
+            return
+
+    # Save
+    with open(pid_file, "w") as f:
+        f.write(str(pid))
+
+    print("[✔] vLLM server started in detached mode.")
+    print(f"Running detached: {full_cmd_str}")
+    print(f"(instance_id: {instance_id} pid: {pid}).")
+    print(f"Logs: {log_file}")


### PR DESCRIPTION
- Add -d/--detach option to vllm serve for background running

Motivation:
- Running multiple models (e.g., chat + embedding) often requires multiple terminals or ports.
- On Linux servers, it's common to manage processes via CLI without GUI or multiple windows.
- Background mode makes it easier to start services without blocking the terminal.

Features:
- Launches vllm serve as a detached subprocess.
- Fontend logs are saved to timestamped files (e.g., vllm_2025-05-13_16-45-00.log) automatically.
- CLI experience remains unchanged for non-detached usage.

```

vllm serve --help
INFO 05-13 17:54:03 [__init__.py:248] Automatically detected platform cuda.
usage: vllm serve [model_tag] [options]

Start the vLLM OpenAI Compatible API server.

  -d, --detach          Run the vLLM server in detached mode (background). (default: False)

-t TIMEOUT, --timeout TIMEOUT
                        Timeout (in seconds) to wait for server startup when using --detach.
                        (default: 60)

--log-dir LOG_DIR  Directory to store vLLM log files (only with -d). Fallback to ~/.vllm/logs if
                   no permission. (default: /var/log/vllm)

--pid-dir PID_DIR  Directory to store PID files (only with -d). Fallback to ~/.vllm/pids if no
                   permission. (default: /var/run/vllm)

$vllm serve meta-llama/Meta-Llama-3-8B-Instruct -d
Running detached: vllm serve meta-llama/Meta-Llama-3-8B-Instruct
vLLM server started in detached mode (instance_id: 355c017e, pid: 21967).
Logs: /Users/xx/.vllm_process/355c017e.log

