### PR TITLE
[CI/Build][Quantization] Investigate the failing GGUF Llama tests

### DIFF
--- a/tests/models/quantization/test_gguf.py
+++ b/tests/models/quantization/test_gguf.py
@@ -36,8 +36,8 @@ class GGUFTestConfig(NamedTuple):
 
 LLAMA_CONFIG = GGUFTestConfig(
     original_model="meta-llama/Llama-3.2-1B-Instruct",
-    gguf_repo="bartowski/Llama-3.2-1B-Instruct-GGUF",
-    gguf_filename="Llama-3.2-1B-Instruct-IQ4_XS.gguf",
+    gguf_repo="unsloth/Llama-3.2-1B-Instruct-GGUF",
+    gguf_filename="Llama-3.2-1B-Instruct-IQ4_NL.gguf",
 )
 
 QWEN2_CONFIG = GGUFTestConfig(

--- a/tests/models/quantization/test_gguf.py
+++ b/tests/models/quantization/test_gguf.py
@@ -36,8 +36,8 @@ class GGUFTestConfig(NamedTuple):
 
 LLAMA_CONFIG = GGUFTestConfig(
     original_model="meta-llama/Llama-3.2-1B-Instruct",
-    gguf_repo="unsloth/Llama-3.2-1B-Instruct-GGUF",
-    gguf_filename="Llama-3.2-1B-Instruct-IQ4_NL.gguf",
+    gguf_repo="bartowski/Llama-3.2-1B-Instruct-GGUF",
+    gguf_filename="Llama-3.2-1B-Instruct-Q6_K.gguf",
 )
 
 QWEN2_CONFIG = GGUFTestConfig(


### PR DESCRIPTION

- Can't reproduce the failing Llama GGUF tests on main branch locally.
- Try to switch to Q6_K models with higher BPW to see if the test can pass now.

<!--- pyml disable-next-line no-emphasis-as-heading -->
