### PR TITLE
[Bugfix][Config] Fix EAGLEConfig dtype set error

### DIFF
--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -72,7 +72,12 @@ class EAGLEConfig(PretrainedConfig):
         if self.model is not None:
             for k, v in self.model.to_dict().items():
                 if k not in kwargs:
-                    setattr(self, k, v)
+                    if k == "torch_dtype" and v is not None and isinstance(
+                            v, str):
+                        import torch
+                        setattr(self, k, getattr(torch, v))
+                    else:
+                        setattr(self, k, v)
 
     @classmethod
     def from_pretrained(


### PR DESCRIPTION
Fix config dtype set error in `EAGLEConfig` by convertting `torch_dtype` to `torch.dtype` if it is a str object.

I find this bug when testing `tests/spec_decode/test_spec_decode_worker.py::test_correctly_load_weight_for_eagle` locally. `config_dtype` could be str when loading eagle model, and this lead `_get_and_verify_dtype` to do **a wrong dtype casting**.

I debug `_get_and_verify_dtype` with some logs on type of `config_dtype`, and running pytest of `tests/spec_decode/test_spec_decode_worker.py::test_correctly_load_weight_for_eagle`:
```diff
diff --git a/vllm/config.py b/vllm/config.py
index fe2ad70f5..088158512 100644
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3074,6 +3074,8 @@ def _get_and_verify_dtype(
     # NOTE: getattr(config, "torch_dtype", torch.float32) is not correct
     # because config.torch_dtype can be None.
     config_dtype = getattr(config, "torch_dtype", None)
+    print(100*"&")
+    print(config_dtype, type(config_dtype))
 
     # Fallbacks for multi-modal models if the root config
     # does not define torch_dtype
@@ -3104,6 +3106,10 @@ def _get_and_verify_dtype(
 
             # Deal with torch dtype fallback for device compatibility.
             from vllm.platforms import current_platform
+            print(torch_dtype, type(torch_dtype), config_dtype, type(config_dtype))
+            print(config.get_text_config())
+            print(100*"&")
+
             if torch_dtype not in current_platform.supported_dtypes:
                 device_name = current_platform.get_device_name()
```

<details> 
<summary> bug description </summary>

**Before this pr**, when vllm get a `config_dtype`, which is a str object, `if torch_dtype not in current_platform.supported_dtypes` won't get the correct result, cause it always not in a list of elements `torch.dtype`.
Then the dtype will be automatically casted accoarding to `current_platform.supported_dtypes[0]`, eventhough the `config_dtype` acctually is supported on current device.
```bash
Your Tesla T4 device (with compute capability 7.5) doesn't support float32. Falling back to torch.float16 for compatibility.
```
**more log**:
```bash
&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
float32 <class 'str'>
float32 <class 'str'> float32 <class 'str'>
EAGLEConfig {
  "architectures": [
    "EAGLEModel"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 0,
  "eos_token_id": 2,
  "head_dim": 64,
  "hidden_act": "silu",
  "hidden_size": 768,
  "initializer_range": 0.02,
  "intermediate_size": 3072,
  "max_position_embeddings": 2048,
  "mlp_bias": false,
  "model": {
    "_attn_implementation_autoset": false,
    "_name_or_path": "JackFram/llama-68m",
    "add_cross_attention": false,
    "architectures": [
      "LlamaForCausalLM"
    ],
    "attention_bias": false,
    "attention_dropout": 0.0,
    "bad_words_ids": null,
    "begin_suppress_tokens": null,
    "bos_token_id": 0,
    "chunk_size_feed_forward": 0,
    "cross_attention_hidden_size": null,
    "decoder_start_token_id": null,
    "diversity_penalty": 0.0,
    "do_sample": false,
    "early_stopping": false,
    "encoder_no_repeat_ngram_size": 0,
    "eos_token_id": 2,
    "exponential_decay_length_penalty": null,
    "finetuning_task": null,
    "forced_bos_token_id": null,
    "forced_eos_token_id": null,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 768,
    "id2label": {
      "0": "LABEL_0",
      "1": "LABEL_1"
    },
    "initializer_range": 0.02,
    "intermediate_size": 3072,
    "is_decoder": false,
    "is_encoder_decoder": false,
    "label2id": {
      "LABEL_0": 0,
      "LABEL_1": 1
    },
    "length_penalty": 1.0,
    "max_length": 20,
    "max_position_embeddings": 2048,
    "min_length": 0,
    "mlp_bias": false,
    "model_type": "llama",
    "no_repeat_ngram_size": 0,
    "num_attention_heads": 12,
    "num_beam_groups": 1,
    "num_beams": 1,
    "num_hidden_layers": 1,
    "num_key_value_heads": 12,
    "num_return_sequences": 1,
    "output_attentions": false,
    "output_hidden_states": false,
    "output_scores": false,
    "pad_token_id": 1,
    "prefix": null,
    "pretraining_tp": 1,
    "problem_type": null,
    "pruned_heads": {},
    "remove_invalid_values": false,
    "repetition_penalty": 1.0,
    "return_dict": true,
    "return_dict_in_generate": false,
    "rms_norm_eps": 1e-06,
    "rope_scaling": null,
    "rope_theta": 10000.0,
    "sep_token_id": null,
    "suppress_tokens": null,
    "task_specific_params": null,
    "temperature": 1.0,
    "tf_legacy_loss": false,
    "tie_encoder_decoder": false,
    "tie_word_embeddings": false,
    "tokenizer_class": null,
    "top_k": 50,
    "top_p": 1.0,
    "torch_dtype": "float32",
    "torchscript": false,
    "typical_p": 1.0,
    "use_bfloat16": false,
    "use_cache": true,
    "vocab_size": 32000
  },
  "model_type": "eagle",
  "num_attention_heads": 12,
  "num_hidden_layers": 1,
  "num_key_value_heads": 12,
  "pad_token_id": 1,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-06,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "float32",
  "transformers_version": "4.51.3",
  "truncated_vocab_size": 32000,
  "use_cache": true,
  "vocab_size": 32000
}

&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
WARNING 05-30 10:48:47 [config.py:3127] Your Tesla T4 device (with compute capability 7.5) doesn't support float32. Falling back to torch.float16 for compatibility.
WARNING 05-30 10:48:47 [config.py:3166] Casting float32 to torch.float16.
INFO 05-30 10:48:57 [config.py:813] This model supports multiple tasks: {'classify', 'reward', 'score', 'embed', 'generate'}. Defaulting to 'generate'.
WARNING 05-30 10:48:57 [cuda.py:90] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
WARNING 05-30 10:48:57 [config.py:4577] Current vLLM config is not set.
INFO 05-30 10:48:57 [model_runner.py:1170] Starting to load model abhigoyal/vllm-eagle-llama-68m-random...
INFO 05-30 10:48:57 [weight_utils.py:291] Using model weights format ['*.safetensors']
INFO 05-30 10:48:58 [weight_utils.py:344] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 510.57it/s]

INFO 05-30 10:48:58 [default_loader.py:280] Loading weights took 0.06 seconds
INFO 05-30 10:48:58 [model_runner.py:1202] Model loading took 0.1580 GiB and 1.022662 seconds
```

</details> 


<details> 
<summary> fix result </summary>

**After this pr**, dtype could be check correctly, and no dtype cast happen:
```bash
&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
float32 <class 'str'>
torch.float16 <class 'torch.dtype'> torch.float32 <class 'torch.dtype'>
EAGLEConfig {
  "architectures": [
    "EAGLEModel"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 0,
  "eos_token_id": 2,
  "head_dim": 64,
  "hidden_act": "silu",
  "hidden_size": 768,
  "initializer_range": 0.02,
  "intermediate_size": 3072,
  "max_position_embeddings": 2048,
  "mlp_bias": false,
  "model": {
    "_attn_implementation_autoset": false,
    "_name_or_path": "JackFram/llama-68m",
    "add_cross_attention": false,
    "architectures": [
      "LlamaForCausalLM"
    ],
    "attention_bias": false,
    "attention_dropout": 0.0,
    "bad_words_ids": null,
    "begin_suppress_tokens": null,
    "bos_token_id": 0,
    "chunk_size_feed_forward": 0,
    "cross_attention_hidden_size": null,
    "decoder_start_token_id": null,
    "diversity_penalty": 0.0,
    "do_sample": false,
    "early_stopping": false,
    "encoder_no_repeat_ngram_size": 0,
    "eos_token_id": 2,
    "exponential_decay_length_penalty": null,
    "finetuning_task": null,
    "forced_bos_token_id": null,
    "forced_eos_token_id": null,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 768,
    "id2label": {
      "0": "LABEL_0",
      "1": "LABEL_1"
    },
    "initializer_range": 0.02,
    "intermediate_size": 3072,
    "is_decoder": false,
    "is_encoder_decoder": false,
    "label2id": {
      "LABEL_0": 0,
      "LABEL_1": 1
    },
    "length_penalty": 1.0,
    "max_length": 20,
    "max_position_embeddings": 2048,
    "min_length": 0,
    "mlp_bias": false,
    "model_type": "llama",
    "no_repeat_ngram_size": 0,
    "num_attention_heads": 12,
    "num_beam_groups": 1,
    "num_beams": 1,
    "num_hidden_layers": 1,
    "num_key_value_heads": 12,
    "num_return_sequences": 1,
    "output_attentions": false,
    "output_hidden_states": false,
    "output_scores": false,
    "pad_token_id": 1,
    "prefix": null,
    "pretraining_tp": 1,
    "problem_type": null,
    "pruned_heads": {},
    "remove_invalid_values": false,
    "repetition_penalty": 1.0,
    "return_dict": true,
    "return_dict_in_generate": false,
    "rms_norm_eps": 1e-06,
    "rope_scaling": null,
    "rope_theta": 10000.0,
    "sep_token_id": null,
    "suppress_tokens": null,
    "task_specific_params": null,
    "temperature": 1.0,
    "tf_legacy_loss": false,
    "tie_encoder_decoder": false,
    "tie_word_embeddings": false,
    "tokenizer_class": null,
    "top_k": 50,
    "top_p": 1.0,
    "torch_dtype": "float32",
    "torchscript": false,
    "typical_p": 1.0,
    "use_bfloat16": false,
    "use_cache": true,
    "vocab_size": 32000
  },
  "model_type": "eagle",
  "num_attention_heads": 12,
  "num_hidden_layers": 1,
  "num_key_value_heads": 12,
  "pad_token_id": 1,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-06,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "float32",
  "transformers_version": "4.51.3",
  "truncated_vocab_size": 32000,
  "use_cache": true,
  "vocab_size": 32000
}

&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
INFO 05-30 11:37:45 [config.py:3163] Downcasting torch.float32 to torch.float16.
INFO 05-30 11:37:55 [config.py:813] This model supports multiple tasks: {'reward', 'generate', 'score', 'classify', 'embed'}. Defaulting to 'generate'.
WARNING 05-30 11:37:55 [cuda.py:90] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
WARNING 05-30 11:37:55 [config.py:4578] Current vLLM config is not set.
INFO 05-30 11:37:55 [model_runner.py:1170] Starting to load model abhigoyal/vllm-eagle-llama-68m-random...
INFO 05-30 11:37:56 [weight_utils.py:291] Using model weights format ['*.safetensors']
INFO 05-30 11:37:56 [weight_utils.py:344] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 506.56it/s]

INFO 05-30 11:37:56 [default_loader.py:280] Loading weights took 0.06 seconds
INFO 05-30 11:37:57 [model_runner.py:1202] Model loading took 0.1580 GiB and 1.196266 seconds
```
</details> 