### PR TITLE
Raise more exceptions from None in MP engine

### DIFF
--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -229,8 +229,8 @@ class MQLLMEngine:
         """Engine step wrapper with error handling."""
         try:
             return self.engine.step()
-        except SystemExit:
-            raise
+        except SystemExit as e:
+            raise e from None
         except InputProcessingError as e:
             # Special case where we handle an error preparing the inputs for
             # a single request in the batch
@@ -245,7 +245,7 @@ class MQLLMEngine:
                                is_engine_errored=True,
                                exception=e)
             self._send_outputs(rpc_err)
-            raise e
+            raise e from None
 
     def handle_new_input(self):
         """Handle new input from the socket"""


### PR DESCRIPTION
This PR is a follow-up to https://github.com/vllm-project/vllm/pull/17800 We should `raise e from None`, otherwise, re-raised error is considered new while processing the original one.