### PR TITLE
[V1] Fix _pickle.PicklingError: Can't pickle <class 'transformers_modules.deepseek-ai.DeepSeek-V2-Lite...

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -20,6 +20,8 @@ from vllm.outputs import RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import SamplingParams
+from vllm.transformers_utils.config import (
+    maybe_register_config_serialize_by_value)
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizer_group import init_tokenizer_from_configs
 from vllm.usage.usage_lib import UsageContext
@@ -79,6 +81,9 @@ class AsyncLLM(EngineClient):
                 "This should not happen. As a workaround, try using "
                 "AsyncLLMEngine.from_vllm_config(...) or explicitly set "
                 "VLLM_USE_V1=0 or 1 and report this issue on Github.")
+
+        # Ensure we can serialize custom transformer configs
+        maybe_register_config_serialize_by_value()
 
         self.model_config = vllm_config.model_config
         self.vllm_config = vllm_config


### PR DESCRIPTION
Starting with a fix similar to #15009. We hit this when instantiating an `AsyncLLM` with DeepSeek models which have custom configs. 

I think this was meant to be handled by calling `maybe_register_config_serialize_by_value()` in  `EngineCoreProc`'s `run_engine_core()`, but it seems to be missed, at least in my case. Next step: spend some time to understand why. (New to the system so please flag if the answer is obvious).

Reproducer `python serve.py`:
```
# serve.py
from ray import serve
from ray.serve.llm import LLMConfig, build_openai_app

llm_config = LLMConfig(
    model_loading_config=dict(
        model_id="deepseek-ai/DeepSeek-V2-Lite",
        model_source="deepseek-ai/DeepSeek-V2-Lite",
    ),
    runtime_env=dict(
        env_vars={"VLLM_USE_V1": "1"}
    ),
    deployment_config=dict(
        autoscaling_config=dict(min_replicas=1, max_replicas=1)
    ),
    engine_kwargs=dict(
        max_num_seqs=40,
        max_model_len=16384,
        enable_chunked_prefill=True,
        enable_prefix_caching=True,
        trust_remote_code=True,
        tensor_parallel_size=4,
    ),
)

app = build_openai_app({"llm_configs": [llm_config]})
serve.run(app, blocking=True)
```

Engine instantiation (in Ray library code):
```
# ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
        engine = vllm.v1.engine.async_llm.AsyncLLM(
            vllm_config=vllm_config,
            executor_class=executor_class,
            log_stats=not engine_args.disable_log_stats,
            stat_loggers=custom_stat_loggers,
        )
```

vLLM version
```
$ vllm --version
INFO 05-23 17:46:09 [__init__.py:239] Automatically detected platform cuda.
0.8.5
```

Stack trace:
```
(ServeController pid=23528) ERROR 2025-05-23 17:22:55,206 controller 23528 -- Exception in Replica(id='xw3xulcb', deployment='LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite', app='default'), the replica will be stopped.
(ServeController pid=23528) Traceback (most recent call last):
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/deployment_state.py", line 706, in check_ready
(ServeController pid=23528)     ) = ray.get(self._ready_obj_ref)
(ServeController pid=23528)         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
(ServeController pid=23528)     return fn(*args, **kwargs)
(ServeController pid=23528)            ^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
(ServeController pid=23528)     return func(*args, **kwargs)
(ServeController pid=23528)            ^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 2847, in get
(ServeController pid=23528)     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
(ServeController pid=23528)                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 935, in get_objects
(ServeController pid=23528)     raise value.as_instanceof_cause()
(ServeController pid=23528) ray.exceptions.RayTaskError(RuntimeError): ray::ServeReplica:default:LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite.initialize_and_get_metadata() (pid=43533, ip=10.0.142.45, actor_id=6ce6feffc8bd96da66334d5a02000000, repr=<ray.serve._private.replica.ServeReplica:default:LLMDeploymentdeepseek-ai--DeepSeek-V2-Lite object at 0x7e61c4162f10>)
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 449, in result
(ServeController pid=23528)     return self.__get_result()
(ServeController pid=23528)            ^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
(ServeController pid=23528)     raise self._exception
(ServeController pid=23528)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 997, in initialize_and_get_metadata
(ServeController pid=23528)     await self._replica_impl.initialize(deployment_config)
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 718, in initialize
(ServeController pid=23528)     raise RuntimeError(traceback.format_exc()) from None
(ServeController pid=23528) RuntimeError: Traceback (most recent call last):
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 691, in initialize
(ServeController pid=23528)     self._user_callable_asgi_app = await asyncio.wrap_future(
(ServeController pid=23528)                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1414, in initialize_callable
(ServeController pid=23528)     await self._call_func_or_gen(
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1360, in _call_func_or_gen
(ServeController pid=23528)     result = await result
(ServeController pid=23528)              ^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 443, in __init__
(ServeController pid=23528)     await asyncio.wait_for(self._start_engine(), timeout=ENGINE_START_TIMEOUT_S)
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/asyncio/tasks.py", line 489, in wait_for
(ServeController pid=23528)     return fut.result()
(ServeController pid=23528)            ^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 489, in _start_engine
(ServeController pid=23528)     await self.engine.start()
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 280, in start
(ServeController pid=23528)     self.engine = await self._start_engine()
(ServeController pid=23528)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 337, in _start_engine
(ServeController pid=23528)     return await self._start_engine_v1()
(ServeController pid=23528)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 405, in _start_engine_v1
(ServeController pid=23528)     return self._start_async_llm_engine(
(ServeController pid=23528)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 530, in _start_async_llm_engine
(ServeController pid=23528)     engine = vllm.engine.async_llm_engine.AsyncLLMEngine(
(ServeController pid=23528)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 118, in __init__
(ServeController pid=23528)     self.engine_core = core_client_class(
(ServeController pid=23528)                        ^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 642, in __init__
(ServeController pid=23528)     super().__init__(
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 394, in __init__
(ServeController pid=23528)     self._init_core_engines(vllm_config, new_core_engine,
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 450, in _init_core_engines
(ServeController pid=23528)     core_engine = new_core_engine(
(ServeController pid=23528)                   ^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 389, in <lambda>
(ServeController pid=23528)     new_core_engine = lambda index, local_dp_rank=None: CoreEngine(
(ServeController pid=23528)                                                         ^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 274, in __init__
(ServeController pid=23528)     self.proc_handle = BackgroundProcHandle(
(ServeController pid=23528)                        ^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/utils.py", line 122, in __init__
(ServeController pid=23528)     self.proc.start()
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/process.py", line 121, in start
(ServeController pid=23528)     self._popen = self._Popen(self)
(ServeController pid=23528)                   ^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/context.py", line 288, in _Popen
(ServeController pid=23528)     return Popen(process_obj)
(ServeController pid=23528)            ^^^^^^^^^^^^^^^^^^
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 32, in __init__
(ServeController pid=23528)     super().__init__(process_obj)
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_fork.py", line 19, in __init__
(ServeController pid=23528)     self._launch(process_obj)
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 47, in _launch
(ServeController pid=23528)     reduction.dump(process_obj, fp)
(ServeController pid=23528)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/reduction.py", line 60, in dump
(ServeController pid=23528)     ForkingPickler(file, protocol).dump(obj)
(ServeController pid=23528) _pickle.PicklingError: Can't pickle <class 'transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek.DeepseekV2Config'>: it's not the same object as transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek.DeepseekV2Config
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing/overview.html>** (anything written below this line will be removed by GitHub Actions)
