### PR TITLE
[Misc][Tools][Benchmark] Add benchmark_serving supports for llama.cpp. 

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -324,7 +324,7 @@ async def async_request_openai_completions(
 
                                 most_recent_timestamp = timestamp
                                 generated_text += text or ""
-                            elif usage := data.get("usage"):
+                            if usage := data.get("usage"):
                                 output.output_tokens = usage.get("completion_tokens")
                     if first_chunk_received:
                         output.success = True
@@ -611,6 +611,7 @@ ASYNC_REQUEST_FUNCS = {
     "tensorrt-llm": async_request_trt_llm,
     "scalellm": async_request_openai_completions,
     "sglang": async_request_openai_completions,
+    "llama.cpp": async_request_openai_completions,
 }
 
 OPENAI_COMPATIBLE_BACKENDS = [

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -762,6 +762,10 @@ def main(args: argparse.Namespace):
     if "temperature" not in sampling_params:
         sampling_params["temperature"] = 0.0  # Default to greedy decoding.
 
+    if args.backend == "llama.cpp":
+        # Disable prompt caching in llama.cpp backend
+        sampling_params["cache_prompt"] = False
+
     # Avoid GC processing "static" data - reduce pause times.
     gc.collect()
     gc.freeze()


### PR DESCRIPTION

Support [llama.cpp](https://github.com/ggml-org/llama.cpp) backend in benchmark_serving.py

Below is llama.cpp's streaming output.
```
data: {"choices":[{"text":" culture","index":0,"logprobs":null,"finish_reason":null}],"created":1748230478,"model":"deepseek","system_fingerprint":"b5428-f0adb80b","object":"text_completion","id":"chatcmpl-hYFX7uFFebs6Es7OFjrk1NOM7cmifCSA"}

data: {"choices":[{"text":",","index":0,"logprobs":null,"finish_reason":null}],"created":1748230479,"model":"deepseek","system_fingerprint":"b5428-f0adb80b","object":"text_completion","id":"chatcmpl-hYFX7uFFebs6Es7OFjrk1NOM7cmifCSA"}

data: {"choices":[{"text":"","index":0,"logprobs":null,"finish_reason":"length"}],"created":1748230479,"model":"deepseek","system_fingerprint":"b5428-f0adb80b","object":"text_completion","usage":{"completion_tokens":7,"prompt_tokens":5,"total_tokens":12},"id":"chatcmpl-hYFX7uFFebs6Es7OFjrk1NOM7cmifCSA","timings":{"prompt_n":5,"prompt_ms":1295.52,"prompt_per_token_ms":259.104,"prompt_per_second":3.8594541188094356,"predicted_n":7,"predicted_ms":1910.528,"predicted_per_token_ms":272.9325714285714,"predicted_per_second":3.663908615838135}}

data: [DONE]

```

Below is vllm's.
```
data: {"id":"cmpl-8d90e6f71fcb47beb545746854215344","object":"text_completion","created":1748224040,"model":"deepseek","choices":[{"index":0,"text":" California","logprobs":null,"finish_reason":null,"stop_reason":null}],"usage":{"prompt_tokens":4,"total_tokens":10,"completion_tokens":6}}

data: {"id":"cmpl-8d90e6f71fcb47beb545746854215344","object":"text_completion","created":1748224040,"model":"deepseek","choices":[{"index":0,"text":",","logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":4,"total_tokens":11,"completion_tokens":7}}

data: {"id":"cmpl-8d90e6f71fcb47beb545746854215344","object":"text_completion","created":1748224040,"model":"deepseek","choices":[],"usage":{"prompt_tokens":4,"total_tokens":11,"completion_tokens":7}}                                                                

data: [DONE]
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
