### PR TITLE
[V1] Fix general plugins not loaded in engine for multiproc

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -57,6 +57,10 @@ class EngineCore:
                  executor_fail_callback: Optional[Callable] = None):
         assert vllm_config.model_config.runner_type != "pooling"
 
+        # plugins need to be loaded at the engine/scheduler level too
+        from vllm.plugins import load_general_plugins
+        load_general_plugins()
+
         self.vllm_config = vllm_config
         logger.info("Initializing a V1 LLM engine (v%s) with config: %s",
                     VLLM_VERSION, vllm_config)


### PR DESCRIPTION
[vLLM general plugins](https://docs.vllm.ai/en/latest/design/plugin_system.html#types-of-supported-plugins) are primarily used to register custom, out-of-tree (OOT) models.

Currently, when multi-processing is used (e.g. TP>1), plugins will not be loaded at the engine level. This is because general plugins are only loaded at the worker level [here](https://github.com/vllm-project/vllm/blob/main/vllm/worker/worker_base.py#L554-L555). This is ok when using `UniProcExecutor` (e.g. TP=1), because the worker is on the same process as the engine, so after the plugins are loaded in the worker, the OOT models will be registered in ModelRegistry at the engine level as well. However, for `MultiProcExecutor`, workers are created in separate processes, and thus the engine will not load the plugins.

To fix this, we can explicitly load the general plugins at the engine level. Note this is required in the first place because `EngineCore` is initialized in a separate process [here](https://github.com/vllm-project/vllm/blob/main/vllm/v1/utils.py#L130-L136).

Why might we want plugins loaded at the engine level? For example, the scheduler (which runs in the same process as the engine) might require OOT models to be registered, e.g. when calculating the encoder cache size [here](https://github.com/vllm-project/vllm/blob/main/vllm/v1/core/sched/scheduler.py#L114-L118). At this point, the scheduler needs to look up the correct multi-modal processor for OOT models [here](https://github.com/vllm-project/vllm/blob/main/vllm/multimodal/registry.py#L276) but this doesn't happen currently, so we need to load the general plugin when initializing the engine in a separate process.

cc @youkaichao 