### PR TITLE
Abstract mooncake store connector to kv store connector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -103,8 +103,13 @@ KVConnectorFactory.register_connector(
 
 KVConnectorFactory.register_connector(
     "MooncakeStoreConnector",
-    "vllm.distributed.kv_transfer.kv_connector.mooncake_store_connector",
-    "MooncakeStoreConnector")
+    "vllm.distributed.kv_transfer.kv_connector.kv_store_connector",
+    "KVStoreConnector")
+
+KVConnectorFactory.register_connector(
+    "FileStoreConnector",
+    "vllm.distributed.kv_transfer.kv_connector.kv_store_connector",
+    "KVStoreConnector")
 
 KVConnectorFactory.register_connector(
     "SharedStorageConnector",

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/file_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/file_store.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Local file system based KV store implementation."""
+import os
+from typing import Optional
+
+import torch
+from safetensors.torch import load_file as safetensors_load
+from safetensors.torch import save_file as safetensors_save
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_lookup_buffer.base import (
+    KVStoreBufferBase)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class FileStore(KVStoreBufferBase):
+    """KV store implementation using local filesystem with safetensors."""
+
+    def __init__(
+        self,
+        config: VllmConfig,
+    ):
+        self.storage_path = config.kv_transfer_config.get_from_extra_config(
+            "fs_storage_path", "/tmp/vllm_kv_cache")
+        os.makedirs(self.storage_path, exist_ok=True)
+
+    def close(self):
+        """No resources to clean up for file storage"""
+        pass
+
+    def put(self, key: str, value: Optional[torch.Tensor]) -> None:
+        """Save tensor to file with key as filename."""
+        if value is None:
+            return
+
+        file_path = os.path.join(self.storage_path, f"{key}.safetensors")
+        device_id = value.device.index if value.device.type == 'cuda' else -1
+        device_tensor = torch.tensor(device_id, dtype=torch.int32)
+
+        safetensors_save({
+            "tensor": value.cpu(),
+            "device_id": device_tensor
+        }, file_path)
+
+    def get(self, key: str) -> Optional[torch.Tensor]:
+        """Load tensor from file with key as filename."""
+        file_path = os.path.join(self.storage_path, f"{key}.safetensors")
+        if not os.path.exists(file_path):
+            return None
+
+        try:
+            data = safetensors_load(file_path)
+            tensor = data["tensor"]
+            device_id = int(data["device_id"].item())
+
+            device = torch.device(
+                'cuda', device_id) if device_id >= 0 else torch.device('cpu')
+            return tensor.to(device)
+        except Exception as e:
+            logger.error("Error loading tensor %s: %s", key, str(e))
+            return None


### PR DESCRIPTION
After this abstraction, kvstore connector will support
- mooncakestore
- filestore
- any other store, will be implemented by contributors future.

# How to test

For the `MooncakeStoreConnector`, everything remain as same as before.

The following is a test for `FileStoreConnector`.

- Start vllm
```shell
VLLM_MLA_DISABLE=0 VLLM_USE_V1=0 \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 1 \
           --enforce-eager --kv-transfer-config '{"kv_connector":"FileStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"fs_storage_path":"/disc/data1/baoloongmao/file_store/data/"}}'
```
- Start a test by curl
```shell
curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
    }'
```

- Check the file
```shell
ll /disc/data1/baoloongmao/file_store/data/
total 848
drwxr-xr-x 2 root root    105 May 30 20:13 ./
drwxr-xr-x 3 root root     26 May 30 20:01 ../
-rw-r--r-- 1 root root 808860 May 30 20:15 412762975381691241_0.safetensors
-rw-r--r-- 1 root root  53396 May 30 20:15 412762975381691241_hidden_0.safetensors
```

- Check the log
```
INFO 05-30 05:15:12 [logger.py:39] Received request chatcmpl-49c705d748c74ecb96c510f05bb4f94c: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 05-30 05:15:12 [engine.py:310] Added request chatcmpl-49c705d748c74ecb96c510f05bb4f94c.
```

