### PR TITLE
[BugFix] Fix import error for fused_moe

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -41,6 +41,7 @@ if current_platform.is_cuda_alike():
         from .pplx_prepare_finalize import PplxPrepareAndFinalize
 else:
     fused_experts = None  # type: ignore
+    FusedMoEPermuteExpertsUnpermute = None  # type: ignore
     FusedMoEPrepareAndFinalize = None  # type: ignore
 if is_rocm_aiter_moe_enabled():
     from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (  # noqa: E501


### PR DESCRIPTION
Like https://github.com/vllm-project/vllm/issues/18178, the global variable should be alway available, otherwise `NameError` will be raised on non-cuda platform. 

This bug is introduced by https://github.com/vllm-project/vllm/commit/6a7988c55bb0a54240f479033313eb98344e6431  , so this fix should be included in 0.9 release as well.