### PR TITLE
[Spec Decode] Make EAGLE3 draft token ID mapping optional

### DIFF
--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -213,6 +213,9 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
     ) -> Optional[torch.Tensor]:
         logits = self.logits_processor(self.lm_head, hidden_states,
                                        sampling_metadata)
+        if self.draft_id_to_target_id is None:
+            return logits
+
         base = torch.arange(self.config.draft_vocab_size, device=logits.device)
         targets = base + self.draft_id_to_target_id
         logits_new = logits.new_full((

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -248,4 +248,10 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
                 name = "model." + name
             model_weights[name] = loaded_weight
 
-        return loader.load_weights(model_weights.items())
+        loaded_weights = loader.load_weights(model_weights.items())
+
+        if 'd2t' not in loaded_weights:
+            del self.draft_id_to_target_id
+            self.draft_id_to_target_id = None
+
+        return loaded_weights

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -251,7 +251,6 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         loaded_weights = loader.load_weights(model_weights.items())
 
         if 'd2t' not in loaded_weights:
-            del self.draft_id_to_target_id
             self.draft_id_to_target_id = None
 
         return loaded_weights

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -334,6 +334,14 @@ class EagleProposer:
             logger.info("Loading EAGLE LM head weights from the target model.")
             self.model.lm_head = target_model.lm_head
 
+        if self.vllm_config.speculative_config.method == "eagle3" and \
+                hasattr(target_model, "draft_id_to_target_id") and \
+                "d2t" not in loaded_weights:
+            logger.info("Draft id to target id mapping not found. Assuming "
+                        "draft and target model share the same vocab.")
+            del self.model.draft_id_to_target_id
+            self.model.draft_id_to_target_id = None
+
     @torch.inference_mode()
     def dummy_run(
         self,

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -334,14 +334,6 @@ class EagleProposer:
             logger.info("Loading EAGLE LM head weights from the target model.")
             self.model.lm_head = target_model.lm_head
 
-        if self.vllm_config.speculative_config.method == "eagle3" and \
-                hasattr(target_model, "draft_id_to_target_id") and \
-                "d2t" not in loaded_weights:
-            logger.info("Draft id to target id mapping not found. Assuming "
-                        "draft and target model share the same vocab.")
-            del self.model.draft_id_to_target_id
-            self.model.draft_id_to_target_id = None
-
     @torch.inference_mode()
     def dummy_run(
         self,


### PR DESCRIPTION
Small compatibility fix for EAGLE3 models which do not have the "d2t" mapping defined. In this case, the logits can be returned as-is.