### PR TITLE
[Bugfix] Fix EAGLE3 broken logits

### DIFF
--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -215,6 +215,9 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         logits = self.logits_processor(self.lm_head, hidden_states,
                                        sampling_metadata)
         if self.draft_id_to_target_id is None:
+            assert logits.shape[1] == self.config.vocab_size, \
+                "Expected logits to have shape " \
+                f"(*, {self.config.vocab_size}), but got {logits.shape}"
             return logits
 
         base = torch.arange(self.config.draft_vocab_size, device=logits.device)
@@ -251,7 +254,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
 
         loaded_weights = loader.load_weights(model_weights.items())
 
-        if 'd2t' not in loaded_weights:
+        if not any('draft_id_to_target_id' in name for name in loaded_weights):
             self.draft_id_to_target_id = None
 
         return loaded_weights

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -237,24 +237,22 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         return self.model.fc(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-        loader = AutoWeightsLoader(
-            self,
-            skip_prefixes=None,
-        )
-
         model_weights = {}
+        includes_draft_id_mapping = False
         for name, loaded_weight in weights:
             if "t2d" in name:
                 continue
             if "d2t" in name:
                 name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
             elif "lm_head" not in name:
                 name = "model." + name
             model_weights[name] = loaded_weight
 
-        loaded_weights = loader.load_weights(model_weights.items())
-
-        if not any('draft_id_to_target_id' in name for name in loaded_weights):
-            self.draft_id_to_target_id = None
-
-        return loaded_weights
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=["draft_id_to_target_id"] \
+                if not includes_draft_id_mapping else None,
+        )
+        loader.load_weights(model_weights.items())


### PR DESCRIPTION
[This PR](https://github.com/vllm-project/vllm/pull/18488) incorrectly checks the loaded_weights and will always set `draft_id_to_target_id` to `None` (sorry!).

This PR fixes the bug by checking the updated name instead of 'd2t', checks for inclusion instead of exact-match for a more reliable check in case it gets moved in the future, and adds an assertion to prevent regression.

- Confirmed that the previous code hits the assertion and fails:
```
ERROR 05-29 15:17:48 [core.py:502]     assert logits.shape[1] == self.config.vocab_size, \
ERROR 05-29 15:17:48 [core.py:502] AssertionError: Expected logits to have shape (*, 128256), but got torch.Size([1, 32000])
```
- Previous acceptance on sample data (4 requests from MT_Bench):
```
--------------------------------------------------
mean acceptance length: 1.12
--------------------------------------------------
acceptance at token 0:0.11
acceptance at token 1:0.01
acceptance at token 2:0.00
acceptance at token 3:0.00
```
- New acceptance on the same data:
```
--------------------------------------------------
mean acceptance length: 2.99
--------------------------------------------------
acceptance at token 0:0.77
acceptance at token 1:0.55
acceptance at token 2:0.38
acceptance at token 3:0.29
```
- To reproduce:
```
VLLM_USE_V1=1 python3 examples/offline_inference/eagle.py --method eagle3 --max_num_seqs 1 --num_spec_tokens 4 --dataset mt_bench.jsonl --num_prompts 4 --enforce_eager
```
