### PR TITLE
Let max_num_batched_tokens use human_readable_int for large numbers

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -224,7 +224,7 @@ def get_kwargs(cls: ConfigType) -> dict[str, Any]:
         elif contains_type(type_hints, int):
             kwargs[name]["type"] = int
             # Special case for large integers
-            if name in {"max_model_len"}:
+            if name in {"max_model_len", "max_num_batched_tokens"}:
                 kwargs[name]["type"] = human_readable_int
         elif contains_type(type_hints, float):
             kwargs[name]["type"] = float


### PR DESCRIPTION
Allow `--max-num-batched-tokens` to have human-readable integers like '1k', '2M', etc - like we have for `--max-model-len`

```
vllm serve meta-llama/Llama-3.1-8B-Instruct --enforce-eager --max-num-batched-tokens 10k
INFO 05-30 17:19:21 [__init__.py:243] Automatically detected platform cuda.
INFO 05-30 17:19:23 [__init__.py:31] Available plugins for group vllm.general_plugins:
INFO 05-30 17:19:23 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 05-30 17:19:23 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
usage: vllm serve [model_tag] [options]
vllm serve: error: argument --max-num-batched-tokens: invalid int value: '10k'
```

After:
```
vllm serve meta-llama/Llama-3.1-8B-Instruct --enforce-eager --max-num-batched-tokens 10k
INFO 05-30 17:19:35 [__init__.py:243] Automatically detected platform cuda.
INFO 05-30 17:19:37 [__init__.py:31] Available plugins for group vllm.general_plugins:
INFO 05-30 17:19:37 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 05-30 17:19:37 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-30 17:19:38 [api_server.py:1276] vLLM API server version 0.9.1.dev287+g89b1388d8
INFO 05-30 17:19:38 [cli_args.py:300] non-default args: {'enforce_eager': True, 'max_num_batched_tokens': 10000}
```