### PR TITLE
[Misc][MacOS] fix bfloat16 error

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -36,7 +36,7 @@ class CpuPlatform(Platform):
             # instead of checking the OS. For instance M2 shall supports bf16
             # already. But we need to modify `cpu_extension.cmake` to activate
             # the feature in the build.
-            return [torch.bfloat16, torch.float32]
+            return [torch.float16, torch.float32]
         # x86/aarch64 CPU has supported both bf16 and fp16 natively.
         return [torch.bfloat16, torch.float16, torch.float32]
 


### PR DESCRIPTION

- In MacOS When try to request the API,  and serve the model with `auto` dtype, it would cause the [BFloat16 error](https://github.com/vllm-project/vllm/issues/11814)  , it should fixed before [11696](https://github.com/vllm-project/vllm/pull/11696/files#diff-7eaad0b7dee0626bf29d10081b0f0c5e3ea15a4af97e7b182a4e0d35f8346953) based on description currently it should still need to  to modify `cpu_extension.cmake` to activate(and hard to make it).
- seems update it in https://github.com/vllm-project/vllm/commit/5c4c08f6f1609960b047c8b9d6aa003e9afc2897#diff-7eaad0b7dee0626bf29d10081b0f0c5e3ea15a4af97e7b182a4e0d35f8346953
```
vllm serve qwen/Qwen1.5-0.5B-Chat

line 276, in rms_norm
ERROR 05-16 11:28:20 [engine.py:161]     torch.ops._C.rms_norm(out, input_contiguous, weight, epsilon)
ERROR 05-16 11:28:20 [engine.py:161]   File "/opt/miniconda3/envs/vllm/lib/python3.12/site-packages/torch/_ops.py", line 1158, in __call__
ERROR 05-16 11:28:20 [engine.py:161]     return self._op(*args, **(kwargs or {}))
ERROR 05-16 11:28:20 [engine.py:161]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-16 11:28:20 [engine.py:161] RuntimeError: "rms_norm_impl" not implemented for 'BFloat16'
```
So it would be better to bring it back.
