### PR TITLE
[V1][Sampler] Improve performance of FlashInfer sampling by sampling logits instead of probs

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -259,7 +259,7 @@ def flashinfer_sample(
     p: Optional[torch.Tensor],
     generators: dict[int, torch.Generator],
 ) -> torch.Tensor:
-    """Sample from the probabilities using FlashInfer.
+    """Sample from the logits using FlashInfer.
 
     Statistically, this function is equivalent to the `random_sample` function.
     However, this function is faster because it avoids sorting the logits tensor

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -89,18 +89,18 @@ class TopKTopPSampler(nn.Module):
         p: Optional[torch.Tensor],
     ) -> torch.Tensor:
         """More optimized implementation for top-k and top-p sampling."""
-        probs = logits.softmax(dim=-1, dtype=torch.float32)
         if k is None and p is None:
             # We prefer `random_sample` over `flashinfer_sample` when sorting is
             # not needed. This is because `random_sample` does not require
             # CPU-GPU synchronization while `flashinfer_sample` does.
+            probs = logits.softmax(dim=-1, dtype=torch.float32)
             return random_sample(probs, generators)
         if generators:
             logger.warning("FlashInfer 0.2.3+ does not support "
                            "per-request generators. Falling back to "
                            "PyTorch-native implementation.")
             return self.forward_native(logits, generators, k, p)
-        return flashinfer_sample(probs, k, p, generators)
+        return flashinfer_sample(logits, k, p, generators)
 
     def forward_tpu(
         self,
@@ -254,7 +254,7 @@ def random_sample(
 
 
 def flashinfer_sample(
-    probs: torch.Tensor,
+    logits: torch.Tensor,
     k: Optional[torch.Tensor],
     p: Optional[torch.Tensor],
     generators: dict[int, torch.Generator],
@@ -264,7 +264,7 @@ def flashinfer_sample(
     Statistically, this function is equivalent to the `random_sample` function.
     However, this function is faster because it avoids sorting the logits tensor
     via rejection sampling.
-    
+
     NOTE: The outputs of this function do not necessarily match the outputs of
     the `random_sample` function. It only guarantees that the outputs are
     statistically equivalent.
@@ -274,18 +274,19 @@ def flashinfer_sample(
     the synchronization overhead.
     """
     assert not (k is None and p is None)
-
     if k is None:
         # Top-p only.
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
         next_token_ids = flashinfer.sampling.top_p_sampling_from_probs(
             probs, p, deterministic=True)
     elif p is None:
         # Top-k only.
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
         next_token_ids = flashinfer.sampling.top_k_sampling_from_probs(
             probs, k, deterministic=True)
     else:
         # Both top-k and top-p.
-        next_token_ids = (flashinfer.sampling.top_k_top_p_sampling_from_probs(
-            probs, k, p, deterministic=True))
+        next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+            logits, k, p, deterministic=True)
 
     return next_token_ids.view(-1)


### PR DESCRIPTION
This PR replaces `flashinfer.sampling.top_k_top_p_sampling_from_probs` with `flashinfer.sampling.top_k_top_p_sampling_from_logits`.

The `top_k_top_p_sampling_from_props` path calls [`(softmax) -> top_k_renorm_probs -> top_p_sampling_from_probs`](https://github.com/flashinfer-ai/flashinfer/blob/8bc22a1a6c58da1e0a02605f3b19b5d9e6224ad1/flashinfer/sampling.py#L1016-L1017) , `top_k_top_p_sampling_from_logits` calls [`top_k_mask_logits -> softmax -> top_p_sampling_from_probs`](https://github.com/flashinfer-ai/flashinfer/blob/8bc22a1a6c58da1e0a02605f3b19b5d9e6224ad1/flashinfer/sampling.py#L901-L903) which is faster.

In a quick micro benchmark on an **L40s GPU** I am seeing a **9.3 % speedup** with this PR and jitted flashinfer using Cuda 12.8.

<details><summary><strong>Expand for script to reproduce toy benchmark</strong></summary>
<p>

```python
import time

import torch
import flashinfer.sampling

from vllm.platforms import current_platform
from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, FlexibleArgumentParser


@torch.inference_mode()
def main(
    batch_size: int,
    num_classes: int,
    dtype: torch.dtype,
    seed: int = 0,
    num_warmup_iters: int = 5,
    num_iters: int = 100,
) -> None:
    current_platform.seed_everything(seed)
    torch.set_default_device("cuda")

    logits = torch.randn(batch_size, num_classes, dtype=dtype)
    k = torch.ones(batch_size, dtype=torch.int32) * 64
    p = torch.ones(batch_size, dtype=dtype) * 0.95

    def run_cuda_benchmark(num_iters: int) -> float:
        torch.cuda.synchronize()
        start_time = time.perf_counter()

        for _ in range(num_iters):
            # probs = logits.softmax(dim=-1, dtype=torch.float32)
            # next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_probs(
            # probs, k, p, deterministic=True)
            next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_logits(
                logits, k, p, deterministic=True
            )
        torch.cuda.synchronize()

        end_time = time.perf_counter()
        return (end_time - start_time) / num_iters

    print("Warming up...")
    run_benchmark = run_cuda_benchmark
    run_benchmark(num_iters=num_warmup_iters)
    latency = run_benchmark(num_iters=num_iters)
    print(f"Kernel running time: {latency * 1000000:.3f} us")


if __name__ == "__main__":
    parser = FlexibleArgumentParser(description="Benchmark the layernorm kernel.")
    parser.add_argument("--batch-size", type=int, default=40)
    parser.add_argument("--num-classes", type=int, default=262208)
    parser.add_argument("--add-residual", action="store_true")
    parser.add_argument(
        "--dtype", type=str, choices=["half", "bfloat16", "float"], default="float"
    )
    parser.add_argument("--seed", type=int, default=0)
    parser.add_argument("--num-warmup-iters", type=int, default=5)
    parser.add_argument(
        "--num-iters", type=int, default=5000, help="Number of benchmark iterations."
    )

    args = parser.parse_args()
    print(args)

    main(
        batch_size=args.batch_size,
        num_classes=args.num_classes,
        dtype=STR_DTYPE_TO_TORCH_DTYPE[args.dtype],
        seed=args.seed,
        num_warmup_iters=args.num_warmup_iters,
        num_iters=args.num_iters,
    )
```

</p>
</details> 

End to end this also results in a **1.75 % improvement in throughput** for `google/gemma-3-12b-it`:
```shell
vllm serve google/gemma-3-12b-it --disable-log-requests
python benchmarks/benchmark_serving.py --backend openai-chat --model google/gemma-3-12b-it --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/VisionArena-Chat --hf-split train --num-prompts 1000
```

**Baseline**:
```
============ Serving Benchmark Result ============
Successful requests:                     984
Benchmark duration (s):                  187.19
Total input tokens:                      95362
Total generated tokens:                  115951
Request throughput (req/s):              5.26
Output token throughput (tok/s):         619.43
Total Token throughput (tok/s):          1128.87
---------------Time to First Token----------------
Mean TTFT (ms):                          92076.57
Median TTFT (ms):                        87454.65
P99 TTFT (ms):                           176229.15
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          123.15
Median TPOT (ms):                        126.41
P99 TPOT (ms):                           474.41
---------------Inter-token Latency----------------
Mean ITL (ms):                           134.43
Median ITL (ms):                         65.22
P99 ITL (ms):                            592.16
==================================================
```

**This PR**:
```
============ Serving Benchmark Result ============
Successful requests:                     984
Benchmark duration (s):                  184.04
Total input tokens:                      95362
Total generated tokens:                  116033
Request throughput (req/s):              5.35
Output token throughput (tok/s):         630.47
Total Token throughput (tok/s):          1148.62
---------------Time to First Token----------------
Mean TTFT (ms):                          90823.37
Median TTFT (ms):                        85678.72
P99 TTFT (ms):                           175009.27
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          120.16
Median TPOT (ms):                        125.98
P99 TPOT (ms):                           444.52
---------------Inter-token Latency----------------
Mean ITL (ms):                           133.26
Median ITL (ms):                         65.33
P99 ITL (ms):                            592.79
==================================================
```


