### PR TITLE
[Bugfix] Ensure tensors are contiguous during serialisation

### DIFF
--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -158,6 +158,8 @@ class MsgpackEncoder:
         self, obj: torch.Tensor
     ) -> tuple[str, tuple[int, ...], Union[int, memoryview]]:
         assert self.aux_buffers is not None
+        # this creates a copy of the tensor if it's not already contiguous
+        obj = obj.contiguous()
         #  view the tensor as a 1D array of bytes
         arr = obj.flatten().view(torch.uint8).numpy()
         if obj.nbytes < self.size_threshold:

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -158,10 +158,8 @@ class MsgpackEncoder:
         self, obj: torch.Tensor
     ) -> tuple[str, tuple[int, ...], Union[int, memoryview]]:
         assert self.aux_buffers is not None
-        # this creates a copy of the tensor if it's not already contiguous
-        obj = obj.contiguous()
-        #  view the tensor as a 1D array of bytes
-        arr = obj.flatten().view(torch.uint8).numpy()
+        # view the tensor as a contiguous 1D array of bytes
+        arr = obj.flatten().contiguous().view(torch.uint8).numpy()
         if obj.nbytes < self.size_threshold:
             # Smaller tensors are encoded inline, just like ndarrays.
             data = msgpack.Ext(CUSTOM_TYPE_RAW_VIEW, arr.data)


### PR DESCRIPTION
This was removed in #18774 but breaks CI.

Sorry for missing this, I thought `.flatten()` would always return contiguous data.

@njhill Replaces #18857