### PR TITLE
[Cleanup][v1]:remote guided-decoding-backend for example

### DIFF
--- a/examples/online_serving/openai_chat_completion_structured_outputs.py
+++ b/examples/online_serving/openai_chat_completion_structured_outputs.py
@@ -138,7 +138,6 @@ def extra_backend_options_completion(client: OpenAI, model: str):
             extra_body={
                 "guided_regex": r"\w+@\w+\.com\n",
                 "stop": ["\n"],
-                "guided_decoding_backend": "xgrammar",
                 "guided_decoding_disable_fallback": True,
             },
         )


### PR DESCRIPTION
Exec the example will result in the following error because, in v1, the Request-level structured output does not support the `guided_decoding_backend` parameter.

https://github.com/vllm-project/vllm/blob/main/vllm/v1/engine/processor.py#L161

<img width="921" alt="image" src="https://github.com/user-attachments/assets/ec2a9355-0451-4ba9-8144-23b278e7aed5" />
