### PR TITLE
[Misc] Do not override NCCL_CUMEM_ENABLE if set explicitly

### DIFF
--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -18,7 +18,6 @@ if os.environ.get('NCCL_CUMEM_ENABLE') == '1':
         "This may increase memory overhead with cudagraph+allreduce: "
         "https://github.com/NVIDIA/nccl/issues/1234")
 elif not os.path.exists('/dev/nvidia-caps-imex-channels'):
-    logger.warning("Overriding NCCL_CUMEM_ENABLE=0")
     # NCCL requires NCCL_CUMEM_ENABLE to work with
     # multi-node NVLink, typically on GB200-NVL72 systems.
     # The ultimate way to detect multi-node NVLink is to use
@@ -32,10 +31,8 @@ elif not os.path.exists('/dev/nvidia-caps-imex-channels'):
 
 # see https://github.com/vllm-project/vllm/pull/15951
 # it avoids unintentional cuda initialization from torch.cuda.is_available()
-logger.warning("Overriding PYTORCH_NVML_BASED_CUDA_CHECK=1")
 os.environ['PYTORCH_NVML_BASED_CUDA_CHECK'] = '1'
 
-logger.warning("Overriding TORCHINDUCTOR_COMPILE_THREADS=1")
 # see https://github.com/vllm-project/vllm/issues/10480
 os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
 # see https://github.com/vllm-project/vllm/issues/10619

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -14,9 +14,10 @@ logger = init_logger(__name__)
 
 if 'NCCL_CUMEM_ENABLE' in os.environ:
     logger.warning(
-        "NCCL_CUMEM_ENABLE explicitly set, skipping override. "
+        "NCCL_CUMEM_ENABLE explicitly set to %s, skipping override. "
         "This may increase memory overhead with cudagraph+allreduce: "
-        "https://github.com/NVIDIA/nccl/issues/1234")
+        "https://github.com/NVIDIA/nccl/issues/1234",
+        os.environ['NCCL_CUMEM_ENABLE'])
 elif not os.path.exists('/dev/nvidia-caps-imex-channels'):
     # NCCL requires NCCL_CUMEM_ENABLE to work with
     # multi-node NVLink, typically on GB200-NVL72 systems.

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -14,7 +14,7 @@ logger = init_logger(__name__)
 
 if 'NCCL_CUMEM_ENABLE' in os.environ:
     logger.warning(
-        "NCCL_CUMEM_ENABLE explicitly set to %s, skipping override. "
+        "NCCL_CUMEM_ENABLE is set to %s, skipping override. "
         "This may increase memory overhead with cudagraph+allreduce: "
         "https://github.com/NVIDIA/nccl/issues/1234",
         os.environ['NCCL_CUMEM_ENABLE'])

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -12,9 +12,9 @@ logger = init_logger(__name__)
 # that interact with vllm workers.
 # they are executed whenever `import vllm` is called.
 
-if os.environ.get('NCCL_CUMEM_ENABLE') == '1':
+if 'NCCL_CUMEM_ENABLE' in os.environ:
     logger.warning(
-        "NCCL_CUMEM_ENABLE explicitly set to 1, skipping override. "
+        "NCCL_CUMEM_ENABLE explicitly set, skipping override. "
         "This may increase memory overhead with cudagraph+allreduce: "
         "https://github.com/NVIDIA/nccl/issues/1234")
 elif not os.path.exists('/dev/nvidia-caps-imex-channels'):

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -3,17 +3,23 @@ import os
 
 import torch
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 # set some common config/environment variables that should be set
 # for all processes created by vllm and all processes
 # that interact with vllm workers.
 # they are executed whenever `import vllm` is called.
 
-if not os.path.exists('/dev/nvidia-caps-imex-channels'):
-    # normally, we disable NCCL_CUMEM_ENABLE because it
-    # will cost 1~2 GiB GPU memory with cudagraph+allreduce,
-    # see https://github.com/NVIDIA/nccl/issues/1234
-    # for more details.
-    # However, NCCL requires NCCL_CUMEM_ENABLE to work with
+if os.environ.get('NCCL_CUMEM_ENABLE') == '1':
+    logger.warning(
+        "NCCL_CUMEM_ENABLE explicitly set to 1, skipping override. "
+        "This may increase memory overhead with cudagraph+allreduce: "
+        "https://github.com/NVIDIA/nccl/issues/1234")
+elif not os.path.exists('/dev/nvidia-caps-imex-channels'):
+    logger.warning("Overriding NCCL_CUMEM_ENABLE=0")
+    # NCCL requires NCCL_CUMEM_ENABLE to work with
     # multi-node NVLink, typically on GB200-NVL72 systems.
     # The ultimate way to detect multi-node NVLink is to use
     # NVML APIs, which are too expensive to call here.
@@ -26,8 +32,10 @@ if not os.path.exists('/dev/nvidia-caps-imex-channels'):
 
 # see https://github.com/vllm-project/vllm/pull/15951
 # it avoids unintentional cuda initialization from torch.cuda.is_available()
+logger.warning("Overriding PYTORCH_NVML_BASED_CUDA_CHECK=1")
 os.environ['PYTORCH_NVML_BASED_CUDA_CHECK'] = '1'
 
+logger.warning("Overriding TORCHINDUCTOR_COMPILE_THREADS=1")
 # see https://github.com/vllm-project/vllm/issues/10480
 os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
 # see https://github.com/vllm-project/vllm/issues/10619


### PR DESCRIPTION
## Purpose
This PR provides the user an option to control `NCCL_CUMEM_ENABLE`, especially for RLHF cases.
~~This PR also adds explicit logging for all env overrides.~~

## Test Plan
simple vllm run

## Test Result
```
WARNING 06-04 23:08:34 [env_override.py:16] NCCL_CUMEM_ENABLE explicitly set to 1, skipping override. This may increase memory overhead with cudagraph+allreduce: https://github.com/NVIDIA/nccl/issues/1234
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
