### PR TITLE
[BugFix] FA2 MLA Accuracy Issue

### DIFF
--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -143,8 +143,11 @@ void merge_attn_states_launcher(torch::Tensor& output,
   const uint pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0,
               "headsize must be multiple of pack_size:", pack_size);
-  TORCH_CHECK(output.stride(-2) == head_size && prefix_output.stride(-2) == head_size && suffix_output.stride(-2) == head_size && output.stride(-1) == 1 && prefix_output.stride(-1) == 1 && suffix_output.stride(-1) == 1,
-              "Heads must be contiguous");
+  TORCH_CHECK(
+      output.stride(-2) == head_size && prefix_output.stride(-2) == head_size &&
+          suffix_output.stride(-2) == head_size && output.stride(-1) == 1 &&
+          prefix_output.stride(-1) == 1 && suffix_output.stride(-1) == 1,
+      "Heads must be contiguous");
   float* output_lse_ptr = nullptr;
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -143,6 +143,8 @@ void merge_attn_states_launcher(torch::Tensor& output,
   const uint pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0,
               "headsize must be multiple of pack_size:", pack_size);
+  TORCH_CHECK(output.stride(-2) == head_size && prefix_output.stride(-2) == head_size && suffix_output.stride(-2) == head_size && output.stride(-1) == 1 && prefix_output.stride(-1) == 1 && suffix_output.stride(-1) == 1,
+              "Heads must be contiguous");
   float* output_lse_ptr = nullptr;
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -143,11 +143,14 @@ void merge_attn_states_launcher(torch::Tensor& output,
   const uint pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0,
               "headsize must be multiple of pack_size:", pack_size);
+  TORCH_CHECK(output.stride(-2) == head_size && output.stride(-1) == 1,
+              "output heads must be contiguous in memory");
   TORCH_CHECK(
-      output.stride(-2) == head_size && prefix_output.stride(-2) == head_size &&
-          suffix_output.stride(-2) == head_size && output.stride(-1) == 1 &&
-          prefix_output.stride(-1) == 1 && suffix_output.stride(-1) == 1,
-      "Heads must be contiguous");
+      prefix_output.stride(-2) == head_size && prefix_output.stride(-1) == 1,
+      "prefix_output heads must be contiguous in memory");
+  TORCH_CHECK(
+      suffix_output.stride(-2) == head_size && suffix_output.stride(-1) == 1,
+      "suffix_output heads must be contiguous in memory");
   float* output_lse_ptr = nullptr;
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1093,10 +1093,6 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         if isinstance(attn_out, tuple):
             attn_out, *rest = attn_out
 
-        # unpad if necessary
-        if self._pad_v:
-            attn_out = attn_out[..., :v.shape[-1]]
-
         # Remain consistent with old `flash_attn_varlen_func` where there
         # is only one output tensor if `return_softmax_lse` is False.
         if return_softmax_lse:
@@ -1293,6 +1289,10 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
                 suffix_output=suffix_output,
                 suffix_lse=suffix_lse,
             )
+
+        # unpad if necessary
+        if self._pad_v:
+            output = output[..., :v.shape[-1]]
 
         return output.flatten(start_dim=-2)
 

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -653,10 +653,6 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         if isinstance(attn_out, tuple):
             attn_out, lse = attn_out[0], attn_out[1]
 
-        # unpad if necessary
-        if self._pad_v:
-            attn_out = attn_out[..., :v.shape[-1]]
-
         # Remain consistent with old `flash_attn_varlen_func` where there
         # is only one output tensor if `return_softmax_lse` is False.
         if return_softmax_lse:
@@ -838,6 +834,10 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 suffix_output=suffix_output,
                 suffix_lse=suffix_lse,
             )
+
+        # unpad if necessary
+        if self._pad_v:
+            output = output[..., :v.shape[-1]]
 
         return output.flatten(start_dim=-2)
 


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/18561
FIX #18766

`merge_attn_states` doesnt support tensor slices, so avoid slicing till after all the attn states are merged

After this PR (tested on an A100):

```
lm_eval --model vllm --model_args pretrained=deepseek-ai/DeepSeek-V2-Lite-Chat --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto
...
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6672|±  |0.0130|
|     |       |strict-match    |     5|exact_match|↑  |0.6588|±  |0.0131|
```

```
VLLM_USE_V1=0 lm_eval --model vllm --model_args pretrained=deepseek-ai/DeepSeek-V2-Lite-Chat --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto
...
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6702|±  |0.0129|
|     |       |strict-match    |     5|exact_match|↑  |0.6649|±  |0.0130|
```