### PR TITLE
[Bugfix]Change the exception thrown by call_hf_processor from RuntimeError to ValueError

### DIFF
--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -159,7 +159,7 @@ class InputProcessingContext(InputContext):
             msg = (f"Failed to apply {type(hf_processor).__name__} "
                    f"on data={data} with kwargs={merged_kwargs}")
 
-            raise RuntimeError(msg) from exc
+            raise ValueError(msg) from exc
 
 
 class DummyData(NamedTuple):


### PR DESCRIPTION
In our multimodal scenario, when the input image size does not match the model's requirements, the `call_hf_processor` function throws a `RuntimeError`. 

In the `async_llm_engine.py`, the `engine_step` function only catches `ValueError`, which leads to that the client hangs and cannot exit. If the `call_hf_processor` function throws a `ValueError` instead, the client can exit normally. 

In fact, an image size mismatch should be considered a `ValueError`.