### PR TITLE
[Model][Gemma3] Cast image pixel values already on CPU

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -263,6 +263,11 @@ class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
             mm_data,
             mm_kwargs,
         )
+        if "pixel_values" in processed_outputs:
+            # Cast pixel values to model dtype already here,
+            # so we need to transfer less data to the GPU
+            processed_outputs["pixel_values"] = processed_outputs[
+                "pixel_values"].to(self.info.ctx.model_config.dtype)
 
         # HF processor pops the `num_crops` kwarg, which is needed by vLLM
         if (images := mm_data.get("images")) is not None:
@@ -549,9 +554,7 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
         vision_tower: SiglipVisionModel,
         pixel_values: torch.Tensor,
     ) -> torch.Tensor:
-        target_dtype = vision_tower.get_input_embeddings().weight.dtype
-        image_features = vision_tower(pixel_values.to(dtype=target_dtype))
-        return image_features
+        return vision_tower(pixel_values)
 
     def _process_image_input(
         self,


### PR DESCRIPTION
Gemma3 by default uses the `bfloat16` dtype, however the hugging face processor outputs the pixel values of the 896x896 images in `float32` which means these values need to be casted to the gemma3 data type. This currently happens on GPU.

This PR moves the casting to CPU during the input processing which halves the amount of image data that needs to be copied from CPU to GPU and should also save a bit of GPU memory in prompts with lots of images.

This change seems to improve throughput by **2.4 %**  of the 4B model on a **L40s** GPU and improves latency, measured using the following script:
```shell
vllm serve google/gemma-3-4b-it --disable-log-requests
python benchmarks/benchmark_serving.py --backend openai-chat --model google/gemma-3-4b-it --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/VisionArena-Chat --hf-split train --num-prompts 5000
```

**Baseline** (based on #18710):
```
============ Serving Benchmark Result ============
Successful requests:                     985
Benchmark duration (s):                  89.50
Total input tokens:                      95454
Total generated tokens:                  115301
Request throughput (req/s):              11.01
Output token throughput (tok/s):         1288.35
Total Token throughput (tok/s):          2354.93
---------------Time to First Token----------------
Mean TTFT (ms):                          52647.14
Median TTFT (ms):                        44711.12
P99 TTFT (ms):                           84957.94
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          112.01
Median TPOT (ms):                        111.66
P99 TPOT (ms):                           283.39
---------------Inter-token Latency----------------
Mean ITL (ms):                           109.95
Median ITL (ms):                         50.29
P99 ITL (ms):                            423.10
==================================================
```

**This PR:**
```
============ Serving Benchmark Result ============
Successful requests:                     985
Benchmark duration (s):                  87.41
Total input tokens:                      95454
Total generated tokens:                  115232
Request throughput (req/s):              11.27
Output token throughput (tok/s):         1318.31
Total Token throughput (tok/s):          2410.35
---------------Time to First Token----------------
Mean TTFT (ms):                          52161.96
Median TTFT (ms):                        43351.32
P99 TTFT (ms):                           82530.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          102.06
Median TPOT (ms):                        100.74
P99 TPOT (ms):                           263.27
---------------Inter-token Latency----------------
Mean ITL (ms):                           100.50
Median ITL (ms):                         48.11
P99 ITL (ms):                            405.93
==================================================
```

I'm very new to the vllm code base, so please let me know if this could lead to problems with other dtype/quantisation configs. I'm also not sure whether this is the best benchmark to evaluate this change or how noisy these benchmarks tend to be.