### PR TITLE
S3 Tokenizer from model param

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -620,11 +620,18 @@ class ModelConfig:
             tokenizer: The tokenizer name or path.
 
         """
-        if is_s3(model) or is_s3(tokenizer):
+        if model == tokenizer:
+            s3_model = S3Model()
+            s3_model.pull_files(
+                model, allow_pattern=["*.model", "*.py", "*.json"])
+            self.model_weights = self.model
+            self.model = s3_model.dir
+            self.tokenizer = s3_model.dir
+        else:
             if is_s3(model):
                 s3_model = S3Model()
                 s3_model.pull_files(
-                    model, allow_pattern=["*.model", "*.py", "*.json"])
+                    model, allow_pattern=["*.pt", "*.safetensors", "*.bin"])
                 self.model_weights = self.model
                 self.model = s3_model.dir
 


### PR DESCRIPTION
This PR comes because of the following issue:
FIX https://github.com/vllm-project/vllm/issues/18016

Which describe further deeper issue, which is not handled in this PR.

There are 2 relevant flags:
1. Model - Mandatory
2. Tokenizer - Optional (= Model in case not supplied)

The issue comes from the fact that the `whisper tokenizer` search for the tokenizer fils in the model field and not tokenizer field.
That means if someone, without `runai_model_streamer` want to use whisper model with other tokenizer he is not able to.

Its relevant to `runai_model_streamer` s3 capabilities because we any case download it to different directories (1 for model and 2 for tokenizer files)

This change means that if the tokenizer not supplied and its exact as the model, download it all to single dir