### PR TITLE
[Bugfix] Fix cpu usage and cache hit stats reporting on cpu environment

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1664,7 +1664,7 @@ class LLMEngine:
 
         # Exchange the uasge and cache hit stats between gpu and cpu when
         # running on cpu because the cpu_work.py intentionally reports the
-        # number of cpu blocks as gpu blockers in favor of cache management.
+        # number of cpu blocks as gpu blocks in favor of cache management.
         if self.device_config.device_type == "cpu":
             num_total_gpu, num_total_cpu = num_total_cpu, num_total_gpu
             gpu_cache_usage_sys, cpu_cache_usage_sys = (

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1663,9 +1663,8 @@ class LLMEngine:
             0].get_prefix_cache_hit_rate(Device.GPU)
 
         # Exchange the uasge and cache hit stats between gpu and cpu when
-        # running on cpu because the cpu worker intentionally reports the
+        # running on cpu because the cpu_work.py intentionally reports the
         # number of cpu blocks as gpu blockers in favor of cache management.
-        # See https://github.com/vllm-project/vllm/blob/b554ab736e7c725bf7ddebb80b814e6c53232b46/vllm/worker/cpu_worker.py#L253-L257
         if self.device_config.device_type == "cpu":
             num_total_gpu, num_total_cpu = num_total_cpu, num_total_gpu
             gpu_cache_usage_sys, cpu_cache_usage_sys = (

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1662,6 +1662,21 @@ class LLMEngine:
         gpu_prefix_cache_hit_rate = self.scheduler[
             0].get_prefix_cache_hit_rate(Device.GPU)
 
+        # Exchange the uasge and cache hit stats between gpu and cpu when
+        # running on cpu because the cpu worker intentionally reports the
+        # number of cpu blocks as gpu blockers in favor of cache management.
+        # See https://github.com/vllm-project/vllm/blob/b554ab736e7c725bf7ddebb80b814e6c53232b46/vllm/worker/cpu_worker.py#L253-L257
+        if self.device_config.device_type == "cpu":
+            num_total_gpu, num_total_cpu = num_total_cpu, num_total_gpu
+            gpu_cache_usage_sys, cpu_cache_usage_sys = (
+                cpu_cache_usage_sys,
+                gpu_cache_usage_sys,
+            )
+            gpu_prefix_cache_hit_rate, cpu_prefix_cache_hit_rate = (
+                cpu_prefix_cache_hit_rate,
+                gpu_prefix_cache_hit_rate,
+            )
+
         # Iteration stats
         num_prompt_tokens_iter = 0
         num_generation_tokens_iter = 0

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1663,7 +1663,7 @@ class LLMEngine:
             0].get_prefix_cache_hit_rate(Device.GPU)
 
         # Exchange the uasge and cache hit stats between gpu and cpu when
-        # running on cpu because the cpu_work.py intentionally reports the
+        # running on cpu because the cpu_worker.py intentionally reports the
         # number of cpu blocks as gpu blocks in favor of cache management.
         if self.device_config.device_type == "cpu":
             num_total_gpu, num_total_cpu = num_total_cpu, num_total_gpu


### PR DESCRIPTION
In cpu worker https://github.com/vllm-project/vllm/blob/b554ab736e7c725bf7ddebb80b814e6c53232b46/vllm/worker/cpu_worker.py#L253-L257
the returned num_gpu_blocks is the actual num_cpu_blocks. It's done for simplifying cache management, but the number is incorrectly used in _get_stats and logged. This change fixed the number when generating the stats for logging to avoid confusions.

FIX #17954 (*link existing issues this PR will resolve*)