### PR TITLE
[Bugfix][Nixl] Fix DP Metadata Handshake

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -175,7 +175,8 @@ class NixlConnectorScheduler:
         self.side_channel_host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
         self.side_channel_port = (
             envs.VLLM_NIXL_SIDE_CHANNEL_PORT +
-            vllm_config.parallel_config.data_parallel_rank_local)
+            vllm_config.parallel_config.data_parallel_rank_local *
+            vllm_config.parallel_config.tensor_parallel_size)
         logger.info("Initializing NIXL Scheduler %s", engine_id)
 
         # Requests that need to start recv.
@@ -340,7 +341,8 @@ class NixlConnectorWorker:
         # Each TP rank listens/queries on the base_port + tp_rank.
         self.side_channel_port = (
             envs.VLLM_NIXL_SIDE_CHANNEL_PORT +
-            vllm_config.parallel_config.data_parallel_rank_local)
+            vllm_config.parallel_config.data_parallel_rank_local *
+            vllm_config.parallel_config.tensor_parallel_size)
 
         # Metadata.
         self.engine_id = engine_id

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -429,7 +429,7 @@ class NixlConnectorWorker:
         # This is a hack to keep us moving. We will switch when
         # we switch to HTTP-based NIXL metadata exchange.
         path = make_zmq_path("tcp", host, port + self.tp_rank)
-        logger.info("Querying metadata on path: %s", path)
+        logger.debug("Querying metadata on path: %s", path)
         with zmq_ctx(zmq.REQ, path) as sock:
             # Send query for the request.
             sock.send(GET_META_MSG)


### PR DESCRIPTION
SUMMARY:
* metadata exchange was using the wrong ports as any dp group can exchange with any other dp group

SAMPLE JUSTFILE:

```
# Setting this allows creating a symlink to Justfile from another dir
set working-directory := "/home/rshaw/vllm/pd_examples/"

# Needed for the proxy server
vllm-directory := "/home/rshaw/vllm/" 

MODEL := "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"

TP_SIZE := "1"
DP_SIZE := "4"
DP_SIZE_LOCAL := "2"
DATA_PARALLEL_ADDR := "127.0.0.1"
DATA_PARALLEL_PORT_P := "5555"
DATA_PARALLEL_PORT_D := "5556"

port PORT: 
  @python port_allocator.py {{PORT}}


p_leader:
    VLLM_NIXL_SIDE_CHANNEL_PORT=$(just port 5557) \
    CUDA_VISIBLE_DEVICES=0,1 \
    vllm serve {{MODEL}} \
      --port $(just port 8100) \
      --disable-log-requests \
      --enforce-eager \
      --kv-transfer-config \
        '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
      --enable-expert-parallel \
      --tensor-parallel-size {{TP_SIZE}} \
      --data-parallel-size {{DP_SIZE}} \
      --data-parallel-size-local {{DP_SIZE_LOCAL}} \
      --data-parallel-address {{DATA_PARALLEL_ADDR}} \
      --data-parallel-rpc-port $(just port {{DATA_PARALLEL_PORT_P}}) \
      --trust-remote-code

p_worker:
    VLLM_NIXL_SIDE_CHANNEL_PORT=$(just port 5558) \
    CUDA_VISIBLE_DEVICES=2,3 \
    vllm serve {{MODEL}} \
      --port $(just port 8100) \
      --disable-log-requests \
      --enforce-eager \
      --kv-transfer-config \
        '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
      --enable-expert-parallel \
      --tensor-parallel-size {{TP_SIZE}} \
      --data-parallel-size {{DP_SIZE}} \
      --data-parallel-size-local {{DP_SIZE_LOCAL}} \
      --data-parallel-address {{DATA_PARALLEL_ADDR}} \
      --data-parallel-rpc-port $(just port {{DATA_PARALLEL_PORT_P}}) \
      --headless \
      --data-parallel-start-rank {{DP_SIZE_LOCAL}} \
      --trust-remote-code


d_leader:
    VLLM_NIXL_SIDE_CHANNEL_PORT=$(just port 5559) \
    CUDA_VISIBLE_DEVICES=4,5 \
    vllm serve {{MODEL}} \
      --port $(just port 8200) \
      --disable-log-requests \
      --enforce-eager \
      --kv-transfer-config \
        '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
      --enable-expert-parallel \
      --tensor-parallel-size {{TP_SIZE}} \
      --data-parallel-size {{DP_SIZE}} \
      --data-parallel-size-local {{DP_SIZE_LOCAL}} \
      --data-parallel-address {{DATA_PARALLEL_ADDR}} \
      --data-parallel-rpc-port $(just port {{DATA_PARALLEL_PORT_D}}) \
      --trust-remote-code

d_worker:
    VLLM_NIXL_SIDE_CHANNEL_PORT=$(just port 5560) \
    CUDA_VISIBLE_DEVICES=6,7 \
    vllm serve {{MODEL}} \
      --port $(just port 8200) \
      --disable-log-requests \
      --enforce-eager \
      --kv-transfer-config \
        '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
      --enable-expert-parallel \
      --tensor-parallel-size {{TP_SIZE}} \
      --data-parallel-size {{DP_SIZE}} \
      --data-parallel-size-local {{DP_SIZE_LOCAL}} \
      --data-parallel-address {{DATA_PARALLEL_ADDR}} \
      --data-parallel-rpc-port $(just port {{DATA_PARALLEL_PORT_D}}) \
      --headless \
      --data-parallel-start-rank {{DP_SIZE_LOCAL}} \
      --trust-remote-code


proxy:
    python "{{vllm-directory}}tests/v1/kv_connector/nixl_integration/toy_proxy_server.py" \
      --port $(just port 8192) \
      --prefiller-port $(just port 8100) \
      --decoder-port $(just port 8200)  

eval:
  lm_eval --model local-completions --tasks gsm8k \
    --model_args model={{MODEL}},base_url=http://127.0.0.1:$(just port 8192)/v1/completions,num_concurrent=50,max_retries=3,tokenized_requests=False \
    --limit 1000

```

<!--- pyml disable-next-line no-emphasis-as-heading -->
