### PR TITLE
[Kernel] [V1] Fix performance regression for triton unified attention

### DIFF
--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -56,11 +56,11 @@ def kernel_unified_attention_2d(
     stride_k_cache_0: tl.int64,  # int
     stride_k_cache_1: tl.int64,  # int
     stride_k_cache_2: tl.int64,  # int
-    stride_k_cache_3: tl.int64,  # int
+    stride_k_cache_3: tl.constexpr,  # int
     stride_v_cache_0: tl.int64,  # int
     stride_v_cache_1: tl.int64,  # int
     stride_v_cache_2: tl.int64,  # int
-    stride_v_cache_3: tl.int64,  # int
+    stride_v_cache_3: tl.constexpr,  # int
     query_start_len_ptr,  # [num_seqs+1]
     BLOCK_Q: tl.constexpr,  # int
     num_seqs: tl.int32,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -1,19 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 """Attention layer with PagedAttention and Triton prefix prefill."""
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
 from vllm import _custom_ops as ops
-from vllm.attention.backends.abstract import (AttentionBackend,
+from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionMetadata, AttentionType)
 from vllm.attention.ops.triton_unified_attention import unified_attention
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.flash_attn import (
-    FlashAttentionImpl, FlashAttentionMetadata, FlashAttentionMetadataBuilder)
+    FlashAttentionMetadata, FlashAttentionMetadataBuilder)
+from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.worker.block_table import BlockTable
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 logger = init_logger(__name__)
+
+
+class TritonAttentionMetadataBuilder(FlashAttentionMetadataBuilder):
+
+    def __init__(self, runner: "GPUModelRunner", kv_cache_spec: AttentionSpec,
+                 block_table: BlockTable):
+        super().__init__(runner, kv_cache_spec, block_table)
+        self.aot_schedule = False
 
 
 class TritonAttentionBackend(AttentionBackend):
@@ -52,11 +65,11 @@ class TritonAttentionBackend(AttentionBackend):
         return False
 
     @staticmethod
-    def get_builder_cls() -> type["FlashAttentionMetadataBuilder"]:
-        return FlashAttentionMetadataBuilder
+    def get_builder_cls() -> type["TritonAttentionMetadataBuilder"]:
+        return TritonAttentionMetadataBuilder
 
 
-class TritonAttentionImpl(FlashAttentionImpl):
+class TritonAttentionImpl(AttentionImpl):
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -5,13 +5,13 @@ from typing import Any, Optional
 import torch
 
 from vllm import _custom_ops as ops
-from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
+from vllm.attention.backends.abstract import (AttentionBackend,
                                               AttentionMetadata, AttentionType)
 from vllm.attention.ops.triton_unified_attention import unified_attention
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.flash_attn import (
-    FlashAttentionMetadata, FlashAttentionMetadataBuilder)
+    FlashAttentionImpl, FlashAttentionMetadata, FlashAttentionMetadataBuilder)
 
 logger = init_logger(__name__)
 
@@ -56,7 +56,7 @@ class TritonAttentionBackend(AttentionBackend):
         return FlashAttentionMetadataBuilder
 
 
-class TritonAttentionImpl(AttentionImpl):
+class TritonAttentionImpl(FlashAttentionImpl):
 
     def __init__(
         self,


### PR DESCRIPTION
We have observed a pretty severe (~40%) performance regression for the `triton_unified_attention` kernel when moving from triton 3.2 to triton 3.3. 

After a lot of investigation, I was able to figure out that it came from [this](https://github.com/triton-lang/triton/pull/5512) commit to Triton. This change reworked the way that Triton determines what kernel arguments are constant. It seems that before this PR, Triton was (correctly) detecting that `stride_k_cache_3` and `stride_v_cache_3` are constant and leveraging this to obtain a faster kernel. For whatever reason, the new logic doesn't do this and we need to explicitly tell the compiler to interpret these strides as constant.

This minor change recovers the performance. 

There is one other small change: the TritonBackend no longer works on main because of [this](https://github.com/vllm-project/vllm/blob/main/vllm/v1/attention/backends/flash_attn.py#L287) assert. Since the TritonBackend re-uses the `FlashAttentionMetadata` and `FlashAttentionMetadataBuilder` directly (this is intentional to reduce duplicate code), this assert doesn't really make sense unless `TritonAttentionImpl` inherits from `FlashAttentionImpl`. Happy to consider other ways to solve that, but would like to avoid create entirely new `TritonAttentionMetadata` etc that are just duplicates. 

cc @SageMoore @bringlein 
  
Main branch:
```
++++++++++++++++++ Repetition 0 ++++++++++++++++++
============ Serving Benchmark Result ============
Successful requests:                     985       
Benchmark duration (s):                  26.18     
Total input tokens:                      209782    
Total generated tokens:                  125289    
Request throughput (req/s):              37.62     
Output token throughput (tok/s):         4785.69   
Total Token throughput (tok/s):          12798.78  
---------------Time to First Token----------------
Mean TTFT (ms):                          4889.40   
Median TTFT (ms):                        4844.86   
P99 TTFT (ms):                           8946.27   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          110.97    
Median TPOT (ms):                        53.41     
P99 TPOT (ms):                           390.86    
---------------Inter-token Latency----------------
Mean ITL (ms):                           46.36     
Median ITL (ms):                         28.78     
P99 ITL (ms):                            324.39    
==================================================

=++++++++++++++++++ Repetition 1 ++++++++++++++++++
============ Serving Benchmark Result ============
Successful requests:                     985       
Benchmark duration (s):                  24.18     
Total input tokens:                      209782    
Total generated tokens:                  125289    
Request throughput (req/s):              40.74     
Output token throughput (tok/s):         5181.56   
Total Token throughput (tok/s):          13857.49  
---------------Time to First Token----------------
Mean TTFT (ms):                          4455.20   
Median TTFT (ms):                        4315.81   
P99 TTFT (ms):                           8447.30   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          103.56    
Median TPOT (ms):                        49.74     
P99 TPOT (ms):                           312.85    
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.30     
Median ITL (ms):                         26.91     
P99 ITL (ms):                            322.73    
==================================================

++++++++++++++++++ Repetition 2 ++++++++++++++++++
============ Serving Benchmark Result ============
Successful requests:                     985       
Benchmark duration (s):                  24.19     
Total input tokens:                      209782    
Total generated tokens:                  125305    
Request throughput (req/s):              40.73     
Output token throughput (tok/s):         5181.00   
Total Token throughput (tok/s):          13854.88  
---------------Time to First Token----------------
Mean TTFT (ms):                          4453.85   
Median TTFT (ms):                        4283.36   
P99 TTFT (ms):                           8430.35   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          103.24    
Median TPOT (ms):                        49.79     
P99 TPOT (ms):                           311.08    
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.17     
Median ITL (ms):                         26.91     
P99 ITL (ms):                            325.18    
==================================================
```

With the changes from this PR:
```
++++++++++++++++++ Repetition 0 ++++++++++++++++++
============ Serving Benchmark Result ============
Successful requests:                     985       
Benchmark duration (s):                  18.36     
Total input tokens:                      209782    
Total generated tokens:                  125289    
Request throughput (req/s):              53.64     
Output token throughput (tok/s):         6823.19   
Total Token throughput (tok/s):          18247.83  
---------------Time to First Token----------------
Mean TTFT (ms):                          3535.61   
Median TTFT (ms):                        3447.89   
P99 TTFT (ms):                           6488.40   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          78.28     
Median TPOT (ms):                        38.20     
P99 TPOT (ms):                           231.30    
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.68     
Median ITL (ms):                         20.25     
P99 ITL (ms):                            235.62    
==================================================

++++++++++++++++++ Repetition 1 ++++++++++++++++++
============ Serving Benchmark Result ============
Successful requests:                     985       
Benchmark duration (s):                  17.13     
Total input tokens:                      209782    
Total generated tokens:                  125289    
Request throughput (req/s):              57.50     
Output token throughput (tok/s):         7313.20   
Total Token throughput (tok/s):          19558.30  
---------------Time to First Token----------------
Mean TTFT (ms):                          3358.98   
Median TTFT (ms):                        3277.33   
P99 TTFT (ms):                           6301.26   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          76.65     
Median TPOT (ms):                        36.04     
P99 TPOT (ms):                           230.60    
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.80     
Median ITL (ms):                         18.56     
P99 ITL (ms):                            232.08    
==================================================


++++++++++++++++++ Repetition 2 ++++++++++++++++++
============ Serving Benchmark Result ============
Successful requests:                     985       
Benchmark duration (s):                  17.37     
Total input tokens:                      209782    
Total generated tokens:                  125289    
Request throughput (req/s):              56.72     
Output token throughput (tok/s):         7214.31   
Total Token throughput (tok/s):          19293.85  
---------------Time to First Token----------------
Mean TTFT (ms):                          3571.61   
Median TTFT (ms):                        3417.45   
P99 TTFT (ms):                           6460.17   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          76.82     
Median TPOT (ms):                        36.22     
P99 TPOT (ms):                           231.26    
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.74     
Median ITL (ms):                         18.33     
P99 ITL (ms):                            234.79    
==================================================
```