### PR TITLE
[P/D][V1] Support dynamic loading of external KV connector implementations

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3491,10 +3491,6 @@ class KVTransferConfig:
     """The KV connector for vLLM to transmit KV caches between vLLM instances.
     """
 
-    kv_connector_module_path: Optional[str] = None
-    """The Python module path to dynamically load the KV connector from.
-    Only supported in V1."""
-
     engine_id: str = str(uuid.uuid4())
     """The engine id for KV transfers."""
 
@@ -3527,6 +3523,10 @@ class KVTransferConfig:
 
     kv_connector_extra_config: dict[str, Any] = field(default_factory=dict)
     """any extra config that the connector may need."""
+
+    kv_connector_module_path: Optional[str] = None
+    """The Python module path to dynamically load the KV connector from.
+    Only supported in V1."""
 
     def compute_hash(self) -> str:
         """

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3491,6 +3491,10 @@ class KVTransferConfig:
     """The KV connector for vLLM to transmit KV caches between vLLM instances.
     """
 
+    kv_connector_module_path: Optional[str] = None
+    """The Python module path to dynamically load the KV connector from.
+    Only supported in V1."""
+
     engine_id: str = str(uuid.uuid4())
     """The engine id for KV transfers."""
 


### PR DESCRIPTION
This PR introduces a new mechanism to simplify the integration of external KV connectors in vLLM's V1 prefill-decode (P/D) disaggregation pipeline.

### 📌 Motivation
Currently, external packages implementing KVConnectorBase_V1 must define a connector class and upstream it into the vLLM codebase, even if the class simply delegates to an external implementation. This causes unnecessary boilerplate and maintenance overhead for both vendors and vLLM maintainers.

### ✅ What this PR adds

- A new config field:
```
kv_connector_module_path: Optional[str]
```
This allows users to specify the Python module path from which the connector class should be dynamically loaded.

- Updated `KVConnectorFactory` logic:
If a `kv_connector` is not found in the internal registry, the factory attempts to load the class from the given `kv_connector_module_path` via `importlib`.

### 🔧 Usage Example
This enables setups like the following, without requiring any code to be added to the vLLM repo:
```
KVTransferConfig(
    kv_connector="MyVendorConnector",
    kv_role="kv_both",
    kv_connector_module_path="myvendor.vllm.my_kv_connector"
)
```

### ✅ Benefits
- Avoids duplicating boilerplate classes that only wrap vendor code.
- No need to upstream vendor-specific connectors into vLLM.