### PR TITLE
Support sequence parallelism combined with pipeline parallelism

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -4222,18 +4222,6 @@ class VllmConfig:
             self.compilation_config.level = CompilationLevel.PIECEWISE
             self.compilation_config.set_splitting_ops_for_v1()
 
-        if self.parallel_config is not None and \
-            self.parallel_config.tensor_parallel_size > 1 and \
-            self.parallel_config.pipeline_parallel_size > 1 and \
-            self.compilation_config is not None and \
-                self.compilation_config.pass_config is not None and \
-            self.compilation_config.pass_config.enable_sequence_parallelism:
-            logger.warning_once(
-                "Sequence parallelism is not supported with pipeline "
-                "parallelism. Disabling sequence parallelism.")
-            self.compilation_config.pass_config.\
-                enable_sequence_parallelism = False
-
         self._set_cudagraph_sizes()
 
         if self.cache_config is not None and \

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1067,6 +1067,40 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             indices=out_indices,
         )
 
+    def sync_and_slice_intermediate_tensors(
+            self, num_tokens: int, intermediate_tensors: IntermediateTensors,
+            sync_self: bool) -> IntermediateTensors:
+
+        assert self.intermediate_tensors is not None
+
+        tp = self.vllm_config.parallel_config.tensor_parallel_size
+        enabled_sp = self.vllm_config.compilation_config.pass_config. \
+            enable_sequence_parallelism
+        if enabled_sp:
+            # When sequence parallelism is enabled, we always pad num_tokens
+            # to be a multiple of tensor_parallel_size (tp) earlier
+            assert num_tokens % tp == 0
+        is_residual_scattered = tp > 1 and enabled_sp \
+            and num_tokens % tp == 0
+
+        # When sequence parallelism is enabled, the "residual" tensor is sharded
+        # across tensor parallel ranks, so each rank only needs its own slice.
+        if sync_self:
+            assert intermediate_tensors is not None
+            for k, v in intermediate_tensors.items():
+                is_scattered = "residual" and is_residual_scattered
+                copy_len = num_tokens // tp if is_scattered else \
+                    num_tokens
+                self.intermediate_tensors[k][:copy_len].copy_(
+                    v[:copy_len], non_blocking=True)
+
+        return IntermediateTensors({
+            k:
+            v[:num_tokens // tp]
+            if k == "residual" and is_residual_scattered else v[:num_tokens]
+            for k, v in self.intermediate_tensors.items()
+        })
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -1143,27 +1177,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if get_pp_group().is_first_rank:
             intermediate_tensors = None
         else:
-            assert intermediate_tensors is not None
-            assert self.intermediate_tensors is not None
-            tp = self.vllm_config.parallel_config.tensor_parallel_size
-            enabled_sp = self.vllm_config.compilation_config.pass_config. \
-                enable_sequence_parallelism
-            is_residual_scattered = tp > 1 and enabled_sp \
-                and num_input_tokens % tp == 0
-
-            for k, v in intermediate_tensors.items():
-                is_scattered = "residual" and is_residual_scattered
-                copy_len = num_input_tokens // tp if is_scattered else \
-                    num_input_tokens
-                self.intermediate_tensors[k][:copy_len].copy_(
-                    v[:copy_len], non_blocking=True)
-
-            intermediate_tensors = IntermediateTensors({
-                k:
-                v[:num_input_tokens // tp] if k == "residual"
-                and is_residual_scattered else v[:num_input_tokens]
-                for k, v in self.intermediate_tensors.items()
-            })
+            intermediate_tensors = self.sync_and_slice_intermediate_tensors(
+                num_input_tokens, intermediate_tensors, True)
 
         # Run the decoder.
         # Use persistent buffers for CUDA graphs.
@@ -1582,18 +1597,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                             dtype=self.model_config.dtype,
                             device=self.device))
 
-                tp = self.vllm_config.parallel_config.tensor_parallel_size
-                enabled_sp = self.vllm_config.compilation_config.pass_config. \
-                    enable_sequence_parallelism
-                is_residual_scattered = tp > 1 and enabled_sp \
-                    and num_tokens % tp == 0
-
-                intermediate_tensors = IntermediateTensors({
-                    k:
-                    v[:num_tokens // tp] if k == "residual"
-                    and is_residual_scattered else v[:num_tokens]
-                    for k, v in self.intermediate_tensors.items()
-                })
+                intermediate_tensors = self.sync_and_slice_intermediate_tensors(
+                    num_tokens, None, False)
 
             with set_forward_context(attn_metadata,
                                      self.vllm_config,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1199,7 +1199,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         if not get_pp_group().is_last_rank:
             # For mid-pipeline stages, return the hidden states.
-            # print(f"cascade pp is not last rank, return hidden states")
             return hidden_states
 
         sample_hidden_states = hidden_states[logits_indices]


### PR DESCRIPTION
this PR adds support for sp+pp scenario.
```
vllm serve meta-llama/Llama-3.2-1B-Instruct --tensor-parallel-size 2 --pipeline-parallel-size 2 --distributed-executor-backend mp -O '{"level": 3, "compile_sizes": [4, 8, 16], "splitting_ops": [], "pass_config": {"enable_sequence_parallelism" : true}}'
```
