### PR TITLE
[P/D] Exchange NIXL metadata through rank 0

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -435,9 +435,14 @@ class NixlConnectorWorker:
             while True:
                 identity, _, msg = sock.recv_multipart()
                 # Decode the message which contains (GET_META_MSG, rank)
+<<<<<<< HEAD
                 msg, target_rank = msgspec.msgpack.decode(msg)
                 logger.info("Received message from rank %s", target_rank)
                 if msg != GET_META_MSG:
+=======
+                msg_tuple = msgspec.msgpack.decode(msg)
+                if msg_tuple[0] != GET_META_MSG:
+>>>>>>> 93850c220 (clean logging)
                     logger.warning(
                         "Connection listener got unexpected message %s", msg)
                 sock.send_multipart(
@@ -627,9 +632,7 @@ class NixlConnectorWorker:
         # Other ranks send their metadata to rank 0
         if self.tp_rank == 0:
             # After KV Caches registered, listen for new connections.
-            logger.info("Rank %s: Starting handshake listener", self.tp_rank)
-            logger.info("Rank %s: Waiting for metadata from other ranks",
-                        self.tp_rank)
+            logger.debug("Rank %s: Starting handshake listener", self.tp_rank)
             combined_metadata = [rank_metadata]
             for i in range(1, self.world_size):
                 combined_metadata.append(self.tp_group.recv_object(src=i))
@@ -639,9 +642,9 @@ class NixlConnectorWorker:
                         "Received metadata from different engine id: %s",
                         remote_metadata.engine_id)
 
-            logger.info("Rank %s: Received metadata from other ranks",
-                        self.tp_rank)
-            
+            logger.debug("Rank %s: Received metadata from other ranks",
+                         self.tp_rank)
+
             ready_event = threading.Event()
             self._nixl_handshake_listener_t = threading.Thread(
                 target=self._nixl_handshake_listener,
@@ -652,7 +655,7 @@ class NixlConnectorWorker:
             ready_event.wait()
         else:
             # Other ranks send their metadata to rank 0
-            logger.info("Rank %s: Sending metadata to rank 0", self.tp_rank)
+            logger.debug("Rank %s: Sending metadata to rank 0", self.tp_rank)
             self.tp_group.send_object(rank_metadata, dst=0)
 
     def add_remote_agent(self,
@@ -995,10 +998,10 @@ class NixlConnectorWorker:
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
 
-        logger.info("Rank %s: local_block_descs_ids: %s", self.tp_rank,
-                    local_block_descs_ids)
-        logger.info("Rank %s: remote_block_descs_ids: %s", self.tp_rank,
-                    remote_block_descs_ids)
+        logger.debug("Rank %s: local_block_descs_ids: %s", self.tp_rank,
+                     local_block_descs_ids)
+        logger.debug("Rank %s: remote_block_descs_ids: %s", self.tp_rank,
+                     remote_block_descs_ids)
 
         # Prepare transfer with Nixl.
         handle = self.nixl_wrapper.make_prepped_xfer(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -336,7 +336,7 @@ class NixlConnectorWorker:
 
         # NIXL handshake port.
         # NOTE(rob): Within a DP group, each DP rank gets its own
-        # base port (which is sent in the KVTransferParams).
+        # port (which is sent in the KVTransferParams).
         self.side_channel_port = (
             envs.VLLM_NIXL_SIDE_CHANNEL_PORT +
             vllm_config.parallel_config.data_parallel_rank_local)
@@ -413,7 +413,7 @@ class NixlConnectorWorker:
 
     @staticmethod
     def _nixl_handshake_listener(metadata: list[NixlAgentMetadata],
-                                 ready_event: threading.Event, base_port: int):
+                                 ready_event: threading.Event, port: int):
         """Background thread for getting new NIXL handshakes."""
         # NOTE(rob): this is a simple implementation. We will move
         # to a better approach via HTTP endpoint soon.
@@ -428,7 +428,7 @@ class NixlConnectorWorker:
 
         # Listen for new requests for metadata.
         host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
-        path = make_zmq_path("tcp", host, base_port)
+        path = make_zmq_path("tcp", host, port)
         logger.debug("Starting listening on path: %s", path)
         with zmq_ctx(zmq.ROUTER, path) as sock:
             ready_event.set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -435,14 +435,9 @@ class NixlConnectorWorker:
             while True:
                 identity, _, msg = sock.recv_multipart()
                 # Decode the message which contains (GET_META_MSG, rank)
-<<<<<<< HEAD
                 msg, target_rank = msgspec.msgpack.decode(msg)
-                logger.info("Received message from rank %s", target_rank)
+                logger.debug("Received message from rank %s", target_rank)
                 if msg != GET_META_MSG:
-=======
-                msg_tuple = msgspec.msgpack.decode(msg)
-                if msg_tuple[0] != GET_META_MSG:
->>>>>>> 93850c220 (clean logging)
                     logger.warning(
                         "Connection listener got unexpected message %s", msg)
                 sock.send_multipart(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -998,11 +998,6 @@ class NixlConnectorWorker:
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
 
-        logger.debug("Rank %s: local_block_descs_ids: %s", self.tp_rank,
-                     local_block_descs_ids)
-        logger.debug("Rank %s: remote_block_descs_ids: %s", self.tp_rank,
-                     remote_block_descs_ids)
-
         # Prepare transfer with Nixl.
         handle = self.nixl_wrapper.make_prepped_xfer(
             "READ",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -60,6 +60,7 @@ class NixlAgentMetadata(
     tp_size: int
     block_len: int
     attn_backend_name: str
+    device_id: int
 
 
 @dataclass
@@ -336,11 +337,9 @@ class NixlConnectorWorker:
         # NIXL handshake port.
         # NOTE(rob): Within a DP group, each DP rank gets its own
         # base port (which is sent in the KVTransferParams).
-        # Each TP rank listens/queries on the base_port + tp_rank.
         self.side_channel_port = (
             envs.VLLM_NIXL_SIDE_CHANNEL_PORT +
-            vllm_config.parallel_config.data_parallel_rank_local *
-            vllm_config.parallel_config.tensor_parallel_size)
+            vllm_config.parallel_config.data_parallel_rank_local)
 
         # Metadata.
         self.engine_id = engine_id
@@ -413,31 +412,36 @@ class NixlConnectorWorker:
         self.consumer_notification_counts_by_req = defaultdict[str, int](int)
 
     @staticmethod
-    def _nixl_handshake_listener(metadata: NixlAgentMetadata,
-                                 ready_event: threading.Event, base_port: int,
-                                 tp_rank: int):
+    def _nixl_handshake_listener(metadata: list[NixlAgentMetadata],
+                                 ready_event: threading.Event, base_port: int):
         """Background thread for getting new NIXL handshakes."""
         # NOTE(rob): this is a simple implementation. We will move
         # to a better approach via HTTP endpoint soon.
 
-        encoder = msgspec.msgpack.Encoder()
-        encoded_data = encoder.encode(metadata)
-        size_in_bytes = len(encoded_data)
+        encoded_data = []
+        for rank_metadata in metadata:
+            encoder = msgspec.msgpack.Encoder()
+            encoded_data.append(encoder.encode(rank_metadata))
+        size_in_bytes = sum(len(data) for data in encoded_data)
         logger.debug("Size of encoded NixlAgentMetadata: %s bytes",
                      str(size_in_bytes))
 
         # Listen for new requests for metadata.
         host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
-        path = make_zmq_path("tcp", host, base_port + tp_rank)
+        path = make_zmq_path("tcp", host, base_port)
         logger.debug("Starting listening on path: %s", path)
         with zmq_ctx(zmq.ROUTER, path) as sock:
             ready_event.set()
             while True:
                 identity, _, msg = sock.recv_multipart()
+                # Decode the message which contains (GET_META_MSG, rank)
+                msg, target_rank = msgspec.msgpack.decode(msg)
+                logger.info("Received message from rank %s", target_rank)
                 if msg != GET_META_MSG:
                     logger.warning(
                         "Connection listener got unexpected message %s", msg)
-                sock.send_multipart((identity, b"", encoded_data))
+                sock.send_multipart(
+                    (identity, b"", encoded_data[target_rank]))
 
     def _nixl_handshake(self, host: str, port: int):
         """Do a NIXL handshake with a remote instance."""
@@ -451,7 +455,8 @@ class NixlConnectorWorker:
         def handshake(path: str, rank: int) -> NixlAgentMetadata:
             # Send query for the request.
             with zmq_ctx(zmq.REQ, path) as sock:
-                sock.send(GET_META_MSG)
+                msg = msgspec.msgpack.encode((GET_META_MSG, rank))
+                sock.send(msg)
                 metadata_bytes = sock.recv()
                 decoder = msgspec.msgpack.Decoder(NixlAgentMetadata)
                 metadata = decoder.decode(metadata_bytes)
@@ -532,6 +537,8 @@ class NixlConnectorWorker:
         kv_caches_base_addr = []
         caches_data = []
 
+        cache_device_id = first_kv_cache.device.index
+
         # Note(tms): I modified this from the original region setup code.
         # K and V are now in different regions. Advantage is that we can
         # elegantly support MLA and any cases where the K and V tensors
@@ -545,10 +552,13 @@ class NixlConnectorWorker:
             cache_list = [cache_or_caches] if use_mla or self._use_flashinfer \
                 else cache_or_caches
             for cache in cache_list:
+                assert cache_device_id == cache.device.index, (
+                    f"Cache device id {cache_device_id} does not match "
+                    f"cache device index {cache.device.index}")
                 base_addr = cache.data_ptr()
                 region_len = self.num_blocks * self.block_len
                 caches_data.append(
-                    (base_addr, region_len, cache.device.index, ""))
+                    (base_addr, region_len, cache_device_id, ""))
                 kv_caches_base_addr.append(base_addr)
         self.kv_caches_base_addr[self.engine_id] = kv_caches_base_addr
         self.num_regions = len(caches_data)
@@ -592,7 +602,7 @@ class NixlConnectorWorker:
                 block_offset = block_id * self.block_len
                 addr = base_addr + block_offset
                 # (addr, len, device id)
-                blocks_data.append((addr, self.block_len, self.tp_rank))
+                blocks_data.append((addr, self.block_len, cache_device_id))
         logger.debug("Created %s blocks for src engine %s and rank %s",
                      len(blocks_data), self.engine_id, self.tp_rank)
 
@@ -602,22 +612,47 @@ class NixlConnectorWorker:
             "NIXL_INIT_AGENT", descs)
 
         # After KV Caches registered, listen for new connections.
-        metadata = NixlAgentMetadata(
+        rank_metadata = NixlAgentMetadata(
             engine_id=self.engine_id,
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id],
             num_blocks=self.num_blocks,
             tp_size=self.world_size,
             block_len=self.block_len,
-            attn_backend_name=self.backend_name)
-        ready_event = threading.Event()
-        self._nixl_handshake_listener_t = threading.Thread(
-            target=self._nixl_handshake_listener,
-            args=(metadata, ready_event, self.side_channel_port, self.tp_rank),
-            daemon=True,
-            name="nixl_handshake_listener")
-        self._nixl_handshake_listener_t.start()
-        ready_event.wait()
+            attn_backend_name=self.backend_name,
+            device_id=cache_device_id)
+
+
+        # Only rank 0 starts the handshake listener
+        if self.tp_rank == 0:
+            # After KV Caches registered, listen for new connections.
+            logger.info("Rank %s: Starting handshake listener", self.tp_rank)
+            logger.info("Rank %s: Waiting for metadata from other ranks",
+                        self.tp_rank)
+            combined_metadata = [rank_metadata]
+            for i in range(1, self.world_size):
+                combined_metadata.append(self.tp_group.recv_object(src=i))
+            for remote_metadata in combined_metadata:
+                if remote_metadata.engine_id != self.engine_id:
+                    raise RuntimeError(
+                        "Received metadata from different engine id: %s",
+                        remote_metadata.engine_id)
+
+            logger.info("Rank %s: Received metadata from other ranks",
+                        self.tp_rank)
+            
+            ready_event = threading.Event()
+            self._nixl_handshake_listener_t = threading.Thread(
+                target=self._nixl_handshake_listener,
+                args=(combined_metadata, ready_event, self.side_channel_port),
+                daemon=True,
+                name="nixl_handshake_listener")
+            self._nixl_handshake_listener_t.start()
+            ready_event.wait()
+        else:
+            # Other ranks send their metadata to rank 0
+            logger.info("Rank %s: Sending metadata to rank 0", self.tp_rank)
+            self.tp_group.send_object(rank_metadata, dst=0)
 
     def add_remote_agent(self,
                          nixl_agent_meta: NixlAgentMetadata,
@@ -732,7 +767,7 @@ class NixlConnectorWorker:
                     # self.block_len == remote_block_len//tp_ratio bytes.
                     addr = base_addr + block_offset + rank_offset
                     # (addr, len, device id)
-                    blocks_data.append((addr, self.block_len, remote_tp_rank))
+                    blocks_data.append((addr, self.block_len, nixl_agent_meta.device_id))
             logger.debug(
                 "Created %s blocks for dst engine %s with remote rank %s and "
                 "local rank %s", len(blocks_data), engine_id, remote_tp_rank,
@@ -958,6 +993,11 @@ class NixlConnectorWorker:
                 remote_block_descs_ids.extend(layer_remote_desc_ids)
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
+
+        logger.info("Rank %s: local_block_descs_ids: %s", self.tp_rank,
+                    local_block_descs_ids)
+        logger.info("Rank %s: remote_block_descs_ids: %s", self.tp_rank,
+                    remote_block_descs_ids)
 
         # Prepare transfer with Nixl.
         handle = self.nixl_wrapper.make_prepped_xfer(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -623,7 +623,8 @@ class NixlConnectorWorker:
             device_id=cache_device_id)
 
 
-        # Only rank 0 starts the handshake listener
+        # Only rank 0 starts the handshake listener and send it to remote models
+        # Other ranks send their metadata to rank 0
         if self.tp_rank == 0:
             # After KV Caches registered, listen for new connections.
             logger.info("Rank %s: Starting handshake listener", self.tp_rank)


### PR DESCRIPTION
Currently `NixlConnector` binds and connect to sockets on `VLLM_NIXL_SIDE_CHANNEL_HOST` and sends info about it in `remote_host` field, but with multi-node workers have different hosts. This is currently not handled.

To solve that in this PR rank 0 worker receives NIXL metadata from all other workers and remote workers connects always to rank 0 listener. This solves the problem with multiple hosts and also reduces number of ports used to single port per DP rank.


<!--- pyml disable-next-line no-emphasis-as-heading -->
