### PR TITLE
[Misc] Add packages for benchmark as extra dependency

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -77,6 +77,8 @@ vllm complete --quick "The future of AI is"
 
 Run benchmark tests for latency online serving throughput and offline inference throughput.
 
+To use benchmark commands, please install with extra dependencies using `pip install vllm[bench]`.
+
 Available Commands:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -687,6 +687,7 @@ setup(
     ext_modules=ext_modules,
     install_requires=get_requirements(),
     extras_require={
+        "benchmark": ["pandas", "datasets"],
         "tensorizer": ["tensorizer>=2.9.0"],
         "fastsafetensors": ["fastsafetensors >= 0.1.10"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],

--- a/setup.py
+++ b/setup.py
@@ -687,7 +687,7 @@ setup(
     ext_modules=ext_modules,
     install_requires=get_requirements(),
     extras_require={
-        "benchmark": ["pandas", "datasets"],
+        "bench": ["pandas", "datasets"],
         "tensorizer": ["tensorizer>=2.9.0"],
         "fastsafetensors": ["fastsafetensors >= 0.1.10"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -23,7 +23,6 @@ from io import BytesIO
 from typing import Any, Callable, Optional, Union
 
 import numpy as np
-import pandas as pd
 from PIL import Image
 from transformers import PreTrainedTokenizerBase
 
@@ -32,6 +31,18 @@ from vllm.lora.utils import get_adapter_absolute_path
 from vllm.multimodal import MultiModalDataDict
 from vllm.multimodal.image import convert_image_mode
 from vllm.transformers_utils.tokenizer import AnyTokenizer, get_lora_tokenizer
+from vllm.utils import PlaceholderModule
+
+try:
+    from datasets import load_dataset
+except ImportError:
+    datasets = PlaceholderModule("datasets")
+    load_dataset = datasets.placeholder_attr("load_dataset")
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = PlaceholderModule("pandas")
 
 logger = logging.getLogger(__name__)
 
@@ -716,13 +727,6 @@ class HuggingFaceDataset(BenchmarkDataset):
 
     def load_data(self) -> None:
         """Load data from HuggingFace datasets."""
-        try:
-            from datasets import load_dataset
-        except ImportError as e:
-            raise ImportError(
-                "Hugging Face datasets library is required for this dataset. "
-                "Please install it using `pip install datasets`.") from e
-
         self.data = load_dataset(
             self.dataset_path,
             name=self.dataset_subset,

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -44,6 +44,11 @@ try:
 except ImportError:
     pd = PlaceholderModule("pandas")
 
+try:
+    import librosa
+except ImportError:
+    librosa = PlaceholderModule("librosa")
+
 logger = logging.getLogger(__name__)
 
 # -----------------------------------------------------------------------------
@@ -646,13 +651,6 @@ class BurstGPTDataset(BenchmarkDataset):
         if self.dataset_path is None:
             raise ValueError("dataset_path must be provided for loading data.")
 
-        try:
-            import pandas as pd
-        except ImportError as e:
-            raise ImportError(
-                "Pandas is required for BurstGPTDataset. Please install it "
-                "using `pip install pandas`.") from e
-
         df = pd.read_csv(self.dataset_path)
         # Filter to keep only GPT-4 rows.
         gpt4_df = df[df["Model"] == "GPT-4"]
@@ -1138,13 +1136,6 @@ class ASRDataset(HuggingFaceDataset):
         output_len: Optional[int] = None,
         **kwargs,
     ) -> list:
-        try:
-            import librosa
-        except ImportError as e:
-            raise ImportError(
-                "librosa is required for ASRDataset. Please install it "
-                "using `pip install librosa`.") from e
-
         output_len = (output_len
                       if output_len is not None else self.DEFAULT_OUTPUT_LEN)
         prompt = ASRDataset.TRANSCRIPTION_PREAMBLE

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -4,6 +4,7 @@
 import signal
 import sys
 
+import vllm.entrypoints.cli.benchmark.main
 import vllm.entrypoints.cli.collect_env
 import vllm.entrypoints.cli.openai
 import vllm.entrypoints.cli.run_batch
@@ -15,15 +16,10 @@ from vllm.utils import FlexibleArgumentParser
 CMD_MODULES = [
     vllm.entrypoints.cli.openai,
     vllm.entrypoints.cli.serve,
+    vllm.entrypoints.cli.benchmark.main,
     vllm.entrypoints.cli.collect_env,
     vllm.entrypoints.cli.run_batch,
 ]
-
-try:
-    import vllm.entrypoints.cli.benchmark.main
-    CMD_MODULES.append(vllm.entrypoints.cli.benchmark.main)
-except ModuleNotFoundError:
-    pass
 
 
 def register_signal_handlers():

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -4,7 +4,6 @@
 import signal
 import sys
 
-import vllm.entrypoints.cli.benchmark.main
 import vllm.entrypoints.cli.collect_env
 import vllm.entrypoints.cli.openai
 import vllm.entrypoints.cli.run_batch
@@ -16,10 +15,15 @@ from vllm.utils import FlexibleArgumentParser
 CMD_MODULES = [
     vllm.entrypoints.cli.openai,
     vllm.entrypoints.cli.serve,
-    vllm.entrypoints.cli.benchmark.main,
     vllm.entrypoints.cli.collect_env,
     vllm.entrypoints.cli.run_batch,
 ]
+
+try:
+    import vllm.entrypoints.cli.benchmark.main
+    CMD_MODULES.append(vllm.entrypoints.cli.benchmark.main)
+except ModuleNotFoundError:
+    pass
 
 
 def register_signal_handlers():


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/19078
- To run benchmark cli, we need to install extra packages like `pandas` and `datasets`
- This PR adds them as extra dependency, so users can install them through `pip install vllm[bench]`

<!--- pyml disable-next-line no-emphasis-as-heading -->
