### PR TITLE
[Bugfix] [ROCm]: Remove assertion logic when using AITER fused moe in unquantizedMethod to reenable LLama4 BF16

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -503,7 +503,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             indices_type=torch.uint32 if self.moe.use_pplx_kernels else None)
 
         if self.rocm_aiter_moe_enabled:
-            assert not apply_router_weight_on_input
             assert expert_map is None
             return self.rocm_aiter_fused_experts(
                 hidden_states=x,


### PR DESCRIPTION
Remove the assert introduced in this PR https://github.com/vllm-project/vllm/pull/15956 to remove the blockage for running llama4 bf16 model with AITER fused moe.

@bnellnm May we know what was the intention behind of adding the assertions on the `rocm_aiter_fused_moe` code path? 



Error when running llama4

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/app/upstreamcheckrocm64/vllmtests/fast_check_acc/test_accuracy.py", line 92, in <module>
[rank0]:     main(args)
[rank0]:   File "/app/upstreamcheckrocm64/vllmtests/fast_check_acc/test_accuracy.py", line 18, in main
[rank0]:     llm = LLM(**dataclasses.asdict(engine_args))
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/utils.py", line 1176, in inner
[rank0]:     return fn(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/entrypoints/llm.py", line 250, in __init__
[rank0]:     self.llm_engine = LLMEngine.from_engine_args(
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/engine/llm_engine.py", line 511, in from_engine_args
[rank0]:     return engine_cls.from_vllm_config(
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/engine/llm_engine.py", line 487, in from_vllm_config
[rank0]:     return cls(
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/engine/llm_engine.py", line 278, in __init__
[rank0]:     self._initialize_kv_caches()
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/engine/llm_engine.py", line 423, in _initialize_kv_caches
[rank0]:     self.model_executor.determine_num_available_blocks())
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/executor/executor_base.py", line 103, in determine_num_available_blocks
[rank0]:     results = self.collective_rpc("determine_num_available_blocks")
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/executor/executor_base.py", line 331, in collective_rpc
[rank0]:     return self._run_workers(method, *args, **(kwargs or {}))
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/executor/mp_distributed_executor.py", line 185, in _run_workers
[rank0]:     driver_worker_output = run_method(self.driver_worker, sent_method,
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/utils.py", line 2552, in run_method
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/worker/worker.py", line 254, in determine_num_available_blocks
[rank0]:     self.model_runner.profile_run()
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/worker/model_runner.py", line 1302, in profile_run
[rank0]:     self._dummy_run(max_num_batched_tokens, max_num_seqs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/worker/model_runner.py", line 1428, in _dummy_run
[rank0]:     self.execute_model(model_input, kv_caches, intermediate_tensors)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/worker/model_runner.py", line 1846, in execute_model
[rank0]:     hidden_or_intermediate_states = model_executable(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/models/mllama4.py", line 768, in forward
[rank0]:     return self.language_model(input_ids, positions, intermediate_tensors,
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/models/llama.py", line 573, in forward
[rank0]:     model_output = self.model(input_ids, positions, intermediate_tensors,
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/compilation/decorators.py", line 172, in __call__
[rank0]:     return self.forward(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/models/llama.py", line 384, in forward
[rank0]:     hidden_states, residual = layer(positions, hidden_states, residual)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/models/llama4.py", line 318, in forward
[rank0]:     hidden_states = self.feed_forward(hidden_states)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/models/llama4.py", line 98, in forward
[rank0]:     routed_out = self.experts(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/layers/fused_moe/layer.py", line 1262, in forward
[rank0]:     return self.forward_impl(hidden_states, router_logits)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/layers/fused_moe/layer.py", line 1328, in forward_impl
[rank0]:     final_hidden_states = self.quant_method.apply(
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/layers/fused_moe/layer.py", line 416, in apply
[rank0]:     return self.forward(
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/custom_op.py", line 23, in forward
[rank0]:     return self._forward_method(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/custom_op.py", line 38, in forward_hip
[rank0]:     return self.forward_cuda(*args, **kwargs)
[rank0]:   File "/app/upstreamcheckrocm64/vllmmain/vllm/model_executor/layers/fused_moe/layer.py", line 506, in forward_cuda
[rank0]:     assert not apply_router_weight_on_input
[rank0]: AssertionError
```
<!--- pyml disable-next-line no-emphasis-as-heading -->
