### PR TITLE
[Deprecation] Remove unused sync methods in `async_timeout`

### DIFF
--- a/vllm/engine/async_timeout.py
+++ b/vllm/engine/async_timeout.py
@@ -8,7 +8,6 @@
 import asyncio
 import enum
 import sys
-import warnings
 from types import TracebackType
 from typing import Any, Optional, Type
 
@@ -65,24 +64,6 @@ else:
                 self._deadline = None  # type: Optional[float]
             else:
                 self.update(deadline)
-
-        def __enter__(self) -> "Timeout":
-            warnings.warn(
-                "with timeout() is deprecated, use async with timeout()",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self._do_enter()
-            return self
-
-        def __exit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc_val: Optional[BaseException],
-            exc_tb: Optional[TracebackType],
-        ) -> Optional[bool]:
-            self._do_exit(exc_type)
-            return None
 
         async def __aenter__(self) -> "Timeout":
             self._do_enter()


### PR DESCRIPTION
This method isn't used in vLLM so it's safe to remove it.