### PR TITLE
[CI/build] fix no regex

### DIFF
--- a/.github/workflows/cleanup_pr_body.yml
+++ b/.github/workflows/cleanup_pr_body.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3.12 -m pip install --upgrade pip
-          python3.12 -m pip install regex
+          python3 -m pip install --upgrade pip
+          python3 -m pip install regex
 
       - name: Update PR description
         env:

--- a/.github/workflows/cleanup_pr_body.yml
+++ b/.github/workflows/cleanup_pr_body.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install Python dependencies
+        run: |
+          python3.12 -m pip install --upgrade pip
+          python3.12 -m pip install regex
+
       - name: Update PR description
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

For https://github.com/vllm-project/vllm/actions/runs/15235978058/job/42849840987?pr=18666
```
Run bash .github/scripts/cleanup_pr_body.sh "18666"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'regex'
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
