### PR TITLE
[Hardware][CPU] Update intel_extension_for_pytorch 2.7.0 and move to `requirements/cpu.txt` 

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -51,9 +51,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --upgrade pip && \
     uv pip install -r requirements/cpu.txt
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install intel-openmp==2024.2.1 intel_extension_for_pytorch==2.6.0
-
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4:/opt/venv/lib/libiomp5.so:$LD_PRELOAD"
 
 RUN echo 'ulimit -c 0' >> ~/.bashrc

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -20,3 +20,7 @@ datasets # for benchmark scripts
 
 # cpu cannot use triton 3.3.0
 triton==3.2.0; platform_machine == "x86_64"
+
+# Intel Extension for PyTorch, only for x86_64 CPUs
+intel-openmp; platform_machine == "x86_64"
+intel_extension_for_pytorch==2.7.0; platform_machine == "x86_64"

--- a/vllm/model_executor/layers/quantization/ipex_quant.py
+++ b/vllm/model_executor/layers/quantization/ipex_quant.py
@@ -14,7 +14,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.gptq import GPTQLinearMethod
 from vllm.platforms import current_platform
 
-MIN_IPEX_VERSION = "2.5.0"
+MIN_IPEX_VERSION = "2.7.0"
 
 
 class IPEXConfig(QuantizationConfig):


### PR DESCRIPTION
Fix #17225

When running on the CPU, a RuntimeError occurs: `"reshape_and_cache_cpu_impl" not implemented for 'Half'`. Changing the version of intel_extension_for_pytorch in `Dockerfile.cpu` from 2.6.0 to 2.7.0 resolves the issue, ref to https://github.com/vllm-project/vllm/issues/17225#issuecomment-2863329443

Since PyTorch has been upgraded to 2.7.0(Related to #16859), it is unreasonable to continue using intel_extension_for_pytorch 2.6.0. Therefore, we have upgraded intel_extension_for_pytorch to 2.7.0.
And it's moved from the `Dockerfile` to `requirements/cpu.txt`, making dependency management more convenient. https://docs.vllm.ai/en/latest/getting_started/installation/cpu.html for it to run correctly.

Furthermore, we have also moved intel-openmp to `requirements/cpu.txt`, removed the version lock, and are now using the latest version.

Additionally, it has been noted that #18430 can also resolve the issue. However, the two solutions do not conflict with each other.

