### PR TITLE
[Doc] Fix wrong code block of mkdocs

### DIFF
--- a/examples/other/tensorize_vllm_model.py
+++ b/examples/other/tensorize_vllm_model.py
@@ -106,12 +106,10 @@ You can then use the LoRA adapter with `vllm serve`, for instance, by ensuring
 the LoRA artifacts are in your model artifacts directory and specifying 
 `--enable-lora`. For instance:
 
-```
 vllm serve <model_path> \
     --load-format tensorizer \
     --model-loader-extra-config '{"tensorizer_uri": "<model_path>.tensors"}' \
     --enable-lora
-```
 """
 
 


### PR DESCRIPTION
I fixed wrong code block of [Tensorize vLLM Model](https://docs.vllm.ai/en/latest/getting_started/examples/other/tensorize_vllm_model/) page (related: #18145) as below:

<img width="1007" alt="Screenshot 2025-05-23 at 8 27 09 PM" src="https://github.com/user-attachments/assets/77fb519f-8717-4f95-ab35-028addeec690" />

