### PR TITLE
[Bugfix][ROCm] fix the power of 2 exception from triton_unified_attention.py when running llama4 models and unit test fix

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -13,7 +13,9 @@ HEAD_SIZES = [128, 256]
 BLOCK_SIZES = [16, 32]
 
 DTYPES = [torch.float16, torch.bfloat16]
-QDTYPES = [None, torch.float8_e4m3fn]
+QDTYPES = [None, torch.float8_e4m3fn] if not current_platform.is_rocm() else [
+    None, torch.float8_e4m3fnuz
+]
 # one value large enough to test overflow in index calculation.
 # one value small enough to test the schema op check
 NUM_BLOCKS = [32768, 2048]

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -294,10 +294,6 @@ def unified_attention(
     #   <= floor(\sum_i(query_len[i]) / BLOCK_Q) + num_seqs
     #    = floor(q.shape[0] / BLOCK_Q) + num_seqs
     total_num_q_blocks = q.shape[0] // BLOCK_Q + num_seqs
-    
-    print(f"grid size dimention 0: total_num_q_blocks: {total_num_q_blocks}")
-    print(f"grid_size_dimention 1: num_kv_heads: {num_kv_heads}")
-
 
     kernel_unified_attention_2d[(
         total_num_q_blocks,

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -64,7 +64,7 @@ def kernel_unified_attention_2d(
     query_start_len_ptr,  # [num_seqs+1]
     BLOCK_Q: tl.constexpr,  # int
     num_seqs: tl.int32,
-    BLOCK_Q_NUM_QUERY_PER_KV_PADDED: tl.constexpr,  # int, must be power of 2
+    BLOCK_M: tl.constexpr,  # int
 ):
 
     q_block_global_idx = tl.program_id(0)
@@ -95,37 +95,21 @@ def kernel_unified_attention_2d(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
-    # Use power of 2 for arange
-    offs_m = tl.arange(0, BLOCK_Q_NUM_QUERY_PER_KV_PADDED)
-    # Create a mask for valid indices
-    m_mask = offs_m < (BLOCK_Q * num_queries_per_kv)
-
+    offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+    query_pos = q_block_local_idx * BLOCK_Q + offs_m // num_queries_per_kv
 
-    # Only use valid indices from offs_m
-    query_pos = q_block_local_idx * BLOCK_Q + (offs_m // num_queries_per_kv)
-
-    # Apply mask for valid positions
-    query_pos_valid = tl.where(m_mask, query_pos, 0)
-
-    query_offset_0 = cur_batch_in_all_start_index + query_pos_valid
+    query_offset_0 = cur_batch_in_all_start_index + query_pos
     query_offset_1 = kv_head_idx * num_queries_per_kv + \
-        (offs_m % num_queries_per_kv)
-
-    # Apply mask for valid offsets
-    query_offset_1_valid = tl.where(m_mask, query_offset_1, 0)
-
+        offs_m % num_queries_per_kv
     query_offset = (query_offset_0[:, None] * query_stride_0 +
-                    query_offset_1_valid[:, None] * query_stride_1 +
-                    offs_d[None, :])
+                    query_offset_1[:, None] * query_stride_1 + offs_d[None, :])
 
     dim_mask = tl.where(offs_d < HEAD_SIZE, 1, 0).to(tl.int1)
-    query_mask_0 = tl.where((query_pos_valid < cur_batch_query_len) & m_mask,
-                            1, 0).to(tl.int1)
-    query_mask_1 = tl.where((query_offset_1_valid < num_query_heads) & m_mask,
-                            1, 0).to(tl.int1)
+    query_mask_0 = tl.where(query_pos < cur_batch_query_len, 1, 0).to(tl.int1)
+    query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
 
-    # Q : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED, HEAD_SIZE_PADDED)
+    # Q : (BLOCK_M, HEAD_SIZE_PADDED)
     Q = tl.load(
         query_ptr + query_offset,
         mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
@@ -134,11 +118,11 @@ def kernel_unified_attention_2d(
 
     block_table_offset = seq_idx * block_table_stride
 
-    M = tl.full([BLOCK_Q_NUM_QUERY_PER_KV_PADDED],
+    M = tl.full([BLOCK_M],
                 float("-inf"),
                 dtype=tl.float32)
-    L = tl.full([BLOCK_Q_NUM_QUERY_PER_KV_PADDED], 1.0, dtype=tl.float32)
-    acc = tl.zeros([BLOCK_Q_NUM_QUERY_PER_KV_PADDED, HEAD_SIZE_PADDED],
+    L = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_SIZE_PADDED],
                    dtype=tl.float32)
 
     # sequence len for this particular sequence
@@ -149,7 +133,7 @@ def kernel_unified_attention_2d(
 
     # alibi slope for this head
     if USE_ALIBI_SLOPES:
-        alibi_slope = tl.load(alibi_slopes_ptr + query_offset_1_valid,
+        alibi_slope = tl.load(alibi_slopes_ptr + query_offset_1,
                               mask=query_mask_1,
                               other=0.0)
 
@@ -160,7 +144,6 @@ def kernel_unified_attention_2d(
 
         physical_block_idx = tl.load(block_tables_ptr + block_table_offset + j)
 
-        # BLOCK_SIZE is already a power of 2, so we can use it directly
         offs_n = tl.arange(0, BLOCK_SIZE)
 
         v_offset = (physical_block_idx * stride_v_cache_0 +
@@ -202,10 +185,10 @@ def kernel_unified_attention_2d(
         seq_offset = j * BLOCK_SIZE + offs_n
 
         seq_mask = seq_offset[
-            None, :] < context_len + query_pos_valid[:, None] + 1
+            None, :] < context_len + query_pos[:, None] + 1
 
-        # S : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED, BLOCK_SIZE)
-        S = tl.zeros(shape=(BLOCK_Q_NUM_QUERY_PER_KV_PADDED, BLOCK_SIZE),
+        # S : (BLOCK_M, BLOCK_SIZE)
+        S = tl.zeros(shape=(BLOCK_M, BLOCK_SIZE),
                      dtype=tl.float32)
 
         S += scale * tl.dot(Q, K)
@@ -213,56 +196,53 @@ def kernel_unified_attention_2d(
         if USE_SOFTCAP:
             S = apply_softcap(S, softcap)
 
-        S = tl.where(
-            query_mask_1[:, None] & query_mask_0[:, None] & seq_mask
-            & m_mask[:, None], S, float("-inf"))
+        S = tl.where(query_mask_1[:, None] & query_mask_0[:, None] & seq_mask,
+                     S, float("-inf"))
 
         if SLIDING_WINDOW > 0:
-            S = tl.where(
-                (context_len + query_pos_valid[:, None] - seq_offset[None, :])
-                < SLIDING_WINDOW, S, float("-inf"))
+            S = tl.where((context_len + query_pos[:, None] - seq_offset)
+                         < SLIDING_WINDOW, S, float("-inf"))
 
         if USE_ALIBI_SLOPES:
-            S += alibi_slope[:, None] * (seq_offset[None, :] - context_len)
+            S += alibi_slope[:, None] * (seq_offset - context_len)
 
         # compute running maximum
-        # m_j : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED,)
+        # m_j : (BLOCK_M,)
         m_j = tl.maximum(M, tl.max(S, axis=1))
         # For sliding window there's a chance the max is -inf due to masking of
         # the entire row. In this case we need to set m_j 0 to avoid NaN
         m_j = tl.where(m_j > float("-inf"), m_j, 0.0)
 
-        # P : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED, BLOCK_SIZE)
+        # P : (BLOCK_M, BLOCK_SIZE)
         P = tl.exp(S - m_j[:, None])
 
-        # l_j : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED,)
+        # l_j : (BLOCK_M,)
         l_j = tl.sum(P, axis=1)
 
-        # alpha : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED, )
+        # alpha : (BLOCK_M, )
         alpha = tl.exp(M - m_j)
 
-        # acc : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED, HEAD_SIZE_PADDED)
+        # acc : (BLOCK_M, HEAD_SIZE_PADDED)
         acc = acc * alpha[:, None]
 
         # update constants
         L = L * alpha + l_j
         M = m_j
 
-        # acc : (BLOCK_Q_NUM_QUERY_PER_KV_PADDED, HEAD_SIZE_PADDED)
+        # acc : (BLOCK_M, HEAD_SIZE_PADDED)
         acc += tl.dot(P.to(V.dtype), V)
 
     # epilogue
     acc = acc / L[:, None]
 
     output_offset = (query_offset_0[:, None] * output_stride_0 +
-                     query_offset_1_valid[:, None] * output_stride_1 +
+                     query_offset_1[:, None] * output_stride_1 +
                      offs_d[None, :])
 
     tl.store(
         output_ptr + output_offset,
         acc,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None]
-        & m_mask[:, None],
+        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
     )
 
 
@@ -314,6 +294,10 @@ def unified_attention(
     #   <= floor(\sum_i(query_len[i]) / BLOCK_Q) + num_seqs
     #    = floor(q.shape[0] / BLOCK_Q) + num_seqs
     total_num_q_blocks = q.shape[0] // BLOCK_Q + num_seqs
+    
+    print(f"grid size dimention 0: total_num_q_blocks: {total_num_q_blocks}")
+    print(f"grid_size_dimention 1: num_kv_heads: {num_kv_heads}")
+
 
     kernel_unified_attention_2d[(
         total_num_q_blocks,
@@ -353,5 +337,4 @@ def unified_attention(
        query_start_len_ptr=cu_seqlens_q,
        BLOCK_Q=BLOCK_Q,
        num_seqs=num_seqs,
-       BLOCK_Q_NUM_QUERY_PER_KV_PADDED=triton.next_power_of_2(
-           BLOCK_Q * num_queries_per_kv))
+       BLOCK_M=BLOCK_M,)

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -96,7 +96,7 @@ def kernel_unified_attention_2d(
 
     # avoid power of 2 issue and pad it
     BLOCK_Q_NUM_QUERY_PER_KV_PADDED: tl.constexpr = triton.next_power_of_2(
-            BLOCK_Q * num_queries_per_kv)
+        BLOCK_Q * num_queries_per_kv)
     offs_m = tl.arange(0, BLOCK_Q_NUM_QUERY_PER_KV_PADDED)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
 

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -95,7 +95,8 @@ def kernel_unified_attention_2d(
         return
 
     # avoid power of 2 issue and pad it
-    BLOCK_Q_NUM_QUERY_PER_KV_PADDED: tl.constexpr = triton.next_power_of_2(BLOCK_Q * num_queries_per_kv)
+    BLOCK_Q_NUM_QUERY_PER_KV_PADDED: tl.constexpr = triton.next_power_of_2(
+            BLOCK_Q * num_queries_per_kv)
     offs_m = tl.arange(0, BLOCK_Q_NUM_QUERY_PER_KV_PADDED)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
 


### PR DESCRIPTION
FIX  *https://github.com/vllm-project/vllm/issues/18088*

As detailed in the above issue, when running V1 on llama4 issues, we saw the exception that requires the parameter is a power of 2. However, when running on llama4 128E FP8 models, the following expression in (https://github.com/vllm-project/vllm/blob/main/vllm/attention/ops/triton_unified_attention.py#L97) is not a power of 2.
```
 offs_m = tl.arange(0, BLOCK_Q * num_queries_per_kv)
```

Debugging found that those values are:
print("BLOCK_Q:", BLOCK_Q) -> 3
print("num_queries_per_kv:", num_queries_per_kv) -> 5
print("Product:", BLOCK_Q * num_queries_per_kv) -> 15

Noticed if we pass the BLOCK_M as the parameter which is hard-coded to 16 now, we can prevent this power of two issue, and also simplify the code without needing the padding.
```
BLOCK_M = 16
BLOCK_Q = BLOCK_M // num_queries_per_kv
```
So, the `BLOCK_Q * num_queries_per_kv` essentially = `BLOCK_M`

(2) It also uses a tl.constexpr BLOCK_M to replace many places to avoid multiple re-calculations of the same expression later on.

(3) This PR also fixed the the test_triton_unified_attention.py so that it can run successfully on ROCm.

Tests:

Initially, the `test_triton_unified_attention.py` would abort on ROCm platform. After the unit test fix, it is able to run the full test suite without issue. 

(1) Passed the test_triton_unified_attention.py
```
root@tx:/vllm/tests/kernels/attention# pytest test_triton_unified_attention.py
/usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=================================================================== test session starts ===================================================================
platform linux -- Python 3.12.10, pytest-8.3.5, pluggy-1.6.0
rootdir: /dockerx/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0, asyncio-1.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1152 items                                                                                                                                      

test_triton_unified_attention.py .................................................................................................................. [  9%]
................................................................................................................................................... [ 22%]
................................................................................................................................................... [ 35%]
................................................................................................................................................... [ 48%]
.....................ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssss [ 60%]
ssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............sssssssss [ 73%]
sss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss [ 86%]
............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss............ssssssssssss... [ 99%]
.........                                                                                                                                           [100%]

==================================================================== warnings summary =====================================================================
../../../vllm/__init__.py:5
  /dockerx/vllm/vllm/__init__.py:5: RuntimeWarning: Failed to read commit hash:
  No module named 'vllm._version'
    from .version import __version__, __version_tuple__  # isort:skip

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 864 passed, 288 skipped, 1 warning in 349.31s (0:05:49) =================================================

```
(2) After this change, I was able to run llama4 model in V1 (by bypassing fall-back fix).

<!--- pyml disable-next-line no-emphasis-as-heading -->
