### PR TITLE
[Bugfix] Fix test_eagle test

### DIFF
--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -159,6 +159,7 @@ def test_load_model(mock_set_config, mock_set_dtype, mock_get_loader,
     # Make mock_get_layers return different values for each call
     mock_get_layers.side_effect = [target_attn_layers, all_attn_layers]
 
+    # Setup mock for pp group to return the appropriate value for world size
     mock_pp_group = mock.MagicMock()
     mock_pp_group.world_size = 2 if method == "eagle" else 1
     mock_get_pp_group.return_value = mock_pp_group

--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -115,14 +115,15 @@ def test_prepare_inputs():
         ("eagle3", lambda k: _create_proposer("eagle3", k), eagle3_dir,
          ('model', 'embed_tokens')),
     ])
+@mock.patch('vllm.v1.spec_decode.eagle.get_pp_group')
 @mock.patch('vllm.v1.spec_decode.eagle.get_layers_from_vllm_config')
 @mock.patch('vllm.v1.spec_decode.eagle.ModelRegistry')
 @mock.patch('vllm.v1.spec_decode.eagle.get_model_loader')
 @mock.patch('vllm.v1.spec_decode.eagle.set_default_torch_dtype')
 @mock.patch('vllm.v1.spec_decode.eagle.set_current_vllm_config')
 def test_load_model(mock_set_config, mock_set_dtype, mock_get_loader,
-                    mock_registry, mock_get_layers, method, proposer_helper,
-                    draft_model_dir, target_attribute_path):
+                    mock_registry, mock_get_layers, mock_get_pp_group, method,
+                    proposer_helper, draft_model_dir, target_attribute_path):
 
     # Setup mock for model class
     mock_model_cls = mock.MagicMock()
@@ -157,6 +158,10 @@ def test_load_model(mock_set_config, mock_set_dtype, mock_get_loader,
 
     # Make mock_get_layers return different values for each call
     mock_get_layers.side_effect = [target_attn_layers, all_attn_layers]
+
+    mock_pp_group = mock.MagicMock()
+    mock_pp_group.world_size = 2 if method == "eagle" else 1
+    mock_get_pp_group.return_value = mock_pp_group
 
     # Setup model loader mock
     mock_loader = mock.MagicMock()


### PR DESCRIPTION
V1 test failed in trunk:

Fix test for `pytest -v tests/v1/spec_decode/test_eagle.py`
Before changes, we got below for test_load_model


```
    def get_pp_group() -> GroupCoordinator:
>       assert _PP is not None, (
            "pipeline model parallel group is not initialized")
E       AssertionError: pipeline model parallel group is not initialized
```



Now:

```
ests/v1/spec_decode/test_eagle.py::test_prepare_inputs PASSED                                                                                   [ 16%]
tests/v1/spec_decode/test_eagle.py::test_load_model[eagle-<lambda>-yuhuili/EAGLE-LLaMA3.1-Instruct-8B-target_attribute_path0] PASSED             [ 33%]
tests/v1/spec_decode/test_eagle.py::test_load_model[eagle3-<lambda>-yuhuili/EAGLE3-LLaMA3.1-Instruct-8B-target_attribute_path1] PASSED           [ 50%]
tests/v1/spec_decode/test_eagle.py::test_propose[1] PASSED                                                                                       [ 66%]
tests/v1/spec_decode/test_eagle.py::test_propose[3] PASSED                                                                                       [ 83%]
tests/v1/spec_decode/test_eagle.py::test_propose[8] PASSED                                                                                       [100%]

=================================================================== warnings summary ===================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================ 6 passed, 2 warnings in 16.97s ============================================================

```

