### PR TITLE
[Bugfix] Fix MRoPE Errors in the Qwen-VL Model When Processing Pure Text

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -729,8 +729,6 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
         mm_kwargs, placeholder_maps = MultiModalPlaceholderMap.from_seq_group(
             seq_group_metadata,
             range(positions[0], positions[0] + len(positions)))
-        if not mm_kwargs:
-            return
 
         inter_data.multi_modal_kwargs = mm_kwargs
         inter_data.multi_modal_placeholder_maps = placeholder_maps
@@ -741,12 +739,6 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             video_grid_thw = mm_kwargs.get("video_grid_thw", None)
             audio_feature_lengths = mm_kwargs.get("audio_feature_lengths",
                                                   None)
-            assert (
-                image_grid_thw is not None or video_grid_thw is not None
-                or audio_feature_lengths is not None), (
-                    "mrope embedding type requires multi-modal input mapper "
-                    "returns 'image_grid_thw' or 'video_grid_thw' or "
-                    "'audio_feature_lengths'.")
 
             second_per_grid_ts = mm_kwargs.get("second_per_grid_ts", None)
             use_audio_in_video = mm_kwargs.get("use_audio_in_video", False)


### PR DESCRIPTION
We found that under the V0 engine, when the Qwen-VL model is given pure text input, the `get_input_positions` function incorrectly generates `position_ids`  with shape `[n]` instead of the expected `[3, n]`. This leads to inconsistent outputs between eager mode and CUDA Graph mode. 

This PR mainly fixes the `position_ids`  issue when the model processes pure text inputs. 

Thanks to the vLLM team for their excellent work!


FIX https://github.com/QwenLM/Qwen2.5-VL/issues/1215