### PR TITLE
[Bugfix]: Fix moe_unpermute compatibility by aligning function signatures under CUDA < 12.0

### DIFF
--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -142,7 +142,7 @@ void moe_permute(const torch::Tensor& input, const torch::Tensor& topk_weights,
                  torch::Tensor& expert_first_token_offset,
                  torch::Tensor& src_row_id2dst_row_id_map,
                  torch::Tensor& m_indices) {
-  TORCH_CHECK(false, "moe_unpermute is not supported on CUDA < 12.0");
+  TORCH_CHECK(false, "moe_permute is not supported on CUDA < 12.0");
 }
 
 void moe_unpermute(const torch::Tensor& input,

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -72,21 +72,22 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "expert_first_token_offset, Tensor! src_row_id2dst_row_id_map, Tensor! "
       "m_indices)->()");
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12000)
-    m.def(
-        "moe_unpermute(Tensor permuted_hidden_states, Tensor topk_weights,"
-        "Tensor topk_ids,Tensor src_row_id2dst_row_id_map, Tensor "
-        "expert_first_token_offset, int n_expert, int n_local_expert,int "
-        "topk, Tensor! hidden_states)->()");
-#else
-    m.def(
-        "moe_unpermute(Tensor input, Tensor topk_weights, Tensor! topk_ids,"
-        "Tensor token_expert_indicies, Tensor? expert_map, int n_expert,"
-        "int n_local_expert,"
-        "int topk, int? align_block_size,Tensor! permuted_input, Tensor! "
-        "expert_first_token_offset, Tensor! src_row_id2dst_row_id_map, Tensor! "
-        "m_indices)->()");
-#endif
+  #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12000)
+  m.def(
+      "moe_unpermute(Tensor permuted_hidden_states, Tensor topk_weights,"
+      "Tensor topk_ids,Tensor src_row_id2dst_row_id_map, Tensor "
+      "expert_first_token_offset, int n_expert, int n_local_expert,int "
+      "topk, Tensor! hidden_states)->()");
+
+  #else
+  m.def(
+      "moe_unpermute(Tensor input, Tensor topk_weights, Tensor! topk_ids,"
+      "Tensor token_expert_indicies, Tensor? expert_map, int n_expert,"
+      "int n_local_expert,"
+      "int topk, int? align_block_size,Tensor! permuted_input, Tensor! "
+      "expert_first_token_offset, Tensor! src_row_id2dst_row_id_map, Tensor! "
+      "m_indices)->()");
+  #endif
 
   m.def("moe_permute_unpermute_supported() -> bool");
   m.impl("moe_permute_unpermute_supported", &moe_permute_unpermute_supported);

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -72,11 +72,21 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "expert_first_token_offset, Tensor! src_row_id2dst_row_id_map, Tensor! "
       "m_indices)->()");
 
-  m.def(
-      "moe_unpermute(Tensor permuted_hidden_states, Tensor topk_weights,"
-      "Tensor topk_ids,Tensor src_row_id2dst_row_id_map, Tensor "
-      "expert_first_token_offset, int n_expert, int n_local_expert,int "
-      "topk, Tensor! hidden_states)->()");
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12000)
+    m.def(
+        "moe_unpermute(Tensor permuted_hidden_states, Tensor topk_weights,"
+        "Tensor topk_ids,Tensor src_row_id2dst_row_id_map, Tensor "
+        "expert_first_token_offset, int n_expert, int n_local_expert,int "
+        "topk, Tensor! hidden_states)->()");
+#else
+    m.def(
+        "moe_unpermute(Tensor input, Tensor topk_weights, Tensor! topk_ids,"
+        "Tensor token_expert_indicies, Tensor? expert_map, int n_expert,"
+        "int n_local_expert,"
+        "int topk, int? align_block_size,Tensor! permuted_input, Tensor! "
+        "expert_first_token_offset, Tensor! src_row_id2dst_row_id_map, Tensor! "
+        "m_indices)->()");
+#endif
 
   m.def("moe_permute_unpermute_supported() -> bool");
   m.impl("moe_permute_unpermute_supported", &moe_permute_unpermute_supported);


### PR DESCRIPTION

FIX #18746, align moe_unpermute bindings with impl under CUDA < 12.0, 
