### PR TITLE
[Bugfix] Add kwargs to RequestOutput __init__ to be forward compatible

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -59,6 +59,7 @@ steps:
   - pytest -v -s async_engine # AsyncLLMEngine
   - NUM_SCHEDULER_STEPS=4 pytest -v -s async_engine/test_async_llm_engine.py
   - pytest -v -s test_inputs.py
+  - pytest -v -s test_outputs.py
   - pytest -v -s multimodal
   - pytest -v -s test_utils.py # Utils
   - pytest -v -s worker # Worker

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.outputs import RequestOutput
+
+
+def test_request_output_forward_compatible():
+    output = RequestOutput(request_id="test_request_id",
+                           prompt="test prompt",
+                           prompt_token_ids=[1, 2, 3],
+                           prompt_logprobs=None,
+                           outputs=[],
+                           finished=False,
+                           example_arg_added_in_new_version="some_value")
+    assert output is not None

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -9,11 +9,14 @@ from typing import Any, Generic, Optional, Union
 import torch
 from typing_extensions import TypeVar, deprecated
 
+from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalPlaceholderDict
 from vllm.sampling_params import RequestOutputKind
 from vllm.sequence import (PromptLogprobs, RequestMetrics, SampleLogprobs,
                            SequenceGroup, SequenceGroupBase, SequenceStatus)
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -126,6 +129,9 @@ class RequestOutput:
         # still run with older versions of vLLM without breaking.
         **kwargs: Any,
     ) -> None:
+        if kwargs:
+            logger.warning("RequestOutput: Ignoring extra arguments: %s",
+                           str(kwargs))
         self.request_id = request_id
         self.prompt = prompt
         self.prompt_token_ids = prompt_token_ids

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -130,8 +130,8 @@ class RequestOutput:
         **kwargs: Any,
     ) -> None:
         if kwargs:
-            logger.warning("RequestOutput: Ignoring extra arguments: %s",
-                           str(kwargs))
+            logger.warning_once("RequestOutput: Ignoring extra arguments: %s",
+                                str(kwargs))
         self.request_id = request_id
         self.prompt = prompt
         self.prompt_token_ids = prompt_token_ids

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -122,6 +122,9 @@ class RequestOutput:
         *,
         multi_modal_placeholders: Optional[MultiModalPlaceholderDict] = None,
         kv_transfer_params: Optional[dict[str, Any]] = None,
+        # Forward compatibility, code that uses args added in new release can
+        # still run with older versions of vLLM without breaking.
+        **kwargs: Any,
     ) -> None:
         self.request_id = request_id
         self.prompt = prompt


### PR DESCRIPTION
Added `kwargs` will capture unexpected args silently, without raising exception.

Libraries that depends on vLLM may want to work across multiple versions of vLLM. When these libraries use new args (e.g. `kv_transfer_params`) they no longer work with older vLLM versions.