### PR TITLE
[CI] Fix race condition in test_kv_cache_events test

### DIFF
--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -290,7 +290,6 @@ def test_kv_cache_events(
             log_stats=False,
         )
         endpoint = publisher_config.endpoint.replace("*", "127.0.0.1")
-        time.sleep(0.1)
         subscriber = MockSubscriber(endpoint,
                                     topic=publisher_config.topic,
                                     decode_type=KVEventBatch)

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -130,6 +130,7 @@ class ZmqEventPublisher(EventPublisher):
         self._endpoint = endpoint
         self._replay_endpoint = replay_endpoint
         self._hwm = hwm
+        self._socket_setup()
 
         # Payload
         self._seq_gen = count()
@@ -207,7 +208,6 @@ class ZmqEventPublisher(EventPublisher):
     def _publisher_thread(self) -> None:
         """Background thread that processes the event queue."""
         self._pack = msgspec.msgpack.Encoder()
-        self._socket_setup()
 
         assert self._pub is not None  # narrows type for mypy
 


### PR DESCRIPTION
We observed an occasional failure on this test case:

tests/v1/engine/test_engine_core_client.py::test_kv_cache_events[True-tcp]

I believe this change should resolve it. The KV event publisher was
initializing its zmq socket in a new thread, which gives a window of
opportunity for the subscriber created in the test to try to connect too
soon, putting things in a bad state and missing the event expected.

The `time.sleep(0.1)` in the test is a pretty good hint that this is a
problem. I assume whoever put that there observed this race and found
that this yield seemed to be enough to fix it. Unfortunately this sort
of thing is usually still bound to fail on occassion.

The fix here is to move zmq socket initialization back into the main
flow of control prior to creating the background thread. That way we
know it's created before the test creates the subscriber. The change
also removes the sleep, as it should no longer be necessary if this race
condition was the reason it was added originally.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
