### PR TITLE
[Misc] Fixed the abnormally high TTFT issue in the PD disaggregation example

### DIFF
--- a/examples/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py
+++ b/examples/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py
@@ -135,7 +135,7 @@ async def handle_completions(request: Request):
                 yield chunk
 
         return StreamingResponse(generate_stream(),
-                                 media_type="application/json")
+                                 media_type="text/event-stream")
 
     except Exception as e:
         import sys
@@ -172,7 +172,7 @@ async def handle_chat_completions(request: Request):
                 yield chunk
 
         return StreamingResponse(generate_stream(),
-                                 media_type="application/json")
+                                 media_type="text/event-stream")
 
     except Exception as e:
         import sys


### PR DESCRIPTION
The response in the decode phase is not set to the event-stream format, resulting in an abnormally high TTFT. even when the load is very low (for example, concurrency is 1). The reason is that all tokens are returned together.
**Before Fix**
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/a7747222-7688-42ee-9cb4-e07d8481df66" />

**After Fix**
<img width="845" alt="image" src="https://github.com/user-attachments/assets/f9be7ecf-fdad-407e-8413-246b09c8e10b" />

**Reproduce script**
```bash
#/bin/bash
model="/vllm-workspace/models/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic"
 
# Input sequence length.
isl=3000
# Output sequence length.
osl=150
 
# Concurrency levels to test.
for concurrency in 1; do
 
  genai-perf profile \
    --model ${model} \
    --tokenizer ${model} \
    --service-kind openai \
    --endpoint-type chat \
    --endpoint v1/chat/completions \
    --streaming \
    --url http://localhost:9000 \
    --synthetic-input-tokens-mean ${isl} \
    --synthetic-input-tokens-stddev 0 \
    --output-tokens-mean ${osl} \
    --output-tokens-stddev 0 \
    --extra-inputs max_tokens:${osl} \
    --extra-inputs min_tokens:${osl} \
    --extra-inputs ignore_eos:true \
    --concurrency ${concurrency} \
    --request-count $(($concurrency*10)) \
    --warmup-request-count $(($concurrency*2)) \
    --num-dataset-entries $(($concurrency*12)) \
    --random-seed 100 \
    -- \
    -v \
    --max-threads 256 \
    -H 'Authorization: Bearer NOT USED' \
    -H 'Accept: text/event-stream'
 
done
```


<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing/overview.html>** (anything written below this line will be removed by GitHub Actions)
