### PR TITLE
[Bugfix] Use cmake 3.26.1 instead of 3.26 to avoid build failure

### DIFF
--- a/docker/Dockerfile.neuron
+++ b/docker/Dockerfile.neuron
@@ -34,7 +34,7 @@ RUN --mount=type=bind,source=.git,target=.git \
     if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh ; fi
 
 RUN python3 -m pip install -U \
-        'cmake>=3.26' ninja packaging 'setuptools-scm>=8' wheel jinja2 \
+        'cmake>=3.26.1' ninja packaging 'setuptools-scm>=8' wheel jinja2 \
         -r requirements/neuron.txt
 
 ENV VLLM_TARGET_DEVICE neuron

--- a/docs/getting_started/installation/cpu/build.inc.md
+++ b/docs/getting_started/installation/cpu/build.inc.md
@@ -17,7 +17,7 @@ Third, install Python packages for vLLM CPU backend building:
 
 ```console
 pip install --upgrade pip
-pip install "cmake>=3.26" wheel packaging ninja "setuptools-scm>=8" numpy
+pip install "cmake>=3.26.1" wheel packaging ninja "setuptools-scm>=8" numpy
 pip install -v -r requirements/cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Should be mirrored in requirements/build.txt
 requires = [
-    "cmake>=3.26",
+    "cmake>=3.26.1",
     "ninja",
     "packaging>=24.2",
     "setuptools>=77.0.3,<80.0.0",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,5 +1,5 @@
 # Should be mirrored in pyproject.toml
-cmake>=3.26
+cmake>=3.26.1
 ninja
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -7,7 +7,7 @@ torchvision==0.22.0
 torchaudio==2.7.0
 
 triton==3.2
-cmake>=3.26,<4
+cmake>=3.26.1,<4
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8

--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -2,7 +2,7 @@
 -r common.txt
 
 # Dependencies for TPU
-cmake>=3.26
+cmake>=3.26.1
 packaging>=24.2
 setuptools-scm>=8
 wheel

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -2,7 +2,7 @@
 -r common.txt
 
 ray>=2.9
-cmake>=3.26
+cmake>=3.26.1
 packaging>=24.2
 setuptools-scm>=8
 setuptools>=77.0.3,<80.0.0


### PR DESCRIPTION
To address https://github.com/vllm-project/vllm/issues/18748

Test plan:

Verified with cmake 3.26.0 (problematic), 3.26.1, 3.27.9, 3.30.5, 4.0.2. All others are good, only 3.26.0 only generate _C.so, not _C.abi3.so.

python setup.py develop with cmake==3.26.0
```
-- Install configuration: "RelWithDebInfo"
-- Installing: /home/lufang/gitrepos/vllm/build/lib.linux-x86_64-cpython-310/vllm/_moe_C.so
-- Set runtime path of "/home/lufang/gitrepos/vllm/build/lib.linux-x86_64-cpython-310/vllm/_moe_C.so" to ""
-- Install configuration: "RelWithDebInfo"
-- Installing: /home/lufang/gitrepos/vllm/build/lib.linux-x86_64-cpython-310/vllm/_rocm_C.so
-- Set runtime path of "/home/lufang/gitrepos/vllm/build/lib.linux-x86_64-cpython-310/vllm/_rocm_C.so" to ""
-- Install configuration: "RelWithDebInfo"
-- Installing: /home/lufang/gitrepos/vllm/build/lib.linux-x86_64-cpython-310/vllm/_C.so
-- Set runtime path of "/home/lufang/gitrepos/vllm/build/lib.linux-x86_64-cpython-310/vllm/_C.so" to ""
error: can't copy 'build/lib.linux-x86_64-cpython-310/vllm/_moe_C.abi3.so': doesn't exist or not a regular file
```

python setup.py develop with cmake>=3.26.1
```
Using /home/lufang/gitrepos/vllm/.venv/lib/python3.10/site-packages
Finished processing dependencies for vllm==0.9.1.dev108+g432ec9926.d20250602.rocm631
```