### PR TITLE
[Bugfix] Fix pydantic `ValidationError` bug

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2231,7 +2231,7 @@ Device = Literal["auto", "cuda", "neuron", "cpu", "tpu", "xpu", "hpu"]
 class DeviceConfig:
     """Configuration for the device to use for vLLM execution."""
 
-    device: Union[Device, torch.device] = "auto"
+    device: Union[str, Device, torch.device] = "auto"
     """Device type for vLLM execution.
     This parameter is deprecated and will be 
     removed in a future release. 


### PR DESCRIPTION
For oot platforms, such as npu, the class `DeviceConfig` raised an unexpected  ValidationError before initialization:
```bash
device.literal['auto','cuda','neuron','cpu','tpu','xpu','hpu']
  Input should be 'auto', 'cuda', 'neuron', 'cpu', 'tpu', 'xpu' or 'hpu' [type=literal_error, input_value='npu', input_type=str]
```
i think it is for the pydantic's Validation, fix #17599