### PR TITLE
[bugfix] small fix logic issue

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -451,7 +451,7 @@ class EngineArgs:
             title="ModelConfig",
             description=ModelConfig.__doc__,
         )
-        if 'serve' not in sys.argv[1:] and '--help' not in sys.argv[1:]:
+        if not ('serve' in sys.argv[1:] and '--help' in sys.argv[1:]):
             model_group.add_argument("--model", **model_kwargs["model"])
         model_group.add_argument("--task", **model_kwargs["task"])
         model_group.add_argument("--tokenizer", **model_kwargs["tokenizer"])


### PR DESCRIPTION

Model in `vllm serve` should only use `positional arg`.
```
$ cat /tmp/config.yaml
# config.yaml

model: meta-llama/Meta-Llama-3-8B-Instruct
host: "127.0.0.1"
port: 6379
uvicorn-log-level: "info"

vllm serve  --config /tmp/config.yaml
usage: vllm serve [model_tag] [options]
vllm serve: error: ambiguous option: --model could match --model-impl, --model-loader-extra-config


vllm serve meta-llama/Meta-Llama-3-8B-Instruct --config /tmp/config.yaml
usage: vllm serve [model_tag] [options]
vllm serve: error: ambiguous option: --model could match --model-impl, --model-loader-extra-config

--------------------------------------------
$ cat /tmp/config.yaml
# config.yaml

host: "127.0.0.1"
port: 6379
uvicorn-log-level: "info"

vllm serve meta-llama/Meta-Llama-3-8B-Instruct --config /tmp/config.yaml
INFO:     Started server process [12414]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
