### PR TITLE
[Bugfix][Failing Test] Fix nixl connector test when promt size < block size

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -259,6 +259,15 @@ class NixlConnectorScheduler:
         # Loop through scheduled reqs and convert to ReqMeta.
         for req_id, (req, block_ids) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
+            # For the case where there are no remote blocks to pull
+            # (remote_block_ids is empty), we don't need to schedule
+            # an async read on the worker side.
+            if not req.kv_transfer_params.get("remote_block_ids"):
+                logger.debug(
+                    "Skipping adding request %s to NixlConnectorMetadata, "
+                    "as there are no remote blocks to pull", req_id)
+                continue
+
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -260,9 +260,9 @@ class NixlConnectorScheduler:
         for req_id, (req, block_ids) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
             # For the case where there are no remote blocks to pull
-            # (remote_block_ids is empty), we don't need to schedule
+            # (block_ids is empty), we don't need to schedule
             # an async read on the worker side.
-            if not req.kv_transfer_params.get("remote_block_ids"):
+            if not block_ids:
                 logger.debug(
                     "Skipping adding request %s to NixlConnectorMetadata, "
                     "as there are no remote blocks to pull", req_id)


### PR DESCRIPTION
Fix nixl connector test when promt size < block size, mentioned in issue #18419. 

In #18232, we decided to adds the request to `self._reqs_need_recv` with **an empty block list** when it has a prompt size less than a block. In this case, we should skip to schedule an async read. 


