### PR TITLE
[Bugfix] [Model] Fixed idefics3 bug after transformers update

### DIFF
--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -203,8 +203,8 @@ class Idefics3ProcessingInfo(BaseProcessingInfo):
             processor: Optional[Idefics3Processor]) -> tuple[str, str, str]:
         if processor is None:
             processor = self.get_hf_processor()
-        image_token = processor.image_token.content
-        fake_image_token = processor.fake_image_token.content
+        image_token = processor.image_token
+        fake_image_token = processor.fake_image_token
         global_image_token = processor.global_image_tag
         return image_token, fake_image_token, global_image_token
 


### PR DESCRIPTION
As reported on [slack](https://vllm-dev.slack.com/archives/C07QP347J4D/p1748553306249599), there is an issue in vLLM v0.9.0+

It seems like maybe [this commit](https://github.com/huggingface/transformers/commit/32eca7197a8d2618417a0d665db38d0af3695a2c#diff-7ae1d9ac449e0e23c6d0cf0bb644a4a261aba93f2d8f5ee73460f675fd5d25ff) in transformers and [this commit in vLLM](https://github.com/vllm-project/vllm/commit/102bf967f09d16df654aab68bc86969fc2f58fcc#diff-92ad5a7b094adf2123c5b0d5b2dd1bbb8489047dfac7134f801eda6b20f60e56) didn’t quite match up. In `transformers`, `self.image_token` is set to the `AddedToken.content` value, whereas in vLLM, it’s trying to access the `.content` attribute on `image_token`.