### PR TITLE
[Benchmark] Add hf_stream arg to  enable or disable datasets streaming loading

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -707,6 +707,7 @@ class HuggingFaceDataset(BenchmarkDataset):
 
         self.dataset_split = dataset_split
         self.dataset_subset = dataset_subset
+        self.dagaset_stream = dataset_stream
         self.load_data()
 
     def load_data(self) -> None:

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -700,6 +700,7 @@ class HuggingFaceDataset(BenchmarkDataset):
         dataset_path: str,
         dataset_split: str,
         dataset_subset: Optional[str] = None,
+        dataset_stream: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(dataset_path=dataset_path, **kwargs)
@@ -714,7 +715,7 @@ class HuggingFaceDataset(BenchmarkDataset):
             self.dataset_path,
             name=self.dataset_subset,
             split=self.dataset_split,
-            streaming=True,
+            streaming=self.dataset_stream,
         )
         self.data = self.data.shuffle(seed=self.random_seed)
 

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -715,6 +715,7 @@ def main(args: argparse.Namespace):
             dataset_path=args.dataset_path,
             dataset_subset=args.hf_subset,
             dataset_split=args.hf_split,
+            dataset_stream=args.hf_stream,
             random_seed=args.seed,
         ).sample(
             num_requests=args.num_prompts,
@@ -1164,6 +1165,15 @@ if __name__ == "__main__":
         default=None,
         help="Output length for each request. Overrides the output lengths "
         "from the sampled HF dataset.",
+    )
+    hf_group.add_argument(
+        "--hf-stream",
+        action="store_true",
+        default=True,
+        help="Whether to stream the HF dataset. "
+        "If set, the dataset will be streamed "
+        "instead of loaded into memory. "
+        "This is useful for large datasets that do not fit into memory.",
     )
 
     sampling_group = parser.add_argument_group("sampling parameters")

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -1169,7 +1169,6 @@ if __name__ == "__main__":
     hf_group.add_argument(
         "--hf-stream",
         action="store_true",
-        default=True,
         help="Whether to stream the HF dataset. "
         "If set, the dataset will be streamed "
         "instead of loaded into memory. "

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -719,7 +719,7 @@ if __name__ == "__main__":
         "--hf-stream",
         action="store_true",
         default=True,
-        help="Use streaming mode for HF datasets. "
+        help="Use streaming mode for HF datasets. ",
     )
 
     parser = AsyncEngineArgs.add_cli_args(parser)

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -355,6 +355,7 @@ def get_requests(args, tokenizer):
     elif args.dataset_name == "burstgpt":
         dataset_cls = BurstGPTDataset
     elif args.dataset_name == "hf":
+        common_kwargs["dataset_stream"] = args.hf_stream
         if args.dataset_path in VisionArenaDataset.SUPPORTED_DATASET_PATHS:
             dataset_cls = VisionArenaDataset
             common_kwargs["dataset_subset"] = None
@@ -713,6 +714,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--hf-split", type=str, default=None, help="Split of the HF dataset."
+    )
+    parser.add_argument(
+        "--hf-stream",
+        action="store_true",
+        default=True,
+        help="Use streaming mode for HF datasets. "
     )
 
     parser = AsyncEngineArgs.add_cli_args(parser)

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -718,7 +718,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--hf-stream",
         action="store_true",
-        default=True,
         help="Use streaming mode for HF datasets. ",
     )
 


### PR DESCRIPTION
This pr adds  `hf_stream` arg for benchmark_serving to enable or disable datasets streaming loading, Because some users have to load the dataset from local due to network reasons, we added this parameter to let users decide whether to enable streaming loading