### PR TITLE
[Model] Use sigmoid for single-label classification

### DIFF
--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -242,9 +242,16 @@ class PoolerHead(nn.Module):
 
         if self.softmax:
             if isinstance(pooled_data, list):
-                pooled_data = [F.softmax(data, dim=-1) for data in pooled_data]
+                pooled_data = [
+                    F.softmax(data, dim=-1)
+                    if data.shape[-1] >= 2 else F.sigmoid(data)
+                    for data in pooled_data
+                ]
             else:
-                pooled_data = F.softmax(pooled_data, dim=-1)
+                if pooled_data.shape[-1] >= 2:
+                    pooled_data = F.softmax(pooled_data, dim=-1)
+                else:
+                    pooled_data = F.sigmoid(pooled_data)
 
         return pooled_data
 


### PR DESCRIPTION
In classification problems, two labels are often reduced to one label because they are equivalent, both representing binary classification. For a single label, we should apply `sigmoid` instead of `softmax`

Related to #18052

cc @maxdebayser @DarkLight1337 @WoosukKwon @houseroad 