### PR TITLE
[Doc] Avoid documenting dynamic / internal modules

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -60,6 +60,10 @@ plugins:
   - api-autonav:
       modules: ["vllm"]
       api_root_uri: "api"
+      exclude:
+        - "re:vllm\\._.*"  # Internal modules
+        - "vllm.third_party"
+        - "vllm.vllm_flash_attn"
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
This PR fixes an issue where I can't run `mkdocs serve` locally (I'm developing using `python -m pip install -e .`)