### PR TITLE
[Frontend] Plugin for OpenAI server (prototype)

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -5,7 +5,7 @@ import argparse
 import uvloop
 
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.openai.api_server import run_server
+from vllm.entrypoints.openai.api_server import prepare_plugins, run_server
 from vllm.entrypoints.openai.cli_args import (make_arg_parser,
                                               validate_parsed_serve_args)
 from vllm.utils import FlexibleArgumentParser
@@ -52,7 +52,10 @@ class ServeSubcommand(CLISubcommand):
             "https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#cli-reference"
         )
 
-        return make_arg_parser(serve_parser)
+        serve_parser = make_arg_parser(serve_parser)
+        serve_parser = prepare_plugins(serve_parser)
+
+        return serve_parser
 
 
 def cmd_init() -> list[CLISubcommand]:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -43,7 +43,8 @@ from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.cli_args import (make_arg_parser,
                                               validate_parsed_serve_args)
-from vllm.entrypoints.openai.plugins import ServerPlugin, load_server_plugins
+from vllm.entrypoints.openai.plugins import (get_server_plugins,
+                                             load_server_plugins)
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
@@ -1039,9 +1040,7 @@ def create_server_socket(addr: tuple[str, int]) -> socket.socket:
     return sock
 
 
-async def run_server(args,
-                     plugins: dict[str, ServerPlugin] = None,
-                     **uvicorn_kwargs) -> None:
+async def run_server(args, **uvicorn_kwargs) -> None:
     logger.info("vLLM API server version %s", VLLM_VERSION)
     logger.info("args: %s", args)
 
@@ -1082,8 +1081,9 @@ async def run_server(args,
 
         vllm_config = await engine_client.get_vllm_config()
         await init_app_state(engine_client, vllm_config, app.state, args)
-        if plugins:
-            for plugin_name, plugin in plugins.items():
+        loaded_server_plugins = get_server_plugins()
+        if loaded_server_plugins:
+            for plugin_name, plugin in loaded_server_plugins.items():
                 try:
                     plugin.apply_plugin(app, engine_client, vllm_config,
                                         app.state, args)
@@ -1126,6 +1126,20 @@ async def run_server(args,
         sock.close()
 
 
+def prepare_plugins(parser: FlexibleArgumentParser):
+    # Load server plugins
+    if envs.VLLM_ALLOW_SERVER_PLUGINS:
+        logger.warning("Server plugins are enabled in the API server. "
+                       "This may introduce security vulnerabilities. "
+                       "Only use plugins from trusted sources.")
+        loaded_server_plugins = load_server_plugins()
+        for plugin_name, plugin in loaded_server_plugins.items():
+            logger.info("Adding plugin %s to the parser", plugin_name)
+            # Add plugin-specific arguments to the parser
+            plugin.make_arg_parser(parser)
+    return parser
+
+
 if __name__ == "__main__":
     # NOTE(simon):
     # This section should be in sync with vllm/entrypoints/cli/main.py for CLI
@@ -1135,22 +1149,9 @@ if __name__ == "__main__":
         description="vLLM OpenAI-Compatible RESTful API server.")
     parser = make_arg_parser(parser)
 
-    # Load server plugins
-    if envs.VLLM_ALLOW_SERVER_PLUGINS:
-        logger.warning("Server plugins are enabled in the API server. "
-                       "This may introduce security vulnerabilities. "
-                       "Only use plugins from trusted sources.")
-        plugins: dict[str, ServerPlugin] = load_server_plugins()
-        for plugin_name, plugin in plugins.items():
-            logger.info("Loaded server plugin: %s", plugin_name)
-            # Add plugin-specific arguments to the parser
-            plugin.make_arg_parser(parser)
-            # Register the plugin's parser
-            plugin.register_parser()
-    else:
-        plugins = {}
+    prepare_plugins(parser)
 
     args = parser.parse_args()
     validate_parsed_serve_args(args)
 
-    uvloop.run(run_server(args, plugins=plugins))
+    uvloop.run(run_server(args))

--- a/vllm/entrypoints/openai/plugins/__init__.py
+++ b/vllm/entrypoints/openai/plugins/__init__.py
@@ -1,20 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
+from vllm.logger import init_logger
 from vllm.plugins import load_plugins_by_group
 
 from .abs_server_plugin import ServerPlugin
 
+logger = init_logger(__name__)
+
+loaded_server_plugins: dict[str, ServerPlugin] = {}
+
 
 def load_server_plugins() -> dict[str, ServerPlugin]:
+    global loaded_server_plugins
     platform_plugins = load_plugins_by_group("vllm.server_plugins")
 
     activated_plugins = {}
 
     for name, plugin_cls in platform_plugins.items():
         try:
-            assert isinstance(plugin_cls, type)
-            assert issubclass(plugin_cls, ServerPlugin)
+            assert isinstance(plugin_cls, type), "Plugin class must be a type"
+            assert issubclass(
+                plugin_cls, ServerPlugin
+            ), "Plugin class must be a subclass of ServerPlugin"
             activated_plugins[name] = plugin_cls
-        except Exception as e:
-            print(f"Failed to load plugin {name}: {e}")
+        except AssertionError as e:
+            logger.error("Failed to load plugin %s: %s", name, e)
+            continue
 
-    return activated_plugins
+    loaded_server_plugins = activated_plugins
+    logger.info("Loaded server plugins: %s",
+                list(loaded_server_plugins.keys()))
+
+    return loaded_server_plugins
+
+
+def get_server_plugins() -> dict[str, ServerPlugin]:
+    """Get the loaded server plugins.
+
+    Returns:
+        dict[str, ServerPlugin]: A dictionary of loaded server plugins.
+    """
+    global loaded_server_plugins
+    return loaded_server_plugins

--- a/vllm/entrypoints/openai/plugins/__init__.py
+++ b/vllm/entrypoints/openai/plugins/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+from vllm.plugins import load_plugins_by_group
+
+from .abs_server_plugin import ServerPlugin
+
+
+def load_server_plugins() -> dict[str, ServerPlugin]:
+    platform_plugins = load_plugins_by_group("vllm.server_plugins")
+
+    activated_plugins = {}
+
+    for name, plugin_cls in platform_plugins.items():
+        try:
+            assert isinstance(plugin_cls, type)
+            assert issubclass(plugin_cls, ServerPlugin)
+            activated_plugins[name] = plugin_cls
+        except Exception as e:
+            print(f"Failed to load plugin {name}: {e}")
+
+    return activated_plugins

--- a/vllm/entrypoints/openai/plugins/abs_server_plugin.py
+++ b/vllm/entrypoints/openai/plugins/abs_server_plugin.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+from argparse import Namespace
+
+from fastapi import FastAPI
+from fastapi.datastructures import State
+
+from vllm.config import ModelConfig
+from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.openai.reasoning_parsers import (ReasoningParser,
+                                                       ReasoningParserManager)
+from vllm.entrypoints.openai.tool_parsers import ToolParser, ToolParserManager
+from vllm.utils import FlexibleArgumentParser
+
+
+class ServerPlugin:
+    """
+    Base class for server plugins. All server plugins should inherit from this
+    class and implement the abstract methods `make_arg_parser` and
+    `apply_plugin`.
+    """
+
+    _additional_tool_parsers: dict[str, ToolParser] = {}
+    _additional_reasoning_parsers: dict[str, ReasoningParser] = {}
+
+    @classmethod
+    def make_arg_parser(
+            cls, parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
+        """
+        Add plugin-specific arguments to the argument parser.
+        """
+        return parser
+
+    @classmethod
+    def register_parser(cls):
+        """
+        Register parsers such as ToolParsers and ReasoningParsers into
+        corresponding registries.
+        """
+        for name, parser in cls._additional_tool_parsers.items():
+            ToolParserManager.register_module(name=name, module=parser)
+        for name, parser in cls._additional_reasoning_parsers.items():
+            ReasoningParserManager.register_module(name=name, module=parser)
+
+    @classmethod
+    def apply_plugin(
+        cls,
+        app: FastAPI,
+        engine_client: EngineClient,
+        model_config: ModelConfig,
+        state: State,
+        args: Namespace,
+    ):
+        """
+        Apply the plugin to the server application.
+        """
+        pass

--- a/vllm/entrypoints/openai/plugins/abs_server_plugin.py
+++ b/vllm/entrypoints/openai/plugins/abs_server_plugin.py
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-from argparse import Namespace
+from typing import TYPE_CHECKING
 
-from fastapi import FastAPI
-from fastapi.datastructures import State
+if TYPE_CHECKING:
+    from argparse import Namespace
 
-from vllm.config import ModelConfig
-from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.openai.reasoning_parsers import (ReasoningParser,
-                                                       ReasoningParserManager)
-from vllm.entrypoints.openai.tool_parsers import ToolParser, ToolParserManager
-from vllm.utils import FlexibleArgumentParser
+    from fastapi import FastAPI
+    from fastapi.datastructures import State
+
+    from vllm.config import VllmConfig
+    from vllm.engine.protocol import EngineClient
+    from vllm.utils import FlexibleArgumentParser
 
 
 class ServerPlugin:
@@ -19,36 +19,22 @@ class ServerPlugin:
     `apply_plugin`.
     """
 
-    _additional_tool_parsers: dict[str, ToolParser] = {}
-    _additional_reasoning_parsers: dict[str, ReasoningParser] = {}
-
     @classmethod
     def make_arg_parser(
-            cls, parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
+            cls, parser: "FlexibleArgumentParser") -> "FlexibleArgumentParser":
         """
         Add plugin-specific arguments to the argument parser.
         """
         return parser
 
     @classmethod
-    def register_parser(cls):
-        """
-        Register parsers such as ToolParsers and ReasoningParsers into
-        corresponding registries.
-        """
-        for name, parser in cls._additional_tool_parsers.items():
-            ToolParserManager.register_module(name=name, module=parser)
-        for name, parser in cls._additional_reasoning_parsers.items():
-            ReasoningParserManager.register_module(name=name, module=parser)
-
-    @classmethod
     def apply_plugin(
         cls,
-        app: FastAPI,
-        engine_client: EngineClient,
-        model_config: ModelConfig,
-        state: State,
-        args: Namespace,
+        app: "FastAPI",
+        engine_client: "EngineClient",
+        vllm_config: "VllmConfig",
+        state: "State",
+        args: "Namespace",
     ):
         """
         Apply the plugin to the server application.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -110,6 +110,7 @@ if TYPE_CHECKING:
     VLLM_USE_DEEP_GEMM: bool = False
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
+    VLLM_ALLOW_SERVER_PLUGINS: bool = False
 
 
 def get_default_cache_root():
@@ -727,6 +728,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # limit will actually be zero-copy decoded.
     "VLLM_MSGPACK_ZERO_COPY_THRESHOLD":
     lambda: int(os.getenv("VLLM_MSGPACK_ZERO_COPY_THRESHOLD", "256")),
+
+    # Whether to allow server plugins to be loaded,
+    # default is False
+    "VLLM_ALLOW_SERVER_PLUGINS":
+    lambda: bool(int(os.getenv("VLLM_ALLOW_SERVER_PLUGINS", "0"))),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
### Design: Server Plugin for vLLM OpenAI Server

**1. Background and Motivation**

The vLLM OpenAI Server component provides OpenAI API-compatible server endpoints, greatly simplifying its integration into existing ecosystems. However, in practical application scenarios, we often require extended functionalities beyond the standard OpenAI API scope, such as:

* Dynamically adjusting inference parameters for specific requests (e.g., enabling/disabling a custom parser), or providing dedicated API endpoints for specific model behaviors.
* Integrating special logging or monitoring metrics.
* Supporting specific formats for input preprocessing or output postprocessing.

Currently, a common solution is to wrap an additional service layer around the vLLM OpenAI Server. This approach has inherent limitations:
* **Access Restrictions:** The external service cannot directly access vLLM's internal `EngineClient` instance, `VllmConfig`, or FastAPI's `State`. It can only interact through standard API interfaces, limiting the depth and efficiency of functionalities.
* **Performance Overhead:** The additional service layer and network calls can introduce unnecessary latency.
* **Complexity:** Maintaining and deploying an additional service increases the overall system complexity.

To address these issues and draw inspiration from the success of vLLM's existing Plugin system, we propose a **Server Plugin** mechanism. This mechanism allows developers to inject custom logic at the OpenAI Server level, register new API interfaces, and directly access the core `EngineClient` instance and other related service components.

**2. Core Design: Server Plugin**

The core idea behind Server Plugins is to provide a well-defined interface that allows developers to create pluggable modules to extend the functionality of the OpenAI Server.

* **Plugin Format:** Each Server Plugin is a Python class that inherits from the `vllm.entrypoints.openai.plugins.ServerPlugin` base class. Plugins interact with the main service by implementing specific class methods (`@classmethod`).
* **Core Capabilities:**
    * Register new command-line arguments to vLLM's startup parameters for the plugin's own configuration.
    * Register new API routes (endpoints) to the FastAPI application.
    * Directly access the `EngineClient` instance, `VllmConfig` configuration object, FastAPI's `app.state`, and parsed command-line arguments.

**3. Plugin Interface Definition**

A Server Plugin class needs to inherit from `vllm.entrypoints.openai.plugins.ServerPlugin` and can implement the following class methods:

* `make_arg_parser(cls, parser: FlexibleArgumentParser) -> FlexibleArgumentParser:`
    * **Annotation:** `@classmethod`
    * **Purpose:** Allows the plugin to add custom arguments to vLLM's main command-line argument parser (`FlexibleArgumentParser`).
    * **Invocation Timing:** During vLLM service startup, before global argument parsing.
    * **Parameters:**
        * `parser: FlexibleArgumentParser`: The argument parser instance used by vLLM. The plugin should call `parser.add_argument(...)` on this object.
    * **Return Value:** The modified `FlexibleArgumentParser` instance.
    * **Example:** A plugin can define arguments like `--my-plugin-feature-flag` or `--my-plugin-config-value` in this method.

* `apply_plugin(cls, app: FastAPI, engine_client: EngineClient, vllm_config: VllmConfig, state: State, args: Namespace) -> None:`
    * **Annotation:** `@classmethod`
    * **Purpose:** The plugin's main initialization and application logic. Its core task is to register new API routes and configure plugin behavior.
    * **Invocation Timing:** After the FastAPI application (`app`) and `EngineClient` are initialized, and all command-line arguments (`args`) have been fully parsed, but before the service starts listening for requests.
    * **Parameters:**
        * `app: FastAPI`: The FastAPI application instance. The plugin can use it to register new HTTP interfaces via `app.add_api_route(...)` or `app.include_router(...)`.
        * `engine_client: EngineClient`: The `EngineClient` instance. The plugin can save a reference to this object or use it directly to interact with the vLLM engine.
        * `vllm_config: VllmConfig`: vLLM's main configuration object, containing model configuration (`model_config`), etc.
        * `state: State`: FastAPI application's global state object (`app.state`). Can be used for data sharing between plugins or accessing state set by the main service (e.g., `state.openai_serving_models`).
        * `args: Namespace`: An `argparse.Namespace` object containing all parsed command-line arguments (including those added by the plugin itself via `make_arg_parser`).
    * **Return Value:** None.

**4. Workflow**

1.  **Plugin Discovery:** During startup, the vLLM Server scans specified locations (e.g., module paths specified via configuration files or Python files in a specific plugin directory) to discover all classes inheriting from `ServerPlugin`.
2.  **Argument Registration:** For each discovered plugin class, if it implements the `make_arg_parser` method, this method is called to add the plugin-defined arguments to the global `FlexibleArgumentParser`.
3.  **Argument Parsing:** vLLM parses all collected command-line arguments (from the main service and all plugins).
4.  **Plugin Application:** For each discovered plugin class, if it implements the `apply_plugin` method, this method is called, passing in `app`, `engine_client`, `vllm_config`, `state`, and the parsed `args`. The plugin completes all its setup and route registration in this phase.

**5. Example Use Cases**

**Example 1: Extra Reasoning API (based on `ExtraReasoningRoutePlugin`)**

* **Problem Description:** In some scenarios (e.g., Deepseek deployment), I need to provide two sets of APIs: one that is fully standard OpenAI API (without reasoning content), and another that is Deepseek-style reasoning API (with reasoning content). Currently, vLLM only allows global configuration of the Reasoning Parser at service startup.

* **Plugin Solution (`ExtraReasoningRoutePlugin`):**
    1.  **Define plugin class:**
        ```python
        from vllm.entrypoints.openai.plugins import ServerPlugin
        from vllm.utils import FlexibleArgumentParser
        from fastapi import FastAPI, Request
        from fastapi.datastructures import State
        from argparse import Namespace
        from vllm.config import VllmConfig
        from vllm.engine.protocol import EngineClient
        from vllm.entrypoints.openai.serving_chat import OpenAIServingChat # Actual import path may differ
        from vllm.entrypoints.chat_utils import load_chat_template # Actual import path may differ
        from vllm.entrypoints.logger import RequestLogger # Actual import path may differ
        # from vllm.entrypoints.openai.protocol import ChatCompletionRequest # Actual import path may differ
        # from vllm.entrypoints.utils import with_cancellation # Actual import path may differ
        # from vllm.logger import init_logger # Actual import path may differ
        # logger = init_logger(__name__) # Typically at the top of the module

        class ExtraReasoningRoutePlugin(ServerPlugin):
            @classmethod
            def make_arg_parser(cls, parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
                """
                Add extra arguments for the plugin.
                """
                parser.add_argument(
                    "--extra-reasoning-route", action="store_true", default=False,
                    help="Whether to enable extra route for reasoning"
                )
                parser.add_argument(
                    "--extra-reasoning-route-prefix", type=str, default="reasoning",
                    help="The route prefix for reasoning"
                )
                parser.add_argument(
                    "--extra-reasoning-parser", type=str, default=None,
                    help="Extra reasoning parser (e.g., path to a module or a registered name)"
                )
                return parser

            @classmethod
            def apply_plugin(cls, app: FastAPI, engine_client: EngineClient,
                             vllm_config: VllmConfig, state: State, args: Namespace):
                if not args.extra_reasoning_route:
                    return
                
                # logger.info("Enabling extra reasoning route for prefix: /%s", args.extra_reasoning_route_prefix) # Assuming logger is defined
                
                request_logger = RequestLogger(max_log_len=args.max_log_len) if hasattr(args, 'disable_log_requests') and not args.disable_log_requests and hasattr(args, 'max_log_len') else None
                resolved_chat_template = load_chat_template(args.chat_template) if hasattr(args, 'chat_template') and args.chat_template else None

                openai_serving_reasoning = OpenAIServingChat(
                    engine_client,
                    vllm_config.model_config,
                    state.openai_serving_models, 
                    args.response_role if hasattr(args, 'response_role') else "assistant", # Provide a default value
                    request_logger=request_logger,
                    chat_template=resolved_chat_template,
                    # ... Ensure other necessary parameters for OpenAIServingChat are passed from args or vllm_config ...
                    # For example:
                    # chat_template_content_format=args.chat_template_content_format if hasattr(args, 'chat_template_content_format') else None,
                    # return_tokens_as_token_ids=args.return_tokens_as_token_ids if hasattr(args, 'return_tokens_as_token_ids') else False,
                    # enable_auto_tools=args.enable_auto_tool_choice if hasattr(args, 'enable_auto_tool_choice') else False,
                    # tool_parser=args.tool_call_parser if hasattr(args, 'tool_call_parser') else None,
                    # enable_prompt_tokens_details=args.enable_prompt_tokens_details if hasattr(args, 'enable_prompt_tokens_details') else False,
                    reasoning_parser=args.extra_reasoning_parser, 
                )

                @app.post(
                    f"/{args.extra_reasoning_route_prefix}/chat/completions",
                    # dependencies=[Depends(validate_json_request)], # Ensure validate_json_request is defined or imported
                )
                # @with_cancellation # Ensure with_cancellation is defined or imported
                async def create_chat_completion(
                    # request: ChatCompletionRequest, # Ensure ChatCompletionRequest is defined or imported
                    request: dict, # Or use a more generic type
                    raw_request: Request 
                ):
                    # generator = await openai_serving_reasoning.create_chat_completion(
                    # request, raw_request
                    # )
                    # # ... (Logic for handling the response, returning StreamingResponse or JSONResponse) ...
                    # # from fastapi.responses import JSONResponse, StreamingResponse # Ensure import
                    # if isinstance(generator, ErrorResponse): # Ensure ErrorResponse is defined or imported
                    # return JSONResponse(content=generator.model_dump(), status_code=generator.code)
                    # elif isinstance(generator, ChatCompletionResponse): # Ensure ChatCompletionResponse is defined or imported
                    # return JSONResponse(content=generator.model_dump())
                    # return StreamingResponse(content=generator, media_type="text/event-stream")
                    pass # Placeholder, actual implementation should be here
        ```
    2.  **Effect:**
        * When starting vLLM, this plugin can be enabled and the route customized via arguments like `--extra-reasoning-route --extra-reasoning-parser deepseek_r1 --extra-reasoning-route-prefix my-reasoning`.
        * The service will additionally provide an interface, for example, `/my-reasoning/chat/completions`.
        * Calls to this interface will use the parser specified by `--extra-reasoning-parser`, while the standard `/v1/chat/completions` interface behavior remains unchanged.

**(Recommendation: Consider adding another example of a different type of plugin, such as custom authentication or adding an auxiliary interface like `/v1/models/{model_name}`, to more comprehensively demonstrate the flexibility of Server Plugins.)**

**6. Advantages**

* **Modularity and Maintainability:** Extended functionalities are developed and maintained independently as plugins, without intruding into the vLLM core code.
* **Powerful Customization:** Direct access to core components like `EngineClient`, `VllmConfig`, and `app.state` allows plugins to implement almost any logic interacting with the engine and service.
* **Flexibility:** New API interfaces and custom startup arguments can be easily added to adapt to various specific business needs.
* **Reduced Complexity of External Wrappers:** Much of the logic that would otherwise require external service wrappers can be implemented directly within vLLM via plugins.
* **Encourages Community Contributions:** Provides a standardized way for community members to contribute and share extensions mãeeting specific needs.

**7. Security, Performance, and Isolation Considerations**

The Server Plugin has access to the core components of the server, which may break the original interface, and security and performance may also be affected. So I've added additional environment variables to control whether the Server Plugin is enabled or not. Perhaps we also need to consider isolation from the original interface to ensure that the plugin doesn't accidentally affect the behavior of other APIs.

Another option that comes to mind for the Server Plugin is to expose the EngineClient's capabilities to API or RPC calls, so that they can be accessed directly in an external service, rather than being called directly in the fastapi service.

