### PR TITLE
[Model][Speculative Decoding] Integrate PARD into vLLM

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -49,6 +49,8 @@ tme = "tme"
 dout = "dout"
 Pn = "Pn"
 arange = "arange"
+pard = "pard"
+PARD = "PARD"
 
 [type.py]
 extend-glob = []

--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -73,14 +73,17 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
             if VLLM_INVALID_TOKEN_ID not in proposals
         ]
 
-        (spec_indices, non_spec_indices, target_seq_group_metadata_list, num_scoring_tokens) = self._expand_batch(
+        (spec_indices, non_spec_indices, target_seq_group_metadata_list,
+         num_scoring_tokens) = self._expand_batch(
              seq_group_metadata_list=execute_model_req.seq_group_metadata_list,
              proposal_token_ids_list=proposal_token_ids_list_without_skips,
              proposal_lens_list=proposal_lens_list,
          )
 
         if keep_index is not None:
-            target_seq_group_metadata_list = [target_seq_group_metadata_list[i] for i in keep_index]
+            target_seq_group_metadata_list = [
+                target_seq_group_metadata_list[i] for i in keep_index
+            ]
         target_sampler_output = self._scorer_worker.execute_model(
             execute_model_req=execute_model_req.clone(
                 seq_group_metadata_list=target_seq_group_metadata_list))

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -107,7 +107,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
                 self.worker.model_runner.return_hidden_states = True
 
             if hasattr(self, "pard") and self.pard is True:
-                filtered_model_outputs = self.pard_infer(execute_model_req, sample_len)
+                filtered_model_outputs = self.pard_infer(expanded_request, sample_len)
                 return filtered_model_outputs, True
 
             for _ in range(sample_len):

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -136,7 +136,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
         # prepare recompute kv token
         # update seq_group_metadata_list
         mask_token_id = self.pard_token
-        request_by_id = {}
+        request_by_id: Dict[str, List[SequenceGroupMetadata]] = {}
         for tmp in expanded_request.seq_group_metadata_list:
             name = tmp.request_id
             request_by_id[name] = request_by_id.get(name, [])

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -13,13 +13,11 @@ from vllm.platforms import current_platform
 from vllm.sequence import (ExecuteModelRequest, HiddenStates, SequenceData,
                            SequenceGroupMetadata)
 from vllm.spec_decode.interfaces import SpeculativeProposals
-from vllm.spec_decode.batch_expansion import BatchExpansionTop1Scorer
 
 if current_platform.is_cuda_alike():
     from vllm.spec_decode.draft_model_runner import TP1DraftModelRunner
 
-from vllm.spec_decode.interfaces import (SpeculativeProposals,
-                                         SpeculativeProposer)
+from vllm.spec_decode.interfaces import SpeculativeProposer
 from vllm.spec_decode.proposer_worker_base import ProposerWorkerBase
 from vllm.spec_decode.top1_proposer import Top1Proposer
 from vllm.worker.worker_base import DelegateWorkerBase
@@ -89,7 +87,8 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
         model_outputs: List[SamplerOutput] = []
         if current_platform.is_cuda_alike() and isinstance(
                 self.model_runner, TP1DraftModelRunner
-        ) and self.model_runner.supports_gpu_multi_step(expanded_request) and not self.pard:
+        ) and self.model_runner.supports_gpu_multi_step(
+                expanded_request) and not self.pard:
             # Here we run the draft_model_runner with multi-step prepare
             # on the GPU directly
             expanded_request.num_steps = sample_len
@@ -107,7 +106,8 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
                 self.worker.model_runner.return_hidden_states = True
 
             if hasattr(self, "pard") and self.pard is True:
-                filtered_model_outputs = self.pard_infer(expanded_request, sample_len)
+                filtered_model_outputs = self.pard_infer(
+                    expanded_request, sample_len)
                 return filtered_model_outputs, True
 
             for _ in range(sample_len):
@@ -124,7 +124,6 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
                     indices_of_seq_with_bonus_tokens)
                 model_outputs.append(model_output)
 
-
         # move indices to device to avoid stream sync
         indices_of_seq_with_bonus_tokens = torch.tensor(
             indices_of_seq_with_bonus_tokens, device=self.device)
@@ -133,7 +132,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
         return filtered_model_outputs, True
 
     def pard_infer(self, expanded_request: ExecuteModelRequest,
-            sample_len: int) -> List[SamplerOutput]:
+                   sample_len: int) -> List[SamplerOutput]:
         # prepare recompute kv token
         # update seq_group_metadata_list
         mask_token_id = self.pard_token
@@ -147,69 +146,92 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
         for name, tmp_request in request_by_id.items():
             seq_num_base = len(tmp_request)
             group_key = list(tmp_request[-1].seq_data.keys())[0]
-            output_token_ids = tmp_request[-1].seq_data[group_key].output_token_ids
-            rm_num = min(sample_len - 1 + seq_num_base - 1, len(output_token_ids) - 1)
-            rm_token_ids = list(output_token_ids[len(output_token_ids) - rm_num:])
+            output_token_ids = tmp_request[-1].seq_data[
+                group_key].output_token_ids
+            rm_num = min(sample_len - 1 + seq_num_base - 1,
+                         len(output_token_ids) - 1)
+            rm_token_ids = list(output_token_ids[len(output_token_ids) -
+                                                 rm_num:])
             all_rm_token_ids.append(rm_token_ids)
             tmp_new_requests = tmp_request[-1]
-            tmp_new_requests.seq_data[group_key].output_token_ids = output_token_ids[:len(output_token_ids) - rm_num]
+            tmp_new_requests.seq_data[
+                group_key].output_token_ids = output_token_ids[:len(
+                    output_token_ids) - rm_num]
             tmp_new_requests.seq_data[group_key]._num_computed_tokens -= rm_num
             new_request_list.append(tmp_new_requests)
         expanded_request.seq_group_metadata_list = new_request_list
         max_rm_num = max([len(i) for i in all_rm_token_ids])
-        min_rm_num = min([len(i) for i in all_rm_token_ids])
 
         # get proposal
         proposal = SpeculativeProposals(
-                proposal_token_ids = torch.tensor([
-                    rm_token_ids + [mask_token_id for i in range(sample_len -1 + max_rm_num - len(rm_token_ids))] 
-                    for rm_token_ids in all_rm_token_ids], device=self.device),
-                proposal_probs=torch.tensor([sample_len - 1 + max_rm_num] * len(new_request_list), device=self.device), #fake
-                proposal_lens=torch.tensor([sample_len - 1 + max_rm_num] * len(new_request_list), device=self.device)
-                )
+            proposal_token_ids=torch.tensor([
+                rm_token_ids + [
+                    mask_token_id for i in range(sample_len - 1 + max_rm_num -
+                                                 len(rm_token_ids))
+                ] for rm_token_ids in all_rm_token_ids
+            ],
+                                            device=self.device),
+            proposal_probs=torch.tensor([sample_len - 1 + max_rm_num] *
+                                        len(new_request_list),
+                                        device=self.device),  #fake
+            proposal_lens=torch.tensor([sample_len - 1 + max_rm_num] *
+                                       len(new_request_list),
+                                       device=self.device))
 
         # pard forward
         keep_index = []
         rm_token_num = []
         rm_token_num_sum = []
         for i, rm_token_ids in enumerate(all_rm_token_ids):
-            keep_index.extend([i * (sample_len + max_rm_num) + j for j in range(sample_len + len(rm_token_ids))])
+            keep_index.extend([
+                i * (sample_len + max_rm_num) + j
+                for j in range(sample_len + len(rm_token_ids))
+            ])
             rm_token_num.append(len(rm_token_ids))
             rm_token_num_sum.append(sum(rm_token_num))
 
-        pard_draft_out = self.pard_scorer.score_proposals(expanded_request, proposal, return_output=True, keep_index=keep_index)
+        pard_draft_out = self.pard_scorer.score_proposals(
+            expanded_request,
+            proposal,
+            return_output=True,
+            keep_index=keep_index)
 
         # align probs shape of target and draft model
         target_dim = self.pard_scorer._vocab_size
         if pard_draft_out.sampled_token_probs.shape[1] > target_dim:
-            pard_draft_out.sampled_token_probs = pard_draft_out.sampled_token_probs[:, :target_dim]
+            tmp_draft_probs = pard_draft_out.sampled_token_probs[:, :
+                                                                 target_dim]
+            pard_draft_out.sampled_token_probs = tmp_draft_probs
         elif pard_draft_out.sampled_token_probs.shape[1] < target_dim:
             pard_draft_out.sampled_token_probs = torch.nn.functional.pad(
-                    pard_draft_out.sampled_token_probs, (0, target_dim - pard_draft_out.sampled_token_probs.shape[1]), value=0)
+                pard_draft_out.sampled_token_probs,
+                (0, target_dim - pard_draft_out.sampled_token_probs.shape[1]),
+                value=0)
 
         # get output
-        output_indices = torch.tensor([[i + tmp_rm + j * sample_len for j, tmp_rm in enumerate(rm_token_num_sum)] 
-            for i in range(sample_len)], device=self.device)
+        output_indices = torch.tensor([[
+            i + tmp_rm + j * sample_len
+            for j, tmp_rm in enumerate(rm_token_num_sum)
+        ] for i in range(sample_len)],
+                                      device=self.device)
         filtered_model_outputs = [
             SamplerOutput(
                 outputs=[
                     pard_draft_out.outputs[i] for i in output_indices_to_retain
                 ] if len(pard_draft_out.outputs) > 0 else [],
                 sampled_token_probs=(
-                    pard_draft_out.sampled_token_probs[output_indices_to_retain]
-                    if pard_draft_out.sampled_token_probs is not None
-                    else None),
-                logprobs=(
-                     pard_draft_out.logprobs[output_indices_to_retain]
-                    if  pard_draft_out.logprobs is not None else None),
-                sampled_token_ids=(pard_draft_out.
-                                   sampled_token_ids[output_indices_to_retain]
-                                   if pard_draft_out.sampled_token_ids
-                                   is not None else None))
+                    pard_draft_out.
+                    sampled_token_probs[output_indices_to_retain] if
+                    pard_draft_out.sampled_token_probs is not None else None),
+                logprobs=(pard_draft_out.logprobs[output_indices_to_retain]
+                          if pard_draft_out.logprobs is not None else None),
+                sampled_token_ids=(
+                    pard_draft_out.sampled_token_ids[output_indices_to_retain]
+                    if pard_draft_out.sampled_token_ids is not None else None))
             for output_indices_to_retain in output_indices
-            ]
+        ]
         return filtered_model_outputs
- 
+
     @staticmethod
     def _maybe_update_previous_hidden_states(
             model_output: SamplerOutput,

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -12,6 +12,8 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.platforms import current_platform
 from vllm.sequence import (ExecuteModelRequest, HiddenStates, SequenceData,
                            SequenceGroupMetadata)
+from vllm.spec_decode.interfaces import SpeculativeProposals
+from vllm.spec_decode.batch_expansion import BatchExpansionTop1Scorer
 
 if current_platform.is_cuda_alike():
     from vllm.spec_decode.draft_model_runner import TP1DraftModelRunner
@@ -87,7 +89,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
         model_outputs: List[SamplerOutput] = []
         if current_platform.is_cuda_alike() and isinstance(
                 self.model_runner, TP1DraftModelRunner
-        ) and self.model_runner.supports_gpu_multi_step(expanded_request):
+        ) and self.model_runner.supports_gpu_multi_step(expanded_request) and not self.pard:
             # Here we run the draft_model_runner with multi-step prepare
             # on the GPU directly
             expanded_request.num_steps = sample_len
@@ -103,6 +105,11 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
             # supports_gpu_multi_step(..)
             if expanded_request.previous_hidden_states is not None:
                 self.worker.model_runner.return_hidden_states = True
+
+            if hasattr(self, "pard") and self.pard is True:
+                filtered_model_outputs = self.pard_infer(execute_model_req, sample_len)
+                return filtered_model_outputs, True
+
             for _ in range(sample_len):
                 model_output: List[SamplerOutput] = self.worker.execute_model(
                     execute_model_req=expanded_request)
@@ -117,6 +124,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
                     indices_of_seq_with_bonus_tokens)
                 model_outputs.append(model_output)
 
+
         # move indices to device to avoid stream sync
         indices_of_seq_with_bonus_tokens = torch.tensor(
             indices_of_seq_with_bonus_tokens, device=self.device)
@@ -124,6 +132,84 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
             model_outputs, indices_of_seq_with_bonus_tokens)
         return filtered_model_outputs, True
 
+    def pard_infer(self, expanded_request: ExecuteModelRequest,
+            sample_len: int) -> List[SamplerOutput]:
+        # prepare recompute kv token
+        # update seq_group_metadata_list
+        mask_token_id = self.pard_token
+        request_by_id = {}
+        for tmp in expanded_request.seq_group_metadata_list:
+            name = tmp.request_id
+            request_by_id[name] = request_by_id.get(name, [])
+            request_by_id[name].append(tmp)
+        all_rm_token_ids = []
+        new_request_list = []
+        for name, tmp_request in request_by_id.items():
+            seq_num_base = len(tmp_request)
+            group_key = list(tmp_request[-1].seq_data.keys())[0]
+            output_token_ids = tmp_request[-1].seq_data[group_key].output_token_ids
+            rm_num = min(sample_len - 1 + seq_num_base - 1, len(output_token_ids) - 1)
+            rm_token_ids = list(output_token_ids[len(output_token_ids) - rm_num:])
+            all_rm_token_ids.append(rm_token_ids)
+            tmp_new_requests = tmp_request[-1]
+            tmp_new_requests.seq_data[group_key].output_token_ids = output_token_ids[:len(output_token_ids) - rm_num]
+            tmp_new_requests.seq_data[group_key]._num_computed_tokens -= rm_num
+            new_request_list.append(tmp_new_requests)
+        expanded_request.seq_group_metadata_list = new_request_list
+        max_rm_num = max([len(i) for i in all_rm_token_ids])
+        min_rm_num = min([len(i) for i in all_rm_token_ids])
+
+        # get proposal
+        proposal = SpeculativeProposals(
+                proposal_token_ids = torch.tensor([
+                    rm_token_ids + [mask_token_id for i in range(sample_len -1 + max_rm_num - len(rm_token_ids))] 
+                    for rm_token_ids in all_rm_token_ids], device=self.device),
+                proposal_probs=torch.tensor([sample_len - 1 + max_rm_num] * len(new_request_list), device=self.device), #fake
+                proposal_lens=torch.tensor([sample_len - 1 + max_rm_num] * len(new_request_list), device=self.device)
+                )
+
+        # pard forward
+        keep_index = []
+        rm_token_num = []
+        rm_token_num_sum = []
+        for i, rm_token_ids in enumerate(all_rm_token_ids):
+            keep_index.extend([i * (sample_len + max_rm_num) + j for j in range(sample_len + len(rm_token_ids))])
+            rm_token_num.append(len(rm_token_ids))
+            rm_token_num_sum.append(sum(rm_token_num))
+
+        pard_draft_out = self.pard_scorer.score_proposals(expanded_request, proposal, return_output=True, keep_index=keep_index)
+
+        # align probs shape of target and draft model
+        target_dim = self.pard_scorer._vocab_size
+        if pard_draft_out.sampled_token_probs.shape[1] > target_dim:
+            pard_draft_out.sampled_token_probs = pard_draft_out.sampled_token_probs[:, :target_dim]
+        elif pard_draft_out.sampled_token_probs.shape[1] < target_dim:
+            pard_draft_out.sampled_token_probs = torch.nn.functional.pad(
+                    pard_draft_out.sampled_token_probs, (0, target_dim - pard_draft_out.sampled_token_probs.shape[1]), value=0)
+
+        # get output
+        output_indices = torch.tensor([[i + tmp_rm + j * sample_len for j, tmp_rm in enumerate(rm_token_num_sum)] 
+            for i in range(sample_len)], device=self.device)
+        filtered_model_outputs = [
+            SamplerOutput(
+                outputs=[
+                    pard_draft_out.outputs[i] for i in output_indices_to_retain
+                ] if len(pard_draft_out.outputs) > 0 else [],
+                sampled_token_probs=(
+                    pard_draft_out.sampled_token_probs[output_indices_to_retain]
+                    if pard_draft_out.sampled_token_probs is not None
+                    else None),
+                logprobs=(
+                     pard_draft_out.logprobs[output_indices_to_retain]
+                    if  pard_draft_out.logprobs is not None else None),
+                sampled_token_ids=(pard_draft_out.
+                                   sampled_token_ids[output_indices_to_retain]
+                                   if pard_draft_out.sampled_token_ids
+                                   is not None else None))
+            for output_indices_to_retain in output_indices
+            ]
+        return filtered_model_outputs
+ 
     @staticmethod
     def _maybe_update_previous_hidden_states(
             model_output: SamplerOutput,

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -101,10 +101,8 @@ def create_spec_worker(*args, **kwargs) -> "SpecDecodeWorker":
         scorer_worker=target_worker,
         draft_worker_kwargs=draft_worker_kwargs,
         disable_mqa_scorer=speculative_config.disable_mqa_scorer,
-        disable_by_batch_size=speculative_config.
-        disable_by_batch_size,
-        draft_token_acceptance_method=speculative_config.
-        acceptance_method,
+        disable_by_batch_size=speculative_config.disable_by_batch_size,
+        draft_token_acceptance_method=speculative_config.acceptance_method,
         typical_acceptance_sampler_posterior_threshold=speculative_config.
         posterior_threshold,
         typical_acceptance_sampler_posterior_alpha=speculative_config.
@@ -201,7 +199,6 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                 if draft_model_config.hf_config.model_type == "eagle":
                     enable_lm_head_weight_load = True
 
-
                 proposer_worker = MultiStepWorker(**draft_worker_kwargs)
 
                 if draft_model_config.hf_config.model_type == "deepseek_mtp":
@@ -210,10 +207,13 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
 
             proposer_worker = SmallerTpProposerWorker.maybe_wrap_worker(
                 proposer_worker, draft_tp, target_tp)
-            pard = draft_model_config.hf_config.__dict__.get('spd_type', None) == 'pard'
+            pard = draft_model_config.hf_config.__dict__.get('spd_type',
+                                                             None) == 'pard'
             proposer_worker.pard = pard
             if pard:
-                proposer_worker.pard_token = draft_model_config.hf_config.__dict__['pard_token']
+                pard_token = draft_model_config.hf_config.__dict__[
+                    'pard_token']
+                proposer_worker.pard_token = pard_token
 
         logger.info("Configuring SpecDecodeWorker with proposer=%s",
                     type(proposer_worker))
@@ -350,7 +350,6 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         self._disable_log_stats = disable_log_stats
         self._num_spec_prefill_steps = num_spec_prefill_steps
 
-
     def init_device(self) -> None:
         """Initialize both scorer and proposer models.
         """
@@ -396,11 +395,11 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                                  device=self.device,
                                  vocab_size=self._vocab_size)
 
-
         if self.proposer_worker.pard:
-            self.proposer_worker.pard_scorer = scorer_cls(scorer_worker=self.proposer_worker,
-                                 device=self.device,
-                                 vocab_size=self._vocab_size)
+            self.proposer_worker.pard_scorer = scorer_cls(
+                scorer_worker=self.proposer_worker,
+                device=self.device,
+                vocab_size=self._vocab_size)
 
         self._configure_model_sampler_for_spec_decode()
 
@@ -796,7 +795,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         # Pass last hidden states from target model to proposer
         execute_model_req.previous_hidden_states = self.previous_hidden_states
         self.previous_hidden_states = None
-        
+
         with Timer() as proposal_timer:
             # Generate proposals using draft worker.
             proposals = self.proposer_worker.get_spec_proposals(
@@ -1275,7 +1274,8 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
             for worker in [self.proposer_worker, self.scorer_worker]
         ]
         if not self.proposer_worker.pard:
-            assert all(vocab_sizes[0] == vocab_size for vocab_size in vocab_sizes)
+            assert all(vocab_sizes[0] == vocab_size
+                       for vocab_size in vocab_sizes)
         return vocab_sizes[0]
 
     @property

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -1276,7 +1276,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         if not self.proposer_worker.pard:
             assert all(vocab_sizes[0] == vocab_size
                        for vocab_size in vocab_sizes)
-        return vocab_sizes[0]
+        return vocab_sizes[1]
 
     @property
     def rank(self):


### PR DESCRIPTION
## Description:

This PR integrates PARD into vLLM. PARD (PARallel Draft model) is a speculative decoding method that enables low-cost adaptation of autoregressive draft models into parallel draft models. It improves inference efficiency by allowing the draft model to predict multiple future tokens in a single forward pass, significantly reducing decoding latency. For detailed technical information, please refer to the [technical report](https://arxiv.org/pdf/2504.18583), [github](https://github.com/AMD-AIG-AIMA/PARD) and [blog](https://www.amd.com/en/developer/resources/technical-articles/accelerating-generative-llms-interface-with-parallel-draft-model-pard.html).


<p align="center">
  <figure style="display: inline-block; text-align: center;">
    <img src="https://cdn-uploads.huggingface.co/production/uploads/630cb01cc169245d78fe76b6/Dh-7wE-l0YAfU9lXWssKf.png" width="100%">
    <figcaption style="font-style: italic; margin-top: 2px;">
      AR and AR+ represent baseline auto-regressive generation using Transformers and Transformers+, respectively. VSD denotes vanilla speculative decoding. PARD refers to the proposed method in this work.
    </figcaption>
  </figure>
</p>

## Support Model Series
Supports acceleration for models across various sizes in the following series: Llama3, Deepseek-R1-distilled-Qwen, and Qwen1.5/2/2.5.
| Model Series | Draft Model Name                            | link      |
|--------------|---------------------------------------|---------------|
| llama3       | PARD-Llama-3.2-1B                     | [🤗 HuggingFace](https://huggingface.co/amd/PARD-Llama-3.2-1B)  |
| DSR Qwen     | PARD-DeepSeek-R1-Distill-Qwen-1.5B    | [🤗 HuggingFace](https://huggingface.co/amd/PARD-DeepSeek-R1-Distill-Qwen-1.5B) |
| Qwen         | PARD-Qwen2.5-0.5B                     | [🤗 HuggingFace](https://huggingface.co/amd/PARD-Qwen2.5-0.5B) |

## Summary of changes:
### 1. **vllm/spec_decode/multi_step_worker.py**:
 Added the **pard_infer** function to support PARD-based speculative decoding. Key logic includes:
- **KV cache recomputation & seq_group_metadata_list update**: Some of PARD's KV cache is derived from mask_token and needs to be recomputed. New mask tokens are introduced accordingly.

- **Proposal generation**: Uses the SpeculativeProposals function to obtain token proposals.

- **Draft model forward**: Only a single forward pass is needed for the draft model to generate multiple tokens.

- **Logits shape alignment**: Aligns the logits shapes of the target and draft models when they differ.

- **Output conversion**: Converts intermediate results into the standard output format.

### 2. **vllm/spec_decode/batch_expansion.py**:
Modified score_proposal to support:

- **keep_index**: If not None, only returns results for specified indices. Recomputed KV cache outputs will be excluded.

- **return_output**: If True, returns the full target_sampler_output.

### 3. **vllm/spec_decode/spec_decode_worker.py**:
Added a new interface to enable PARD inference.

## Test
### Test Code
```
import argparse
import json
import os
from vllm import LLM, SamplingParams
import requests
import numpy as np

os.environ.update({
    "VLLM_USE_V1": "0"
})
def parse_args():
    parser = argparse.ArgumentParser()
    parser.add_argument("--model", type=str, default="unsloth/Meta-Llama-3.1-8B-Instruct")
    parser.add_argument("--draft", type=str, default="amd/PARD-Llama-3.2-1B")
    parser.add_argument("--benchmark", type=str, default="humaneval")
    parser.add_argument("--max_num_seqs", type=int, default=1)
    parser.add_argument("--num_prompts", type=int, default=80)
    parser.add_argument("--num_spec_tokens", type=int, default=16)
    parser.add_argument("--tp", type=int, default=1)
    parser.add_argument("--temp", type=float, default=0)
    parser.add_argument("--ar", action='store_true')
    parser.add_argument("--disable-warmup", action='store_true')
    return parser.parse_args()

def main():
    args = parse_args()
    prompts = []
    for line in requests.get(f'https://raw.githubusercontent.com/AMD-AIG-AIMA/PARD/master/datas/bmk/{args.benchmark}.jsonl').text.splitlines():
        if line:
            prompts.append(json.loads(line)['data'])
    prompts = prompts[:args.num_prompts]
    datas = [[{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": prompt}] for prompt in prompts]
    llm = LLM(
        model=args.model,
        enable_prefix_caching=False,
        tensor_parallel_size=args.tp,
        max_num_batched_tokens=8192,
        max_model_len=8192,
        max_num_seqs=args.max_num_seqs,
        gpu_memory_utilization=0.8,
        speculative_config=None if args.ar else {
            "model": args.draft,
            "num_speculative_tokens": args.num_spec_tokens
            },
    )

    sampling_params = SamplingParams(temperature=args.temp, max_tokens=512)

    ## warmup
    if not args.disable_warmup:
        print("warmup...")
        outputs = llm.chat(
            datas,
            sampling_params=sampling_params,
        )

    # inference
    print("inference...")
    outputs = llm.chat(
        datas,
        sampling_params=sampling_params,
    )

    # speed
    speed = []
    for output in outputs:
        speed.append([len(output.outputs[0].token_ids), (output.metrics.finished_time - output.metrics.first_token_time)])
        print(f"[anwer]:\n {output.outputs[0].text}")

    print(f"\n\n{'='*100}\n\n")
    print(f'[speed]: {np.array(speed)[:,0].sum() / np.array(speed)[:,1].sum()}\n')

    # accepted
    if not args.ar:
        acceptance_counts = [0] * (args.num_spec_tokens + 1)
        for output in outputs:
            for step, count in enumerate(
                    output.metrics.spec_token_acceptance_counts):
                acceptance_counts[step] += count

        print(f"[acceptance length]: {1 + (sum(acceptance_counts) / acceptance_counts[0])}")
    print(f"\n\n{'='*100}\n\n")


if __name__ == "__main__":
    main()
```
### Test Result
- Target model: Meta-Llama-3.1-8B-Instruct
- Task: humaneval

| Device       |  Accept Length | Baseline AR t/s    | PARD t/s |
|-------------|---------|--------|-----------|
| MI300  | 6.2 | 181.29 | 416.30 |
| MI250    | 6.2 | 67.99 | 169.08 |
| H20    | 6.2 | 153.16 |   295.85 |