### PR TITLE
[Doc] Fix indent of contributing to vllm

### DIFF
--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -16,9 +16,9 @@ Finally, one of the most impactful ways to support us is by raising awareness ab
 Unsure on where to start? Check out the following links for tasks to work on:
 
 - [Good first issues](https://github.com/vllm-project/vllm/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
-  - [Selected onboarding tasks](gh-project:6)
+    - [Selected onboarding tasks](gh-project:6)
 - [New model requests](https://github.com/vllm-project/vllm/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22new-model%22)
-  - [Models with multi-modal capabilities](gh-project:10)
+    - [Models with multi-modal capabilities](gh-project:10)
 
 ## License
 


### PR DESCRIPTION
I fixed wrong indent as below:

<img width="2411" alt="Screenshot 2025-05-23 at 8 52 00 PM" src="https://github.com/user-attachments/assets/a2b6f210-7dc7-4507-b906-bd2e4e4b21c4" />
(left: current page, right: fixed page)
