### PR TITLE
decrement server_load on listen for disconnect

### DIFF
--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -26,6 +26,11 @@ async def listen_for_disconnect(request: Request) -> None:
     while True:
         message = await request.receive()
         if message["type"] == "http.disconnect":
+            if request.app.state.enable_server_load_tracking:
+                # on timeout/cancellation the BackgroundTask in load_aware_call
+                # cannot decrement the server load metrics.
+                # Must be decremented by with_cancellation instead.
+                request.app.state.server_load_metrics -= 1
             break
 
 


### PR DESCRIPTION
the background task to decrement server_load can only trigger if there's a response. If the connection is terminated (i.e. canceled or timeout), then we need to ensure server load is decremented elsewhere