### PR TITLE
[Bugfix] Add seed to benchmark_serving.py

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -749,6 +749,7 @@ def main(args: argparse.Namespace):
             "top_k": args.top_k,
             "min_p": args.min_p,
             "temperature": args.temperature,
+            "seed": args.seed,
         }.items()
         if v is not None
     }


### PR DESCRIPTION
Following https://github.com/vllm-project/vllm/pull/17929, this PR uses seed for benchmark_serving script. Will be used  for TP > 1 bench of SD method like this https://github.com/vllm-project/vllm/pull/17202