### PR TITLE
[Core] Enable CUDA graphs for DP + All2All kernels 

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -47,9 +47,7 @@ class DPMetadata:
         return num_tokens_tensor
 
     @staticmethod
-    def make(parallel_config: ParallelConfig,
-             attn_metadata: Union["AttentionMetadata",
-                                  dict[str, "AttentionMetadata"]],
+    def make(parallel_config: ParallelConfig, attn_metadata: Any,
              num_tokens: int) -> "DPMetadata":
 
         assert parallel_config.data_parallel_size > 1

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -47,7 +47,9 @@ class DPMetadata:
         return num_tokens_tensor
 
     @staticmethod
-    def make(parallel_config: ParallelConfig, attn_metadata: AttentionMetadata,
+    def make(parallel_config: ParallelConfig,
+             attn_metadata: Union["AttentionMetadata",
+                                  dict[str, "AttentionMetadata"]],
              num_tokens: int) -> "DPMetadata":
 
         assert parallel_config.data_parallel_size > 1

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -10,7 +10,7 @@ import torch
 import torch.distributed as dist
 
 import vllm.envs as envs
-from vllm.config import VllmConfig
+from vllm.config import ParallelConfig, VllmConfig
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -29,6 +29,44 @@ batchsize_forward_time: defaultdict = defaultdict(list)
 class DPMetadata:
     max_tokens_across_dp_cpu: torch.Tensor
     cu_tokens_across_dp_cpu: torch.Tensor
+
+    @staticmethod
+    def num_tokens_across_dp(num_tokens: int, dp_size: int,
+                             dp_rank: int) -> torch.Tensor:
+        """
+        Gather the num_tokens across all DP ranks and return results in a
+        CPU tensor of size dp_size.
+        """
+        num_tokens_across_dp = [0] * dp_size
+        num_tokens_across_dp[dp_rank] = num_tokens
+        num_tokens_tensor = torch.tensor(num_tokens_across_dp,
+                                         device="cpu",
+                                         dtype=torch.int32)
+        from vllm.distributed.parallel_state import get_dp_group
+        dist.all_reduce(num_tokens_tensor, group=get_dp_group().cpu_group)
+        return num_tokens_tensor
+
+    @staticmethod
+    def make(parallel_config: ParallelConfig, attn_metadata: AttentionMetadata,
+             num_tokens: int) -> "DPMetadata":
+
+        assert parallel_config.data_parallel_size > 1
+        dp_size = parallel_config.data_parallel_size
+        dp_rank = parallel_config.data_parallel_rank
+        if attn_metadata is not None and hasattr(attn_metadata,
+                                                 "num_prefill_tokens"):
+            # for v0 attention backends
+            batchsize = attn_metadata.num_prefill_tokens + \
+                attn_metadata.num_decode_tokens
+        else:
+            # for v1 attention backends or no attn_metadata
+            batchsize = num_tokens
+
+        num_tokens_tensor = DPMetadata.num_tokens_across_dp(
+            batchsize, dp_size, dp_rank)
+        max_tokens_across_dp_cpu = torch.max(num_tokens_tensor)
+        cu_tokens_across_dp_cpu = torch.cumsum(num_tokens_tensor, dim=0)
+        return DPMetadata(max_tokens_across_dp_cpu, cu_tokens_across_dp_cpu)
 
 
 @dataclass
@@ -74,27 +112,8 @@ def set_forward_context(attn_metadata: Any,
         forward_start_time = time.perf_counter()
     dp_metadata: Optional[DPMetadata] = None
     if vllm_config.parallel_config.data_parallel_size > 1:
-        dp_size = vllm_config.parallel_config.data_parallel_size
-        dp_rank = vllm_config.parallel_config.data_parallel_rank
-        if attn_metadata is not None and hasattr(attn_metadata,
-                                                 "num_prefill_tokens"):
-            # for v0 attention backends
-            batchsize = attn_metadata.num_prefill_tokens + \
-                attn_metadata.num_decode_tokens
-        else:
-            # for v1 attention backends or no attn_metadata
-            batchsize = num_tokens
-        num_tokens_across_dp = [0] * dp_size
-        num_tokens_across_dp[dp_rank] = batchsize
-        num_tokens_tensor = torch.tensor(num_tokens_across_dp,
-                                         device="cpu",
-                                         dtype=torch.int32)
-        from vllm.distributed.parallel_state import get_dp_group
-        dist.all_reduce(num_tokens_tensor, group=get_dp_group().cpu_group)
-        max_tokens_across_dp_cpu = torch.max(num_tokens_tensor)
-        cu_tokens_across_dp_cpu = torch.cumsum(num_tokens_tensor, dim=0)
-        dp_metadata = DPMetadata(max_tokens_across_dp_cpu,
-                                 cu_tokens_across_dp_cpu)
+        dp_metadata = DPMetadata.make(vllm_config.parallel_config,
+                                      attn_metadata, num_tokens)
 
     global _forward_context
     prev_context = _forward_context

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1251,8 +1251,10 @@ class FusedMoE(torch.nn.Module):
             hidden_states = full_hidden_states[chunk_start:chunk_end, :]
             router_logits = full_router_logits[chunk_start:chunk_end, :]
 
-            assert self.batched_hidden_states.size(0) >= chunk_size
-            assert self.batched_router_logits.size(0) >= chunk_size
+            assert (self.batched_hidden_states.size(0)
+                    >= chunk_size)  # type: ignore
+            assert (self.batched_router_logits.size(0)
+                    >= chunk_size)  # type: ignore
             staged_hidden_states = self.batched_hidden_states[:
                                                               chunk_size, :]  # type: ignore
             staged_router_logits = self.batched_router_logits[:

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -833,7 +833,7 @@ class FusedMoE(torch.nn.Module):
         # Chunked all2all staging tensor
         self.batched_hidden_states = None
         self.batched_router_logits = None
-        if self.moe_parallel_config.dp_size > 1:
+        if self.moe_parallel_config.use_pplx_kernels:
             self.batched_hidden_states = torch.zeros(
                 (MOE_DP_CHUNK_SIZE, self.hidden_size),
                 dtype=torch.bfloat16,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1251,10 +1251,10 @@ class FusedMoE(torch.nn.Module):
             hidden_states = full_hidden_states[chunk_start:chunk_end, :]
             router_logits = full_router_logits[chunk_start:chunk_end, :]
 
-            assert (self.batched_hidden_states.size(0)
-                    >= chunk_size)  # type: ignore
-            assert (self.batched_router_logits.size(0)
-                    >= chunk_size)  # type: ignore
+            assert (self.batched_hidden_states.size(0)  # type: ignore
+                    >= chunk_size)
+            assert (self.batched_router_logits.size(0)  # type: ignore 
+                    >= chunk_size)
             staged_hidden_states = self.batched_hidden_states[:
                                                               chunk_size, :]  # type: ignore
             staged_router_logits = self.batched_router_logits[:

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -831,8 +831,8 @@ class FusedMoE(torch.nn.Module):
         self.quant_method.create_weights(layer=self, **moe_quant_params)
 
         # Chunked all2all staging tensor
-        self.batched_hidden_states = None
-        self.batched_router_logits = None
+        self.batched_hidden_states: Optional[torch.Tensor] = None
+        self.batched_router_logits: Optional[torch.Tensor] = None
         if self.moe_parallel_config.use_pplx_kernels:
             self.batched_hidden_states = torch.zeros(
                 (MOE_DP_CHUNK_SIZE, self.hidden_size),
@@ -1233,7 +1233,6 @@ class FusedMoE(torch.nn.Module):
 
     def forward_impl_chunked(self, full_hidden_states: torch.Tensor,
                              full_router_logits: torch.Tensor):
-
         assert self.batched_hidden_states is not None
         assert self.batched_router_logits is not None
 

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1238,6 +1238,11 @@ class FusedMoE(torch.nn.Module):
         assert self.batched_router_logits is not None
         assert self.batched_hidden_states.dtype == full_hidden_states.dtype
         assert self.batched_router_logits.dtype == full_router_logits.dtype
+        # Check size compatibility.
+        assert (self.batched_hidden_states.size(-1) ==
+                full_final_hidden_states.size(-1))
+        assert (
+            self.batched_router_logits.size(-1) == full_router_logits.size(-1))
 
         full_final_hidden_states = torch.empty_like(full_hidden_states)
 
@@ -1246,6 +1251,8 @@ class FusedMoE(torch.nn.Module):
             hidden_states = full_hidden_states[chunk_start:chunk_end, :]
             router_logits = full_router_logits[chunk_start:chunk_end, :]
 
+            assert self.batched_hidden_states.size(0) >= chunk_size
+            assert self.batched_router_logits.size(0) >= chunk_size
             staged_hidden_states = self.batched_hidden_states[:
                                                               chunk_size, :]  # type: ignore
             staged_router_logits = self.batched_router_logits[:

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -834,7 +834,7 @@ class FusedMoE(torch.nn.Module):
         self.batched_hidden_states: Optional[torch.Tensor] = None
         self.batched_router_logits: Optional[torch.Tensor] = None
         if self.moe_parallel_config.use_pplx_kernels:
-            act_dtype = torch.get_default_dtype()
+            act_dtype = vllm_config.model_config.dtype
             self.batched_hidden_states = torch.zeros(
                 (MOE_DP_CHUNK_SIZE, self.hidden_size),
                 dtype=act_dtype,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1239,8 +1239,8 @@ class FusedMoE(torch.nn.Module):
         assert self.batched_hidden_states.dtype == full_hidden_states.dtype
         assert self.batched_router_logits.dtype == full_router_logits.dtype
         # Check size compatibility.
-        assert (self.batched_hidden_states.size(-1) ==
-                full_final_hidden_states.size(-1))
+        assert (
+            self.batched_hidden_states.size(-1) == full_hidden_states.size(-1))
         assert (
             self.batched_router_logits.size(-1) == full_router_logits.size(-1))
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -7,9 +7,9 @@ import os
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 
+import torch
 from typing_extensions import ParamSpec
 
-import torch
 # import custom ops, trigger op registration
 import vllm._C  # noqa
 import vllm.envs as envs

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -7,9 +7,9 @@ import os
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 
-import torch
 from typing_extensions import ParamSpec
 
+import torch
 # import custom ops, trigger op registration
 import vllm._C  # noqa
 import vllm.envs as envs
@@ -103,7 +103,6 @@ class CudaPlatformBase(Platform):
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config
-        compilation_config = vllm_config.compilation_config
         model_config = vllm_config.model_config
 
         if parallel_config.worker_cls == "auto":
@@ -150,16 +149,6 @@ class CudaPlatformBase(Platform):
                 cache_config.block_size = 64
                 logger.info(
                     "Forcing kv cache block size to 64 for FlashMLA backend.")
-
-        if (parallel_config.data_parallel_size > 1
-                and compilation_config.use_cudagraph):
-            logger.info(
-                "Data Parallel: Forcing enforce eager to be True since DP is "
-                "currently not supported with CUDA Graphs.")
-            vllm_config.model_config.enforce_eager = True
-            compilation_config.use_cudagraph = False
-            # FIXME: inductor breaks cudagraph (from @bnell)
-            compilation_config.use_inductor = False
 
     @classmethod
     def get_current_memory_usage(cls,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7,10 +7,10 @@ import weakref
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
-import torch
 import torch.distributed
 import torch.nn as nn
 
+import torch
 from vllm.attention import AttentionType, get_attn_backend
 from vllm.attention.backends.abstract import (AttentionBackend,
                                               AttentionMetadataBuilder)
@@ -1914,6 +1914,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         with graph_capture(device=self.device):
             skip_attn = not self.vllm_config.compilation_config.full_cuda_graph
             for num_tokens in reversed(self.cudagraph_batch_sizes):
+                print(f"capturing graph for {num_tokens} ...")
                 for _ in range(self.vllm_config.compilation_config.
                                cudagraph_num_of_warmups):
                     self._dummy_run(num_tokens, skip_attn=skip_attn)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1119,8 +1119,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         torch.distributed.all_reduce(num_tokens_tensor,
                                      group=get_dp_group().cpu_group)
         max_tokens_across_dp_cpu = torch.max(num_tokens_tensor).item()
-
-        # TODO (varun) : limit by cudagraphs
         return max_tokens_across_dp_cpu - num_tokens
 
     @torch.inference_mode()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1108,6 +1108,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def get_dp_padding(self, num_tokens: int):
         dp_size = self.vllm_config.parallel_config.data_parallel_size
         dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+        if dp_size == 1:
+            # Early exit.
+            return 0
 
         # Gather num_tokens across dp rank
         num_tokens_across_dp = [0] * dp_size

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1936,7 +1936,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         with graph_capture(device=self.device):
             skip_attn = not self.vllm_config.compilation_config.full_cuda_graph
             for num_tokens in reversed(self.cudagraph_batch_sizes):
-                print(f"capturing graph for {num_tokens} ...")
                 for _ in range(self.vllm_config.compilation_config.
                                cudagraph_num_of_warmups):
                     self._dummy_run(num_tokens, skip_attn=skip_attn)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7,10 +7,10 @@ import weakref
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
+import torch
 import torch.distributed
 import torch.nn as nn
 
-import torch
 from vllm.attention import AttentionType, get_attn_backend
 from vllm.attention.backends.abstract import (AttentionBackend,
                                               AttentionMetadataBuilder)


### PR DESCRIPTION
Enable CUDA Graphs for DP + All2All kernels.

Fixes:
 1. The input buffers to the quant_method aren't captured properly when using CUDAGraphs + torch.compile. This PR introduces a staging area where the hidden_states and router_logits are copied into and it is this tensor that gets passed into quant_method.
 2. It is important that all DP ranks invoke the same number of dispatch and combine kernels. The kernels need to synchronize between DP ranks. When this requirement isn't respected, it manifests as a deadlock. To this effect, introduce a `get_dp_padding` method in `gpu_model_runner.py`.
 
 Tests:
 Verified correctness  using lm_eval locally on 4xH100.