### PR TITLE
[V1][P/D] Release nixl xfer handles

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -623,8 +623,7 @@ class NixlConnectorWorker:
                 xfer_state = self.nixl_wrapper.check_xfer_state(handle)
                 if xfer_state == "DONE":
                     self.nixl_wrapper.release_xfer_handle(handle)
-                    continue
-                if xfer_state == "PROC":
+                elif xfer_state == "PROC":
                     running_reqs.append(handle)
                 else:
                     raise RuntimeError("Transfer failed with state %s",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -622,8 +622,7 @@ class NixlConnectorWorker:
             for handle in handles:
                 xfer_state = self.nixl_wrapper.check_xfer_state(handle)
                 if xfer_state == "DONE":
-                    # TODO ptarasiewicz: why abort is throwing errors?
-                    # self.nixl_wrapper.release_xfer_handle(handle)
+                    self.nixl_wrapper.release_xfer_handle(handle)
                     continue
                 if xfer_state == "PROC":
                     running_reqs.append(handle)


### PR DESCRIPTION

`nixl_wrapper.release_xfer_handle` is fixed in the current NIXL release so it can be called to release the transfer handles after they are done so they are not kept in memory.

<!--- pyml disable-next-line no-emphasis-as-heading -->
