### PR TITLE
[Model][Gemma3] Simplify image input validation

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -503,26 +503,12 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
     def dtype(self):
         return next(self.parameters()).dtype
 
-    def _validate_pixel_values(self, data: torch.Tensor) -> torch.Tensor:
-        h = w = self.config.vision_config.image_size
-        expected_dims = (3, h, w)
-
-        def _validate_shape(d: torch.Tensor):
-            if d.shape != expected_dims:
-                raise ValueError(
-                    "The expected shape of pixel values per image per batch "
-                    f"is {expected_dims}. You supplied {tuple(d.shape)}.")
-
-        for d in data:
-            _validate_shape(d)
-
-        return data
-
-    def _parse_and_validate_image_input(
-            self, **kwargs: object) -> Optional[Gemma3ImageInputs]:
-        pixel_values = kwargs.pop("pixel_values", None)
-        num_crops = kwargs.pop("num_crops", None)
-        image_embeds = kwargs.pop("image_embeds", None)
+    def _parse_and_validate_image_input(self,
+                                        pixel_values=None,
+                                        num_crops=None,
+                                        image_embeds=None,
+                                        **kwargs
+                                        ) -> Optional[Gemma3ImageInputs]:
         assert image_embeds is None, "Gemma3 does not support image_embeds."
         if pixel_values is None:
             return None
@@ -538,9 +524,16 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
         pixel_values = flatten_bn(pixel_values, concat=True)
         num_crops = flatten_bn(num_crops, concat=True)
 
+        image_size = self.config.vision_config.image_size
+        expected_dims = (3, image_size, image_size)
+        if pixel_values.shape[1:] != expected_dims:
+            raise ValueError(
+                "The expected shape of pixel values per image per batch is "
+                f"{expected_dims}. You supplied {tuple(pixel_values.shape)}.")
+
         return Gemma3ImagePixelInputs(
             type="pixel_values",
-            pixel_values=self._validate_pixel_values(pixel_values),
+            pixel_values=pixel_values,
             num_patches=num_crops + 1,
         )
 


### PR DESCRIPTION
Image input validation in Gemma 3 takes a surprisingly long time:
<img width="701" alt="Screenshot 2025-05-26 at 13 01 01" src="https://github.com/user-attachments/assets/7ddb22d3-e973-4238-af13-62616f8665d6" />

After `flatten_bn(pixel_values, concat=True)` even in V0 `pixel_values` will be tensors so there's no need to handle lists here. So there's no need to iterate over the tensor just to check the shapes, this PR fixes this. 