### PR TITLE
[Fix] Fix typo in `resolve_hf_chat_template`

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -339,7 +339,7 @@ def resolve_hf_chat_template(
     tools: Optional[list[dict[str, Any]]],
     *,
     model_config: ModelConfig,
-    trsut_remote_code: Optional[bool] = None,
+    trust_remote_code: Optional[bool] = None,
 ) -> Optional[str]:
     # 1st priority: The given chat template
     if chat_template is not None:


### PR DESCRIPTION
This makes `lm_eval --model vllm` fail.