### PR TITLE
Improve "failed to get the hash of the compiled graph" error

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -415,8 +415,14 @@ class InductorAdaptor(CompilerInterface):
         # compilation cache. So turn off the checks if we disable the
         # compilation cache.
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
-            assert hash_str is not None, (
-                "failed to get the hash of the compiled graph")
+            if hash_str is None:
+                raise RuntimeError(
+                    "vLLM failed to compile the model. The most "
+                    "likely reason for this is that a previous compilation "
+                    "failed, leading to a corrupted compilation artifact. "
+                    "We recommend trying to "
+                    "remove ~/.cache/vllm/torch_compile_cache and try again "
+                    "to see the real issue. ")
             assert file_path is not None, (
                 "failed to get the file path of the compiled graph")
         return compiled_graph, (hash_str, file_path)


### PR DESCRIPTION
The most common form of the error is that a previous compilation failed, leading to a corrupted cache artifact. This error usually hides some other error (that caused the compilation to fail in the first place), so we update the error message so that users will loook for the other error instead.

See #18851 for an example where people are confused and where this error
message would have helped.

We will not automatically delete the cache directory yet; that becomes unnecessary in PyTorch 2.8.0+ where we switch over to standalone_compile.