### PR TITLE
[ROCm] Remove unnecessary assertion of max_model_len in ROCM_AITER_MLA attention backend.

### DIFF
--- a/vllm/attention/backends/rocm_aiter_mla.py
+++ b/vllm/attention/backends/rocm_aiter_mla.py
@@ -132,8 +132,6 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
     def __init__(self, input_builder: "ModelInputForGPUBuilder"):
         super().__init__(input_builder)
-        assert self.runner.model_config.max_model_len == 32768,\
-                "AITER MLA requires max model len to be set to 32768"
         assert self.block_size == 1, "AITER MLA requires only block size 1."
 
     def prepare(self):

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -66,9 +66,6 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
     def __init__(self, runner, kv_cache_spec: AttentionSpec,
                  block_table: BlockTable):
         super().__init__(runner, kv_cache_spec, block_table)
-        max_model_len = self.runner.model_config.max_model_len
-        assert max_model_len == 32768,\
-            "AITER MLA requires max_model_len=32768"
         assert self.kv_cache_spec.block_size == 1, "AITER MLA" \
             "only supports block size 1."
 


### PR DESCRIPTION
This PR removes the unnecessary constraint and assertion of a specific `max_model_len value` from the `ROCM_AITER_MLA` attention backend on both VLLM v1 and v0 engines.

### lm_eval results on DeepSeek-V2-Lite-Chat with default engine args on both VLLM v0 and v1 engines.

`VLLM_USE_V1=1
VLLM_ROCM_USE_AITER=1
VLLM_ROCM_USE_AITER_MOE=0
VLLM_ROCM_USE_AITER_RMSNORM=0
VLLM_ROCM_USE_AITER_LINEAR=0
lm_eval --model vllm --model_args pretrained=deepseek-ai/DeepSeek-V2-Lite-Chat,tensor_parallel_size=1,block_size=1 --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto`

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6657|±  |0.0130|
|     |       |strict-match    |     5|exact_match|↑  |0.6543|±  |0.0131|

`VLLM_USE_V1=0
VLLM_ROCM_USE_AITER=1
VLLM_ROCM_USE_AITER_MOE=0
VLLM_ROCM_USE_AITER_RMSNORM=0
VLLM_ROCM_USE_AITER_LINEAR=0
lm_eval --model vllm --model_args pretrained=deepseek-ai/DeepSeek-V2-Lite-Chat,tensor_parallel_size=1,block_size=1 --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto`

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5974|±  |0.0135|
|     |       |strict-match    |     5|exact_match|↑  |0.5876|±  |0.0136|

<!--- pyml disable-next-line no-emphasis-as-heading -->
