### PR TITLE
[BugFix][Spec Decode] Improve Prefix Caching Logic in Speculative Decoding

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -174,6 +174,7 @@ class KVCacheManager:
         num_new_tokens: int,
         num_new_computed_tokens: int = 0,
         new_computed_blocks: Optional[KVCacheBlocks] = None,
+        num_draft_tokens: int = 0,
         num_lookahead_tokens: int = 0,
         delay_cache_blocks: bool = False,
     ) -> Optional[KVCacheBlocks]:
@@ -273,7 +274,7 @@ class KVCacheManager:
         # generated (accepted) tokens.
         self.single_type_manager.cache_blocks(
             request, self.req_to_block_hashes[request.request_id],
-            num_computed_tokens + num_new_tokens - len(request.spec_token_ids))
+            num_computed_tokens + num_new_tokens - num_draft_tokens)
 
         return KVCacheBlocks(new_blocks)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -227,9 +227,9 @@ class Scheduler(SchedulerInterface):
                 req_index += 1
                 continue
 
-            num_draft_tokens = (num_new_tokens + request.num_computed_tokens -
-                                request.num_tokens)
-            assert num_draft_tokens >= 0
+            num_draft_tokens = max(
+                num_new_tokens + request.num_computed_tokens -
+                request.num_tokens, 0)
 
             while True:
                 new_blocks = self.kv_cache_manager.allocate_slots(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -227,10 +227,15 @@ class Scheduler(SchedulerInterface):
                 req_index += 1
                 continue
 
+            num_draft_tokens = (num_new_tokens + request.num_computed_tokens -
+                                request.num_tokens)
+            assert num_draft_tokens >= 0
+
             while True:
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     num_new_tokens,
+                    num_draft_tokens=num_draft_tokens,
                     num_lookahead_tokens=self.num_lookahead_tokens)
                 if new_blocks is None:
                     # The request cannot be scheduled.


### PR DESCRIPTION
Currently, prefix caching is inaccurate (too conservative) during speculative decoding.
This PR updates the logic to use `num_draft_tokens` (the actual number of scheduled draft tokens) instead of `len(spec_token_ids)`, which may include unscheduled draft tokens.