### PR TITLE
[Doc]  Fix codeblocks formatting in LoRA adapters documentation

### DIFF
--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -165,6 +165,7 @@ it will first look in the local directory for a directory `foobar`, and attempt 
 that adapter will then be available for normal use on the server.
 
 Alternatively, follow these example steps to implement your own plugin:
+
 1. Implement the LoRAResolver interface.
 
     Example of a simple S3 LoRAResolver implementation:
@@ -198,9 +199,9 @@ Alternatively, follow these example steps to implement your own plugin:
             return lora_request
     ```
 
-2. Register LoRAResolver plugin.
+2. Register `LoRAResolver` plugin.
 
-     ```python
+    ```python
     from vllm.lora.resolver import LoRAResolverRegistry
 
     s3_resolver = S3LoRAResolver()


### PR DESCRIPTION
## Summary
This PR fixes formatting issues in the LoRA adapters documentation to improve readability and maintain consistent code block styling.

## Changes Made
- Added missing line break before the numbered list in the LoRA plugin implementation section
- Fixed indentation for the Python code block in step 2
- Updated text formatting to use proper inline code styling for `LoRAResolver`

<img width="2964" alt="Screenshot 2025-05-29 at 11 19 22 PM" src="https://github.com/user-attachments/assets/8116a336-1c1c-4de3-9cf0-706a5b07a391" />

(left: current docs, right: fixed docs)
