### PR TITLE
[Bugfix] Max concurrency estimation and check_enough_kv_cache_memory for models with sliding window layers

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -11,13 +11,11 @@ from vllm.utils import GiB_bytes, sha256
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 # disable yapf here as it formats differently than isort such that both fail
 # yapf: disable
-from vllm.v1.core.kv_cache_utils import (FreeKVCacheBlockQueue, KVCacheBlock,
-                                         PrefixCachingMetrics,
-                                         estimate_max_model_len,
-                                         generate_block_hash_extra_keys,
-                                         hash_block_tokens,
-                                         hash_request_tokens,
-                                         unify_kv_cache_configs)
+from vllm.v1.core.kv_cache_utils import (
+    FreeKVCacheBlockQueue, KVCacheBlock, PrefixCachingMetrics,
+    estimate_max_model_len, generate_block_hash_extra_keys,
+    get_max_concurrency_for_kv_cache_config, hash_block_tokens,
+    hash_request_tokens, unify_kv_cache_configs)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, KVCacheTensor,
                                         SlidingWindowSpec)
@@ -596,6 +594,89 @@ def test_estimate_max_model_len(model_id, max_model_len,
     estimated_max_len = estimate_max_model_len(vllm_config, kv_cache_spec,
                                                8 * GiB_bytes)
     assert estimated_max_len == want_estimated_max_len
+
+
+def test_get_max_concurrency_for_kv_cache_config():
+    # Create a VllmConfig
+    model_id = "Qwen/Qwen1.5-7B"
+    max_model_len = 16384
+    model_config = ModelConfig(
+        model_id,
+        task="generate",
+        tokenizer=model_id,
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        seed=0,
+        dtype="float16",
+        max_model_len=max_model_len,
+    )
+    scheduler_config = SchedulerConfig(max_num_batched_tokens=1024,
+                                       enable_chunked_prefill=True)
+
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        scheduler_config=scheduler_config,
+    )
+
+    full_attention_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=32,
+        head_size=128,
+        dtype=torch.float16,
+        use_mla=False,
+    )
+
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=32,
+        head_size=128,
+        dtype=torch.float16,
+        use_mla=False,
+        sliding_window=1024,
+    )
+
+    # block_size * num_kv_heads * head_size * 2 (fp16) * 2 (k, v) * num_layers
+    memory_per_block_bytes = 16 * 32 * 128 * 2 * 2 * 32
+    kv_cache_config_full_attention = KVCacheConfig(
+        num_blocks=int(1024 * 1.5),
+        tensors={},
+        kv_cache_groups=[
+            KVCacheGroupSpec([f"layer_{i}" for i in range(32)],
+                             full_attention_spec),
+        ],
+    )
+    max_concurrency_full_attention = get_max_concurrency_for_kv_cache_config(
+        vllm_config,
+        kv_cache_config_full_attention,
+        memory_per_block_bytes,
+    )
+    assert max_concurrency_full_attention == 1.5
+
+    kv_cache_config_sliding_window = KVCacheConfig(
+        num_blocks=129 * 3,
+        tensors={},
+        kv_cache_groups=[
+            KVCacheGroupSpec([f"layer_{i}" for i in range(32)],
+                             sliding_window_spec),
+        ],
+    )
+    max_concurrency_sliding_window = get_max_concurrency_for_kv_cache_config(
+        vllm_config, kv_cache_config_sliding_window, memory_per_block_bytes)
+    assert max_concurrency_sliding_window == 3
+
+    kv_cache_config_hybrid_model = KVCacheConfig(
+        num_blocks=(1024 + 129) * 3,
+        tensors={},
+        kv_cache_groups=[
+            KVCacheGroupSpec([f"layer_{i}" for i in range(32)],
+                             full_attention_spec),
+            KVCacheGroupSpec([f"layer_{i}" for i in range(32, 64)],
+                             sliding_window_spec),
+        ],
+    )
+    max_concurrency_hybrid_model = get_max_concurrency_for_kv_cache_config(
+        vllm_config, kv_cache_config_hybrid_model, memory_per_block_bytes)
+    assert max_concurrency_hybrid_model == 3
 
 
 def test_allocate_with_lookahead():

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -635,8 +635,6 @@ def test_get_max_concurrency_for_kv_cache_config():
         sliding_window=1024,
     )
 
-    # block_size * num_kv_heads * head_size * 2 (fp16) * 2 (k, v) * num_layers
-    memory_per_block_bytes = 16 * 32 * 128 * 2 * 2 * 32
     kv_cache_config_full_attention = KVCacheConfig(
         num_blocks=int(1024 * 1.5),
         tensors={},
@@ -646,10 +644,7 @@ def test_get_max_concurrency_for_kv_cache_config():
         ],
     )
     max_concurrency_full_attention = get_max_concurrency_for_kv_cache_config(
-        vllm_config,
-        kv_cache_config_full_attention,
-        memory_per_block_bytes,
-    )
+        vllm_config, kv_cache_config_full_attention)
     assert max_concurrency_full_attention == 1.5
 
     kv_cache_config_sliding_window = KVCacheConfig(
@@ -661,7 +656,7 @@ def test_get_max_concurrency_for_kv_cache_config():
         ],
     )
     max_concurrency_sliding_window = get_max_concurrency_for_kv_cache_config(
-        vllm_config, kv_cache_config_sliding_window, memory_per_block_bytes)
+        vllm_config, kv_cache_config_sliding_window)
     assert max_concurrency_sliding_window == 3
 
     kv_cache_config_hybrid_model = KVCacheConfig(
@@ -675,7 +670,7 @@ def test_get_max_concurrency_for_kv_cache_config():
         ],
     )
     max_concurrency_hybrid_model = get_max_concurrency_for_kv_cache_config(
-        vllm_config, kv_cache_config_hybrid_model, memory_per_block_bytes)
+        vllm_config, kv_cache_config_hybrid_model)
     assert max_concurrency_hybrid_model == 3
 
 


### PR DESCRIPTION
This PR fixes two bugs:
1. If a model contains both sliding window attention and full attention, the sliding window attention layers are regarded as full attention layers when allocating kv cache, but in `check_enough_kv_cache_memory`, they are still regarded as sliding window attention layers. This PR fix it by changing the order of `unify_hybrid_kv_cache_specs` and `check_enough_kv_cache_memory` so that we first change sliding window layers to full attention layers, and then perform the check.

2. The max concurrency estimation in `_get_kv_cache_config_uniform_type` didn't considered models with sliding window layers. This PR fixes it.

* `vllm serve bigcode/starcoder2-3b` (a model that all layers use sliding window attention, result changed)

Main branch:
```
INFO 06-02 08:17:03 [kv_cache_utils.py:638] GPU KV cache size: 2,198,512 tokens
INFO 06-02 08:17:03 [kv_cache_utils.py:641] Maximum concurrency for 16,384 tokens per request: 134.19x
```

This PR:
```
INFO 06-02 08:11:22 [kv_cache_utils.py:675] GPU KV cache size: 2,198,512 tokens
INFO 06-02 08:11:22 [kv_cache_utils.py:679] Maximum concurrency for 16,384 tokens per request: 178.68x
```

* `vllm serve meta-llama/Llama-3.1-8B-Instruct` (a model that all layers use full attention, result not changed)

Main branch:
```
INFO 06-02 08:18:09 [kv_cache_utils.py:638] GPU KV cache size: 415,248 tokens
INFO 06-02 08:18:09 [kv_cache_utils.py:641] Maximum concurrency for 131,072 tokens per request: 3.17x
```

This PR:
```
INFO 06-02 08:13:24 [kv_cache_utils.py:675] GPU KV cache size: 415,248 tokens
INFO 06-02 08:13:24 [kv_cache_utils.py:679] Maximum concurrency for 131,072 tokens per request: 3.17x
```