### PR TITLE
[ROCm] [AITER] [Bugfix] Patch for AITER commit `648764942e552a8bb5fe16026703716a81f05374`

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -12,7 +12,7 @@ ARG PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
 ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
 ARG FA_BRANCH="1a7f4dfa"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="c1debd8"
+ARG AITER_BRANCH="6487649"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
 FROM ${BASE_IMAGE} AS base

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -21,8 +21,9 @@ class QuantMethod(IntEnum):
     NO = 0  # a16w16
     PER_TENSOR = 1  # w8a8 (pre_Tensor)
     PER_TOKEN = 2  # w8a8/w8a4 (per_Token)
-    BLOCK_1X128 = 3  # block quantized w8a8 (per_1x128)
-    BLOCK_128x128 = 4  # block quantized w8a8 (per_128x128)
+    BLOCK_1X32 = 3  # fp4x2
+    BLOCK_1X128 = 4  # block quantized w8a8 (per_1x128)
+    BLOCK_128x128 = 5  # block quantized w8a8 (per_128x128)
 
 
 class ActivationMethod(IntEnum):


### PR DESCRIPTION
This PR is a bugfix after PR (https://github.com/vllm-project/vllm/pull/18596). **ONLY Merge this after PR (https://github.com/vllm-project/vllm/pull/18596).**

This PR also include upgrading the AITER commit of the Dockerfile.

PR (https://github.com/vllm-project/vllm/pull/18596) introduced the use of AITER MHA which depends on a new AITER commit `648764942e552a8bb5fe16026703716a81f05374`.

AITER commit: https://github.com/ROCm/aiter/commit/a02a93ddde3176815df0ef09122ae20d0aa198d5 has introduced a new enum value in a breaking changes manner.



# lm_eval after fix

## Qwen/Qwen3-235B-A22B-FP8
```
vllm (pretrained=Qwen/Qwen3-235B-A22B-FP8,tensor_parallel_size=2,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8613|±  |0.0095|
|     |       |strict-match    |     5|exact_match|↑  |0.8408|±  |0.0101|
```

## mistralai/Mixtral-8x7B-Instruct-v0.1
```
vllm (pretrained=mistralai/Mixtral-8x7B-Instruct-v0.1,tensor_parallel_size=2,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6399|±  |0.0132|
|     |       |strict-match    |     5|exact_match|↑  |0.6361|±  |0.0133|
```

## mistralai/Mixtral-8x7B-Instruct-v0.1 dynamic fp8 quantization
```
vllm (pretrained=mistralai/Mixtral-8x7B-Instruct-v0.1,tensor_parallel_size=2,quantization=fp8,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5777|±  |0.0136|
|     |       |strict-match    |     5|exact_match|↑  |0.5754|±  |0.0136|
```

## deepseek-ai/DeepSeek-V3
```
vllm (pretrained=deepseek-ai/DeepSeek-V3,tensor_parallel_size=8,block_size=1,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9454|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|
```

Note:
Even if the AITER commit: `648764942e552a8bb5fe16026703716a81f05374` introduced a new input argument `min_seqlen_q` to `flash_attn_varlen_func`. It seems that the default value is set to `0` which retains compatibility with how the MHA is used in the ROCm MLA v1 class. Refer to https://github.com/ROCm/aiter/blob/2c1a21adad9c5b5e02619c7dd05d63f9afda3642/aiter/ops/mha.py#L1369

<!--- pyml disable-next-line no-emphasis-as-heading -->
