### PR TITLE
[Bugfix] Mistral Devstral tool calling

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -161,6 +161,13 @@ def make_mistral_chat_completion_request(
             if isinstance(content, list):
                 content = "\n".join(chunk.get("text") for chunk in content)
                 message["content"] = content
+            if "reasoning_content" in message:
+                del message["reasoning_content"]
+        if message.get("role") == "tool":
+            content = message.get("content")
+            if isinstance(content, list):
+                content = "\n".join(chunk.get("text") for chunk in content)
+                message["content"] = content
 
     # The Mistral client, in comparison to the OpenAI client, requires the
     # "parameters" dict to be present, even if it's empty.


### PR DESCRIPTION
Mistral's Codestral model `mistralai/Devstral-Small-2505` fails when using with tools.
Similar to the existing patch for `assistant` message content (converting to string) we must convert `tool` message content to string + make sure the `reasoning_content` is not present.


FIX [Tools usage with mistralai/Devstral-Small-2505 failsMistral](https://github.com/vllm-project/vllm/issues/18628)

<!--- pyml disable-next-line no-emphasis-as-heading -->
