### PR TITLE
[Feature] support torchrun PP with concurrent requests

### DIFF
--- a/tests/distributed/test_broadcast_async.py
+++ b/tests/distributed/test_broadcast_async.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import multiprocessing
+
+import numpy as np
+import torch.distributed as dist
+
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.utils import get_ip, update_environment_variables
+
+from ..utils import init_test_distributed_environment
+
+
+def get_arrays(n: int, seed: int = 0) -> list[np.ndarray]:
+    np.random.seed(seed)
+    sizes = np.random.randint(1, 10_000, n)
+    # on average, each array will have 5k elements
+    # with int64, each array will have 40kb
+    return [np.random.randint(1, 100, i) for i in sizes]
+
+
+def distributed_run(fn, world_size):
+    number_of_processes = world_size
+    processes = []
+    for i in range(number_of_processes):
+        env = {}
+        env['RANK'] = str(i)
+        env['LOCAL_RANK'] = str(i)
+        env['WORLD_SIZE'] = str(number_of_processes)
+        env['LOCAL_WORLD_SIZE'] = str(number_of_processes)
+        env['MASTER_ADDR'] = 'localhost'
+        env['MASTER_PORT'] = '12345'
+        p = multiprocessing.Process(target=fn, args=(env, ))
+        processes.append(p)
+        p.start()
+
+    for p in processes:
+        p.join()
+
+    for p in processes:
+        assert p.exitcode == 0
+
+
+def worker_fn_wrapper(fn):
+
+    def wrapped_fn(env):
+        update_environment_variables(env)
+        init_test_distributed_environment(1, 2, int(env['RANK']), "12345")
+        fn()
+
+    return wrapped_fn
+
+
+@worker_fn_wrapper
+def worker_fn():
+
+    rank = dist.get_rank()
+    ip = get_ip()
+    port = 1345
+    pp_group = get_pp_group()
+    if rank == 1:
+        broadcast_object = {"ip": ip, "port": port}
+        pp_group.broadcast_object_async(broadcast_object, src=1)
+    else:
+        recv = pp_group.broadcast_object_async(None, src=1)
+        result = recv.result()
+        assert result["ip"] == ip, f"Expected {ip}, got {result['ip']}"
+        assert result["port"] == port, f"Expected {port}, got {result['port']}"
+
+
+def test_broadcast_async():
+    distributed_run(worker_fn, 2)

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -97,6 +97,7 @@ def _get_unique_name(name: str) -> str:
 
 _groups: dict[str, Callable[[], Optional["GroupCoordinator"]]] = {}
 
+
 def _register_group(group: "GroupCoordinator") -> None:
     _groups[group.unique_name] = weakref.ref(group)
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -27,7 +27,6 @@ import gc
 import pickle
 import weakref
 from collections import namedtuple
-from concurrent.futures import Future
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from multiprocessing import shared_memory

--- a/vllm/executor/uniproc_executor.py
+++ b/vllm/executor/uniproc_executor.py
@@ -100,7 +100,6 @@ class ExecutorWithExternalLauncher(UniProcExecutor):
             "please set VLLM_ENABLE_V1_MULTIPROCESSING=0")
         self.driver_worker = WorkerWrapperBase(vllm_config=self.vllm_config,
                                                rpc_rank=0)
-        self.non_blocking: bool = False
         self.excecute_model_thread_pool: Optional[ThreadPoolExecutor] = None
         # engines are launched in torchrun-compatible launchers
         # so we can use the env:// method.

--- a/vllm/executor/uniproc_executor.py
+++ b/vllm/executor/uniproc_executor.py
@@ -5,8 +5,10 @@ import os
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
+import threading
 import torch.distributed as dist
 
+from concurrent.futures import ThreadPoolExecutor
 import vllm.envs as envs
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.executor.executor_base import ExecutorBase
@@ -98,6 +100,8 @@ class ExecutorWithExternalLauncher(UniProcExecutor):
             "please set VLLM_ENABLE_V1_MULTIPROCESSING=0")
         self.driver_worker = WorkerWrapperBase(vllm_config=self.vllm_config,
                                                rpc_rank=0)
+        self.non_blocking: bool = False
+        self.excecute_model_thread_pool: Optional[ThreadPoolExecutor] = None
         # engines are launched in torchrun-compatible launchers
         # so we can use the env:// method.
         # required env vars:
@@ -121,10 +125,26 @@ class ExecutorWithExternalLauncher(UniProcExecutor):
         self.collective_rpc("init_device")
         self.collective_rpc("load_model")
         self.pp_rank = get_pp_group().rank_in_group
+        self.pp_lock: Optional[threading.Lock] = None
+        if self.max_concurrent_batches > 1:
+            self.pp_lock = threading.Lock()
+            self.excecute_model_thread_pool = ThreadPoolExecutor(
+                max_workers=self.max_concurrent_batches, thread_name_prefix="external_exec_")
 
     @property
     def max_concurrent_batches(self) -> int:
-        return self.parallel_config.pipeline_parallel_size - self.pp_rank
+        return self.parallel_config.pipeline_parallel_size
+    
+    def execute_model_pp(self, device: int, args: Tuple = (),kwargs: Optional[Dict] = None):
+        assert self.pp_lock is not None, "self.pp_lock is not initialized."
+        with self.pp_lock:
+            device = torch.cuda.set_device(device)
+            answer = run_method(self.driver_worker, "execute_model", args, kwargs)
+            # transfer the answer from the last PP rank
+            # to first PP rank with async torch.dist P2P
+            answer = get_pp_group().broadcast_object_async(
+                answer, src=self.parallel_config.pipeline_parallel_size - 1)
+        return answer.wait()
 
     def collective_rpc(self,
                        method: Union[str, Callable],
@@ -134,13 +154,17 @@ class ExecutorWithExternalLauncher(UniProcExecutor):
         if kwargs is None:
             kwargs = {}
         assert kwargs is not None
-        answer = run_method(self.driver_worker, method, args, kwargs)
         if method == "execute_model" \
-            and self.parallel_config.pipeline_parallel_size > 1:
-            # transfer the answer from the last PP rank
-            # to first PP rank with async torch.dist P2P
-            answer = get_pp_group().broadcast_object_async(
-                answer, src=self.parallel_config.pipeline_parallel_size - 1)
+                    and self.parallel_config.pipeline_parallel_size > 1:
+            device = torch.cuda.current_device()
+            assert self.excecute_model_thread_pool is not None, \
+                "self.excecute_model_thread_pool is not initialized."
+            answer = self.excecute_model_thread_pool.submit(
+                self.execute_model_pp, device, args, kwargs)
+
+        else:
+            answer = run_method(self.driver_worker, method, args, kwargs)
+
         return [answer]
 
     def determine_num_available_blocks(self) -> Tuple[int, int]:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -194,8 +194,7 @@ class Scheduler(SchedulerInterface):
         scheduled_timestamp = time.monotonic()
 
         # First, schedule the RUNNING requests.
-        req_index = 0 
-
+        req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
 
@@ -221,6 +220,7 @@ class Scheduler(SchedulerInterface):
                  new_encoder_budget) = self._try_schedule_encoder_inputs(
                      request, request.num_computed_tokens, num_new_tokens,
                      encoder_budget)
+
             if num_new_tokens == 0:
                 # The request cannot be scheduled because one of the following
                 # reasons:
@@ -356,7 +356,6 @@ class Scheduler(SchedulerInterface):
                         not in scheduled_loras):
                     # Scheduling would exceed max_loras, skip.
                     self.waiting.popleft()
-
                     skipped_waiting_requests.appendleft(request)
                     continue
 
@@ -488,6 +487,7 @@ class Scheduler(SchedulerInterface):
         # Put back any skipped requests at the head of the waiting queue
         if skipped_waiting_requests:
             self.waiting.extendleft(skipped_waiting_requests)
+
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
@@ -580,7 +580,7 @@ class Scheduler(SchedulerInterface):
         #    computed tokens will be adjusted in update_from_output.
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             self.requests[req_id].num_computed_tokens += num_scheduled_token
-        
+
         self.finished_req_ids = set()
         return scheduler_output
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import torch
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -193,7 +194,8 @@ class Scheduler(SchedulerInterface):
         scheduled_timestamp = time.monotonic()
 
         # First, schedule the RUNNING requests.
-        req_index = 0
+        req_index = 0 
+
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
 
@@ -219,7 +221,6 @@ class Scheduler(SchedulerInterface):
                  new_encoder_budget) = self._try_schedule_encoder_inputs(
                      request, request.num_computed_tokens, num_new_tokens,
                      encoder_budget)
-
             if num_new_tokens == 0:
                 # The request cannot be scheduled because one of the following
                 # reasons:
@@ -355,6 +356,7 @@ class Scheduler(SchedulerInterface):
                         not in scheduled_loras):
                     # Scheduling would exceed max_loras, skip.
                     self.waiting.popleft()
+
                     skipped_waiting_requests.appendleft(request)
                     continue
 
@@ -486,7 +488,6 @@ class Scheduler(SchedulerInterface):
         # Put back any skipped requests at the head of the waiting queue
         if skipped_waiting_requests:
             self.waiting.extendleft(skipped_waiting_requests)
-
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
@@ -579,7 +580,7 @@ class Scheduler(SchedulerInterface):
         #    computed tokens will be adjusted in update_from_output.
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             self.requests[req_id].num_computed_tokens += num_scheduled_token
-
+        
         self.finished_req_ids = set()
         return scheduler_output
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -3,7 +3,6 @@
 import os
 import queue
 import signal
-import torch
 import sys
 import threading
 import time

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -223,7 +223,7 @@ class InprocClient(EngineCoreClient):
         self.engine_core = EngineCore(*args, **kwargs)
 
     def get_output(self) -> EngineCoreOutputs:
-        outputs, _ = self.engine_core.step()
+        outputs, _ = self.engine_core.step_fn()
         return outputs.get(0) or EngineCoreOutputs()
 
     def add_request(self, request: EngineCoreRequest) -> None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -224,7 +224,10 @@ class InprocClient(EngineCoreClient):
 
     def get_output(self) -> EngineCoreOutputs:
         outputs, _ = self.engine_core.step_fn()
-        return outputs.get(0) or EngineCoreOutputs()
+        if outputs is not None:
+            return outputs.get(0) or EngineCoreOutputs()
+        else:
+            return EngineCoreOutputs()
 
     def add_request(self, request: EngineCoreRequest) -> None:
         self.engine_core.add_request(request)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -240,12 +240,12 @@ class LLMEngine:
 
         # 3) Abort any reqs that finished due to stop strings.
         self.engine_core.abort_requests(processed_outputs.reqs_to_abort)
+
         # 4) Record stats
         if self.stat_logger is not None:
             assert outputs.scheduler_stats is not None
-            self.stat_logger.record(
-                scheduler_stats=outputs.scheduler_stats,
-                iteration_stats=iteration_stats)
+            self.stat_logger.record(scheduler_stats=outputs.scheduler_stats,
+                                    iteration_stats=iteration_stats)
 
         return processed_outputs.request_outputs
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -233,21 +233,23 @@ class LLMEngine:
 
         # 2) Process EngineCoreOutputs.
         iteration_stats = IterationStats() if self.log_stats else None
-        processed_outputs = self.output_processor.process_outputs(
-            outputs.outputs,
-            engine_core_timestamp=outputs.timestamp,
-            iteration_stats=iteration_stats)
+        if outputs is not None:
+            processed_outputs = self.output_processor.process_outputs(
+                outputs.outputs,
+                engine_core_timestamp=outputs.timestamp,
+                iteration_stats=iteration_stats)
 
-        # 3) Abort any reqs that finished due to stop strings.
-        self.engine_core.abort_requests(processed_outputs.reqs_to_abort)
+            # 3) Abort any reqs that finished due to stop strings.
+            self.engine_core.abort_requests(processed_outputs.reqs_to_abort)
+            # 4) Record stats
+            if self.stat_logger is not None:
+                assert outputs.scheduler_stats is not None
+                self.stat_logger.record(
+                    scheduler_stats=outputs.scheduler_stats,
+                    iteration_stats=iteration_stats)
 
-        # 4) Record stats
-        if self.stat_logger is not None:
-            assert outputs.scheduler_stats is not None
-            self.stat_logger.record(scheduler_stats=outputs.scheduler_stats,
-                                    iteration_stats=iteration_stats)
-
-        return processed_outputs.request_outputs
+            return processed_outputs.request_outputs
+        return []
 
     def get_vllm_config(self):
         return self.vllm_config

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1122,7 +1122,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # across tensor parallel ranks, so each rank only needs its own slice.
         if sync_self:
             assert intermediate_tensors is not None
-            for k, v in intermediate_tensors.items():
+            for k, v in intermediate_tensors.items()
                 is_scattered = "residual" and is_residual_scattered
                 copy_len = num_tokens // tp if is_scattered else \
                     num_tokens

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1122,7 +1122,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # across tensor parallel ranks, so each rank only needs its own slice.
         if sync_self:
             assert intermediate_tensors is not None
-            for k, v in intermediate_tensors.items()
+            for k, v in intermediate_tensors.items():
                 is_scattered = "residual" and is_residual_scattered
                 copy_len = num_tokens // tp if is_scattered else \
                     num_tokens

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1266,33 +1266,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             hidden_states, aux_hidden_states = model_output
         else:
             hidden_states = model_output
-        # Broadcast PP output for external_launcher (torchrun)
-        # to make sure we are synced across pp ranks
-        # TODO: Support overlapping mirco-batches
-        # https://github.com/vllm-project/vllm/issues/18019
-        broadcast_pp_output = \
-            self.parallel_config.distributed_executor_backend \
-            == "external_launcher" and len(get_pp_group().ranks) > 0
         if not get_pp_group().is_last_rank:
             # For mid-pipeline stages, return the hidden states.
-            if not broadcast_pp_output:
-                return hidden_states
-            assert isinstance(hidden_states, IntermediateTensors)
-            get_pp_group().send_tensor_dict(hidden_states.tensors,
-                                            all_gather_group=get_tp_group())
-            logits = None
+            return hidden_states
         else:
             sample_hidden_states = hidden_states[logits_indices]
             logits = self.model.compute_logits(sample_hidden_states, None)
-        if broadcast_pp_output:
-            model_output_broadcast_data = {
-                "logits": logits.contiguous(),
-            } if logits is not None else {}
-            model_output_broadcast_data = get_pp_group().broadcast_tensor_dict(
-                model_output_broadcast_data, src=len(get_pp_group().ranks) - 1)
-            assert model_output_broadcast_data is not None
-            logits = model_output_broadcast_data["logits"]
-
         # Apply structured output bitmasks if present
         if scheduler_output.grammar_bitmask is not None:
             self.apply_grammar_bitmask(scheduler_output, logits)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -305,7 +305,6 @@ class Worker(WorkerBase):
             intermediate_tensors = IntermediateTensors(
                 get_pp_group().recv_tensor_dict(
                     all_gather_group=get_tp_group()))
-
         output = self.model_runner.execute_model(scheduler_output,
                                                  intermediate_tensors)
         if not get_pp_group().is_last_rank:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -308,9 +308,7 @@ class Worker(WorkerBase):
 
         output = self.model_runner.execute_model(scheduler_output,
                                                  intermediate_tensors)
-        parallel_config = self.vllm_config.parallel_config
-        if parallel_config.distributed_executor_backend != "external_launcher" \
-            and not get_pp_group().is_last_rank:
+        if not get_pp_group().is_last_rank:
             assert isinstance(output, IntermediateTensors)
             get_pp_group().send_tensor_dict(output.tensors,
                                             all_gather_group=get_tp_group())

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -305,6 +305,7 @@ class Worker(WorkerBase):
             intermediate_tensors = IntermediateTensors(
                 get_pp_group().recv_tensor_dict(
                     all_gather_group=get_tp_group()))
+
         output = self.model_runner.execute_model(scheduler_output,
                                                  intermediate_tensors)
         if not get_pp_group().is_last_rank:


### PR DESCRIPTION
## Description
This PR support torchrun PP with concurrent requests (overlapping micro-batches across ranks/stages, https://github.com/vllm-project/vllm/issues/18019) through 

1. async broadcast output (we still need broadcast to keep all our ranks with same scheduling output since we don't broadcast inputs)
2.  calling `step_with_batch_queue`.

Potentially we should use P2P in online serving, so this PR also added isend/irecv comm utilities

![image](https://github.com/user-attachments/assets/08e2bea9-e09d-4921-b476-8fec94bf1f0e)
Tasks:
- [x] E2E runnable on single node
- [x] E2E runnable on multi node
- [x] E2E Test to verify
- [x] Unit tests

```
torchrun --nnodes 1 --nproc-per-node 4  examples/offline_inference/torchrun_example.py
```

```
torchrun --nnodes 2 --nproc-per-node 2 --rdzv-id=random12345 --rdzv-backend=c10d --rdzv-endpoint <host:port>   examples/offline_inference/torchrun_example.py
```

```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Hilary and I have been a full time Licensed Massage Therapist since 199'

--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' a leader of the free world. His actions and statements have a direct impact on'

--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' the largest city in the country and a major European metropolis. It is also'

--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' not as promising as you might think\nWith a preponderance of artificial intelligence'

--------------------------------------------------
```

`CUDA_VISIBLE_DEVICES=2,3,4,6 PP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example.py`
