### PR TITLE
[Core] Fix abrupt request abort

### DIFF
--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -164,9 +164,8 @@ class KVCacheCoordinator(ABC):
         Get the blocks for the request.
         """
         return [
-            manager.req_to_blocks[request_id]
+            manager.req_to_blocks.get(request_id) or []
             for manager in self.single_type_managers
-            if request_id in manager.req_to_blocks
         ]
 
     @abstractmethod

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -166,6 +166,7 @@ class KVCacheCoordinator(ABC):
         return [
             manager.req_to_blocks[request_id]
             for manager in self.single_type_managers
+            if request_id in manager.req_to_blocks
         ]
 
     @abstractmethod

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -388,4 +388,3 @@ class KVCacheManager:
     def create_empty_block_list(self) -> KVCacheBlocks:
         """Creates a new KVCacheBlocks instance with no blocks."""
         return KVCacheBlocks([[] for _ in range(self.num_kv_cache_groups)])
-

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -388,3 +388,4 @@ class KVCacheManager:
     def create_empty_block_list(self) -> KVCacheBlocks:
         """Creates a new KVCacheBlocks instance with no blocks."""
         return KVCacheBlocks([[] for _ in range(self.num_kv_cache_groups)])
+

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -991,9 +991,10 @@ class Scheduler(SchedulerInterface):
             request.request_id not in
             self.kv_cache_manager.single_type_manager.req_to_blocks):
             # Ensure empty blocks ids are passed to respect connector interface
-            block_ids = KVCacheBlocks.create_empty().get_block_ids()
+            block_ids = KVCacheBlocks.create_empty().get_block_ids()[0]
         else:
-            block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
+            block_ids = self.kv_cache_manager.get_block_ids(
+                request.request_id)[0]
         return self.connector.request_finished(request, block_ids)
 
     def _update_waiting_for_remote_kv(self, request: Request) -> bool:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -76,6 +76,9 @@ class Scheduler(SchedulerInterface):
         # KV Connector pushes/pull of remote KVs for P/D and offloading.
         self.connector = None
         if self.vllm_config.kv_transfer_config is not None:
+            assert len(self.kv_cache_config.kv_cache_groups) == 1, (
+                "Multiple KV cache groups are not currently supported "
+                "with KV connectors")
             self.connector = KVConnectorFactory.create_connector_v1(
                 config=self.vllm_config, role=KVConnectorRole.SCHEDULER)
 
@@ -985,16 +988,8 @@ class Scheduler(SchedulerInterface):
         """
         if self.connector is None:
             return False, None
-        assert len(self.kv_cache_config.kv_cache_groups
-                   ) == 1, "KV connector only supports one KV cache group now"
-        if (request.status == RequestStatus.FINISHED_ABORTED and \
-            request.request_id not in
-            self.kv_cache_manager.single_type_manager.req_to_blocks):
-            # Ensure empty blocks ids are passed to respect connector interface
-            block_ids = KVCacheBlocks.create_empty().get_block_ids()[0]
-        else:
-            block_ids = self.kv_cache_manager.get_block_ids(
-                request.request_id)[0]
+
+        (block_ids, ) = self.kv_cache_manager.get_block_ids(request.request_id)
         return self.connector.request_finished(request, block_ids)
 
     def _update_waiting_for_remote_kv(self, request: Request) -> bool:
@@ -1009,12 +1004,12 @@ class Scheduler(SchedulerInterface):
         and the request state will be moved back to WAITING from
         WAITING_FOR_REMOTE_KV.
         """
+        assert self.connector is not None
         if request.request_id not in self.finished_recving_kv_req_ids:
             return False
-        assert len(self.kv_cache_config.kv_cache_groups
-                   ) == 1, "KV connector only supports one KV cache group now"
+
         # Now that the blocks are ready, actually cache them.
-        block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
+        (block_ids, ) = self.kv_cache_manager.get_block_ids(request.request_id)
         num_computed_tokens = len(block_ids) * self.block_size
         # Handle the case where num request tokens less then one block.
         num_computed_tokens = min(num_computed_tokens, request.num_tokens)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -987,6 +987,11 @@ class Scheduler(SchedulerInterface):
             return False, None
         assert len(self.kv_cache_config.kv_cache_groups
                    ) == 1, "KV connector only supports one KV cache group now"
+        if (request.status == RequestStatus.FINISHED_ABORTED and \
+            request.request_id not in
+            self.kv_cache_manager.single_type_manager.req_to_blocks):
+            return False, None
+
         block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
         return self.connector.request_finished(request, block_ids)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -990,9 +990,10 @@ class Scheduler(SchedulerInterface):
         if (request.status == RequestStatus.FINISHED_ABORTED and \
             request.request_id not in
             self.kv_cache_manager.single_type_manager.req_to_blocks):
-            return False, None
-
-        block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
+            # Ensure empty blocks ids are passed to respect connector interface
+            block_ids = KVCacheBlocks.create_empty().get_block_ids()
+        else:
+            block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
         return self.connector.request_finished(request, block_ids)
 
     def _update_waiting_for_remote_kv(self, request: Request) -> bool:


### PR DESCRIPTION
There's currently an issue when a KV Connector is in use and requests are aborted before they have been scheduled (and so before any blocks have been allocated in the kv cache manager). The scheduler `_connector_finished` method is invoked and it calls `kv_cache_manager.get_block_ids(request_id)` which raises an exception because the kv cache manager doesn't recognize the request.

We do still want to invoke the connector in this case, so that it can perform external cleanup if needed, but it makes sense to pass it empty blocks.

It's not always 100% guaranteed due to timings, but this setup makes it pretty reproducible:
```bash
# start P
VLLM_NIXL_SIDE_CHANNEL_PORT=$5557 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-0.6B --port 8100 --enforce-eager --disable-log-requests --tensor-parallel-size 1 --gpu-memory-utilization 0.5 --trust-remote-code --max-model-len 128 --max-num-seqs 1 --max-num-batched-tokens 128 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

# start D
VLLM_NIXL_SIDE_CHANNEL_PORT=5558 CUDA_VISIBLE_DEVICES=1 vllm serve Qwen/Qwen3-0.6B --port 8200 --enforce-eager --disable-log-requests --tensor-parallel-size 1 --gpu-memory-utilization 0.5 --trust-remote-code --max-model-len 128 --max-num-seqs 1  --max-num-batched-tokens 128 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

# start proxy server
python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py --port 8192 \
      --prefiller-port 8100 \
      --decoder-port 8200
...
# send some requests and abort some of those
python simulate_abort.py
```

simulate_abort.py
```
import asyncio
import httpx


API_URL = "http://localhost:40876/v1/completions" 
# API_URL = "http://localhost:8000/v1/completions" 
NUM_REQUESTS = 10
ABORT_INDICES = {1, 9} 

async def send_request(i, abort=False):
    async with httpx.AsyncClient(timeout=None) as client:
        task = asyncio.create_task(client.post(
            API_URL,
            json={
                "model": "Qwen/Qwen3-0.6B",
                "prompt": f"This is test request {i}. what do you say",
                "max_tokens": 100,
            },
            timeout=None
        ))

        if abort:
            # await asyncio.sleep(0.2 + random.random() * 0.3)  
            await asyncio.sleep(0.5)
            task.cancel()
            try:
                await task
            except asyncio.CancelledError:
                print(f"Request {i} aborted!!\n")
        else:
            try:
                response = await task
                print(f"Request {i} completed: {response.status_code}")
            except Exception as e:
                print(f"Request {i} failed: {e}")

async def main():
    tasks = [
        send_request(i, abort=(i in ABORT_INDICES))
        for i in range(NUM_REQUESTS)
    ]
    await asyncio.gather(*tasks, return_exceptions=True)

asyncio.run(main())

```

Client gets 500, D crashes with logs:
```bash
DEBUG 05-21 12:59:23 [loggers.py:116] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
ERROR 05-21 12:59:23 [core.py:495] EngineCore encountered a fatal error.
ERROR 05-21 12:59:23 [core.py:495] Traceback (most recent call last):
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/engine/core.py", line 486, in run_engine_core
ERROR 05-21 12:59:23 [core.py:495]     engine_core.run_busy_loop()
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/engine/core.py", line 511, in run_busy_loop
ERROR 05-21 12:59:23 [core.py:495]     self._process_input_queue()
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/engine/core.py", line 532, in _process_input_queue
ERROR 05-21 12:59:23 [core.py:495]     self._handle_client_request(*req)
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/engine/core.py", line 550, in _handle_client_request
ERROR 05-21 12:59:23 [core.py:495]     self.abort_requests(request)
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/engine/core.py", line 202, in abort_requests
ERROR 05-21 12:59:23 [core.py:495]     self.scheduler.finish_requests(request_ids,
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/core/sched/scheduler.py", line 866, in finish_requests
ERROR 05-21 12:59:23 [core.py:495]     self._free_request(request)
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/core/sched/scheduler.py", line 872, in _free_request
ERROR 05-21 12:59:23 [core.py:495]     delay_free_blocks, kv_xfer_params = self._connector_finished(request)
ERROR 05-21 12:59:23 [core.py:495]                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/core/sched/scheduler.py", line 952, in _connector_finished
ERROR 05-21 12:59:23 [core.py:495]     block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
ERROR 05-21 12:59:23 [core.py:495]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-21 12:59:23 [core.py:495]   File "/home/nicolo/vllmd/vllm/vllm/v1/core/kv_cache_manager.py", line 369, in get_block_ids
ERROR 05-21 12:59:23 [core.py:495]     assert request_id in self.single_type_manager.req_to_blocks
ERROR 05-21 12:59:23 [core.py:495]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-21 12:59:23 [core.py:495] AssertionError
```

The following is a straightforward fix to the issue, let me know if you see a better solution to this.
