### PR TITLE
Make it so `mypy` runs the same locally as in CI

### DIFF
--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -13,14 +13,14 @@ fi
 
 run_mypy() {
     echo "Running mypy on $1"
-    if [ "$CI" -eq 1 ] && [ -z "$1" ]; then
+    if [ -z "$1" ]; then
         mypy --python-version "${PYTHON_VERSION}" "$@"
         return
     fi
     mypy --follow-imports skip --python-version "${PYTHON_VERSION}" "$@"
 }
 
-run_mypy # Note that this is less strict than CI
+run_mypy
 run_mypy tests
 run_mypy vllm/attention
 run_mypy vllm/compilation

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -528,12 +528,12 @@ class RayDistributedExecutor(DistributedExecutorBase):
         ray.get(parallel_worker_tasks)
 
     def _check_ray_cgraph_installation(self):
-        import pkg_resources
+        import importlib.metadata
+
         from packaging import version
 
         required_version = version.parse("2.43.0")
-        current_version = version.parse(
-            pkg_resources.get_distribution("ray").version)
+        current_version = version.parse(importlib.metadata("ray").version)
         if current_version < required_version:
             raise ValueError(f"Ray version {required_version} is "
                              f"required, but found {current_version}")


### PR DESCRIPTION
Also updates a deprecated import which will cause problems once the current pre-commit cache in CI is invalidated. 