### PR TITLE
[feature] Integrate quick allreduce into custom allreduce and select the best allreduce implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,6 +638,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
 # if CUDA endif
 endif()
 
+if (VLLM_GPU_LANG STREQUAL "HIP")
+  # must be rocm
+  list(APPEND VLLM_EXT_SRC
+    "csrc/quick_all_reduce.cu"
+  )
+endif()
+
+
 message(STATUS "Enabling C extension.")
 define_gpu_extension_target(
   _C

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -360,3 +360,14 @@ std::tuple<int64_t, torch::Tensor> allocate_shared_buffer_and_handle(
     int64_t size);
 int64_t open_mem_handle(torch::Tensor& mem_handle);
 void free_shared_buffer(int64_t buffer);
+
+#ifdef USE_ROCM
+fptr_t init_quick_ar(int64_t world_size, int64_t rank);
+torch::Tensor qr_get_comm_handle(fptr_t _fa);
+void qr_set_comm_handles(fptr_t _fa,
+                         std::vector<torch::Tensor> const& comm_handles);
+void qr_all_reduce(fptr_t _fa, int64_t profile, torch::Tensor const& inp,
+                   torch::Tensor& out);
+void qr_destroy(fptr_t _fa);
+void is_quickreduce_available();
+#endif

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -367,7 +367,7 @@ torch::Tensor qr_get_comm_handle(fptr_t _fa);
 void qr_set_comm_handles(fptr_t _fa,
                          std::vector<torch::Tensor> const& comm_handles);
 void qr_all_reduce(fptr_t _fa, int64_t profile, torch::Tensor const& inp,
-                   torch::Tensor& out);
+                   torch::Tensor& out, bool cast_bf162half);
 void qr_destroy(fptr_t _fa);
 void is_quickreduce_available();
 #endif

--- a/csrc/quick_all_reduce.cu
+++ b/csrc/quick_all_reduce.cu
@@ -1,0 +1,273 @@
+#include <hip/hip_runtime.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+
+#include "quick_all_reduce.cuh"
+
+namespace quickreduce {
+
+// ============================================================
+// CONTEXT
+// ============================================================
+void DeviceComms::init(int world_size, int rank) {
+  destroy();
+  this->world_size = world_size;
+  this->rank = rank;
+
+  // Allocate buffer size for worst case: Twoshot FP16 2-stage buffer.
+  long flags_buffer_size = 2 * world_size * kMaxTiles * sizeof(int);
+  long data_buffer_size = 2 * kMaxProblemSize;
+  long total_buffer_size = flags_buffer_size + data_buffer_size;
+  data_offset = flags_buffer_size;
+  HIP_CHECK(hipExtMallocWithFlags((void**)&dbuffer, total_buffer_size,
+                                  hipDeviceMallocUncached));
+
+  // Clear the flags buffer.
+  hipMemset(dbuffer, 0, flags_buffer_size);
+
+  // Device-side list of IPC buffers.
+  buffer_list.resize(world_size);
+  hipMalloc(&dbuffer_list, world_size * sizeof(uint8_t*));
+
+  // Create IPC handles for rank's communication buffer.
+  all_buffer_ipc_handles.resize(world_size);
+  hipIpcGetMemHandle(&buffer_ipc_handle, dbuffer);
+
+  initialized = true;
+}
+
+void DeviceComms::destroy() {
+  if (initialized) {
+    for (int i = 0; i < world_size; i++) {
+      if (i != rank) {
+        hipIpcCloseMemHandle(dbuffer_list[i]);
+      }
+    }
+
+    hipFree(dbuffer);
+    hipFree(dbuffer_list);
+
+    initialized = false;
+  }
+}
+
+void DeviceComms::open_ipc_handles(
+    std::vector<hipIpcMemHandle_t> const& ipc_handles) {
+  for (int i = 0; i < world_size; i++) {
+    all_buffer_ipc_handles[i] = ipc_handles[i];
+  }
+
+  // Open device memory access to the IPC communication buffers.
+  // Note: For our own rank, we do not need to open a handle.
+  for (int i = 0; i < world_size; i++) {
+    if (i != rank) {
+      hipIpcOpenMemHandle((void**)&buffer_list[i], all_buffer_ipc_handles[i],
+                          hipIpcMemLazyEnablePeerAccess);
+    } else {
+      buffer_list[i] = dbuffer;
+    }
+  }
+
+  hipMemcpy(dbuffer_list, buffer_list.data(), world_size * sizeof(uint8_t*),
+            hipMemcpyHostToDevice);
+}
+
+// ============================================================
+// KERNEL
+// ============================================================
+template <typename AllReduceKenel, typename T>
+__global__ __quickreduce_launch_bounds__ static void allreduce_prototype(
+    T const* A, T* B, int N, int num_blocks, int world_size, int rank,
+    uint8_t** dbuffer_list, long data_offset, int flag_color) {
+  int block = blockIdx.x;
+  int grid = gridDim.x;
+
+  while (block < num_blocks) {
+    AllReduceKenel::run(A, B, N, block, num_blocks, world_size, rank,
+                        dbuffer_list, data_offset, flag_color);
+    block += grid;
+  }
+}
+
+// ============================================================
+// DISPATCH
+// ============================================================
+#define TWOSHOT_DISPATCH(__codec)                                             \
+  if (world_size == 2) {                                                      \
+    using LineCodec = __codec<2, T>;                                          \
+    using AllReduceKernel = AllReduceTwoshot<LineCodec, T>;                   \
+    hipLaunchKernelGGL((allreduce_prototype<AllReduceKernel, T>), dim3(grid), \
+                       dim3(kBlock), 0, stream, A, B, N, num_blocks,          \
+                       world_size, rank, dbuffer_list, data_offset,           \
+                       flag_color);                                           \
+  } else if (world_size == 4) {                                               \
+    using LineCodec = __codec<4, T>;                                          \
+    using AllReduceKernel = AllReduceTwoshot<LineCodec, T>;                   \
+    hipLaunchKernelGGL((allreduce_prototype<AllReduceKernel, T>), dim3(grid), \
+                       dim3(kBlock), 0, stream, A, B, N, num_blocks,          \
+                       world_size, rank, dbuffer_list, data_offset,           \
+                       flag_color);                                           \
+  } else if (world_size == 8) {                                               \
+    using LineCodec = __codec<8, T>;                                          \
+    using AllReduceKernel = AllReduceTwoshot<LineCodec, T>;                   \
+    hipLaunchKernelGGL((allreduce_prototype<AllReduceKernel, T>), dim3(grid), \
+                       dim3(kBlock), 0, stream, A, B, N, num_blocks,          \
+                       world_size, rank, dbuffer_list, data_offset,           \
+                       flag_color);                                           \
+  }
+
+template <typename T>
+void DeviceComms::allreduce(int profile, hipStream_t stream, T const* A, T* B,
+                            int N) {
+  static_assert(sizeof(T) == 2,
+                "Template parameter T must be 16 bits (2 bytes) in size.");
+  if (world_size != 2 && world_size != 4 && world_size != 8) {
+    throw std::runtime_error("All Reduce not supported for world_size = " +
+                             std::to_string(world_size));
+  }
+
+  // Configuration.
+  long msg_size = N * sizeof(T);
+  int num_blocks = divceil(msg_size, kTileSize);
+  int grid = min(304 * 4, num_blocks);
+
+  // -------------------------------------------------
+  // All reduce dispatch.
+  QuickReduceProfile dprofile = static_cast<QuickReduceProfile>(profile);
+  switch (dprofile) {
+    case QuickReduceProfile::TWOSHOT_FP8:
+      TWOSHOT_DISPATCH(TwoshotFP8LineCodec)
+      break;
+    case QuickReduceProfile::TWOSHOT_Q8:
+      TWOSHOT_DISPATCH(TwoshotQ8LineCodec)
+      break;
+    case QuickReduceProfile::TWOSHOT_Q6:
+      TWOSHOT_DISPATCH(TwoshotQ6LineCodec)
+      break;
+    case QuickReduceProfile::TWOSHOT_Q4:
+      TWOSHOT_DISPATCH(TwoshotQ4LineCodec)
+      break;
+    case QuickReduceProfile::ONESHOT_F16:
+      using AllReduceKernel = AllReduceOneshot<T>;
+      hipLaunchKernelGGL((allreduce_prototype<AllReduceKernel, T>), dim3(grid),
+                         dim3(kBlock), 0, stream, A, B, N, num_blocks,
+                         world_size, rank, dbuffer_list, data_offset,
+                         flag_color);
+      break;
+    default:
+      TWOSHOT_DISPATCH(TwoshotF16LineCodec)
+      break;
+  }
+
+  // -------------------------------------------------
+  // Rotate the flag color.
+  flag_color++;
+}
+
+}  // namespace quickreduce
+
+/**
+ * Make sure tensor t's data lies completely within ((char)t.data_ptr()) +
+ * t.numel() * t.element_size(). This is slightly weaker than t.is_contiguous()
+ * because it allows transpose of contiguous slice (i.e. slicing the first
+ * dimension). Currently, we require this because stride information is not
+ * passed into the kernels and we treat input tensors as flat.
+ *
+ * Examples
+ * A = torch.zeros(3, 3, 3)
+ * 1. A: OK
+ * 2. A[1:]: OK
+ * 3. A.permute(2, 0, 1): OK
+ * 4. A[1:].permute(2, 0, 1): OK
+ * 5. A[None].expand(2, -1, -1, -1): Not OK
+ * 6. A[:, 1:, 1:]: Not OK
+ */
+bool _is_weak_contiguous(torch::Tensor const& t) {
+  return t.is_contiguous() ||
+         (t.storage().nbytes() - t.storage_offset() * t.element_size() ==
+          t.numel() * t.element_size());
+}
+
+fptr_t init_quick_ar(int64_t world_size, int64_t rank) {
+  if (world_size > 8)
+    throw std::invalid_argument("world size > 8 is not supported");
+  if (world_size == 6)
+    throw std::invalid_argument("world size == 6 is not supported");
+  if (world_size % 2 != 0)
+    throw std::invalid_argument("Odd num gpus is not supported for now");
+  if (rank < 0 || rank >= world_size)
+    throw std::invalid_argument("invalid rank passed in");
+
+  quickreduce::DeviceComms* dev_comm = new quickreduce::DeviceComms();
+  dev_comm->init(world_size, rank);
+  return reinterpret_cast<fptr_t>(dev_comm);
+}
+
+torch::Tensor qr_get_comm_handle(fptr_t _fa) {
+  auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+  hipIpcMemHandle_t handle = fa->get_handle();
+  auto options =
+      torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCPU);
+  torch::Tensor tensor_handle =
+      torch::empty({static_cast<int64_t>(sizeof(hipIpcMemHandle_t))}, options);
+  std::memcpy(tensor_handle.data_ptr(), &handle, sizeof(hipIpcMemHandle_t));
+  return tensor_handle;
+}
+
+void qr_set_comm_handles(fptr_t _fa,
+                         std::vector<torch::Tensor> const& comm_handles) {
+  auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+  auto world_size = comm_handles.size();
+  std::vector<hipIpcMemHandle_t> ipc_handles(world_size);
+
+  for (int i = 0; i < world_size; ++i) {
+    const auto& tensor = comm_handles[i];
+    TORCH_CHECK(tensor.device().is_cpu(), "Comm handle tensor must be on CPU");
+    TORCH_CHECK(tensor.scalar_type() == torch::kUInt8,
+                "Comm handle tensor must be of type uint8");
+    TORCH_CHECK(tensor.numel() == sizeof(hipIpcMemHandle_t),
+                "Comm handle tensor must have ", sizeof(hipIpcMemHandle_t),
+                " elements");
+
+    std::memcpy(&(ipc_handles[i]), tensor.data_ptr(),
+                sizeof(hipIpcMemHandle_t));
+  }
+  fa->open_ipc_handles(ipc_handles);
+}
+
+void qr_all_reduce(fptr_t _fa, int64_t profile, torch::Tensor const& inp,
+                   torch::Tensor& out) {
+  quickreduce::DeviceComms* fa =
+      reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();  // hipStream_t
+
+  TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
+  TORCH_CHECK_EQ(inp.numel(), out.numel());
+  TORCH_CHECK(_is_weak_contiguous(out));
+  TORCH_CHECK(_is_weak_contiguous(inp));
+
+  auto input_size = inp.numel() * inp.element_size();
+
+  if (out.scalar_type() == at::ScalarType::Half) {
+    fa->allreduce<half>(profile, stream,
+                        reinterpret_cast<half const*>(inp.data_ptr()),
+                        reinterpret_cast<half*>(out.data_ptr()), inp.numel());
+  } else if (out.scalar_type() == at::ScalarType::BFloat16) {
+    fa->allreduce<nv_bfloat16>(
+        profile, stream, reinterpret_cast<nv_bfloat16 const*>(inp.data_ptr()),
+        reinterpret_cast<nv_bfloat16*>(out.data_ptr()), inp.numel());
+  } else {
+    throw std::runtime_error(
+        "quick allreduce only supports float16 and bfloat16 for now.");
+  }
+}
+
+void qr_destroy(fptr_t _fa) {
+  if (_fa) {
+    auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+    fa->destroy();
+    delete fa;
+  }
+}
+
+void is_quickreduce_available() {};

--- a/csrc/quick_all_reduce.cu
+++ b/csrc/quick_all_reduce.cu
@@ -147,13 +147,6 @@ void DeviceComms::allreduce(int profile, hipStream_t stream, T const* A, T* B,
     case QuickReduceProfile::TWOSHOT_Q4:
       TWOSHOT_DISPATCH(TwoshotQ4LineCodec)
       break;
-    case QuickReduceProfile::ONESHOT_F16:
-      using AllReduceKernel = AllReduceOneshot<T>;
-      hipLaunchKernelGGL((allreduce_prototype<AllReduceKernel, T>), dim3(grid),
-                         dim3(kBlock), 0, stream, A, B, N, num_blocks,
-                         world_size, rank, dbuffer_list, data_offset,
-                         flag_color);
-      break;
     default:
       TWOSHOT_DISPATCH(TwoshotF16LineCodec)
       break;

--- a/csrc/quick_all_reduce.cuh
+++ b/csrc/quick_all_reduce.cuh
@@ -1,0 +1,1120 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include "quick_all_reduce.h"
+
+namespace quickreduce {
+
+// ============================================================
+// Twoshot
+// ============================================================
+// MARK: FP16 Line Codec
+template <int world_size, typename T>
+struct TwoshotF16LineCodec {
+  /*
+      Default FP16 line codec for Twoshot collectives.
+      No actual compression is involved.
+  */
+
+  static int constexpr kAtoms = 8;
+  static int constexpr kAtomStride = 256;
+  static int constexpr kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each thread processes atoms of fp16x8_t (16B).
+  static int constexpr kRankAtoms = kAtoms / kWorldSize;
+  static int constexpr kRankTileSize = 256 * kRankAtoms * sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static int constexpr kTileSize = kRankTileSize * kWorldSize;
+
+  int const thread;
+  int const rank;
+
+  __device_inline__ TwoshotF16LineCodec(int thread, int rank)
+      : thread(thread), rank(rank) {
+    static_assert(kRankTileSize % 16 == 0,
+                  "kRankTileSize must be 16B aligned.");
+  }
+
+  __device_inline__ void send(int32x4_t* __restrict__ send_buffer,
+                              int32x4_t const* __restrict__ data) {
+    for (int i = 0; i < kRankAtoms; i++) {
+      __builtin_nontemporal_store(data[i], send_buffer + thread);
+      send_buffer += kAtomStride;
+    }
+  }
+
+  __device_inline__ void recv(int32x4_t** __restrict__ recv_buffer,
+                              int32x4_t* __restrict__ data) {
+    for (int i = 0; i < kRankAtoms; i++) {
+      data[i] = __builtin_nontemporal_load(*recv_buffer + thread);
+      *recv_buffer += kAtomStride;
+    }
+  }
+};
+
+// MARK: FP8 Line Codec
+template <int world_size, typename T>
+struct TwoshotFP8LineCodec {
+  /*
+      FP8 Line codec for Twoshot collectives.
+      We quantize the FP16 data to block-scaled FP8 in blocks of 32.
+  */
+
+  static int constexpr kAtoms = 8;
+  static int constexpr kAtomStride = 256;
+  static int constexpr kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each threads processes a fragment of fp16x8_t (16B),
+  // into a fp8x8_t (8B) and a fp16 scale shared among 32 values.
+  static int constexpr kRankAtoms = kAtoms / kWorldSize;
+  static int constexpr kRankTileStride = 2176;
+  static int constexpr kRankTileScaleOffset = 2048;
+  static int constexpr kRankTileSize = kRankTileStride * kRankAtoms;
+
+  static int constexpr kRankBufferTileStride =
+      kRankTileStride / sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static int constexpr kTileSize = kRankTileSize * kWorldSize;
+
+  // FP8 Maximum value (on AMD Instinct MI300X - float8_e4m3fnuz)
+  static float constexpr kFP8Max = 240.0f;
+  static int constexpr kScaleFactor =
+      Quantfp8Const<T>::kScaleFactor;  // {1/240.0h, 1/240.0h}
+  static int constexpr kScaleEpsilon =
+      Quantfp8Const<T>::kScaleEpsilon;  // {1e-7, 1e-7}
+
+  int const thread;
+  int const rank;
+  int const group_leader;
+
+  __device_inline__ TwoshotFP8LineCodec(int thread, int rank)
+      : thread(thread), rank(rank), group_leader((threadIdx.x / 8) * 8) {
+    static_assert(kRankTileSize % 16 == 0,
+                  "kRankTileSize must be 16B aligned.");
+    set_fp16_ovfl(true);
+  }
+
+  __device_inline__ void send(int32x4_t* __restrict__ send_buffer,
+                              int32x4_t const* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      int32x4_t const atom = data[k];
+
+      // abs(w)
+      int32x4_t w;
+      {
+        T const* x = reinterpret_cast<T const*>(&atom);
+        T* y = reinterpret_cast<T*>(&w);
+        for (int i = 0; i < 8; i++) {
+          y[i] = __habs(x[i]);
+        }
+      }
+
+      // max(w)
+      int wmax;
+      {
+        int a, b;
+        int* dw = reinterpret_cast<int*>(&w);
+        a = pk_max<T>(dw[0], dw[1]);
+        b = pk_max<T>(dw[2], dw[3]);
+        wmax = pk_max<T>(a, b);
+
+        // Reduce the max among a group of 8 threads
+        // Note: This is basically 2 blocks of 32 values setup as the
+        // upper/lower halves of the fp16x2_t
+        for (int i = 1; i < 8; i <<= 1) {
+          int x = __shfl_down(wmax, i);
+          wmax = pk_max<T>(wmax, x);
+        }
+
+        // Share with the cohort
+        wmax = __shfl(wmax, group_leader);
+      }
+
+      // Derive scales
+      int decoding_scale = pk_mul<T>(wmax, kScaleFactor);
+      int encoding_scale = pk_add<T>(decoding_scale, kScaleEpsilon);
+      encoding_scale = pk_hcp<T>(encoding_scale);
+
+      // Apply scales to get quantized values
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(atom[i], encoding_scale);
+      }
+
+      // Convert to packed FP8
+      fp32x8_t wf;
+      {
+        if constexpr (std::is_same<T, half>::value) {
+          half2 const* x = reinterpret_cast<half2 const*>(&w);
+          float2* y = reinterpret_cast<float2*>(&wf);
+          for (int i = 0; i < 4; i++) {
+            y[i] = __half22float2(x[i]);
+          }
+        } else {
+          nv_bfloat162 const* x = reinterpret_cast<nv_bfloat162 const*>(&w);
+          float2* y = reinterpret_cast<float2*>(&wf);
+          for (int i = 0; i < 4; i++) {
+            y[i] = __bfloat1622float2(x[i]);
+          }
+        }
+      }
+
+      int32x2_t qw;
+      qw[0] = __builtin_amdgcn_cvt_pk_fp8_f32(wf[0], wf[1], qw[0], 0);
+      qw[0] = __builtin_amdgcn_cvt_pk_fp8_f32(wf[2], wf[3], qw[0], 1);
+      qw[1] = __builtin_amdgcn_cvt_pk_fp8_f32(wf[4], wf[5], qw[1], 0);
+      qw[1] = __builtin_amdgcn_cvt_pk_fp8_f32(wf[6], wf[7], qw[1], 1);
+
+      // Write quantized atom to send_buffer
+      // note: only the group leader stores the scale
+      uint8_t* atom_ptr =
+          reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+      int32x2_t* qw_ptr = reinterpret_cast<int32x2_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      __builtin_nontemporal_store(qw, qw_ptr);
+      if (threadIdx.x == group_leader) {
+        __builtin_nontemporal_store(decoding_scale, qs_ptr);
+      }
+    }
+  }
+
+  __device_inline__ void recv(int32x4_t** __restrict__ recv_buffer,
+                              int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      // Directly read quantized atom from recv_buffer
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+      int32x2_t* qw_ptr = reinterpret_cast<int32x2_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      int32x2_t qw = __builtin_nontemporal_load(qw_ptr);
+      int qs = __builtin_nontemporal_load(qs_ptr);
+
+      *recv_buffer += kRankBufferTileStride;
+
+      // Unpack FP8
+      int32x4_t w;
+      {
+        if constexpr (std::is_same<T, half>::value) {
+          for (int i = 0; i < 2; i++) {
+            fp32x2_t wf0 = __builtin_amdgcn_cvt_pk_f32_fp8(qw[i], 0);
+            fp32x2_t wf1 = __builtin_amdgcn_cvt_pk_f32_fp8(qw[i], 1);
+
+            asm volatile("v_cvt_pkrtz_f16_f32 %0, %1, %2"
+                         : "=v"(w[i * 2 + 0])
+                         : "v"(wf0[0]), "v"(wf0[1]));
+            asm volatile("v_cvt_pkrtz_f16_f32 %0, %1, %2"
+                         : "=v"(w[i * 2 + 1])
+                         : "v"(wf1[0]), "v"(wf1[1]));
+          }
+        } else {
+          nv_bfloat16* wbf = reinterpret_cast<nv_bfloat16*>(&w);
+          for (int i = 0; i < 2; i++) {
+            fp32x2_t wf0_vec = __builtin_amdgcn_cvt_pk_f32_fp8(qw[i], 0);
+            fp32x2_t wf1_vec = __builtin_amdgcn_cvt_pk_f32_fp8(qw[i], 1);
+            wbf[i * 4 + 0] = __float2bfloat16(wf0_vec[0]);
+            wbf[i * 4 + 1] = __float2bfloat16(wf0_vec[1]);
+            wbf[i * 4 + 2] = __float2bfloat16(wf1_vec[0]);
+            wbf[i * 4 + 3] = __float2bfloat16(wf1_vec[1]);
+          }
+        }
+      }
+
+      // Apply decoding scales
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(w[i], qs);
+      }
+
+      // That's pretty much it...
+      data[k] = w;
+    }
+  }
+};
+
+// MARK: Q4 Line Codec
+template <int world_size, typename T>
+struct TwoshotQ4LineCodec {
+  /*
+      Int4-blocking Line codec for Twoshot collectives.
+      We quantize the FP16 data to block-scaled Int4 in blocks of 32.
+  */
+
+  static int constexpr kAtoms = 8;
+  static int constexpr kAtomStride = 256;
+  static int constexpr kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each threads processes a fragment of fp16x8_t (16B),
+  // into a int4x8_t (4B) and a fp16 scale shared among 32 values.
+  static int constexpr kRankAtoms = kAtoms / kWorldSize;
+  static int constexpr kRankTileStride = 1152;
+  static int constexpr kRankTileScaleOffset = 1024;
+  static int constexpr kRankTileSize = kRankTileStride * kRankAtoms;
+
+  static int constexpr kRankBufferTileStride =
+      kRankTileStride / sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static int constexpr kTileSize = kRankTileSize * kWorldSize;
+
+  // Q4 configuration
+  static int constexpr kScaleFactor =
+      Quant4Const<T>::kScaleFactor;  // {-1/8.0h, -1/8.0h}, fp16x2_t
+  static int constexpr kScaleEpsilon = Quant4Const<T>::kScaleEpsilon;
+  ;  // {1e-7, 1e-7}, fp16x2_t
+  static int constexpr kRangeMin = Quant4Const<T>::kRangeMin;
+  ;  // {-8, -8}, fp16x2_t
+  static int constexpr kRangeMax = Quant4Const<T>::kRangeMax;
+  ;                                              // {+7, +7}, fp16x2_t
+  static int constexpr kRangeBias = 0x00080008;  // {+8, +8}, int16x2_t
+
+  int const thread;
+  int const rank;
+  int const group_leader;
+
+  __device_inline__ TwoshotQ4LineCodec(int thread, int rank)
+      : thread(thread), rank(rank), group_leader((threadIdx.x / 8) * 8) {
+    static_assert(kRankTileSize % 16 == 0,
+                  "kRankTileSize must be 16B aligned.");
+    set_fp16_ovfl(true);
+  }
+
+  __device_inline__ void send(int32x4_t* __restrict__ send_buffer,
+                              int32x4_t const* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      int32x4_t const atom = data[k];
+
+      // max(w), min(w)
+      int wmax, wmin, wblockmax;
+      {
+        int a, b;
+        a = pk_max<T>(atom[0], atom[1]);
+        b = pk_max<T>(atom[2], atom[3]);
+        wmax = pk_max<T>(a, b);
+
+        a = pk_min<T>(atom[0], atom[1]);
+        b = pk_min<T>(atom[2], atom[3]);
+        wmin = pk_min<T>(a, b);
+
+        // Reduce the max among a group of 8 threads
+        // Note: This is basically 2 blocks of 32 values setup as the
+        // upper/lower halves of the fp16x2_t
+        for (int i = 1; i < 8; i <<= 1) {
+          int x = __shfl_down(wmax, i);
+          wmax = pk_max<T>(wmax, x);
+
+          int y = __shfl_down(wmin, i);
+          wmin = pk_min<T>(wmin, y);
+        }
+
+        wblockmax = pk_max_abs<T>(wmax, wmin);
+        // Share with the cohort
+        wblockmax = __shfl(wblockmax, group_leader);
+      }
+
+      // Derive scales
+      int decoding_scale = pk_mul<T>(wblockmax, kScaleFactor);
+      int encoding_scale = pk_add<T>(decoding_scale, kScaleEpsilon);
+      encoding_scale = pk_hcp<T>(encoding_scale);
+
+      // Apply scales to get quantized values
+      int32x4_t w;
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(atom[i], encoding_scale);
+        w[i] = pk_max<T>(w[i], kRangeMin);
+        w[i] = pk_min<T>(w[i], kRangeMax);
+      }
+
+      // Convert from fp16x2_t to uint16x2_t
+      int32x4_t q;
+      {
+        int16_t* qi = reinterpret_cast<int16_t*>(&q);
+        T* wh = reinterpret_cast<T*>(&w);
+        for (int i = 0; i < 8; i++) qi[i] = (int16_t)rintf(T2float(wh[i]));
+
+        for (int i = 0; i < 4; i++) {
+          asm volatile("v_pk_add_i16 %0, %1, %2"
+                       : "=v"(q[i])
+                       : "v"(q[i]), "v"(kRangeBias));
+        }
+      }
+
+      // Pack 8 x q4 into int32_t
+      int qw = q[0] | (q[1] << 4) | (q[2] << 8) | (q[3] << 12);
+
+      // Write quantized atom to send_buffer
+      // note: only the group leader stores the scale
+      uint8_t* atom_ptr =
+          reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+      int32_t* qw_ptr = reinterpret_cast<int32_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      __builtin_nontemporal_store(qw, qw_ptr);
+      if (threadIdx.x == group_leader) {
+        __builtin_nontemporal_store(decoding_scale, qs_ptr);
+      }
+    }
+  }
+
+  __device_inline__ void recv(int32x4_t** __restrict__ recv_buffer,
+                              int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      // Directly read quantized atom from recv_buffer
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+      int32_t* qw_ptr = reinterpret_cast<int32_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      int32_t qw = __builtin_nontemporal_load(qw_ptr);
+      int qs = __builtin_nontemporal_load(qs_ptr);
+
+      *recv_buffer += kRankBufferTileStride;
+
+      // Unpack q4 into fp16x8_t
+      int32x4_t w;
+      {
+        static uint constexpr kMask000F = 0x000F000F;
+        static uint constexpr kHalf2_1024 =
+            0x64006400;  // {1024.0, 1024.0}, fp16x2_t
+        static uint constexpr kHalf2_1032 =
+            0xE408E408;  // {-1032.0, -1032.0}, fp16x2_t
+
+        for (int i = 0; i < 4; i++) {
+          if constexpr (std::is_same<T, half>::value) {
+            int32_t q4 = ((qw >> (i * 4)) & kMask000F) | kHalf2_1024;
+            asm volatile("v_pk_add_f16 %0, %1, %2"
+                         : "=v"(w[i])
+                         : "v"(q4), "v"(kHalf2_1032));
+          } else {
+            int32_t int16_2 = (qw >> (i * 4)) & kMask000F;
+            int16_t low = static_cast<int16_t>(int16_2 & 0xFFFF);
+            int16_t high = static_cast<int16_t>((int16_2 >> 16) & 0xFFFF);
+
+            nv_bfloat16 bf_low = __float2bfloat16(static_cast<float>(low));
+            nv_bfloat16 bf_high = __float2bfloat16(static_cast<float>(high));
+
+            nv_bfloat162 bf2 = __halves2bfloat162(bf_low, bf_high);
+            int32_t packed_bf16 = *reinterpret_cast<int32_t*>(&bf2);
+            w[i] = pk_add<nv_bfloat16>(packed_bf16, kRangeMin);
+          }
+        }
+      }
+
+      // Apply decoding scales
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(w[i], qs);
+      }
+
+      // That's pretty much it...
+      data[k] = w;
+    }
+  }
+};
+
+// MARK: Q6 Line Codec
+template <int world_size, typename T>
+struct TwoshotQ6LineCodec {
+  /*
+      Int6-blocking Line codec for Twoshot collectives.
+      We quantize the FP16 data to block-scaled Int64 in blocks of 32.
+  */
+
+  static int constexpr kAtoms = 8;
+  static int constexpr kAtomStride = 256;
+  static int constexpr kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each threads processes a fragment of fp16x8_t (16B),
+  // into a int6x8_t (4B + 2B) and a fp16 scale shared among 32 values.
+  static int constexpr kRankAtoms = kAtoms / kWorldSize;
+  static int constexpr kRankTileStride = 1664;
+  static int constexpr kRankTileQ2Offset = 1024;
+  static int constexpr kRankTileScaleOffset = 1536;
+  static int constexpr kRankTileSize = kRankTileStride * kRankAtoms;
+
+  static int constexpr kRankBufferTileStride =
+      kRankTileStride / sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static int constexpr kTileSize = kRankTileSize * kWorldSize;
+
+  // Q6 configuration
+  static int constexpr kScaleFactor =
+      Quant6Const<T>::kScaleFactor;  // {-1/32.0h, -1/32.0h}, fp16x2_t
+  static int constexpr kScaleEpsilon =
+      Quant6Const<T>::kScaleEpsilon;  // {1e-7, 1e-7}, fp16x2_t
+  static int constexpr kRangeMin =
+      Quant6Const<T>::kRangeMin;  // {-32, -32}, fp16x2_t
+  static int constexpr kRangeMax =
+      Quant6Const<T>::kRangeMax;                 // {+31, +31}, fp16x2_t
+  static int constexpr kRangeBias = 0x00200020;  // {+32, +32}, int16x2_t
+
+  int const thread;
+  int const rank;
+  int const group_leader;
+
+  __device_inline__ TwoshotQ6LineCodec(int thread, int rank)
+      : thread(thread), rank(rank), group_leader((threadIdx.x / 8) * 8) {
+    static_assert(kRankTileSize % 16 == 0,
+                  "kRankTileSize must be 16B aligned.");
+    set_fp16_ovfl(true);
+  }
+
+  __device_inline__ void send(int32x4_t* __restrict__ send_buffer,
+                              int32x4_t const* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      int32x4_t const atom = data[k];
+
+      // max(w), min(w)
+      int wmax, wmin, wblockmax;
+      {
+        int a, b;
+        a = pk_max<T>(atom[0], atom[1]);
+        b = pk_max<T>(atom[2], atom[3]);
+        wmax = pk_max<T>(a, b);
+
+        a = pk_min<T>(atom[0], atom[1]);
+        b = pk_min<T>(atom[2], atom[3]);
+        wmin = pk_min<T>(a, b);
+
+        // Reduce the max among a group of 8 threads
+        // Note: This is basically 2 blocks of 32 values setup as the
+        // upper/lower halves of the fp16x2_t
+        for (int i = 1; i < 8; i <<= 1) {
+          int x = __shfl_down(wmax, i);
+          wmax = pk_max<T>(wmax, x);
+
+          int y = __shfl_down(wmin, i);
+          wmin = pk_min<T>(wmin, y);
+        }
+
+        wblockmax = pk_max_abs<T>(wmax, wmin);
+
+        // Share with the cohort
+        wblockmax = __shfl(wblockmax, group_leader);
+      }
+
+      // Derive scales
+      int decoding_scale = pk_mul<T>(wblockmax, kScaleFactor);
+      int encoding_scale = pk_add<T>(decoding_scale, kScaleEpsilon);
+      encoding_scale = pk_hcp<T>(encoding_scale);
+
+      // Apply scales to get quantized values
+      int32x4_t w;
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(atom[i], encoding_scale);
+        w[i] = pk_max<T>(w[i], kRangeMin);
+        w[i] = pk_min<T>(w[i], kRangeMax);
+      }
+
+      // Convert from fp16x2_t to uint16x2_t
+      int32x4_t q;
+      {
+        int16_t* qi = reinterpret_cast<int16_t*>(&q);
+        T* wh = reinterpret_cast<T*>(&w);
+        for (int i = 0; i < 8; i++) qi[i] = (int16_t)rintf(T2float(wh[i]));
+
+        for (int i = 0; i < 4; i++) {
+          asm volatile("v_pk_add_i16 %0, %1, %2"
+                       : "=v"(q[i])
+                       : "v"(q[i]), "v"(kRangeBias));
+        }
+      }
+
+      // Pack 8 x q6 into int32_t + int16_t
+      uint32_t q4w;
+      uint16_t q2w = 0;
+      q4w = (q[0] & 0x000F000F) | ((q[1] & 0x000F000F) << 4) |
+            ((q[2] & 0x000F000F) << 8) | ((q[3] & 0x000F000F) << 12);
+      {
+        int16_t* tw = reinterpret_cast<int16_t*>(&q);
+#pragma unroll
+        for (int i = 0; i < 8; i++) {
+          q2w |= (tw[i] >> 4) << (i * 2);
+        }
+      }
+
+      // Write quantized atom to send_buffer
+      // note: only the group leader stores the scale
+      uint8_t* atom_ptr =
+          reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+      uint32_t* q4w_ptr = reinterpret_cast<uint32_t*>(atom_ptr) + thread;
+      uint16_t* q2w_ptr =
+          reinterpret_cast<uint16_t*>(atom_ptr + kRankTileQ2Offset) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      __builtin_nontemporal_store(q4w, q4w_ptr);
+      __builtin_nontemporal_store(q2w, q2w_ptr);
+      if (threadIdx.x == group_leader) {
+        __builtin_nontemporal_store(decoding_scale, qs_ptr);
+      }
+    }
+  }
+
+  __device_inline__ void recv(int32x4_t** __restrict__ recv_buffer,
+                              int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      // Directly read quantized atom from recv_buffer
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+      uint32_t* q4w_ptr = reinterpret_cast<uint32_t*>(atom_ptr) + thread;
+      uint16_t* q2w_ptr =
+          reinterpret_cast<uint16_t*>(atom_ptr + kRankTileQ2Offset) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      uint32_t q4w = __builtin_nontemporal_load(q4w_ptr);
+      uint16_t q2w = __builtin_nontemporal_load(q2w_ptr);
+      int qs = __builtin_nontemporal_load(qs_ptr);
+
+      *recv_buffer += kRankBufferTileStride;
+
+      // Unpack q6 into fp16x8_t
+      int32x4_t w;
+      {
+        static uint constexpr kMask000F = 0x000F000F;
+        static uint constexpr kMask00FF = 0x00FF00FF;
+        static uint constexpr kHalf2_1024 =
+            0x64006400;  // {1024.0, 1024.0}, fp16x2_t
+        static uint constexpr kHalf2_1056 =
+            0xE420E420;  // {-1056.0, -1056.0}, fp16x2_t
+
+#pragma unroll
+        for (int i = 0; i < 4; i++) {
+          int32_t q4 = q4w & kMask000F;
+          int32_t q2 = (q2w & 0x3) | ((q2w & 0xC) << 14);
+          q4w >>= 4;
+          q2w >>= 4;
+          if constexpr (std::is_same<T, half>::value) {
+            int32_t q6 = q4 | (q2 << 4) | kHalf2_1024;
+            asm volatile("v_pk_add_f16 %0, %1, %2"
+                         : "=v"(w[i])
+                         : "v"(q6), "v"(kHalf2_1056));
+          } else {
+            int32_t int16_2 = q4 | (q2 << 4);
+            int16_t low = static_cast<int16_t>(int16_2 & 0xFFFF);
+            int16_t high = static_cast<int16_t>((int16_2 >> 16) & 0xFFFF);
+
+            nv_bfloat16 bf_low = __float2bfloat16(static_cast<float>(low));
+            nv_bfloat16 bf_high = __float2bfloat16(static_cast<float>(high));
+            nv_bfloat162 bf2 = __halves2bfloat162(bf_low, bf_high);
+            int32_t packed_bf16 = *reinterpret_cast<int32_t*>(&bf2);
+            w[i] = pk_add<nv_bfloat16>(packed_bf16, kRangeMin);
+          }
+        }
+      }
+
+      // Apply decoding scales
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(w[i], qs);
+      }
+
+      // That's pretty much it...
+      data[k] = w;
+    }
+  }
+};
+
+// MARK: Q8 Line Codec
+template <int world_size, typename T>
+struct TwoshotQ8LineCodec {
+  /*
+      Int8-blocking Line codec for Twoshot collectives.
+      We quantize the FP16 data to block-scaled Int8 in blocks of 32.
+  */
+
+  static int constexpr kAtoms = 8;
+  static int constexpr kAtomStride = 256;
+  static int constexpr kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each threads processes a fragment of fp16x8_t (16B),
+  // into a int8x8_t (8B) and a fp16 scale shared among 32 values.
+  static int constexpr kRankAtoms = kAtoms / kWorldSize;
+  static int constexpr kRankTileStride = 2176;
+  static int constexpr kRankTileScaleOffset = 2048;
+  static int constexpr kRankTileSize = kRankTileStride * kRankAtoms;
+
+  static int constexpr kRankBufferTileStride =
+      kRankTileStride / sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static int constexpr kTileSize = kRankTileSize * kWorldSize;
+
+  // Q8 configuration
+  static int constexpr kScaleFactor =
+      Quant8Const<T>::kScaleFactor;  // {-1/128.0h, -1/128.0h}, fp16x2_t
+  static int constexpr kScaleEpsilon =
+      Quant8Const<T>::kScaleEpsilon;  // {1e-7, 1e-7}, fp16x2_t
+  static int constexpr kRangeMin =
+      Quant8Const<T>::kRangeMin;  // {-128, -128}, fp16x2_t
+  static int constexpr kRangeMax =
+      Quant8Const<T>::kRangeMax;  // {+127, +127}, fp16x2_t
+  static constexpr int kRangeBias = 0x00800080;
+  // {+128, +128}, int16x2_t
+
+  int const thread;
+  int const rank;
+  int const group_leader;
+
+  __device_inline__ TwoshotQ8LineCodec(int thread, int rank)
+      : thread(thread), rank(rank), group_leader((threadIdx.x / 8) * 8) {
+    static_assert(kRankTileSize % 16 == 0,
+                  "kRankTileSize must be 16B aligned.");
+    set_fp16_ovfl(true);
+  }
+
+  __device_inline__ void send(int32x4_t* __restrict__ send_buffer,
+                              int32x4_t const* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      int32x4_t const atom = data[k];
+
+      // max(w), min(w)
+      int wmax, wmin, wblockmax;
+      {
+        int a, b;
+        a = pk_max<T>(atom[0], atom[1]);
+        b = pk_max<T>(atom[2], atom[3]);
+        wmax = pk_max<T>(a, b);
+
+        a = pk_min<T>(atom[0], atom[1]);
+        b = pk_min<T>(atom[2], atom[3]);
+        wmin = pk_min<T>(a, b);
+
+        // Reduce the max among a group of 8 threads
+        // Note: This is basically 2 blocks of 32 values setup as the
+        // upper/lower halves of the fp16x2_t
+        for (int i = 1; i < 8; i <<= 1) {
+          int x = __shfl_down(wmax, i);
+          wmax = pk_max<T>(wmax, x);
+
+          int y = __shfl_down(wmin, i);
+          wmin = pk_min<T>(wmin, y);
+        }
+
+        wblockmax = pk_max_abs<T>(wmax, wmin);
+        // Share with the cohort
+        wblockmax = __shfl(wblockmax, group_leader);
+      }
+
+      // Derive scales
+      int decoding_scale = pk_mul<T>(wblockmax, kScaleFactor);
+      int encoding_scale = pk_add<T>(decoding_scale, kScaleEpsilon);
+      encoding_scale = pk_hcp<T>(encoding_scale);
+
+      // Apply scales to get quantized values
+      int32x4_t w;
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(atom[i], encoding_scale);
+        w[i] = pk_max<T>(w[i], kRangeMin);
+        w[i] = pk_min<T>(w[i], kRangeMax);
+      }
+
+      // Convert from fp16x2_t to uint16x2_t
+      int32x4_t q;
+      {
+        int16_t* qi = reinterpret_cast<int16_t*>(&q);
+        T* wh = reinterpret_cast<T*>(&w);
+        for (int i = 0; i < 8; i++) qi[i] = (int16_t)rintf(T2float(wh[i]));
+
+        for (int i = 0; i < 4; i++) {
+          asm volatile("v_pk_add_i16 %0, %1, %2"
+                       : "=v"(q[i])
+                       : "v"(q[i]), "v"(kRangeBias));  // shared
+        }
+      }
+
+      // Pack 8 x q8 into int32x2_t
+      int32x2_t qw;
+      qw[0] = q[0] | (q[1] << 8);
+      qw[1] = q[2] | (q[3] << 8);
+
+      // Write quantized atom to send_buffer
+      // note: only the group leader stores the scale
+      uint8_t* atom_ptr =
+          reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+      int32x2_t* qw_ptr = reinterpret_cast<int32x2_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      __builtin_nontemporal_store(qw, qw_ptr);
+      if (threadIdx.x == group_leader) {
+        __builtin_nontemporal_store(decoding_scale, qs_ptr);
+      }
+    }
+  }
+
+  __device_inline__ void recv(int32x4_t** __restrict__ recv_buffer,
+                              int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      // Directly read quantized atom from recv_buffer
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+      int32x2_t* qw_ptr = reinterpret_cast<int32x2_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) +
+                    (thread / 8);
+
+      int32x2_t qw = __builtin_nontemporal_load(qw_ptr);
+      int qs = __builtin_nontemporal_load(qs_ptr);
+
+      *recv_buffer += kRankBufferTileStride;
+
+      // Unpack q8 into fp16x8_t
+      int32x4_t w;
+      {
+        static uint constexpr kMask00FF = 0x00FF00FF;
+        static uint constexpr kHalf2_1024 =
+            0x64006400;  // {1024.0, 1024.0}, fp16x2_t
+        static uint constexpr kHalf2_1152 =
+            0xE480E480;  // {-1152.0, -1152.0}, fp16x2_t
+
+#pragma unroll
+        for (int i = 0; i < 4; i++) {
+          if constexpr (std::is_same<T, half>::value) {
+            int32_t q8 =
+                ((qw[i / 2] >> ((i % 2) * 8)) & kMask00FF) | kHalf2_1024;
+            asm volatile("v_pk_add_f16 %0, %1, %2"
+                         : "=v"(w[i])
+                         : "v"(q8), "v"(kHalf2_1152));
+
+          } else {
+            int32_t int16_2 = (qw[i / 2] >> ((i % 2) * 8)) & kMask00FF;
+            int16_t low = static_cast<int16_t>(int16_2 & 0xFFFF);
+            int16_t high = static_cast<int16_t>((int16_2 >> 16) & 0xFFFF);
+
+            nv_bfloat16 bf_low = __float2bfloat16(static_cast<float>(low));
+            nv_bfloat16 bf_high = __float2bfloat16(static_cast<float>(high));
+
+            nv_bfloat162 bf2 = __halves2bfloat162(bf_low, bf_high);
+            int32_t packed_bf16 = *reinterpret_cast<int32_t*>(&bf2);
+            w[i] = pk_add<nv_bfloat16>(packed_bf16, kRangeMin);
+          }
+        }
+      }
+
+      // Apply decoding scales
+      for (int i = 0; i < 4; i++) {
+        w[i] = pk_mul<T>(w[i], qs);
+      }
+
+      // That's pretty much it...
+      data[k] = w;
+    }
+  }
+};
+
+// MARK: Twoshot All Reduce
+template <class LineCodec, typename T>
+struct AllReduceTwoshot {
+  // Fixed magic implementation.
+  // We will use a workgroup of 256 threads (standard kBlock) across 8 atoms of
+  // work.
+  static int constexpr kAtoms = 8;
+
+  // Size and atom stride of source/destination data that the workgroup will
+  // process.
+  static int constexpr kTileSize = 256 * kAtoms * sizeof(int32x4_t);
+  static int constexpr kAtomStride = 256;
+
+  static int constexpr kWorldSize = LineCodec::kWorldSize;
+
+  __device__ static void run(
+      T const* __restrict__ A,  // input
+      T* __restrict__ B,        // output
+      int const N,              // number of elements
+      int const block,          // block index
+      int const num_blocks,     // number of blocks
+      int const world_size,     // unused - only kept around for API consistency
+      int const rank,           // rank index
+      uint8_t** __restrict__ buffer_list,  // communication buffers
+      long const data_offset,              // offset to start of the data buffer
+      int flag_color) {
+    // Topology
+    int thread = threadIdx.x + threadIdx.y * kWavefront;
+    uint8_t* rank_buffer = buffer_list[rank];
+
+    LineCodec codec(thread, rank);
+
+    // --------------------------------------------------------
+    // Read A into registers
+    int32x4_t tA[kAtoms];
+
+    BufferResource src_buffer(const_cast<T*>(A), N * sizeof(T));
+    int src_offset = block * kTileSize + thread * sizeof(int32x4_t);
+
+    for (int i = 0; i < kAtoms; i++) {
+      tA[i] = buffer_load_dwordx4(src_buffer.descriptor, src_offset, 0, 0);
+      src_offset += kAtomStride * sizeof(int32x4_t);
+    }
+
+    // --------------------------------------------------------
+    // Phase-1A: Write segment data into the communication buffer of the target
+    // rank responsible for this segment.
+    long comm_data0_offset = data_offset + block * LineCodec::kTileSize;
+    long comm_data1_offset =
+        num_blocks * LineCodec::kTileSize + comm_data0_offset;
+
+    long comm_flags0_offset = block * (kWorldSize * sizeof(int));
+    long comm_flags1_offset =
+        num_blocks * (kWorldSize * sizeof(int)) + comm_flags0_offset;
+
+    for (int r = 0; r < kWorldSize; r++) {
+      int32x4_t* send_buffer = reinterpret_cast<int32x4_t*>(
+          buffer_list[r] + comm_data0_offset + rank * LineCodec::kRankTileSize);
+      codec.send(send_buffer, &tA[r * LineCodec::kRankAtoms]);
+    }
+
+    __syncthreads();
+    if (thread < kWorldSize) {
+      int r = thread;
+      int* flag_ptr = reinterpret_cast<int*>(
+          buffer_list[r] + comm_flags0_offset + rank * sizeof(int));
+      __atomic_store_n(flag_ptr, flag_color, __ATOMIC_RELEASE);
+    }
+
+    // --------------------------------------------------------
+    // Phase-1B: Reduce the segment data from the communication buffers.
+    int32x4_t tR[LineCodec::kRankAtoms] = {};
+    {
+      // Read the data from the communication buffer.
+      int32x4_t* recv_buffer =
+          reinterpret_cast<int32x4_t*>(rank_buffer + comm_data0_offset);
+      int* flag_ptr = reinterpret_cast<int*>(rank_buffer + comm_flags0_offset);
+
+      for (int r = 0; r < kWorldSize; r++) {
+        // Wait for the flags to be set.
+        if (thread == 0) {
+          while (__atomic_load_n(&flag_ptr[r], __ATOMIC_RELAXED) !=
+                 flag_color) {
+          }
+        }
+        __syncthreads();
+
+        // note: we reuse tA as temp buffer here
+        codec.recv(&recv_buffer, tA);
+
+        for (int i = 0; i < LineCodec::kRankAtoms; i++) {
+          int32x4_t& tA_fragment = tA[i];
+          int32x4_t& tR_fragment = tR[i];
+          tR_fragment[0] = pk_add<T>(tR_fragment[0], tA_fragment[0]);
+          tR_fragment[1] = pk_add<T>(tR_fragment[1], tA_fragment[1]);
+          tR_fragment[2] = pk_add<T>(tR_fragment[2], tA_fragment[2]);
+          tR_fragment[3] = pk_add<T>(tR_fragment[3], tA_fragment[3]);
+        }
+      }
+    }
+
+    // --------------------------------------------------------
+    // Phase-2: Write the reduced segment to every other rank
+    // This is basically an all-gather.
+    for (int r = 0; r < kWorldSize; r++) {
+      int32x4_t* send_buffer = reinterpret_cast<int32x4_t*>(
+          buffer_list[r] + comm_data1_offset + rank * LineCodec::kRankTileSize);
+      codec.send(send_buffer, tR);
+    }
+
+    __syncthreads();
+    if (thread < kWorldSize) {
+      int r = thread;
+      int* flag_ptr = reinterpret_cast<int*>(
+          buffer_list[r] + comm_flags1_offset + rank * sizeof(int));
+      __atomic_store_n(flag_ptr, flag_color, __ATOMIC_RELEASE);
+    }
+
+    // --------------------------------------------------------
+    // Phase-2: Read the gather segments from the rank's communication buffer.
+    {
+      // Read the data from the communication buffer.
+      int32x4_t* recv_buffer =
+          reinterpret_cast<int32x4_t*>(rank_buffer + comm_data1_offset);
+      int* flag_ptr = reinterpret_cast<int*>(rank_buffer + comm_flags1_offset);
+
+      for (int r = 0; r < kWorldSize; r++) {
+        // Wait for the flags to be set.
+        if (thread == 0) {
+          while (__atomic_load_n(&flag_ptr[r], __ATOMIC_RELAXED) !=
+                 flag_color) {
+          }
+        }
+        __syncthreads();
+
+        // Gather all reduced and final rank segments into tA.
+        codec.recv(&recv_buffer, &tA[r * LineCodec::kRankAtoms]);
+      }
+    }
+
+    // --------------------------------------------------------
+    // Write the result to B.
+    BufferResource dst_buffer(B, N * sizeof(T));
+    int dst_offset = block * kTileSize + thread * sizeof(int32x4_t);
+
+    for (int i = 0; i < kAtoms; i++) {
+      buffer_store_dwordx4(tA[i], dst_buffer.descriptor, dst_offset, 0, 0);
+      dst_offset += kAtomStride * sizeof(int32x4_t);
+    }
+  }
+};
+
+// ============================================================
+// Oneshot
+// ============================================================
+// MARK: Oneshot All Reduce
+template <typename T>
+struct AllReduceOneshot {
+  // Fixed magic implementation.
+  // We will use a workgroup of 256 threads (standard kBlock) across 8 atoms of
+  // work.
+  static int constexpr kAtoms = 8;
+
+  // Size and atom stride of data that the workgroup will process.
+  static int constexpr kTileSize = 256 * kAtoms * sizeof(int32x4_t);
+  static int constexpr kAtomStride = 256;
+
+  __device__ static void run(
+      T const* __restrict__ A,             // input
+      T* __restrict__ B,                   // output
+      int const N,                         // number of elements
+      int const block,                     // this block's index
+      int const num_blocks,                // total number of blocks
+      int const world_size,                // total number of ranks
+      int const rank,                      // this rank's index
+      uint8_t** __restrict__ buffer_list,  // communication buffers
+      long const data_offset,              // offset to start of the data buffer
+      int flag_color                       // Flag color for the network barrier
+  ) {
+    // Topology
+    int thread = threadIdx.x + threadIdx.y * kWavefront;
+
+    long data_stride = num_blocks * kTileSize;
+    long flags_stride = num_blocks * sizeof(int);
+
+    uint8_t* rank_buffer = buffer_list[rank];
+
+    // --------------------------------------------------------
+    // Read A into registers
+    int32x4_t tA[kAtoms];
+
+    BufferResource src_buffer(const_cast<T*>(A), N * sizeof(T));
+    int src_offset = block * kTileSize + thread * sizeof(int32x4_t);
+
+    for (int i = 0; i < kAtoms; i++) {
+      tA[i] = buffer_load_dwordx4(src_buffer.descriptor, src_offset, 0, 0);
+      src_offset += kAtomStride * sizeof(int32x4_t);
+    }
+
+    // --------------------------------------------------------
+    // Write rank data into this rank segment of every rank's communication
+    // buffer.
+    long comm_data_offset =
+        data_offset + rank * data_stride + block * kTileSize;
+    long comm_flags_offset = rank * flags_stride + block * sizeof(int);
+
+    if (thread < world_size) {
+      int r = thread;
+      int* flag_ptr =
+          reinterpret_cast<int*>(buffer_list[r] + comm_flags_offset);
+      while (__atomic_load_n(flag_ptr, __ATOMIC_RELAXED) != flag_color - 1) {
+      }
+    }
+    __syncthreads();
+
+    for (int r = 0; r < world_size; r++) {
+      int32x4_t* send_buffer =
+          reinterpret_cast<int32x4_t*>(buffer_list[r] + comm_data_offset);
+      for (int i = 0; i < kAtoms; i++) {
+        __builtin_nontemporal_store(tA[i], send_buffer + thread);
+        send_buffer += kAtomStride;
+      }
+    }
+
+    // Inform the other ranks that th data has been posted.
+    __syncthreads();
+    if (thread < world_size) {
+      int r = thread;
+      int* flag_ptr =
+          reinterpret_cast<int*>(buffer_list[r] + comm_flags_offset);
+      __atomic_store_n(flag_ptr, flag_color, __ATOMIC_RELEASE);
+    }
+
+    // --------------------------------------------------------
+    // Read and reduce the data from this rank's communication buffer.
+    int32x4_t tB[kAtoms];
+
+    {
+      int r = 0;
+
+      // Wait for the flags to be set.
+      int* flag_ptr = reinterpret_cast<int*>(rank_buffer + r * flags_stride +
+                                             block * sizeof(int));
+      if (thread == 0) {
+        while (__atomic_load_n(flag_ptr, __ATOMIC_RELAXED) != flag_color) {
+        }
+      }
+      __syncthreads();
+
+      // Read posted data from the rank's communication buffer.
+      int32x4_t* recv_buffer = reinterpret_cast<int32x4_t*>(
+          rank_buffer + data_offset + r * data_stride + block * kTileSize);
+
+      for (int i = 0; i < kAtoms; i++) {
+        tB[i] = __builtin_nontemporal_load(recv_buffer + thread);
+        recv_buffer += kAtomStride;
+      }
+    }
+
+    for (int r = 1; r < world_size; r++) {
+      // Wait for the flags to be set.
+      int* flag_ptr = reinterpret_cast<int*>(rank_buffer + r * flags_stride +
+                                             block * sizeof(int));
+      if (thread == 0) {
+        while (__atomic_load_n(flag_ptr, __ATOMIC_RELAXED) != flag_color) {
+        }
+      }
+      __syncthreads();
+
+      // Read posted data from the rank's communication buffer.
+      int32x4_t* recv_buffer = reinterpret_cast<int32x4_t*>(
+          rank_buffer + data_offset + r * data_stride + block * kTileSize);
+
+      for (int i = 0; i < kAtoms; i++) {
+        tA[i] = __builtin_nontemporal_load(recv_buffer + thread);
+        recv_buffer += kAtomStride;
+      }
+
+      // Reduce.
+      for (int i = 0; i < kAtoms; i++) {
+        int32x4_t& tA_fragment = tA[i];
+        int32x4_t& tB_fragment = tB[i];
+        tB_fragment[0] = pk_add<T>(tB_fragment[0], tA_fragment[0]);
+        tB_fragment[1] = pk_add<T>(tB_fragment[1], tA_fragment[1]);
+        tB_fragment[2] = pk_add<T>(tB_fragment[2], tA_fragment[2]);
+        tB_fragment[3] = pk_add<T>(tB_fragment[3], tA_fragment[3]);
+      }
+    }
+
+    __syncthreads();
+    if (thread < world_size) {
+      int r = thread;
+      int* flag_ptr = reinterpret_cast<int*>(rank_buffer + r * flags_stride +
+                                             block * sizeof(int));
+      __atomic_store_n(flag_ptr, flag_color, __ATOMIC_RELAXED);
+    }
+
+    // --------------------------------------------------------
+    // Write the result to B.
+    BufferResource dst_buffer(B, N * sizeof(T));
+    int dst_offset = block * kTileSize + thread * sizeof(int32x4_t);
+
+    for (int i = 0; i < kAtoms; i++) {
+      buffer_store_dwordx4(tB[i], dst_buffer.descriptor, dst_offset, 0, 0);
+      dst_offset += kAtomStride * sizeof(int32x4_t);
+    }
+  }
+};
+
+}  // namespace quickreduce

--- a/csrc/quick_all_reduce.h
+++ b/csrc/quick_all_reduce.h
@@ -128,7 +128,6 @@ __device_inline__ static void set_fp16_ovfl(bool const value) {
   } while (0)
 
 enum struct QuickReduceProfile {
-  ONESHOT_F16 = 0,
   TWOSHOT_F16 = 1,
   TWOSHOT_FP8 = 2,
   TWOSHOT_Q8 = 3,

--- a/csrc/quick_all_reduce.h
+++ b/csrc/quick_all_reduce.h
@@ -176,7 +176,8 @@ struct DeviceComms {
   hipIpcMemHandle_t const get_handle() { return buffer_ipc_handle; }
   void open_ipc_handles(std::vector<hipIpcMemHandle_t> const& ipc_handles);
   template <typename T>
-  void allreduce(int profile, hipStream_t stream, T const* A, T* B, int N);
+  void allreduce(int profile, hipStream_t stream, T const* A, T* B, int N,
+                 bool cast_bf162half);
   torch::Tensor qr_get_comm_handle();
 };
 
@@ -417,6 +418,6 @@ torch::Tensor qr_get_comm_handle(fptr_t _fa);
 void qr_set_comm_handles(fptr_t _fa,
                          std::vector<torch::Tensor> const& comm_handles);
 void qr_all_reduce(fptr_t _fa, int64_t profile, torch::Tensor const& inp,
-                   torch::Tensor& out);
+                   torch::Tensor& out, bool cast_bf162half);
 void qr_destroy(fptr_t _fa);
 void is_quickreduce_available();

--- a/csrc/quick_all_reduce.h
+++ b/csrc/quick_all_reduce.h
@@ -1,0 +1,423 @@
+#pragma once
+
+#include <cstdint>
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+
+#include <vector>
+#include <torch/torch.h>
+
+typedef __hip_bfloat16 nv_bfloat16;
+typedef __hip_bfloat162 nv_bfloat162;
+
+#define __device_inline__ __device__ __forceinline__
+#define __quickreduce_launch_bounds__ __launch_bounds__(256, 4)
+
+// Setup acquire-release semantics for vector memory reads (mubuf instruction)
+// as per architecture.
+#if defined(__gfx942__)
+  // CDNA3: Scope bits sc0, sc1
+  #define MUBUF_ACQUIRE 16
+  #define MUBUF_RELEASE 16
+#elif (defined(__gfx908__) || defined(__gfx90a__))
+  // CDNA1 and CDNA2 - glc bit
+  #define MUBUF_ACQUIRE 1
+  #define MUBUF_RELEASE 0
+#endif
+
+namespace quickreduce {
+
+// Vector types
+using int8x8_t = __attribute__((__vector_size__(8 * sizeof(int8_t)))) int8_t;
+
+using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
+using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+using int32x16_t = __attribute__((__vector_size__(16 * sizeof(int)))) int;
+
+using fp8_t = uint8_t;
+using fp8x8_t = __attribute__((__vector_size__(8 * sizeof(uint8_t)))) uint8_t;
+
+using fp16x4_t = __attribute__((__vector_size__(4 * sizeof(__fp16)))) __fp16;
+using fp16x8_t = __attribute__((__vector_size__(8 * sizeof(__fp16)))) __fp16;
+using fp16x16_t = __attribute__((__vector_size__(16 * sizeof(__fp16)))) __fp16;
+
+using fp32x2_t = __attribute__((__vector_size__(2 * sizeof(float)))) float;
+using fp32x4_t = __attribute__((__vector_size__(4 * sizeof(float)))) float;
+using fp32x8_t = __attribute__((__vector_size__(8 * sizeof(float)))) float;
+using fp32x16_t = __attribute__((__vector_size__(16 * sizeof(float)))) float;
+
+// Standard CDNA wavefront size.
+static int constexpr kWavefront = 64;
+
+// 256 thread, 4 wavefronts.
+static dim3 constexpr kBlock = {64, 4, 1};
+
+// Methods
+__device_inline__ __host__ int divceil(int x, int y) {
+  return ((x + y - 1) / y);
+}
+
+__device_inline__ __host__ constexpr int divceil_constexpr(int const x,
+                                                           int const y) {
+  return ((x + y - 1) / y);
+}
+
+/*
+===============================================================
+Desc:
+    Utility container to describe the Buffer Resource used in VMEM operations.
+Operation:
+    BufferResource can be initialized to tensor base address and range/size (in
+bytes). The range is used for OOB checks. For example the range for a MxK
+dtype=fp16 tensor would have a range of [M * K * sizeof(half)].
+    The last dword of the buffer resource description is to a default config
+with DFMT=32b.
+    Instructions that used the buffer resource (buffer_load/store_dwordx4) wait
+on the `vmcnt`.
+*/
+
+union BufferResource {
+  __device_inline__ constexpr BufferResource() : config(0x00020000U) {}
+
+  __device_inline__ constexpr BufferResource(void* buffer_address,
+                                             uint32_t buffer_size)
+      : address(buffer_address), range(buffer_size), config(0x00020000U) {}
+
+  int32x4_t descriptor;
+  struct {
+    void* address;   // 8B, out of which first 48b is address, and 16b is stride
+                     // (unused)
+    uint32_t range;  // Byte range for the buffer resource
+    uint32_t config;  // Constant, DFMT=32b
+  };
+};
+
+__device_inline__ static int32x4_t buffer_load_dwordx4(
+    int32x4_t srsrc, int32_t voffset, int32_t soffset,
+    int32_t aux) __asm("llvm.amdgcn.raw.buffer.load.v4i32");
+
+__device_inline__ static void buffer_store_dwordx4(
+    int32x4_t data, int32x4_t srsrc, int32_t voffset, int32_t soffset,
+    int32_t aux) __asm("llvm.amdgcn.raw.buffer.store.v4i32");
+
+__device_inline__ static void set_fp16_ovfl(bool const value) {
+  // short size = 0b00001;    // Specifies the bit size to modify
+  // const short offset = 0b10111;  // Corrected offset to 23, which is the bit
+  // position of FP16_OVFL const short hwRegId = 0b000001; // HW register ID for
+  // MODE const short simm16 = (size << 11) | (offset << 6) | hwRegId; simm16 =
+  // 0xdc1
+
+#if defined(__gfx942__)
+  if (value) {
+    asm volatile("s_setreg_imm32_b32 0xdc1, 1;" ::);
+  } else {
+    asm volatile("s_setreg_imm32_b32 0xdc1, 0;" ::);
+  }
+#endif
+}
+
+#define HIP_CHECK(err)                                                  \
+  do {                                                                  \
+    hipError_t err_ = (err);                                            \
+    if (err_ != hipSuccess) {                                           \
+      std::printf("HIP error %d at %s:%d\n", err_, __FILE__, __LINE__); \
+      throw std::runtime_error("HIP error");                            \
+    }                                                                   \
+  } while (0)
+
+enum struct QuickReduceProfile {
+  ONESHOT_F16 = 0,
+  TWOSHOT_F16 = 1,
+  TWOSHOT_FP8 = 2,
+  TWOSHOT_Q8 = 3,
+  TWOSHOT_Q6 = 4,
+  TWOSHOT_Q4 = 5,
+};
+
+/*
+===============================================================
+Desc:
+    Device Comms Handle
+*/
+struct DeviceComms {
+  // Workgroup scope = Tile = (256 threads x 16B x 8 atoms)
+  static long constexpr kTileSize = 256 * 16 * 8;
+
+  // Max problem size is 512MB (in bytes)
+  static long constexpr kMaxProblemSize = 536870912;
+  static long constexpr kMaxTiles = kMaxProblemSize / kTileSize;
+
+  // Max TP-8
+  static int constexpr kMaxWorldSize = 8;
+
+  bool initialized = false;
+  int flag_color = 1;
+  int world_size;
+  int rank;
+
+  uint8_t* dbuffer;
+  uint8_t** dbuffer_list;
+  hipIpcMemHandle_t buffer_ipc_handle;
+  std::vector<hipIpcMemHandle_t> all_buffer_ipc_handles;
+  std::vector<uint8_t*> buffer_list;
+
+  long data_offset;
+
+  DeviceComms() : initialized(false), world_size(1), rank(0) {}
+  ~DeviceComms() { destroy(); }
+
+  void init(int world_size, int rank);
+  int get_world_size() { return world_size; }
+  int get_rank() { return rank; }
+  bool status() { return initialized; }
+  void destroy();
+
+  hipIpcMemHandle_t const get_handle() { return buffer_ipc_handle; }
+  void open_ipc_handles(std::vector<hipIpcMemHandle_t> const& ipc_handles);
+  template <typename T>
+  void allreduce(int profile, hipStream_t stream, T const* A, T* B, int N);
+  torch::Tensor qr_get_comm_handle();
+};
+
+// Function Template for two dtypes
+union bf162_int_union {
+  int i;
+  nv_bfloat162 bf2;
+};
+
+// packed add
+template <typename T>
+__device_inline__ int pk_add(int a, int b);
+
+template <>
+__device_inline__ int pk_add<half>(int a, int b) {
+  int res;
+  asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(res) : "v"(a), "v"(b));
+  return res;
+}
+
+template <>
+__device_inline__ int pk_add<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2 = __hadd2(A.bf2, B.bf2);
+  return R.i;
+}
+
+// packed max
+template <typename T>
+__device_inline__ int pk_max(int a, int b);
+
+template <>
+__device_inline__ int pk_max<half>(int a, int b) {
+  int res;
+  asm volatile("v_pk_max_f16 %0, %1, %2" : "=v"(res) : "v"(a), "v"(b));
+  return res;
+}
+
+template <>
+__device_inline__ int pk_max<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2 = __hmax2(A.bf2, B.bf2);
+  return R.i;
+}
+
+// packed min
+template <typename T>
+__device_inline__ int pk_min(int a, int b);
+
+template <>
+__device_inline__ int pk_min<half>(int a, int b) {
+  int res;
+  asm volatile("v_pk_min_f16 %0, %1, %2" : "=v"(res) : "v"(a), "v"(b));
+  return res;
+}
+
+template <>
+__device_inline__ int pk_min<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2 = __hmin2(A.bf2, B.bf2);
+  return R.i;
+}
+
+// pk_max_abs
+template <typename T>
+__device_inline__ int pk_max_abs(int a, int b);
+
+template <>
+__device_inline__ int pk_max_abs<half>(int a, int b) {
+  half2 wmaxh2 = __builtin_bit_cast(half2, a);
+  half2 wminh2 = __builtin_bit_cast(half2, b);
+  half2 wblockmaxh2;
+
+  wblockmaxh2.x =
+      __half2float(__habs(wmaxh2.x)) > __half2float(__habs(wminh2.x))
+          ? wmaxh2.x
+          : wminh2.x;
+  wblockmaxh2.y =
+      __half2float(__habs(wmaxh2.y)) > __half2float(__habs(wminh2.y))
+          ? wmaxh2.y
+          : wminh2.y;
+  return __builtin_bit_cast(int, wblockmaxh2);
+}
+
+template <>
+__device_inline__ int pk_max_abs<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2.x =
+      __bfloat162float(__habs(A.bf2.x)) > __bfloat162float(__habs(B.bf2.x))
+          ? A.bf2.x
+          : B.bf2.x;
+  R.bf2.y =
+      __bfloat162float(__habs(A.bf2.y)) > __bfloat162float(__habs(B.bf2.y))
+          ? A.bf2.y
+          : B.bf2.y;
+  return R.i;
+}
+
+// pk_mul
+template <typename T>
+__device_inline__ int pk_mul(int a, int b);
+
+template <>
+__device_inline__ int pk_mul<half>(int a, int b) {
+  int res;
+  asm volatile("v_pk_mul_f16 %0, %1, %2" : "=v"(res) : "v"(a), "v"(b));
+  return res;
+}
+
+template <>
+__device_inline__ int pk_mul<nv_bfloat16>(int a, int b) {
+  nv_bfloat162* tA = reinterpret_cast<nv_bfloat162*>(&a);
+  nv_bfloat162* tB = reinterpret_cast<nv_bfloat162*>(&b);
+  nv_bfloat162 tR = __hmul2(*tA, *tB);
+  return *(reinterpret_cast<int*>(&tR));
+}
+
+// pk_hcp
+template <typename T>
+__device_inline__ int pk_hcp(int a);
+
+template <>
+__device_inline__ int pk_hcp<half>(int a) {
+  return __builtin_bit_cast(int, h2rcp(__builtin_bit_cast(half2, a)));
+}
+
+template <>
+__device_inline__ int pk_hcp<nv_bfloat16>(int a) {
+  bf162_int_union A, R;
+  A.i = a;
+  R.bf2 = h2rcp(A.bf2);
+  return R.i;
+}
+
+// changes dtype
+__device_inline__ float T2float(half a) { return __half2float(a); }
+
+__device_inline__ float T2float(nv_bfloat16 a) { return __bfloat162float(a); }
+
+// const Q8
+template <typename T>
+struct Quant8Const;
+
+template <>
+struct Quant8Const<half> {
+  static constexpr int kScaleFactor =
+      0xA000A000;  // {-1/128.0h, -1/128.0h}, fp16x2_t
+  static constexpr int kScaleEpsilon = 0x00010001;  // {1e-7, 1e-7}, fp16x2_t
+  static constexpr int kRangeMin = 0xD800D800;      // {-128, -128}, fp16x2_t
+  static constexpr int kRangeMax = 0x57F057F0;      // {+127, +127}, fp16x2_t
+};
+
+template <>
+struct Quant8Const<nv_bfloat16> {
+  static constexpr int kScaleFactor =
+      0xBC00BC00;  // {-1/128.0h, -1/128.0h}, fp16x2_t
+  static constexpr int kScaleEpsilon = 0x33D733D7;  // {1e-7, 1e-7}, fp16x2_t
+  static constexpr int kRangeMin = 0xC300C300;      // {-128, -128}, fp16x2_t
+  static constexpr int kRangeMax = 0x42FE42FE;      // {+127, +127}, fp16x2_t
+};
+// const Q6
+template <typename T>
+struct Quant6Const;
+
+template <>
+struct Quant6Const<half> {
+  static int constexpr kScaleFactor =
+      0xA800A800;  // {-1/32.0h, -1/32.0h}, fp16x2_t
+  static int constexpr kScaleEpsilon = 0x00010001;  // {1e-7, 1e-7}, fp16x2_t
+  static int constexpr kRangeMin = 0xD000D000;      // {-32, -32}, fp16x2_t
+  static int constexpr kRangeMax = 0x4FC04FC0;      // {+31, +31}, fp16x2_t
+};
+
+template <>
+struct Quant6Const<nv_bfloat16> {
+  static int constexpr kScaleFactor =
+      0xBD00BD00;  // {-1/32.0h, -1/32.0h}, fp16x2_t
+  static int constexpr kScaleEpsilon = 0x33D733D7;  // {1e-7, 1e-7}, fp16x2_t
+  static int constexpr kRangeMin = 0xC200C200;      // {-32, -32}, fp16x2_t
+  static int constexpr kRangeMax = 0x41F841F8;      // {+31, +31}, fp16x2_t
+};
+
+// const Q4
+template <typename T>
+struct Quant4Const;
+
+template <>
+struct Quant4Const<half> {
+  static int constexpr kScaleFactor =
+      0xB000B000;  // {-1/8.0h, -1/8.0h}, fp16x2_t
+  static int constexpr kScaleEpsilon = 0x00010001;  // {1e-7, 1e-7}, fp16x2_t
+  static int constexpr kRangeMin = 0xC800C800;      // {-8, -8}, fp16x2_t
+  static int constexpr kRangeMax = 0x47004700;      // {+7, +7}, fp16x2_t
+};
+
+template <>
+struct Quant4Const<nv_bfloat16> {
+  static int constexpr kScaleFactor =
+      0xBE00BE00;  // {-1/8.0h, -1/8.0h}, fp16x2_t
+  static int constexpr kScaleEpsilon = 0x33D733D7;  // {1e-7, 1e-7}, fp16x2_t
+  static int constexpr kRangeMin = 0xC100C100;      // {-8, -8}, fp16x2_t
+  static int constexpr kRangeMax = 0x40E040E0;      // {+7, +7}, fp16x2_t
+};
+
+// const fp8
+template <typename T>
+struct Quantfp8Const;
+
+template <>
+struct Quantfp8Const<half> {
+  static int constexpr kScaleFactor = 0x1C441C44;   // {1/240.0h, 1/240.0h}
+  static int constexpr kScaleEpsilon = 0x00010001;  // {1e-7, 1e-7}
+};
+
+template <>
+struct Quantfp8Const<nv_bfloat16> {
+  static int constexpr kScaleFactor = 0x3B883B88;   // {1/240.0h, 1/240.0h}  bf
+  static int constexpr kScaleEpsilon = 0x33D733D7;  // {1e-7, 1e-7} bf
+};
+}  // namespace quickreduce
+
+// /*
+// ===============================================================
+// API
+// */
+using fptr_t = int64_t;
+static_assert(sizeof(void*) == sizeof(fptr_t));
+fptr_t init_quick_ar(int64_t world_size, int64_t rank);
+torch::Tensor qr_get_comm_handle(fptr_t _fa);
+void qr_set_comm_handles(fptr_t _fa,
+                         std::vector<torch::Tensor> const& comm_handles);
+void qr_all_reduce(fptr_t _fa, int64_t profile, torch::Tensor const& inp,
+                   torch::Tensor& out);
+void qr_destroy(fptr_t _fa);
+void is_quickreduce_available();

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -727,4 +727,23 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _custom_ar), custom_ar) {
   custom_ar.def("free_shared_buffer", &free_shared_buffer);
 }
 
+#ifdef USE_ROCM
+TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _quick_ar), quick_ar) {
+  // quick all reduce kernels
+  quick_ar.def("init_quick_ar(int world_size, int rank) -> int");
+  quick_ar.def("qr_get_comm_handle(int _fa) -> Tensor");
+  quick_ar.def("qr_set_comm_handles(int _fa, Tensor[] handles) -> ()");
+  quick_ar.def(
+      "qr_all_reduce(int _fa, int profile, Tensor inp, Tensor out) -> ()");
+  quick_ar.def("qr_destroy(int _fa) -> ()");
+  quick_ar.def("is_quickreduce_available() -> ()");
+  quick_ar.impl("init_quick_ar", &init_quick_ar);
+  quick_ar.impl("qr_get_comm_handle", &qr_get_comm_handle);
+  quick_ar.impl("qr_set_comm_handles", &qr_set_comm_handles);
+  quick_ar.impl("qr_all_reduce", torch::kCUDA, &qr_all_reduce);
+  quick_ar.impl("qr_destroy", &qr_destroy);
+  quick_ar.impl("is_quickreduce_available", &is_quickreduce_available);
+}
+#endif
+
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -734,7 +734,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _quick_ar), quick_ar) {
   quick_ar.def("qr_get_comm_handle(int _fa) -> Tensor");
   quick_ar.def("qr_set_comm_handles(int _fa, Tensor[] handles) -> ()");
   quick_ar.def(
-      "qr_all_reduce(int _fa, int profile, Tensor inp, Tensor out) -> ()");
+      "qr_all_reduce(int _fa, int profile, Tensor inp, Tensor out, bool "
+      "cast_bf162half) -> ()");
   quick_ar.def("qr_destroy(int _fa) -> ()");
   quick_ar.def("is_quickreduce_available() -> ()");
   quick_ar.impl("init_quick_ar", &init_quick_ar);

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1758,6 +1758,38 @@ def free_shared_buffer(ptr: int) -> None:
     torch.ops._C_custom_ar.free_shared_buffer(ptr)
 
 
+# quick ar
+def init_quick_ar(world_size: int, rank: int) -> int:
+    """Initialize the QuickReduce environment and return a Device Comms Handle api."""
+    return torch.ops._C_quick_ar.init_quick_ar(world_size, rank)
+
+
+def qr_get_comm_handle(fa: int) -> torch.Tensor:
+    """Return a Tensor handle"""
+    return torch.ops._C_quick_ar.qr_get_comm_handle(fa)
+
+
+def qr_set_comm_handles(fa: int, handles: list[torch.Tensor]) -> None:
+    """Set the communication handle list."""
+    torch.ops._C_quick_ar.qr_set_comm_handles(fa, handles)
+
+
+def qr_all_reduce(fa: int, profile: int, inp: torch.Tensor,
+                  out: torch.Tensor) -> None:
+    """Perform all-reduce across devices with optional profile."""
+    torch.ops._C_quick_ar.qr_all_reduce(fa, profile, inp, out)
+
+
+def qr_destroy(fa: int) -> None:
+    """Clean up and destroy the Device Comms Handle."""
+    torch.ops._C_quick_ar.qr_destroy(fa)
+
+
+def is_quickreduce_available() -> None:
+    """Only used to test whether module was properly imported."""
+    torch.ops._C_quick_ar.is_quickreduce_available()
+
+
 def get_flash_mla_metadata(
     cache_seqlens: torch.Tensor,
     num_heads_per_head_k: int,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1774,10 +1774,10 @@ def qr_set_comm_handles(fa: int, handles: list[torch.Tensor]) -> None:
     torch.ops._C_quick_ar.qr_set_comm_handles(fa, handles)
 
 
-def qr_all_reduce(fa: int, profile: int, inp: torch.Tensor,
-                  out: torch.Tensor) -> None:
+def qr_all_reduce(fa: int, profile: int, inp: torch.Tensor, out: torch.Tensor,
+                  cast_bf162half: bool) -> None:
     """Perform all-reduce across devices with optional profile."""
-    torch.ops._C_quick_ar.qr_all_reduce(fa, profile, inp, out)
+    torch.ops._C_quick_ar.qr_all_reduce(fa, profile, inp, out, cast_bf162half)
 
 
 def qr_destroy(fa: int) -> None:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -381,7 +381,7 @@ class CustomAllreduce:
                 return torch.empty_like(input)
             return self.qr_all_reduce(input)
 
-        elif self.should_custom_allreduce(input):
+        if self.should_custom_allreduce(input):
             if self._IS_CAPTURING:
                 if torch.cuda.is_current_stream_capturing():
                     return self.cr_all_reduce(input, registered=True)
@@ -395,6 +395,8 @@ class CustomAllreduce:
                 # (<=1% of overall latency) compared to the performance
                 # gain of using custom kernels
                 return self.cr_all_reduce(input, registered=False)
+
+        return None
 
     def close(self):
         if not self.disabled:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -328,8 +328,14 @@ class CustomAllreduce:
         if inp.dtype == torch.float16:
             return inp_size <= self.qr_max_size and inp_size >= self.qr_min_size
         elif inp.dtype == torch.bfloat16:
-            return (inp_size <= self.qr_max_size
-                    and inp_size > 1024 * 1024 * 16 and self.world_size == 2)
+            if self.cast_bf162half:
+                # cast2half, so the same condition
+                return inp_size <= self.qr_max_size and \
+                    inp_size >= self.qr_min_size
+            else:
+                return (inp_size <= self.qr_max_size
+                        and inp_size > 1024 * 1024 * 16
+                        and self.world_size == 2)
         return False
 
     def should_custom_allreduce(self, inp: torch.Tensor):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -610,7 +610,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # 1 for 2stage f16, 2 for 2stage fp8, 3 for 2stage Q8,
     # 4 for 2stage Q6, 5 for 2stage Q4.
     "VLLM_QUICK_ALLREDUCE_LEVEL":
-    lambda: int(os.getenv("VLLM_QUICK_ALLREDUCE_LEVEL", "1")),
+    lambda: int(os.getenv("VLLM_QUICK_ALLREDUCE_LEVEL", "2")),
 
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -128,7 +128,8 @@ if TYPE_CHECKING:
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_SLEEP_WHEN_IDLE: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
-    VLLM_QUICK_ALLREDUCE_LEVEL: int = 2
+    VLLM_ROCM_QR_LEVEL: int = 4,
+    VLLM_ROCM_QR_CAST_BF16_TO_FP16: bool = False
 
 
 def get_default_cache_root():
@@ -606,12 +607,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SKIP_P2P_CHECK":
     lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "0") == "1",
 
-    # quick allreduce level. 0 means closed,
-    # 1 for 2stage f16, 2 for 2stage fp8, 3 for 2stage Q8,
-    # 4 for 2stage Q6, 5 for 2stage Q4.
-    "VLLM_QUICK_ALLREDUCE_LEVEL":
-    lambda: int(os.getenv("VLLM_QUICK_ALLREDUCE_LEVEL", "2")),
-
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel
     # selection
@@ -675,6 +670,22 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # custom paged attention kernel for MI3* cards
     "VLLM_ROCM_CUSTOM_PAGED_ATTN":
     lambda: (os.getenv("VLLM_ROCM_CUSTOM_PAGED_ATTN", "True").lower() in
+             ("true", "1")),
+
+    # Custom quick allreduce kernel for MI3* cards.
+    # 0 means closed, 1 for 2stage f16, 2 for 2stage fp8,
+    # 3 for 2stage Q8, 4 for 2stage Q6, 5 for 2stage Q4.
+    # Recommended for large models to get doubled allreduce
+    # speedup with less precision loss.
+    "VLLM_ROCM_QR_LEVEL":
+    lambda: int(os.getenv("VLLM_ROCM_QR_LEVEL", "4")),
+
+    # Custom quick allreduce kernel for MI3* cards
+    # Due to the lack of the bfloat16 asm instruction, bfloat16
+    # kernels are slower than fp16,
+    # If environment is not set to 1, we convert inp from bf to fp16
+    "VLLM_ROCM_QR_CAST_BF16_TO_FP16":
+    lambda: (os.getenv("VLLM_ROCM_QR_CAST_BF16_TO_FP16", "True").lower() in
              ("true", "1")),
 
     # If set, when running in Quark emulation mode, do not dequantize the

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_SLEEP_WHEN_IDLE: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
+    VLLM_QUICK_ALLREDUCE_LEVEL: int = 2
 
 
 def get_default_cache_root():
@@ -604,6 +605,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # and trust the driver's peer-to-peer capability report.
     "VLLM_SKIP_P2P_CHECK":
     lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "0") == "1",
+
+    # quick allreduce level. 0 means closed,
+    # 1 for 2stage f16, 2 for 2stage fp8, 3 for 2stage Q8,
+    # 4 for 2stage Q6, 5 for 2stage Q4.
+    "VLLM_QUICK_ALLREDUCE_LEVEL":
+    lambda: int(os.getenv("VLLM_QUICK_ALLREDUCE_LEVEL", "2")),
+
 
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -610,8 +610,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # 1 for 2stage f16, 2 for 2stage fp8, 3 for 2stage Q8,
     # 4 for 2stage Q6, 5 for 2stage Q4.
     "VLLM_QUICK_ALLREDUCE_LEVEL":
-    lambda: int(os.getenv("VLLM_QUICK_ALLREDUCE_LEVEL", "2")),
-
+    lambda: int(os.getenv("VLLM_QUICK_ALLREDUCE_LEVEL", "1")),
 
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel


### PR DESCRIPTION
1.With its low-granularity quantization, https://github.com/mk1-project/quickreduce brings huge performance gains to allreduce on tp2 and tp4 on rocm, and does not significantly degrade the model's performance.
2.We integrated quick allreduce into vllm to support 1stage(f16 ), and 2stage(f16, fp8, Q8, Q6, Q4).
3.It is worth mentioning that the speedup of qr is brought about by sacrificing a certain amount of precision, and custom_qr is significantly better than qr's 1stage and 2stage methods at low data volumes (less than 128kb), so we need to judge whether to choose qr or cr or rccl by some conditions.(According to the results of the following experimental kernel, oneshot has no advantageous scenario, so we remove it)
base on https://github.com/vllm-project/vllm/pull/18473
4.Considering that qr has limited usage scenarios and that the interfaces of qr and cr are very similar, we merge qr into cr to minimize user confusion.
5.Q4 scenarios can cause serious accuracy problems on some models, so we default to fp8 quantization.