### PR TITLE
[BugFix] Increase TP execute_model timeout

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -38,7 +38,7 @@ logger = init_logger(__name__)
 POLLING_TIMEOUT_MS = 5000
 POLLING_TIMEOUT_S = POLLING_TIMEOUT_MS // 1000
 
-EXECUTE_MODEL_TIMEOUT_S = 40
+EXECUTE_MODEL_TIMEOUT_S = 300
 
 
 class MultiprocExecutor(Executor):


### PR DESCRIPTION
The timeout for execute_model (forward pass) running in TP workers was set to 40 seconds but there are a number of reports of this being hit. We assume the workers are in a bad state when this happens and the engine goes into a failure state.

It's not clear in which cases the model forward pass takes this long but for now we can increase the timeout to 5 minutes.

Resolves https://github.com/vllm-project/vllm/issues/17965
