### PR TITLE
feat: add data parallel rank to KVEventBatch

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -145,6 +145,7 @@ steps:
   - examples/offline_inference/rlhf_colocate.py
   - tests/examples/offline_inference/data_parallel.py
   - tests/v1/test_async_llm_dp.py
+  - tests/v1/engine/test_engine_core_client.py
   commands:
   # test with tp=2 and external_dp=2
   - VLLM_USE_V1=0 torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
@@ -154,6 +155,7 @@ steps:
   # test with internal dp
   - python3 ../examples/offline_inference/data_parallel.py
   - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/test_async_llm_dp.py
+  - pytest -v -s v1/engine/test_engine_core_client.py::test_kv_cache_events_dp
   - pytest -v -s distributed/test_utils.py
   - pytest -v -s compile/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py

--- a/tests/distributed/conftest.py
+++ b/tests/distributed/conftest.py
@@ -16,7 +16,7 @@ from .test_events import SampleBatch
 @pytest.fixture
 def random_port():
     """Generate a random port number for testing"""
-    return random.randint(10000, 60000)
+    return random.randint(10000, 59900)
 
 
 @pytest.fixture
@@ -29,15 +29,17 @@ def publisher_config(random_port, request):
         replay_endpoint = endpoint + "-replay"
     else:
         endpoint = f"tcp://*:{random_port}"
-        replay_endpoint = f"tcp://*:{random_port + 1}"
+        replay_endpoint = f"tcp://*:{random_port + 100}"
 
-    return KVEventsConfig(enable_kv_cache_events=True,
-                          publisher="zmq",
-                          endpoint=endpoint,
-                          replay_endpoint=replay_endpoint,
-                          buffer_steps=100,
-                          hwm=1000,
-                          topic="test")
+    return KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="zmq",
+        endpoint=endpoint,
+        replay_endpoint=replay_endpoint,
+        buffer_steps=100,
+        hwm=1000,
+        topic="test",
+    )
 
 
 @pytest.fixture
@@ -59,7 +61,11 @@ def subscriber(publisher_config):
     if replay_endpoint and replay_endpoint.startswith("tcp://*"):
         replay_endpoint = replay_endpoint.replace("*", "127.0.0.1")
 
-    sub = MockSubscriber(endpoint, replay_endpoint, publisher_config.topic)
+    sub = MockSubscriber(
+        [endpoint],
+        [replay_endpoint] if replay_endpoint else None,
+        publisher_config.topic,
+    )
     yield sub
     sub.close()
 
@@ -67,26 +73,37 @@ def subscriber(publisher_config):
 class MockSubscriber:
     """Helper class to receive and verify published events"""
 
-    def __init__(self,
-                 pub_endpoint: str,
-                 replay_endpoint: Optional[str] = None,
-                 topic: str = "",
-                 decode_type=SampleBatch):
+    def __init__(
+        self,
+        pub_endpoints: Union[str, list[str]],
+        replay_endpoints: Optional[Union[str, list[str]]] = None,
+        topic: str = "",
+        decode_type=SampleBatch,
+    ):
         self.ctx = zmq.Context.instance()
 
-        # Set up subscriber socket
-        self.sub = self.ctx.socket(zmq.SUB)
-        self.sub.setsockopt(zmq.SUBSCRIBE, topic.encode('utf-8'))
-        self.sub.connect(pub_endpoint)
+        # Convert single endpoint to list for consistency
+        if isinstance(pub_endpoints, str):
+            pub_endpoints = [pub_endpoints]
+        if isinstance(replay_endpoints, str):
+            replay_endpoints = [replay_endpoints]
 
-        # Set up replay socket if provided
-        self.replay = None
-        if replay_endpoint:
-            self.replay = self.ctx.socket(zmq.REQ)
-            self.replay.connect(replay_endpoint)
+        # Set up subscriber socket - connect to all endpoints
+        self.sub = self.ctx.socket(zmq.SUB)
+        self.sub.setsockopt(zmq.SUBSCRIBE, topic.encode("utf-8"))
+        for endpoint in pub_endpoints:
+            self.sub.connect(endpoint)
+
+        # Set up replay sockets if provided
+        self.replay_sockets = []
+        if replay_endpoints:
+            for replay_endpoint in replay_endpoints:
+                replay = self.ctx.socket(zmq.REQ)
+                replay.connect(replay_endpoint)
+                self.replay_sockets.append(replay)
 
         self.topic = topic
-        self.topic_bytes = topic.encode('utf-8')
+        self.topic_bytes = topic.encode("utf-8")
         self.received_msgs: list[tuple[int, SampleBatch]] = []
         self.last_seq = -1
         self.decoder = msgspec.msgpack.Decoder(type=decode_type)
@@ -106,25 +123,31 @@ class MockSubscriber:
         self.received_msgs.append((seq, data))
         return seq, data
 
-    def request_replay(self, start_seq: int) -> None:
+    def request_replay(self, start_seq: int, socket_idx: int = 0) -> None:
         """Request replay of messages starting from start_seq"""
-        if not self.replay:
-            raise ValueError("Replay socket not initialized")
+        if not self.replay_sockets:
+            raise ValueError("Replay sockets not initialized")
+        if socket_idx >= len(self.replay_sockets):
+            raise ValueError(f"Invalid socket index {socket_idx}")
 
-        self.replay.send(start_seq.to_bytes(8, "big"))
+        self.replay_sockets[socket_idx].send(start_seq.to_bytes(8, "big"))
 
-    def receive_replay(self) -> list[tuple[int, SampleBatch]]:
-        """Receive replayed messages"""
-        if not self.replay:
-            raise ValueError("Replay socket not initialized")
+    def receive_replay(self,
+                       socket_idx: int = 0) -> list[tuple[int, SampleBatch]]:
+        """Receive replayed messages from a specific replay socket"""
+        if not self.replay_sockets:
+            raise ValueError("Replay sockets not initialized")
+        if socket_idx >= len(self.replay_sockets):
+            raise ValueError(f"Invalid socket index {socket_idx}")
 
+        replay_socket = self.replay_sockets[socket_idx]
         replayed: list[tuple[int, SampleBatch]] = []
         while True:
             try:
-                if not self.replay.poll(1000):
+                if not replay_socket.poll(1000):
                     break
 
-                frames = self.replay.recv_multipart()
+                frames = replay_socket.recv_multipart()
                 if not frames or not frames[-1]:
                     # End of replay marker
                     break
@@ -141,5 +164,5 @@ class MockSubscriber:
     def close(self):
         """Clean up resources"""
         self.sub.close()
-        if self.replay:
-            self.replay.close()
+        for replay in self.replay_sockets:
+            replay.close()

--- a/tests/distributed/conftest.py
+++ b/tests/distributed/conftest.py
@@ -12,6 +12,8 @@ from vllm.distributed.kv_events import EventPublisherFactory
 
 from .test_events import SampleBatch
 
+DP_RANK = 0
+
 
 @pytest.fixture
 def random_port():
@@ -45,7 +47,7 @@ def publisher_config(random_port, request):
 @pytest.fixture
 def publisher(publisher_config):
     """Create and return a publisher instance"""
-    pub = EventPublisherFactory.create(publisher_config)
+    pub = EventPublisherFactory.create(publisher_config, DP_RANK)
     yield pub
     pub.shutdown()
 

--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -8,6 +8,8 @@ import pytest
 from vllm.distributed.kv_events import (EventBatch, EventPublisherFactory,
                                         NullEventPublisher)
 
+DP_RANK = 0
+
 
 class EventSample(
         msgspec.Struct,
@@ -120,7 +122,7 @@ def test_topic_filtering(publisher_config):
     publisher_config.replay_endpoint = None
 
     publisher_config.topic = "foo"
-    pub = EventPublisherFactory.create(publisher_config)
+    pub = EventPublisherFactory.create(publisher_config, DP_RANK)
 
     from .conftest import MockSubscriber
     sub_foo = MockSubscriber(publisher_config.endpoint, None, "foo")
@@ -184,9 +186,84 @@ def test_high_volume(publisher, subscriber):
 
 def test_null_publisher():
     """Test that NullEventPublisher can be used without errors"""
-    publisher = NullEventPublisher()
+    publisher = NullEventPublisher(DP_RANK)
 
     # This should not raise any errors
     batch = create_test_events(5)
     publisher.publish(batch)
     publisher.shutdown()
+
+
+def test_data_parallel_rank_tagging(publisher_config):
+    """Test that events are properly tagged with their data parallel rank"""
+    from vllm.config import ParallelConfig
+    from vllm.distributed.kv_events import get_kv_event_publisher
+
+    # Create mock parallel configs for different DP ranks
+    parallel_config_0 = ParallelConfig(data_parallel_size=2,
+                                       data_parallel_rank=0,
+                                       tensor_parallel_size=1,
+                                       pipeline_parallel_size=1)
+
+    parallel_config_1 = ParallelConfig(data_parallel_size=2,
+                                       data_parallel_rank=1,
+                                       tensor_parallel_size=1,
+                                       pipeline_parallel_size=1)
+
+    pub_0 = get_kv_event_publisher(parallel_config_0, publisher_config)
+    pub_1 = get_kv_event_publisher(parallel_config_1, publisher_config)
+
+    # Hardcode the expected endpoints based on port offsetting behavior
+    # Both ranks get offsets according to _offset_endpoint_port function
+    base_endpoint = publisher_config.endpoint
+    if "tcp://" in base_endpoint:
+        # For TCP endpoints: tcp://localhost:5557 -> tcp://localhost:5557, tcp://localhost:5558
+        expected_endpoint_0 = base_endpoint  # rank 0 gets port + 0 = same port
+        expected_endpoint_1 = base_endpoint.replace(
+            ":5557", ":5558")  # rank 1 gets port + 1
+    else:
+        # For inproc endpoints: inproc://test -> inproc://test_dp0, inproc://test_dp1
+        expected_endpoint_0 = base_endpoint + "_dp0"  # rank 0 gets _dp0
+        expected_endpoint_1 = base_endpoint + "_dp1"  # rank 1 gets _dp1
+
+    from .conftest import MockSubscriber
+    sub_0 = MockSubscriber(expected_endpoint_0, None, publisher_config.topic)
+    sub_1 = MockSubscriber(expected_endpoint_1, None, publisher_config.topic)
+
+    try:
+        time.sleep(0.1)  # Let publishers start up
+
+        # Publish events from different ranks
+        batch_0 = create_test_events(2)
+        batch_1 = create_test_events(3)
+
+        pub_0.publish(batch_0)
+        pub_1.publish(batch_1)
+
+        # Receive events from rank 0
+        result_0 = sub_0.receive_one(timeout=200)
+        assert result_0 is not None, "No message received from rank 0"
+        seq_0, received_0 = result_0
+
+        # Receive events from rank 1
+        result_1 = sub_1.receive_one(timeout=200)
+        assert result_1 is not None, "No message received from rank 1"
+        seq_1, received_1 = result_1
+
+        # Verify DP rank tagging
+        assert received_0.data_parallel_rank == 0, (
+            f"Expected DP rank 0, got {received_0.data_parallel_rank}")
+        assert received_1.data_parallel_rank == 1, (
+            f"Expected DP rank 1, got {received_1.data_parallel_rank}")
+
+        # Verify event content is correct
+        assert len(
+            received_0.events) == 2, "Wrong number of events from rank 0"
+        assert len(
+            received_1.events) == 3, "Wrong number of events from rank 1"
+
+    finally:
+        pub_0.shutdown()
+        pub_1.shutdown()
+        sub_0.close()
+        sub_1.close()

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -116,13 +116,10 @@ async def loop_until_fully_done_async(client: EngineCoreClient,
             outputs[out.request_id].append(out)
 
         # Check if all request IDs in outputs have finished
-        for req_id in outputs:
-            request_finished = any(out.finished for out in outputs[req_id])
-            if not request_finished:
-                await asyncio.sleep(0.1)
-                continue
+        if all(outs and outs[-1].finished for outs in outputs.values()):
+            break
 
-        break
+        await asyncio.sleep(0.1)
 
 
 # Dummy utility function to monkey-patch into engine core.

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -354,15 +354,15 @@ async def test_kv_cache_events_dp(
         m.setenv("VLLM_USE_V1", "1")
         block_size = 16
         num_blocks = 2
-        dp_size = 1
-        # tp_size = 2
+        dp_size = 2
+        tp_size = 1
 
         engine_args = EngineArgs(
             model=MODEL_NAME,
             enforce_eager=True,
             enable_prefix_caching=True,
             data_parallel_size=dp_size,
-            # tensor_parallel_size=tp_size,
+            tensor_parallel_size=tp_size,
             block_size=block_size,
         )
         engine_args.kv_events_config = publisher_config

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -13,7 +13,7 @@ from transformers import AutoTokenizer
 
 from vllm import SamplingParams
 from vllm.distributed.kv_events import (BlockStored, KVEventBatch,
-                                        _offset_endpoint_port)
+                                        ZmqEventPublisher)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.platforms import current_platform
 from vllm.usage.usage_lib import UsageContext
@@ -405,7 +405,8 @@ async def test_kv_cache_events_dp(
         base_endpoint = publisher_config.endpoint.replace("*", "127.0.0.1")
         endpoints = []
         for i in range(dp_size):
-            offset_endpoint = _offset_endpoint_port(base_endpoint, i)
+            offset_endpoint = ZmqEventPublisher.offset_endpoint_port(
+                base_endpoint, i)
             endpoints.append(offset_endpoint)
 
         subscriber = MockSubscriber(endpoints,

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -275,6 +275,8 @@ def test_kv_cache_events(
         engine_args = EngineArgs(model=MODEL_NAME,
                                  enforce_eager=True,
                                  enable_prefix_caching=True,
+                                 data_parallel_size=2,
+                                 tensor_parallel_size=2,
                                  block_size=block_size)
         engine_args.kv_events_config = publisher_config
 
@@ -319,9 +321,12 @@ def test_kv_cache_events(
 
             seq, received = result
 
+            # Print the dp_name
+            print(f"received.dp_name: {received.dp_name}")
+
             assert seq == 0, "Sequence number mismatch"
-            assert len(received.events) == 1, (
-                "We should have exactly one BlockStored event")
+            assert len(received.events) == 2, (
+                "We should have exactly two BlockStored event")
             event = received.events[0]
             assert isinstance(
                 event, BlockStored), ("We should have a BlockStored event")

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -12,7 +12,8 @@ import pytest
 from transformers import AutoTokenizer
 
 from vllm import SamplingParams
-from vllm.distributed.kv_events import BlockStored, KVEventBatch
+from vllm.distributed.kv_events import (BlockStored, KVEventBatch,
+                                        _offset_endpoint_port)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.platforms import current_platform
 from vllm.usage.usage_lib import UsageContext
@@ -36,10 +37,15 @@ PROMPT = "Hello my name is Robert and I love quantization kernels"
 PROMPT_TOKENS = TOKENIZER(PROMPT).input_ids
 
 
-def make_request(params: SamplingParams) -> EngineCoreRequest:
+def make_request(
+        params: SamplingParams,
+        prompt_tokens_ids: Optional[list[int]] = None) -> EngineCoreRequest:
+    if not prompt_tokens_ids:
+        prompt_tokens_ids = PROMPT_TOKENS
+
     return EngineCoreRequest(
         request_id=str(uuid.uuid4()),
-        prompt_token_ids=PROMPT_TOKENS,
+        prompt_token_ids=prompt_tokens_ids,
         mm_inputs=None,
         mm_hashes=None,
         mm_placeholders=None,
@@ -272,12 +278,12 @@ def test_kv_cache_events(
         block_size = 16
         num_blocks = 2
 
-        engine_args = EngineArgs(model=MODEL_NAME,
-                                 enforce_eager=True,
-                                 enable_prefix_caching=True,
-                                 data_parallel_size=2,
-                                 tensor_parallel_size=2,
-                                 block_size=block_size)
+        engine_args = EngineArgs(
+            model=MODEL_NAME,
+            enforce_eager=True,
+            enable_prefix_caching=True,
+            block_size=block_size,
+        )
         engine_args.kv_events_config = publisher_config
 
         vllm_config = engine_args.create_engine_config(
@@ -298,19 +304,8 @@ def test_kv_cache_events(
 
         try:
             custom_tokens = list(range(num_blocks * block_size))
-            request = EngineCoreRequest(
-                request_id=str(uuid.uuid4()),
-                prompt_token_ids=custom_tokens,
-                mm_inputs=None,
-                mm_hashes=None,
-                mm_placeholders=None,
-                sampling_params=SamplingParams(
-                    max_tokens=1),  # Short completion for speed
-                eos_token_id=None,
-                arrival_time=time.time(),
-                lora_request=None,
-                cache_salt=None,
-            )
+            sampling_params = SamplingParams(max_tokens=1)
+            request = make_request(sampling_params, custom_tokens)
             client.add_request(request)
 
             outputs: dict[str, list] = {request.request_id: []}
@@ -321,28 +316,144 @@ def test_kv_cache_events(
 
             seq, received = result
 
-            # Print the dp_name
-            print(f"received.dp_name: {received.dp_name}")
-
             assert seq == 0, "Sequence number mismatch"
-            assert len(received.events) == 2, (
-                "We should have exactly two BlockStored event")
+            assert (len(received.events) == 1
+                    ), "We should have exactly one BlockStored event"
             event = received.events[0]
             assert isinstance(
-                event, BlockStored), ("We should have a BlockStored event")
-            assert len(event.block_hashes) == num_blocks, (
-                "We should have a BlockStored event with 2 block_hashes")
-            assert event.block_size == block_size, (
-                "Block size should be the same as the block size")
-            assert event.parent_block_hash is None, (
-                "Parent block hash should be None")
+                event, BlockStored), "We should have a BlockStored event"
+            assert (len(event.block_hashes) == num_blocks
+                    ), "We should have a BlockStored event with 2 block_hashes"
+            assert (event.block_size == block_size
+                    ), "Block size should be the same as the block size"
+            assert (event.parent_block_hash
+                    is None), "Parent block hash should be None"
             assert event.lora_id is None, "Lora id should be None"
-            assert len(event.token_ids) == num_blocks * block_size, (
-                "Token ids should be the same as the custom tokens")
-            assert event.token_ids == custom_tokens, (
-                "Token ids should be the same as the custom tokens")
+            assert (len(event.token_ids) == num_blocks * block_size
+                    ), "Token ids should be the same as the custom tokens"
+            assert (event.token_ids == custom_tokens
+                    ), "Token ids should be the same as the custom tokens"
         finally:
             client.shutdown()
+            subscriber.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "multiprocessing_mode,publisher_config",
+    # [(True, "tcp"), (False, "inproc")],
+    [(True, "tcp")],
+    indirect=["publisher_config"],
+)
+async def test_kv_cache_events_dp(
+    monkeypatch: pytest.MonkeyPatch,
+    multiprocessing_mode: bool,
+    publisher_config,
+):
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+        block_size = 16
+        num_blocks = 2
+        dp_size = 2
+        tp_size = 2
+
+        engine_args = EngineArgs(
+            model=MODEL_NAME,
+            enforce_eager=True,
+            enable_prefix_caching=True,
+            data_parallel_size=dp_size,
+            tensor_parallel_size=tp_size,
+            block_size=block_size,
+        )
+        engine_args.kv_events_config = publisher_config
+
+        vllm_config = engine_args.create_engine_config(
+            UsageContext.UNKNOWN_CONTEXT)
+
+        executor_class = Executor.get_class(vllm_config)
+        client = EngineCoreClient.make_client(
+            multiprocess_mode=multiprocessing_mode,
+            asyncio_mode=True,
+            vllm_config=vllm_config,
+            executor_class=executor_class,
+            log_stats=False,
+        )
+        await asyncio.sleep(1)
+
+        # Build endpoints for all DP ranks
+        base_endpoint = publisher_config.endpoint.replace("*", "127.0.0.1")
+        endpoints = []
+        for i in range(dp_size):
+            offset_endpoint = _offset_endpoint_port(base_endpoint, i)
+            endpoints.append(offset_endpoint)
+
+        subscriber = MockSubscriber(endpoints,
+                                    topic=publisher_config.topic,
+                                    decode_type=KVEventBatch)
+
+        try:
+            custom_tokens = list(range(num_blocks * block_size))
+            sampling_params = SamplingParams(max_tokens=1)
+            all_request_ids = []
+
+            # Create and add 10 cloned requests
+            # NOTE: attempts to force routing to both dp groups but can be flaky
+            for i in range(10):
+                await asyncio.sleep(0.01)
+                request = make_request(sampling_params, custom_tokens)
+                await client.add_request_async(request)
+                all_request_ids.append(request.request_id)
+
+            await asyncio.sleep(0.1)
+
+            # Initialize outputs dict for all requests
+            outputs: dict[str, list] = {
+                req_id: []
+                for req_id in all_request_ids
+            }
+
+            print("processing requests...")
+            await loop_until_done_async(client, outputs)
+
+            # Receive from subscriber until no more messages
+            print("collecting results...")
+            results = []
+            while True:
+                # NOTE: timeout here can be flaky
+                result = subscriber.receive_one(timeout=1)
+                print(result)
+                if result is None:
+                    break
+                results.append(result)
+
+            # Collect all events and data_parallel_ranks from all results
+            all_events = []
+            all_dp_ranks = []
+
+            for _, received in results:
+                all_events.extend(received.events)
+                all_dp_ranks.append(received.data_parallel_rank)
+
+            # Extract all block hashes from BlockStored events
+            all_block_hashes = []
+            for event in all_events:
+                if isinstance(event, BlockStored):
+                    all_block_hashes.extend(event.block_hashes)
+
+            # Verify unique counts
+            unique_hashes = set(all_block_hashes)
+            unique_dps = set(all_dp_ranks)
+
+            assert (
+                len(unique_hashes) == 2
+            ), f"Expected 2 unique block hashes, got {len(unique_hashes)}"
+            assert (
+                len(unique_dps) == 2
+            ), f"Expected 2 unique data_parallel_ranks, got {len(unique_dps)}"
+        finally:
+            client.shutdown()
+            subscriber.close()
 
 
 @pytest.mark.timeout(20)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3743,6 +3743,10 @@ class KVEventsConfig:
     this topic to receive events.
     """
 
+    data_parallel_rank: int = None
+    """The DP rank where the event is emitted from
+    """
+
 
 class CompilationLevel:
     # constants for the levels of the compilation process

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3743,10 +3743,6 @@ class KVEventsConfig:
     this topic to receive events.
     """
 
-    data_parallel_rank: int = 0
-    """The DP rank where the event is emitted from
-    """
-
 
 class CompilationLevel:
     # constants for the levels of the compilation process

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3743,7 +3743,7 @@ class KVEventsConfig:
     this topic to receive events.
     """
 
-    data_parallel_rank: int = None
+    data_parallel_rank: int = 0
     """The DP rank where the event is emitted from
     """
 

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -56,6 +56,7 @@ class AllBlocksCleared(KVCacheEvent):
 
 class KVEventBatch(EventBatch):
     events: list[Union[BlockStored, BlockRemoved, AllBlocksCleared]]
+    dp_name: Optional[str] = None
 
 
 class EventPublisher(ABC):

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -317,7 +317,7 @@ def _offset_endpoint_port(endpoint: str, data_parallel_rank: int) -> str:
     """
     if "inproc" in endpoint:
         return f"{endpoint}_dp{data_parallel_rank}"
-    elif "tcp" in endpoint:
+    if "tcp" in endpoint:
         if endpoint and ":" in endpoint:
             # Get everything after the last colon (the port)
             last_colon_idx = endpoint.rfind(":")

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -75,7 +75,7 @@ class EventPublisher(ABC):
     operates independently of DP topology and shouldn't need DP awareness.
     """
 
-    def __init__(self, data_parallel_rank: int) -> None:
+    def __init__(self, data_parallel_rank: int = 0) -> None:
         self._data_parallel_rank = data_parallel_rank
 
     @abstractmethod
@@ -302,7 +302,8 @@ class EventPublisherFactory:
         cls._registry[name] = ctor
 
     @classmethod
-    def create(cls, config: Optional[KVEventsConfig],
+    def create(cls,
+               config: Optional[KVEventsConfig],
                data_parallel_rank: int = 0) -> EventPublisher:
         """Create publisher from a config mapping."""
         if not config:

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -303,7 +303,7 @@ class EventPublisherFactory:
 
     @classmethod
     def create(cls, config: Optional[KVEventsConfig],
-               data_parallel_rank: int) -> EventPublisher:
+               data_parallel_rank: int = 0) -> EventPublisher:
         """Create publisher from a config mapping."""
         if not config:
             return NullEventPublisher()

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -363,26 +363,11 @@ def get_kv_event_publisher(
     original_endpoint = modified_config.endpoint
     modified_config.endpoint = _offset_endpoint_port(original_endpoint,
                                                      data_parallel_rank)
-    if original_endpoint != modified_config.endpoint:
-        logger.info(
-            "KV event publisher endpoint adjusted from %s to %s for DP rank %d",
-            original_endpoint,
-            modified_config.endpoint,
-            data_parallel_rank,
-        )
 
     # Apply port offsetting to the replay_endpoint if it exists
     if modified_config.replay_endpoint:
         original_replay_endpoint = modified_config.replay_endpoint
         modified_config.replay_endpoint = _offset_endpoint_port(
             original_replay_endpoint, data_parallel_rank)
-        if original_replay_endpoint != modified_config.replay_endpoint:
-            logger.info(
-                ("KV event publisher replay_endpoint "
-                 "adjusted from %s to %s for DP rank %d"),
-                original_replay_endpoint,
-                modified_config.replay_endpoint,
-                data_parallel_rank,
-            )
 
     return EventPublisherFactory.create(modified_config)

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -326,8 +326,7 @@ def _offset_endpoint_port(endpoint: str, data_parallel_rank: int) -> str:
             new_port = base_port + data_parallel_rank
             return f"{base_addr}:{new_port}"
         return endpoint
-    else:
-        raise ValueError("Invalid endpoint: must contain 'inproc' or 'tcp'")
+    raise ValueError("Invalid endpoint: must contain 'inproc' or 'tcp'")
 
 
 def get_kv_event_publisher(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -557,11 +557,12 @@ class Scheduler(SchedulerInterface):
             scheduler_output.kv_connector_metadata = meta
 
         events = self.kv_cache_manager.take_events()
-        dp_rank = self.vllm_config.parallel_config.data_parallel_rank
-        batch = KVEventBatch(ts=time.time(),
-                             events=events,
-                             data_parallel_rank=dp_rank)
-        self.kv_event_publisher.publish(batch)
+        if events:
+            dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+            batch = KVEventBatch(ts=time.time(),
+                                 events=events,
+                                 data_parallel_rank=dp_rank)
+            self.kv_event_publisher.publish(batch)
 
         # Advance the number of computed tokens for the request AFTER
         # the request is scheduled.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -146,8 +146,6 @@ class Scheduler(SchedulerInterface):
             enable_kv_cache_events=self.enable_kv_cache_events,
         )
 
-        self.data_parallel_rank = \
-            self.vllm_config.parallel_config.data_parallel_rank
         self.kv_event_publisher = get_kv_event_publisher(
             vllm_config.parallel_config, self.kv_events_config)
 
@@ -559,9 +557,10 @@ class Scheduler(SchedulerInterface):
             scheduler_output.kv_connector_metadata = meta
 
         events = self.kv_cache_manager.take_events()
+        dp_rank = self.vllm_config.parallel_config.data_parallel_rank
         batch = KVEventBatch(ts=time.time(),
                              events=events,
-                             data_parallel_rank=self.data_parallel_rank)
+                             data_parallel_rank=dp_rank)
         self.kv_event_publisher.publish(batch)
 
         # Advance the number of computed tokens for the request AFTER

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -558,10 +558,7 @@ class Scheduler(SchedulerInterface):
 
         events = self.kv_cache_manager.take_events()
         if events:
-            dp_rank = self.vllm_config.parallel_config.data_parallel_rank
-            batch = KVEventBatch(ts=time.time(),
-                                 events=events,
-                                 data_parallel_rank=dp_rank)
+            batch = KVEventBatch(ts=time.time(), events=events)
             self.kv_event_publisher.publish(batch)
 
         # Advance the number of computed tokens for the request AFTER


### PR DESCRIPTION
Overview:

1. Add `data_parallel_rank` to `KvEventBatch`, so it can be published along with the block storage / removal events
2. Perform a port offset based on the dp rank for `EventPublisher` so there is no port conflict
3. Allow the mock subscriber to subscribe to multiple ports for testing
4. Added a test for testing the behavior of the publisher under async multi-proc, `dp=2` and `tp=2`

Resolves #18924 

<!--- pyml disable-next-line no-emphasis-as-heading -->
