### PR TITLE
[V0] Support multiple kv connectors

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -46,7 +46,9 @@ class KVConnectorFactory:
 
         connector_cls = cls._registry[connector_name]()
         assert issubclass(connector_cls, KVConnectorBase)
-        return connector_cls(rank, local_rank, config)
+        connector = connector_cls(rank, local_rank, config)
+        KVConnectorBase.__init__(connector, rank, local_rank, config)
+        return connector
 
     @classmethod
     def create_connector_v1(
@@ -104,6 +106,11 @@ KVConnectorFactory.register_connector(
     "MooncakeStoreConnector",
     "vllm.distributed.kv_transfer.kv_connector.mooncake_store_connector",
     "MooncakeStoreConnector")
+
+KVConnectorFactory.register_connector(
+    "MultiConnectorV0",
+    "vllm.distributed.kv_transfer.kv_connector.multi_connector",
+    "MultiConnectorV0")
 
 KVConnectorFactory.register_connector(
     "SharedStorageConnector",

--- a/vllm/distributed/kv_transfer/kv_connector/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/multi_connector.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MultiConnectorV0 - v0 implementation combining multiple KV connectors
+"""
+import copy
+from typing import TYPE_CHECKING, Union
+
+import torch
+
+from vllm.config import KVTransferConfig, VllmConfig, logger
+from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
+from vllm.distributed.kv_transfer.kv_connector.factory import (
+    KVConnectorFactory)
+from vllm.sequence import IntermediateTensors
+
+if TYPE_CHECKING:
+    from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
+
+
+class MultiConnectorV0(KVConnectorBase):
+
+    def __init__(
+        self,
+        rank: int,
+        local_rank: int,
+        config: VllmConfig,
+    ):
+        self._connectors = []
+        ktcs = config.kv_transfer_config.kv_connector_extra_config.get(
+            "connectors", [])
+        assert ktcs is not None
+        for ktc in ktcs:
+            temp_config = copy.copy(config)
+            temp_config.kv_transfer_config = KVTransferConfig(**ktc)
+            self._connectors.append(
+                KVConnectorFactory.create_connector_v0(rank, local_rank,
+                                                       temp_config))
+
+    def recv_kv_caches_and_hidden_states(
+        self, model_executable: torch.nn.Module,
+        model_input: "ModelInputForGPUWithSamplingMetadata",
+        kv_caches: list[torch.Tensor]
+    ) -> tuple[Union[torch.Tensor, IntermediateTensors], bool,
+               "ModelInputForGPUWithSamplingMetadata"]:
+        for connector in self._connectors:
+            if connector.get_config().kv_transfer_config.is_kv_consumer:
+                hidden, bypass, new_input = (
+                    connector.recv_kv_caches_and_hidden_states(
+                        model_executable, model_input, kv_caches))
+                # if bypass or model_input changed, return immediately
+                if len(self._connectors
+                       ) == 1 or bypass or new_input is not model_input:
+                    return hidden, bypass, new_input
+        return None, False, model_input
+
+    def send_kv_caches_and_hidden_states(
+        self,
+        model_executable: torch.nn.Module,
+        model_input: "ModelInputForGPUWithSamplingMetadata",
+        kv_caches: list[torch.Tensor],
+        hidden_or_intermediate_states: Union[torch.Tensor,
+                                             IntermediateTensors],
+    ) -> None:
+        raise RuntimeError("Should not call this method in multi connector")
+
+    def send_kv_caches_and_hidden_states_with_ori_input(
+        self,
+        model_executable: torch.nn.Module,
+        model_input: "ModelInputForGPUWithSamplingMetadata",
+        model_input_before_recv: "ModelInputForGPUWithSamplingMetadata",
+        kv_caches: list[torch.Tensor],
+        hidden_or_intermediate_states: Union[torch.Tensor,
+                                             IntermediateTensors],
+    ) -> None:
+        for connector in self._connectors:
+            kv_transfer_config = connector.get_config().kv_transfer_config
+            if kv_transfer_config.is_kv_producer:
+                is_transfer = kv_transfer_config.kv_connector_extra_config.get(
+                    "transfer", False)
+                if is_transfer:
+                    model_input = model_input_before_recv
+                connector.send_kv_caches_and_hidden_states(
+                    model_executable, model_input, kv_caches,
+                    hidden_or_intermediate_states)
+                logger.debug(
+                    "sent to connector %s with mode transfer=%s",
+                    connector.get_config().kv_transfer_config.kv_connector,
+                    is_transfer)
+            else:
+                logger.debug(
+                    "not sending to connector %s",
+                    connector.get_config().kv_transfer_config.kv_connector)
+
+    def close(self) -> None:
+        for connector in self._connectors:
+            connector.close()

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1815,6 +1815,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         # we can skip prefilling on tokens that successfully received KV caches
         # NOTE: The receive operation is blocking
         bypass_model_exec = False
+        model_input_before_recv = model_input
         if self.need_recv_kv(model_input, kv_caches):
             hidden_or_intermediate_states, bypass_model_exec, model_input = \
                 get_kv_transfer_group().recv_kv_caches_and_hidden_states(
@@ -1861,12 +1862,14 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         # Sending KV cache in distributed KV cache transfer setting
         # NOTE: the send operation is non-blocking
         if self.need_send_kv(model_input, kv_caches):
-            get_kv_transfer_group().send_kv_caches_and_hidden_states(
+            get_kv_transfer_group(
+            ).send_kv_caches_and_hidden_states_with_ori_input(
                 # model_executable is used to know which layer the current
                 # worker is working on, so that we can send KV for only those
                 # layers.
                 model_executable,
                 model_input,
+                model_input_before_recv,
                 kv_caches,
                 hidden_or_intermediate_states,
             )


### PR DESCRIPTION
# Motivation
Inspired by #17564 which make v1 support multiple connectors co-exist.

This PR aimed to implement  MultiConnectorV0 for v0.

# How to test

Start a 1P 1D cluster, and use lmcacheConnector as an offload purpose connector in the P instance, use FSConnector in the both P and D instance as a PD transfer connector.(Will submit another PR for introduce FSConnector, but you can use any other connector instead as P/D transfer connector)

- run an vllm instance for prefill role
```Shell
CUDA_VISIBLE_DEVICES=0 \
VLLM_LOGGING_LEVEL=DEBUG \
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false LMCACHE_LOG_LEVEL=DEBUG \
LMCACHE_CONFIG_FILE=/disc/data1/baoloongmao/cpu/lmcache-cpu.yaml \
VLLM_MLA_DISABLE=1 VLLM_USE_V1=0 \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 1 \
           --no-enable-prefix-caching \
           --max-num-batched-tokens 64000 \
           --kv-transfer-config '{"kv_connector":"MultiConnectorV0","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"FSConnector","kv_role":"kv_producer","kv_connector_extra_config":{"fs_storage_path":"fs_local_storage","transfer":true}},{"kv_connector":"LMCacheConnector","kv_role":"kv_both"}]}}'
```
- run an vllm instance for decode role
```shell
CUDA_VISIBLE_DEVICES=1 \
VLLM_LOGGING_LEVEL=DEBUG \
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false LMCACHE_LOG_LEVEL=DEBUG \
LMCACHE_CONFIG_FILE=/disc/data1/baoloongmao/cpu/lmcache-cpu.yaml \
VLLM_MLA_DISABLE=1 VLLM_USE_V1=0 \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 1 \
           --no-enable-prefix-caching \
           --max-num-batched-tokens 64000 \
           --kv-transfer-config '{"kv_connector":"FSConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"fs_storage_path":"fs_local_storage"}}' \
           --port 8001
```

- Send request by curl and check the output log and file in the `fs_local_storage` folder
```shell

curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 1,
    "temperature": 0,
    "top_p": 0.95
    }'
{"id":"chatcmpl-94b0c6c0941343af9499f895789febe1","object":"chat.completion","created":1747727609,"model":"vllm_cpu_offload","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":" Hello","tool_calls":[]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":409,"total_tokens":410,"completion_tokens":1,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null}

curl http://localhost:8001/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
    }'
```

- log in P 
```
INFO 05-20 00:52:26 [logger.py:39] Received request chatcmpl-4c385ad864cb426dab9c3e31c82d073c: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=1, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 05-20 00:52:26 [engine.py:313] Added request chatcmpl-4c385ad864cb426dab9c3e31c82d073c.
[2025-05-20 00:52:26,864] LMCache DEBUG: Retrieved 0 out of 409 out of total 409 tokens (cache_engine.py:330:lmcache.experimental.cache_engine)
[2025-05-20 00:52:26,864] LMCache DEBUG: Injected token number: 0 (vllm_adapter.py:747:lmcache.integration.vllm.vllm_adapter)
[2025-05-20 00:52:26,864] LMCache DEBUG: Returning the original input! (vllm_adapter.py:789:lmcache.integration.vllm.vllm_adapter)
DEBUG 05-20 00:52:27 [fs_connector.py:94] [rank0]: KV send DONE.
INFO 05-20 00:52:27 [multi_connector.py:67] sent to connector FSConnector
[2025-05-20 00:52:27,062] LMCache DEBUG: Stored 409 out of total 409 tokens (cache_engine.py:257:lmcache.experimental.cache_engine)
[2025-05-20 00:52:27,062] LMCache DEBUG: Store skips 0 tokens and then stores 409 tokens (vllm_adapter.py:561:lmcache.integration.vllm.vllm_adapter)
INFO 05-20 00:52:27 [multi_connector.py:67] sent to connector LMCacheConnector

INFO 05-20 00:52:57 [logger.py:39] Received request chatcmpl-ae3020fdc9974caaaea4167112dcba5b: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=1, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 05-20 00:52:57 [engine.py:313] Added request chatcmpl-ae3020fdc9974caaaea4167112dcba5b.
[2025-05-20 00:52:57,507] LMCache DEBUG: Retrieved 409 out of 409 out of total 409 tokens (cache_engine.py:330:lmcache.experimental.cache_engine)
[2025-05-20 00:52:57,507] LMCache DEBUG: Injected token number: 408 (vllm_adapter.py:747:lmcache.integration.vllm.vllm_adapter)
[2025-05-20 00:52:57,517] LMCache DEBUG: Rebuilt the input! (vllm_adapter.py:786:lmcache.integration.vllm.vllm_adapter)
DEBUG 05-20 00:52:57 [fs_connector.py:94] [rank0]: KV send DONE.
INFO 05-20 00:52:57 [multi_connector.py:67] sent to connector FSConnector
[2025-05-20 00:52:57,558] LMCache DEBUG: Store skips 409 tokens and then stores 0 tokens (vllm_adapter.py:561:lmcache.integration.vllm.vllm_adapter)
INFO 05-20 00:52:57 [multi_connector.py:67] sent to connector LMCacheConnector

INFO 05-20 00:53:29 [logger.py:39] Received request chatcmpl-94b0c6c0941343af9499f895789febe1: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=1, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 05-20 00:53:29 [engine.py:313] Added request chatcmpl-94b0c6c0941343af9499f895789febe1.
[2025-05-20 00:53:29,635] LMCache DEBUG: Retrieved 409 out of 409 out of total 409 tokens (cache_engine.py:330:lmcache.experimental.cache_engine)
[2025-05-20 00:53:29,635] LMCache DEBUG: Injected token number: 408 (vllm_adapter.py:747:lmcache.integration.vllm.vllm_adapter)
[2025-05-20 00:53:29,638] LMCache DEBUG: Rebuilt the input! (vllm_adapter.py:786:lmcache.integration.vllm.vllm_adapter)
DEBUG 05-20 00:53:29 [fs_connector.py:94] [rank0]: KV send DONE.
INFO 05-20 00:53:29 [multi_connector.py:67] sent to connector FSConnector
[2025-05-20 00:53:29,671] LMCache DEBUG: Store skips 409 tokens and then stores 0 tokens (vllm_adapter.py:561:lmcache.integration.vllm.vllm_adapter)
INFO 05-20 00:53:29 [multi_connector.py:67] sent to connector LMCacheConnector
```

- log in D
```
INFO 05-20 00:52:46 [logger.py:39] Received request chatcmpl-471ab3691c8741768686f04e4a3123f1: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 05-20 00:52:46 [engine.py:313] Added request chatcmpl-471ab3691c8741768686f04e4a3123f1.
DEBUG 05-20 00:52:46 [fs_connector.py:170] [rank0]: Successfully received all KVs and hidden states, skip model forwarding.

INFO 05-20 00:53:09 [logger.py:39] Received request chatcmpl-d0deb766738a425aa0129134ef52955e: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 05-20 00:53:09 [engine.py:313] Added request chatcmpl-d0deb766738a425aa0129134ef52955e.
DEBUG 05-20 00:53:09 [fs_connector.py:170] [rank0]: Successfully received all KVs and hidden states, skip model forwarding.
```