### PR TITLE
Export NaNs in logits to scheduler_stats if output is corrupted

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -4,6 +4,7 @@
 import random
 
 import pytest
+import torch
 
 from vllm.attention import Attention
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
@@ -275,6 +276,54 @@ def test_update_states_request_resumed(model_runner):
     assert _is_req_added(model_runner, req_id)
     assert _is_req_scheduled(model_runner, req_id)
     assert _is_req_state_block_table_match(model_runner, req_id)
+
+
+def test_get_nans_in_logits(model_runner):
+    req_ids = ("req_0", "req_1")
+
+    scheduler_output = _schedule_new_request(*req_ids)
+    model_runner._update_states(scheduler_output)
+
+    logits = torch.tensor([
+        [1.0, 2.0, 3.0],
+        [3.0, 2.0, 1.0],
+    ], device=DEVICE)
+    result = model_runner._get_nans_in_logits(logits)
+    assert result == {"req_0": 0, "req_1": 0}
+
+    logits = torch.tensor([
+        [1.0, float('nan'), 3.0],
+        [4.0, float('nan'), float('nan')],
+    ],
+                          device=DEVICE)
+    result = model_runner._get_nans_in_logits(logits)
+    assert result == {"req_0": 1, "req_1": 2}
+
+    logits = torch.tensor([
+        [1.0, 2.0, 3.0],
+        [4.0, float('nan'), float('nan')],
+    ],
+                          device=DEVICE)
+    result = model_runner._get_nans_in_logits(logits)
+    assert result == {"req_0": 0, "req_1": 2}
+
+    result = model_runner._get_nans_in_logits(logits=None)
+    assert result == {"req_0": 0, "req_1": 0}
+
+    logits = torch.tensor([
+        [1.0, float('nan'), 3.0],
+    ], device=DEVICE)
+    result = model_runner._get_nans_in_logits(logits)
+    assert result == {'req_0': 1, 'req_1': 0}
+
+    logits = torch.tensor([
+        [float('nan'), float('nan'), 2.0],
+        [1.0, 2.0, 3.0],
+        [float('nan'), 2.0, 3.0],
+    ],
+                          device=DEVICE)
+    result = model_runner._get_nans_in_logits(logits)
+    assert result == {'req_0': 2, 'req_1': 0}
 
 
 def test_update_states_no_changes(model_runner):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
     VLLM_SLEEP_WHEN_IDLE: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_KV_CACHE_LAYOUT: Optional[str] = None
+    VLLM_COMPUTE_NANS_IN_LOGITS: bool = False
 
 
 def get_default_cache_root():
@@ -897,7 +898,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # leave the layout choice to the backend. Mind that backends may only
     # implement and support a subset of all possible layouts.
     "VLLM_KV_CACHE_LAYOUT":
-    lambda: os.getenv("VLLM_KV_CACHE_LAYOUT", None)
+    lambda: os.getenv("VLLM_KV_CACHE_LAYOUT", None),
+
+    # Enable checking whether the generated logits contain NaNs,
+    # indicating corrupted output. Useful for debugging low level bugs
+    # or bad hardware but it may add compute overhead.
+    "VLLM_COMPUTE_NANS_IN_LOGITS":
+    lambda: bool(int(os.getenv("VLLM_COMPUTE_NANS_IN_LOGITS", "0"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -40,6 +40,8 @@ class SchedulerStats:
 
     spec_decoding_stats: Optional[SpecDecodingStats] = None
 
+    num_corrupted_reqs: int = 0
+
 
 @dataclass
 class LoRAStats:

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -108,6 +108,9 @@ class ModelRunnerOutput:
     finished_sending: Optional[set[str]] = None
     finished_recving: Optional[set[str]] = None
 
+    # req_id -> num_nans_in_logits
+    num_nans_in_logits: Optional[dict[str, int]] = None
+
 
 EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[],
                                               req_id_to_index={},
@@ -117,4 +120,5 @@ EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[],
                                               prompt_logprobs_dict={},
                                               pooler_output=[],
                                               finished_sending=None,
-                                              finished_recving=None)
+                                              finished_recving=None,
+                                              num_nans_in_logits=None)

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -97,6 +97,10 @@ class Request:
         # The number of tokens with prefix cache hits.
         self.num_cached_tokens = -1
 
+        # The number of NaNs in logits. A value greater than 0
+        # indicates that the output is corrupted
+        self.num_nans_in_logits = 0
+
     @classmethod
     def from_engine_core_request(cls, request: EngineCoreRequest) -> "Request":
         if request.mm_inputs is not None:
@@ -131,6 +135,10 @@ class Request:
         else:
             self._output_token_ids.extend(token_ids)
             self._all_token_ids.extend(token_ids)
+
+    @property
+    def is_output_corrupted(self) -> bool:
+        return self.num_nans_in_logits > 0
 
     @property
     def num_tokens(self) -> int:


### PR DESCRIPTION
Signed-off-by: Vlad Mihailescu vladmihailescu@meta.com

Summary:
Report nan in logits in scheduler_stats. This can be used later exported as Phrometeus counter but for now this is required so we can export it in our internal counter infra.

This counter is used to identify bad hosts or bad GPUs which cause NaNs in logits.

 It's a common metric we expose.

Reviewed By: Adolfo-Karim

Differential Revision: D75423285

```
NO ENV VAR (NaN counting off):
I0618 22:24:27.611000 180881 reporter.py:195] Part 1: High-level performance metrics
Ran 404/404 requests in 56.56s
Success rate:        100.00%
QPS:                 7.14
Avg latency:         11.361s
Avg TTFT (client):   8245.31ms
P50 TTFT (client):   8262.13ms
P99 TTFT (client):   8283.14ms
Avg TTIT (client):   311.60ms
P50 TTIT (client):   323.78ms
P99 TTIT (client):   334.87ms
Avg TTFT (server):   6748.17ms
Avg TTIT (server):   357.83ms
Avg prefill len:     2587.54 tokens
P50 prefill len:     2587.00 tokens
P99 prefill len:     2596.00 tokens
Avg decode len:      10.00 tokens
P50 decode len:      10.00 tokens
P99 decode len:      10.00 tokens
I0618 22:22:13.811000 141492 reporter.py:195] Part 1: High-level performance metrics
Ran 404/404 requests in 56.30s
Success rate:        100.00%
QPS:                 7.18
Avg latency:         11.312s
Avg TTFT (client):   8209.60ms
P50 TTFT (client):   8214.03ms
P99 TTFT (client):   8273.95ms
Avg TTIT (client):   310.22ms
P50 TTIT (client):   322.10ms
P99 TTIT (client):   325.09ms
Avg TTFT (server):   6639.55ms
Avg TTIT (server):   355.36ms
Avg prefill len:     2587.49 tokens
P50 prefill len:     2587.00 tokens
P99 prefill len:     2595.00 tokens
Avg decode len:      10.00 tokens
P50 decode len:      10.00 tokens
P99 decode len:      10.00 tokens
```

```
WITH ENVVAR (NaN counting on):
I0618 22:44:09.103000 508486 reporter.py:195] Part 1: High-level performance metrics
Ran 404/404 requests in 56.18s
Success rate:        100.00%
QPS:                 7.19
Avg latency:         11.291s
Avg TTFT (client):   8193.95ms
P50 TTFT (client):   8208.52ms
P99 TTFT (client):   8232.08ms
Avg TTIT (client):   309.75ms
P50 TTIT (client):   321.92ms
P99 TTIT (client):   333.03ms
Avg TTFT (server):   8574.45ms
Avg TTIT (server):   355.91ms
Avg prefill len:     2587.90 tokens
P50 prefill len:     2588.00 tokens
P99 prefill len:     2596.00 tokens
Avg decode len:      10.00 tokens
P50 decode len:      10.00 tokens
P99 decode len:      10.00 tokens
I0618 22:47:21.294000 566871 reporter.py:195] Part 1: High-level performance metrics
Ran 404/404 requests in 57.23s
Success rate:        100.00%
QPS:                 7.06
Avg latency:         11.532s
Avg TTFT (client):   8365.60ms
P50 TTFT (client):   8229.34ms
P99 TTFT (client):   9156.80ms
Avg TTIT (client):   316.59ms
P50 TTIT (client):   322.71ms
P99 TTIT (client):   414.20ms
Avg TTFT (server):   6794.25ms
Avg TTIT (server):   358.08ms
Avg prefill len:     2587.78 tokens
P50 prefill len:     2587.00 tokens
P99 prefill len:     2597.00 tokens
Avg decode len:      10.00 tokens
P50 decode len:      10.00 tokens
P99 decode len:      10.00 tokens
```

And unit test

```
pytest -s -v tests/v1/worker/test_gpu_model_runner.py
```
```
tests/v1/worker/test_gpu_model_runner.py::test_get_nans_in_logits INFO 06-19 02:06:26 [config.py:1444] Using max model len 2048
WARNING 06-19 02:06:26 [config.py:4758] Current vLLM config is not set.
WARNING 06-19 02:06:26 [config.py:4758] Current vLLM config is not set.
WARNING 06-19 02:06:26 [topk_topp_sampler.py:59] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
PASSED
```

FIX https://github.com/vllm-project/vllm/issues/17123
