### PR TITLE
Add unique_id_from_bytes for NCCLLibrary

### DIFF
--- a/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -271,6 +271,27 @@ class NCCLLibrary:
             ctypes.byref(unique_id)))
         return unique_id
 
+    def unique_id_from_bytes(self, data: bytes) -> ncclUniqueId:
+        """
+        Reconstructs an `ncclUniqueId` object from bytes data.
+
+        Args:
+            data: Must be a 128-byte data block (matching NCCL's unique_id).
+
+        Returns:
+            ncclUniqueId: The reconstructed NCCL Unique ID object.
+
+        Raises:
+            ValueError: If the input data length is not 128 bytes.
+        """
+        if len(data) != 128:
+            raise ValueError(
+                f"Expected 128 bytes for ncclUniqueId, got {len(data)} bytes")
+
+        unique_id = ncclUniqueId()
+        ctypes.memmove(ctypes.addressof(unique_id.internal), data, 128)
+        return unique_id
+
     def ncclCommInitRank(self, world_size: int, unique_id: ncclUniqueId,
                          rank: int) -> ncclComm_t:
         comm = ncclComm_t()


### PR DESCRIPTION
Reconstructs an `ncclUniqueId` object from bytes data for NCCLLibrary

Provide a function that converts bytes into a `ncclUniqueId` for NCCL to establish connections. This function can be used in dynamic point-to-point communication scenarios, such as PD separation, to establish point-to-point communication for transmitting KV Cache.

First, the bytes can be transmitted via zmq or other methods. Then, the `unique_id_from_bytes` function is used to convert the bytes into a `ncclUniqueId`. Finally, the `ncclCommInitRank` function is called to complete the point-to-point NCCL connection.