### PR TITLE
[Frontend] improve vllm serve --help display

### DIFF
--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -9,7 +9,7 @@ import vllm.entrypoints.cli.collect_env
 import vllm.entrypoints.cli.openai
 import vllm.entrypoints.cli.serve
 import vllm.version
-from vllm.entrypoints.utils import cli_env_setup
+from vllm.entrypoints.utils import VLLM_SERVE_PARSER_EPILOG, cli_env_setup
 from vllm.utils import FlexibleArgumentParser
 
 CMD_MODULES = [
@@ -32,7 +32,10 @@ def register_signal_handlers():
 def main():
     cli_env_setup()
 
-    parser = FlexibleArgumentParser(description="vLLM CLI")
+    parser = FlexibleArgumentParser(
+        description="vLLM CLI",
+        epilog=VLLM_SERVE_PARSER_EPILOG,
+    )
     parser.add_argument('-v',
                         '--version',
                         action='version',

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -11,6 +11,8 @@ from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.openai.api_server import run_server
 from vllm.entrypoints.openai.cli_args import (make_arg_parser,
                                               validate_parsed_serve_args)
+from vllm.entrypoints.utils import (VLLM_SERVE_PARSER_EPILOG,
+                                    show_filtered_argument_or_group_from_help)
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import FlexibleArgumentParser, get_tcp_uri
@@ -77,7 +79,10 @@ class ServeSubcommand(CLISubcommand):
             "https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#cli-reference"
         )
 
-        return make_arg_parser(serve_parser)
+        serve_parser = make_arg_parser(serve_parser)
+        show_filtered_argument_or_group_from_help(serve_parser)
+        serve_parser.epilog = VLLM_SERVE_PARSER_EPILOG
+        return serve_parser
 
 
 def cmd_init() -> list[CLISubcommand]:

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -33,7 +33,8 @@ import uuid
 import warnings
 import weakref
 from argparse import (Action, ArgumentDefaultsHelpFormatter, ArgumentParser,
-                      ArgumentTypeError, _ArgumentGroup)
+                      ArgumentTypeError, RawDescriptionHelpFormatter,
+                      _ArgumentGroup)
 from asyncio import FIRST_COMPLETED, AbstractEventLoop, Task
 from collections import UserDict, defaultdict
 from collections.abc import (AsyncGenerator, Awaitable, Generator, Hashable,
@@ -1323,7 +1324,8 @@ class StoreBoolean(Action):
                              "Expected 'true' or 'false'.")
 
 
-class SortedHelpFormatter(ArgumentDefaultsHelpFormatter):
+class SortedHelpFormatter(ArgumentDefaultsHelpFormatter,
+                          RawDescriptionHelpFormatter):
     """SortedHelpFormatter that sorts arguments by their option strings."""
 
     def _split_lines(self, text, width):


### PR DESCRIPTION
For `vllm serve --help`, there are about `180 arguments` and about `800 lines` for the output.
Seems it is not a good experience to view, try to introduce a search/list function from help to improve this.

From:
```
$ vllm serve --help
usage: vllm serve [model_tag] [options]

Start the vLLM OpenAI Compatible API server.

positional arguments:
  model_tag             The model tag to serve (optional if specified in config) (default: None)

options:
  --allow-credentials   Allow credentials. (default: False)
  --allowed-headers ALLOWED_HEADERS
                        Allowed headers. (default: ['*'])
  --allowed-methods ALLOWED_METHODS
                        Allowed methods. (default: ['*'])
  --allowed-origins ALLOWED_ORIGINS
                        Allowed origins. (default: ['*'])
  --api-key API_KEY     If provided, the server will require this key to be presented in the
                        header. (default: None)
  --chat-template CHAT_TEMPLATE
                        The file path to the chat template, or the template in single-line form
                        for the specified model. (default: None)
  --chat-template-content-format {auto,string,openai}
                        The format to render message content within a chat template.
                        * "string" will render the content as a string. Example: ``"Hello World"``
                        * "openai" will render the content as a list of dictionaries, similar to
                        OpenAI schema. Example: ``[{"type": "text", "text": "Hello world!"}]``
                        (default: auto)
  --config CONFIG       Read CLI options from a config file.Must be a YAML with the following opti
                        ons:https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#c
                        li-reference (default: )
  --data-parallel-start-rank DATA_PARALLEL_START_RANK, -dpr DATA_PARALLEL_START_RANK
                        Starting data parallel rank for secondary nodes. (default: 0)
  --disable-fastapi-docs
                        Disable FastAPI's OpenAPI schema, Swagger UI, and ReDoc endpoint.
                        (default: False)
  --disable-frontend-multiprocessing
                        If specified, will run the OpenAI frontend server in the same process as
                        the model serving engine. (default: False)
.....

$ vllm serve --help | wc -l
     892

$ vllm serve --help | grep "\-\-" | wc -l
     187
```

To:
```
$ vllm --help
vLLM CLI

positional arguments:
  {chat,complete,serve,bench,collect-env}
    chat                Generate chat completions via the running API server.
    complete            Generate text completions based on the given prompt via the running API
                        server.
    serve               Start the vLLM OpenAI Compatible API server.
    bench               vLLM bench subcommand.
    collect-env         Start collecting environment information.

options:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit

Tip: Use `vllm serve --help=<keyword>` to explore arguments from help.
   - To view a argument group:     --help=ModelConfig
   - To view a single argument:    --help=max-num-seqs
   - To search by keyword:         --help=max
   - To list all groups:           --help=listgroup

$ vllm serve --help=listgroup
Available argument groups:
  - options

  - ModelConfig
    Configuration for the model.

  - LoadConfig
    Configuration for loading the model weights.

  - DecodingConfig
    Dataclass which contains the decoding strategy of the engine.

  - ParallelConfig
    Configuration for the distributed execution.

  - CacheConfig
    Configuration for the KV cache.

  - TokenizerPoolConfig
    This config is deprecated and will be removed in a future release.

    Passing these parameters will have no effect. Please remove them from your
    configurations.

  - MultiModalConfig
    Controls the behavior of multimodal models.

  - LoRAConfig
    Configuration for LoRA.

  - PromptAdapterConfig
    Configuration for PromptAdapters.

  - DeviceConfig
    Configuration for the device to use for vLLM execution.

  - SpeculativeConfig
    Configuration for speculative decoding.

  - ObservabilityConfig
    Configuration for observability - metrics and tracing.

  - SchedulerConfig
    Scheduler configuration.

  - VllmConfig
    Dataclass which contains all vllm-related configuration. This
    simplifies passing around the distinct configurations in the codebase.


$ vllm serve --help=ObservabilityConfig
ObservabilityConfig:
  Configuration for observability - metrics and tracing.

  --collect-detailed-traces {all,model,worker,None} [{all,model,worker,None} ...]
                        It makes sense to set this only if `--otlp-traces-endpoint` is set. If
                        set, it will collect detailed traces for the specified modules. This
                        involves use of possibly costly and or blocking operations and hence might
                        have a performance impact.
                        Note that collecting detailed timing information for each request can be
                        expensive. (default: None)
  --otlp-traces-endpoint OTLP_TRACES_ENDPOINT
                        Target URL to which OpenTelemetry traces will be sent. (default: None)
  --show-hidden-metrics-for-version SHOW_HIDDEN_METRICS_FOR_VERSION
                        Enable deprecated Prometheus metrics that have been hidden since the
                        specified version. For example, if a previously deprecated metric has been
                        hidden since the v0.7.0 release, you use `--show-hidden-metrics-for-
                        version=0.7` as a temporary escape hatch while you migrate to new metrics.
                        The metric is likely to be removed completely in an upcoming release.
                        (default: None)

$ vllm serve --help=max
Parameters matching 'max':

--max-cpu-loras MAX_CPU_LORAS
                        Maximum number of LoRAs to store in CPU memory. Must be >= than
                        `max_loras`. (default: None)
--max-log-len MAX_LOG_LEN
                        Max number of prompt characters or prompt ID numbers being printed in log.
                        The default of None means unlimited. (default: None)
--max-logprobs MAX_LOGPROBS
                        Maximum number of log probabilities to return when `logprobs` is specified
                        in `SamplingParams`. The default value comes the default for the OpenAI
                        Chat Completions API. (default: 20)
--max-long-partial-prefills MAX_LONG_PARTIAL_PREFILLS
                        For chunked prefill, the maximum number of prompts longer than
                        long_prefill_token_threshold that will be prefilled concurrently. Setting
                        this less than max_num_partial_prefills will allow shorter prompts to jump
                        the queue in front of longer prompts in some cases, improving latency.
                        (default: 1)
--max-lora-rank MAX_LORA_RANK
                        Max LoRA rank. (default: 16)
--max-loras MAX_LORAS   Max number of LoRAs in a single batch. (default: 1)
```

