### PR TITLE
[Bugfix][Model] Make Olmo2Model weight loading return loaded weights

### DIFF
--- a/vllm/model_executor/models/olmo2.py
+++ b/vllm/model_executor/models/olmo2.py
@@ -314,7 +314,8 @@ class Olmo2Model(nn.Module):
         hidden_states = self.norm(hidden_states)
         return hidden_states
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),

--- a/vllm/model_executor/models/olmo2.py
+++ b/vllm/model_executor/models/olmo2.py
@@ -314,7 +314,7 @@ class Olmo2Model(nn.Module):
         hidden_states = self.norm(hidden_states)
         return hidden_states
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -325,6 +325,7 @@ class Olmo2Model(nn.Module):
         ]
 
         params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_params: set[str] = set()
         for name, loaded_weight in weights:
             if is_pp_missing_parameter(name, self):
                 continue
@@ -347,6 +348,8 @@ class Olmo2Model(nn.Module):
                 weight_loader = getattr(param, "weight_loader",
                                         default_weight_loader)
                 weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
 
 
 class Olmo2ForCausalLM(nn.Module, SupportsPP):


### PR DESCRIPTION
Issue: OLMo 2 models recently started to fail to load. The root cause is that OLMo 2 does not track initialized weights, but https://github.com/vllm-project/vllm/pull/18113 caused `Olmo2ForCausalLM` to try return the set of initialized weights. Since  `Olmo2Model`, which has the bulk of the weight loading logic, does not return the set of initialized weights, it results in `Olmo2ForCausalLM` returning an empty set (or at least nearly empty). Thus vllm thinks that no weights loaded when in fact all weights loaded.

Fix: Update `Olmo2Model.load_weights` to return the set of initialized weights.

FIX #18503

<!--- pyml disable-next-line no-emphasis-as-heading -->
