### PR TITLE
Disable prefix cache by default for benchmark

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -189,5 +189,8 @@ if __name__ == "__main__":
     )
 
     parser = EngineArgs.add_cli_args(parser)
+    # V1 enables prefix caching by default which skews the latency
+    # numbers. We need to disable prefix caching by default.
+    parser.set_defaults(enable_prefix_caching=False)
     args = parser.parse_args()
     main(args)

--- a/vllm/benchmarks/latency.py
+++ b/vllm/benchmarks/latency.py
@@ -80,6 +80,9 @@ def add_cli_args(parser: argparse.ArgumentParser):
     )
 
     parser = EngineArgs.add_cli_args(parser)
+    # V1 enables prefix caching by default which skews the latency
+    # numbers. We need to disable prefix caching by default.
+    parser.set_defaults(enable_prefix_caching=True)
 
 
 def main(args: argparse.Namespace):


### PR DESCRIPTION
v1 has prefix cache enabled by default to improve performance. 
However, this creates misleading latency numbers when running benchmarks without explicitly disabling it.
This PR disables prefix cache in the benchmark script to improve usability for new users.