### PR TITLE
[Bugfix] Temporary fix for quantization + CPU offloading

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -13,6 +13,8 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.worker.gpu_input_batch import InputBatch
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
+from .test_gpu_input_batch import setup_cpu_tensors
+
 
 def initialize_kv_cache(runner: GPUModelRunner):
     """
@@ -45,6 +47,7 @@ def initialize_kv_cache(runner: GPUModelRunner):
         vocab_size=runner.model_config.get_vocab_size(),
         kv_cache_config=kv_cache_config,
     )
+    setup_cpu_tensors(runner.input_batch, kv_cache_config)
     runner.initialize_attn_backend(kv_cache_config)
 
 

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -31,23 +31,18 @@ class BlockTable:
             device=self.device,
             dtype=torch.int32,
         )
-        self.block_table_cpu = torch.zeros(
-            (max_num_reqs, max_num_blocks_per_req),
-            device="cpu",
-            dtype=torch.int32,
-            pin_memory=pin_memory,
-        )
-        self.block_table_np = self.block_table_cpu.numpy()
         self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
 
-        self.slot_mapping_cpu = torch.zeros(self.max_num_batched_tokens,
-                                            dtype=torch.int64,
-                                            device="cpu",
-                                            pin_memory=self.pin_memory)
-        self.slot_mapping_np = self.slot_mapping_cpu.numpy()
         self.slot_mapping = torch.zeros(self.max_num_batched_tokens,
                                         dtype=torch.int64,
                                         device=self.device)
+
+    def init_block_table_cpu(self, block_table_cpu_tensor: torch.Tensor,
+                             slot_mapping_cpu_tensor: torch.Tensor):
+        self.block_table_cpu = block_table_cpu_tensor
+        self.block_table_np = self.block_table_cpu.numpy()
+        self.slot_mapping_cpu = slot_mapping_cpu_tensor
+        self.slot_mapping_np = self.slot_mapping_cpu.numpy()
 
     def append_row(
         self,


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/17945 breaks the quantization + CPU offloading test. The reason is that https://github.com/vllm-project/vllm/pull/17945 delays the initialization of `GPUModelRunner.InputBatch` from `GPUModelRunner.__init__` to `GPUModelRunner.initialize_kv_cache` and triggers some unknown bug in quantization + CPU offloading. This PR provides a temporary fix by moving the initialization of some tensors back to `GPUModelRunner.__init__`.

I believe the CI failure is not caused by a bug in https://github.com/vllm-project/vllm/pull/17945 because https://github.com/vllm-project/vllm/pull/18298 that only moves the input batch fails on the same test.

pls revert this PR after finding the root cause.

Related: https://github.com/vllm-project/vllm/issues/18425, https://github.com/vllm-project/vllm/pull/18459