### PR TITLE
[doc] wrong output

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -57,7 +57,7 @@ mkdocs --version
 Example output:
 
 ```console
-mkdocs, version 1.6.1 from /opt/miniconda3/envs/mkdoc/lib/python3.9/site-packages/mkdocs (Python 3.9)
+mkdocs, version 1.6.1 from /opt/miniconda3/envs/mkdoc/lib/python3.10/site-packages/mkdocs (Python 3.10)
 ```
 
 #### Clone the `vLLM` repository


### PR DESCRIPTION


Due to the different test env, based on the `Note`, it should 3.10.

```
    Ensure that your Python version is compatible with the plugins (e.g., `mkdocs-awesome-nav` requires Python 3.10+)
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
