### PR TITLE
[rocm] Fix wrong attention log

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -194,8 +194,9 @@ class RocmPlatform(Platform):
                     f" The selected backend, {selected_backend.name},"
                     f"is not MLA type while requested for MLA backend.")
 
-        selected_backend = (_Backend.ROCM_FLASH if selected_backend
-                            == _Backend.FLASH_ATTN else selected_backend)
+        if selected_backend is None or selected_backend == _Backend.FLASH_ATTN:
+            selected_backend = _Backend.ROCM_FLASH
+
         if envs.VLLM_USE_V1:
             logger.info("Using Triton Attention backend on V1 engine.")
             return ("vllm.v1.attention.backends."


### PR DESCRIPTION
As per title, the log `INFO 05-27 14:35:30 [rocm.py:208] None is not supported in AMD GPUs.` may get printed for non-deepseek model (see https://github.com/vllm-project/vllm/blob/6b6d4961147220fb80f9cc7dcb74db478f9c9a23/vllm/config.py#L1363-L1365), as `selected_backend` may be `None` in case it is not set with an env var or through a global https://github.com/vllm-project/vllm/blob/6b6d4961147220fb80f9cc7dcb74db478f9c9a23/vllm/attention/selector.py#L136-L145

Actually, I am not sure why https://github.com/vllm-project/vllm/blob/6b6d4961147220fb80f9cc7dcb74db478f9c9a23/vllm/platforms/rocm.py#L208 is just logged as info and not an error (as the user has set `VLLM_ATTENTION_BACKEND` to an unsupported attn backend in this case).