### PR TITLE
[doc] fix multimodal example script

### DIFF
--- a/examples/online_serving/openai_chat_completion_client_for_multimodal.py
+++ b/examples/online_serving/openai_chat_completion_client_for_multimodal.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""An example showing how to use vLLM to serve multimodal models 
+"""An example showing how to use vLLM to serve multimodal models
 and run online serving with OpenAI client.
 
 Launch the vLLM server with the following command:
@@ -12,12 +12,18 @@ vllm serve microsoft/Phi-3.5-vision-instruct --task generate \
     --trust-remote-code --max-model-len 4096 --limit-mm-per-prompt '{"image":2}'
 
 (audio inference with Ultravox)
-vllm serve fixie-ai/ultravox-v0_5-llama-3_2-1b --max-model-len 4096
+vllm serve fixie-ai/ultravox-v0_5-llama-3_2-1b \
+    --max-model-len 4096 --trust-remote-code
+
+run the script with
+python openai_chat_completion_client_for_multimodal.py --chat-type audio
 """
+
 import base64
 
 import requests
 from openai import OpenAI
+from utils import get_first_model
 
 from vllm.utils import FlexibleArgumentParser
 
@@ -31,9 +37,6 @@ client = OpenAI(
     base_url=openai_api_base,
 )
 
-models = client.models.list()
-model = models.data[0].id
-
 
 def encode_base64_content_from_url(content_url: str) -> str:
     """Encode a content retrieved from a remote url to base64 format."""
@@ -46,7 +49,7 @@ def encode_base64_content_from_url(content_url: str) -> str:
 
 
 # Text-only inference
-def run_text_only() -> None:
+def run_text_only(model: str) -> None:
     chat_completion = client.chat.completions.create(
         messages=[{
             "role": "user",
@@ -61,7 +64,7 @@ def run_text_only() -> None:
 
 
 # Single-image input inference
-def run_single_image() -> None:
+def run_single_image(model: str) -> None:
 
     ## Use image url in the payload
     image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
@@ -117,7 +120,7 @@ def run_single_image() -> None:
 
 
 # Multi-image input inference
-def run_multi_image() -> None:
+def run_multi_image(model: str) -> None:
     image_url_duck = "https://upload.wikimedia.org/wikipedia/commons/d/da/2015_Kaczka_krzy%C5%BCowka_w_wodzie_%28samiec%29.jpg"
     image_url_lion = "https://upload.wikimedia.org/wikipedia/commons/7/77/002_The_lion_king_Snyggve_in_the_Serengeti_National_Park_Photo_by_Giles_Laurent.jpg"
     chat_completion_from_url = client.chat.completions.create(
@@ -152,7 +155,7 @@ def run_multi_image() -> None:
 
 
 # Video input inference
-def run_video() -> None:
+def run_video(model: str) -> None:
     video_url = "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4"
     video_base64 = encode_base64_content_from_url(video_url)
 
@@ -208,7 +211,7 @@ def run_video() -> None:
 
 
 # Audio input inference
-def run_audio() -> None:
+def run_audio(model: str) -> None:
     from vllm.assets.audio import AudioAsset
 
     audio_url = AudioAsset("winning_call").url
@@ -318,7 +321,8 @@ def parse_args():
 
 def main(args) -> None:
     chat_type = args.chat_type
-    example_function_map[chat_type]()
+    model = get_first_model(client)
+    example_function_map[chat_type](model)
 
 
 if __name__ == "__main__":

--- a/examples/online_serving/utils.py
+++ b/examples/online_serving/utils.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+from openai import APIConnectionError, OpenAI
+from openai.pagination import SyncPage
+from openai.types.model import Model
+
+
+def get_first_model(client: OpenAI) -> str:
+    """
+    Get the first model from the vLLM server.
+    """
+    try:
+        models: SyncPage[Model] = client.models.list()
+    except APIConnectionError as e:
+        raise RuntimeError(
+            "Failed to get the list of models from the vLLM server at "
+            f"{client.base_url} with API key {client.api_key}. Check\n"
+            "1. the server is running\n"
+            "2. the server URL is correct\n"
+            "3. the API key is correct") from e
+
+    if len(models.data) == 0:
+        raise RuntimeError(
+            f"No models found on the vLLM server at {client.base_url}")
+
+    return models.data[0].id


### PR DESCRIPTION
We can't run the script with `--help` to see the help message without connecting to a running vLLM server. This change allows us to do that.

We also improve the error message when the script cannot get a list of models
from vLLM.

```
RuntimeError: Failed to get the list of models from the vLLM server at http://localhost:8000/v1 with API key EMPTY. Check
1. the server is running
2. the server URL is correct
3. the API key is correct
```

<details>
<summary>before</summary>

```bash
$ python examples/online_serving/openai_chat_completion_client_for_multimodal.py 
INFO 05-13 16:12:29 [__init__.py:248] Automatically detected platform cpu.
Traceback (most recent call last):
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 72, in map_httpcore_exceptions
    yield
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 236, in handle_request
    resp = self._pool.handle_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection_pool.py", line 216, in handle_request
    raise exc from None
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection_pool.py", line 196, in handle_request
    response = connection.handle_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection.py", line 99, in handle_request
    raise exc
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection.py", line 76, in handle_request
    stream = self._connect(request)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection.py", line 122, in _connect
    stream = self._network_backend.connect_tcp(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_backends/sync.py", line 205, in connect_tcp
    with map_exceptions(exc_map):
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.ConnectError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 989, in _request
    response = self._client.send(
               ^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 926, in send
    response = self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 954, in _send_handling_auth
    response = self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 991, in _send_handling_redirects
    response = self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1027, in _send_single_request
    response = transport.handle_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 235, in handle_request
    with map_httpcore_exceptions():
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 89, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/examples/online_serving/openai_chat_completion_client_for_multimodal.py", line 34, in <module>
    models = client.models.list()
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/resources/models.py", line 91, in list
    return self._get_api_list(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1325, in get_api_list
    return self._request_api_list(model, page, opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1176, in _request_api_list
    return self.request(page, options, stream=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 949, in request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1013, in _request
    return self._retry_request(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1091, in _retry_request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1013, in _request
    return self._retry_request(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1091, in _retry_request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1023, in _request
    raise APIConnectionError(request=request) from err
openai.APIConnectionError: Connection error.
```
</details>

<details>
<summary>after</summary>

```bash
$ python examples/online_serving/openai_chat_completion_client_for_multimodal.py 
INFO 05-13 16:09:22 [__init__.py:248] Automatically detected platform cpu.
Traceback (most recent call last):
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 72, in map_httpcore_exceptions
    yield
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 236, in handle_request
    resp = self._pool.handle_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection_pool.py", line 216, in handle_request
    raise exc from None
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection_pool.py", line 196, in handle_request
    response = connection.handle_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection.py", line 99, in handle_request
    raise exc
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection.py", line 76, in handle_request
    stream = self._connect(request)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_sync/connection.py", line 122, in _connect
    stream = self._network_backend.connect_tcp(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_backends/sync.py", line 205, in connect_tcp
    with map_exceptions(exc_map):
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.ConnectError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 989, in _request
    response = self._client.send(
               ^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 926, in send
    response = self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 954, in _send_handling_auth
    response = self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 991, in _send_handling_redirects
    response = self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1027, in _send_single_request
    response = transport.handle_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 235, in handle_request
    with map_httpcore_exceptions():
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 89, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/examples/online_serving/openai_chat_completion_client_for_multimodal.py", line 314, in get_model
    models: SyncPage[Model] = client.models.list()
                              ^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/resources/models.py", line 91, in list
    return self._get_api_list(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1325, in get_api_list
    return self._request_api_list(model, page, opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1176, in _request_api_list
    return self.request(page, options, stream=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 949, in request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1013, in _request
    return self._retry_request(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1091, in _retry_request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1013, in _request
    return self._retry_request(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1091, in _retry_request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1023, in _request
    raise APIConnectionError(request=request) from err
openai.APIConnectionError: Connection error.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/examples/online_serving/openai_chat_completion_client_for_multimodal.py", line 350, in <module>
    main(args)
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/examples/online_serving/openai_chat_completion_client_for_multimodal.py", line 344, in main
    model = get_model()
            ^^^^^^^^^^^
  File "/home/dxia/src/github.com/vllm-project/vllm-upstream/examples/online_serving/openai_chat_completion_client_for_multimodal.py", line 316, in get_model
    raise RuntimeError(
RuntimeError: Failed to get the list of models from the vLLM server at http://localhost:8000/v1 with API key EMPTY. Check
1. the server is running
2. the server URL is correct
3. the API key is correct
```
</details>