### PR TITLE
[P/D] Heterogeneous TP

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
@@ -8,7 +8,9 @@ MODELS=(
 
 # Number of prefill and decode instances to create
 NUM_PREFILL_INSTANCES=${NUM_PREFILL_INSTANCES:-1} # Default to 1
-NUM_DECODE_INSTANCES=${NUM_DECODE_INSTANCES:-2}   # Default to 2
+NUM_DECODE_INSTANCES=${NUM_DECODE_INSTANCES:-1}   # Default to 1
+PREFILLER_TP_SIZE=${PREFILLER_TP_SIZE:-1}
+DECODER_TP_SIZE=${DECODER_TP_SIZE:-1}
 
 # Find the git repository root directory
 GIT_ROOT=$(git rev-parse --show-toplevel)
@@ -44,40 +46,6 @@ get_model_args() {
   echo "$extra_args"
 }
 
-set_cli_args() {
-  PREFILLER_TP_SIZE=1
-  DECODER_TP_SIZE=1
-  # Iterate through the rest of the arguments
-  while [[ $# -gt 0 ]]; do
-    echo $#
-    case "$1" in
-      --prefiller-tp-size)
-        if [[ -n "$2" ]]; then
-          PREFILLER_TP_SIZE="$2"
-          shift 2 # Consume the flag and its value ($2)
-        else
-          echo "Error: --prefiller-tp-size requires a value." >&2
-          exit 1
-        fi
-        ;;
-      --decoder-tp-size)
-        if [[ -n "$2" ]]; then
-          DECODER_TP_SIZE="$2"
-          shift 2
-        else
-          echo "Error: --decoder-tp-size requires a value." >&2
-          exit 1
-        fi
-        ;;
-      *)
-        # Handle any arguments not recognized
-        shift # Ignore unknown argument
-        ;;
-    esac
-  done
-}
-
-
 # Function to run tests for a specific model
 run_tests_for_model() {
   local model_name=$1
@@ -87,7 +55,6 @@ run_tests_for_model() {
 
   # Get model-specific arguments
   local model_args=$(get_model_args "$model_name")
-  set_cli_args "$@"
 
   # Arrays to store all hosts and ports
   PREFILL_HOSTS=()
@@ -100,15 +67,16 @@ run_tests_for_model() {
     # Calculate GPU ID - we'll distribute across available GPUs
     GPU_ID=$((i % $(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)))
 
+
     # Calculate port number (base port + instance number)
     PORT=$((8100 + i))
     # Calculate side channel port. Avoid clash with with TP workers. 
-    SIDE_CHANNEL_PORT=$((5559 + i * $PREFILLER_TP_SIZE))
+    SIDE_CHANNEL_PORT=$((5559 + i))
 
     echo "Starting prefill instance $i on GPU $GPU_ID, port $PORT"
 
     # Build the command with or without model-specific args
-    BASE_CMD="VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
     --port $PORT \
     --enforce-eager \
     --disable-log-requests \
@@ -137,12 +105,12 @@ run_tests_for_model() {
     # Calculate port number (base port + instance number)
     PORT=$((8200 + i))
     # Calculate side channel port
-    SIDE_CHANNEL_PORT=$((5659 + i * $PREFILLER_TP_SIZE))
+    SIDE_CHANNEL_PORT=$((5659 + i * $DECODER_TP_SIZE))
 
     echo "Starting decode instance $i on GPU $GPU_ID, port $PORT"
 
     # Build the command with or without model-specific args
-    BASE_CMD="VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
     --port $PORT \
     --enforce-eager \
     --disable-log-requests \
@@ -203,7 +171,7 @@ run_tests_for_model() {
 
 # Run tests for each model
 for model in "${MODELS[@]}"; do
-  run_tests_for_model "$model" "$@"
+  run_tests_for_model "$model"
 done
 
 echo "All tests completed!"

--- a/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
@@ -44,6 +44,39 @@ get_model_args() {
   echo "$extra_args"
 }
 
+set_cli_args() {
+  PREFILLER_TP_SIZE=1
+  DECODER_TP_SIZE=1
+  # Iterate through the rest of the arguments
+  while [[ $# -gt 0 ]]; do
+    echo $#
+    case "$1" in
+      --prefiller-tp-size)
+        if [[ -n "$2" ]]; then
+          PREFILLER_TP_SIZE="$2"
+          shift 2 # Consume the flag and its value ($2)
+        else
+          echo "Error: --prefiller-tp-size requires a value." >&2
+          exit 1
+        fi
+        ;;
+      --decoder-tp-size)
+        if [[ -n "$2" ]]; then
+          DECODER_TP_SIZE="$2"
+          shift 2
+        else
+          echo "Error: --decoder-tp-size requires a value." >&2
+          exit 1
+        fi
+        ;;
+      *)
+        # Handle any arguments not recognized
+        shift # Ignore unknown argument
+        ;;
+    esac
+  done
+}
+
 
 # Function to run tests for a specific model
 run_tests_for_model() {
@@ -54,6 +87,7 @@ run_tests_for_model() {
 
   # Get model-specific arguments
   local model_args=$(get_model_args "$model_name")
+  set_cli_args "$@"
 
   # Arrays to store all hosts and ports
   PREFILL_HOSTS=()
@@ -65,19 +99,21 @@ run_tests_for_model() {
   for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
     # Calculate GPU ID - we'll distribute across available GPUs
     GPU_ID=$((i % $(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)))
+
     # Calculate port number (base port + instance number)
     PORT=$((8100 + i))
-    # Calculate side channel port
-    SIDE_CHANNEL_PORT=$((5559 + i))
+    # Calculate side channel port. Avoid clash with with TP workers. 
+    SIDE_CHANNEL_PORT=$((5559 + i * $PREFILLER_TP_SIZE))
 
     echo "Starting prefill instance $i on GPU $GPU_ID, port $PORT"
 
     # Build the command with or without model-specific args
-    BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    BASE_CMD="VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
     --port $PORT \
     --enforce-eager \
     --disable-log-requests \
     --gpu-memory-utilization 0.2 \
+    --tensor-parallel-size $PREFILLER_TP_SIZE \
     --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
 
     if [ -n "$model_args" ]; then
@@ -97,19 +133,21 @@ run_tests_for_model() {
   for i in $(seq 0 $((NUM_DECODE_INSTANCES-1))); do
     # Calculate GPU ID - we'll distribute across available GPUs, starting from after prefill GPUs
     GPU_ID=$(((i + NUM_PREFILL_INSTANCES) % $(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)))
+
     # Calculate port number (base port + instance number)
     PORT=$((8200 + i))
     # Calculate side channel port
-    SIDE_CHANNEL_PORT=$((5659 + i))
+    SIDE_CHANNEL_PORT=$((5659 + i * $PREFILLER_TP_SIZE))
 
     echo "Starting decode instance $i on GPU $GPU_ID, port $PORT"
 
     # Build the command with or without model-specific args
-    BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    BASE_CMD="VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
     --port $PORT \
     --enforce-eager \
     --disable-log-requests \
     --gpu-memory-utilization 0.2 \
+    --tensor-parallel-size $DECODER_TP_SIZE \
     --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
 
     if [ -n "$model_args" ]; then
@@ -165,7 +203,7 @@ run_tests_for_model() {
 
 # Run tests for each model
 for model in "${MODELS[@]}"; do
-  run_tests_for_model "$model"
+  run_tests_for_model "$model" "$@"
 done
 
 echo "All tests completed!"

--- a/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
+++ b/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
@@ -151,8 +151,18 @@ async def send_request_to_service(client_info: dict, endpoint: str,
     Send a request to a service using a client from the pool.
     """
     req_data = req_data.copy()
-    req_data['do_remote_decode'] = True
+    req_data['kv_transfer_params'] = {
+        "do_remote_decode": True,
+        "do_remote_prefill": False,
+        "remote_engine_id": None,
+        "remote_block_ids": None,
+        "remote_host": None,
+        "remote_port": None
+    }
     req_data["stream"] = False
+    req_data["max_tokens"] = 1
+    if "stream_options" in req_data:
+        del req_data["stream_options"]
     headers = {
         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
         "X-Request-Id": request_id
@@ -167,9 +177,7 @@ async def send_request_to_service(client_info: dict, endpoint: str,
 
 
 async def stream_service_response(client_info: dict, endpoint: str,
-                                  req_data: dict, remote_block_ids: list[int],
-                                  remote_engine_id: str, remote_host: str,
-                                  remote_port: int, request_id: str):
+                                  req_data: dict, request_id: str):
     """
     Asynchronously stream response from a service using a client from the pool.
     """
@@ -177,12 +185,6 @@ async def stream_service_response(client_info: dict, endpoint: str,
         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
         "X-Request-Id": request_id
     }
-    req_data = req_data.copy()
-    req_data['do_remote_prefill'] = True
-    req_data["remote_block_ids"] = remote_block_ids
-    req_data['remote_engine_id'] = remote_engine_id
-    req_data["remote_host"] = remote_host
-    req_data["remote_port"] = remote_port
 
     async with client_info['client'].stream("POST",
                                             endpoint,
@@ -209,10 +211,9 @@ async def handle_completions(request: Request):
 
         # Extract the needed fields
         response_json = response.json()
-        remote_block_ids = response_json.get('remote_block_ids', [])
-        remote_engine_id = response_json.get('remote_engine_id', '')
-        remote_host = response_json.get('remote_host', '')
-        remote_port = response_json.get('remote_port', 0)
+        kv_transfer_params = response_json.get('kv_transfer_params', {})
+        if kv_transfer_params:
+            req_data["kv_transfer_params"] = kv_transfer_params
 
         # Get the next decode client in round-robin fashion
         decode_client_info = get_next_client(request.app, 'decode')
@@ -221,15 +222,10 @@ async def handle_completions(request: Request):
 
         # Stream response from decode service
         async def generate_stream():
-            async for chunk in stream_service_response(
-                    decode_client_info,
-                    "/completions",
-                    req_data,
-                    remote_block_ids=remote_block_ids,
-                    remote_engine_id=remote_engine_id,
-                    remote_host=remote_host,
-                    remote_port=remote_port,
-                    request_id=request_id):
+            async for chunk in stream_service_response(decode_client_info,
+                                                       "/completions",
+                                                       req_data,
+                                                       request_id=request_id):
                 yield chunk
 
         return StreamingResponse(generate_stream(),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -845,7 +845,9 @@ class NixlConnectorWorker:
         # just notify P worker that we have the blocks we need.
         num_local_blocks = len(local_block_ids)
         if num_local_blocks == 0:
-            self.nixl_wrapper.send_notif(dst_engine_id, notif_msg=notif_id)
+            remote_rank = self.rank // tp_ratio
+            remote_agent = self._remote_agents[dst_engine_id][remote_rank]
+            self.nixl_wrapper.send_notif(remote_agent, notif_msg=notif_id)
             return
 
         # Partial prefix cache hit: just read uncomputed blocks.
@@ -912,7 +914,7 @@ class NixlConnectorWorker:
         self.nixl_wrapper.transfer(handle)
 
         # Use handle to check completion in future step().
-        # TODO surface xfer elapsed time
+        # TODO (NickLucche) surface xfer elapsed time
         self._recving_transfers[request_id].append(
             (handle, time.perf_counter()))
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -763,8 +763,8 @@ class NixlConnectorWorker:
                 req_id, tp_ratio = notif.decode("utf-8").rsplit(":", 1)
                 self.consumer_notification_counts_by_req[req_id] += 1
                 # Wait all consumers (D) to be done reading before freeing.
-                if self.consumer_notification_counts_by_req[
-                        req_id] == tp_ratio:
+                if self.consumer_notification_counts_by_req[req_id] == int(
+                        tp_ratio):
                     notified_req_ids.add(req_id)
                     del self.consumer_notification_counts_by_req[req_id]
         return notified_req_ids
@@ -929,6 +929,7 @@ class NixlConnectorWorker:
         If layer_idx is provided, we use the region_ids for the given layer.
         Otherwise, we use all regions.
         """
+        # TODO TP docs
 
         if layer_idx is None:
             region_ids = range(self.num_regions)
@@ -951,9 +952,9 @@ class NixlConnectorWorker:
         descs_ids: list[int] = []
         for reg_id in region_ids:
             for block_id in block_ids:
-                for kv_block in range(self.block_size):
+                for slot_id in range(self.block_size):
                     descs_ids.append(reg_id * num_blocks * self.block_size +
-                                     block_id * self.block_size + kv_block)
+                                     block_id * self.block_size + slot_id)
         return descs_ids
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -782,8 +782,7 @@ class NixlConnectorWorker:
             for handle, xfer_stime in handles:
                 xfer_state = self.nixl_wrapper.check_xfer_state(handle)
                 if xfer_state == "DONE":
-                    # TODO ptarasiewicz: why abort is throwing errors?
-                    # self.nixl_wrapper.release_xfer_handle(handle)
+                    self.nixl_wrapper.release_xfer_handle(handle)
                     done_req_ids.add(req_id)
                     del transfers[req_id]
                 elif xfer_state == "PROC":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -949,6 +949,11 @@ class Scheduler(SchedulerInterface):
             return False, None
         assert len(self.kv_cache_config.kv_cache_groups
                    ) == 1, "KV connector only supports one KV cache group now"
+        if (request.status == RequestStatus.FINISHED_ABORTED and \
+            request.request_id not in
+            self.kv_cache_manager.single_type_manager.req_to_blocks):
+            return False, None
+
         block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
         return self.connector.request_finished(request, block_ids)
 


### PR DESCRIPTION
### What this PR does:

- Adds support for heterogenous TP sizes. So far tested with P_TP=1 and D_TP=2/4.
- It does so by splitting the remote kv cache among D_TP/P_TP D workers along the kv_head dim. block_size and kv precision must match. 
-  (JIT) Discovery is done by first querying the rank0 of the dst_engine_id to get the TP size of destination group. After that, every D TP worker will only pull from a single remote P TP worker, hence the setup only requires two exchanges on the side channel (rank0 and target rank_j).
  
### How to test

```
DECODER_TP_SIZE=2 PREFILLER_TP_SIZE=2 NUM_DECODE_INSTANCES=1 bash tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh 
```


DP TP worker rank and kv split assignment:

![image](https://github.com/user-attachments/assets/3084de55-613b-49b8-a4c5-c655c96d08b1)