### PR TITLE
[Misc] Update deprecation message for `--enable-reasoning`

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -577,7 +577,7 @@ class EngineArgs:
             action=argparse.BooleanOptionalAction,
             deprecated=True,
             help="[DEPRECATED] The `--enable-reasoning` flag is deprecated as "
-            "of v0.8.6. Use `--reasoning-parser` to specify the reasoning "
+            "of v0.9.0. Use `--reasoning-parser` to specify the reasoning "
             "parser backend instead. This flag (`--enable-reasoning`) will be "
             "removed in v0.10.0. When `--reasoning-parser` is specified, "
             "reasoning mode is automatically enabled.")


### PR DESCRIPTION
The `--enable-reasoning` option was deprecated starting from `v0.9.0`, and there was no `v0.8.6` release.

https://github.com/vllm-project/vllm/blob/dc1440cf9f8f6233a3c464e1a01daa12207f8680/vllm/engine/arg_utils.py#L580

<!--- pyml disable-next-line no-emphasis-as-heading -->
