### PR TITLE
Skip device and quant Pydantic validation to make plugin device work

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -304,7 +304,7 @@ class ModelConfig:
     - 25.6k -> 25,600"""
     spec_target_max_model_len: Optional[int] = None
     """Specify the maximum length for spec decoding draft models."""
-    quantization: Optional[QuantizationMethods] = None
+    quantization: SkipValidation[Optional[QuantizationMethods]] = None
     """Method used to quantize the weights. If `None`, we first check the
     `quantization_config` attribute in the model config file. If that is
     `None`, we assume the model weights are not quantized and use `dtype` to

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2231,7 +2231,7 @@ Device = Literal["auto", "cuda", "neuron", "cpu", "tpu", "xpu", "hpu"]
 class DeviceConfig:
     """Configuration for the device to use for vLLM execution."""
 
-    device: Union[Device, torch.device] = "auto"
+    device: SkipValidation[Union[Device, torch.device]] = "auto"
     """Device type for vLLM execution.
     This parameter is deprecated and will be 
     removed in a future release. 


### PR DESCRIPTION
### What this PR does / why we need it?

Since https://github.com/vllm-project/vllm/commit/4c2b38ce9e90a0ac7c3e7ca400daf3a622cc7bca , it converted configs to Pydantic dataclasses and enable Pydantic checks. Due to config.Device has strict validation, run the model test on the plugin device (vllm-ascend in my case) will not work and raise the error:

```
FAILED tests/singlecard/test_offline_inference.py::test_models[5-half-Qwen/Qwen2.5-0.5B-Instruct]
- pydantic_core._pydantic_core.ValidationError: 2 validation errors for DeviceConfig
device.literal['auto','cuda','neuron','cpu','tpu','xpu','hpu']
  Input should be 'auto', 'cuda', 'neuron', 'cpu', 'tpu', 'xpu' or 'hpu' [type=literal_error, input_value='npu', input_type=str]
```
See also here: https://github.com/vllm-project/vllm-ascend/actions/runs/15303026138/job/43048387981?pr=958

This patch try to resolve it by skip device field validation to make plugin device work.

### How was this patch tested?
```
# Apply patch, do regresion test and CI passed
$ pytest -sv tests/singlecard/test_offline_inference.py::test_model
tests/singlecard/test_offline_inference.py::test_models PASSED
```
