### PR TITLE
Update deprecated type hinting in worker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,6 @@ exclude = [
 "vllm/model_executor/models/**/*.py" = ["UP006", "UP035"]
 "vllm/prompt_adapter/**/*.py" = ["UP006", "UP035"]
 "vllm/spec_decode/**/*.py" = ["UP006", "UP035"]
-"vllm/worker/**/*.py" = ["UP006", "UP035"]
-"vllm/utils.py" = ["UP006", "UP035"]
 
 [tool.ruff.lint]
 select = [

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -37,14 +37,13 @@ from argparse import (Action, ArgumentDefaultsHelpFormatter, ArgumentParser,
 from asyncio import FIRST_COMPLETED, AbstractEventLoop, Task
 from collections import UserDict, defaultdict
 from collections.abc import (AsyncGenerator, Awaitable, Generator, Hashable,
-                             Iterable, Iterator, KeysView, Mapping)
+                             Iterable, Iterator, KeysView, Mapping, Sequence)
 from concurrent.futures.process import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from functools import cache, lru_cache, partial, wraps
 from types import MappingProxyType
 from typing import (TYPE_CHECKING, Any, Callable, Generic, Literal, NamedTuple,
-                    Optional, Sequence, Tuple, Type, TypeVar, Union, cast,
-                    overload)
+                    Optional, TypeVar, Union, cast, overload)
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -1767,9 +1766,9 @@ class LazyDict(Mapping[str, T], Generic[T]):
         return len(self._factory)
 
 
-class ClassRegistry(UserDict[Type[T], _V]):
+class ClassRegistry(UserDict[type[T], _V]):
 
-    def __getitem__(self, key: Type[T]) -> _V:
+    def __getitem__(self, key: type[T]) -> _V:
         for cls in key.mro():
             if cls in self.data:
                 return self.data[cls]
@@ -2088,7 +2087,7 @@ def direct_register_custom_op(
         fake_impl: Optional[Callable] = None,
         target_lib: Optional[Library] = None,
         dispatch_key: str = "CUDA",
-        tags: Tuple[torch.Tag, ...] = (),
+        tags: tuple[torch.Tag, ...] = (),
 ):
     """
     `torch.library.custom_op` can have significant overhead because it
@@ -2329,7 +2328,7 @@ def get_exception_traceback():
     return err_str
 
 
-def split_zmq_path(path: str) -> Tuple[str, str, str]:
+def split_zmq_path(path: str) -> tuple[str, str, str]:
     """Split a zmq path into its parts."""
     parsed = urlparse(path)
     if not parsed.scheme:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """CacheEngine class for managing the KV cache."""
-from typing import List
-
 import torch
 
 from vllm.attention import get_attn_backend
@@ -69,12 +67,12 @@ class CacheEngine:
         self,
         num_blocks: int,
         device: str,
-    ) -> List[torch.Tensor]:
+    ) -> list[torch.Tensor]:
         """Allocates KV cache on the specified device."""
         kv_cache_generic_shape = self.attn_backend.get_kv_cache_shape(
             num_blocks, self.block_size, self.num_kv_heads, self.head_size)
         pin_memory = is_pin_memory_available() if device == "cpu" else False
-        kv_cache: List[torch.Tensor] = []
+        kv_cache: list[torch.Tensor] = []
         try:
             kv_cache_stride_order = self.attn_backend.get_kv_cache_stride_order(
             )

--- a/vllm/worker/cpu_enc_dec_model_runner.py
+++ b/vllm/worker/cpu_enc_dec_model_runner.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import torch
 
@@ -31,7 +31,7 @@ class EncoderDecoderModelInputForCPU(ModelInputForCPUWithSamplingMetadata):
     encoder_input_tokens: Optional[torch.Tensor] = None
     encoder_input_positions: Optional[torch.Tensor] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "input_positions": self.input_positions,
@@ -47,7 +47,7 @@ class EncoderDecoderModelInputForCPU(ModelInputForCPUWithSamplingMetadata):
     @classmethod
     def from_broadcasted_tensor_dict(
         cls,
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> "EncoderDecoderModelInputForCPU":
         return cast(
@@ -57,19 +57,19 @@ class EncoderDecoderModelInputForCPU(ModelInputForCPUWithSamplingMetadata):
 
 class CPUEncoderDecoderModelRunner(
         CPUModelRunnerBase[EncoderDecoderModelInputForCPU]):
-    _model_input_cls: Type[EncoderDecoderModelInputForCPU] = (
+    _model_input_cls: type[EncoderDecoderModelInputForCPU] = (
         EncoderDecoderModelInputForCPU)
-    _builder_cls: Type[ModelInputForCPUBuilder] = ModelInputForCPUBuilder
+    _builder_cls: type[ModelInputForCPUBuilder] = ModelInputForCPUBuilder
 
     def _list_to_int32_tensor(
         self,
-        _list: List[int],
+        _list: list[int],
     ) -> torch.Tensor:
         return torch.tensor(_list, dtype=torch.int32, device=self.device)
 
     def _list_to_long_tensor(
         self,
-        _list: List[int],
+        _list: list[int],
     ) -> torch.Tensor:
         return torch.tensor(_list, dtype=torch.long, device=self.device)
 
@@ -80,7 +80,7 @@ class CPUEncoderDecoderModelRunner(
         return self._list_to_long_tensor([])
 
     def make_model_input_from_broadcasted_tensor_dict(
-            self, tensor_dict: Dict[str,
+            self, tensor_dict: dict[str,
                                     Any]) -> EncoderDecoderModelInputForCPU:
         return EncoderDecoderModelInputForCPU.from_broadcasted_tensor_dict(
             tensor_dict,
@@ -89,9 +89,9 @@ class CPUEncoderDecoderModelRunner(
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[list[str]] = None
     ) -> EncoderDecoderModelInputForCPU:
         model_input = self._prepare_model_input_tensors(
             seq_group_metadata_list, finished_requests_ids)
@@ -120,9 +120,9 @@ class CPUEncoderDecoderModelRunner(
 
     def _prepare_encoder_model_input_tensors(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         model_input: EncoderDecoderModelInputForCPU,
-    ) -> Tuple[AttentionMetadata, Optional[torch.Tensor],
+    ) -> tuple[AttentionMetadata, Optional[torch.Tensor],
                Optional[torch.Tensor]]:
         """Helper method to prepare the encoder- and cross-attn-related
         model inputs based on a given sequence group. These additional inputs
@@ -167,7 +167,7 @@ class CPUEncoderDecoderModelRunner(
         is_prompt = seq_group_metadata_list[0].is_prompt
 
         # Build encoder inputs
-        encoder_seq_lens: List[int] = []
+        encoder_seq_lens: list[int] = []
         if is_prompt:
             # Prefill phase.
             cross_block_tables = self._empty_int32_tensor().view(
@@ -279,10 +279,10 @@ class CPUEncoderDecoderModelRunner(
     def execute_model(
         self,
         model_input: EncoderDecoderModelInputForCPU,
-        kv_caches: List[torch.Tensor],
+        kv_caches: list[torch.Tensor],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         if num_steps > 1:
             raise ValueError(
                 "CPU worker does not support multi-step execution.")

--- a/vllm/worker/cpu_pooling_model_runner.py
+++ b/vllm/worker/cpu_pooling_model_runner.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 import torch
 
@@ -25,18 +25,18 @@ class ModelInputForCPUWithPoolingMetadata(ModelInputForCPU):
 
 class CPUPoolingModelRunner(
         CPUModelRunnerBase[ModelInputForCPUWithPoolingMetadata]):
-    _model_input_cls: Type[ModelInputForCPUWithPoolingMetadata] = (
+    _model_input_cls: type[ModelInputForCPUWithPoolingMetadata] = (
         ModelInputForCPUWithPoolingMetadata)
-    _builder_cls: Type[ModelInputForCPUBuilder] = ModelInputForCPUBuilder
+    _builder_cls: type[ModelInputForCPUBuilder] = ModelInputForCPUBuilder
 
     @torch.inference_mode()
     def execute_model(
         self,
         model_input: ModelInputForCPUWithPoolingMetadata,
-        kv_caches: List[torch.Tensor],
+        kv_caches: list[torch.Tensor],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[Union[List[PoolerOutput], IntermediateTensors]]:
+    ) -> Optional[Union[list[PoolerOutput], IntermediateTensors]]:
         if num_steps > 1:
             raise ValueError(
                 "CPU worker does not support multi-step execution.")
@@ -72,7 +72,7 @@ class CPUPoolingModelRunner(
 
     def make_model_input_from_broadcasted_tensor_dict(
             self,
-            tensor_dict: Dict[str,
+            tensor_dict: dict[str,
                               Any]) -> ModelInputForCPUWithPoolingMetadata:
         return ModelInputForCPUWithPoolingMetadata.from_broadcasted_tensor_dict(
             tensor_dict,
@@ -81,9 +81,9 @@ class CPUPoolingModelRunner(
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: Optional[List[SequenceGroupMetadata]],
+        seq_group_metadata_list: Optional[list[SequenceGroupMetadata]],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[list[str]] = None
     ) -> ModelInputForCPUWithPoolingMetadata:
         assert seq_group_metadata_list is not None
         model_input = self._prepare_model_input_tensors(
@@ -99,17 +99,17 @@ class CPUPoolingModelRunner(
 
     def _prepare_pooling(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-        prompt_lens: List[int],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+        prompt_lens: list[int],
     ) -> PoolingMetadata:
         """Prepare PoolingMetadata for the sequence group metadata list."""
-        seq_groups: List[Tuple[List[int], PoolingParams]] = []
+        seq_groups: list[tuple[list[int], PoolingParams]] = []
         for i, seq_group_metadata in enumerate(seq_group_metadata_list):
             seq_ids = list(seq_group_metadata.seq_data.keys())
             pooling_params = seq_group_metadata.pooling_params
             seq_groups.append((seq_ids, pooling_params))
 
-        seq_data: Dict[int, SequenceData] = {}
+        seq_data: dict[int, SequenceData] = {}
         for seq_group_metadata in seq_group_metadata_list:
             seq_data.update(seq_group_metadata.seq_data)
 

--- a/vllm/worker/cpu_worker.py
+++ b/vllm/worker/cpu_worker.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """A CPU worker class."""
 import os
-from typing import Dict, List, Optional, Set, Tuple, Type
+from typing import Optional
 
 import torch
 import torch.distributed
@@ -76,23 +76,23 @@ class CPUCacheEngine:
     def _allocate_kv_cache(
         self,
         num_blocks: int,
-    ) -> List[torch.Tensor]:
+    ) -> list[torch.Tensor]:
         """Allocates KV cache on CPU."""
         kv_cache_shape = self.attn_backend.get_kv_cache_shape(
             num_blocks, self.block_size, self.num_heads, self.head_size)
-        kv_cache: List[torch.Tensor] = []
+        kv_cache: list[torch.Tensor] = []
         for _ in range(self.num_layers):
             kv_cache.append(
                 torch.empty(kv_cache_shape, dtype=self.dtype, device="cpu"))
         return kv_cache
 
-    def swap_in(self, src_to_dst: Dict[int, int]) -> None:
+    def swap_in(self, src_to_dst: dict[int, int]) -> None:
         raise NotImplementedError("Swap is not supported in CPUCacheEngine.")
 
-    def swap_out(self, src_to_dst: Dict[int, int]) -> None:
+    def swap_out(self, src_to_dst: dict[int, int]) -> None:
         raise NotImplementedError("Swap is not supported in CPUCacheEngine.")
 
-    def copy(self, src_to_dsts: Dict[int, List[int]]) -> None:
+    def copy(self, src_to_dsts: dict[int, list[int]]) -> None:
         self.attn_backend.copy_blocks(self.cpu_cache, src_to_dsts)
 
     @staticmethod
@@ -134,7 +134,7 @@ class CPUWorker(LocalOrDistributedWorkerBase):
         distributed_init_method: str,
         kv_cache_dtype: Optional[str] = "auto",
         is_driver_worker: bool = False,
-        model_runner_cls: Optional[Type[CPUModelRunner]] = None,
+        model_runner_cls: Optional[type[CPUModelRunner]] = None,
     ) -> None:
         WorkerBase.__init__(self, vllm_config=vllm_config)
 
@@ -170,7 +170,7 @@ class CPUWorker(LocalOrDistributedWorkerBase):
             or (speculative_config.draft_model_config.hf_config.model_type
                 not in ["medusa", "mlp_speculator", "eagle"]) \
                     else {"return_hidden_states": True}
-        ModelRunnerClass: Type[CPUModelRunnerBase] = CPUModelRunner
+        ModelRunnerClass: type[CPUModelRunnerBase] = CPUModelRunner
         if self.model_config.runner_type == "pooling":
             ModelRunnerClass = CPUPoolingModelRunner
         elif self.model_config.is_encoder_decoder:
@@ -185,9 +185,9 @@ class CPUWorker(LocalOrDistributedWorkerBase):
             self.model_runner = model_runner_cls(self.model_runner)
         # Uninitialized cache engine. Will be initialized by
         # initialize_cache.
-        self.cache_engine: List[CPUCacheEngine]
+        self.cache_engine: list[CPUCacheEngine]
         # Initialize cpu_cache as pooling models don't initialize kv_caches
-        self.cpu_cache: Optional[List[List[torch.Tensor]]] = None
+        self.cpu_cache: Optional[list[list[torch.Tensor]]] = None
 
         # Torch profiler. Enabled and configured through env vars:
         # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
@@ -232,7 +232,7 @@ class CPUWorker(LocalOrDistributedWorkerBase):
     def load_model(self):
         self.model_runner.load_model()
 
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         """Determine the number of blocks available for the KV cache.
 
         This determines how many KV blocks can fit into the configured CPU
@@ -287,7 +287,7 @@ class CPUWorker(LocalOrDistributedWorkerBase):
     def pin_lora(self, lora_id: int) -> bool:
         return self.model_runner.pin_lora(lora_id)
 
-    def list_loras(self) -> Set[int]:
+    def list_loras(self) -> set[int]:
         return self.model_runner.list_loras()
 
     def _validate_num_cpu_blocks(self, num_cpu_blocks: int) -> None:
@@ -335,7 +335,7 @@ class CPUWorker(LocalOrDistributedWorkerBase):
         return self.parallel_config.tensor_parallel_size > 1
 
     @property
-    def kv_cache(self) -> Optional[List[List[torch.Tensor]]]:
+    def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         return self.cpu_cache
 
     @property

--- a/vllm/worker/enc_dec_model_runner.py
+++ b/vllm/worker/enc_dec_model_runner.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import itertools
-from typing import Any, Dict, List, Optional, Tuple, Type, cast
+from typing import Any, Optional, cast
 
 import torch
 import torch.distributed
@@ -46,7 +46,7 @@ class EncoderDecoderModelInput(ModelInputForGPUWithSamplingMetadata):
     encoder_input_tokens: Optional[torch.Tensor] = None
     encoder_input_positions: Optional[torch.Tensor] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "inputs_embeds": self.inputs_embeds,
@@ -66,7 +66,7 @@ class EncoderDecoderModelInput(ModelInputForGPUWithSamplingMetadata):
     @classmethod
     def from_broadcasted_tensor_dict(
         cls,
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> "EncoderDecoderModelInput":
         return cast(
@@ -75,9 +75,9 @@ class EncoderDecoderModelInput(ModelInputForGPUWithSamplingMetadata):
 
 
 class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
-    _model_input_cls: Type[EncoderDecoderModelInput] = (
+    _model_input_cls: type[EncoderDecoderModelInput] = (
         EncoderDecoderModelInput)
-    _builder_cls: Type[ModelInputForGPUBuilder] = (ModelInputForGPUBuilder)
+    _builder_cls: type[ModelInputForGPUBuilder] = (ModelInputForGPUBuilder)
 
     def __init__(
         self,
@@ -138,13 +138,13 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
 
     def _list_to_int32_tensor(
         self,
-        _list: List[int],
+        _list: list[int],
     ) -> torch.Tensor:
         return torch.tensor(_list, dtype=torch.int32, device=self.device)
 
     def _list_to_long_tensor(
         self,
-        _list: List[int],
+        _list: list[int],
     ) -> torch.Tensor:
         return torch.tensor(_list, dtype=torch.long, device=self.device)
 
@@ -158,10 +158,10 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
     def execute_model(
         self,
         model_input: EncoderDecoderModelInput,
-        kv_caches: List[torch.Tensor],
+        kv_caches: list[torch.Tensor],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[List[PoolerOutput]]:
+    ) -> Optional[list[PoolerOutput]]:
         if num_steps > 1:
             raise ValueError("num_steps > 1 is not supported in "
                              "EncoderDecoderModelRunner")
@@ -224,7 +224,7 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
         return [output]
 
     def make_model_input_from_broadcasted_tensor_dict(
-            self, tensor_dict: Dict[str, Any]) -> EncoderDecoderModelInput:
+            self, tensor_dict: dict[str, Any]) -> EncoderDecoderModelInput:
         return EncoderDecoderModelInput.from_broadcasted_tensor_dict(
             tensor_dict,
             attn_backend=self.attn_backend,
@@ -232,9 +232,9 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[list[str]] = None
     ) -> EncoderDecoderModelInput:
         """Prepare the model input based on a given sequence group, including
         metadata for the sampling step.
@@ -290,8 +290,8 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
         # memory consumption. Create dummy lora request copies from the
         # lora request passed in, which contains a lora from the lora
         # warmup path.
-        dummy_lora_requests: List[LoRARequest] = []
-        dummy_lora_requests_per_seq: List[LoRARequest] = []
+        dummy_lora_requests: list[LoRARequest] = []
+        dummy_lora_requests_per_seq: list[LoRARequest] = []
         if self.lora_config:
             dummy_lora_requests = self._add_dummy_loras(
                 self.lora_config.max_loras)
@@ -303,7 +303,7 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
 
         # Profile memory usage with max_num_sequences sequences and the total
         # number of tokens equal to max_num_batched_tokens.
-        seqs: List[SequenceGroupMetadata] = []
+        seqs: list[SequenceGroupMetadata] = []
 
         max_mm_tokens = self.mm_registry.get_max_multimodal_tokens(
             self.model_config)
@@ -367,9 +367,9 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
 
     def _prepare_encoder_model_input_tensors(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         model_input: EncoderDecoderModelInput,
-    ) -> Tuple[AttentionMetadata, Optional[torch.Tensor],
+    ) -> tuple[AttentionMetadata, Optional[torch.Tensor],
                Optional[torch.Tensor]]:
         """Helper method to prepare the encoder- and cross-attn-related
         model inputs based on a given sequence group. These additional inputs
@@ -414,7 +414,7 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
         is_prompt = seq_group_metadata_list[0].is_prompt
 
         # Build encoder inputs
-        encoder_seq_lens: List[int] = []
+        encoder_seq_lens: list[int] = []
         if is_prompt:
             # Prefill phase.
             cross_block_tables = self._empty_int32_tensor().view(

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -8,8 +8,7 @@ import time
 import weakref
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set,
-                    Tuple, Type, TypeVar, Union)
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 
 import numpy as np
 import torch
@@ -89,22 +88,22 @@ class ModelInputForGPU(ModelRunnerInputBase):
     inputs_embeds: Optional[torch.Tensor] = None
     input_positions: Optional[torch.Tensor] = None
     token_types: Optional[torch.Tensor] = None
-    seq_lens: Optional[List[int]] = None
-    query_lens: Optional[List[int]] = None
+    seq_lens: Optional[list[int]] = None
+    query_lens: Optional[list[int]] = None
     lora_mapping: Optional["LoRAMapping"] = None
-    lora_requests: Optional[Set[LoRARequest]] = None
+    lora_requests: Optional[set[LoRARequest]] = None
     attn_metadata: Optional["AttentionMetadata"] = None
     prompt_adapter_mapping: Optional[PromptAdapterMapping] = None
-    prompt_adapter_requests: Optional[Set[PromptAdapterRequest]] = None
+    prompt_adapter_requests: Optional[set[PromptAdapterRequest]] = None
     multi_modal_kwargs: Optional[BatchedTensorInputs] = None
-    request_ids_to_seq_ids: Optional[Dict[str, List[int]]] = None
-    finished_requests_ids: Optional[List[str]] = None
+    request_ids_to_seq_ids: Optional[dict[str, list[int]]] = None
+    finished_requests_ids: Optional[list[str]] = None
     virtual_engine: int = 0
     async_callback: Optional[Callable] = None
     scheduler_outputs: Optional[SchedulerOutputs] = None
     previous_hidden_states: Optional[torch.Tensor] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "inputs_embeds": self.inputs_embeds,
@@ -123,8 +122,8 @@ class ModelInputForGPU(ModelRunnerInputBase):
 
     @classmethod
     def from_broadcasted_tensor_dict(
-        cls: Type[TModelInputForGPU],
-        tensor_dict: Dict[str, Any],
+        cls: type[TModelInputForGPU],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> TModelInputForGPU:
         if attn_backend is not None:
@@ -155,7 +154,7 @@ class ModelInputForGPUWithSamplingMetadata(ModelInputForGPU):
     # used by the driver worker.
     is_prompt: Optional[bool] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "inputs_embeds": self.inputs_embeds,
@@ -177,7 +176,7 @@ class ModelInputForGPUWithSamplingMetadata(ModelInputForGPU):
     @classmethod
     def from_broadcasted_tensor_dict(
         cls,
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> "ModelInputForGPUWithSamplingMetadata":
         tensor_dict = _init_sampling_metadata_from_tensor_dict(tensor_dict)
@@ -219,46 +218,46 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             *,
             # From sequence group metadata.
             request_id: str,
-            seq_ids: List[int],
+            seq_ids: list[int],
             is_prompt: bool,
-            block_tables: Optional[Dict[int, List[int]]],
-            computed_block_nums: List[int],
+            block_tables: Optional[dict[int, list[int]]],
+            computed_block_nums: list[int],
             n_seqs: int = 0,
 
             # Input tokens and positions.
-            input_tokens: Optional[List[List[int]]] = None,
+            input_tokens: Optional[list[list[int]]] = None,
             inputs_embeds: Optional[torch.Tensor] = None,
-            input_positions: Optional[List[List[int]]] = None,
-            token_types: Optional[List[List[int]]] = None,
-            mrope_input_positions: Optional[List[List[List[int]]]] = None,
+            input_positions: Optional[list[list[int]]] = None,
+            token_types: Optional[list[list[int]]] = None,
+            mrope_input_positions: Optional[list[list[list[int]]]] = None,
 
             # The sequence length (may be capped to the sliding window).
-            seq_lens: Optional[List[int]] = None,
+            seq_lens: Optional[list[int]] = None,
             # The original sequence length (before applying sliding window).
             # This is used to compute slot mapping.
-            orig_seq_lens: Optional[List[int]] = None,
+            orig_seq_lens: Optional[list[int]] = None,
             # This is used in the dual-chunk flash attention backend.
-            prompt_lens: Optional[List[int]] = None,
+            prompt_lens: Optional[list[int]] = None,
             # The query length.
-            query_lens: Optional[List[int]] = None,
+            query_lens: Optional[list[int]] = None,
             # The number of tokens that are already computed.
-            context_lens: Optional[List[int]] = None,
+            context_lens: Optional[list[int]] = None,
             # The current sliding window block.
-            curr_sliding_window_blocks: Optional[List[int]] = None,
+            curr_sliding_window_blocks: Optional[list[int]] = None,
 
             # LoRA inputs.
-            lora_index_mapping: Optional[List[List[int]]] = None,
-            lora_prompt_mapping: Optional[List[List[int]]] = None,
-            lora_requests: Optional[Set[LoRARequest]] = None,
+            lora_index_mapping: Optional[list[list[int]]] = None,
+            lora_prompt_mapping: Optional[list[list[int]]] = None,
+            lora_requests: Optional[set[LoRARequest]] = None,
 
             # Prompt adapter inputs.
-            prompt_adapter_index_mapping: Optional[List[int]] = None,
-            prompt_adapter_prompt_mapping: Optional[List[int]] = None,
+            prompt_adapter_index_mapping: Optional[list[int]] = None,
+            prompt_adapter_prompt_mapping: Optional[list[int]] = None,
             prompt_adapter_request: Optional[PromptAdapterRequest] = None,
 
             # Multi-modal inputs.
             multi_modal_kwargs: Optional[MultiModalKwargs] = None,
-            multi_modal_placeholder_maps: Optional[Dict[
+            multi_modal_placeholder_maps: Optional[dict[
                 str, MultiModalPlaceholderMap]] = None,
 
             # Whether the prefix cache is hit (prefill only).
@@ -471,7 +470,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
     def __init__(self,
                  runner: "GPUModelRunnerBase",
-                 finished_requests_ids: Optional[List[str]] = None):
+                 finished_requests_ids: Optional[list[str]] = None):
         super().__init__()
         # Compute functions for each sequence in a sequence group.
         # WARNING: The order of the functions matters!
@@ -515,7 +514,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                 self.sliding_window_blocks * self.block_size
 
     def prepare(self,
-                finished_requests_ids: Optional[List[str]] = None) -> None:
+                finished_requests_ids: Optional[list[str]] = None) -> None:
         self.finished_requests_ids = finished_requests_ids
 
         # if the current batch is decode-only.
@@ -524,7 +523,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         # Intermediate data (data in CPU before going to GPU) for
         # the current sequence group.
-        self.inter_data_list: List[
+        self.inter_data_list: list[
             ModelInputForGPUBuilder.InterDataForSeqGroup] = []
 
         self.attn_metadata_builder.prepare()
@@ -898,7 +897,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             # prefix caching and there is no decode request.
             return self.model_input_cls()
 
-        mrope_input_positions: Optional[List[List[int]]] = None
+        mrope_input_positions: Optional[list[list[int]]] = None
         if any(inter_data.mrope_input_positions is not None
                for inter_data in self.inter_data_list):
             mrope_input_positions = [[] for _ in range(3)]
@@ -1012,7 +1011,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                        is_prefill=not self.decode_only))
 
         # Prompt adapter data.
-        prompt_adapter_requests: Set[PromptAdapterRequest] = set()
+        prompt_adapter_requests: set[PromptAdapterRequest] = set()
         prompt_adapter_mapping = None
         if self.enable_prompt_adapter:
             prompt_adapter_requests = set(
@@ -1062,8 +1061,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
     """
     Helper class for shared methods between GPU model runners.
     """
-    _model_input_cls: Type[TModelInputForGPU]
-    _builder_cls: Type[ModelInputForGPUBuilder]
+    _model_input_cls: type[TModelInputForGPU]
+    _builder_cls: type[ModelInputForGPUBuilder]
     builder: ModelInputForGPUBuilder
 
     def __init__(
@@ -1094,10 +1093,10 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             self.vllm_config.compilation_config.max_capture_size
 
         #
-        self.graph_runners: List[Dict[Tuple[int, bool], CUDAGraphRunner]] = [
+        self.graph_runners: list[dict[tuple[int, bool], CUDAGraphRunner]] = [
             {} for _ in range(self.parallel_config.pipeline_parallel_size)
         ]
-        self.graph_memory_pool: Optional[Tuple[
+        self.graph_memory_pool: Optional[tuple[
             int, int]] = None  # Set during graph capture.
 
         self.has_inner_state = model_config.has_inner_state
@@ -1153,7 +1152,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             int(self.cache_config.cpu_offload_gb * 1024**3))
 
         # Used to cache python objects
-        self.inter_data_cache: Dict[int, PyObjectCache] = {}
+        self.inter_data_cache: dict[int, PyObjectCache] = {}
 
         # Using the PythonizationCache in Pipeline-Parallel clobbers the
         # SequenceGroupToSample object. In Pipeline-Parallel, we have
@@ -1256,8 +1255,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
 
     def _prepare_model_input_tensors(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-        finished_requests_ids: Optional[List[str]] = None
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+        finished_requests_ids: Optional[list[str]] = None
     ) -> TModelInputForGPU:
         """Helper method to prepare the model input based on a given sequence
         group. Prepares metadata needed for the base model forward pass but not
@@ -1337,8 +1336,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             # memory consumption. Create dummy lora request copies from the
             # lora request passed in, which contains a lora from the lora
             # warmup path.
-            dummy_lora_requests: List[LoRARequest] = []
-            dummy_lora_requests_per_seq: List[LoRARequest] = []
+            dummy_lora_requests: list[LoRARequest] = []
+            dummy_lora_requests_per_seq: list[LoRARequest] = []
             if self.lora_config:
                 dummy_lora_requests = self._add_dummy_loras(
                     self.lora_config.max_loras)
@@ -1350,7 +1349,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
 
             # Profile memory usage with max_num_sequences sequences and the
             # total number of tokens equal to max_num_batched_tokens.
-            seqs: List[SequenceGroupMetadata] = []
+            seqs: list[SequenceGroupMetadata] = []
             # Additional GPU memory may be needed for multi-modal encoding,
             # which needs to be accounted for when calculating the GPU blocks
             # for vLLM blocker manager.
@@ -1437,7 +1436,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             raise RuntimeError("LoRA is not enabled.")
         self.lora_manager.remove_all_adapters()
 
-    def set_active_loras(self, lora_requests: Set[LoRARequest],
+    def set_active_loras(self, lora_requests: set[LoRARequest],
                          lora_mapping: LoRAMapping) -> None:
         if not self.lora_manager:
             raise RuntimeError("LoRA is not enabled.")
@@ -1458,7 +1457,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             raise RuntimeError("LoRA is not enabled.")
         return self.lora_manager.pin_adapter(lora_id)
 
-    def list_loras(self) -> Set[int]:
+    def list_loras(self) -> set[int]:
         if not self.lora_manager:
             raise RuntimeError("LoRA is not enabled.")
         return self.lora_manager.list_adapters()
@@ -1469,7 +1468,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
         self.prompt_adapter_manager.remove_all_adapters()
 
     def set_active_prompt_adapters(
-            self, prompt_adapter_requests: Set[PromptAdapterRequest],
+            self, prompt_adapter_requests: set[PromptAdapterRequest],
             prompt_adapter_mapping: PromptAdapterMapping) -> None:
         if not self.prompt_adapter_manager:
             raise RuntimeError("PromptAdapter is not enabled.")
@@ -1492,13 +1491,13 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             raise RuntimeError("PromptAdapter is not enabled.")
         return self.prompt_adapter_manager.pin_adapter(prompt_adapter_id)
 
-    def list_prompt_adapters(self) -> Set[int]:
+    def list_prompt_adapters(self) -> set[int]:
         if not self.prompt_adapter_manager:
             raise RuntimeError("PromptAdapter is not enabled.")
         return self.prompt_adapter_manager.list_adapters()
 
     @torch.inference_mode()
-    def capture_model(self, kv_caches: List[List[torch.Tensor]]) -> None:
+    def capture_model(self, kv_caches: list[list[torch.Tensor]]) -> None:
         """Cuda graph capture a model.
 
         Note that CUDA graph's performance gain is negligible if number
@@ -1674,7 +1673,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                     elapsed_time, cuda_graph_size / GiB_bytes)
 
     def _update_inputs_to_capture_for_enc_dec_model(self,
-                                                    capture_inputs: Dict[str,
+                                                    capture_inputs: dict[str,
                                                                          Any]):
         """
         Updates the set of input tensors needed for CUDA graph capture in an
@@ -1702,13 +1701,13 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
     """
     GPU model runner with sampling step.
     """
-    _model_input_cls: Type[ModelInputForGPUWithSamplingMetadata] = (
+    _model_input_cls: type[ModelInputForGPUWithSamplingMetadata] = (
         ModelInputForGPUWithSamplingMetadata)
-    _builder_cls: Type[ModelInputForGPUBuilder] = ModelInputForGPUBuilder
+    _builder_cls: type[ModelInputForGPUBuilder] = ModelInputForGPUBuilder
 
     def make_model_input_from_broadcasted_tensor_dict(
         self,
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
     ) -> ModelInputForGPUWithSamplingMetadata:
         model_input = \
             ModelInputForGPUWithSamplingMetadata.from_broadcasted_tensor_dict(
@@ -1719,9 +1718,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None,
+        finished_requests_ids: Optional[list[str]] = None,
     ) -> ModelInputForGPUWithSamplingMetadata:
         """Prepare the model input based on a given sequence group, including
         metadata for the sampling step.
@@ -1758,11 +1757,11 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
     def execute_model(
         self,
         model_input: ModelInputForGPUWithSamplingMetadata,
-        kv_caches: List[torch.Tensor],
+        kv_caches: list[torch.Tensor],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
         **kwargs,
-    ) -> Optional[Union[List[SamplerOutput], IntermediateTensors]]:
+    ) -> Optional[Union[list[SamplerOutput], IntermediateTensors]]:
         if num_steps > 1:
             raise ValueError("num_steps > 1 is not supported in ModelRunner")
 
@@ -2017,8 +2016,8 @@ class CUDAGraphRunner(nn.Module):
         self.backend_name = backend_name
         self.attn_state = attn_state
 
-        self.input_buffers: Dict[str, torch.Tensor] = {}
-        self.output_buffers: Dict[str, torch.Tensor] = {}
+        self.input_buffers: dict[str, torch.Tensor] = {}
+        self.output_buffers: dict[str, torch.Tensor] = {}
 
         self._graph: Optional[torch.cuda.CUDAGraph] = None
         self._is_encoder_decoder_model = is_encoder_decoder_model
@@ -2034,9 +2033,9 @@ class CUDAGraphRunner(nn.Module):
         inputs_embeds: Optional[torch.Tensor],
         positions: torch.Tensor,
         intermediate_inputs: Optional[IntermediateTensors],
-        kv_caches: List[torch.Tensor],
+        kv_caches: list[torch.Tensor],
         attn_metadata: AttentionMetadata,
-        memory_pool: Optional[Tuple[int, int]],
+        memory_pool: Optional[tuple[int, int]],
         stream: torch.cuda.Stream,
         **kwargs,
     ):

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -2,8 +2,7 @@
 
 import dataclasses
 from abc import ABC, abstractmethod
-from typing import (TYPE_CHECKING, Any, Dict, Generic, List, Optional, Type,
-                    TypeVar)
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 
 import torch
 import torch.nn as nn
@@ -24,7 +23,7 @@ T = TypeVar('T', bound="BroadcastableModelInput")
 
 
 def _add_attn_metadata_broadcastable_dict(
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
         attn_metadata: Optional["AttentionMetadata"]) -> None:
     """
     Helper method to update tensor_dict with broadcastable
@@ -36,8 +35,8 @@ def _add_attn_metadata_broadcastable_dict(
 
 def _init_attn_metadata_from_tensor_dict(
     attn_backend: "AttentionBackend",
-    tensor_dict: Dict[str, Any],
-) -> Dict[str, Any]:
+    tensor_dict: dict[str, Any],
+) -> dict[str, Any]:
     """
     Helper method to initialize AttentionMetadata based on an
     AttentionBackend and broadcastable AttentionMetadata fields.
@@ -57,7 +56,7 @@ def _init_attn_metadata_from_tensor_dict(
 
 
 def _init_sampling_metadata_from_tensor_dict(  # type: ignore
-        tensor_dict: Dict[str, Any]) -> Dict[str, Any]:
+        tensor_dict: dict[str, Any]) -> dict[str, Any]:
     """
     Helper method to initialize SamplingMetadata based on broadcastable
     SamplingMetadata fields.
@@ -78,7 +77,7 @@ def _init_sampling_metadata_from_tensor_dict(  # type: ignore
 
 
 def _add_sampling_metadata_broadcastable_dict(
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
         sampling_metadata: Optional["SamplingMetadata"]) -> None:
     """
     Helper method to update tensor_dict with broadcastable
@@ -90,8 +89,8 @@ def _add_sampling_metadata_broadcastable_dict(
 
 
 def _init_frozen_model_input_from_tensor_dict(
-        frozen_model_input_cls: Type["ModelRunnerInputBase"],
-        tensor_dict: Dict[str, Any]) -> Dict[str, Any]:
+        frozen_model_input_cls: type["ModelRunnerInputBase"],
+        tensor_dict: dict[str, Any]) -> dict[str, Any]:
     """
     Helper method to initialize a frozen ModelInput based on broadcastable
     """
@@ -109,7 +108,7 @@ def _init_frozen_model_input_from_tensor_dict(
 class BroadcastableModelInput(ABC):
 
     @abstractmethod
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         """
         Extract broadcastable fields. Override for fields that require some
         custom deserialization.
@@ -119,8 +118,8 @@ class BroadcastableModelInput(ABC):
     @classmethod
     @abstractmethod
     def from_broadcasted_tensor_dict(
-        cls: Type[T],
-        tensor_dict: Dict[str, Any],
+        cls: type[T],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> T:
         """
@@ -150,7 +149,7 @@ class ModelRunnerInputBuilderBase(ABC, Generic[T]):
 
     @abstractmethod
     def prepare(self,
-                finished_requests_ids: Optional[List[str]] = None) -> None:
+                finished_requests_ids: Optional[list[str]] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -191,12 +190,12 @@ class ModelRunnerBase(ABC, Generic[T]):
         self.observability_config = vllm_config.observability_config
 
     # Map of request_id -> generator used for seeded random sampling
-    generators: Dict[str, torch.Generator] = {}
+    generators: dict[str, torch.Generator] = {}
 
     @abstractmethod
     def make_model_input_from_broadcasted_tensor_dict(
         self,
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
     ) -> T:
         """
         Make an instance of a ModelRunnerInputBase from the broadcasted tensor
@@ -207,9 +206,9 @@ class ModelRunnerBase(ABC, Generic[T]):
     @abstractmethod
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None,
+        finished_requests_ids: Optional[list[str]] = None,
     ) -> T:
         """
         Prepare the inputs to ModelRunnerBase.execute_model from an execution
@@ -225,17 +224,17 @@ class ModelRunnerBase(ABC, Generic[T]):
     def execute_model(
         self,
         model_input: T,
-        kv_caches: Optional[List[torch.Tensor]],
+        kv_caches: Optional[list[torch.Tensor]],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
         **kwargs,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         """
         Execute the model on the given input.
         """
         raise NotImplementedError
 
-    def get_generators(self, finished_request_ids: Optional[List[str]] = None):
+    def get_generators(self, finished_request_ids: Optional[list[str]] = None):
         """
         Return dict of per-request generators used for random sampling.
         """

--- a/vllm/worker/multi_step_hpu_worker.py
+++ b/vllm/worker/multi_step_hpu_worker.py
@@ -5,7 +5,7 @@
 ###############################################################################
 
 import dataclasses
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -24,7 +24,7 @@ class MultiStepHPUWorker(HPUWorker):
 
     def _get_driver_input_and_broadcast(
         self, execute_model_req: ExecuteModelRequest
-    ) -> Tuple[ModelInputForHPU, WorkerInput, Dict[str, torch.Tensor]]:
+    ) -> tuple[ModelInputForHPU, WorkerInput, dict[str, torch.Tensor]]:
         """
         Get the driver input and broadcast it to other workers.
         """
@@ -82,7 +82,7 @@ class MultiStepHPUWorker(HPUWorker):
     def prepare_input(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None,
-    ) -> Optional[Tuple[ModelInputForHPU, WorkerInput, Dict[str,
+    ) -> Optional[tuple[ModelInputForHPU, WorkerInput, dict[str,
                                                             torch.Tensor]]]:
         if self.is_driver_worker:
             if execute_model_req is None:

--- a/vllm/worker/multi_step_neuron_model_runner.py
+++ b/vllm/worker/multi_step_neuron_model_runner.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from importlib.util import find_spec
-from typing import List, Optional
+from typing import Optional
 
 import torch
 
@@ -62,10 +62,10 @@ class MultiStepNeuronModelRunner(NeuronModelRunner):
     def execute_model(
         self,
         model_input: ModelInputForNeuron,
-        kv_caches: Optional[List[torch.Tensor]] = None,
+        kv_caches: Optional[list[torch.Tensor]] = None,
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         logits = self.model(
             input_ids=model_input.input_tokens,
             positions=model_input.input_positions,

--- a/vllm/worker/multi_step_neuronx_distributed_model_runner.py
+++ b/vllm/worker/multi_step_neuronx_distributed_model_runner.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-from typing import List, Optional
+from typing import Optional
 
 import torch
 
@@ -34,10 +34,10 @@ class MultiStepNeuronxDistributedModelRunner(NeuronxDistributedModelRunner):
     def execute_model(
         self,
         model_input,
-        kv_caches: Optional[List[torch.Tensor]] = None,
+        kv_caches: Optional[list[torch.Tensor]] = None,
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         sampling_params = torch.tensor([[
             seq_group.sampling_params.top_k,
             seq_group.sampling_params.top_p,

--- a/vllm/worker/multi_step_tpu_worker.py
+++ b/vllm/worker/multi_step_tpu_worker.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -20,7 +20,7 @@ class MultiStepTPUWorker(TPUWorker):
 
     def _get_driver_input_and_broadcast(
         self, execute_model_req: ExecuteModelRequest
-    ) -> Tuple[ModelInputForTPU, WorkerInput, Dict[str, torch.Tensor]]:
+    ) -> tuple[ModelInputForTPU, WorkerInput, dict[str, torch.Tensor]]:
         assert self.is_driver_worker
         assert execute_model_req.virtual_engine == 0
 
@@ -71,7 +71,7 @@ class MultiStepTPUWorker(TPUWorker):
     def prepare_input(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None,
-    ) -> Optional[Tuple[ModelInputForTPU, WorkerInput, Dict[str,
+    ) -> Optional[tuple[ModelInputForTPU, WorkerInput, dict[str,
                                                             torch.Tensor]]]:
         if self.is_driver_worker:
             if execute_model_req is None:

--- a/vllm/worker/multi_step_worker.py
+++ b/vllm/worker/multi_step_worker.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -35,13 +35,13 @@ class MultiStepWorker(Worker):
         )
 
         pipeline_parallel_size = self.parallel_config.pipeline_parallel_size
-        self.multi_step_states: List[
+        self.multi_step_states: list[
             Optional[MultiStepState]] = [None] * pipeline_parallel_size
         self.temp_output = None
 
     def _get_driver_input_and_broadcast(
         self, execute_model_req: ExecuteModelRequest
-    ) -> Tuple[BroadcastableModelInput, WorkerInput, Dict[str, torch.Tensor]]:
+    ) -> tuple[BroadcastableModelInput, WorkerInput, dict[str, torch.Tensor]]:
         """
         Get the driver input and broadcast it to other workers.
         """
@@ -136,7 +136,7 @@ class MultiStepWorker(Worker):
     def prepare_input(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None,
-    ) -> Optional[Tuple[StatefulModelInput, WorkerInput, Dict[str,
+    ) -> Optional[tuple[StatefulModelInput, WorkerInput, dict[str,
                                                               torch.Tensor]]]:
         """
         Depending on the current state of the request and multi step worker,

--- a/vllm/worker/neuron_worker.py
+++ b/vllm/worker/neuron_worker.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """A Neuron worker class."""
 import os
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import torch.distributed
 
@@ -86,7 +86,7 @@ class NeuronWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
     def load_model(self):
         self.model_runner.load_model()
 
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         """Determine the number of available KV blocks.
 
         Swapping is not yet supported, so always return num_cpu_blocks=0.
@@ -120,7 +120,7 @@ class NeuronWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         return False
 
     @property
-    def kv_cache(self) -> Optional[List[List[torch.Tensor]]]:
+    def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         return None
 
     @torch.inference_mode()

--- a/vllm/worker/neuronx_distributed_model_runner.py
+++ b/vllm/worker/neuronx_distributed_model_runner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional
+from typing import Optional
 
 import torch
 from neuronx_distributed_inference.modules.generation.sampling import (
@@ -65,10 +65,10 @@ class NeuronxDistributedModelRunner(NeuronModelRunner):
     def execute_model(
         self,
         model_input: ModelInputForNeuron,
-        kv_caches: Optional[List[torch.Tensor]] = None,
+        kv_caches: Optional[list[torch.Tensor]] = None,
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         if num_steps > 1:
             raise ValueError(
                 "NeuronModelRunner does not support multi-step execution.")

--- a/vllm/worker/pooling_model_runner.py
+++ b/vllm/worker/pooling_model_runner.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 import torch
 
@@ -30,9 +30,9 @@ class ModelInputForGPUWithPoolingMetadata(ModelInputForGPU):
 
 class PoolingModelRunner(
         GPUModelRunnerBase[ModelInputForGPUWithPoolingMetadata]):
-    _model_input_cls: Type[ModelInputForGPUWithPoolingMetadata] = (
+    _model_input_cls: type[ModelInputForGPUWithPoolingMetadata] = (
         ModelInputForGPUWithPoolingMetadata)
-    _builder_cls: Type[ModelInputForGPUBuilder] = ModelInputForGPUBuilder
+    _builder_cls: type[ModelInputForGPUBuilder] = ModelInputForGPUBuilder
 
     def __init__(
         self,
@@ -48,10 +48,10 @@ class PoolingModelRunner(
     def execute_model(
         self,
         model_input: ModelInputForGPUWithPoolingMetadata,
-        kv_caches: List[torch.Tensor],
+        kv_caches: list[torch.Tensor],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[Union[List[PoolerOutput], IntermediateTensors]]:
+    ) -> Optional[Union[list[PoolerOutput], IntermediateTensors]]:
         if num_steps > 1:
             raise ValueError(
                 "PoolingModelRunner does not support multi-step execution.")
@@ -158,7 +158,7 @@ class PoolingModelRunner(
 
     def make_model_input_from_broadcasted_tensor_dict(
             self,
-            tensor_dict: Dict[str,
+            tensor_dict: dict[str,
                               Any]) -> ModelInputForGPUWithPoolingMetadata:
         return ModelInputForGPUWithPoolingMetadata.from_broadcasted_tensor_dict(
             tensor_dict,
@@ -167,9 +167,9 @@ class PoolingModelRunner(
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: Optional[List[SequenceGroupMetadata]],
+        seq_group_metadata_list: Optional[list[SequenceGroupMetadata]],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[list[str]] = None
     ) -> ModelInputForGPUWithPoolingMetadata:
         assert seq_group_metadata_list is not None
         model_input = self._prepare_model_input_tensors(
@@ -184,17 +184,17 @@ class PoolingModelRunner(
 
     def _prepare_pooling(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-        prompt_lens: List[int],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+        prompt_lens: list[int],
     ) -> PoolingMetadata:
         """Prepare PoolingMetadata for the sequence group metadata list."""
-        seq_groups: List[Tuple[List[int], PoolingParams]] = []
+        seq_groups: list[tuple[list[int], PoolingParams]] = []
         for i, seq_group_metadata in enumerate(seq_group_metadata_list):
             seq_ids = list(seq_group_metadata.seq_data.keys())
             pooling_params = seq_group_metadata.pooling_params
             seq_groups.append((seq_ids, pooling_params))
 
-        seq_data: Dict[int, SequenceData] = {}
+        seq_data: dict[int, SequenceData] = {}
         for seq_group_metadata in seq_group_metadata_list:
             seq_data.update(seq_group_metadata.seq_data)
 

--- a/vllm/worker/tpu_model_runner.py
+++ b/vllm/worker/tpu_model_runner.py
@@ -3,8 +3,7 @@
 import enum
 import time
 from dataclasses import dataclass
-from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
-                    Type, Union)
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from unittest.mock import patch
 
 import numpy as np
@@ -60,15 +59,15 @@ class ModelInputForTPU(ModelRunnerInputBase):
     t: torch.Tensor
     p: torch.Tensor
     num_samples: int
-    n: List[int]
-    seq_groups: List[List[int]]
+    n: list[int]
+    seq_groups: list[list[int]]
     is_first_multi_step: bool = True
     is_last_step: bool = True
     virtual_engine: int = 0
     async_callback: Optional[Callable] = None
 
     def as_broadcastable_tensor_dict(
-            self) -> Dict[str, Union[int, torch.Tensor]]:
+            self) -> dict[str, Union[int, torch.Tensor]]:
         tensor_dict = {
             "token_ids": self.token_ids,
             "position_ids": self.position_ids,
@@ -87,8 +86,8 @@ class ModelInputForTPU(ModelRunnerInputBase):
 
     @classmethod
     def from_broadcasted_tensor_dict(
-        cls: Type["ModelInputForTPU"],
-        tensor_dict: Dict[str, Any],
+        cls: type["ModelInputForTPU"],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> "ModelInputForTPU":
         if attn_backend is not None:
@@ -121,7 +120,7 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
             self.model_config.is_attention_free,
             False,
         )
-        self.cached_step_outputs: List[torch.Tensor] = []
+        self.cached_step_outputs: list[torch.Tensor] = []
 
         smem_size = 512 * 1024
         block_table_size = 4 * self.block_tables.size
@@ -167,7 +166,7 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
         self,
         batch_size: int,
         seq_len: int,
-        kv_caches: List[Tuple[torch.Tensor, torch.Tensor]],
+        kv_caches: list[tuple[torch.Tensor, torch.Tensor]],
         exec_mode: ExecutionMode,
     ) -> None:
         exec_mode = ExecutionMode(exec_mode)
@@ -280,7 +279,7 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
 
     def warmup_model(
         self,
-        kv_caches: List[Tuple[torch.Tensor, torch.Tensor]],
+        kv_caches: list[tuple[torch.Tensor, torch.Tensor]],
     ) -> None:
         # Prefill
         logger.info("Compiling the model with different input shapes...")
@@ -347,14 +346,14 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
 
     def _prepare_prompt(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-    ) -> Tuple[torch.Tensor, torch.Tensor, AttentionMetadata, torch.Tensor]:
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+    ) -> tuple[torch.Tensor, torch.Tensor, AttentionMetadata, torch.Tensor]:
         assert len(seq_group_metadata_list) > 0
-        input_tokens: List[int] = []
-        input_positions: List[int] = []
-        prompt_lens: List[int] = []
-        context_lens: List[int] = []
-        slot_mapping: List[int] = []
+        input_tokens: list[int] = []
+        input_positions: list[int] = []
+        prompt_lens: list[int] = []
+        context_lens: list[int] = []
+        slot_mapping: list[int] = []
 
         for batch_idx, seq_group_metadata in enumerate(
                 seq_group_metadata_list):
@@ -439,13 +438,13 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
 
     def _prepare_decode(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-    ) -> Tuple[torch.Tensor, torch.Tensor, AttentionMetadata, torch.Tensor]:
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+    ) -> tuple[torch.Tensor, torch.Tensor, AttentionMetadata, torch.Tensor]:
         assert len(seq_group_metadata_list) > 0
-        input_tokens: List[List[int]] = []
-        input_positions: List[List[int]] = []
-        slot_mapping: List[List[int]] = []
-        context_lens: List[int] = []
+        input_tokens: list[list[int]] = []
+        input_positions: list[list[int]] = []
+        slot_mapping: list[list[int]] = []
+        context_lens: list[int] = []
 
         batch_idx = 0
         for seq_group_metadata in seq_group_metadata_list:
@@ -510,9 +509,9 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
 
     def _prepare_sample(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         padded_batch_size: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor, List[int]]:
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
         assert len(seq_group_metadata_list) > 0
         t = []
         p = []
@@ -558,9 +557,9 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None,
+        finished_requests_ids: Optional[list[str]] = None,
     ) -> ModelInputForTPU:
         del finished_requests_ids  # Unused.
         assert virtual_engine == 0
@@ -586,7 +585,7 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
                                 input_lens, t, p, num_samples, n, seq_groups)
 
     def make_model_input_from_broadcasted_tensor_dict(
-            self, tensor_dict: Dict[str, Any]) -> ModelInputForTPU:
+            self, tensor_dict: dict[str, Any]) -> ModelInputForTPU:
         model_input = ModelInputForTPU.from_broadcasted_tensor_dict(
             tensor_dict, attn_backend=self.attn_backend)
         return model_input
@@ -595,10 +594,10 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
     def execute_model(
         self,
         model_input: ModelInputForTPU,
-        kv_caches: Optional[List[Any]],
+        kv_caches: Optional[list[Any]],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> List[SamplerOutput]:
+    ) -> list[SamplerOutput]:
         assert intermediate_tensors is None
         if not model_input.is_first_multi_step:
             if not model_input.is_last_step:
@@ -781,7 +780,7 @@ class ModelWrapper(nn.Module):
         t: torch.Tensor,
         p: torch.Tensor,
         num_samples: int,
-        kv_caches: List[Tuple[torch.Tensor, torch.Tensor]],
+        kv_caches: list[tuple[torch.Tensor, torch.Tensor]],
     ) -> torch.Tensor:
         """Executes the forward pass of the model and samples the next token.
 
@@ -888,8 +887,8 @@ def _apply_top_p(logits: torch.Tensor, p: torch.Tensor) -> torch.Tensor:
 
 
 def _make_decode_output(
-    next_token_ids: List[int],
-    seq_groups: List[List[int]],
+    next_token_ids: list[int],
+    seq_groups: list[list[int]],
 ) -> SamplerOutput:
     zero_logprob = Logprob(0.0)
     sampler_outputs = []

--- a/vllm/worker/tpu_worker.py
+++ b/vllm/worker/tpu_worker.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 import torch_xla.core.xla_model as xm
@@ -133,7 +133,7 @@ class TPUWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
     def load_model(self):
         self.model_runner.load_model()
 
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         num_layers = self.model_config.get_num_layers(self.parallel_config)
         head_size = self.model_config.get_head_size()
         num_kv_heads = self.model_config.get_num_kv_heads(self.parallel_config)
@@ -194,8 +194,8 @@ class TPUWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         num_kv_heads = self.model_config.get_num_kv_heads(self.parallel_config)
         head_size = self.model_config.get_head_size()
 
-        self.cpu_cache: List[Tuple[torch.Tensor, torch.Tensor]] = []
-        self.tpu_cache: List[Tuple[torch.Tensor, torch.Tensor]] = []
+        self.cpu_cache: list[tuple[torch.Tensor, torch.Tensor]] = []
+        self.tpu_cache: list[tuple[torch.Tensor, torch.Tensor]] = []
         tpu_cache_shape = self.model_runner.attn_backend.get_kv_cache_shape(
             num_gpu_blocks, self.block_size, num_kv_heads, head_size)
         cpu_cache_shape = self.model_runner.attn_backend.get_kv_cache_shape(
@@ -244,7 +244,7 @@ class TPUWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         return self.parallel_config.tensor_parallel_size > 1
 
     @property
-    def kv_cache(self) -> Optional[List[List[torch.Tensor]]]:
+    def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         # NOTE(woosuk): This assumes virtual_engine == 0, i.e., no pipeline
         # parallelism.
         return [self.tpu_cache]
@@ -305,10 +305,10 @@ class TPUWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
 
 
 def _make_src_to_dst(
-    mapping: List[Tuple[int, int]],
+    mapping: list[tuple[int, int]],
     src_device: Union[torch.device, str],
     dst_device: Union[torch.device, str],
-) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+) -> Optional[tuple[torch.Tensor, torch.Tensor]]:
     if not mapping:
         return None
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -2,7 +2,7 @@
 """A GPU worker class."""
 import gc
 import os
-from typing import Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Optional, Union
 
 import torch
 import torch.distributed
@@ -50,7 +50,7 @@ class Worker(LocalOrDistributedWorkerBase):
         rank: int,
         distributed_init_method: str,
         is_driver_worker: bool = False,
-        model_runner_cls: Optional[Type[GPUModelRunnerBase]] = None,
+        model_runner_cls: Optional[type[GPUModelRunnerBase]] = None,
     ) -> None:
         WorkerBase.__init__(self, vllm_config)
         self.parallel_config.rank = rank
@@ -78,7 +78,7 @@ class Worker(LocalOrDistributedWorkerBase):
                          "mimo_mtp")) \
                     else {"return_hidden_states": True}
 
-        ModelRunnerClass: Type[GPUModelRunnerBase] = ModelRunner
+        ModelRunnerClass: type[GPUModelRunnerBase] = ModelRunner
         if model_config.runner_type == "pooling":
             ModelRunnerClass = PoolingModelRunner
         elif self.model_config.is_encoder_decoder:
@@ -94,13 +94,13 @@ class Worker(LocalOrDistributedWorkerBase):
 
         # Uninitialized cache engine. Will be initialized by
         # initialize_cache.
-        self.cache_engine: List[CacheEngine]
+        self.cache_engine: list[CacheEngine]
         # Initialize gpu_cache as pooling models don't initialize kv_caches
-        self.gpu_cache: Optional[List[List[torch.Tensor]]] = None
-        self._seq_group_metadata_cache: Dict[str, SequenceGroupMetadata] = {}
+        self.gpu_cache: Optional[list[list[torch.Tensor]]] = None
+        self._seq_group_metadata_cache: dict[str, SequenceGroupMetadata] = {}
 
         # Buffers saved before sleep
-        self._sleep_saved_buffers: Dict[str, torch.Tensor] = {}
+        self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
 
         # Torch profiler. Enabled and configured through env vars:
         # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
@@ -226,7 +226,7 @@ class Worker(LocalOrDistributedWorkerBase):
             tensorizer_config=tensorizer_config, )
 
     @torch.inference_mode()
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         """Profiles the peak memory usage of the model to determine how many
         KV blocks may be allocated without OOMs.
 
@@ -370,7 +370,7 @@ class Worker(LocalOrDistributedWorkerBase):
         return self.parallel_config.tensor_parallel_size > 1
 
     @property
-    def kv_cache(self) -> Optional[List[List[torch.Tensor]]]:
+    def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         return self.gpu_cache
 
     @torch.inference_mode()
@@ -421,9 +421,9 @@ class Worker(LocalOrDistributedWorkerBase):
 
     def _get_cached_seq_group_metadata(
             self,
-            seq_group_metadata_list: List[Union[SequenceGroupMetadata,
+            seq_group_metadata_list: list[Union[SequenceGroupMetadata,
                                                 SequenceGroupMetadataDelta]],
-            finished_request_ids: List[str]) -> List[SequenceGroupMetadata]:
+            finished_request_ids: list[str]) -> list[SequenceGroupMetadata]:
         """Return a list of cached Sequence Group Metadata after updating its
         state.
 
@@ -464,7 +464,7 @@ class Worker(LocalOrDistributedWorkerBase):
         self,
         execute_model_req: ExecuteModelRequest,
         intermediate_tensors: Optional[IntermediateTensors] = None,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         if execute_model_req is not None:
             new_seq_group_metadata_list = self._get_cached_seq_group_metadata(
                 execute_model_req.seq_group_metadata_list,
@@ -485,7 +485,7 @@ class Worker(LocalOrDistributedWorkerBase):
     def pin_lora(self, lora_id: int) -> bool:
         return self.model_runner.pin_lora(lora_id)
 
-    def list_loras(self) -> Set[int]:
+    def list_loras(self) -> set[int]:
         return self.model_runner.list_loras()
 
     def add_prompt_adapter(
@@ -498,7 +498,7 @@ class Worker(LocalOrDistributedWorkerBase):
     def pin_prompt_adapter(self, prompt_adapter_id: int) -> bool:
         return self.model_runner.pin_prompt_adapter(prompt_adapter_id)
 
-    def list_prompt_adapters(self) -> Set[int]:
+    def list_prompt_adapters(self) -> set[int]:
         return self.model_runner.list_prompt_adapters()
 
     @property

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -4,7 +4,7 @@ import dataclasses
 import os
 import time
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 import cloudpickle
 import torch
@@ -77,7 +77,7 @@ class WorkerBase:
     def execute_model(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         raise NotImplementedError
 
     def start_worker_execution_loop(self) -> None:
@@ -92,7 +92,7 @@ class WorkerBase:
                 if output is None:
                     return None
 
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         """Determine the number of available blocks for the GPU KV cache and
         swappable CPU KV cache.
 
@@ -121,7 +121,7 @@ class WorkerBase:
     def pin_lora(self, lora_id: int) -> bool:
         raise NotImplementedError
 
-    def list_loras(self) -> Set[int]:
+    def list_loras(self) -> set[int]:
         raise NotImplementedError
 
     @property
@@ -150,7 +150,7 @@ class DelegateWorkerBase(WorkerBase):
     def init_device(self) -> None:
         self.worker.init_device()
 
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         return self.worker.determine_num_available_blocks()
 
     def initialize_cache(self, num_gpu_blocks: int,
@@ -167,7 +167,7 @@ class DelegateWorkerBase(WorkerBase):
     def execute_model(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         return self.worker.execute_model(execute_model_req)
 
     def get_cache_block_size_bytes(self) -> int:
@@ -182,7 +182,7 @@ class DelegateWorkerBase(WorkerBase):
     def pin_lora(self, lora_id: int) -> bool:
         return self.worker.pin_lora(lora_id)
 
-    def list_loras(self) -> Set[int]:
+    def list_loras(self) -> set[int]:
         return self.worker.list_loras()
 
     def __getattr__(self, attr):
@@ -204,7 +204,7 @@ class LoRANotSupportedWorkerBase(WorkerBase):
         return ValueError(
             f"{type(self)} does not support LoRA")  # type: ignore
 
-    def list_loras(self) -> Set[int]:
+    def list_loras(self) -> set[int]:
         raise ValueError(f"{type(self)} does not support LoRA")
 
 
@@ -223,8 +223,8 @@ class WorkerInput:
 
     @classmethod
     def from_broadcasted_tensor_dict(
-        cls: Type["WorkerInput"],
-        tensor_dict: Dict[str, Any],
+        cls: type["WorkerInput"],
+        tensor_dict: dict[str, Any],
     ) -> "WorkerInput":
         """
         Pop fields from the given tensor_dict and populate a new instance of
@@ -240,7 +240,7 @@ class WorkerInput:
         )
 
     def as_broadcastable_tensor_dict(
-            self) -> Dict[str, Union[int, torch.Tensor]]:
+            self) -> dict[str, Union[int, torch.Tensor]]:
         """
         Extract broadcastable fields.
         """
@@ -282,7 +282,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
 
     @property
     @abstractmethod
-    def kv_cache(self) -> Optional[List[List[torch.Tensor]]]:
+    def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         """
         Gets the list of kv caches to pass to the worker's model runner. Each
         element in the list is a kv cache corresponding to a particular virtual
@@ -311,7 +311,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
 
     def _get_worker_input_from_broadcast(
         self
-    ) -> Optional[Tuple[BroadcastableModelInput, WorkerInput, Dict[
+    ) -> Optional[tuple[BroadcastableModelInput, WorkerInput, dict[
             str, torch.Tensor]]]:
         """ Get the worker input from the broadcasted tensor dict. """
         assert self.do_metadata_broadcast
@@ -331,7 +331,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
 
     def _get_driver_input_and_broadcast(
         self, execute_model_req: ExecuteModelRequest
-    ) -> Tuple[BroadcastableModelInput, WorkerInput, Dict[str, torch.Tensor]]:
+    ) -> tuple[BroadcastableModelInput, WorkerInput, dict[str, torch.Tensor]]:
         """ Get the driver input and broadcast it to other workers.  """
         assert self.is_driver_worker
 
@@ -361,7 +361,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
     def prepare_input(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None
-    ) -> Optional[Tuple[BroadcastableModelInput, WorkerInput, Dict[
+    ) -> Optional[tuple[BroadcastableModelInput, WorkerInput, dict[
             str, torch.Tensor]]]:
         """
         Prepare the inputs to ModelRunner and workers.
@@ -386,7 +386,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
     def execute_model(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         """Executes at least one model step on the given sequences, unless no
         sequences are provided."""
         start_time = time.perf_counter()
@@ -451,7 +451,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         self,
         execute_model_req: ExecuteModelRequest,
         intermediate_tensors: Optional[IntermediateTensors] = None
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         """
         Execute model in Single Program Multiple Data (SPMD) fashion.
         All workers take the same request, prepare the input and
@@ -521,7 +521,7 @@ class WorkerWrapperBase:
                 from vllm.utils import init_cached_hf_modules
                 init_cached_hf_modules()
 
-    def adjust_rank(self, rank_mapping: Dict[int, int]) -> None:
+    def adjust_rank(self, rank_mapping: dict[int, int]) -> None:
         """
         Adjust the rpc_rank based on the given mapping.
         It is only used during the initialization of the executor,
@@ -530,7 +530,7 @@ class WorkerWrapperBase:
         if self.rpc_rank in rank_mapping:
             self.rpc_rank = rank_mapping[self.rpc_rank]
 
-    def update_environment_variables(self, envs_list: List[Dict[str,
+    def update_environment_variables(self, envs_list: list[dict[str,
                                                                 str]]) -> None:
         envs = envs_list[self.rpc_rank]
         key = 'CUDA_VISIBLE_DEVICES'
@@ -540,7 +540,7 @@ class WorkerWrapperBase:
             del os.environ[key]
         update_environment_variables(envs)
 
-    def init_worker(self, all_kwargs: List[Dict[str, Any]]) -> None:
+    def init_worker(self, all_kwargs: list[dict[str, Any]]) -> None:
         """
         Here we inject some common logic before initializing the worker.
         Arguments are passed to the worker class constructor.
@@ -594,7 +594,7 @@ class WorkerWrapperBase:
             self.worker = worker_class(**kwargs)
             assert self.worker is not None
 
-    def initialize_from_config(self, kv_cache_configs: List[Any]) -> None:
+    def initialize_from_config(self, kv_cache_configs: list[Any]) -> None:
         kv_cache_config = kv_cache_configs[self.rpc_rank]
         self.worker.initialize_from_config(kv_cache_config)  # type: ignore
 
@@ -625,8 +625,8 @@ class WorkerWrapperBase:
 
 
 def extract_previous_hidden_states(
-        data: Union[ExecuteModelRequest, Dict[str, torch.Tensor]]) -> \
-            Dict[str, torch.Tensor]:
+        data: Union[ExecuteModelRequest, dict[str, torch.Tensor]]) -> \
+            dict[str, torch.Tensor]:
     """If data contains previous_hidden_states, extract it. This returns a dict
     which can be used directly as additional kwargs in any following 
     execute_model calls. This is used in draft models like EAGLE."""

--- a/vllm/worker/xpu_model_runner.py
+++ b/vllm/worker/xpu_model_runner.py
@@ -5,8 +5,7 @@ import time
 import weakref
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
-                    Type, TypeVar)
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 import torch
 import torch.nn as nn
@@ -54,11 +53,11 @@ class ModelInputForXPU(ModelRunnerInputBase):
     attn_metadata: Optional["AttentionMetadata"] = None
     multi_modal_kwargs: Optional[BatchedTensorInputs] = None
     virtual_engine: Optional[int] = None
-    seq_lens: Optional[List[int]] = None
-    query_lens: Optional[List[int]] = None
+    seq_lens: Optional[list[int]] = None
+    query_lens: Optional[list[int]] = None
     async_callback: Optional[Callable] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "input_positions": self.input_positions,
@@ -69,8 +68,8 @@ class ModelInputForXPU(ModelRunnerInputBase):
 
     @classmethod
     def from_broadcasted_tensor_dict(
-        cls: Type[TModelInputForXPU],
-        tensor_dict: Dict[str, Any],
+        cls: type[TModelInputForXPU],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> TModelInputForXPU:
         if attn_backend is not None:
@@ -86,7 +85,7 @@ class ModelInputForXPUWithSamplingMetadata(ModelInputForXPU):
     """
     sampling_metadata: Optional["SamplingMetadata"] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "input_positions": self.input_positions,
@@ -99,7 +98,7 @@ class ModelInputForXPUWithSamplingMetadata(ModelInputForXPU):
     @classmethod
     def from_broadcasted_tensor_dict(
         cls,
-        tensor_dict: Dict[str, Any],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> "ModelInputForXPUWithSamplingMetadata":
         tensor_dict = _init_sampling_metadata_from_tensor_dict(tensor_dict)
@@ -113,7 +112,7 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
 
     def __init__(self,
                  runner: "XPUModelRunner",
-                 finished_requests_ids: Optional[List[str]] = None) -> None:
+                 finished_requests_ids: Optional[list[str]] = None) -> None:
         super().__init__()
         self.runner = runner
         self.model_input_cls = self.runner._model_input_cls
@@ -123,8 +122,8 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
         self.device = self.runner.device
 
     def prepare(self,
-                finished_requests_ids: Optional[List[str]] = None) -> None:
-        self.seq_group_metadata_list: List[SequenceGroupMetadata] = []
+                finished_requests_ids: Optional[list[str]] = None) -> None:
+        self.seq_group_metadata_list: list[SequenceGroupMetadata] = []
 
     def add_seq_group(self, seq_group_metadata: SequenceGroupMetadata):
         self.seq_group_metadata_list.append(seq_group_metadata)
@@ -154,16 +153,16 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
 
     def _prepare_prompt(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-    ) -> Tuple[torch.Tensor, torch.Tensor, AttentionMetadata, List[int],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+    ) -> tuple[torch.Tensor, torch.Tensor, AttentionMetadata, list[int],
                BatchedTensorInputs]:
         assert len(seq_group_metadata_list) > 0
-        input_tokens: List[int] = []
-        input_positions: List[int] = []
-        slot_mapping: List[int] = []
-        seq_lens: List[int] = []
-        multi_modal_kwargs_list: List[MultiModalKwargs] = []
-        multi_modal_placeholder_maps: Dict[
+        input_tokens: list[int] = []
+        input_positions: list[int] = []
+        slot_mapping: list[int] = []
+        seq_lens: list[int] = []
+        multi_modal_kwargs_list: list[MultiModalKwargs] = []
+        multi_modal_placeholder_maps: dict[
             str,
             MultiModalPlaceholderMap] = defaultdict(MultiModalPlaceholderMap)
 
@@ -273,14 +272,14 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
 
     def _prepare_decode(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-    ) -> Tuple[torch.Tensor, torch.Tensor, AttentionMetadata]:
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+    ) -> tuple[torch.Tensor, torch.Tensor, AttentionMetadata]:
         assert len(seq_group_metadata_list) > 0
-        input_tokens: List[int] = []
-        input_positions: List[int] = []
-        slot_mapping: List[int] = []
-        seq_lens: List[int] = []
-        block_tables: List[List[int]] = []
+        input_tokens: list[int] = []
+        input_positions: list[int] = []
+        slot_mapping: list[int] = []
+        seq_lens: list[int] = []
+        block_tables: list[list[int]] = []
 
         for seq_group_metadata in seq_group_metadata_list:
             assert not seq_group_metadata.is_prompt
@@ -358,9 +357,9 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
 
 
 class XPUModelRunner(ModelRunnerBase[ModelInputForXPUWithSamplingMetadata]):
-    _model_input_cls: Type[ModelInputForXPUWithSamplingMetadata] = (
+    _model_input_cls: type[ModelInputForXPUWithSamplingMetadata] = (
         ModelInputForXPUWithSamplingMetadata)
-    _builder_cls: Type[ModelInputForXPUBuilder] = ModelInputForXPUBuilder
+    _builder_cls: type[ModelInputForXPUBuilder] = ModelInputForXPUBuilder
 
     def __init__(
         self,
@@ -430,7 +429,7 @@ class XPUModelRunner(ModelRunnerBase[ModelInputForXPUWithSamplingMetadata]):
 
         # Profile memory usage with max_num_sequences sequences and the total
         # number of tokens equal to max_num_batched_tokens.
-        seqs: List[SequenceGroupMetadata] = []
+        seqs: list[SequenceGroupMetadata] = []
         # Additional GPU memory may be needed for multi-modal encoding, which
         # needs to be accounted for when calculating the GPU blocks for
         # vLLM blocker manager.
@@ -488,7 +487,7 @@ class XPUModelRunner(ModelRunnerBase[ModelInputForXPUWithSamplingMetadata]):
 
     def make_model_input_from_broadcasted_tensor_dict(
             self,
-            tensor_dict: Dict[str,
+            tensor_dict: dict[str,
                               Any]) -> ModelInputForXPUWithSamplingMetadata:
         return (
             ModelInputForXPUWithSamplingMetadata.from_broadcasted_tensor_dict(
@@ -498,8 +497,8 @@ class XPUModelRunner(ModelRunnerBase[ModelInputForXPUWithSamplingMetadata]):
 
     def _prepare_model_input_tensors(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-        finished_requests_ids: Optional[List[str]] = None
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+        finished_requests_ids: Optional[list[str]] = None
     ) -> ModelInputForXPUWithSamplingMetadata:
         """Helper method to prepare the model input based on a given sequence
         group. Prepares metadata needed for the base model forward pass but not
@@ -515,9 +514,9 @@ class XPUModelRunner(ModelRunnerBase[ModelInputForXPUWithSamplingMetadata]):
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[list[str]] = None
     ) -> ModelInputForXPUWithSamplingMetadata:
         """Prepare the model input based on a given sequence group, including
         metadata for the sampling step.
@@ -544,10 +543,10 @@ class XPUModelRunner(ModelRunnerBase[ModelInputForXPUWithSamplingMetadata]):
     def execute_model(
         self,
         model_input: ModelInputForXPUWithSamplingMetadata,
-        kv_caches: List[torch.Tensor],
+        kv_caches: list[torch.Tensor],
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
         if num_steps > 1:
             raise ValueError(
                 "XPUModelRunner does not support multi-step execution.")

--- a/vllm/worker/xpu_worker.py
+++ b/vllm/worker/xpu_worker.py
@@ -2,7 +2,7 @@
 """A XPU worker class."""
 import gc
 import os
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import intel_extension_for_pytorch  # noqa: F401
 import oneccl_bindings_for_pytorch  # noqa: F401
@@ -64,8 +64,8 @@ class XPUWorker(LoRANotSupportedWorkerBase, Worker):
         )
         # Uninitialized cache engine. Will be initialized by
         # initialize_cache.
-        self.cache_engine: List[CacheEngine]
-        self.gpu_cache: Optional[List[List[torch.Tensor]]]
+        self.cache_engine: list[CacheEngine]
+        self.gpu_cache: Optional[list[list[torch.Tensor]]]
 
     def init_device(self) -> None:
         if self.device_config.device.type == "xpu" and current_platform.is_xpu(
@@ -85,7 +85,7 @@ class XPUWorker(LoRANotSupportedWorkerBase, Worker):
 
     # keep this method for `empty_cache` and `synchronize` api
     @torch.inference_mode()
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         """Profiles the peak memory usage of the model to determine how many
         KV blocks may be allocated without OOMs.
 


### PR DESCRIPTION


- help to remove the deprecated Python 3.8 syntax.

<!--- pyml disable-next-line no-emphasis-as-heading -->
