### PR TITLE
[CI/Build] remove regex from build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires = [
     "setuptools-scm>=8.0",
     "torch == 2.7.0",
     "wheel",
-    "regex",
     "jinja2",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
 from shutil import which
 
-import regex as re
 import torch
 from packaging.version import Version, parse
 from setuptools import Extension, setup

--- a/tools/enforce_regex_import.py
+++ b/tools/enforce_regex_import.py
@@ -36,6 +36,7 @@ def is_forbidden_import(line: str) -> bool:
 
 
 def check_file(filepath: str) -> list[tuple[int, str]]:
+
     violations = []
     try:
         with open(filepath, encoding='utf-8') as f:
@@ -56,6 +57,9 @@ def main() -> int:
 
     for filepath in files:
         if not Path(filepath).exists():
+            continue
+
+        if filepath == "setup.py":
             continue
 
         violations = check_file(filepath)

--- a/tools/enforce_regex_import.py
+++ b/tools/enforce_regex_import.py
@@ -36,7 +36,6 @@ def is_forbidden_import(line: str) -> bool:
 
 
 def check_file(filepath: str) -> list[tuple[int, str]]:
-
     violations = []
     try:
         with open(filepath, encoding='utf-8') as f:


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/18454 migrated all uses of the `re` stdlib module to the `regex` due to a security vulnerability explained [here](https://github.com/vllm-project/vllm/security/advisories/GHSA-w6q7-j642-7c25)

We have no security vulnerabilities by using the `re` module in `setup.py`, it just causes more problems: e.g. [it broke the ROCm build](https://github.com/vllm-project/vllm/pull/18944) and possibly others, due to how vllm is built differently for different target devices.

Signed-off-by: Daniele Trifirò <dtrifiro@redhat.com>
