### PR TITLE
[Core][Multimodal] Convert PIL Image to array without data copy when hashing

### DIFF
--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -36,8 +36,8 @@ class MultiModalHasher:
             return np.array(obj).tobytes()
 
         if isinstance(obj, Image.Image):
-            return cls.item_to_bytes("image",
-                                     np.array(convert_image_mode(obj, "RGBA")))
+            return cls.item_to_bytes(
+                "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
             return cls.item_to_bytes("tensor", obj.numpy())
         if isinstance(obj, np.ndarray):

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -164,7 +164,7 @@ class VideoMediaIO(MediaIO[npt.NDArray]):
             )
 
             return np.stack([
-                np.array(load_frame(frame_data))
+                np.asarray(load_frame(frame_data))
                 for frame_data in data.split(",")
             ])
 


### PR DESCRIPTION
This PR favours [`np.asarray`](https://numpy.org/doc/stable/reference/generated/numpy.asarray.html) over `np.array` when converting from `PIL.Image` to an array. This is recommended in [their docs](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.fromarray) as it uses the array interface and doesn't need to copy the data which is faster.
I haven't done any end2end benchmarks since I don't expect any measurable improvements but since this change doesn't reduce readability I think it's still worth having