### PR TITLE
[Deprecation] Require overriding `get_dummy_text` and `get_dummy_mm_data`

### DIFF
--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Generic, NamedTuple, Optional, TypeVar, Union, cast
@@ -60,29 +59,14 @@ class BaseDummyInputsBuilder(ABC, Generic[_I]):
 
         self.info = info
 
-    # TODO: @abstractmethod after transition
+    @abstractmethod
     def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
         """
         Build the text input corresponding to `mm_counts`.
         """
-        if (type(self).get_dummy_processor_inputs ==
-                BaseDummyInputsBuilder.get_dummy_processor_inputs):
-            raise NotImplementedError
+        raise NotImplementedError
 
-        logger.warning_once("`get_dummy_processor_inputs` has been split up "
-                            "into `get_dummy_text` and `get_dummy_mm_data`. "
-                            "These two methods will be marked as abstract "
-                            "in an upcoming release.")
-
-        seq_len = self.info.ctx.model_config.max_model_len
-
-        prompt = self.get_dummy_processor_inputs(seq_len, mm_counts).prompt
-        if not isinstance(prompt, str):
-            prompt = self.info.get_tokenizer().decode(prompt)
-
-        return prompt
-
-    # TODO: @abstractmethod after transition
+    @abstractmethod
     def get_dummy_mm_data(
         self,
         seq_len: int,


### PR DESCRIPTION
In #16416, we split up `get_dummy_processor_inputs` but kept back-compatibility to give model developers some time to update. Enough time has passed that we can make `get_dummy_text` and `get_dummy_mm_data` abstract methods now.