### PR TITLE
Update run_cluster.sh

### DIFF
--- a/examples/online_serving/run_cluster.sh
+++ b/examples/online_serving/run_cluster.sh
@@ -2,7 +2,7 @@
 
 # Check for minimum number of required arguments
 if [ $# -lt 4 ]; then
-    echo "Usage: $0 docker_image head_node_address --head|--worker path_to_hf_home [additional_args...]"
+    echo "Usage: $0 docker_image head_node_address --head|--worker path_to_hf_home [--dashboard] [additional_args...]"
     exit 1
 fi
 
@@ -22,6 +22,18 @@ if [ "${NODE_TYPE}" != "--head" ] && [ "${NODE_TYPE}" != "--worker" ]; then
     exit 1
 fi
 
+# Process additional arguments to check for --dashboard
+DASHBOARD_ENABLED=false
+NEW_ADDITIONAL_ARGS=()
+for arg in "${ADDITIONAL_ARGS[@]}"; do
+    if [ "$arg" == "--dashboard" ]; then
+        DASHBOARD_ENABLED=true
+    else
+        NEW_ADDITIONAL_ARGS+=("$arg")
+    fi
+done
+ADDITIONAL_ARGS=("${NEW_ADDITIONAL_ARGS[@]}")
+
 # Define a function to cleanup on EXIT signal
 cleanup() {
     docker stop node
@@ -33,8 +45,16 @@ trap cleanup EXIT
 RAY_START_CMD="ray start --block"
 if [ "${NODE_TYPE}" == "--head" ]; then
     RAY_START_CMD+=" --head --port=6379"
+    if [ "${DASHBOARD_ENABLED}" == "true" ]; then
+        RAY_START_CMD+=" --dashboard-host=0.0.0.0 --include-dashboard=true"
+    fi
 else
     RAY_START_CMD+=" --address=${HEAD_NODE_ADDRESS}:6379"
+fi
+
+# Prepend pip install command if dashboard is enabled and it's the head node
+if [ "${DASHBOARD_ENABLED}" == "true" ] && [ "${NODE_TYPE}" == "--head" ]; then
+    RAY_START_CMD="pip install \"ray[default]\" && ${RAY_START_CMD}"
 fi
 
 # Run the docker command with the user specified parameters and additional arguments


### PR DESCRIPTION
This PR adds an optional `--dashboard` flag to `run_cluster.sh` to enable the Ray dashboard on the head node, improving cluster monitoring. When set, it installs `ray[default]` dependencies and configures the dashboard.

## Improvements
- Added `--dashboard` flag to enable dashboard on head node with `--dashboard-host=0.0.0.0 --include-dashboard=true`.
- Installs `ray[default]` via `pip` for head node when `--dashboard` is used.
- Flag is optional and ignored for worker nodes, preserving existing functionality.

## Usage
Head node with dashboard:
```bash
bash run_cluster.sh vllm/vllm-openai ip_of_head_node --head /home/user/.cache/huggingface --dashboard -e VLLM_HOST_IP=ip_of_this_node
```
Worker node:
```bash
bash run_cluster.sh vllm/vllm-openai ip_of_head_node --worker /home/user/.cache/huggingface -e VLLM_HOST_IP=ip_of_this_node
```

## Testing
- Confirmed dashboard and dependencies activate on head node with `--dashboard`.
- Verified no changes for worker nodes or without `--dashboard`.