### PR TITLE
update kv-event configs to be more flexible

### DIFF
--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -289,9 +289,9 @@ def test_kv_cache_events(
             executor_class=executor_class,
             log_stats=False,
         )
-        endpoint = publisher_config.endpoint.replace("*", "127.0.0.1")
+        endpoint = publisher_config.config.endpoint.replace("*", "127.0.0.1")
         subscriber = MockSubscriber(endpoint,
-                                    topic=publisher_config.topic,
+                                    topic=publisher_config.config.topic,
                                     decode_type=KVEventBatch)
 
         try:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3585,10 +3585,26 @@ class KVEventsConfig:
     Events can be published externally by zmq using the event publisher config.
     """
 
-    publisher: str = "null"
+    publisher: Union[Literal["null", "zmq"], str] = "null"
     """The publisher to use for publishing kv events. Can be "null", "zmq".
+    Publishers can be registered via the `register_publisher` method at runtime.
     """
 
+    config: Optional[Union["ZMQPublisherConfig",
+                           dict[str, Any]]] = field(default_factory=dict)
+    """The config for the publisher. Publishers can be registered via the 
+    `register_publisher` and this field used to pass arguments to the 
+    constructor.
+    """
+
+    def __post_init__(self):
+        if isinstance(self.config, dict) and self.publisher == "zmq":
+            self.config = ZMQPublisherConfig(**self.config)
+
+
+@config
+@dataclass
+class ZMQPublisherConfig:
     endpoint: str = "tcp://*:5557"
     """The zmq endpoint to use for publishing kv events.
     """


### PR DESCRIPTION
For KV Event Publishing, you can register your own Publisher, however the configs don't offer the flexibility to properly initialize a custom Publisher. This fixes that problem. 

<!--- pyml disable-next-line no-emphasis-as-heading -->
