### PR TITLE
[Deprecation] Remove fallbacks for Embeddings API

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -796,17 +796,12 @@ class ModelConfig:
         else:
             # Aliases
             if task_option == "embedding":
-                preferred_task = self._get_preferred_task(
-                    architectures, supported_tasks)
-                if preferred_task != "embed":
-                    msg = ("The 'embedding' task will be restricted to "
-                           "embedding models in a future release. Please "
-                           "pass `--task classify`, `--task score`, or "
-                           "`--task reward` explicitly for other pooling "
-                           "models.")
-                    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+                msg = ("The 'embedding' task has been renamed to "
+                       "'embed', please use the new name. The old name "
+                       "will be removed in v1.0.")
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-                task_option = preferred_task or "embed"
+                task_option = "embed"
 
             if task_option not in supported_tasks:
                 msg = (

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Generic, Optional, Union
 
 import torch
-from typing_extensions import TypeVar, deprecated
+from typing_extensions import TypeVar
 
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -75,14 +75,6 @@ class PoolingOutput:
     def __eq__(self, other: object) -> bool:
         return (isinstance(other, self.__class__) and bool(
             (self.data == other.data).all()))
-
-    @property
-    @deprecated("`LLM.encode()` now stores raw outputs in the `data` "
-                "attribute. To return embeddings, use `LLM.embed()`. "
-                "To return class probabilities, use `LLM.classify()` "
-                "and access the `probs` attribute. ")
-    def embedding(self) -> list[float]:
-        return self.data.tolist()
 
 
 class RequestOutput:
@@ -505,12 +497,6 @@ class ScoringOutput:
 
     def __repr__(self) -> str:
         return f"ScoringOutput(score={self.score})"
-
-    @property
-    @deprecated("`LLM.score()` now returns scalar scores. "
-                "Please access it via the `score` attribute. ")
-    def embedding(self) -> list[float]:
-        return [self.score]
 
 
 class ScoringRequestOutput(PoolingRequestOutput[ScoringOutput]):


### PR DESCRIPTION
Back in #11457, we deprecated the use of Embeddings API outputs for other types of Pooling models. This PR completes the deprecation by removing related code.

cc @maxdebayser @22quinn 