### PR TITLE
[Docs] Add developer doc about CI failures

### DIFF
--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -25,7 +25,7 @@ the failure?
    [CI Failure]: failing-test-job - regex/matching/failing:test
    ```
 
-4. **For the environment field:**
+3. **For the environment field:**
 
    ```
    Still failing on main as of commit abcdef123

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -15,48 +15,48 @@ the failure?
 
 ## Filing a CI Test Failure Issue
 
-1. **File a bug report:**  
-   👉 [New CI Failure Report](https://github.com/vllm-project/vllm/issues/new?template=450-ci-failure.yml)
+- **File a bug report:**  
+    👉 [New CI Failure Report](https://github.com/vllm-project/vllm/issues/new?template=450-ci-failure.yml)
 
-1. **Use this title format:**
-
-```text
-   [CI Failure]: failing-test-job - regex/matching/failing:test
-   ```
-
-1. **For the environment field:**
-
-   ```text
-Still failing on main as of commit abcdef123
-
-   ```
-
-1. **In the description, include failing tests:**
-   ```text
-   FAILED failing/test.py:failing_test1 - Failure description  
-FAILED failing/test.py:failing_test2 - Failure description  
-   https://github.com/orgs/vllm-project/projects/20  
-   https://github.com/vllm-project/vllm/issues/new?template=400-bug-report.yml  
-   FAILED failing/test.py:failing_test3 - Failure description  
-   ```
-
-1. **Attach logs** (collapsible section example):
-   <details>
-   <summary>Logs:</summary>
-
-   ```text
-   ERROR 05-20 03:26:38 [dump_input.py:68] Dumping input data  
-   --- Logging error ---  
-   Traceback (most recent call last):  
-     File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 203, in execute_model  
-       return self.model_executor.execute_model(scheduler_output)  
-   ...
-   FAILED failing/test.py:failing_test1 - Failure description  
-   FAILED failing/test.py:failing_test2 - Failure description  
-   FAILED failing/test.py:failing_test3 - Failure description  
-   ```
+- **Use this title format:**
   
-</details>
+    ```
+    [CI Failure]: failing-test-job - regex/matching/failing:test
+    ```
+
+- **For the environment field:**
+  
+    ```
+ Still failing on main as of commit abcdef123
+    ```
+
+- **In the description, include failing tests:**
+  
+    ```
+    FAILED failing/test.py:failing_test1 - Failure description  
+ FAILED failing/test.py:failing_test2 - Failure description  
+    https://github.com/orgs/vllm-project/projects/20  
+    https://github.com/vllm-project/vllm/issues/new?template=400-bug-report.yml  
+    FAILED failing/test.py:failing_test3 - Failure description  
+    ```
+
+- **Attach logs** (collapsible section example):
+    <details>
+    <summary>Logs:</summary>
+
+    ```text
+    ERROR 05-20 03:26:38 [dump_input.py:68] Dumping input data  
+    --- Logging error ---  
+    Traceback (most recent call last):  
+      File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 203, in execute_model  
+        return self.model_executor.execute_model(scheduler_output)  
+    ...
+    FAILED failing/test.py:failing_test1 - Failure description  
+    FAILED failing/test.py:failing_test2 - Failure description  
+    FAILED failing/test.py:failing_test3 - Failure description  
+    ```
+  
+    </details>
 
 ## Logs Wrangling
 

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -16,7 +16,7 @@ the failure?
 ## Filing a CI Test Failure Issue
 
 1. **File a bug report:**  
-   👉 [New Bug Report](https://github.com/vllm-project/vllm/issues/new?template=400-bug-report.yml)
+   👉 [New CI Failure Report](https://github.com/vllm-project/vllm/issues/new?template=450-ci-failure.yml)
 
 2. **Set the `ci-failure` label.**
 

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -1,0 +1,123 @@
+# CI Failures
+
+What should I do when a CI job fails on my PR, but I don’t think my PR caused
+the failure?
+
+- Check the dashboard of current CI test failures:  
+  👉 [CI Failures Dashboard](https://github.com/orgs/vllm-project/projects/20)
+
+- If your failure **is already listed**, it's likely unrelated to your PR.  
+  Help fixing it is always welcome!  
+  - Leave comments with links to additional instances of the failure.  
+  - React with a 👍 to signal how many are affected.
+
+- If your failure **is not listed**, you should **file an issue**.
+
+## Filing a CI Test Failure Issue
+
+1. **File a bug report:**  
+   👉 [New Bug Report](https://github.com/vllm-project/vllm/issues/new?template=400-bug-report.yml)
+
+2. **Set the `ci-failure` label.**
+
+3. **Use this title format:**
+
+   ```
+   [Bug][Test Failure]: failing-test-job - regex/matching/failing:test
+   ```
+
+4. **For the environment field:**
+
+   ```
+   Still failing on main as of commit abcdef123
+   ```
+
+5. **In the description, include failing tests:**
+
+   ```text
+   FAILED failing/test.py:failing_test1 - Failure description  
+   FAILED failing/test.py:failing_test2 - Failure description  
+   https://github.com/orgs/vllm-project/projects/20  
+   https://github.com/vllm-project/vllm/issues/new?template=400-bug-report.yml  
+   FAILED failing/test.py:failing_test3 - Failure description  
+   ```
+
+6. **Attach logs** (collapsible section example):
+
+   <details>
+   <summary>Logs:</summary>
+
+   ```text
+   ERROR 05-20 03:26:38 [dump_input.py:68] Dumping input data  
+   --- Logging error ---  
+   Traceback (most recent call last):  
+     File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 203, in execute_model  
+       return self.model_executor.execute_model(scheduler_output)  
+   ...
+   FAILED failing/test.py:failing_test1 - Failure description  
+   FAILED failing/test.py:failing_test2 - Failure description  
+   FAILED failing/test.py:failing_test3 - Failure description  
+   ```
+  
+</details>
+
+## Logs Wrangling
+
+Download the full log file from Buildkite locally.
+
+Strip timestamps and colorization:
+
+```bash
+# Strip timestamps
+sed -i 's/^\[[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}Z\] //' ci.log
+
+# Strip colorization
+sed -i -r 's/\x1B\[[0-9;]*[mK]//g' ci.log
+```
+
+Use a tool for quick copy-pasting:
+
+```bash
+tail -525 ci_build.log | wl-copy
+```
+
+## Investigating a CI Test Failure
+
+1. Go to 👉 [Buildkite main branch](https://buildkite.com/vllm/ci/builds?branch=main)  
+2. Bisect to find the first build that shows the issue.  
+3. Add your findings to the GitHub issue.  
+4. If you find a strong candidate PR, mention it in the issue and ping contributors.
+
+## Reproducing a Failure
+
+CI test failures may be flaky. Use a bash loop to run repeatedly:
+
+```bash
+COUNT=1; while pytest -sv tests/v1/engine/test_engine_core_client.py::test_kv_cache_events[True-tcp]; do  
+  COUNT=$[$COUNT + 1]; echo "RUN NUMBER ${COUNT}";  
+done
+```
+
+## Submitting a PR
+
+If you submit a PR to fix a CI failure:
+
+- Link the PR to the issue:  
+  Add `Closes #12345` to the PR description.
+- Add the `ci-failure` label:  
+  This helps track it in the [CI Failures GitHub Project](https://github.com/orgs/vllm-project/projects/20).
+
+## Other Resources
+
+- 🔍 [Test Reliability on `main`](https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests?branch=main&order=ASC&sort_by=reliability)
+- 🧪 [Latest Buildkite CI Runs](https://buildkite.com/vllm/ci/builds?branch=main)
+
+## Daily Triage
+
+Use [Buildkite analytics (2-day view)](https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests?branch=main&period=2days) to:
+
+- Identify recent test failures **on `main`**.
+- Exclude legitimate test failures on PRs.
+- (Optional) Ignore tests with 0% reliability.
+
+Compare to the [CI Failures Dashboard](https://github.com/orgs/vllm-project/projects/20).

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -41,7 +41,7 @@ the failure?
    FAILED failing/test.py:failing_test3 - Failure description  
    ```
 
-6. **Attach logs** (collapsible section example):
+5. **Attach logs** (collapsible section example):
 
    <details>
    <summary>Logs:</summary>

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -19,7 +19,7 @@ the failure?
    👉 [New CI Failure Report](https://github.com/vllm-project/vllm/issues/new?template=450-ci-failure.yml)
 
 
-3. **Use this title format:**
+2. **Use this title format:**
 
    ```
    [CI Failure]: failing-test-job - regex/matching/failing:test

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -1,6 +1,6 @@
 # CI Failures
 
-What should I do when a CI job fails on my PR, but I don’t think my PR caused
+What should I do when a CI job fails on my PR, but I don't think my PR caused
 the failure?
 
 - Check the dashboard of current CI test failures:  
@@ -18,30 +18,29 @@ the failure?
 1. **File a bug report:**  
    👉 [New CI Failure Report](https://github.com/vllm-project/vllm/issues/new?template=450-ci-failure.yml)
 
-2. **Use this title format:**
+1. **Use this title format:**
 
-   ```
+```text
    [CI Failure]: failing-test-job - regex/matching/failing:test
    ```
 
-3. **For the environment field:**
-
-   ```
-   Still failing on main as of commit abcdef123
-   ```
-
-4. **In the description, include failing tests:**
+1. **For the environment field:**
 
    ```text
+Still failing on main as of commit abcdef123
+
+   ```
+
+1. **In the description, include failing tests:**
+   ```text
    FAILED failing/test.py:failing_test1 - Failure description  
-   FAILED failing/test.py:failing_test2 - Failure description  
+FAILED failing/test.py:failing_test2 - Failure description  
    https://github.com/orgs/vllm-project/projects/20  
    https://github.com/vllm-project/vllm/issues/new?template=400-bug-report.yml  
    FAILED failing/test.py:failing_test3 - Failure description  
    ```
 
-5. **Attach logs** (collapsible section example):
-
+1. **Attach logs** (collapsible section example):
    <details>
    <summary>Logs:</summary>
 

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -31,7 +31,7 @@ the failure?
    Still failing on main as of commit abcdef123
    ```
 
-5. **In the description, include failing tests:**
+4. **In the description, include failing tests:**
 
    ```text
    FAILED failing/test.py:failing_test1 - Failure description  

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -22,7 +22,7 @@ the failure?
 3. **Use this title format:**
 
    ```
-   [Bug][Test Failure]: failing-test-job - regex/matching/failing:test
+   [CI Failure]: failing-test-job - regex/matching/failing:test
    ```
 
 4. **For the environment field:**

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -8,8 +8,8 @@ the failure?
 
 - If your failure **is already listed**, it's likely unrelated to your PR.  
   Help fixing it is always welcome!  
-  - Leave comments with links to additional instances of the failure.  
-  - React with a 👍 to signal how many are affected.
+    - Leave comments with links to additional instances of the failure.  
+    - React with a 👍 to signal how many are affected.
 
 - If your failure **is not listed**, you should **file an issue**.
 
@@ -34,7 +34,7 @@ the failure?
   
     ```
     FAILED failing/test.py:failing_test1 - Failure description  
- FAILED failing/test.py:failing_test2 - Failure description  
+     FAILED failing/test.py:failing_test2 - Failure description  
     https://github.com/orgs/vllm-project/projects/20  
     https://github.com/vllm-project/vllm/issues/new?template=400-bug-report.yml  
     FAILED failing/test.py:failing_test3 - Failure description  

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -18,7 +18,6 @@ the failure?
 1. **File a bug report:**  
    👉 [New CI Failure Report](https://github.com/vllm-project/vllm/issues/new?template=450-ci-failure.yml)
 
-2. **Set the `ci-failure` label.**
 
 3. **Use this title format:**
 

--- a/docs/contributing/ci-failures.md
+++ b/docs/contributing/ci-failures.md
@@ -18,7 +18,6 @@ the failure?
 1. **File a bug report:**  
    👉 [New CI Failure Report](https://github.com/vllm-project/vllm/issues/new?template=450-ci-failure.yml)
 
-
 2. **Use this title format:**
 
    ```


### PR DESCRIPTION
This document describes what to do when CI fails on a PR and appears to
be unrelated to the changes in the PR. We have a GitHub dashboard of
open issues related to failing tests. This doc encourages more people to
help file and fix these issues.

Co-authored-by: Mark McLoughlin <markmc@redhat.com>
Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

Preview: https://vllm--18782.org.readthedocs.build/en/18782/contributing/ci-failures.html
