### PR TITLE
[Bugfix] fix adding bias twice in ipex GPTQ quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/ipex_quant.py
+++ b/vllm/model_executor/layers/quantization/ipex_quant.py
@@ -181,8 +181,6 @@ class IPEXGPTQLinearMethod(GPTQLinearMethod):
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         reshaped_x = x.reshape(-1, x.shape[-1])
         out = layer.ipex_qlinear(reshaped_x)
-        if bias is not None:
-            out.add_(bias)
         return out.reshape(x.shape[:-1] + (layer.ipex_output_size, ))
 
 


### PR DESCRIPTION
`ipex_qlinear` has already added bias in it, but the current implementation added bias again to the output of `ipex_qlinear`. This causes GPTQ quantized models with QKV bias such as [Qwen2.5-0.5B-Instruct-GPTQ-Int4](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int4) to have wrong outputs on CPU.