### PR TITLE
[Docs] Change mkdocs to not use directory urls

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -119,3 +119,8 @@ extra_css:
 extra_javascript:
   - mkdocs/javascript/run_llm_widget.js
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+
+# Makes the url format end in .html rather than act as a dir
+# So index.md generates as index.html and is available under URL /index.html
+# https://www.mkdocs.org/user-guide/configuration/#use_directory_urls
+use_directory_urls: false


### PR DESCRIPTION
The old docs style used files as the URL rather than directories, however mkdocs uses directories by default. https://www.mkdocs.org/user-guide/configuration/#use_directory_urls

As an example, this link used to work: https://docs.vllm.ai/en/latest/getting_started/quickstart.html but currently results in 
![image](https://github.com/user-attachments/assets/4a584c4e-5861-4028-9469-ed18f825897c)

The current default style results in https://docs.vllm.ai/en/latest/getting_started/quickstart/ being the new link.

This PR reverts to the old behavior to not break existing links