### PR TITLE
Fix: [NixlConnector] use agent_name instead of engine_id in nixl send_notif()

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -721,7 +721,7 @@ class NixlConnectorWorker:
         # just notify P worker that we have the blocks we need.
         num_local_blocks = len(local_block_ids)
         if num_local_blocks == 0:
-            self.nixl_wrapper.send_notif(dst_engine_id,
+            self.nixl_wrapper.send_notif(self._remote_agents[dst_engine_id],
                                          notif_msg=request_id.encode("utf-8"))
             return
 


### PR DESCRIPTION
Fix #18439.
<!--- pyml disable-next-line no-emphasis-as-heading -->
