### PR TITLE
[Feature] Support pooler_config for Bert-like model

### DIFF
--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -298,21 +298,18 @@ class CrossEncodingPooler(nn.Module):
 
     def __init__(
         self,
-        config: PretrainedConfig,
         classifier: nn.Module,
         pooler: Optional[nn.Module] = None,
     ):
         super().__init__()
         self.classifier = classifier
         self.pooler = pooler
-        self.default_activation_function = \
-            get_cross_encoder_activation_function(config)
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         pooling_metadata: PoolingMetadata,
-    ) -> PoolerOutput:
+    ) -> torch.Tensor:
         """Pools sentence pair scores from the hidden_states."""
 
         prompt_lens = PoolingTensors.from_pooling_metadata(
@@ -337,7 +334,4 @@ class CrossEncodingPooler(nn.Module):
             # apply classifier once on the full batch if possible
             pooled_output = self.classifier(pooled_output)
 
-        scores = self.default_activation_function(pooled_output).squeeze(-1)
-
-        pooled_outputs = [PoolingSequenceGroupOutput(data) for data in scores]
-        return PoolerOutput(outputs=pooled_outputs)
+        return pooled_output


### PR DESCRIPTION
It would be better to refactor RobertaForSequenceClassification to implement VllmModelForPooling, or to support as_classification_model.


- default softmax=True

```
from vllm.config import PoolerConfig

from vllm import LLM


prompts = ["Hello"]

model = LLM(model="papluca/xlm-roberta-base-language-detection",
            task="classify"
            )

outputs = model.classify(prompts)

for prompt, output in zip(prompts, outputs):
    probs = output.outputs.probs
    probs_trimmed = (str(probs[:16])[:-1] + ", ...]") if len(probs) > 16 else probs
    print(
        f"Prompt: {prompt!r} \n"
        f"Class Probabilities: {probs_trimmed} (size={len(probs)})"
    )
    print("-" * 60)
```

- disable softmax by using override_pooler_config.

```


from vllm.config import PoolerConfig

from vllm import LLM


prompts = ["Hello"]

model = LLM(model="papluca/xlm-roberta-base-language-detection",
            task="classify",
            override_pooler_config=PoolerConfig(softmax=False)
            )

outputs = model.classify(prompts)

for prompt, output in zip(prompts, outputs):
    probs = output.outputs.probs
    probs_trimmed = (str(probs[:16])[:-1] + ", ...]") if len(probs) > 16 else probs
    print(
        f"Prompt: {prompt!r} \n"
        f"Class Probabilities: {probs_trimmed} (size={len(probs)})"
    )
    print("-" * 60)

```

Fix #18727