### PR TITLE
[Bugfix] Fix PP default fallback behavior for V1

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1380,7 +1380,7 @@ class EngineArgs:
 
         if (self.pipeline_parallel_size > 1
                 and self.distributed_executor_backend
-                not in ("ray", "mp", "external_launcher")):
+                not in (ParallelConfig.distributed_executor_backend, "ray", "mp", "external_launcher")):
             name = "Pipeline Parallelism without Ray distributed executor " \
                     "or multiprocessing executor or external launcher"
             _raise_or_fallback(feature_name=name, recommend_to_remove=False)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1380,7 +1380,8 @@ class EngineArgs:
 
         if (self.pipeline_parallel_size > 1
                 and self.distributed_executor_backend
-                not in (ParallelConfig.distributed_executor_backend, "ray", "mp", "external_launcher")):
+                not in (ParallelConfig.distributed_executor_backend, "ray",
+                        "mp", "external_launcher")):
             name = "Pipeline Parallelism without Ray distributed executor " \
                     "or multiprocessing executor or external launcher"
             _raise_or_fallback(feature_name=name, recommend_to_remove=False)


### PR DESCRIPTION
We were not checking if the `distributed_executor_backend` was None (the default) to make the V0 fallback decision.

Before this PR you would see:
```
vllm serve meta-llama/Llama-3.1-8B-Instruct --enforce-eager -pp 2   
...
WARNING 05-29 16:18:03 [arg_utils.py:1586] Pipeline Parallelism without Ray distributed executor or multiprocessing executor or external launcher is not supported by the V1 Engine. Falling back to V0. 
```