### PR TITLE
[Frontend] add --quick option for vllm chat/complete

### DIFF
--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -146,7 +146,7 @@ class ChatCommand(CLISubcommand):
             help=("The system prompt to be added to the chat template, "
                   "used for models that support system prompts."))
         chat_parser.add_argument("-q",
-                                 "--quick-chat",
+                                 "--quick",
                                  type=str,
                                  metavar="MESSAGE",
                                  help=("Send a single prompt as MESSAGE "
@@ -192,7 +192,7 @@ class CompleteCommand(CLISubcommand):
         _add_query_options(complete_parser)
         complete_parser.add_argument(
             "-q",
-            "--quick-complete",
+            "--quick",
             type=str,
             metavar="PROMPT",
             help=

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -102,21 +102,16 @@ class ChatCommand(CLISubcommand):
         system_prompt = args.system_prompt
         conversation: list[ChatCompletionMessageParam] = []
 
+        if system_prompt is not None:
+            conversation.append({"role": "system", "content": system_prompt})
+
         if args.quick_chat:
-            if args.system_prompt:
-                conversation.append({
-                    "role": "system",
-                    "content": args.system_prompt
-                })
             conversation.append({"role": "user", "content": args.quick_chat})
 
             chat_completion = client.chat.completions.create(
                 model=model_name, messages=conversation)
             print(chat_completion.choices[0].message.content)
             return
-
-        if system_prompt is not None:
-            conversation.append({"role": "system", "content": system_prompt})
 
         print("Please enter a message for the chat model:")
         while True:
@@ -150,7 +145,7 @@ class ChatCommand(CLISubcommand):
             default=None,
             help=("The system prompt to be added to the chat template, "
                   "used for models that support system prompts."))
-        chat_parser.add_argument("-qc",
+        chat_parser.add_argument("-q",
                                  "--quick-chat",
                                  type=str,
                                  metavar="MESSAGE",
@@ -169,6 +164,13 @@ class CompleteCommand(CLISubcommand):
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
         model_name, client = _interactive_cli(args)
+
+        if args.quick_complete:
+            completion = client.completions.create(model=model_name,
+                                                   prompt=args.quick_complete)
+            print(completion.choices[0].text)
+            return
+
         print("Please enter prompt to complete:")
         while True:
             input_prompt = input("> ")
@@ -188,6 +190,13 @@ class CompleteCommand(CLISubcommand):
                          "via the running API server."),
             usage="vllm complete [options]")
         _add_query_options(complete_parser)
+        complete_parser.add_argument(
+            "-q",
+            "--quick-complete",
+            type=str,
+            metavar="PROMPT",
+            help=
+            "Send a single prompt and print the completion output, then exit.")
         return complete_parser
 
 

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -101,6 +101,20 @@ class ChatCommand(CLISubcommand):
         model_name, client = _interactive_cli(args)
         system_prompt = args.system_prompt
         conversation: list[ChatCompletionMessageParam] = []
+
+        if args.quick_chat:
+            if args.system_prompt:
+                conversation.append({
+                    "role": "system",
+                    "content": args.system_prompt
+                })
+            conversation.append({"role": "user", "content": args.quick_chat})
+
+            chat_completion = client.chat.completions.create(
+                model=model_name, messages=conversation)
+            print(chat_completion.choices[0].message.content)
+            return
+
         if system_prompt is not None:
             conversation.append({"role": "system", "content": system_prompt})
 
@@ -136,6 +150,12 @@ class ChatCommand(CLISubcommand):
             default=None,
             help=("The system prompt to be added to the chat template, "
                   "used for models that support system prompts."))
+        chat_parser.add_argument("-qc",
+                                 "--quick-chat",
+                                 type=str,
+                                 metavar="MESSAGE",
+                                 help=("Send a single prompt as MESSAGE "
+                                       "and print the response, then exit."))
         return chat_parser
 
 

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -105,8 +105,8 @@ class ChatCommand(CLISubcommand):
         if system_prompt is not None:
             conversation.append({"role": "system", "content": system_prompt})
 
-        if args.quick_chat:
-            conversation.append({"role": "user", "content": args.quick_chat})
+        if args.quick:
+            conversation.append({"role": "user", "content": args.quick})
 
             chat_completion = client.chat.completions.create(
                 model=model_name, messages=conversation)
@@ -165,9 +165,9 @@ class CompleteCommand(CLISubcommand):
     def cmd(args: argparse.Namespace) -> None:
         model_name, client = _interactive_cli(args)
 
-        if args.quick_complete:
+        if args.quick:
             completion = client.completions.create(model=model_name,
-                                                   prompt=args.quick_complete)
+                                                   prompt=args.quick)
             print(completion.choices[0].text)
             return
 


### PR DESCRIPTION
- Add --quick/-q for quick API test
   - As more and more models are supported, it's useful to quickly test the API after serving.
   - -q / --quick sends a single message and prints the response.
   - Exits immediately without entering interactive mode.
   - Helpful for verifying that the model and API are working properly.
```
$ vllm chat --help
  -q MESSAGE, --quick MESSAGE
                        Send a single prompt as MESSAGE and print the response, then exit. (default:
                        None)

  -q PROMPT, --quick PROMPT
                        Send a single prompt and print the completion output, then exit. (default:
                        None)

$ vllm chat -q "who are you?"
Using model: qwen/Qwen1.5-0.5B-Chat
I am a large language model created by Alibaba Cloud. My name is Qwen.
``` 
