### PR TITLE
fix(regression): clone from reference items

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -1494,7 +1494,7 @@ class ParallelSampleSequenceGroup(SequenceGroupBase):
         for i in range(original_params.n):
             request_id_i = f"{request_id}_parallel_sample_{i}"
             group.seq_id_to_index[request_id_i] = i
-            params = params.clone()
+            params = original_params.clone()
             params.n = 1
             if params.seed is not None:
                 params.seed += i


### PR DESCRIPTION
This PR fixes the consistent failure on V1 tests where we clone the deference original_params within the add_request loop.

fixes #18656

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
