### PR TITLE
Respect passed in device overrides in engine args

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -979,7 +979,7 @@ class EngineArgs:
         from vllm.platforms import current_platform
         current_platform.pre_register_and_update()
 
-        device_config = DeviceConfig(device=current_platform.device_type)
+        device_config = DeviceConfig(device=self.device)
         model_config = self.create_model_config()
 
         # * If VLLM_USE_V1 is unset, we enable V1 for "supported features"


### PR DESCRIPTION
Signed-off-by: Adolfo Victoria adovi@meta.com

Summary: When calling `create_engine_config` we don't respect the device set in engine args and instead grab it from the runtime platform directly. This logic is also extraneous since the default behavior (i.e. device=auto) is to set the device to the runtime platform device if auto is passed inside of `__post_init__` inside of `DeviceConfig`

Differential Revision: D75496412


