### PR TITLE
[Frontend] get request id from request body or header

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -30,7 +30,7 @@ _LONG_INFO = torch.iinfo(torch.long)
 
 
 class OpenAIBaseModel(BaseModel):
-    # A unique identifier for the request
+    # Unique identifier for the request
     request_id: str = Field(
         default_factory=lambda: f"{random_uuid()}",
         description=(

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -30,6 +30,14 @@ _LONG_INFO = torch.iinfo(torch.long)
 
 
 class OpenAIBaseModel(BaseModel):
+    # A unique identifier for the request
+    request_id: str = Field(
+        default_factory=lambda: f"{random_uuid()}",
+        description=(
+            "The request_id related to this request. If the caller does "
+            "not set it, a random_uuid will be generated. This id is used "
+            "through out the inference process and return in response."),
+    )
     # OpenAI API does allow extra fields
     model_config = ConfigDict(extra="allow")
 
@@ -369,13 +377,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "
             "if the served model does not use priority scheduling."),
-    )
-    request_id: str = Field(
-        default_factory=lambda: f"{random_uuid()}",
-        description=(
-            "The request_id related to this request. If the caller does "
-            "not set it, a random_uuid will be generated. This id is used "
-            "through out the inference process and return in response."),
     )
     logits_processors: Optional[LogitsProcessors] = Field(
         default=None,

--- a/vllm/entrypoints/openai/serving_classification.py
+++ b/vllm/entrypoints/openai/serving_classification.py
@@ -146,8 +146,9 @@ class ServingClassification(ClassificationMixin):
         raw_request: Request,
     ) -> Union[ClassificationResponse, ErrorResponse]:
         model_name = self._get_model_name(request.model)
-        request_id = (f"{self.request_id_prefix}-"
-                      f"{self._base_request_id(raw_request)}")
+        request_id = (
+            f"{self.request_id_prefix}-"
+            f"{self._base_request_id(raw_request, request.request_id)}")
 
         ctx = ClassificationServeContext(
             request=request,

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -90,7 +90,8 @@ class OpenAIServingCompletion(OpenAIServing):
             return self.create_error_response(
                 "suffix is not currently supported")
 
-        request_id = f"cmpl-{self._base_request_id(raw_request)}"
+        request_id = "cmpl-" \
+                     f"{self._base_request_id(raw_request, request.request_id)}"
         created_time = int(time.time())
 
         request_metadata = RequestResponseMetadata(request_id=request_id)

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -166,8 +166,9 @@ class OpenAIServingEmbedding(EmbeddingMixin):
         for the API specification. This API mimics the OpenAI Embedding API.
         """
         model_name = self._get_model_name(request.model)
-        request_id = (f"{self.request_id_prefix}-"
-                      f"{self._base_request_id(raw_request)}")
+        request_id = (
+            f"{self.request_id_prefix}-"
+            f"{self._base_request_id(raw_request, request.request_id)}")
 
         ctx = EmbeddingServeContext(
             request=request,

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -83,7 +83,8 @@ class OpenAIServingPooling(OpenAIServing):
                 "dimensions is currently not supported")
 
         model_name = self._get_model_name(request.model)
-        request_id = f"pool-{self._base_request_id(raw_request)}"
+        request_id = "pool-" \
+                     f"{self._base_request_id(raw_request, request.request_id)}"
         created_time = int(time.time())
 
         truncate_prompt_tokens = request.truncate_prompt_tokens

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -295,7 +295,8 @@ class ServingScores(OpenAIServing):
         if error_check_ret is not None:
             return error_check_ret
 
-        request_id = f"score-{self._base_request_id(raw_request)}"
+        request_id = "score-" \
+                    f"{self._base_request_id(raw_request, request.request_id)}"
         created_time = int(time.time())
 
         try:
@@ -338,7 +339,8 @@ class ServingScores(OpenAIServing):
         if error_check_ret is not None:
             return error_check_ret
 
-        request_id = f"rerank-{self._base_request_id(raw_request)}"
+        request_id = "rerank-" \
+                    f"{self._base_request_id(raw_request, request.request_id)}"
         documents = request.documents
         top_n = request.top_n if request.top_n > 0 else len(documents)
 

--- a/vllm/entrypoints/openai/serving_tokenization.py
+++ b/vllm/entrypoints/openai/serving_tokenization.py
@@ -54,7 +54,8 @@ class OpenAIServingTokenization(OpenAIServing):
         if error_check_ret is not None:
             return error_check_ret
 
-        request_id = f"tokn-{self._base_request_id(raw_request)}"
+        request_id = "tokn-" \
+                    f"{self._base_request_id(raw_request, request.request_id)}"
 
         try:
             (
@@ -122,7 +123,8 @@ class OpenAIServingTokenization(OpenAIServing):
         if error_check_ret is not None:
             return error_check_ret
 
-        request_id = f"tokn-{self._base_request_id(raw_request)}"
+        request_id = "tokn-" \
+                    f"{self._base_request_id(raw_request, request.request_id)}"
 
         (
             lora_request,

--- a/vllm/entrypoints/openai/serving_transcription.py
+++ b/vllm/entrypoints/openai/serving_transcription.py
@@ -247,7 +247,8 @@ class OpenAIServingTranscription(OpenAIServing):
             return self.create_error_response(
                 "Currently only support response_format `text` or `json`")
 
-        request_id = f"trsc-{self._base_request_id(raw_request)}"
+        request_id = "trsc-" \
+                     f"{self._base_request_id(raw_request, request.request_id)}"
 
         request_metadata = RequestResponseMetadata(request_id=request_id)
         if raw_request:


### PR DESCRIPTION
I would like to unify the way of obtaining the request_id for all APIs, so that it can be retrieved from either the header or the request body. Currently, the serving_chat interface supports this approach, while other interfaces can only obtain the request_id from the header.