### PR TITLE
Update setuptools_scm dependency on setuptools>75

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -15,7 +15,7 @@ RUN apt-get update -q -y && apt-get install -q -y \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
     apt-transport-https ca-certificates wget curl
 # Remove sccache    
-RUN python3 -m pip install --upgrade pip && pip install setuptools==75.8.2 setuptools_scm
+RUN python3 -m pip install --upgrade pip
 RUN apt-get purge -y sccache; python3 -m pip uninstall -y sccache; rm -f "$(which sccache)"
 ARG COMMON_WORKDIR
 WORKDIR ${COMMON_WORKDIR}

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -15,7 +15,7 @@ RUN apt-get update -q -y && apt-get install -q -y \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
     apt-transport-https ca-certificates wget curl
 # Remove sccache    
-RUN python3 -m pip install --upgrade pip && pip install setuptools_scm
+RUN python3 -m pip install --upgrade pip && pip install setuptools==75.8.2 setuptools_scm
 RUN apt-get purge -y sccache; python3 -m pip uninstall -y sccache; rm -f "$(which sccache)"
 ARG COMMON_WORKDIR
 WORKDIR ${COMMON_WORKDIR}

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -35,6 +35,7 @@ mistral_common[opencv] >= 1.5.4
 opencv-python-headless >= 4.11.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
+setuptools>=75.8.2;python_version > '3.9' #Setuptools working combination with setuptools_scm>=8
 setuptools>=77.0.3,<80; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
 compressed-tensors == 0.9.4 # required for compressed-tensors


### PR DESCRIPTION
VLLM code is installing setuptools_scm but not making sure of compatible setuptools version

If any docker doesn't have correct compatible setuptools version for setuptools_scm, it breaks whl file name and found "UNKNOWN" in it's name

creating 'dist/UNKNOWN-0.8.6-cp310-cp310-linux_x86_64.whl' 

This PR will make sure, required compatible version is pulled.

This PR ia doing two changes
1. Removing redundancy by removing setuptools_scm in Dockerfile.rocm because rocm.txt or rocm-build.txt both has this package for installation 
2. Keeping setuptools requirement for setuptools_scm purpose in common.txt
I see that https://github.com/vllm-project/vllm/pull/17389 PR has setuptools changes but it's missing in rocm.txt which is called in Dockerfile.rocm
Since rocm.txt is calling common.txt so kept in common.txt which will help for all.


<!--- pyml disable-next-line no-emphasis-as-heading -->
