### PR TITLE
[Bugfix] handle zero-token batches by creating empty attention metadata for KV cache load

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1429,22 +1429,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def kv_connector_no_forward(
             self, scheduler_output: "SchedulerOutput") -> ModelRunnerOutput:
         # KV send/recv even if no work to do.
-        # Create an empty but valid attention metadata to ensure that the KV cache
-        # load operation continues to work even when encountering zero-token batches.
-        dummy_attn_metadata = {}
-        for layer_name in self.vllm_config.compilation_config.static_forward_context.keys():
-            if hasattr(self, 'attn_metadata_builder'):
-                dummy_attn_metadata[layer_name] = self.attn_metadata_builder.build(
-                    num_reqs=0,
-                    num_actual_tokens=0,
-                    max_query_len=0,
-                    common_prefix_len=0,
-                    common_attn_metadata=CommonAttentionMetadata(
-                        query_start_loc=torch.zeros(1, dtype=torch.int32, device=self.device),
-                        seq_lens=torch.zeros(0, dtype=torch.int32, device=self.device)
-                    )
-                )
-        with set_forward_context(dummy_attn_metadata, self.vllm_config):
+        # Pass an empty dictionary as `attn_metadata` to ensure that
+        # the KV cache load operation continues to work even when
+        # encountering zero-token batches.
+        with set_forward_context({}, self.vllm_config):
             self.maybe_setup_kv_connector(scheduler_output)
             finished_sending, finished_recving = (
                 self.get_finished_kv_transfers(scheduler_output))


### PR DESCRIPTION
FIX #18489

It seems that in the current implementation, when there is no token to calculate(0-token batch), the background cannot load kv cache because the passed attention metadata is `None` and kv cache load function will exit directly. For details, you can see

https://github.com/vllm-project/vllm/blob/fa72f9a8126051abb9d00144f11aeb7615f36d21/vllm/v1/worker/gpu_model_runner.py#L1117

https://github.com/vllm-project/vllm/blob/fa72f9a8126051abb9d00144f11aeb7615f36d21/vllm/v1/worker/gpu_model_runner.py#L1432

https://github.com/vllm-project/vllm/blob/fa72f9a8126051abb9d00144f11aeb7615f36d21/vllm/v1/worker/gpu_model_runner.py#L1459

https://github.com/vllm-project/vllm/blob/fa72f9a8126051abb9d00144f11aeb7615f36d21/vllm/distributed/kv_transfer/kv_connector/v1/shared_storage_connector.py#L146

A relatively minor solution is to create an empty dictionary(i.e. `{}`) as `attn_metadata` instead of `None` and send it down, so that the background can keep loading kv cache even if a zero-token batch is encountered.