### PR TITLE
Allow users to pass arbitrary JSON keys from CLI

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -181,8 +181,8 @@ def test_get_kwargs():
     # literals of literals should have merged choices
     assert kwargs["literal_literal"]["choices"] == [1, 2]
     # dict should have json tip in help
-    json_tip = "\n\nShould be a valid JSON string."
-    assert kwargs["json_tip"]["help"].endswith(json_tip)
+    json_tip = "Should either be a valid JSON string or JSON keys"
+    assert json_tip in kwargs["json_tip"]["help"]
     # nested config should should construct the nested config
     assert kwargs["nested_config"]["type"]('{"field": 2}') == NestedConfig(2)
     # from_cli configs should be constructed with the correct method

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import hashlib
+import json
 import pickle
 import socket
 from collections.abc import AsyncIterator
@@ -138,6 +139,7 @@ def parser():
     parser.add_argument('--model-name')
     parser.add_argument('--batch-size', type=int)
     parser.add_argument('--enable-feature', action='store_true')
+    parser.add_argument('--hf-overrides', type=json.loads)
     return parser
 
 
@@ -249,6 +251,17 @@ def test_config_file(parser_with_config):
 def test_no_model_tag(parser_with_config, cli_config_file):
     with pytest.raises(ValueError):
         parser_with_config.parse_args(['serve', '--config', cli_config_file])
+
+
+def test_dict_args(parser):
+    args = ["--hf-overrides.key1", "val1", "--hf-overrides.key2.key3", "val2"]
+    parsed_args = parser.parse_args(args)
+    assert parsed_args.hf_overrides == {
+        "key1": "val1",
+        "key2": {
+            "key3": "val2"
+        }
+    }
 
 
 # yapf: enable

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -255,6 +255,7 @@ def test_no_model_tag(parser_with_config, cli_config_file):
 
 def test_dict_args(parser):
     args = [
+        "--model-name=something.something",
         "--hf-overrides.key1",
         "val1",
         "--hf-overrides.key2.key3",
@@ -264,6 +265,7 @@ def test_dict_args(parser):
         "--hf-overrides.key5=val4",
     ]
     parsed_args = parser.parse_args(args)
+    assert parsed_args.model_name == "something.something"
     assert parsed_args.hf_overrides == {
         "key1": "val1",
         "key2": {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,6 +261,7 @@ def test_dict_args(parser):
         "val2",
         "--hf-overrides.key2.key4",
         "val3",
+        "--hf-overrides.key5=val4",
     ]
     parsed_args = parser.parse_args(args)
     assert parsed_args.hf_overrides == {
@@ -269,6 +270,7 @@ def test_dict_args(parser):
             "key3": "val2",
             "key4": "val3",
         },
+        "key5": "val4",
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -254,13 +254,21 @@ def test_no_model_tag(parser_with_config, cli_config_file):
 
 
 def test_dict_args(parser):
-    args = ["--hf-overrides.key1", "val1", "--hf-overrides.key2.key3", "val2"]
+    args = [
+        "--hf-overrides.key1",
+        "val1",
+        "--hf-overrides.key2.key3",
+        "val2",
+        "--hf-overrides.key2.key4",
+        "val3",
+    ]
     parsed_args = parser.parse_args(args)
     assert parsed_args.hf_overrides == {
         "key1": "val1",
         "key2": {
-            "key3": "val2"
-        }
+            "key3": "val2",
+            "key4": "val3",
+        },
     }
 
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -183,7 +183,11 @@ def get_kwargs(cls: ConfigType) -> dict[str, Any]:
         kwargs[name] = {"default": default, "help": help}
 
         # Set other kwargs based on the type hints
-        json_tip = "\n\nShould be a valid JSON string."
+        json_tip = """\n\nShould either be a valid JSON string or JSON keys
+        passed individually. For example, the following sets of arguments are
+        equivalent:\n\n
+        - --json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'\n
+        - --json-arg.key1 value1 --json-arg.key2.key3 value2\n\n"""
         if dataclass_cls is not None:
             dataclass_init = lambda x, f=dataclass_cls: f(**json.loads(x))
             # Special case for configs with a from_cli method

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -186,8 +186,8 @@ def get_kwargs(cls: ConfigType) -> dict[str, Any]:
         json_tip = """\n\nShould either be a valid JSON string or JSON keys
         passed individually. For example, the following sets of arguments are
         equivalent:\n\n
-        - --json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'\n
-        - --json-arg.key1 value1 --json-arg.key2.key3 value2\n\n"""
+        - `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`\n
+        - `--json-arg.key1 value1 --json-arg.key2.key3 value2`\n\n"""
         if dataclass_cls is not None:
             dataclass_init = lambda x, f=dataclass_cls: f(**json.loads(x))
             # Special case for configs with a from_cli method

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1444,6 +1444,9 @@ class FlexibleArgumentParser(ArgumentParser):
             if processed_arg.startswith("--") and "." in processed_arg:
                 if "=" in processed_arg:
                     processed_arg, value = processed_arg.split("=", 1)
+                    if "." not in processed_arg:
+                        # False positive, . was only in the value
+                        continue
                 else:
                     value = processed_args[i + 1]
                     processed_args[i + 1] = ""

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1420,12 +1420,13 @@ class FlexibleArgumentParser(ArgumentParser):
             else:
                 processed_args.append(arg)
 
-        def nested_dict(keys: list[str], value: str):
+        def create_nested_dict(keys: list[str], value: str):
+            nested_dict: Any = value
             for key in reversed(keys):
-                value = {key: value}
-            return value
+                nested_dict = {key: nested_dict}
+            return nested_dict
 
-        dict_args = defaultdict(dict)
+        dict_args: dict[str, dict] = defaultdict(dict)
         for i, processed_arg in reversed(list(enumerate(processed_args))):
             if processed_arg.startswith("--") and "." in processed_arg:
                 if "=" in processed_arg:
@@ -1434,11 +1435,11 @@ class FlexibleArgumentParser(ArgumentParser):
                     value = processed_args[i + 1]
                     del processed_args[i + 1]
                 key, *keys = processed_arg.split(".")
-                dict_args[key].update(nested_dict(keys, value))
+                dict_args[key].update(create_nested_dict(keys, value))
                 del processed_args[i]
-        for key, value in dict_args.items():
-            processed_args.append(key)
-            processed_args.append(json.dumps(value))
+        for dict_arg, dict_value in dict_args.items():
+            processed_args.append(dict_arg)
+            processed_args.append(json.dumps(dict_value))
 
         return super().parse_args(processed_args, namespace)
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1421,12 +1421,18 @@ class FlexibleArgumentParser(ArgumentParser):
                 processed_args.append(arg)
 
         def create_nested_dict(keys: list[str], value: str):
+            """Creates a nested dictionary from a list of keys and a value.
+
+            For example, `keys = ["a", "b", "c"]` and `value = 1` will create:
+            `{"a": {"b": {"c": 1}}}`
+            """
             nested_dict: Any = value
             for key in reversed(keys):
                 nested_dict = {key: nested_dict}
             return nested_dict
 
         dict_args: dict[str, dict] = defaultdict(dict)
+        # Loop in reverse because we are modifying the list
         for i, processed_arg in reversed(list(enumerate(processed_args))):
             if processed_arg.startswith("--") and "." in processed_arg:
                 if "=" in processed_arg:
@@ -1435,8 +1441,10 @@ class FlexibleArgumentParser(ArgumentParser):
                     value = processed_args[i + 1]
                     del processed_args[i + 1]
                 key, *keys = processed_arg.split(".")
+                # Merge all values with the same key into a single dict
                 dict_args[key].update(create_nested_dict(keys, value))
                 del processed_args[i]
+        # Add the dict args back as if they were originally passed as JSON
         for dict_arg, dict_value in dict_args.items():
             processed_args.append(dict_arg)
             processed_args.append(json.dumps(dict_value))

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1429,7 +1429,7 @@ class FlexibleArgumentParser(ArgumentParser):
         for i, processed_arg in reversed(list(enumerate(processed_args))):
             if processed_arg.startswith("--") and "." in processed_arg:
                 if "=" in processed_arg:
-                    processed_arg, value = processed_arg.rsplit("=", 1)
+                    processed_arg, value = processed_arg.split("=", 1)
                 else:
                     value = processed_args[i + 1]
                     del processed_args[i + 1]

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1439,6 +1439,7 @@ class FlexibleArgumentParser(ArgumentParser):
                 else:
                     original[k] = v
 
+        delete = set()
         dict_args: dict[str, dict] = defaultdict(dict)
         for i, processed_arg in enumerate(processed_args):
             if processed_arg.startswith("--") and "." in processed_arg:
@@ -1449,14 +1450,16 @@ class FlexibleArgumentParser(ArgumentParser):
                         continue
                 else:
                     value = processed_args[i + 1]
-                    processed_args[i + 1] = ""
+                    delete.add(i + 1)
                 key, *keys = processed_arg.split(".")
                 # Merge all values with the same key into a single dict
                 arg_dict = create_nested_dict(keys, value)
                 recursive_dict_update(dict_args[key], arg_dict)
-                processed_args[i] = ""
-        # Filter out the dict args we set to empty strings
-        processed_args = [a for a in processed_args if a]
+                delete.add(i)
+        # Filter out the dict args we set to None
+        processed_args = [
+            a for i, a in enumerate(processed_args) if i not in delete
+        ]
         # Add the dict args back as if they were originally passed as JSON
         for dict_arg, dict_value in dict_args.items():
             processed_args.append(dict_arg)


### PR DESCRIPTION
Closes #17640
Supersede #17842

Allows users to pass individual JSON keys via `FlexibleArgumentParser` in the format `--json-arg.key1.key2 value`

i.e. `--hf-overrides.key1 val1 --hf-overrides.key2.key3 val2` will result in the following args:

```console
INFO 05-15 17:09:16 [cli_args.py:297] non-default args: {'enforce_eager': True, 'hf_overrides': {'key1': 'val1', 'key2': {'key3': 'val2'}}, 'gpu_memory_utilization': 0.45}
```