### PR TITLE
[Bugfix] Use random hidden states in dummy sampler run

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1721,6 +1721,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        # The dummy hidden states may contain special values,
+        # like `inf` or `nan`.
+        # To avoid breaking the sampler, we use a random tensor here instead.
+        hidden_states = torch.rand_like(hidden_states)
 
         logits = self.model.compute_logits(hidden_states, None)
         num_reqs = logits.size(0)


### PR DESCRIPTION
During model initialization, we perform a profiling run and warmup using dummy tensors, without executing attention operations. As a result, the hidden states and logits produced during this phase may be meaningless and could contain special values such as `inf` or `nan`.

FlashInfer was updated to version 0.2.4 in #15777. In this version, the sampling kernel algorithm was modified. Consequently, if the input probabilities to the sampler contain `nan` values, this may lead to illegal memory access or other runtime errors.

This PR addresses the issue by using random hidden states during the dummy sampler run. This avoids the propagation of special values (`inf`, `nan`) into the sampling kernel, thereby preventing crashes. This change is isolated to the dummy run and does not affect any actual model behavior.

**Note:** The error reported in #18528 may still occur, as expected, but it will no longer result in illegal memory access due to the fix introduced in this PR.

The revert in #18459 may now be safely undone if no further issues arise following this update.

FIX #18147 
FIX #18245
FIX #18416 
FIX #18417 
FIX #18418 
FIX #18425
FIX #18459 
FIX #18462 
FIX #18466
FIX #18498 
FIX #18525 
