### PR TITLE
fix prefix caching logic for running requests without speculative tokens

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -189,6 +189,9 @@ class KVCacheManager:
                 hitting the prefix caching, excluding external tokens.
             new_computed_blocks: The cached blocks for the above new computed 
                 tokens.
+            num_draft_tokens: The number of draft tokens from speculative
+                decoding. This is excluded in cache_blocks because draft
+                tokens might be rejected.
             num_lookahead_tokens: The number of speculative tokens to allocate.
                 This is used by spec decode proposers with kv-cache such 
                 as eagle.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -230,7 +230,7 @@ class Scheduler(SchedulerInterface):
 
             num_draft_tokens = max(
                 num_new_tokens + request.num_computed_tokens -
-                request.num_tokens, 0)
+                request.num_tokens, 0) if request.spec_token_ids else 0
 
             while True:
                 new_blocks = self.kv_cache_manager.allocate_slots(


### PR DESCRIPTION
Summary:
Signed-off-by: Yu Guo <yuguo@meta.com>

for non-speculative decoding requests, the num_draft_tokens is actually accepted tokens and should not be excluded from the caching block. Hence setting num_draft_tokens to zero if speculative tokens are not present. 

https://github.com/vllm-project/vllm/blob/432ec9926ebd3ce826f0d49df0a2a5ae3cc81ec0/vllm/v1/core/kv_cache_manager.py#L277

Differential Revision: D75759797


