### PR TITLE
[Misc] reuse num_tokens_across_dp of get_dp_padding to avoid unnecessary dp all reduce in set_forward_context

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -65,6 +65,11 @@ class DPMetadata:
         else:
             # for v1 attention backends or no attn_metadata
             batchsize = num_tokens
+
+        # If num_tokens_across_dp is None, it will be computed by all_reduce
+        # Otherwise, num_tokens_across_dp[dp_rank] should be equal to batchsize
+        assert (num_tokens_across_dp is None
+                or num_tokens_across_dp[dp_rank] == batchsize)
         if num_tokens_across_dp is None:
             num_tokens_across_dp = DPMetadata.num_tokens_across_dp(
                 batchsize, dp_size, dp_rank)

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -47,8 +47,12 @@ class DPMetadata:
         return num_tokens_tensor
 
     @staticmethod
-    def make(parallel_config: ParallelConfig, attn_metadata: Any,
-             num_tokens: int) -> "DPMetadata":
+    def make(
+            parallel_config: ParallelConfig,
+            attn_metadata: Any,
+            num_tokens: int,
+            num_tokens_across_dp: Optional[torch.Tensor] = None
+    ) -> "DPMetadata":
 
         assert parallel_config.data_parallel_size > 1
         dp_size = parallel_config.data_parallel_size
@@ -61,11 +65,11 @@ class DPMetadata:
         else:
             # for v1 attention backends or no attn_metadata
             batchsize = num_tokens
-
-        num_tokens_tensor = DPMetadata.num_tokens_across_dp(
-            batchsize, dp_size, dp_rank)
-        max_tokens_across_dp_cpu = torch.max(num_tokens_tensor)
-        cu_tokens_across_dp_cpu = torch.cumsum(num_tokens_tensor, dim=0)
+        if num_tokens_across_dp is None:
+            num_tokens_across_dp = DPMetadata.num_tokens_across_dp(
+                batchsize, dp_size, dp_rank)
+        max_tokens_across_dp_cpu = torch.max(num_tokens_across_dp)
+        cu_tokens_across_dp_cpu = torch.cumsum(num_tokens_across_dp, dim=0)
         return DPMetadata(max_tokens_across_dp_cpu, cu_tokens_across_dp_cpu)
 
 
@@ -101,7 +105,8 @@ def get_forward_context() -> ForwardContext:
 def set_forward_context(attn_metadata: Any,
                         vllm_config: VllmConfig,
                         virtual_engine: int = 0,
-                        num_tokens: Optional[int] = None):
+                        num_tokens: Optional[int] = None,
+                        num_tokens_across_dp: Optional[torch.Tensor] = None):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
     Here we can inject common logic for every model forward pass.
@@ -114,7 +119,8 @@ def set_forward_context(attn_metadata: Any,
     if vllm_config.parallel_config.data_parallel_size > 1 and (
             attn_metadata is not None or num_tokens is not None):
         dp_metadata = DPMetadata.make(vllm_config.parallel_config,
-                                      attn_metadata, num_tokens or 0)
+                                      attn_metadata, num_tokens or 0,
+                                      num_tokens_across_dp)
 
     global _forward_context
     prev_context = _forward_context

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1110,7 +1110,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         dp_rank = self.vllm_config.parallel_config.data_parallel_rank
         if dp_size == 1:
             # Early exit.
-            return 0
+            return 0, torch.tensor([num_tokens],
+                                   device="cpu",
+                                   dtype=torch.int32)
 
         num_tokens_across_dp = DPMetadata.num_tokens_across_dp(
             num_tokens, dp_size, dp_rank)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1117,7 +1117,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_tokens_across_dp = DPMetadata.num_tokens_across_dp(
             num_tokens, dp_size, dp_rank)
         max_tokens_across_dp_cpu = torch.max(num_tokens_across_dp).item()
-        return max_tokens_across_dp_cpu - num_tokens, num_tokens_across_dp
+        num_tokens_after_padding = torch.tensor([max_tokens_across_dp_cpu] *
+                                                dp_size,
+                                                device="cpu",
+                                                dtype=torch.int32)
+        return max_tokens_across_dp_cpu - num_tokens, num_tokens_after_padding
 
     @torch.inference_mode()
     def execute_model(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1109,7 +1109,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                        num_tokens: int) -> tuple[int, Optional[torch.Tensor]]:
         dp_size = self.vllm_config.parallel_config.data_parallel_size
         dp_rank = self.vllm_config.parallel_config.data_parallel_rank
-        if dp_size == 1:
+        if dp_size == 1 or self.vllm_config.model_config.enforce_eager:
             # Early exit.
             return 0, None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1109,6 +1109,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                        num_tokens: int) -> tuple[int, Optional[torch.Tensor]]:
         dp_size = self.vllm_config.parallel_config.data_parallel_size
         dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+
+        # For DP: Don't pad when setting enforce_eager.
+        # This lets us set enforce_eager on the prefiller in a P/D setup and
+        # still use CUDA graphs (enabled by this padding) on the decoder.
+        #
+        # TODO(tms) : There are many cases where padding is enabled for
+        # prefills, causing unnecessary and excessive padding of activations.
+
         if dp_size == 1 or self.vllm_config.model_config.enforce_eager:
             # Early exit.
             return 0, None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1105,14 +1105,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             for k, v in self.intermediate_tensors.items()
         })
 
-    def get_dp_padding(self, num_tokens: int):
+    def get_dp_padding(self,
+                       num_tokens: int) -> tuple[int, Optional[torch.Tensor]]:
         dp_size = self.vllm_config.parallel_config.data_parallel_size
         dp_rank = self.vllm_config.parallel_config.data_parallel_rank
         if dp_size == 1:
             # Early exit.
-            return 0, torch.tensor([num_tokens],
-                                   device="cpu",
-                                   dtype=torch.int32)
+            return 0, None
 
         num_tokens_across_dp = DPMetadata.num_tokens_across_dp(
             num_tokens, dp_size, dp_rank)


### PR DESCRIPTION

## PR Description

This PR optimizes data parallel (DP) communication by reusing the `num_tokens_across_dp` tensor, thus avoiding a redundant all-reduce operation.

In the current implementation, both `execute_model` and `_dummy_run` functions in `gpu_model_runner.py` call `get_dp_padding`. This method performs an all-reduce operation to gather the number of tokens on each DP rank (`num_tokens_across_dp`).

Subsequently, these functions call `set_forward_context`, which in turn calls `DPMetadata.make`. Inside `DPMetadata.make`, another all-reduce operation is performed for the exact same purpose – to determine the number of tokens on each DP rank.

This change modifies `get_dp_padding` to return the `num_tokens_across_dp` tensor it computes. This tensor is then passed to `DPMetadata.make` via `set_forward_context`. By doing so, we eliminate the redundant all-reduce in `DPMetadata.make`, reducing inter-GPU communication overhead.

<!--- pyml disable-next-line no-emphasis-as-heading -->
