### PR TITLE
[Bugfix]: handle hf-xet CAS error when loading Qwen3 weights in vLLM

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ tqdm
 blake3
 py-cpuinfo
 transformers >= 4.51.1
-huggingface-hub[hf_xet] >= 0.30.0  # Required for Xet downloads.
+huggingface-hub[hf_xet] >= 0.32.0  # Required for Xet downloads.
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.


### PR DESCRIPTION
Qwen3 models on HuggingFace Hub use the Xet-backed storage system. In certain environments, the `hf-xet` downloader may fail with the following error during model weight loading:

    RuntimeError: Data processing error: CAS service error: Error: single flight error:
    Real call failed: CasObjectError(InternalIOError(Custom { kind: Other,
    error: reqwest::Error { kind: Decode, source: hyper::Error(Body,
    Custom { kind: UnexpectedEof, error: IncompleteBody }) } }))

This causes vLLM workers (e.g., rank 1) to crash during `load_model()`.

Refs:
  - https://github.com/huggingface/huggingface_hub/issues/3089


<!--- pyml disable-next-line no-emphasis-as-heading -->
