### PR TITLE
[Bugfix] fix rotary embedding test for _get_padded_tensor_shape

### DIFF
--- a/tests/kernels/core/test_pos_encoding.py
+++ b/tests/kernels/core/test_pos_encoding.py
@@ -152,6 +152,10 @@ def test_batched_rotary_embedding(
     query = torch.randn(query_shape, dtype=dtype)
     key = torch.randn_like(query) if use_key else None
 
+    # slice tensor if required, noop otherwise
+    query = query[..., :head_size]
+    key = key[..., :head_size] if use_key else None
+
     # NOTE(woosuk): The reference implementation should be executed first
     # because the custom kernel is in-place.
     ref_query, ref_key = rope.forward_native(positions, query, key)


### PR DESCRIPTION
Alternative fix for https://github.com/vllm-project/vllm/pull/18227

Makes sure we tests with padding and that the shapes match