### PR TITLE
[Bugfix][TPU] fix moe custom kernel import

### DIFF
--- a/vllm/model_executor/layers/fused_moe/moe_pallas.py
+++ b/vllm/model_executor/layers/fused_moe/moe_pallas.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch.nn.functional as F
+import torch_xla.experimental.custom_kernel  # noqa: F401
 
 
 def _histogram(input: torch.Tensor, min: int, max: int) -> torch.Tensor:


### PR DESCRIPTION
Fix test_moe_pallas.py. We will get 
```
E               AttributeError: '_OpNamespace' 'xla' object has no attribute 'gmm'` 
```
without this fix.
