### PR TITLE
[Bugfix] fix moe marlin `topk_weight` loading

### DIFF
--- a/csrc/moe/marlin_moe_wna16/marlin_template.h
+++ b/csrc/moe/marlin_moe_wna16/marlin_template.h
@@ -473,15 +473,15 @@ __global__ void Marlin(
       if (mul_topk_weights) {
   #pragma unroll
         for (int i = 0; i < 4; i++) {
+          int idx = tid4 * 4 + i;
+          idx = idx < block_num_valid_tokens ? idx : 0;
           if constexpr (w_type == vllm::kFE2M1f) {
-            sh_block_topk_weights[tid4 * 4 + i] = __hmul2(
-                global_scale,
-                Dtype::num2num2(Dtype::float2num(
-                    topk_weights_ptr[sh_block_sorted_ids[tid4 * 4 + i]])));
+            sh_block_topk_weights[idx] = __hmul2(
+                global_scale, Dtype::num2num2(Dtype::float2num(
+                                  topk_weights_ptr[sh_block_sorted_ids[idx]])));
           } else {
-            sh_block_topk_weights[tid4 * 4 + i] =
-                Dtype::num2num2(Dtype::float2num(
-                    topk_weights_ptr[sh_block_sorted_ids[tid4 * 4 + i]]));
+            sh_block_topk_weights[idx] = Dtype::num2num2(
+                Dtype::float2num(topk_weights_ptr[sh_block_sorted_ids[idx]]));
           }
         }
       }


### PR DESCRIPTION
Fix moe marlin cuda error:

```
...
  File "/root/miniconda3/lib/python3.10/site-packages/vllm/model_executor/layers/fused_moe/layer.py", line 875, in forward_impl
    final_hidden_states = self.quant_method.apply(
  File "/root/miniconda3/lib/python3.10/site-packages/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py", line 342, in apply
    return torch.ops.vllm.fused_marlin_moe(
  File "/root/miniconda3/lib/python3.10/site-packages/torch/_ops.py", line 1123, in __call__
    return self._op(*args, **(kwargs or {}))
  File "/root/miniconda3/lib/python3.10/site-packages/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py", line 196, in fused_marlin_moe
    return torch.sum(intermediate_cache3.view(*intermediate_cache3.shape),
RuntimeError: CUDA error: an illegal memory access was encountered
```

@mgoin 