### PR TITLE
[BugFix] Fix incorrect metrics shutdown error log message

### DIFF
--- a/vllm/v1/metrics/prometheus.py
+++ b/vllm/v1/metrics/prometheus.py
@@ -69,9 +69,13 @@ def unregister_vllm_metrics():
 
 def shutdown_prometheus():
     """Shutdown prometheus metrics."""
+
+    path = _prometheus_multiproc_dir
+    if path is None:
+        return
     try:
         pid = os.getpid()
-        multiprocess.mark_process_dead(pid)
+        multiprocess.mark_process_dead(pid, path)
         logger.debug("Marked Prometheus metrics for process %d as dead", pid)
     except Exception as e:
         logger.error("Error during metrics cleanup: %s", str(e))


### PR DESCRIPTION
Introduced in https://github.com/vllm-project/vllm/pull/17546. We should only call mark_process_dead when we're using prometheus multiprocessing mode (with > 1 API servers).

```
ERROR 05-31 01:04:14 [prometheus.py:77] Error during metrics cleanup: expected str, bytes or os.PathLike object, not NoneType
```

Thanks to @lgeiger for reporting.