### PR TITLE
[Doc] cleanup deprecated flag for doc

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -146,10 +146,9 @@ python3 vllm/benchmarks/benchmark_serving.py \
 
 ``` bash
 VLLM_USE_V1=1 vllm serve meta-llama/Meta-Llama-3-8B-Instruct \
-    --speculative-model "[ngram]" \
     --ngram_prompt_lookup_min 2 \
     --ngram-prompt-lookup-max 5 \
-    --num_speculative_tokens 5
+    --speculative_config '{"model": "[ngram]", "num_speculative_tokens": 5}
 ```
 
 ``` bash
@@ -274,10 +273,9 @@ python3 vllm/benchmarks/benchmark_throughput.py \
     --output-len=100 \
     --num-prompts=2048 \
     --async-engine \
-    --speculative-model="[ngram]" \
     --ngram_prompt_lookup_min=2 \
     --ngram-prompt-lookup-max=5 \
-    --num_speculative_tokens=5
+    --speculative_config '{"model": "[ngram]", "num_speculative_tokens": 5}
 ```
 
 ```


### PR DESCRIPTION
This PR serves as a follow-up to PRs: https://github.com/vllm-project/vllm/pull/15466, https://github.com/vllm-project/vllm/pull/14434

After refactoring the speculative decoding configuration, there are still deprecated flags present in the documentation. They should be cleaned up.