### PR TITLE
[BugFix] Update pydantic to fix error on python 3.10

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,7 @@ protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
 openai >= 1.52.0 # Ensure modern openai package (ensure types module present and max_completion_tokens field support)
-pydantic >= 2.9
+pydantic >= 2.10
 prometheus_client >= 0.18.0
 pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0


### PR DESCRIPTION
Update pydantic to fix error on python 3.10.

FIX issue from #17599.

<!--- pyml disable-next-line no-emphasis-as-heading -->
