### PR TITLE
[Doc] Improve API docs

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -18,7 +18,7 @@ nav:
       - Roadmap: https://roadmap.vllm.ai
       - Releases: https://github.com/vllm-project/vllm/releases
   - User Guide:
-    - usage/README.md
+    - Summary: usage/README.md
     - General:
       - usage/*
     - Inference and Serving:
@@ -44,7 +44,7 @@ nav:
       - features/*
       - features/quantization
   - Developer Guide:
-    - contributing/README.md
+    - Summary: contributing/README.md
     - General:
       - glob: contributing/*
         flatten_single_child_sections: true
@@ -53,7 +53,7 @@ nav:
       - V0: design
       - V1: design/v1
   - API Reference:
-    - api/README.md
+    - Summary: api/README.md
     - Contents:
       - glob: api/vllm/*
         preserve_directory_names: true

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -54,8 +54,9 @@ nav:
       - V1: design/v1
   - API Reference:
     - api/README.md
-    - glob: api/vllm/*
-      preserve_directory_names: true
+    - Contents:
+      - glob: api/vllm/*
+        preserve_directory_names: true
   - Community:
     - community/*
     - Blog: https://blog.vllm.ai

--- a/docs/mkdocs/stylesheets/extra.css
+++ b/docs/mkdocs/stylesheets/extra.css
@@ -5,7 +5,7 @@
 }
 
 /* https://christianoliff.com/blog/styling-external-links-with-an-icon-in-css/ */
-a:not(:has(svg)):not(.md-icon) {
+a:not(:has(svg)):not(.md-icon):not(.autorefs-external) {
     align-items: center;
 
     &[href^="//"]::after,


### PR DESCRIPTION
- Add separator between README and the autogenerated API docs
- Remove external link indicator from API links as it unnecessarily lags out the browser and adds clutter