### PR TITLE
[Model] Use in-place adds in SigLIP

### DIFF
--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -130,11 +130,10 @@ class SiglipVisionEmbeddings(nn.Module):
         embeddings = patch_embeds.flatten(2).transpose(1, 2)
 
         if interpolate_pos_encoding:
-            embeddings = embeddings + self.interpolate_pos_encoding(
+            embeddings += self.interpolate_pos_encoding(
                 embeddings, height, width)
         else:
-            embeddings = embeddings + self.position_embedding(
-                self.position_ids)
+            embeddings += self.position_embedding(self.position_ids)
         return embeddings
 
 
@@ -271,12 +270,12 @@ class SiglipEncoderLayer(nn.Module):
 
         hidden_states = self.layer_norm1(hidden_states)
         hidden_states, _ = self.self_attn(hidden_states=hidden_states)
-        hidden_states = residual + hidden_states
+        hidden_states += residual
 
         residual = hidden_states
         hidden_states = self.layer_norm2(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
+        hidden_states += residual
 
         return hidden_states, None
 
@@ -354,7 +353,8 @@ class SiglipMultiheadAttentionPoolingHead(nn.Module):
 
         residual = hidden_state
         hidden_state = self.layernorm(hidden_state)
-        hidden_state = residual + self.mlp(hidden_state)
+        hidden_state = self.mlp(hidden_state)
+        hidden_state += residual
 
         return hidden_state[:, 0]
 


### PR DESCRIPTION
This changes the SigLIP model definition to use in-place adds where possible. This is important since vision encoders currently run outside of torch compile so things like this won't be automatically optimised away.

This has a surprisingly big performance impact. I'm seeing a **6% increase in throughput** with a gemma-3-4b-it model running on a L40s GPU.

Related to: #23884

Benchmarked with

```shell
vllm serve google/gemma-3-4b-it --disable-log-requests

python benchmarks/benchmark_serving.py --backend openai-chat --model google/gemma-3-4b-it --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/VisionArena-Chat --hf-split train --num-prompts 5000
```

**Baseline:**

```
============ Serving Benchmark Result ============
Successful requests:                     985
Benchmark duration (s):                  89.41
Total input tokens:                      95454
Total generated tokens:                  115276
Request throughput (req/s):              11.02
Output token throughput (tok/s):         1289.34
Total Token throughput (tok/s):          2356.98
---------------Time to First Token----------------
Mean TTFT (ms):                          52451.52
Median TTFT (ms):                        44427.75
P99 TTFT (ms):                           84678.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          112.27
Median TPOT (ms):                        111.49
P99 TPOT (ms):                           291.20
---------------Inter-token Latency----------------
Mean ITL (ms):                           110.17
Median ITL (ms):                         49.28
P99 ITL (ms):                            423.58
==================================================
```

**This PR:**

```
============ Serving Benchmark Result ============
Successful requests:                     985
Benchmark duration (s):                  84.57
Total input tokens:                      95454
Total generated tokens:                  115138
Request throughput (req/s):              11.65
Output token throughput (tok/s):         1361.53
Total Token throughput (tok/s):          2490.29
---------------Time to First Token----------------
Mean TTFT (ms):                          50970.55
Median TTFT (ms):                        42321.73
P99 TTFT (ms):                           79869.31
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          98.13
Median TPOT (ms):                        95.28
P99 TPOT (ms):                           249.69
---------------Inter-token Latency----------------
Mean ITL (ms):                           96.63
Median ITL (ms):                         49.13
P99 ITL (ms):                            386.20
==================================================
```