### PR TITLE
[Bugfix]: import pandas for benchmarks

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,3 +48,4 @@ opentelemetry-sdk>=1.26.0  # vllm.tracing
 opentelemetry-api>=1.26.0  # vllm.tracing
 opentelemetry-exporter-otlp>=1.26.0  # vllm.tracing
 opentelemetry-semantic-conventions-ai>=0.4.1  # vllm.tracing
+pandas == 2.2.3


### PR DESCRIPTION
FIX #19078

`VLLM_USE_PRECOMPILED=1 uv pip install --editable .`, pandas (introduced in #18511) is not installed.  
