### PR TITLE
[Bugfix] Reduce moe_sum test size to avoid OOM

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -577,7 +577,7 @@ def test_moe_align_block_size_opcheck():
              num_tokens_post_pad))
 
 
-@pytest.mark.parametrize("m", [1, 33, 222, 1024 * 128])
+@pytest.mark.parametrize("m", [1, 33, 64, 222])
 @pytest.mark.parametrize("topk", TOP_KS)
 @pytest.mark.parametrize("k", [128, 511, 1024])
 @pytest.mark.parametrize("dtype",


### PR DESCRIPTION
I noticed this test that I just added was OOM-ing on some PRs.  I've reduced the size so that this shouldn't be an issue anymore.

cc @tlrmchlsmth , @mgoin , @WoosukKwon , @DarkLight1337 