### PR TITLE
[V1][Feat] Fail request if FSM fails to advance

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -779,8 +779,15 @@ class Scheduler(SchedulerInterface):
                 # NOTE: structured_output_request
                 # should not be None if use_structured_output, we have
                 # check above, so safe to ignore type warning
-                request.structured_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
-                    req_id, new_token_ids)
+                if not request.structured_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
+                        req_id, new_token_ids):
+                    # Grammar FSM failed to advance - mark request as finished with error
+                    logger.error(
+                        "Structured output FSM failed to advance for request %s. "
+                        "Terminating request.", req_id)
+                    request.status = RequestStatus.FINISHED_ABORTED
+                    stopped = True
+                    self._free_request(request)
 
             # Add newly generated spec token ids to the request.
             if spec_token_ids is not None:


### PR DESCRIPTION
## Fix streaming requests hanging when structured output FSM fails to advance

### Problem

When using structured outputs with the xgrammar backend, streaming requests would hang indefinitely if the FSM (Finite State Machine) failed to advance. This occurred when `accept_tokens()` returned `False` in the xgrammar backend, logging an error but not properly terminating the request.

### Diagnosis

The issue was in the scheduler's `update_from_output()` method. When processing new tokens for structured output requests, the code called `accept_tokens()` but ignored its return value:

```python
request.structured_output_request.grammar.accept_tokens(req_id, new_token_ids)
```

When the xgrammar FSM encountered an invalid token sequence, it would:
1. Log an error: `"Failed to advance FSM for request %s for tokens %s. Please file an issue."`
2. Return `False` from `accept_tokens()`
3. Leave the FSM in an invalid state

Since the scheduler didn't check the return value, it continued processing as if nothing was wrong, causing the streaming response to hang indefinitely without sending a completion signal.

### Solution

The fix checks the return value of `accept_tokens()` and properly terminates the request when it returns `False`:

```python
if not request.structured_output_request.grammar.accept_tokens(req_id, new_token_ids):
    # Grammar FSM failed to advance - mark request as finished with error
    logger.error(
        "Structured output FSM failed to advance for request %s. "
        "Terminating request.", req_id)
    request.status = RequestStatus.FINISHED_ABORTED
    stopped = True
    self._free_request(request)
```

This ensures that:
- The request is marked as `FINISHED_ABORTED`
- Resources are properly freed
- The streaming response terminates with finish_reason: "abort"
- Clients receive a proper completion signal instead of hanging
