### PR TITLE
[Bugfix][V1] fix fallback to v0 engine on ROCm platform.

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1394,7 +1394,7 @@ class EngineArgs:
 
         # Non-[CUDA, TPU] may be supported on V1, but off by default for now.
         v0_hardware = not any(
-            (current_platform.is_cuda(), current_platform.is_tpu()))
+            (current_platform.is_cuda_alike(), current_platform.is_tpu()))
         if v0_hardware and _warn_or_fallback(  # noqa: SIM103
                 current_platform.device_name):
             return False


### PR DESCRIPTION
When serving any model on the ROCm platform with the v1 engine enabled, it falls back to v0, even though the ROCm platform is supported on the v1 engine.

example of serve command:

`VLLM_USE_V1=1 vllm serve mistralai/Mixtral-8x7B-v0.1 -tp 1 --max-model-len 16384 --distributed-executor-backend mp --swap-space 16 --disable-log-requests --port 8007`

logs:

```
INFO 05-21 10:36:34 [__init__.py:248] Automatically detected platform rocm.
INFO 05-21 10:36:37 [__init__.py:30] Available plugins for group vllm.general_plugins:
INFO 05-21 10:36:37 [__init__.py:32] name=lora_filesystem_resolver, value=vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 05-21 10:36:37 [__init__.py:34] all available plugins for group vllm.general_plugins will be loaded.
INFO 05-21 10:36:37 [__init__.py:36] set environment variable VLLM_PLUGINS to control which plugins to load.
INFO 05-21 10:36:37 [__init__.py:44] plugin lora_filesystem_resolver loaded.
INFO 05-21 10:36:39 [api_server.py:1289] vLLM API server version 0.1.dev6617+gfbaa890.d20250521
INFO 05-21 10:36:40 [cli_args.py:300] non-default args: {'port': 8007, 'max_model_len': 16384, 'distributed_executor_backend': 'mp', 'swap_space': 16.0, 'disable_log_requests': True}
INFO 05-21 10:37:01 [config.py:787] This model supports multiple tasks: {'reward', 'embed', 'classify', 'score', 'generate'}. Defaulting to 'generate'.
INFO 05-21 10:37:01 [arg_utils.py:1603] rocm is experimental on VLLM_USE_V1=1. Falling back to V0 Engine.
INFO 05-21 10:37:01 [api_server.py:257] Started engine process with PID 107177
INFO 05-21 10:37:18 [__init__.py:248] Automatically detected platform rocm.
INFO 05-21 10:37:20 [__init__.py:30] Available plugins for group vllm.general_plugins:
INFO 05-21 10:37:20 [__init__.py:32] name=lora_filesystem_resolver, value=vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 05-21 10:37:20 [__init__.py:34] all available plugins for group vllm.general_plugins will be loaded.
INFO 05-21 10:37:20 [__init__.py:36] set environment variable VLLM_PLUGINS to control which plugins to load.
INFO 05-21 10:37:20 [__init__.py:44] plugin lora_filesystem_resolver loaded.
INFO 05-21 10:37:20 [llm_engine.py:240] Initializing a V0 LLM engine (v0.1.dev6617+gfbaa890.d20250521) with config: model='mistralai/Mixtral-8x7B-v0.1', speculative_config=None, tokenizer='mistralai/Mixtral-8x7B-v0.1', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=16384, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=mistralai/Mixtral-8x7B-v0.1, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=True, pooler_config=None, compilation_config={"compile_sizes": [], "inductor_compile_config": {"enable_auto_functionalized_v2": false}, "cudagraph_capture_sizes": [256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176, 168, 160, 152, 144, 136, 128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 4, 2, 1], "max_capture_size": 256}
```


The log message from `arg_utils—INFO 05-21 10:37:01 [arg_utils.py:1603] rocm is experimental on VLLM_USE_V1=1. Falling back to V0 Engine`.—is caused by the code lines below.

https://github.com/vllm-project/vllm/blob/c5bb0ebdc656bdf89013936b4a29666b143eb6a5/vllm/engine/arg_utils.py#L1394-L1399

This PR fixes this issue by changing the condition to `current_platform.is_cuda_alike()` instead of `current_platform.is_cuda()`.

the log result after this changes:

```
INFO 05-21 11:02:35 [__init__.py:248] Automatically detected platform rocm.
INFO 05-21 11:02:39 [__init__.py:30] Available plugins for group vllm.general_plugins:
INFO 05-21 11:02:39 [__init__.py:32] name=lora_filesystem_resolver, value=vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 05-21 11:02:39 [__init__.py:34] all available plugins for group vllm.general_plugins will be loaded.
INFO 05-21 11:02:39 [__init__.py:36] set environment variable VLLM_PLUGINS to control which plugins to load.
INFO 05-21 11:02:39 [__init__.py:44] plugin lora_filesystem_resolver loaded.
INFO 05-21 11:02:42 [api_server.py:1289] vLLM API server version 0.1.dev6612+g83bca04.d20250521
INFO 05-21 11:02:43 [cli_args.py:300] non-default args: {'port': 8007, 'max_model_len': 16384, 'distributed_executor_backend': 'mp', 'swap_space': 16.0, 'disable_log_requests': True}
INFO 05-21 11:03:07 [config.py:787] This model supports multiple tasks: {'embed', 'classify', 'generate', 'score', 'reward'}. Defaulting to 'generate'.
INFO 05-21 11:03:07 [config.py:2112] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 05-21 11:03:25 [__init__.py:248] Automatically detected platform rocm.
INFO 05-21 11:03:29 [core.py:431] Waiting for init message from front-end.
INFO 05-21 11:03:29 [__init__.py:30] Available plugins for group vllm.general_plugins:
INFO 05-21 11:03:29 [__init__.py:32] name=lora_filesystem_resolver, value=vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 05-21 11:03:29 [__init__.py:34] all available plugins for group vllm.general_plugins will be loaded.
INFO 05-21 11:03:29 [__init__.py:36] set environment variable VLLM_PLUGINS to control which plugins to load.
INFO 05-21 11:03:29 [__init__.py:44] plugin lora_filesystem_resolver loaded.
INFO 05-21 11:03:29 [core.py:65] Initializing a V1 LLM engine (v0.1.dev6612+g83bca04.d20250521) with config: model='mistralai/Mixtral-8x7B-v0.1', speculative_config=None, tokenizer='mistralai/Mixtral-8x7B-v0.1', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=16384, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=mistralai/Mixtral-8x7B-v0.1, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level": 3, "custom_ops": ["none"], "splitting_ops": ["vllm.unified_attention", "vllm.unified_attention_with_output"], "compile_sizes": [], "inductor_compile_config": {"enable_auto_functionalized_v2": false}, "use_cudagraph": true, "cudagraph_num_of_warmups": 1, "cudagraph_capture_sizes": [512, 504, 496, 488, 480, 472, 464, 456, 448, 440, 432, 424, 416, 408, 400, 392, 384, 376, 368, 360, 352, 344, 336, 328, 320, 312, 304, 296, 288, 280, 272, 264, 256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176, 168, 160, 152, 144, 136, 128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 4, 2, 1], "max_capture_size": 512}
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
