### PR TITLE
[Core] Delay resolving of current_platform import by moving it inside _cached_get_attn_backend

### DIFF
--- a/vllm/attention/selector.py
+++ b/vllm/attention/selector.py
@@ -10,7 +10,9 @@ import torch
 import vllm.envs as envs
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.logger import init_logger
-from vllm.platforms import _Backend, current_platform
+from vllm.platforms import _Backend
+if os.environ.get("DELAY_CURRENT_PLATFORM_IMPORT") != "1":
+    from vllm.platforms import current_platform
 from vllm.utils import STR_BACKEND_ENV_VAR, resolve_obj_by_qualname
 
 logger = init_logger(__name__)
@@ -145,6 +147,8 @@ def _cached_get_attn_backend(
             selected_backend = backend_name_to_enum(backend_by_env_var)
 
     # get device-specific attn_backend
+    if os.environ.get("DELAY_CURRENT_PLATFORM_IMPORT") == "1":
+        from vllm.platforms import current_platform
     attention_cls = current_platform.get_attn_backend_cls(
         selected_backend, head_size, dtype, kv_cache_dtype, block_size, use_v1,
         use_mla)


### PR DESCRIPTION
Summary:
**Changes:**

* In `selector.py`, the import of `current_platform` from `vllm.platforms` is delayed by moving it inside the `_cached_get_attn_backend` function.
* The delay is conditional, only happening if the `DELAY_CURRENT_PLATFORM_IMPORT` environment variable is set to "1".

**Rationale:**
The change aims to delay the resolution of the `current_platform` import. By moving the import inside the `_cached_get_attn_backend` function, it is only loaded when actually needed. This is necessary to fix issues that arise from importing the platform too early. The conditional delay allows for easy testing and disabling of this behavior by default unless the `DELAY_CURRENT_PLATFORM_IMPORT` environment variable is set to "1".

Differential Revision: D74610999


