### PR TITLE
[Misc] Avoid cuda graph log when sizes still match

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3950,11 +3950,12 @@ class CompilationConfig:
             self.cudagraph_capture_sizes = cudagraph_capture_sizes
         else:
             # de-duplicate the sizes provided by the config
-            self.cudagraph_capture_sizes = list(
-                set(self.cudagraph_capture_sizes))
-            logger.info(("cudagraph sizes specified by model runner"
-                         " %s is overridden by config %s"),
-                        cudagraph_capture_sizes, self.cudagraph_capture_sizes)
+            dedup_sizes = list(set(self.cudagraph_capture_sizes))
+            if len(dedup_sizes) < len(self.cudagraph_capture_sizes):
+                logger.info(("cudagraph sizes specified by model runner"
+                             " %s is overridden by config %s"),
+                            cudagraph_capture_sizes, dedup_sizes)
+            self.cudagraph_capture_sizes = dedup_sizes
 
         computed_compile_sizes = []
         if self.compile_sizes is not None:


### PR DESCRIPTION
Tiniest improvement in log clarity. 
I think printing this log line when cuda graph sizes are not actually overridden it's just clutter

```
# pre
[__init__.py:248] Automatically detected platform tpu.
[config.py:3955] cudagraph sizes specified by model runner [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128] is overridden by config [128, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120]
[core.py:427] Waiting for init message from front-end.

# post
[__init__.py:248] Automatically detected platform tpu.
[core.py:427] Waiting for init message from front-end.
```