### PR TITLE
Tool parser regex timeout handling

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -159,3 +159,27 @@ def test_streaming_tool_call_with_large_steps():
     assert reconstructor.tool_calls[0].function == SIMPLE_FUNCTION_CALL
     assert reconstructor.tool_calls[1].function == PARAMETERLESS_FUNCTION_CALL
     assert reconstructor.tool_calls[2].function == EMPTY_LIST_FUNCTION_CALL
+
+
+@pytest.mark.parametrize("streaming", [False])
+def test_regex_timeout_handling(streaming: bool):
+    """test regex timeout is handled gracefully"""
+    mock_tokenizer = MagicMock()
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser(
+        "llama4_pythonic")(mock_tokenizer)
+
+    fake_problematic_input = "hello world[A(A=" + "\t)A(A=,\t" * 2
+
+    # create a mock regex that raises TimeoutError
+    mock_regex = MagicMock()
+    mock_regex.match.side_effect = TimeoutError("Regex timeout")
+
+    with patch.object(tool_parser, 'TOOL_CALL_REGEX', mock_regex):
+        content, tool_calls = run_tool_extraction(tool_parser,
+                                                  fake_problematic_input,
+                                                  streaming=streaming)
+
+        # should treat as regular text when regex times out
+        assert content == fake_problematic_input
+        assert len(tool_calls) == 0
+        mock_regex.match.assert_called_once()

--- a/vllm/entrypoints/openai/tool_parsers/llama4_pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/llama4_pythonic_tool_parser.py
@@ -7,6 +7,7 @@ from typing import Any, Union
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
+import vllm.envs as envs
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               DeltaFunctionCall, DeltaMessage,
                                               DeltaToolCall,
@@ -14,7 +15,6 @@ from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               FunctionCall, ToolCall)
 from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
     ToolParser, ToolParserManager)
-from vllm.envs import VLLM_TOOL_PARSE_REGEX_TIMEOUT
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -68,7 +68,8 @@ class Llama4PythonicToolParser(ToolParser):
 
         try:
             if not (self.TOOL_CALL_REGEX.match(
-                    model_output, timeout=VLLM_TOOL_PARSE_REGEX_TIMEOUT)):
+                    model_output,
+                    timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS)):
                 return ExtractedToolCallInformation(tools_called=False,
                                                     tool_calls=[],
                                                     content=model_output)

--- a/vllm/entrypoints/openai/tool_parsers/llama4_pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/llama4_pythonic_tool_parser.py
@@ -14,7 +14,7 @@ from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               FunctionCall, ToolCall)
 from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
     ToolParser, ToolParserManager)
-from vllm.entrypoints.openai.tool_parsers.utils import REGEX_TIMEOUT
+from vllm.envs import VLLM_TOOL_PARSE_REGEX_TIMEOUT
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -67,8 +67,8 @@ class Llama4PythonicToolParser(ToolParser):
             model_output = model_output.replace("<|python_end|>", "")
 
         try:
-            if not (self.TOOL_CALL_REGEX.match(model_output,
-                                               timeout=REGEX_TIMEOUT)):
+            if not (self.TOOL_CALL_REGEX.match(
+                    model_output, timeout=VLLM_TOOL_PARSE_REGEX_TIMEOUT)):
                 return ExtractedToolCallInformation(tools_called=False,
                                                     tool_calls=[],
                                                     content=model_output)

--- a/vllm/entrypoints/openai/tool_parsers/llama4_pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/llama4_pythonic_tool_parser.py
@@ -73,9 +73,8 @@ class Llama4PythonicToolParser(ToolParser):
                                                     tool_calls=[],
                                                     content=model_output)
         except TimeoutError:
-            logger.error(
-                "WARNING: Regex search timed out for model output: %s",
-                model_output)
+            logger.warning(
+                "Regex timeout occurred when matching tool call pattern.")
             return ExtractedToolCallInformation(tools_called=False,
                                                 tool_calls=[],
                                                 content=model_output)

--- a/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
@@ -62,18 +62,18 @@ class PythonicToolParser(ToolParser):
         """
         Extract the tool calls from a complete model response.
         """
-        no_tools_response = ExtractedToolCallInformation(tools_called=False,
-                                                         tool_calls=[],
-                                                         content=model_output)
-
         try:
             if not (self.TOOL_CALL_REGEX.match(model_output,
                                                timeout=REGEX_TIMEOUT)):
-                return no_tools_response
+                return ExtractedToolCallInformation(tools_called=False,
+                                                    tool_calls=[],
+                                                    content=model_output)
         except TimeoutError:
             logger.warning(
                 "Regex timeout occurred when matching tool call pattern.")
-            return no_tools_response
+            return ExtractedToolCallInformation(tools_called=False,
+                                                tool_calls=[],
+                                                content=model_output)
 
         try:
             module = ast.parse(model_output)
@@ -93,7 +93,9 @@ class PythonicToolParser(ToolParser):
         except Exception:
             logger.exception("Error in extracting tool call from response.")
             # Treat as regular text
-            return no_tools_response
+            return ExtractedToolCallInformation(tools_called=False,
+                                                tool_calls=[],
+                                                content=model_output)
 
     def extract_tool_calls_streaming(
         self,

--- a/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
@@ -62,16 +62,18 @@ class PythonicToolParser(ToolParser):
         """
         Extract the tool calls from a complete model response.
         """
+        is_tool_call_pattern = False
         try:
-            if not (self.TOOL_CALL_REGEX.match(
-                    model_output,
-                    timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS)):
-                return ExtractedToolCallInformation(tools_called=False,
-                                                    tool_calls=[],
-                                                    content=model_output)
+            is_tool_call_pattern = self.TOOL_CALL_REGEX.match(
+                model_output,
+                timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS) is not None
         except TimeoutError:
             logger.warning(
                 "Regex timeout occurred when matching tool call pattern.")
+            logger.debug("Regex timeout occurred when matching user input: %s",
+                         model_output)
+
+        if not is_tool_call_pattern:
             return ExtractedToolCallInformation(tools_called=False,
                                                 tool_calls=[],
                                                 content=model_output)

--- a/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
@@ -8,6 +8,7 @@ from typing import Any, Union
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
+import vllm.envs as envs
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               DeltaFunctionCall, DeltaMessage,
                                               DeltaToolCall,
@@ -15,7 +16,6 @@ from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               FunctionCall, ToolCall)
 from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
     ToolParser, ToolParserManager)
-from vllm.envs import VLLM_TOOL_PARSE_REGEX_TIMEOUT
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -64,7 +64,8 @@ class PythonicToolParser(ToolParser):
         """
         try:
             if not (self.TOOL_CALL_REGEX.match(
-                    model_output, timeout=VLLM_TOOL_PARSE_REGEX_TIMEOUT)):
+                    model_output,
+                    timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS)):
                 return ExtractedToolCallInformation(tools_called=False,
                                                     tool_calls=[],
                                                     content=model_output)

--- a/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
@@ -15,7 +15,7 @@ from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               FunctionCall, ToolCall)
 from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
     ToolParser, ToolParserManager)
-from vllm.entrypoints.openai.tool_parsers.utils import REGEX_TIMEOUT
+from vllm.envs import VLLM_TOOL_PARSE_REGEX_TIMEOUT
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -63,8 +63,8 @@ class PythonicToolParser(ToolParser):
         Extract the tool calls from a complete model response.
         """
         try:
-            if not (self.TOOL_CALL_REGEX.match(model_output,
-                                               timeout=REGEX_TIMEOUT)):
+            if not (self.TOOL_CALL_REGEX.match(
+                    model_output, timeout=VLLM_TOOL_PARSE_REGEX_TIMEOUT)):
                 return ExtractedToolCallInformation(tools_called=False,
                                                     tool_calls=[],
                                                     content=model_output)

--- a/vllm/entrypoints/openai/tool_parsers/utils.py
+++ b/vllm/entrypoints/openai/tool_parsers/utils.py
@@ -7,6 +7,10 @@ from typing import Any
 import partial_json_parser
 from partial_json_parser.core.options import Allow
 
+# Global timeout for the `regex` module, for use in all of the tool parsers.
+# This is a safety measure to prevent regex operations from hanging.
+REGEX_TIMEOUT = 5
+
 
 def find_common_prefix(s1: str, s2: str) -> str:
     """

--- a/vllm/entrypoints/openai/tool_parsers/utils.py
+++ b/vllm/entrypoints/openai/tool_parsers/utils.py
@@ -7,10 +7,6 @@ from typing import Any
 import partial_json_parser
 from partial_json_parser.core.options import Allow
 
-# Global timeout for the `regex` module, for use in all of the tool parsers.
-# This is a safety measure to prevent regex operations from hanging.
-REGEX_TIMEOUT = 5
-
 
 def find_common_prefix(s1: str, s2: str) -> str:
     """

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -119,7 +119,7 @@ if TYPE_CHECKING:
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
     VLLM_ALL2ALL_BACKEND: str = "naive"
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
-    VLLM_TOOL_PARSE_REGEX_TIMEOUT: int = 5
+    VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
 
 
 def get_default_cache_root():
@@ -831,8 +831,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: int(os.getenv("VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE", "163840")),
 
     # Regex timeout for use by the vLLM tool parsing plugins.
-    "VLLM_TOOL_PARSE_REGEX_TIMEOUT":
-    lambda: int(os.getenv("VLLM_TOOL_PARSE_REGEX_TIMEOUT", "5")),
+    "VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS":
+    lambda: int(os.getenv("VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS", "1")),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -119,6 +119,7 @@ if TYPE_CHECKING:
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
     VLLM_ALL2ALL_BACKEND: str = "naive"
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
+    VLLM_TOOL_PARSE_REGEX_TIMEOUT: int = 5
 
 
 def get_default_cache_root():
@@ -828,6 +829,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # This is used to prevent the kernel from running out of memory.
     "VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE":
     lambda: int(os.getenv("VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE", "163840")),
+
+    # Regex timeout for use by the vLLM tool parsing plugins.
+    "VLLM_TOOL_PARSE_REGEX_TIMEOUT":
+    lambda: int(os.getenv("VLLM_TOOL_PARSE_REGEX_TIMEOUT", "5")),
 }
 
 # --8<-- [end:env-vars-definition]


### PR DESCRIPTION
In https://github.com/vllm-project/vllm/pull/18454 we moved off of the std library regex library in an attempt to prevent catastrophic backtracking. 

The replacement `regex` library also supports a timeout flag, this PR adds a global timeout (making use of the new flag) for  complex tool parsers as an extra layer of protection against malicious input.

<!--- pyml disable-next-line no-emphasis-as-heading -->
