### PR TITLE
[bugfix][v1]fixed the missing prompt value in RequestOutputs

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -69,8 +69,8 @@ def test_incremental_detokenization(request_output_kind: RequestOutputKind,
     ]
 
     # Add requests to the detokenizer.
-    for request, prompt in zip(requests, dummy_test_vectors.prompt_strings):
-        output_processor.add_request(request, prompt)
+    for request in requests:
+        output_processor.add_request(request)
 
     gen_strings = {}
     gen_tokens = {}
@@ -418,8 +418,8 @@ def test_logprobs_processor(request_output_kind: RequestOutputKind,
     ]
 
     # Add requests to the detokenizer.
-    for request, prompt in zip(requests, dummy_test_vectors.prompt_strings):
-        output_processor.add_request(request, prompt)
+    for request in requests:
+        output_processor.add_request(request)
 
     gen_tokens = {}
     gen_logprobs = {}
@@ -546,7 +546,6 @@ def test_stop_token(include_stop_str_in_output: bool,
         generation_logprobs = (
             dummy_test_vectors.generation_logprobs[0] +
             2 * [dummy_test_vectors.generation_logprobs[0][-1]])
-    prompt_string = dummy_test_vectors.prompt_strings[0]
     prompt_tokens = dummy_test_vectors.prompt_tokens[0]
     engine_core = MockEngineCore(
         tokens_list=[generation_tokens],
@@ -581,7 +580,7 @@ def test_stop_token(include_stop_str_in_output: bool,
         ))
 
     # Add request to the detokenizer.
-    output_processor.add_request(request, prompt_string)
+    output_processor.add_request(request)
 
     # Loop over engine core steps; run output processor
     gen_string = ""
@@ -678,8 +677,8 @@ def test_stop_string(include_stop_str_in_output: bool,
     ]
 
     # Add requests to the detokenizer.
-    for request, prompt in zip(requests, dummy_test_vectors.prompt_strings):
-        output_processor.add_request(request, prompt)
+    for request in requests:
+        output_processor.add_request(request)
 
     gen_strings = {}
     gen_tokens = {}
@@ -786,7 +785,7 @@ def test_iteration_stats(dummy_test_vectors):
     # Add all requests except one to the OutputProcessor.
     num_active = len(dummy_test_vectors.generation_tokens) - 1
     for request in requests[:num_active]:
-        output_processor.add_request(request, None)
+        output_processor.add_request(request)
     inactive_request = requests[num_active]
 
     # First iteration has 2 prefills.
@@ -812,7 +811,7 @@ def test_iteration_stats(dummy_test_vectors):
     assert iteration_stats.num_generation_tokens == num_active
 
     # Add a new request - prefill and 2 decodes in this step.
-    output_processor.add_request(inactive_request, None)
+    output_processor.add_request(inactive_request)
     num_active += 1
     outputs = engine_core.get_outputs()[:num_active]
     iteration_stats = IterationStats()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -225,13 +225,15 @@ class AsyncLLM(EngineClient):
         queue = RequestOutputCollector(output_kind=params.output_kind)
 
         # Convert Input --> Request.
-        prompt_str, request = self.processor.process_inputs(
-            request_id, prompt, params, arrival_time, lora_request,
-            tokenization_kwargs, trace_headers, prompt_adapter_request,
-            priority)
+        request = self.processor.process_inputs(request_id, prompt, params,
+                                                arrival_time, lora_request,
+                                                tokenization_kwargs,
+                                                trace_headers,
+                                                prompt_adapter_request,
+                                                priority)
 
         if params.n == 1:
-            await self._add_request(request, prompt_str, None, 0, queue)
+            await self._add_request(request, None, 0, queue)
             return queue
 
         # Fan out child requests (for n>1).
@@ -241,18 +243,15 @@ class AsyncLLM(EngineClient):
             child_request = request if idx == params.n - 1 else copy(request)
             child_request.request_id = request_id
             child_request.sampling_params = params
-            await self._add_request(child_request, prompt_str, parent_request,
-                                    idx, queue)
+            await self._add_request(child_request, parent_request, idx, queue)
         return queue
 
     async def _add_request(self, request: EngineCoreRequest,
-                           prompt: Optional[str],
                            parent_req: Optional[ParentRequest], index: int,
                            queue: RequestOutputCollector):
 
         # Add the request to OutputProcessor (this process).
-        self.output_processor.add_request(request, prompt, parent_req, index,
-                                          queue)
+        self.output_processor.add_request(request, parent_req, index, queue)
 
         # Add the EngineCoreRequest to EngineCore (separate process).
         await self.engine_core.add_request_async(request)

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -34,6 +34,9 @@ class IncrementalDetokenizer:
     def get_next_output_text(self, finished: bool, delta: bool) -> str:
         return ""
 
+    def decode_next(self, next_token_id: int) -> str:
+        raise NotImplementedError
+
     @classmethod
     def from_new_request(
         cls,

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -192,16 +192,18 @@ class LLMEngine:
         priority: int = 0,
     ) -> None:
         # Process raw inputs into the request.
-        prompt_str, request = self.processor.process_inputs(
-            request_id, prompt, params, arrival_time, lora_request,
-            tokenization_kwargs, trace_headers, prompt_adapter_request,
-            priority)
+        request = self.processor.process_inputs(request_id, prompt, params,
+                                                arrival_time, lora_request,
+                                                tokenization_kwargs,
+                                                trace_headers,
+                                                prompt_adapter_request,
+                                                priority)
 
         n = params.n if isinstance(params, SamplingParams) else 1
 
         if n == 1:
             # Make a new RequestState and queue.
-            self.output_processor.add_request(request, prompt_str, None, 0)
+            self.output_processor.add_request(request, None, 0)
             # Add the request to EngineCore.
             self.engine_core.add_request(request)
             return
@@ -215,8 +217,7 @@ class LLMEngine:
             child_request.sampling_params = params
 
             # Make a new RequestState and queue.
-            self.output_processor.add_request(child_request, prompt_str,
-                                              parent_req, idx)
+            self.output_processor.add_request(child_request, parent_req, idx)
             # Add the request to EngineCore.
             self.engine_core.add_request(child_request)
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -109,7 +109,6 @@ class RequestState:
         cls,
         tokenizer: AnyTokenizer,
         request: EngineCoreRequest,
-        prompt: Optional[str],
         parent_req: Optional[ParentRequest],
         request_index: int,
         queue: Optional[RequestOutputCollector],
@@ -117,6 +116,20 @@ class RequestState:
     ) -> "RequestState":
         if not request.sampling_params.detokenize:
             tokenizer = None
+
+        detokenizer = IncrementalDetokenizer.from_new_request(
+            tokenizer=tokenizer,
+            request=request,
+        )
+
+        # When generating the requestState, the prompt_text must
+        # be preserved because this value needs to be written
+        # back to RequestOutputs upon returning. Here, we decode
+        # the prompt_token_ids of the request into prompt_text.
+        prompt_text = ""
+        for token_id in request.prompt_token_ids:
+            prompt_text += detokenizer.decode_next(token_id)
+
         return cls(
             request_id=request.request_id,
             parent_req=parent_req,
@@ -124,16 +137,13 @@ class RequestState:
             lora_name=(request.lora_request.name
                        if request.lora_request is not None else None),
             output_kind=request.sampling_params.output_kind,
-            prompt=prompt,
+            prompt=prompt_text,
             prompt_token_ids=request.prompt_token_ids,
             logprobs_processor=LogprobsProcessor.from_new_request(
                 tokenizer=tokenizer,
                 request=request,
             ),
-            detokenizer=IncrementalDetokenizer.from_new_request(
-                tokenizer=tokenizer,
-                request=request,
-            ),
+            detokenizer=detokenizer,
             max_tokens_param=(request.sampling_params.max_tokens if
                               request.sampling_params is not None else None),
             arrival_time=request.arrival_time,
@@ -275,7 +285,6 @@ class OutputProcessor:
     def add_request(
         self,
         request: EngineCoreRequest,
-        prompt: Optional[str],
         parent_req: Optional[ParentRequest] = None,
         request_index: int = 0,
         queue: Optional[RequestOutputCollector] = None,
@@ -287,7 +296,6 @@ class OutputProcessor:
         req_state = RequestState.from_new_request(
             tokenizer=self.tokenizer.get_lora_tokenizer(request.lora_request),
             request=request,
-            prompt=prompt,
             parent_req=parent_req,
             request_index=request_index,
             queue=queue,

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -211,7 +211,7 @@ class Processor:
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         priority: int = 0,
-    ) -> tuple[Optional[str], EngineCoreRequest]:
+    ) -> EngineCoreRequest:
 
         # TODO(woosuk): Support pooling models.
         # TODO(woosuk): Support encoder-decoder models.
@@ -316,7 +316,7 @@ class Processor:
             else:
                 sorted_mm_inputs = orig_sorted_mm_inputs
 
-        return decoder_inputs.get("prompt"), EngineCoreRequest(
+        return EngineCoreRequest(
             request_id=request_id,
             prompt_token_ids=decoder_inputs["prompt_token_ids"],
             mm_inputs=sorted_mm_inputs,


### PR DESCRIPTION
Since the PR https://github.com/vllm-project/vllm/pull/17214 was merged, a new issue has emerged, the `prompt` field of the `RequestOutputs` object is empty when returned form the request queue. this occurs because when generating the `requestState` object for each request, the `prompt` value returned by `decoder_inputs.get("prompt")` in function `process_inputs` is already empty.  

Therefore, when creating the `requestState` object, we directly decode the prompt characters from the request's `prompt_tokens_ids` and store in the `requestState` object.