### PR TITLE
[Bugfix] Fix for issue 17396

### DIFF
--- a/vllm/lora/ops/torch_ops/lora_ops.py
+++ b/vllm/lora/ops/torch_ops/lora_ops.py
@@ -36,10 +36,13 @@ def bgmv_expand(inputs: torch.Tensor,
     if outputs.shape[0] == 1 and output_tensor.shape[0] != 1:
         limit = 1
 
+    # LoRA adapter and model may add different amounts of padding to output
+    common_len = min(outputs.shape[1], output_tensor.shape[1])
+
     if add_inputs:
-        output_tensor[:, :outputs.shape[1]] += outputs[:limit, :]
+        output_tensor[:, :common_len] += outputs[:limit, :common_len]
     else:
-        output_tensor[:, :outputs.shape[1]] = outputs[:limit, :]
+        output_tensor[:, :common_len] = outputs[:limit, :common_len]
 
 
 def sgmv_shrink(


### PR DESCRIPTION
This PR contains a patch for the bug reported in issue #17396. The LoRA weights embedding layers can have a different amount of padding than the weights of the base model, depending on what hardware the model and LoRA adapters are running on. The existing code in the `bgmv_expand()` kernel compensates for this difference when the LoRA weights have more padding, but it does not compensate for the difference when the LoRA weights have less padding. When LoRA adapters are used on CPU or MPS hardware with default parameters, the LoRA weights have less padding and the server crashes with a PyTorch tensor size mismatch error.

This patch updates the logic in `bgmv_expand()` so that it works regardless of which set of embeddings, LoRA or base, contain more padding dimensions.

FIX #17396 


(anything written below this line will be removed by GitHub Actions)
