### PR TITLE
[Don't merge] Debug failing quantization test with input batch move

### DIFF
--- a/tests/quantization/test_cpu_offload.py
+++ b/tests/quantization/test_cpu_offload.py
@@ -30,14 +30,15 @@ def test_cpu_offload_gptq(monkeypatch):
     # This quant method is sensitive to dummy weights, so we force real weights
     monkeypatch.setenv('VLLM_TEST_FORCE_LOAD_FORMAT', 'auto')
     # Test GPTQ Marlin
-    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4", [],
-                         ["--cpu-offload-gb", "1"],
-                         max_wait_seconds=480)
+    # compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4", [],
+    #                      ["--cpu-offload-gb", "1"],
+    #                      max_wait_seconds=480)
     # Test GPTQ
-    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4",
-                         ["--quantization", "gptq"],
-                         ["--quantization", "gptq", "--cpu-offload-gb", "1"],
-                         max_wait_seconds=480)
+    compare_two_settings(
+        "Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4",
+        ["--quantization", "gptq", '--enforce-eager'],
+        ["--quantization", "gptq", "--cpu-offload-gb", "1", '--enforce-eager'],
+        max_wait_seconds=480)
 
 
 @pytest.mark.skipif(not is_quant_method_supported("awq_marlin"),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -199,33 +199,33 @@ def _test_completion(
 ):
     results = []
 
-    # test with text prompt
-    completion = client.completions.create(model=model,
-                                           prompt=prompt,
-                                           max_tokens=5,
-                                           temperature=0.0)
+    # # test with text prompt
+    # completion = client.completions.create(model=model,
+    #                                        prompt=prompt,
+    #                                        max_tokens=5,
+    #                                        temperature=0.0)
 
-    results.append({
-        "test": "single_completion",
-        "text": completion.choices[0].text,
-        "finish_reason": completion.choices[0].finish_reason,
-        "usage": completion.usage,
-    })
+    # results.append({
+    #     "test": "single_completion",
+    #     "text": completion.choices[0].text,
+    #     "finish_reason": completion.choices[0].finish_reason,
+    #     "usage": completion.usage,
+    # })
 
-    # test using token IDs
-    completion = client.completions.create(
-        model=model,
-        prompt=token_ids,
-        max_tokens=5,
-        temperature=0.0,
-    )
+    # # test using token IDs
+    # completion = client.completions.create(
+    #     model=model,
+    #     prompt=token_ids,
+    #     max_tokens=5,
+    #     temperature=0.0,
+    # )
 
-    results.append({
-        "test": "token_ids",
-        "text": completion.choices[0].text,
-        "finish_reason": completion.choices[0].finish_reason,
-        "usage": completion.usage,
-    })
+    # results.append({
+    #     "test": "token_ids",
+    #     "text": completion.choices[0].text,
+    #     "finish_reason": completion.choices[0].finish_reason,
+    #     "usage": completion.usage,
+    # })
 
     # test seeded random sampling
     completion = client.completions.create(model=model,
@@ -241,56 +241,56 @@ def _test_completion(
         "usage": completion.usage,
     })
 
-    # test seeded random sampling with multiple prompts
-    completion = client.completions.create(model=model,
-                                           prompt=[prompt, prompt],
-                                           max_tokens=5,
-                                           seed=33,
-                                           temperature=1.0)
+    # # test seeded random sampling with multiple prompts
+    # completion = client.completions.create(model=model,
+    #                                        prompt=[prompt, prompt],
+    #                                        max_tokens=5,
+    #                                        seed=33,
+    #                                        temperature=1.0)
 
-    results.append({
-        "test":
-        "seeded_sampling",
-        "text": [choice.text for choice in completion.choices],
-        "finish_reason":
-        [choice.finish_reason for choice in completion.choices],
-        "usage":
-        completion.usage,
-    })
+    # results.append({
+    #     "test":
+    #     "seeded_sampling",
+    #     "text": [choice.text for choice in completion.choices],
+    #     "finish_reason":
+    #     [choice.finish_reason for choice in completion.choices],
+    #     "usage":
+    #     completion.usage,
+    # })
 
-    # test simple list
-    batch = client.completions.create(
-        model=model,
-        prompt=[prompt, prompt],
-        max_tokens=5,
-        temperature=0.0,
-    )
+    # # test simple list
+    # batch = client.completions.create(
+    #     model=model,
+    #     prompt=[prompt, prompt],
+    #     max_tokens=5,
+    #     temperature=0.0,
+    # )
 
-    results.append({
-        "test": "simple_list",
-        "text0": batch.choices[0].text,
-        "text1": batch.choices[1].text,
-    })
+    # results.append({
+    #     "test": "simple_list",
+    #     "text0": batch.choices[0].text,
+    #     "text1": batch.choices[1].text,
+    # })
 
-    # test streaming
-    batch = client.completions.create(
-        model=model,
-        prompt=[prompt, prompt],
-        max_tokens=5,
-        temperature=0.0,
-        stream=True,
-    )
+    # # test streaming
+    # batch = client.completions.create(
+    #     model=model,
+    #     prompt=[prompt, prompt],
+    #     max_tokens=5,
+    #     temperature=0.0,
+    #     stream=True,
+    # )
 
-    texts = [""] * 2
-    for chunk in batch:
-        assert len(chunk.choices) == 1
-        choice = chunk.choices[0]
-        texts[choice.index] += choice.text
+    # texts = [""] * 2
+    # for chunk in batch:
+    #     assert len(chunk.choices) == 1
+    #     choice = chunk.choices[0]
+    #     texts[choice.index] += choice.text
 
-    results.append({
-        "test": "streaming",
-        "texts": texts,
-    })
+    # results.append({
+    #     "test": "streaming",
+    #     "texts": texts,
+    # })
 
     return results
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -200,16 +200,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Request states.
         self.requests: dict[str, CachedRequestState] = {}
-        # Persistent batch.
-        self.input_batch = InputBatch(
-            max_num_reqs=self.max_num_reqs,
-            max_model_len=self.max_model_len,
-            max_num_blocks_per_req=self.max_num_blocks_per_req,
-            max_num_batched_tokens=self.max_num_tokens,
-            device=self.device,
-            pin_memory=self.pin_memory,
-            vocab_size=model_config.get_vocab_size(),
-        )
 
         self.use_cuda_graph = (self.vllm_config.compilation_config.level
                                == CompilationLevel.PIECEWISE
@@ -1834,6 +1824,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 "Hybrid models with more than one KV cache type are not "
                 "supported yet.")
         self.kv_cache_config = kv_cache_config
+        # Persistent batch.
+        self.input_batch = InputBatch(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            max_num_blocks_per_req=self.max_num_blocks_per_req,
+            max_num_batched_tokens=self.max_num_tokens,
+            device=self.device,
+            pin_memory=self.pin_memory,
+            vocab_size=self.model_config.get_vocab_size(),
+        )
 
         kv_caches: dict[str, torch.Tensor] = {}
 


### PR DESCRIPTION
Similar to https://github.com/vllm-project/vllm/pull/18147, the input batch move in https://github.com/vllm-project/vllm/pull/17945 also causes `quantization/test_cpu_offload.py::test_cpu_offload_gptq` fail on main.
```bash
pytest -vs quantization/test_cpu_offload.py::test_cpu_offload_gptq
E                       AssertionError: Results for model='Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4' are not the same.
E                       ref_args=['--quantization', 'gptq', '--enforce-eager'] ref_envs=None
E                       compare_args=['--quantization', 'gptq', '--cpu-offload-gb', '1', '--enforce-eager'] compare_envs=None
E                       ref_result={'test': 'seeded_sampling', 'text': ' Mike', 'finish_reason': 'length', 'usage': CompletionUsage(completion_tokens=1, prompt_tokens=5, total_tokens=6, completion_tokens_details=None, prompt_tokens_details=None)}
E                       compare_result={'test': 'seeded_sampling', 'text': '散', 'finish_reason': 'length', 'usage': CompletionUsage(completion_tokens=1, prompt_tokens=5, total_tokens=6, completion_tokens_details=None, prompt_tokens_details=None)}
```