### PR TITLE
[Bugfix]: Fix DualChunkFlashAttention for short sequences

### DIFF
--- a/examples/offline_inference/qwen_1m.py
+++ b/examples/offline_inference/qwen_1m.py
@@ -62,6 +62,7 @@ def initialize_engine() -> LLM:
 
 def main():
     llm = initialize_engine()
+    process_requests(llm, ["Hello, world!"])
     prompt = load_prompt()
     process_requests(llm, [prompt])
 

--- a/vllm/attention/backends/dual_chunk_flash_attn.py
+++ b/vllm/attention/backends/dual_chunk_flash_attn.py
@@ -1221,7 +1221,6 @@ class DualChunkFlashAttentionImpl(FlashAttentionImpl):
             # Since the key_states and value_states are directly retrieved from the KV cache
             # through the block_table, 
             # setting `block_table` here is both wrong and unnecessary.
-            block_table=None,
             return_softmax_lse=True,
         )
         softmax_lse = softmax_lse.view(q_len, q_heads, 1).transpose(0,

--- a/vllm/attention/backends/dual_chunk_flash_attn.py
+++ b/vllm/attention/backends/dual_chunk_flash_attn.py
@@ -1218,9 +1218,6 @@ class DualChunkFlashAttentionImpl(FlashAttentionImpl):
                                       device=query_states.device),
             max_seqlen_k=max_seqlen_k,
             causal=causal,
-            # Since the key_states and value_states are directly retrieved from the KV cache
-            # through the block_table, 
-            # setting `block_table` here is both wrong and unnecessary.
             return_softmax_lse=True,
         )
         softmax_lse = softmax_lse.view(q_len, q_heads, 1).transpose(0,

--- a/vllm/attention/backends/dual_chunk_flash_attn.py
+++ b/vllm/attention/backends/dual_chunk_flash_attn.py
@@ -1218,7 +1218,10 @@ class DualChunkFlashAttentionImpl(FlashAttentionImpl):
                                       device=query_states.device),
             max_seqlen_k=max_seqlen_k,
             causal=causal,
-            block_table=block_table.unsqueeze(0),
+            # Since the key_states and value_states are directly retrieved from the KV cache
+            # through the block_table, 
+            # setting `block_table` here is both wrong and unnecessary.
+            block_table=None,
             return_softmax_lse=True,
         )
         softmax_lse = softmax_lse.view(q_len, q_heads, 1).transpose(0,


### PR DESCRIPTION
## Env Info

- Python: Python 3.11.11
- vLLM: 0.9.1
- cuda: cuda_12.8
- GPU: NVIDIA L20
- torch: 2.7.0+cu126

## Problem Description

DualChunkFlashAttention fails to handle short prompts correctly. This issue can be reproduced by modifying the [qwen_1m.py](https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/qwen_1m.py) as follows:

```python
def main():
    llm = initialize_engine()
    process_requests(llm, ["Hello, world!"])
    prompt = load_prompt()
    process_requests(llm, [prompt])
```

It failed to handle the simple prompt `Hello, world!`, the following assertion error is raised during execution:

```plain
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]   File "/data/shanhaikang.shk/vllm/vllm/attention/backends/dual_chunk_flash_attn.py", line 493, in forward
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]     self._dual_chunk_flash_attn_prefill(
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]   File "/data/shanhaikang.shk/vllm/vllm/attention/backends/dual_chunk_flash_attn.py", line 673, in _dual_chunk_flash_attn_prefill
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]     current_out = self._dual_chunk_flash_attn_prefill_func(
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]   File "/data/shanhaikang.shk/vllm/vllm/attention/backends/dual_chunk_flash_attn.py", line 1055, in _dual_chunk_flash_attn_prefill_func
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]     flash_result = self._do_flash_attn(
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]                    ^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]   File "/data/shanhaikang.shk/vllm/vllm/attention/backends/dual_chunk_flash_attn.py", line 1207, in _do_flash_attn
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]     output, softmax_lse = flash_attn_varlen_func(
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]                           ^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]   File "/data/shanhaikang.shk/vllm/vllm/vllm_flash_attn/flash_attn_interface.py", line 204, in flash_attn_varlen_func
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]     assert block_table is None or seqused_k is not None, \
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=3970554) ERROR 06-03 20:09:38 [multiproc_worker_utils.py:238] AssertionError: seqused_k must be provided if block_table is provided
```

## Proposed Fix

This issue is introduced in #11844 . 

Since the key_states and value_states are directly retrieved from the KV cache through the block_table, setting `block_table` is both wrong and unnecessary.

