### PR TITLE
[Bugfix] Fix spec decode on non-cuda platforms

### DIFF
--- a/tests/spec_decode/test_metrics.py
+++ b/tests/spec_decode/test_metrics.py
@@ -22,7 +22,7 @@ def test_initial_call_returns_none():
     spec_decode_sampler.num_draft_tokens = 0
 
     collector = AsyncMetricsCollector(spec_decode_sampler)
-    collector.init_gpu_tensors(rank=0)
+    collector.init_tensors(rank=0)
     maybe_metrics = collector.maybe_collect_rejsample_metrics(k=5)
     assert maybe_metrics is None
 
@@ -48,7 +48,7 @@ def test_second_call_returns_metrics():
     collector = AsyncMetricsCollector(spec_decode_sampler=spec_decode_sampler,
                                       timer=timer,
                                       collect_interval_s=collect_interval_s)
-    collector.init_gpu_tensors(rank=0)
+    collector.init_tensors(rank=0)
     _ = collector.maybe_collect_rejsample_metrics(k=5)
     metrics = collector.maybe_collect_rejsample_metrics(k=5)
     assert metrics is not None
@@ -68,7 +68,7 @@ def test_nonzero_rank_noop(rank):
     spec_decode_sampler.num_draft_tokens = 0
 
     collector = AsyncMetricsCollector(spec_decode_sampler)
-    collector.init_gpu_tensors(rank=rank)
+    collector.init_tensors(rank=rank)
     _ = collector.maybe_collect_rejsample_metrics(k=5)
     metrics = collector.maybe_collect_rejsample_metrics(k=5)
     assert metrics is None
@@ -96,7 +96,7 @@ def test_noop_until_time():
     collector = AsyncMetricsCollector(spec_decode_sampler=spec_decode_sampler,
                                       timer=timer,
                                       collect_interval_s=collect_interval_s)
-    collector.init_gpu_tensors(rank=0)
+    collector.init_tensors(rank=0)
 
     _ = collector.maybe_collect_rejsample_metrics(k=5)
     metrics = collector.maybe_collect_rejsample_metrics(k=5)
@@ -135,7 +135,7 @@ def test_timer_is_reset():
     collector = AsyncMetricsCollector(spec_decode_sampler=spec_decode_sampler,
                                       timer=timer,
                                       collect_interval_s=collect_interval_s)
-    collector.init_gpu_tensors(rank=0)
+    collector.init_tensors(rank=0)
 
     _ = collector.maybe_collect_rejsample_metrics(k=5)
     metrics = collector.maybe_collect_rejsample_metrics(k=5)
@@ -185,7 +185,7 @@ def test_initial_metrics_has_correct_values(has_data: bool):
     collector = AsyncMetricsCollector(spec_decode_sampler=spec_decode_sampler,
                                       timer=timer,
                                       collect_interval_s=collect_interval_s)
-    collector.init_gpu_tensors(rank=0)
+    collector.init_tensors(rank=0)
     _ = collector.maybe_collect_rejsample_metrics(k)
     metrics = collector.maybe_collect_rejsample_metrics(k)
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1166,6 +1166,11 @@ def patch_tensor_parallel_group(tp_group: GroupCoordinator):
         _TP = old_tp_group
 
 
+def is_tp_state_patched():
+    """Check if the tp group is patched."""
+    return _TP_STATE_PATCHED
+
+
 def get_tensor_model_parallel_world_size():
     """Return world size for the tensor model parallel group."""
     return get_tp_group().world_size

--- a/vllm/spec_decode/metrics.py
+++ b/vllm/spec_decode/metrics.py
@@ -80,10 +80,6 @@ class AsyncMetricsCollector:
         self._rejsample_metrics_collect_interval_s = collect_interval_s
         self._last_metrics_collect_time = self._timer()
 
-    def init_gpu_tensors(self, rank: int) -> None:
-        self._rank = rank
-        self._copy_stream = torch.cuda.Stream()
-
     def init_tensors(self,
                      rank: int,
                      device_type: Union[torch.device, str] = 'cuda') -> None:

--- a/vllm/spec_decode/metrics.py
+++ b/vllm/spec_decode/metrics.py
@@ -129,9 +129,9 @@ class AsyncMetricsCollector:
         Returns a CUDA event recording when the copy is complete.
         """
         assert self._copy_stream is not None
-        self._copy_stream.wait_stream(torch.cuda.current_stream())
+        self._copy_stream.wait_stream(current_platform.current_stream())
 
-        with torch.cuda.stream(self._copy_stream):
+        with current_platform.stream(self._copy_stream):
             self._aggregate_num_accepted_tokens.copy_(
                 self.spec_decode_sampler.num_accepted_tokens,
                 non_blocking=True)
@@ -142,7 +142,7 @@ class AsyncMetricsCollector:
             self._aggregate_num_draft_tokens = (
                 self.spec_decode_sampler.num_draft_tokens)
 
-        aggregate_metrics_ready = torch.cuda.Event()
+        aggregate_metrics_ready = current_platform.Event()
         aggregate_metrics_ready.record(self._copy_stream)
 
         return aggregate_metrics_ready

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -414,9 +414,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
         self,
         lm_head_weight: torch.Tensor,
     ) -> None:
-        weight_loader = getattr(
-            self.worker.model_runner.model_runner.model.lm_head.weight,
-            "weight_loader", default_weight_loader)
-        weight_loader(
-            self.worker.model_runner.model_runner.model.lm_head.weight,
-            lm_head_weight)
+        weight_loader = getattr(self.worker.model_runner.model.lm_head.weight,
+                                "weight_loader", default_weight_loader)
+        weight_loader(self.worker.model_runner.model.lm_head.weight,
+                      lm_head_weight)

--- a/vllm/spec_decode/smaller_tp_proposer_worker.py
+++ b/vllm/spec_decode/smaller_tp_proposer_worker.py
@@ -185,11 +185,11 @@ class SmallerTpProposerWorker(ProposerWorkerBase):
 
         with self._patch_tensor_parallel_group():
             weight_loader = getattr(
-                self._worker.worker.model_runner.model_runner.model.\
+                self._worker.worker.model_runner.model.\
                     lm_head.weight,
                 "weight_loader",
                 default_weight_loader)
             weight_loader(
-                self._worker.worker.model_runner.model_runner.model.\
+                self._worker.worker.model_runner.model.\
                     lm_head.weight,
                 lm_head_weight)

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -356,7 +356,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         if self._enable_lm_head_weight_load:
             # NOTE(Shangming): gather lm_head weight when tp enabled
             target_lm_head_weight: torch.Tensor = tensor_model_parallel_gather(
-                self.scorer_worker.model_runner.model_runner.model.lm_head.\
+                self.scorer_worker.model_runner.model.lm_head.\
                     weight.data,
                     dim=0,
             )

--- a/vllm/worker/cpu_worker.py
+++ b/vllm/worker/cpu_worker.py
@@ -11,7 +11,8 @@ from vllm.attention import get_attn_backend
 from vllm.config import (CacheConfig, DeviceConfig, ModelConfig,
                          ParallelConfig, VllmConfig)
 from vllm.distributed import (ensure_model_parallel_initialized,
-                              init_distributed_environment)
+                              init_distributed_environment,
+                              is_tp_state_patched)
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
@@ -386,7 +387,9 @@ class CPUWorker(LocalOrDistributedWorkerBase):
         )
 
         # A small all_reduce for warmup.
-        torch.distributed.all_reduce(torch.zeros(1).cpu())
+        # Skip warmup when using SmallerTpProposerWorker to avoid blocking.
+        if not is_tp_state_patched():
+            torch.distributed.all_reduce(torch.zeros(1).cpu())
 
         ensure_model_parallel_initialized(
             parallel_config.tensor_parallel_size,

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -17,7 +17,8 @@ from vllm_hpu_extension.profiler import HabanaMemoryProfiler, format_bytes
 import vllm.envs as envs
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
-                              init_distributed_environment)
+                              init_distributed_environment,
+                              is_tp_state_patched)
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
@@ -439,9 +440,11 @@ def init_worker_distributed_environment(
         )
 
     # A small all_reduce for warmup & checking conformance.
-    dummy_tensor_hpu = torch.ones(1).to('hpu')
-    torch.distributed.all_reduce(dummy_tensor_hpu)
-    assert dummy_tensor_hpu.item() == parallel_config.world_size
+    # Skip warmup when using SmallerTpProposerWorker to avoid blocking.
+    if not is_tp_state_patched():
+        dummy_tensor_hpu = torch.ones(1).to('hpu')
+        torch.distributed.all_reduce(dummy_tensor_hpu)
+        assert dummy_tensor_hpu.item() == parallel_config.world_size
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size,
                                       parallel_config.enable_expert_parallel)


### PR DESCRIPTION
- Replace hardcoded `torch.cuda` to `current_platform` in `AsyncMetricsCollector`. (The type annotations are still `torch.cuda.Event` and `torch.cuda.Stream`. Hope this would not make too much confusion.)
- Some code related to Eagle uses `self._worker.worker.model_runner.model_runner.model` because there is a `TP1DraftModelRunner` wrapper of the model runner on cuda platform. But non-cuda platforms don't have this wrapper. Simply remove one layer of `.model_runner` can fix this
- Skip distributed environment warmup in `CPUWorker` and `HPUWorker` when using `SmallerTpProposerWorker` to avoid blocking