### PR TITLE
[Bugfix] disable processor cache 

### DIFF
--- a/vllm/v1/engine/mm_input_cache.py
+++ b/vllm/v1/engine/mm_input_cache.py
@@ -34,8 +34,8 @@ class MirroredProcessingCache:
 
     def __init__(self, model_config):
         mm_config = model_config.multimodal_config
-        disable_mm_preprocessor_cache = mm_config is not None and \
-            not mm_config.disable_mm_preprocessor_cache
+        disable_mm_preprocessor_cache = (
+            mm_config is not None and mm_config.disable_mm_preprocessor_cache)
         self.use_cache = not disable_mm_preprocessor_cache
         self.mm_cache = ProcessingCache.get_lru_cache(VLLM_MM_INPUT_CACHE_GIB,
                                                       MultiModalKwargs)


### PR DESCRIPTION

Splits out the bugfix from https://github.com/vllm-project/vllm/pull/13754#discussion_r2122660467 to a new PR. Currently passing `disable_mm_preprocessor_cache=True` doesn't do what is expected