### PR TITLE
[P/D] Fix minor case in example disagg_prefill_proxy_server.py

### DIFF
--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -32,6 +32,8 @@ async def handle_request():
         prefill_request = original_request_data.copy()
         # change max_tokens = 1 to let it only do prefill
         prefill_request["max_tokens"] = 1
+        # Also set min_tokens = 1 to avoid the case where min_tokens > max_tokens after max_tokens is set to 1
+        prefill_request["min_tokens"] = 1
 
         # finish prefill
         async for _ in forward_request(

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -32,7 +32,8 @@ async def handle_request():
         prefill_request = original_request_data.copy()
         # change max_tokens = 1 to let it only do prefill
         prefill_request["max_tokens"] = 1
-        # Set min_tokens = 1 to prevent min_tokens > max_tokens errors when max_tokens is 1
+        # Prevent min_tokens > max_tokens error
+        # by setting min_tokens = 1 when max_tokens = 1
         prefill_request["min_tokens"] = 1
 
         # finish prefill

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -32,7 +32,7 @@ async def handle_request():
         prefill_request = original_request_data.copy()
         # change max_tokens = 1 to let it only do prefill
         prefill_request["max_tokens"] = 1
-        # Also set min_tokens = 1 to avoid the case where min_tokens > max_tokens after max_tokens is set to 1
+        # Set min_tokens = 1 to prevent min_tokens > max_tokens errors when max_tokens is 1
         prefill_request["min_tokens"] = 1
 
         # finish prefill


### PR DESCRIPTION
When trying out the disaggregate serving example, I found that disagg_prefill_proxy_server.py only sets max_tokens to 1.

However, if a request includes a min_tokens field, this can cause the request to be rejected due to min_tokens > max_tokens.

This PR fixes the issue by also setting min_tokens to 1 to maintain consistency.


