### PR TITLE
[Bugfix][Benchmarks]Fixed async_request_deepspeed_mii() to get ttft

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -208,36 +208,80 @@ async def async_request_deepspeed_mii(
             "max_tokens": request_func_input.output_len,
             "temperature": 0.01,  # deepspeed-mii does not accept 0.0 temp.
             "top_p": 1.0,
+            "stream": True,
         }
         headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
 
         output = RequestFuncOutput()
         output.prompt_len = request_func_input.prompt_len
 
-        # NOTE: DeepSpeed-MII doesn't support streaming as of Jan 28 2024,
-        # will use 0 as placeholder.
-        # See https://github.com/microsoft/DeepSpeed-MII/pull/311
-        output.ttft = 0
-
+        generated_text = ""
         st = time.perf_counter()
+        most_recent_timestamp = st
+
         try:
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    parsed_resp = await response.json()
-                    output.latency = time.perf_counter() - st
-                    if "choices" in parsed_resp:
-                        output.generated_text = parsed_resp["choices"][0]["text"]
-                    elif "text" in parsed_resp:
-                        output.generated_text = parsed_resp["text"][0]
+                    first_chunk_received = False
+                    async for chunk_bytes in response.content:
+                        chunk_bytes = chunk_bytes.strip()
+                        if not chunk_bytes:
+                            continue
+
+                        chunk = chunk_bytes.decode("utf-8").removeprefix("data: ")
+                        if chunk != "[DONE]":
+                            data = json.loads(chunk)
+
+                            # NOTE: Some completion API might have a last
+                            # usage summary response without a token so we
+                            # want to check a token was generated
+                            if choices := data.get("choices"):
+                                # Note that text could be empty here
+                                # e.g. for special tokens
+                                text = choices[0].get("text")
+                                timestamp = time.perf_counter()
+                                # First token
+                                if not first_chunk_received:
+                                    first_chunk_received = True
+                                    ttft = time.perf_counter() - st
+                                    output.ttft = ttft
+
+                                # Decoding phase
+                                else:
+                                    output.itl.append(timestamp - most_recent_timestamp)
+                                most_recent_timestamp = timestamp
+                                generated_text += text or ""
+
+                            # Note that leaving this because of compatibility concerns
+                            # with older versions of DeepSpeed-MII
+                            # But it's probably okay to delete it.
+                            elif text := data.get("text"):
+                                # Note that text could be empty here
+                                # e.g. for special tokens
+                                timestamp = time.perf_counter()
+                                # First token
+                                if not first_chunk_received:
+                                    first_chunk_received = True
+                                    ttft = time.perf_counter() - st
+                                    output.ttft = ttft
+                                else:
+                                    output.itl.append(timestamp - most_recent_timestamp)
+                                most_recent_timestamp = timestamp
+                                generated_text += text or ""
+                            elif usage := data.get("usage"):
+                                output.output_tokens = usage.get("completion_tokens")
+                    if first_chunk_received:
+                        output.success = True
                     else:
-                        output.error = (
-                            "Unexpected response format: "
-                            "neither 'choices' nor 'text' found"
-                        )
                         output.success = False
-                    output.success = True
+                        output.error = (
+                            "Never received a valid chunk to calculate TTFT."
+                            "This response will be marked as failed!"
+                        )
+                    output.generated_text = generated_text
+                    output.latency = most_recent_timestamp - st
                 else:
                     output.error = response.reason or ""
                     output.success = False


### PR DESCRIPTION
Fixed async_request_deepspeed_mii() to get ttft and itl.

In addition, keeping up with the latest implementation by porting from async_request_openai_completions().

The parts fixed in #15926 patch remain.

#### How to reproduce and logs before and after the fix.

- Starting DeepSpeed-MII server
```
$ python -m mii.entrypoints.openai_api_server --model meta-llama/Meta-Llama-3-8B --port 8000 --api-keys testabc
```

- Running benchmark client with patched and unpatched source code
```
$ export OPENAI_API_KEY=testabc
$ python vllm/benchmarks/benchmark_serving.py --dataset-name sharegpt --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json --model meta-llama/Meta-Llama-3-8B --num_prompts 500 --request-rate 4 --port 8000 --backend deepspeed-mii
```

- logs with unpatched
============ Serving Benchmark Result ============
Successful requests:                     500       
Benchmark duration (s):                  133.74    
Total input tokens:                      100895    
Total generated tokens:                  65786     
Request throughput (req/s):              3.74      
Output token throughput (tok/s):         491.88    
Total Token throughput (tok/s):          1246.27   
---------------Time to First Token----------------
Mean TTFT (ms):                          0.00      
Median TTFT (ms):                        0.00      
P99 TTFT (ms):                           0.00      
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.71     
Median TPOT (ms):                        16.41     
P99 TPOT (ms):                           64.58     
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================


- logs with patched
============ Serving Benchmark Result ============
Successful requests:                     500       
Benchmark duration (s):                  169.84    
Total input tokens:                      100895    
Total generated tokens:                  65941     
Request throughput (req/s):              2.94      
Output token throughput (tok/s):         388.25    
Total Token throughput (tok/s):          982.31    
---------------Time to First Token----------------
Mean TTFT (ms):                          274.65    
Median TTFT (ms):                        253.42    
P99 TTFT (ms):                           683.62    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          121.55    
Median TPOT (ms):                        121.70    
P99 TPOT (ms):                           210.64    
---------------Inter-token Latency----------------
Mean ITL (ms):                           120.79    
Median ITL (ms):                         119.88    
P99 ITL (ms):                            243.75    
==================================================
</details>
