### PR TITLE
[Bugfix] Fix transformers model impl ignored for mixtral quant

### DIFF
--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -225,17 +225,16 @@ def get_model_architecture(
         "fp8", "compressed-tensors", "gptq_marlin", "awq_marlin", "quark"
     ]
 
-    if (model_config.quantization is not None
-            and model_config.quantization not in mixtral_supported
-            and "MixtralForCausalLM" in architectures):
-        architectures = ["QuantMixtralForCausalLM"]
-
     vllm_supported_archs = ModelRegistry.get_supported_archs()
     vllm_not_supported = not any(arch in vllm_supported_archs
                                  for arch in architectures)
     if (model_config.model_impl == ModelImpl.TRANSFORMERS or
             model_config.model_impl != ModelImpl.VLLM and vllm_not_supported):
         architectures = resolve_transformers_arch(model_config, architectures)
+    elif (model_config.quantization is not None
+          and model_config.quantization not in mixtral_supported
+          and "MixtralForCausalLM" in architectures):
+        architectures = ["QuantMixtralForCausalLM"]
 
     model_cls, arch = ModelRegistry.resolve_model_cls(architectures)
     if model_config.task == "embed":


### PR DESCRIPTION

Running `mistralai/Mixtral-8x7B-Instruct-v0.1` with BNB quantization fails because of [this issue](https://github.com/vllm-project/vllm/issues/17199). This issue can be worked around by using the `transformers` model implementation, which does on the other hand support BNB quantization. Unfortunately, when trying to run `mistralai/Mixtral-8x7B-Instruct-v0.1` with `model_impl="transformers` and `quantization="bitsandbytes"`, the model fails to load with:

```
ValueError: Cannot find model module. 'QuantMixtralForCausalLM' is not a registered model in the Transformers library (only relevant if the model is meant to be in Transformers) and 'AutoModel' is not present in the model config's 'auto_map' (relevant if the model is custom).

```

This is because the hacky replacement of the `MixtralForCausalLM` architecture implemented in [this PR](https://github.com/vllm-project/vllm/pull/2673) for unsupported quantization methods occurs before the model implementation is taken into account, and the patched `QuantMixtralForCausalLM` is indeed not implemented in the HF library as it's only meant to be a local and temporary patch in the `vllm` library, so `resolve_transformers_arch` fails on it.

This PR applies the hacky patch only when `vllm` implementation is used, so that the `model_impl="transformers"` is correctly acounted for Mixtral models.

<!--- pyml disable-next-line no-emphasis-as-heading -->
