### PR TITLE
[Bugfix][V1] Fix FlashInfer V1 backend using the wrong VllmConfig

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -14,8 +14,7 @@ import vllm.envs as envs
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionType)
 from vllm.attention.layer import Attention
-from vllm.config import (VllmConfig, get_current_vllm_config,
-                         get_layers_from_vllm_config)
+from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.flash_attn import use_cascade_attention
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
@@ -215,7 +214,7 @@ class FlashInferMetadataBuilder:
         # Global hyperparameters shared by all attention layers
         self.global_hyperparameters: Optional[PerLayerParameters] = None
 
-        self.vllm_config = get_current_vllm_config()
+        self.vllm_config = runner.vllm_config
         self.kv_cache_spec = kv_cache_spec
         self.block_table = block_table
 


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/pull/17483#issuecomment-2875609788

Thanks to @chenyang78 for reporting and @heheda12345 for the fix.

The global vllm config may not be set by `set_current_vllm_config`, so we should read it from runner directly so `self.vllm_config = runner.vllm_config`. This is already what FlashInfer V0 does so this was likely just an oversight https://github.com/vllm-project/vllm/blob/19324d660c61a63c6ea3dfbb18995d255c05ee6d/vllm/attention/backends/flashinfer.py#L200

Before:
```
VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER lm_eval --model vllm --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto 

assert len(per_layer_params) > 0, "No attention layers found in the model."
```

After:
```
VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER lm_eval --model vllm --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto 

vllm (pretrained=meta-llama/Llama-3.1-8B-Instruct,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7892|±  |0.0112|
|     |       |strict-match    |     5|exact_match|↑  |0.7635|±  |0.0117|
```
