### PR TITLE
[Frontend] enable custom logging for the uvicorn server (OpenAI API server)

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -131,7 +131,7 @@ async def run_server(args: Namespace,
     log_config = None
     if getattr(args, "log_config_file", None):
         try:
-            with open(args.log_config_file, "r") as f:
+            with open(args.log_config_file) as f:
                 log_config = json.load(f)
         except Exception as e:
             logger.warning("Failed to load log config from file %s: error %e",

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -130,8 +130,12 @@ async def run_server(args: Namespace,
     # Load logging config for uvicorn if specified
     log_config = None
     if getattr(args, "log_config_file", None):
-        with open(args.log_config_file, "r") as f:
-            log_config = json.load(f)
+        try:
+            with open(args.log_config_file, "r") as f:
+                log_config = json.load(f)
+        except Exception as e:
+            logger.warning("Failed to load log config from file %s: error %e",
+                           args.log_config_file, e)
 
     shutdown_task = await serve_http(
         app,

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -137,8 +137,8 @@ async def run_server(args: Namespace,
             logger.warning("Failed to load log config from file %s: error %e",
                            args.log_config_file, e)
 
-    shutdown_task = await serve_http(
-        app,
+    serve_http_kwargs = dict(
+        app=app,
         sock=None,
         enable_ssl_refresh=args.enable_ssl_refresh,
         host=args.host,
@@ -149,9 +149,12 @@ async def run_server(args: Namespace,
         ssl_certfile=args.ssl_certfile,
         ssl_ca_certs=args.ssl_ca_certs,
         ssl_cert_reqs=args.ssl_cert_reqs,
-        log_config=log_config,
         **uvicorn_kwargs,
     )
+    if log_config is not None:
+        serve_http_kwargs['log_config'] = log_config
+
+    shutdown_task = await serve_http(**serve_http_kwargs)
 
     await shutdown_task
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1337,7 +1337,7 @@ async def run_server_worker(listen_address,
     server_index = client_config.get("client_index", 0) if client_config else 0
 
     # Load logging config for uvicorn if specified
-    log_config = load_log_config(getattr(args, "log_config_file", None))
+    log_config = load_log_config(args.log_config_file)
     if log_config is not None:
         uvicorn_kwargs['log_config'] = log_config
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1343,8 +1343,8 @@ async def run_server_worker(listen_address,
 
         logger.info("Starting vLLM API server %d on %s", server_index,
                     listen_address)
-        shutdown_task = await serve_http(
-            app,
+        serve_http_kwargs = dict(
+            app=app,
             sock=sock,
             enable_ssl_refresh=args.enable_ssl_refresh,
             host=args.host,
@@ -1358,10 +1358,12 @@ async def run_server_worker(listen_address,
             ssl_certfile=args.ssl_certfile,
             ssl_ca_certs=args.ssl_ca_certs,
             ssl_cert_reqs=args.ssl_cert_reqs,
-            log_config=log_config,
             **uvicorn_kwargs,
         )
+        if log_config is not None:
+            serve_http_kwargs['log_config'] = log_config
 
+        shutdown_task = await serve_http(**serve_http_kwargs)
     # NB: Await server shutdown only after the backend context is exited
     try:
         await shutdown_task

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -931,7 +931,7 @@ async def invocations(raw_request: Request):
     """
     try:
         body = await raw_request.json()
-    except JSONDecodeError as e:
+    except json.JSONDecodeError as e:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST.value,
                             detail=f"JSON decode error: {e}") from e
 
@@ -1328,8 +1328,12 @@ async def run_server_worker(listen_address,
     # Load logging config for uvicorn if specified
     log_config = None
     if getattr(args, "log_config_file", None):
-        with open(args.log_config_file, "r") as f:
-            log_config = json.load(f)
+        try:
+            with open(args.log_config_file, "r") as f:
+                log_config = json.load(f)
+        except Exception as e:
+            logger.warning("Failed to load log config from file %s: error %e",
+                           args.log_config_file, e)
 
     async with build_async_engine_client(args, client_config) as engine_client:
         app = build_app(args)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -5,6 +5,7 @@ import atexit
 import gc
 import importlib
 import inspect
+import json
 import multiprocessing
 import os
 import signal
@@ -1324,6 +1325,12 @@ async def run_server_worker(listen_address,
 
     server_index = client_config.get("client_index", 0) if client_config else 0
 
+    # Load logging config for uvicorn if specified
+    log_config = None
+    if getattr(args, "log_config_file", None):
+        with open(args.log_config_file, "r") as f:
+            log_config = json.load(f)
+
     async with build_async_engine_client(args, client_config) as engine_client:
         app = build_app(args)
 
@@ -1347,6 +1354,7 @@ async def run_server_worker(listen_address,
             ssl_certfile=args.ssl_certfile,
             ssl_ca_certs=args.ssl_ca_certs,
             ssl_cert_reqs=args.ssl_cert_reqs,
+            log_config=log_config,
             **uvicorn_kwargs,
         )
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1366,6 +1366,7 @@ async def run_server_worker(listen_address,
             ssl_cert_reqs=args.ssl_cert_reqs,
             **uvicorn_kwargs,
         )
+
     # NB: Await server shutdown only after the backend context is exited
     try:
         await shutdown_task

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -17,7 +17,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from functools import partial
 from http import HTTPStatus
-from json import JSONDecodeError
 from typing import Annotated, Any, Optional
 
 import prometheus_client
@@ -1329,7 +1328,7 @@ async def run_server_worker(listen_address,
     log_config = None
     if getattr(args, "log_config_file", None):
         try:
-            with open(args.log_config_file, "r") as f:
+            with open(args.log_config_file) as f:
                 log_config = json.load(f)
         except Exception as e:
             logger.warning("Failed to load log config from file %s: error %e",

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1003,7 +1003,7 @@ if envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING:
         return Response(status_code=200, content=response)
 
 
-def load_log_config(log_config_file: str) -> Optional[dict]:
+def load_log_config(log_config_file: Optional[str]) -> Optional[dict]:
     if not log_config_file:
         return None
     try:

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -244,13 +244,9 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         " into OpenAI API format, the name register in this plugin can be used "
         "in ``--tool-call-parser``.")
 
-    parser.add_argument(
-        "--log-config-file",
-        type=str,
-        default=os.environ.get("VLLM_LOGGING_CONFIG_PATH", None),
-        help="Path to logging config JSON file for both vllm and uvicorn",
-    )
+import vllm.envs as envs
 
+        default=envs.VLLM_LOGGING_CONFIG_PATH,
     parser = AsyncEngineArgs.add_cli_args(parser)
 
     parser.add_argument('--max-log-len',

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -7,6 +7,7 @@ purposes.
 
 import argparse
 import json
+import os
 import ssl
 from collections.abc import Sequence
 from typing import Optional, Union, get_args
@@ -242,6 +243,13 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         "Special the tool parser plugin write to parse the model-generated tool"
         " into OpenAI API format, the name register in this plugin can be used "
         "in ``--tool-call-parser``.")
+
+    parser.add_argument(
+        "--log-config-file",
+        type=str,
+        default=os.environ.get("VLLM_LOGGING_CONFIG_PATH", None),
+        help="Path to logging config JSON file for both vllm and uvicorn",
+    )
 
     parser = AsyncEngineArgs.add_cli_args(parser)
 

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -7,11 +7,11 @@ purposes.
 
 import argparse
 import json
-import os
 import ssl
 from collections.abc import Sequence
 from typing import Optional, Union, get_args
 
+import vllm.envs as envs
 from vllm.engine.arg_utils import AsyncEngineArgs, optional_type
 from vllm.entrypoints.chat_utils import (ChatTemplateContentFormatOption,
                                          validate_chat_template)
@@ -244,9 +244,13 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         " into OpenAI API format, the name register in this plugin can be used "
         "in ``--tool-call-parser``.")
 
-import vllm.envs as envs
-
+    parser.add_argument(
+        "--log-config-file",
+        type=str,
         default=envs.VLLM_LOGGING_CONFIG_PATH,
+        help="Path to logging config JSON file for both vllm and uvicorn",
+    )
+
     parser = AsyncEngineArgs.add_cli_args(parser)
 
     parser.add_argument('--max-log-len',


### PR DESCRIPTION
This PR introduce the possibility to define a custom logging configuration for the uvicorn server used to expose the OpenAI API compliant API. 
Previously it was possible to modify the log format of the vLLM engine **but** specifying a config file **had no effect** over the uvicorn API.
Hence you always saw something like this uvicorn log format when starting your app (log below)
```log
INFO:     Started server process [128887]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```

This is limitating for use in production systems that have auditing requirement and must expose logs in a specific format to ensure compliance or just to make it easier to parse logs from various systems.

This PR extend the custom logging possibility defined in https://docs.vllm.ai/en/latest/getting_started/examples/logging_configuration.html to enable custom uvicorn logging format.

FIX #18210

---

You can test it yourself with the provided logger config below and making sure to expose it to the vLLM process by doing 
`export VLLM_LOGGING_CONFIG_PATH=./logger-config.json vllm serve....` 

```json
{
  "version": 1,
  "disable_existing_loggers": false,
  "formatters": {
    "plain": {
      "class": "logging.Formatter",
      "format": "%(asctime)s [%(levelname)s] %(filename)s:%(lineno)d - %(funcName)s() - %(message)s",
      "datefmt": "%d-%m-%Y %H:%M:%S"
    },
    "default": {
      "()": "uvicorn.logging.DefaultFormatter",
      "format": "%(asctime)s [%(levelname)s] %(filename)s:%(lineno)d - %(funcName)s() - %(message)s",
      "datefmt": "%d-%m-%Y %H:%M:%S"
    },
    "access": {
      "()": "uvicorn.logging.AccessFormatter",
      "format": "%(asctime)s [%(levelname)s] %(client_addr)s - \"%(request_line)s\" %(status_code)s",
      "datefmt": "%d-%m-%Y %H:%M:%S"
    }
  },
  "handlers": {
    "console": {
      "class": "logging.StreamHandler",
      "formatter": "plain",
      "level": "INFO",
      "stream": "ext://sys.stdout"
    },
    "default": {
      "class": "logging.StreamHandler",
      "formatter": "default",
      "stream": "ext://sys.stderr"
    },
    "access": {
      "class": "logging.StreamHandler",
      "formatter": "access",
      "stream": "ext://sys.stdout"
    }
  },
  "loggers": {
    "vllm": {
      "handlers": ["console"],
      "level": "INFO",
      "propagate": false
    },
    "vllm.entrypoints.api_server": {
      "handlers": ["console"],
      "level": "INFO",
      "propagate": false
    },
    "uvicorn": {
      "handlers": ["default"],
      "level": "INFO",
      "propagate": false
    },
    "uvicorn.error": {
      "level": "INFO"
    },
    "uvicorn.access": {
      "handlers": ["access"],
      "level": "INFO",
      "propagate": false
    }
  }
}

```

You will see the following log at service startup for the uvicorn server:
```log
20-05-2025 10:11:23 [INFO] server.py:83 - _serve() - Started server process [129561]
20-05-2025 10:11:23 [INFO] on.py:48 - startup() - Waiting for application startup.
20-05-2025 10:11:23 [INFO] on.py:62 - startup() - Application startup complete.
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
