### PR TITLE
FIX: NixlConnector: do not skip short do_remote_prefill requests 

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -45,8 +45,10 @@ def test_prompt_less_than_block_size():
     Test that we can handle case where prompt is < block.
 
     In this case, the P worker will send empty remote_block_ids.
-    The D worker should not schedule an async read in this case,
-    since there is nothing to pull.
+    The D worker should not schedule the request but without
+    any async read (empty local_block_ids) since there is nothing to pull.
+    Keeping the request int connector metaata is for notifying the
+    prefill worker so that the remote blocks are freed.
     """
     vllm_config = create_vllm_config()
     scheduler = create_scheduler(vllm_config)
@@ -67,7 +69,10 @@ def test_prompt_less_than_block_size():
     kv_connector_metadata = scheduler_output.kv_connector_metadata
     assert kv_connector_metadata is not None
     assert isinstance(kv_connector_metadata, NixlConnectorMetadata)
-    assert len(kv_connector_metadata.requests) == 0
+    assert len(kv_connector_metadata.requests) == 1
+    req_id, meta = next(iter(kv_connector_metadata.requests.items()))
+    # empty local_block_ids, so that async read will be skipped
+    assert not meta.local_block_ids
 
     # This request should be scheduled regularly.
     assert len(scheduler_output.scheduled_new_reqs) == 1

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -47,8 +47,8 @@ def test_prompt_less_than_block_size():
     In this case, the P worker will send empty remote_block_ids.
     The D worker should not schedule the request but without
     any async read (empty local_block_ids) since there is nothing to pull.
-    Keeping the request int connector metaata is for notifying the
-    prefill worker so that the remote blocks are freed.
+    Keeping the request int connector metadata is for notifying the
+    prefill worker so that its remote blocks can be released.
     """
     vllm_config = create_vllm_config()
     scheduler = create_scheduler(vllm_config)
@@ -72,6 +72,7 @@ def test_prompt_less_than_block_size():
     assert len(kv_connector_metadata.requests) == 1
     req_id, meta = next(iter(kv_connector_metadata.requests.items()))
     # empty local_block_ids, so that async read will be skipped
+    assert hasattr(meta, "local_block_ids")
     assert not meta.local_block_ids
 
     # This request should be scheduled regularly.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -259,15 +259,6 @@ class NixlConnectorScheduler:
         # Loop through scheduled reqs and convert to ReqMeta.
         for req_id, (req, block_ids) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
-            # For the case where there are no remote blocks to pull
-            # (block_ids is empty), we don't need to schedule
-            # an async read on the worker side.
-            if not block_ids:
-                logger.debug(
-                    "Skipping adding request %s to NixlConnectorMetadata, "
-                    "as there are no remote blocks to pull", req_id)
-                continue
-
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,


### PR DESCRIPTION
The original issue is #18490, and #18429 wanted to fix it.

But skipping short `do_remote_prefill` request in connector's metadata will also skip [sending the notification to the prefill worker for releasing remote kv pages](https://github.com/vllm-project/vllm/blob/9c1baa5bc6caedabeac1a6da57ec79b41e13056d/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py#L733-L735).

The modifications here are
1. revoke the changes from #18429 
2. update `test_nixl_connector.py::test_prompt_less_than_block_size` accordingly

FIX #18591

<!--- pyml disable-next-line no-emphasis-as-heading -->
