### PR TITLE
[Bugfix] Fix Hermes tool call parser with streaming

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
@@ -318,14 +318,14 @@ class Hermes2ProToolParser(ToolParser):
                              cur_arguments_json)
 
                 # get the location where previous args differ from current
-                if (delta_text not in cur_arguments_json[:-2]):
+                if delta_text not in cur_arguments_json:
                     return None
-                args_delta_start_loc = cur_arguments_json[:-2]. \
-                                           rindex(delta_text) + \
-                                           len(delta_text)
+
+                args_delta_end_loc = cur_arguments_json.rindex(
+                    delta_text) + len(delta_text)
 
                 # use that to find the actual delta
-                arguments_delta = cur_arguments_json[:args_delta_start_loc]
+                arguments_delta = cur_arguments_json[:args_delta_end_loc]
                 logger.debug("First tokens in arguments received: %s",
                              arguments_delta)
 


### PR DESCRIPTION
Fixes an issue where the first argument returned from a function call is not parsed properly by `hermes_tool_parser.py` when the type of the argument is not a string. This caused the delta of an integer argument to be cut off in the final delta returned to the client, eventually causing the entire first argument of the tool call to be missing.

FIX #18108 