### PR TITLE
Prevent the cross-encoder logic from being applied to classification tasks

### DIFF
--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -311,7 +311,7 @@ class ClassifierPooler(nn.Module):
             self.default_activation_function = nn.Sigmoid() \
                 if config.hf_config.num_labels == 1 else nn.Softmax()
         else:
-            raise NotImplementedError(f"task {config.task} is not supported"
+            raise NotImplementedError(f"task={config.task!r} is not supported"
                                       " with the classification pooler")
 
     def forward(

--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -301,18 +301,18 @@ class ClassifierPooler(nn.Module):
         pooler: Optional[nn.Module] = None,
     ):
         super().__init__()
-        if config.task not in ["classify", "score"]:
-            raise NotImplementedError(f"task {config.task} is not supported"
-                                      " with the classification pooler")
         self.classifier = classifier
         self.pooler = pooler
 
         if config.task == "score":
             self.default_activation_function = \
                 get_cross_encoder_activation_function(config.hf_config)
-        else:
+        elif config.task == "classify":
             self.default_activation_function = nn.Sigmoid() \
                 if config.hf_config.num_labels == 1 else nn.Softmax()
+        else:
+            raise NotImplementedError(f"task {config.task} is not supported"
+                                      " with the classification pooler")
 
     def forward(
         self,

--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -470,7 +470,7 @@ class BertForSequenceClassification(nn.Module, SupportsCrossEncoding,
                               embedding_class=BertEmbedding,
                               add_pooling_layer=True)
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
-        self._pooler = ClassifierPooler(vllm_config.model_config.task, config,
+        self._pooler = ClassifierPooler(vllm_config.model_config,
                                         self.classifier, self.bert.pooler)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):

--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -16,7 +16,7 @@ from vllm.model_executor.layers.activation import get_act_fn
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
                                                RowParallelLinear)
-from vllm.model_executor.layers.pooler import (CrossEncodingPooler, Pooler,
+from vllm.model_executor.layers.pooler import (ClassifierPooler, Pooler,
                                                PoolingType)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -470,8 +470,8 @@ class BertForSequenceClassification(nn.Module, SupportsCrossEncoding,
                               embedding_class=BertEmbedding,
                               add_pooling_layer=True)
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
-        self._pooler = CrossEncodingPooler(config, self.classifier,
-                                           self.bert.pooler)
+        self._pooler = ClassifierPooler(vllm_config.model_config.task, config,
+                                        self.classifier, self.bert.pooler)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
 

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -278,7 +278,7 @@ class ModernBertForSequenceClassification(nn.Module, SupportsCrossEncoding):
         self.model = ModernBertModel(vllm_config=vllm_config,
                                      prefix=maybe_prefix(prefix, "modernbert"))
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
-        self._pooler = ClassifierPooler(vllm_config.model_config.task, config,
+        self._pooler = ClassifierPooler(vllm_config.model_config,
                                         self.classifier,
                                         ModernBertPooler(config))
 

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -12,7 +12,7 @@ from vllm.config import VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.linear import (QKVParallelLinear,
                                                RowParallelLinear)
-from vllm.model_executor.layers.pooler import CrossEncodingPooler
+from vllm.model_executor.layers.pooler import ClassifierPooler
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
@@ -278,8 +278,9 @@ class ModernBertForSequenceClassification(nn.Module, SupportsCrossEncoding):
         self.model = ModernBertModel(vllm_config=vllm_config,
                                      prefix=maybe_prefix(prefix, "modernbert"))
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
-        self._pooler = CrossEncodingPooler(config, self.classifier,
-                                           ModernBertPooler(config))
+        self._pooler = ClassifierPooler(vllm_config.model_config.task, config,
+                                        self.classifier,
+                                        ModernBertPooler(config))
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
 

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -187,7 +187,7 @@ class RobertaForSequenceClassification(nn.Module, SupportsCrossEncoding,
                                  add_pooling_layer=False)
         self.classifier = RobertaClassificationHead(config)
 
-        self._pooler = ClassifierPooler(vllm_config.model_config.task, config,
+        self._pooler = ClassifierPooler(vllm_config.model_config,
                                         self.classifier)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -9,7 +9,7 @@ from torch import nn
 from transformers import RobertaConfig
 
 from vllm.config import VllmConfig
-from vllm.model_executor.layers.pooler import CrossEncodingPooler
+from vllm.model_executor.layers.pooler import ClassifierPooler
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
@@ -186,7 +186,9 @@ class RobertaForSequenceClassification(nn.Module, SupportsCrossEncoding,
                                  embedding_class=RobertaEmbedding,
                                  add_pooling_layer=False)
         self.classifier = RobertaClassificationHead(config)
-        self._pooler = CrossEncodingPooler(config, self.classifier)
+
+        self._pooler = ClassifierPooler(vllm_config.model_config.task, config,
+                                        self.classifier)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         bert_weights, task_weights = roberta_task_weights_filter(weights)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -823,10 +823,17 @@ def try_get_generation_config(
 
 
 def get_cross_encoder_activation_function(config: PretrainedConfig):
-    if (hasattr(config, "sbert_ce_default_activation_function")
-            and config.sbert_ce_default_activation_function is not None):
 
+    function_name: Optional[str] = None
+    if hasattr(config, "sentence_transformers") and "activation_fn" in \
+        config.sentence_transformers:
+        function_name = config.sentence_transformers["activation_fn"]
+
+    elif (hasattr(config, "sbert_ce_default_activation_function")
+          and config.sbert_ce_default_activation_function is not None):
         function_name = config.sbert_ce_default_activation_function
+
+    if function_name is not None:
         assert function_name.startswith("torch.nn.modules."), \
             "Loading of activation functions is restricted to " \
             "torch.nn.modules for security reasons"


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/18727

By default the Bert models for sequence classification were assuming that the task was `score` and applying the same logic as the `CrossEncoder` module of the `sentence-transformers` library. In particular, this meant applying the `Identity` function at the end instead of the `Softmax` function. With this PR the pooler implementation is selected according to the task.

With these changes, the example request of issue https://github.com/vllm-project/vllm/issues/18727 returns the correct result with softmax applied:
```
curl "http://127.0.0.1:8098/classify"   -H "Content-Type: application/json"   -d '{
    "model": "papluca/xlm-roberta-base-language-detection",
    "input": "Hello"
  }'
{"id":"classify-c225e8d0d5054d72874a6340247167d3","object":"list","created":1748445777,"model":"papluca/xlm-roberta-base-language-detection","data":[{"index":0,"label":"en","probs":[0.005031585693359375,0.0194091796875,0.0047149658203125,0.005458831787109375,0.01036834716796875,0.012939453125,0.0068359375,0.0207977294921875,0.009002685546875,0.05029296875,0.010345458984375,0.0284576416015625,0.013916015625,0.712890625,0.0086517333984375,0.01119232177734375,0.01904296875,0.01247406005859375,0.0296783447265625,0.00838470458984375],"num_classes":20}],"usage":{"prompt_tokens":3,"total_tokens":3,"completion_tokens":0,"prompt_tokens_details":null}}```

Additionally, the `get_cross_encoder_activation_function` was updated to replicate updates in the `sentence-transformers`library.

cc: @noooop , @DarkLight1337
