### PR TITLE
[CI/Build] fix ROCm build

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -39,7 +39,7 @@ FROM fetch_vllm AS build_vllm
 ARG USE_CYTHON
 # Build vLLM
 RUN cd vllm \
-    && python3 -m pip install -r requirements/rocm.txt \
+    && python3 -m pip install -r requirements/rocm-build.txt -r requirements/rocm.txt \
     && python3 setup.py clean --all  \
     && if [ ${USE_CYTHON} -eq "1" ]; then python3 tests/build_cython.py build_ext --inplace; fi \
     && python3 setup.py bdist_wheel --dist-dir=dist

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -14,3 +14,4 @@ setuptools-scm>=8
 wheel
 jinja2>=3.1.6
 amdsmi==6.2.4
+regex


### PR DESCRIPTION
The `regex` module requirement introduced in https://github.com/vllm-project/vllm/pull/18454 broke the ROCm build

Signed-off-by: Daniele Trifirò <dtrifiro@redhat.com>
