### PR TITLE
[Neuron] Support quantization on neuron

### DIFF
--- a/tests/neuron/1_core/test_neuron_quant.py
+++ b/tests/neuron/1_core/test_neuron_quant.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+from vllm.model_executor.layers.quantization.neuron_quant import (
+    NeuronQuantConfig)
+
+
+def test_get_supported_act_dtypes():
+    neuron_quant_config = NeuronQuantConfig()
+    supported_act_dtypes = neuron_quant_config.get_supported_act_dtypes()
+    target_list = ["any_dtype1", "any_dtype2"]
+    for dtype in target_list:
+        assert dtype in supported_act_dtypes

--- a/vllm/model_executor/layers/quantization/neuron_quant.py
+++ b/vllm/model_executor/layers/quantization/neuron_quant.py
@@ -13,6 +13,12 @@ from vllm.model_executor.layers.quantization.base_config import (
 SUPPORTED_QUANT_DTYPE_LIST = ['s8', 'f8e4m3fn']
 
 
+class AlwaysSupportedDtypes(list):
+
+    def __contains__(self, item):
+        return True
+
+
 class NeuronQuantConfig(QuantizationConfig):
     """Int8 Quantization Config class for Neuron Backend."""
 
@@ -35,7 +41,8 @@ class NeuronQuantConfig(QuantizationConfig):
         return "neuron_quant"
 
     def get_supported_act_dtypes(self) -> list[str]:
-        return SUPPORTED_QUANT_DTYPE_LIST
+        # Neuron implements custom handling logic for quantization support
+        return AlwaysSupportedDtypes()
 
     @classmethod
     def get_min_capability(cls) -> int:

--- a/vllm/platforms/neuron.py
+++ b/vllm/platforms/neuron.py
@@ -27,7 +27,7 @@ class NeuronPlatform(Platform):
     device_name: str = "neuron"
     device_type: str = "neuron"
     ray_device_key: str = "neuron_cores"
-    supported_quantization: list[str] = ["neuron_quant"]
+    supported_quantization: list[str] = ["neuron_quant", "fbgemm_fp8"]
     device_control_env_var: str = "NEURON_RT_VISIBLE_CORES"
 
     @classmethod


### PR DESCRIPTION
Support quantization on neuron

1. Adds fbgemm_fp8 support for neuron.
2. Allows neuron users to run pre-quantized checkpoints. This includes accepting all act_dtypes as the data type validation is performed in NxDI.

RFC: #15970 