### PR TITLE
[Feature]: reasoning_tokens in Chat Completion Response usage

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1910,3 +1910,17 @@ def make_tool_call_id(id_type: str = "random", func_name=None, idx=None):
     else:
         # by default return random
         return f"chatcmpl-tool-{random_uuid()}"
+
+
+def count_reasoning_tokens(lst: list[int], sub: list[int] | None) -> int:
+    if sub is None:
+        return 0
+    n, m = len(lst), len(sub)
+    if m == 0 or m > n:
+        return 0
+
+    # Search from the end for the last occurrence
+    for i in range(n - m, -1, -1):
+        if lst[i : i + m] == sub:
+            return i + m
+    return 0

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -494,12 +494,12 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         return base(raw_request).create_error_response(
             message="The model does not support Chat Completions API"
         )
-    try:
-        generator = await handler.create_chat_completion(request, raw_request)
-    except Exception as e:
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)
-        ) from e
+    # try:
+    generator = await handler.create_chat_completion(request, raw_request)
+    # except Exception as e:
+        # raise HTTPException(
+            # status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)
+        # ) from e
     if isinstance(generator, ErrorResponse):
         return JSONResponse(
             content=generator.model_dump(), status_code=generator.error.code
@@ -1089,6 +1089,7 @@ async def init_app_state(
             tool_parser=args.tool_call_parser,
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
+            enable_completion_tokens_details=args.enable_completion_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
             exclude_log_deltas=args.exclude_log_deltas,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -494,12 +494,12 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         return base(raw_request).create_error_response(
             message="The model does not support Chat Completions API"
         )
-    # try:
-    generator = await handler.create_chat_completion(request, raw_request)
-    # except Exception as e:
-        # raise HTTPException(
-            # status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)
-        # ) from e
+    try:
+        generator = await handler.create_chat_completion(request, raw_request)
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)
+        ) from e
     if isinstance(generator, ErrorResponse):
         return JSONResponse(
             content=generator.model_dump(), status_code=generator.error.code

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -177,6 +177,8 @@ class FrontendArgs:
     """Disable FastAPI's OpenAPI schema, Swagger UI, and ReDoc endpoint."""
     enable_prompt_tokens_details: bool = False
     """If set to True, enable prompt_tokens_details in usage."""
+    enable_completion_tokens_details: bool = False
+    """If set to True, enable completion_tokens_details in usage."""
     enable_server_load_tracking: bool = False
     """If set to True, enable tracking server_load_metrics in the app state."""
     enable_force_include_usage: bool = False

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -196,11 +196,16 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
 
 
+class CompletionTokensDetails(OpenAIBaseModel):
+    reasoning_tokens: int | None = None
+
+
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: int | None = 0
     prompt_tokens_details: PromptTokenUsageInfo | None = None
+    completion_tokens_details: CompletionTokensDetails | None = None
 
 
 class RequestResponseMetadata(BaseModel):

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1125,6 +1125,7 @@ class OpenAIServingChat(OpenAIServing):
                     if (
                         self.reasoning_parser
                         and reasoning_end_arr[i]
+                        and all_previous_token_ids
                         and (not num_reasoning_tokens[i])
                     ):
                         num_reasoning_tokens[i] = count_reasoning_tokens(
@@ -1652,7 +1653,7 @@ class OpenAIServingChat(OpenAIServing):
             num_generated_tokens += len(output.token_ids)
             if self.reasoning_parser:
                 total_reasoning_tokens += count_reasoning_tokens(
-                    output.token_ids, reasoning_parser.end_token_ids
+                    as_list(output.token_ids), reasoning_parser.end_token_ids
                 )
         usage = UsageInfo(
             prompt_tokens=num_prompt_tokens,

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -660,7 +660,6 @@ class OpenAIServingChat(OpenAIServing):
             all_previous_token_ids = None
 
         try:
-            reasoning_parser = None
             if self.reasoning_parser:
                 if tokenizer is None:
                     raise ValueError(

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1311,7 +1311,7 @@ class OpenAIServingChat(OpenAIServing):
                 if self.enable_completion_tokens_details and self.reasoning_parser:
                     reasoning_tokens = sum(num_reasoning_tokens)
                     final_usage.completion_tokens_details = CompletionTokensDetails(
-                        reasoning_tokens=reasoning_tokens - num_prompt_tokens
+                        reasoning_tokens=reasoning_tokens
                     )
 
                 final_usage_chunk = ChatCompletionStreamResponse(
@@ -1665,7 +1665,7 @@ class OpenAIServingChat(OpenAIServing):
             )
         if self.enable_completion_tokens_details and total_reasoning_tokens:
             usage.completion_tokens_details = CompletionTokensDetails(
-                reasoning_tokens=total_reasoning_tokens - num_prompt_tokens
+                reasoning_tokens=total_reasoning_tokens
             )
         request_metadata.final_usage_info = usage
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -18,6 +18,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     ConversationMessage,
+    count_reasoning_tokens,
     get_history_tool_calls_cnt,
     make_tool_call_id,
 )
@@ -42,6 +43,7 @@ from vllm.entrypoints.openai.protocol import (
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
     ChatMessage,
+    CompletionTokensDetails,
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
@@ -99,6 +101,7 @@ class OpenAIServingChat(OpenAIServing):
         exclude_tools_when_tool_choice_none: bool = False,
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
+        enable_completion_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
         enable_log_outputs: bool = False,
         exclude_log_deltas: bool = False,
@@ -136,6 +139,7 @@ class OpenAIServingChat(OpenAIServing):
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
+        self.enable_completion_tokens_details = enable_completion_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         if self.default_sampling_params:
@@ -613,6 +617,7 @@ class OpenAIServingChat(OpenAIServing):
         num_choices = 1 if request.n is None else request.n
         previous_num_tokens = [0] * num_choices
         finish_reason_sent = [False] * num_choices
+        num_reasoning_tokens = [0] * num_choices
         num_prompt_tokens = 0
         num_cached_tokens = None
         if self.use_harmony:
@@ -655,6 +660,7 @@ class OpenAIServingChat(OpenAIServing):
             all_previous_token_ids = None
 
         try:
+            reasoning_parser = None
             if self.reasoning_parser:
                 if tokenizer is None:
                     raise ValueError(
@@ -1082,6 +1088,12 @@ class OpenAIServingChat(OpenAIServing):
 
                     # when only reasoning
                     elif self.reasoning_parser:
+                        reasoning_end_arr[i] = (
+                            reasoning_parser.is_reasoning_end_streaming(
+                                previous_token_ids,
+                                current_token_ids,
+                            )
+                        )
                         delta_message = reasoning_parser.extract_reasoning_streaming(
                             previous_text,
                             current_text,
@@ -1110,6 +1122,15 @@ class OpenAIServingChat(OpenAIServing):
                     # set the previous values for the next iteration
                     previous_num_tokens[i] += len(output.token_ids)
 
+                    # Count reasoning tokens when reasoning ends
+                    if (
+                        self.reasoning_parser
+                        and reasoning_end_arr[i]
+                        and (not num_reasoning_tokens[i])
+                    ):
+                        num_reasoning_tokens[i] = count_reasoning_tokens(
+                            all_previous_token_ids[i], reasoning_parser.end_token_ids
+                        )
                     # if the message delta is None (e.g. because it was a
                     # "control token" for tool calls or the parser otherwise
                     # wasn't ready to send a token, then
@@ -1286,6 +1307,12 @@ class OpenAIServingChat(OpenAIServing):
                 if self.enable_prompt_tokens_details and num_cached_tokens:
                     final_usage.prompt_tokens_details = PromptTokenUsageInfo(
                         cached_tokens=num_cached_tokens
+                    )
+
+                if self.enable_completion_tokens_details and self.reasoning_parser:
+                    reasoning_tokens = sum(num_reasoning_tokens)
+                    final_usage.completion_tokens_details = CompletionTokensDetails(
+                        reasoning_tokens=reasoning_tokens - num_prompt_tokens
                     )
 
                 final_usage_chunk = ChatCompletionStreamResponse(
@@ -1620,9 +1647,14 @@ class OpenAIServingChat(OpenAIServing):
         num_prompt_tokens = len(final_res.prompt_token_ids)
         if final_res.encoder_prompt_token_ids is not None:
             num_prompt_tokens += len(final_res.encoder_prompt_token_ids)
-        num_generated_tokens = sum(
-            len(output.token_ids) for output in final_res.outputs
-        )
+        num_generated_tokens = 0
+        total_reasoning_tokens = 0
+        for output in final_res.outputs:
+            num_generated_tokens += len(output.token_ids)
+            if self.reasoning_parser:
+                total_reasoning_tokens += count_reasoning_tokens(
+                    output.token_ids, reasoning_parser.end_token_ids
+                )
         usage = UsageInfo(
             prompt_tokens=num_prompt_tokens,
             completion_tokens=num_generated_tokens,
@@ -1632,7 +1664,10 @@ class OpenAIServingChat(OpenAIServing):
             usage.prompt_tokens_details = PromptTokenUsageInfo(
                 cached_tokens=final_res.num_cached_tokens
             )
-
+        if self.enable_completion_tokens_details and total_reasoning_tokens:
+            usage.completion_tokens_details = CompletionTokensDetails(
+                reasoning_tokens=total_reasoning_tokens - num_prompt_tokens
+            )
         request_metadata.final_usage_info = usage
 
         response = ChatCompletionResponse(

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -46,6 +46,12 @@ class ReasoningParser:
         # whereas all tokenizers have .get_vocab()
         return self.model_tokenizer.get_vocab()
 
+    @property
+    @cached_property
+    def end_token_ids(self) -> list[int] | None:
+        """The token IDs that end reasoning content."""
+        return None
+
     @abstractmethod
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         """

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -43,6 +43,11 @@ class BaseThinkingReasoningParser(ReasoningParser):
         """The token that ends reasoning content."""
         raise NotImplementedError
 
+    @property
+    def end_token_ids(self) -> list[int] | None:
+        """The token IDs that end reasoning content."""
+        return [self.end_token_id]
+
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
         super().__init__(tokenizer, *args, **kwargs)
 

--- a/vllm/reasoning/deepseek_v3_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v3_reasoning_parser.py
@@ -34,6 +34,11 @@ class DeepSeekV3ReasoningParser(ReasoningParser):
         else:
             self._parser = IdentityReasoningParser(tokenizer, *args, **kwargs)
 
+    @property
+    def end_token_ids(self) -> list[int] | None:
+        """The token IDs that end reasoning content."""
+        return self._parser.end_token_ids
+
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return self._parser.is_reasoning_end(input_ids)
 

--- a/vllm/reasoning/gptoss_reasoning_parser.py
+++ b/vllm/reasoning/gptoss_reasoning_parser.py
@@ -75,6 +75,11 @@ class GptOssReasoningParser(ReasoningParser):
         self.reasoning_end_token_ids_suffix = self.model_tokenizer.encode("<|message|>")
         self.reasoning_max_num_between_tokens = 20
 
+    @property
+    def end_token_ids(self) -> list[int] | None:
+        """The token IDs that end reasoning content."""
+        return self.reasoning_end_token_ids_suffix
+
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         end_token_ids_prefix = self.reasoning_end_token_ids_prefix
         end_token_ids_suffix = self.reasoning_end_token_ids_suffix

--- a/vllm/reasoning/holo2_reasoning_parser.py
+++ b/vllm/reasoning/holo2_reasoning_parser.py
@@ -54,6 +54,10 @@ class Holo2ReasoningParser(ReasoningParser):
         else:
             self._parser = IdentityReasoningParser(tokenizer, *args, **kwargs)
 
+    @property
+    def end_token_ids(self) -> list[int] | None:
+        return self._parser.end_token_ids()
+
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return self._parser.is_reasoning_end(input_ids)
 

--- a/vllm/reasoning/holo2_reasoning_parser.py
+++ b/vllm/reasoning/holo2_reasoning_parser.py
@@ -56,7 +56,7 @@ class Holo2ReasoningParser(ReasoningParser):
 
     @property
     def end_token_ids(self) -> list[int] | None:
-        return self._parser.end_token_ids()
+        return self._parser.end_token_ids
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return self._parser.is_reasoning_end(input_ids)

--- a/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
+++ b/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
@@ -76,6 +76,11 @@ class HunyuanA13BReasoningParser(ReasoningParser):
         self.token_buffer = []
         self.text_buffer = ""
 
+    @property
+    def end_token_ids(self) -> list[int] | None:
+        """The token IDs that end reasoning content."""
+        return self.response_end_ids
+
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         return self.current_state == "response"
 

--- a/vllm/reasoning/step3_reasoning_parser.py
+++ b/vllm/reasoning/step3_reasoning_parser.py
@@ -40,6 +40,11 @@ class Step3ReasoningParser(ReasoningParser):
                 "token in the tokenizer!"
             )
 
+    @property
+    def end_token_ids(self) -> list[int] | None:
+        """The token IDs that end reasoning content."""
+        return [self.think_end_token_id]
+
     def extract_reasoning_streaming(
         self,
         previous_text: str,


### PR DESCRIPTION
The PR implements [OpenAI's new API](https://openai.com/index/api-prompt-caching/) and adds the number of reasoning token stats for each request.
```
usage: {
  total_tokens: 2306,
  prompt_tokens: 2006,
  completion_tokens: 300,
  
  prompt_tokens_details: {
    cached_tokens: 1920
  },
  completion_tokens_details: {
    reasoning_tokens: 0
  }
}
```
FIX https://github.com/vllm-project/vllm/issues/14335

```
vllm serve /mnt/data4/models/Qwen/Qwen3-0.6B --reasoning-parser qwen3 --enable-prompt-tokens-details --enable-force-include-usage --enable_completion_tokens_details
```



non-stream
```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "messages": [
      { "role": "system", "content": "9.11 and 9.8, which is greater?" }
    ]

  }'
```

```
{
  "id": "chatcmpl-a945fd50d94b2322",
  "object": "chat.completion",
  "created": 1767869673,
  "model": "/mnt/data4/models/Qwen/Qwen3-0.6B",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "\n\nTo determine which of the numbers **9.11** or **9.8** is greater, we compare them digit by digit:\n\n- Both numbers start with **9**.\n- The **tenths place** is the first differing digit: 1 in 9.11 vs. 8 in 9.8.\n- Since **1 < 8**, 9.11 is smaller than 9.8.\n\nTherefore, **9.8 is greater** than 9.11.\n\n$$\n\\boxed{9.8}\n$$",
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning": "\nOkay, so I need to figure out which of the numbers 9.11 or 9.8 is greater. Let me start by recalling how to compare numbers. I remember that when comparing decimals, the first digit that they differ in determines which number is larger. If they are the same up to the first digit, then we look at the next digit, and so on. If all digits are the same, then the numbers are equal.\n\nAlright, so let's compare 9.11 and 9.8. Let me write them down:\n\n9.11\n9.8\n\nFirst, both numbers start with the same digit, which is 9. Then, looking at the next digit, 1 in the tenths place for 9.11 and 8 in the tenths place for 9.8. Since 1 is less than 8, that means 9.11 is smaller than 9.8. Therefore, 9.8 is greater than 9.11.\n\nWait, let me double-check to make sure I didn't make a mistake. Maybe I should convert them to the same number of decimal places or something. Let's try converting both to two decimal places. 9.11 is already two decimal places. 9.8 is also two decimal places. Since the first digit after the decimal is 1 in 9.11 and 8 in 9.8, and 1 < 8, then 9.11 is indeed smaller. Yep, that seems right.\n\nAlternatively, I could think of this as 9.11 versus 9.8. Since 9.11 is less than 9.8, the answer should be 9.8. I don't think I made any mistakes here. It's straightforward. The key is to compare the first differing digit and then decide based on that.\n",
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": null,
      "token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 22,
    "total_tokens": 536,
    "completion_tokens": 514,
    "prompt_tokens_details": null,
    "completion_tokens_details": {
      "reasoning_tokens": 397
    }
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "kv_transfer_params": null
}

```

stream

```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "messages": [
      { "role": "system", "content": "9.11 and 9.8, which is greater?" }
    ],
    "stream": true
  }'

```


```
...
...
data: {"id":"chatcmpl-83169b5b6d07afc1","object":"chat.completion.chunk","created":1767869765,"model":"/mnt/data4/models/Qwen/Qwen3-0.6B","choices":[{"index":0,"delta":{"content":"","reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-83169b5b6d07afc1","object":"chat.completion.chunk","created":1767869765,"model":"/mnt/data4/models/Qwen/Qwen3-0.6B","choices":[],"usage":{"prompt_tokens":22,"total_tokens":679,"completion_tokens":657,"prompt_tokens_details":{"cached_tokens":16},"completion_tokens_details":{"reasoning_tokens":513}}}

data: [DONE]

```