### PR TITLE
add an absolute path for run.sh

### DIFF
--- a/examples/offline_inference/disaggregated-prefill-v1/run.sh
+++ b/examples/offline_inference/disaggregated-prefill-v1/run.sh
@@ -1,5 +1,11 @@
 rm -rf local_storage/
-rm output.txt
 
-VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=0 python3 prefill_example.py
-VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=0 python3 decode_example.py
+if [ -f "output.txt" ]; then
+    rm output.txt
+fi
+
+# The directory of current script
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+
+VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=0 python3 "$SCRIPT_DIR/prefill_example.py"
+VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=0 python3 "$SCRIPT_DIR/decode_example.py"


### PR DESCRIPTION
I tried to execute this example in the root directory of vLLM and encountered an error.

```bash
root@ubuntu:~/vllm# sh examples/offline_inference/disaggregated-prefill-v1/run.sh 
rm: cannot remove 'output.txt': No such file or directory
python3: can't open file '/root/vllm/prefill_example.py': [Errno 2] No such file or directory
python3: can't open file '/root/vllm/decode_example.py': [Errno 2] No such file or directory
root@ubuntu:~/vllm# 
```

so, I add an absolute path for prefill_example.py and decode_example.py, it can work normally.

```bash
root@ubuntu:~/vllm# sh examples/offline_inference/disaggregated-prefill-v1/run.sh 
INFO 05-16 10:49:18 [__init__.py:248] Automatically detected platform cuda.
INFO 05-16 10:49:21 [__init__.py:30] Available plugins for group vllm.general_plugins:
INFO 05-16 10:49:21 [__init__.py:32] name=lora_filesystem_resolver, value=vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 05-16 10:49:21 [__init__.py:34] all available plugins for group vllm.general_plugins will be loaded.
INFO 05-16 10:49:21 [__init__.py:36] set environment variable VLLM_PLUGINS to control which plugins to load.
INFO 05-16 10:49:21 [__init__.py:44] plugin lora_filesystem_resolver loaded.
WARNING 05-16 10:49:21 [config.py:457] The global random seed is set to 0. Since VLLM_ENABLE_V1_MULTIPROCESSING is set to False, this may affect the random state of the Python process that launched vLLM.
```
