### PR TITLE
[Misc] Call `ndarray.tobytes()` directly instead of `ndarray.data.tobytes()`

### DIFF
--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -43,7 +43,7 @@ class MultiModalHasher:
                 "ndarray", {
                     "dtype": obj.dtype.str,
                     "shape": obj.shape,
-                    "data": obj.data.tobytes(),
+                    "data": obj.tobytes(),
                 })
 
         logger.warning(


### PR DESCRIPTION
Call [`ndarray.tobytes()`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tobytes.html) directly instead of `ndarray.data.tobytes()` when serialisation since `ndarray.tobytes()` is already implemented in C in numpy.

Followup on #17378