### PR TITLE
[Bugfix] Fix MRoPE Errors in the Qwen-VL Model When Processing Pure Text

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -729,7 +729,10 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
         mm_kwargs, placeholder_maps = MultiModalPlaceholderMap.from_seq_group(
             seq_group_metadata,
             range(positions[0], positions[0] + len(positions)))
-        if not mm_kwargs:
+
+        # M-RoPE requires mrope_positions even for plain text; return early
+        # when mm_kwargs is empty only if inter_data.is_prompt is False.
+        if not mm_kwargs and (not inter_data.is_prompt):
             return
 
         inter_data.multi_modal_kwargs = mm_kwargs
@@ -741,12 +744,6 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             video_grid_thw = mm_kwargs.get("video_grid_thw", None)
             audio_feature_lengths = mm_kwargs.get("audio_feature_lengths",
                                                   None)
-            assert (
-                image_grid_thw is not None or video_grid_thw is not None
-                or audio_feature_lengths is not None), (
-                    "mrope embedding type requires multi-modal input mapper "
-                    "returns 'image_grid_thw' or 'video_grid_thw' or "
-                    "'audio_feature_lengths'.")
 
             second_per_grid_ts = mm_kwargs.get("second_per_grid_ts", None)
             use_audio_in_video = mm_kwargs.get("use_audio_in_video", False)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -732,7 +732,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         # M-RoPE requires mrope_positions even for plain text; return early
         # when mm_kwargs is empty only if inter_data.is_prompt is False.
-        if not mm_kwargs and (not inter_data.is_prompt):
+        if not mm_kwargs and not inter_data.is_prompt:
             return
 
         inter_data.multi_modal_kwargs = mm_kwargs


### PR DESCRIPTION
Users in our community reported that the VL model performs poorly on plain text input. Upon investigation, I found that in "plain text" mode, mm_kwargs is empty, which causes the function to return early. As a result, mrope_input_positions remains None, ultimately leading to suboptimal results in the V0 engine under CUDA graph.

To fix this, I've added a patch that ensures the early return only occurs outside the prompt phase. Also, I noticed that in eager mode, the results remain correct even when the early return is triggered.

Thanks to the vLLM team for their excellent work!

FIX https://github.com/QwenLM/Qwen2.5-VL/issues/1215
