### PR TITLE
Fix minicpm bug

### DIFF
--- a/vllm/model_executor/models/minicpm.py
+++ b/vllm/model_executor/models/minicpm.py
@@ -242,9 +242,6 @@ class MiniCPMAttention(nn.Module):
             base=rope_theta,
             rope_scaling=rope_scaling,
         )
-        # set rope as fp32 instead of bf16
-        self.rotary_emb.cos_sin_cache = self.rotary_emb._compute_cos_sin_cache(
-        )
         self.attn = Attention(self.num_heads,
                               self.head_dim,
                               self.scaling,


### PR DESCRIPTION
MiniCPM model inference has error on these lines:
```
# set rope as fp32 instead of bf16
self.rotary_emb.cos_sin_cache = self.rotary_emb._compute_cos_sin_cache(
)
```

This line is not nessecary, so we remove this. Removing this line does not affect other components of vllm. 


<!--- pyml disable-next-line no-emphasis-as-heading -->
