### PR TITLE
Support custom implementations of VideoLoader backends.

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import numpy.typing as npt
 
 from vllm.multimodal.video import VIDEO_LOADER_REGISTRY, VideoLoader
-
 
 NUM_FRAMES = 10
 FAKE_OUTPUT_1 = np.random.rand(NUM_FRAMES, 1280, 720, 3)
@@ -16,7 +16,7 @@ class TestVideoLoader1(VideoLoader):
     def load_bytes(cls, data: bytes, num_frames: int = -1) -> npt.NDArray:
         return FAKE_OUTPUT_1
 
-    
+
 @VIDEO_LOADER_REGISTRY.register("test_video_loader_2")
 class TestVideoLoader2(VideoLoader):
 

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import numpy.typing as npt
+import pytest
 
 from vllm.multimodal.video import VIDEO_LOADER_REGISTRY, VideoLoader
 
@@ -33,3 +34,8 @@ def test_video_loader_registry():
     custom_loader_2 = VIDEO_LOADER_REGISTRY.load("test_video_loader_2")
     output_2 = custom_loader_2.load_bytes(b"test")
     np.testing.assert_array_equal(output_2, FAKE_OUTPUT_2)
+
+
+def test_video_loader_type_doesnt_exist():
+    with pytest.raises(AssertionError):
+        VIDEO_LOADER_REGISTRY.load("non_existing_video_loader")

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,0 +1,35 @@
+import numpy as np
+import numpy.typing as npt
+
+from vllm.multimodal.video import VIDEO_LOADER_REGISTRY, VideoLoader
+
+
+NUM_FRAMES = 10
+FAKE_OUTPUT_1 = np.random.rand(NUM_FRAMES, 1280, 720, 3)
+FAKE_OUTPUT_2 = np.random.rand(NUM_FRAMES, 1280, 720, 3)
+
+
+@VIDEO_LOADER_REGISTRY.register("test_video_loader_1")
+class TestVideoLoader1(VideoLoader):
+
+    @classmethod
+    def load_bytes(cls, data: bytes, num_frames: int = -1) -> npt.NDArray:
+        return FAKE_OUTPUT_1
+
+    
+@VIDEO_LOADER_REGISTRY.register("test_video_loader_2")
+class TestVideoLoader2(VideoLoader):
+
+    @classmethod
+    def load_bytes(cls, data: bytes, num_frames: int = -1) -> npt.NDArray:
+        return FAKE_OUTPUT_2
+
+
+def test_video_loader_registry():
+    custom_loader_1 = VIDEO_LOADER_REGISTRY.load("test_video_loader_1")
+    output_1 = custom_loader_1.load_bytes(b"test")
+    np.testing.assert_array_equal(output_1, FAKE_OUTPUT_1)
+
+    custom_loader_2 = VIDEO_LOADER_REGISTRY.load("test_video_loader_2")
+    output_2 = custom_loader_2.load_bytes(b"test")
+    np.testing.assert_array_equal(output_2, FAKE_OUTPUT_2)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     VLLM_VIDEO_FETCH_TIMEOUT: int = 30
     VLLM_AUDIO_FETCH_TIMEOUT: int = 10
     VLLM_MM_INPUT_CACHE_GIB: int = 8
+    VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
     VLLM_TARGET_DEVICE: str = "cuda"
     MAX_JOBS: Optional[str] = None
     NVCC_THREADS: Optional[str] = None
@@ -115,7 +116,6 @@ if TYPE_CHECKING:
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
-    VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
 
 
 def get_default_cache_root():
@@ -446,6 +446,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_AUDIO_FETCH_TIMEOUT":
     lambda: int(os.getenv("VLLM_AUDIO_FETCH_TIMEOUT", "10")),
 
+    # Backend for Video IO
+    # - "opencv": Default backend that uses OpenCV stream buffered backend.
+    #
+    # Custom backend implementations can be registered
+    # via `@VIDEO_LOADER_REGISTRY.register("my_custom_video_loader")` and
+    # imported at runtime.
+    # If a non-existing backend is used, an AssertionError will be thrown.
+    "VLLM_VIDEO_LOADER_BACKEND":
+    lambda: os.getenv("VLLM_VIDEO_LOADER_BACKEND", "opencv"),
+
     # Cache size (in GiB) for multimodal input cache
     # Default is 4 GiB
     "VLLM_MM_INPUT_CACHE_GIB":
@@ -765,10 +775,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_PORT":
     lambda: int(os.getenv("VLLM_NIXL_SIDE_CHANNEL_PORT", "5557")),
-
-    # Backend for Video IO
-    "VLLM_VIDEO_LOADER_BACKEND":
-    lambda: os.getenv("VLLM_VIDEO_LOADER_BACKEND", "opencv"),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -55,8 +55,8 @@ if TYPE_CHECKING:
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
     VLLM_VIDEO_FETCH_TIMEOUT: int = 30
     VLLM_AUDIO_FETCH_TIMEOUT: int = 10
-    VLLM_MM_INPUT_CACHE_GIB: int = 8
     VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
+    VLLM_MM_INPUT_CACHE_GIB: int = 8
     VLLM_TARGET_DEVICE: str = "cuda"
     MAX_JOBS: Optional[str] = None
     NVCC_THREADS: Optional[str] = None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -115,6 +115,7 @@ if TYPE_CHECKING:
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
+    VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
 
 
 def get_default_cache_root():
@@ -764,6 +765,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_PORT":
     lambda: int(os.getenv("VLLM_NIXL_SIDE_CHANNEL_PORT", "5557")),
+
+    # Backend for Video IO
+    "VLLM_VIDEO_LOADER_BACKEND":
+    lambda: os.getenv("VLLM_VIDEO_LOADER_BACKEND", "opencv"),
 }
 
 # end-env-vars-definition

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -70,7 +70,7 @@ class VideoLoaderRegistry:
     @staticmethod
     def load(cls_name: str) -> VideoLoader:
         cls = VIDEO_LOADER_REGISTRY.name2class.get(cls_name)
-        assert cls is not None, f"Class {cls_name} not found"
+        assert cls is not None, f"VideoLoader class {cls_name} not found"
         return cls()
 
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -4,7 +4,7 @@ import base64
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import Type
+
 import numpy as np
 import numpy.typing as npt
 from PIL import Image
@@ -56,7 +56,7 @@ class VideoLoader:
 class VideoLoaderRegistry:
 
     def __init__(self) -> None:
-        self.name2class: dict[str, Type] = {}
+        self.name2class: dict[str, type] = {}
 
     def register(self, name: str):
         def wrap(cls_to_register):

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -9,9 +9,10 @@ import numpy as np
 import numpy.typing as npt
 from PIL import Image
 
+from vllm import envs
+
 from .base import MediaIO
 from .image import ImageMediaIO
-from vllm import envs
 
 
 def resize_video(frames: npt.NDArray, size: tuple[int, int]) -> npt.NDArray:
@@ -59,6 +60,7 @@ class VideoLoaderRegistry:
         self.name2class: dict[str, type] = {}
 
     def register(self, name: str):
+
         def wrap(cls_to_register):
             self.name2class[name] = cls_to_register
             return cls_to_register
@@ -66,9 +68,7 @@ class VideoLoaderRegistry:
         return wrap
 
     @staticmethod
-    def load(
-        cls_name: str
-    ) -> VideoLoader:
+    def load(cls_name: str) -> VideoLoader:
         cls = VIDEO_LOADER_REGISTRY.name2class.get(cls_name)
         assert cls is not None, f"Class {cls_name} not found"
         return cls()

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
+from abc import abstractmethod
 from functools import partial
 from io import BytesIO
 from pathlib import Path
@@ -50,7 +51,8 @@ def sample_frames_from_video(frames: npt.NDArray,
 class VideoLoader:
 
     @classmethod
-    def load_bytes(self, data: bytes, num_frames: int = -1) -> npt.NDArray:
+    @abstractmethod
+    def load_bytes(cls, data: bytes, num_frames: int = -1) -> npt.NDArray:
         raise NotImplementedError
 
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -4,7 +4,7 @@ import base64
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-
+from typing import Type
 import numpy as np
 import numpy.typing as npt
 from PIL import Image
@@ -56,7 +56,7 @@ class VideoLoader:
 class VideoLoaderRegistry:
 
     def __init__(self) -> None:
-        self.name2class = {}
+        self.name2class: dict[str, Type] = {}
 
     def register(self, name: str):
         def wrap(cls_to_register):


### PR DESCRIPTION
Support custom implementations of VideoLoader backends.

Summary:
Currently, only OpenCV-based VideoLoader backend is supported, which depends on the opencv-python-headless library. This can sometimes cause dependency conflicts in runtimes. In this diff, we created a VideoLoaderRegistry that allows custom implementations of VideoLoader backends to be plugged in, instead of having a hard dependency on opencv headless.

Test Plan:
- Unit test
- Meta-internal implementation of video loader.
- `vllm serve` with video_url

Reviewers:

Subscribers:

Tasks:

Tags:



<!--- pyml disable-next-line no-emphasis-as-heading -->
