### PR TITLE
[Model] Add support for Qwen2.5-Omni-7B-AWQ (Qwen2_5OmniForConditionalGeneration)

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -398,6 +398,8 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "Qwen2_5_VLForConditionalGeneration": _HfExamplesInfo("Qwen/Qwen2.5-VL-3B-Instruct"),  # noqa: E501
     "Qwen2_5OmniModel": _HfExamplesInfo("Qwen/Qwen2.5-Omni-3B",
                                         min_transformers_version="4.52"),
+    "Qwen2_5OmniForConditionalGeneration": _HfExamplesInfo("Qwen/Qwen2.5-Omni-7B-AWQ",  # noqa: E501
+                                        min_transformers_version="4.52"),
     "SkyworkR1VChatModel": _HfExamplesInfo("Skywork/Skywork-R1V-38B"),
     "SmolVLMForConditionalGeneration": _HfExamplesInfo("HuggingFaceTB/SmolVLM2-2.2B-Instruct"),  # noqa: E501
     "UltravoxModel": _HfExamplesInfo("fixie-ai/ultravox-v0_5-llama-3_2-1b",  # noqa: E501

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -208,6 +208,7 @@ _MULTIMODAL_MODELS = {
     "Qwen2_5_VLForConditionalGeneration": ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),  # noqa: E501
     "Qwen2AudioForConditionalGeneration": ("qwen2_audio", "Qwen2AudioForConditionalGeneration"),  # noqa: E501
     "Qwen2_5OmniModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
+    "Qwen2_5OmniForConditionalGeneration": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),
     "UltravoxModel": ("ultravox", "UltravoxModel"),
     "Phi4MMForCausalLM": ("phi4mm", "Phi4MMForCausalLM"),
     # [Encoder-decoder]

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -208,7 +208,7 @@ _MULTIMODAL_MODELS = {
     "Qwen2_5_VLForConditionalGeneration": ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),  # noqa: E501
     "Qwen2AudioForConditionalGeneration": ("qwen2_audio", "Qwen2AudioForConditionalGeneration"),  # noqa: E501
     "Qwen2_5OmniModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
-    "Qwen2_5OmniForConditionalGeneration": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),
+    "Qwen2_5OmniForConditionalGeneration": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
     "UltravoxModel": ("ultravox", "UltravoxModel"),
     "Phi4MMForCausalLM": ("phi4mm", "Phi4MMForCausalLM"),
     # [Encoder-decoder]


### PR DESCRIPTION
According to the description and settings of [Issue 18516](https://github.com/vllm-project/vllm/issues/18516)

First, reproduce the issue:
```
INFO 05-23 20:10:40 [api_server.py:246] Started engine process with PID 4024
DEBUG 05-23 20:10:40 [__init__.py:28] No plugins for group vllm.general_plugins found.
INFO 05-23 20:10:40 [llm_engine.py:240] Initializing a V0 LLM engine (v0.8.5) with config: model='/models/Qwen2.5-Omni-7B-AWQ', speculative_config=None, tokenizer='/models/Qwen2.5-Omni-7B-AWQ', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.float16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=awq_marlin, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=Qwen2.5-Omni-7B, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=True, 
INFO 05-23 20:10:40 [cuda.py:292] Using Flash Attention backend.
DEBUG 05-23 20:10:40 [config.py:4110] enabled custom ops: Counter()
DEBUG 05-23 20:10:40 [config.py:4112] disabled custom ops: Counter()
DEBUG 05-23 20:10:41 [parallel_state.py:867] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.12.9.2:58925 backend=nccl
INFO 05-23 20:10:41 [parallel_state.py:1004] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0
DEBUG 05-23 20:10:41 [config.py:4110] enabled custom ops: Counter()
DEBUG 05-23 20:10:41 [config.py:4112] disabled custom ops: Counter()
INFO 05-23 20:10:41 [model_runner.py:1108] Starting to load model /models/Qwen2.5-Omni-7B-AWQ...
WARNING 05-23 20:10:41 [utils.py:35] ttt <vllm.config.ModelConfig object at 0x7f87371943e0> ttt ['Qwen2_5OmniThinkerForConditionalGeneration'] 
ERROR 05-23 20:10:41 [engine.py:448] Qwen2_5OmniThinkerForConditionalGeneration has no vLLM implementation and the Transformers implementation is not compatible with vLLM. Try setting VLLM_USE_V1=0.
```

Comparing to the output of Qwen2.5-Omni-7B:
```
INFO 05-23 21:09:52 [api_server.py:1043] vLLM API server version 0.8.5
INFO 05-23 21:09:52 [api_server.py:1044] args: Namespace(subparser='serve', model_tag=None, config='', host=None, port=8000, uvicorn_log_level='info', disable_uvicorn_access_log=False, allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template=None, chat_template_content_format='auto', response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, enable_ssl_refresh=False, ssl_cert_reqs=0, root_path=None, middleware=[], return_tokens_as_token_ids=False, disable_frontend_multiprocessing=False, enable_request_id_headers=False, enable_auto_tool_choice=True, tool_call_parser='hermes', tool_parser_plugin='', model='/models/Qwen2.5-Omni-7B', task='auto', tokenizer=None, hf_config_path=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=True, allowed_local_media_path=None, load_format='auto', download_dir=None, model_loader_extra_config={}, use_tqdm_on_load=True, config_format=<ConfigFormat.AUTO: 'auto'>, dtype='auto', max_model_len=32768, guided_decoding_backend='xgrammar', reasoning_parser=None, logits_processor_pattern=None, model_impl='auto', distributed_executor_backend=None, pipeline_parallel_size=1, tensor_parallel_size=1, data_parallel_size=1, enable_expert_parallel=False, max_parallel_loading_workers=None, ray_workers_use_nsight=False, disable_custom_all_reduce=False, block_size=None, gpu_memory_utilization=0.9, swap_space=4, kv_cache_dtype='auto', num_gpu_blocks_override=None, enable_prefix_caching=None, prefix_caching_hash_algo='builtin', cpu_offload_gb=0, calculate_kv_scales=False, disable_sliding_window=False, use_v2_block_manager=True, seed=None, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, hf_token=None, hf_overrides=None, enforce_eager=False, max_seq_len_to_capture=8192, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config={}, limit_mm_per_prompt={}, mm_processor_kwargs=None, disable_mm_preprocessor_cache=False, enable_lora=None, enable_lora_bias=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=None, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', speculative_config=None, ignore_patterns=[], served_model_name=['Qwen2.5-Omni-7B'], qlora_adapter_name_or_path=None, show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, disable_async_output_proc=False, max_num_batched_tokens=None, max_num_seqs=None, max_num_partial_prefills=1, max_long_partial_prefills=1, long_prefill_token_threshold=0, num_lookahead_slots=0, scheduler_delay_factor=0.0, preemption_mode=None, num_scheduler_steps=1, multi_step_stream_outputs=True, scheduling_policy='fcfs', enable_chunked_prefill=None, disable_chunked_mm_input=False, scheduler_cls='vllm.core.scheduler.Scheduler', override_neuron_config=None, override_pooler_config=None, compilation_config=None, kv_transfer_config=None, worker_cls='auto', worker_extension_cls='', generation_config='auto', override_generation_config=None, enable_sleep_mode=False, additional_config=None, enable_reasoning=False, disable_cascade_attn=False, disable_log_requests=False, max_log_len=None, disable_fastapi_docs=False, enable_prompt_tokens_details=False, enable_server_load_tracking=False, dispatch_function=<function ServeSubcommand.cmd at 0x7f1205e74540>)
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section'}
INFO 05-23 21:09:52 [config.py:2968] Downcasting torch.float32 to torch.float16.
INFO 05-23 21:10:00 [config.py:717] This model supports multiple tasks: {'classify', 'reward', 'embed', 'generate', 'score'}. Defaulting to 'generate'.
DEBUG 05-23 21:10:00 [api_server.py:223] Multiprocessing frontend to use ipc:///tmp/c54cff6c-9ce2-4fe1-9d14-080c94234fa3 for IPC Path.
DEBUG 05-23 21:10:03 [__init__.py:28] No plugins for group vllm.platform_plugins found.
DEBUG 05-23 21:10:03 [__init__.py:34] Checking if TPU platform is available.
DEBUG 05-23 21:10:03 [__init__.py:44] TPU platform is not available because: No module named 'libtpu'
DEBUG 05-23 21:10:03 [__init__.py:52] Checking if CUDA platform is available.
DEBUG 05-23 21:10:03 [__init__.py:72] Confirmed CUDA platform is available.
DEBUG 05-23 21:10:03 [__init__.py:100] Checking if ROCm platform is available.
DEBUG 05-23 21:10:03 [__init__.py:114] ROCm platform is not available because: No module named 'amdsmi'
DEBUG 05-23 21:10:03 [__init__.py:122] Checking if HPU platform is available.
DEBUG 05-23 21:10:03 [__init__.py:129] HPU platform is not available because habana_frameworks is not found.
DEBUG 05-23 21:10:03 [__init__.py:140] Checking if XPU platform is available.
DEBUG 05-23 21:10:03 [__init__.py:150] XPU platform is not available because: No module named 'intel_extension_for_pytorch'
DEBUG 05-23 21:10:03 [__init__.py:158] Checking if CPU platform is available.
DEBUG 05-23 21:10:03 [__init__.py:180] Checking if Neuron platform is available.
DEBUG 05-23 21:10:03 [__init__.py:187] Neuron platform is not available because: No module named 'transformers_neuronx'
DEBUG 05-23 21:10:03 [__init__.py:52] Checking if CUDA platform is available.
DEBUG 05-23 21:10:03 [__init__.py:72] Confirmed CUDA platform is available.
INFO 05-23 21:10:03 [__init__.py:239] Automatically detected platform cuda.
INFO 05-23 21:10:06 [api_server.py:246] Started engine process with PID 4413
```

We can see model configurations are totally same except AWQ, which means it just because the arch isn't regonized by vllm.
So add the arch Qwen2_5OmniForConditionalGeneration into registry.py to try.
And it succeeds.
```
INFO 05-23 22:22:08 [api_server.py:246] Started engine process with PID 5606
DEBUG 05-23 22:22:08 [__init__.py:28] No plugins for group vllm.general_plugins found.
INFO 05-23 22:22:08 [llm_engine.py:240] Initializing a V0 LLM engine (v0.8.5) with config: model='/models/Qwen2.5-Omni-7B-AWQ', speculative_config=None, tokenizer='/models/Qwen2.5-Omni-7B-AWQ', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.float16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=awq_marlin, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=Qwen2.5-Omni-7B, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=True, 
INFO 05-23 22:22:09 [cuda.py:292] Using Flash Attention backend.
DEBUG 05-23 22:22:09 [config.py:4110] enabled custom ops: Counter()
DEBUG 05-23 22:22:09 [config.py:4112] disabled custom ops: Counter()
DEBUG 05-23 22:22:10 [parallel_state.py:867] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.12.9.2:55737 backend=nccl
INFO 05-23 22:22:10 [parallel_state.py:1004] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0
DEBUG 05-23 22:22:10 [config.py:4110] enabled custom ops: Counter()
DEBUG 05-23 22:22:10 [config.py:4112] disabled custom ops: Counter()
INFO 05-23 22:22:10 [model_runner.py:1108] Starting to load model /models/Qwen2.5-Omni-7B-AWQ...
WARNING 05-23 22:22:10 [utils.py:171] The model class Qwen2_5OmniThinkerForConditionalGeneration has not defined `packed_modules_mapping`, this may lead to incorrect mapping of quantized or ignored modules
WARNING 05-23 22:22:10 [qwen2_5_omni_thinker.py:726] flash_attn is not available, the model may not yield the exactly same result as the transformers implementation in the audio tower part.
WARNING 05-23 22:22:10 [vision.py:93] Current `vllm-flash-attn` has a bug inside vision module, so we use xformers backend instead. You can run `pip install flash-attn` to use flash-attention backend.
INFO 05-23 22:22:10 [config.py:3614] cudagraph sizes specified by model runner [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256] is overridden by config [256, 128, 2, 1, 4, 136, 8, 144, 16, 152, 24, 160, 32, 168, 40, 176, 48, 184, 56, 192, 64, 200, 72, 208, 80, 216, 88, 120, 224, 96, 232, 104, 240, 112, 248]
DEBUG 05-23 22:22:10 [config.py:4110] enabled custom ops: Counter({'rms_norm': 122, 'silu_and_mul': 28, 'rotary_embedding': 1})
DEBUG 05-23 22:22:10 [config.py:4112] disabled custom ops: Counter()
DEBUG 05-23 22:22:10 [config.py:4110] enabled custom ops: Counter({'rms_norm': 122, 'silu_and_mul': 28, 'rotary_embedding': 1})
DEBUG 05-23 22:22:10 [config.py:4112] disabled custom ops: Counter()
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
DEBUG 05-23 22:22:10 [utils.py:237] Skipping missing token2wav
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:00,  4.43it/s]
DEBUG 05-23 22:22:11 [utils.py:156] Loaded weight audio_tower.audio_bos_eos_token.weight with shape torch.Size([2, 3584])
```
