### PR TITLE
Fix Incorrect data_parallel_rank and subsequent errors under torchrun

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -922,9 +922,11 @@ def init_distributed_environment(
     config = get_current_vllm_config()
     if config is not None and config.parallel_config.data_parallel_size > 1:
         parallel_config = config.parallel_config
-        # adjust to take into account data parallelism
-        # offset the rank by the data parallel rank
-        rank = parallel_config.data_parallel_rank * world_size + rank
+        # If external_launcher, rank is from 0 to world_size_across_dp,
+        # no need to adjust. Otherwise, adjust to take into account data
+        # parallelism offset the rank by the data parallel rank.
+        if parallel_config.distributed_executor_backend != "external_launcher":
+            rank = parallel_config.data_parallel_rank * world_size + rank
         # adjust the world size to take into account data parallelism
         world_size = parallel_config.world_size_across_dp
         ip = parallel_config.data_parallel_master_ip


### PR DESCRIPTION
### Problem

When launching vLLM for data-parallel (DP) inference using `torchrun`, as demonstrated by the script below,

**Example `torchrun` CLI command for the script:**
```bash
VLLM_DP_SIZE=2 VLLM_DP_MASTER_IP=127.0.0.1 VLLM_DP_MASTER_PORT=35565 torchrun --nproc_per_node=4 --master_addr=127.0.0.1 --master_port=35565 test.py
```

<details>
<summary>The test script of <code>test.py</code></summary>

```python
import os
from vllm import LLM, SamplingParams

def main(
    model_path,
    tp_size=2,
    enforce_eager=False,
):
    prompts = [
        "Hello, my name is",
        "The president of the United States is",
        "The capital of France is",
        "The future of AI is",
    ]
    sampling_params = SamplingParams(
        temperature=0.8, top_p=0.95, max_tokens=128
    )

    llm = LLM(
        model=model_path,
        tensor_parallel_size=tp_size,
        enforce_eager=enforce_eager,
        distributed_executor_backend="external_launcher",
    )
    outputs = llm.generate(prompts, sampling_params)

    for i, output in enumerate(outputs):
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(
            f"Prompt: {prompt!r}, "
            f"Generated text: {generated_text!r}"
        )

if __name__ == "__main__":
    main(model_path="./Qwen3-7B", tp_size=2)
```
</details>


Due to this `torchrun` launch characteristic, assigning a different `VLLM_DP_RANK` environment variable to each DP rank is not straightforward. `ParallelConfig.data_parallel_rank` **defaults to `0` for all processes**. This incorrect `data_parallel_rank` value has a critical impact:

Inside the `get_dp_padding` function, the `DPMetadata.num_tokens_across_dp` method (which relies on `data_parallel_rank` for allreduce) functions incorrectly. Because all ranks report `data_parallel_rank=0`, the subsequent calculation of `max_tokens_across_dp_cpu` **results in a sum of tokens from all DP ranks, instead of the intended maximum token count across these ranks.**
https://github.com/vllm-project/vllm/blob/d81edded69a5534a80785b68cde26c547cfcd4c6/vllm/v1/worker/gpu_model_runner.py#L1126-L1132

This erroneous sum value for `max_tokens_across_dp_cpu` leads to two significant consequences when `enforce_eager=False`:

1.  **Excessive CUDA Graph Padding**: The system attempts to pad sequences to this much larger (summed) token count, leading to substantial unnecessary memory allocation and computation for padding.
2.  **Profiling Assertion Error**: The inflated token count (due to the sum and subsequent padding logic) can cause an `assert num_tokens <= self.scheduler_config.max_num_batched_tokens` error during the initial memory profiling stage (`determine_available_memory()` -> `profile_run()` -> `_dummy_run()`).

### Contribution

1. Commit1: updates `ParallelConfig.post_init` method to correctly derive `data_parallel_rank` (global DP rank) and `data_parallel_rank_local` (node-local DP rank) for each process. This derivation leverages standard environment variables automatically set by `torchrun` (`RANK`, `LOCAL_RANK`).

2. Commit2: fix  init_distributed_environment error when use external_launcher to skip rank adjust for external_launcher.

### Further Discussion

1. Regarding **Commit1**,maybe alternatively set `VLLM_DP_RANK` in their launch scripts based `torchrun`'s `RANK`. Commit1 automates this within vLLM for better usability.

2. The change in **Commit2** is critical for `external_launcher` (e.g., `torchrun`). `torchrun` already provides correct global `RANK`s (0 to `world_size_across_dp - 1`). The previous rank adjustment logic (`rank = parallel_config.data_parallel_rank * world_size + rank`) would incorrectly inflate these ranks, often making them exceed the total number of processes and breaking `torch.distributed.init_process_group`. 