### PR TITLE
Temporarily Fix TPU CI failure when checking package hash

### DIFF
--- a/docker/Dockerfile.tpu
+++ b/docker/Dockerfile.tpu
@@ -19,11 +19,14 @@ RUN --mount=type=bind,source=.git,target=.git \
 RUN pip uninstall -y torch torch_xla torchvision
 
 ENV VLLM_TARGET_DEVICE="tpu"
+# First install with --no-deps to avoid the hash verification issue
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
     python3 -m pip install \
-        -r requirements/tpu.txt
-RUN python3 -m pip install -e .
+        -r requirements/tpu.txt --no-cache-dir
+
+# Install vLLM without building dependencies
+RUN python3 -m pip install -e . --no-build-isolation
 
 # install development dependencies (for testing)
 RUN python3 -m pip install -e tests/vllm_test_utils

--- a/docker/Dockerfile.tpu
+++ b/docker/Dockerfile.tpu
@@ -19,13 +19,11 @@ RUN --mount=type=bind,source=.git,target=.git \
 RUN pip uninstall -y torch torch_xla torchvision
 
 ENV VLLM_TARGET_DEVICE="tpu"
-# First install with --no-deps to avoid the hash verification issue
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
     python3 -m pip install \
         -r requirements/tpu.txt --no-cache-dir
 
-# Install vLLM without building dependencies
 RUN python3 -m pip install -e . --no-build-isolation
 
 # install development dependencies (for testing)


### PR DESCRIPTION
Example failure (https://buildkite.com/vllm/ci/builds/20105#0196d142-bf61-47b8-b8df-8249be3882cb)
```
16.78       Collecting nvidia-cublas-cu12==12.6.4.1
--
  | 16.78         Downloading nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (393.1 MB)
  | 16.78            ━━━━━━━━━━━━━━━━━━━━━━━━━━━           291.6/393.1 MB 257.4 MB/s eta 0:00:01
  | 16.78       ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
  | 16.78           nvidia-cublas-cu12==12.6.4.1 from https://files.pythonhosted.org/packages/af/eb/ff4b8c503fa1f1796679dce648854d58751982426e4e4b37d6fce49d259c/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (from torch==2.7.0):
  | 16.78               Expected sha256 08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb
  | 16.78                    Got        ec2c4ea862d8226ec197fc31ce80d449ee3696a312cdd3e26e0c2bd0e08881a5

```

<!--- pyml disable-next-line no-emphasis-as-heading -->
