### PR TITLE
Fix ValueError: Missing value for tag key(s): model_name,engine.

### DIFF
--- a/tests/v1/metrics/test_ray_metrics.py
+++ b/tests/v1/metrics/test_ray_metrics.py
@@ -46,11 +46,14 @@ def test_engine_log_metrics_ray(
                 engine_args, stat_loggers=[RayPrometheusStatLogger])
 
             for i, prompt in enumerate(example_prompts):
-                engine.generate(
+                results = engine.generate(
                     request_id=f"request-id-{i}",
                     prompt=prompt,
                     sampling_params=SamplingParams(max_tokens=max_tokens),
                 )
+
+                async for _ in results:
+                    pass
 
     # Create the actor and call the async method
     actor = EngineTestActor.remote()  # type: ignore[attr-defined]

--- a/vllm/v1/metrics/ray_wrappers.py
+++ b/vllm/v1/metrics/ray_wrappers.py
@@ -30,6 +30,10 @@ class RayPrometheusMetric:
 
             self.metric.set_default_tags(labelskwargs)
 
+        if labels:
+            self.metric.set_default_tags(
+                dict(zip(self.metric._tag_keys, labels)))
+
         return self
 
 

--- a/vllm/v1/metrics/ray_wrappers.py
+++ b/vllm/v1/metrics/ray_wrappers.py
@@ -31,6 +31,12 @@ class RayPrometheusMetric:
             self.metric.set_default_tags(labelskwargs)
 
         if labels:
+            if len(labels) != len(self.metric._tag_keys):
+                raise ValueError(
+                    "Number of labels must match the number of tag keys. "
+                    f"Expected {len(self.metric._tag_keys)}, got {len(labels)}"
+                )
+
             self.metric.set_default_tags(
                 dict(zip(self.metric._tag_keys, labels)))
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
- Fix Ray metric wrapper to conform to Prometheus API/usage in vLLM.
- Update test to force engine to materialize results

<details>
<summary> Error when `async for _ in results:` is added </summary>
$ pytest -vs test_ray_metrics.py 
INFO 06-03 15:39:57 [__init__.py:243] Automatically detected platform cuda.
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.11.11, pytest-8.4.0, pluggy-1.5.0 -- /home/ray/anaconda3/bin/python
cachedir: .pytest_cache
rootdir: /home/ray/default/work/vllm
configfile: pyproject.toml
plugins: asyncio-1.0.0, anyio-3.7.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                                    

test_ray_metrics.py::test_engine_log_metrics_ray[16-half-distilbert/distilgpt2] 2025-06-03 15:40:00,799INFO worker.py:1735 -- Connecting to existing Ray cluster at address: 10.0.167.199:6379...
2025-06-03 15:40:00,811 INFO worker.py:1920 -- Connected to Ray cluster. View the dashboard at https://session-y3437bvt83zcm1g3tna3q942x8.i.anyscaleuserdata-staging.com 
2025-06-03 15:40:00,816 INFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_1b6b1eaae6b1980260ee4b7c476a5267f28ada67.zip' (0.01MiB) to Ray cluster...
2025-06-03 15:40:00,816 INFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_1b6b1eaae6b1980260ee4b7c476a5267f28ada67.zip'.
(pid=137002) INFO 06-03 15:40:04 [__init__.py:243] Automatically detected platform cuda.
(EngineTestActor pid=137002) INFO 06-03 15:40:07 [__init__.py:31] Available plugins for group vllm.general_plugins:
(EngineTestActor pid=137002) INFO 06-03 15:40:07 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
(EngineTestActor pid=137002) INFO 06-03 15:40:07 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(EngineTestActor pid=137002) INFO 06-03 15:40:08 [config.py:3131] Downcasting torch.float32 to torch.float16.
(EngineTestActor pid=137002) INFO 06-03 15:40:15 [config.py:793] This model supports multiple tasks: {'score', 'generate', 'classify', 'embed', 'reward'}. Defaulting to 'generate'.
(EngineTestActor pid=137002) WARNING 06-03 15:40:15 [arg_utils.py:1588] Detected VLLM_USE_V1=1 with Engine in background thread. Usage should be considered experimental. Please report any issues on Github.
(EngineTestActor pid=137002) INFO 06-03 15:40:15 [config.py:2118] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineTestActor pid=137002) WARNING 06-03 15:40:15 [utils.py:2531] We must use the `spawn` multiprocessing start method. Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. See https://docs.vllm.ai/en/latest/usage/troubleshooting.html#python-multiprocessing for more information. Reason: In a Ray actor and can only be spawned
(EngineTestActor pid=137002) INFO 06-03 15:40:18 [__init__.py:243] Automatically detected platform cuda.
(EngineTestActor pid=137002) INFO 06-03 15:40:21 [core.py:438] Waiting for init message from front-end.
(EngineTestActor pid=137002) INFO 06-03 15:40:21 [__init__.py:31] Available plugins for group vllm.general_plugins:
(EngineTestActor pid=137002) INFO 06-03 15:40:21 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
(EngineTestActor pid=137002) INFO 06-03 15:40:21 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(EngineTestActor pid=137002) INFO 06-03 15:40:21 [core.py:65] Initializing a V1 LLM engine (v0.9.0.1) with config: model='distilbert/distilgpt2', speculative_config=None, tokenizer='distilbert/distilgpt2', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=1024, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=distilbert/distilgpt2, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level": 3, "custom_ops": ["none"], "splitting_ops": ["vllm.unified_attention", "vllm.unified_attention_with_output"], "compile_sizes": [], "inductor_compile_config": {"enable_auto_functionalized_v2": false}, "use_cudagraph": true, "cudagraph_num_of_warmups": 1, "cudagraph_capture_sizes": [512, 504, 496, 488, 480, 472, 464, 456, 448, 440, 432, 424, 416, 408, 400, 392, 384, 376, 368, 360, 352, 344, 336, 328, 320, 312, 304, 296, 288, 280, 272, 264, 256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176, 168, 160, 152, 144, 136, 128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 4, 2, 1], "max_capture_size": 512}
(EngineTestActor pid=137002) WARNING 06-03 15:40:21 [utils.py:2671] Methods determine_num_available_blocks,device_config,get_cache_block_size_bytes,initialize_cache not implemented in <vllm.v1.worker.gpu_worker.Worker object at 0x728923ae0850>
(EngineTestActor pid=137002) INFO 06-03 15:40:22 [parallel_state.py:1064] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineTestActor pid=137002) WARNING 06-03 15:40:22 [topk_topp_sampler.py:58] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
(EngineTestActor pid=137002) INFO 06-03 15:40:22 [gpu_model_runner.py:1531] Starting to load model distilbert/distilgpt2...
(EngineTestActor pid=137002) INFO 06-03 15:40:22 [cuda.py:217] Using Flash Attention backend on V1 engine.
(EngineTestActor pid=137002) INFO 06-03 15:40:22 [backends.py:35] Using InductorAdaptor
(EngineTestActor pid=137002) INFO 06-03 15:40:23 [weight_utils.py:291] Using model weights format ['*.safetensors']
(EngineTestActor pid=137002) INFO 06-03 15:40:23 [weight_utils.py:344] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  7.35it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  7.34it/s]
(EngineTestActor pid=137002) 
(EngineTestActor pid=137002) INFO 06-03 15:40:23 [default_loader.py:280] Loading weights took 0.15 seconds
(EngineTestActor pid=137002) INFO 06-03 15:40:24 [gpu_model_runner.py:1549] Model loading took 0.1547 GiB and 1.370146 seconds
(EngineTestActor pid=137002) INFO 06-03 15:40:25 [backends.py:459] Using cache directory: /home/ray/.cache/vllm/torch_compile_cache/1f177a5109/rank_0_0 for vLLM's torch.compile
(EngineTestActor pid=137002) INFO 06-03 15:40:25 [backends.py:469] Dynamo bytecode transform time: 1.22 s
(EngineTestActor pid=137002) INFO 06-03 15:40:25 [backends.py:132] Directly load the compiled graph(s) for shape None from the cache, took 0.494 s
(EngineTestActor pid=137002) INFO 06-03 15:40:26 [monitor.py:33] torch.compile takes 1.22 s in total
(EngineTestActor pid=137002) INFO 06-03 15:40:26 [kv_cache_utils.py:637] GPU KV cache size: 1,099,456 tokens
(EngineTestActor pid=137002) INFO 06-03 15:40:26 [kv_cache_utils.py:640] Maximum concurrency for 1,024 tokens per request: 1073.69x
(EngineTestActor pid=137002) INFO 06-03 15:40:40 [gpu_model_runner.py:1933] Graph capturing finished in 14 secs, took 0.14 GiB
(EngineTestActor pid=137002) INFO 06-03 15:40:40 [core.py:167] init engine (profile, create kv cache, warmup model) took 16.61 seconds
(EngineTestActor pid=137002) self._default_tags: {'block_size': '16', 'gpu_memory_utilization': '0.9', 'swap_space': '4', 'cache_dtype': 'auto', 'is_attention_free': 'False', 'num_gpu_blocks_override': 'None', 'sliding_window': 'None', 'enable_prefix_caching': 'True', 'prefix_caching_hash_algo': 'builtin', 'cpu_offload_gb': '0', 'calculate_kv_scales': 'False', 'swap_space_bytes': '4294967296', 'num_gpu_blocks': '68716', 'engine': '0'}
(EngineTestActor pid=137002) final_tags: {'block_size': '16', 'gpu_memory_utilization': '0.9', 'swap_space': '4', 'cache_dtype': 'auto', 'is_attention_free': 'False', 'num_gpu_blocks_override': 'None', 'sliding_window': 'None', 'enable_prefix_caching': 'True', 'prefix_caching_hash_algo': 'builtin', 'cpu_offload_gb': '0', 'calculate_kv_scales': 'False', 'swap_space_bytes': '4294967296', 'num_gpu_blocks': '68716', 'engine': '0'}
(EngineTestActor pid=137002) self._tag_keys: ('block_size', 'gpu_memory_utilization', 'swap_space', 'cache_dtype', 'is_attention_free', 'num_gpu_blocks_override', 'sliding_window', 'enable_prefix_caching', 'prefix_caching_hash_algo', 'cpu_offload_gb', 'calculate_kv_scales', 'swap_space_bytes', 'num_gpu_blocks', 'engine')
(EngineTestActor pid=137002) INFO 06-03 15:40:40 [async_llm.py:261] Added request request-id-0.
(EngineTestActor pid=137002) self._default_tags: {}
(EngineTestActor pid=137002) final_tags: {}
(EngineTestActor pid=137002) self._tag_keys: ('model_name', 'engine')
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408] AsyncLLM output_handler failed.
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408] Traceback (most recent call last):
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 402, in output_handler
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]     AsyncLLM._record_stats(
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 431, in _record_stats
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]     stat_logger.record(scheduler_stats=scheduler_stats,
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/metrics/loggers.py", line 381, in record
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]     self.gauge_scheduler_running.set(scheduler_stats.num_running_reqs)
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/metrics/ray_wrappers.py", line 50, in set
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]     return self.metric.set(value)
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]            ^^^^^^^^^^^^^^^^^^^^^^
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/util/metrics.py", line 339, in set
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]     self._record(value, tags)
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/util/metrics.py", line 124, in _record
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]     self._validate_tags(final_tags)
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/util/metrics.py", line 145, in _validate_tags
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408]     raise ValueError(f"Missing value for tag key(s): {','.join(missing_tags)}.")
(EngineTestActor pid=137002) ERROR 06-03 15:40:40 [async_llm.py:408] ValueError: Missing value for tag key(s): model_name,engine.
(EngineTestActor pid=137002) INFO 06-03 15:40:40 [async_llm.py:339] Request request-id-0 failed (bad request).
FAILED

===================================================================================================== FAILURES ======================================================================================================
____________________________________________________________________________ test_engine_log_metrics_ray[16-half-distilbert/distilgpt2] _____________________________________________________________________________

example_prompts = ['vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs.\n', 'Briefly describe the majo...me.\n', 'Analyze the impact of the COVID-19 pandemic on global economic structures and future business models.\n', ...]
model = 'distilbert/distilgpt2', dtype = 'half', max_tokens = 16

    @pytest.mark.parametrize("model", MODELS)
    @pytest.mark.parametrize("dtype", ["half"])
    @pytest.mark.parametrize("max_tokens", [16])
    def test_engine_log_metrics_ray(
        example_prompts,
        model: str,
        dtype: str,
        max_tokens: int,
    ) -> None:
        """ Simple smoke test, verifying this can be used without exceptions.
        Need to start a Ray cluster in order to verify outputs."""
    
        @ray.remote(num_gpus=1)
        class EngineTestActor:
    
            async def run(self):
                engine_args = AsyncEngineArgs(
                    model=model,
                    dtype=dtype,
                    disable_log_stats=False,
                )
    
                engine = AsyncLLM.from_engine_args(
                    engine_args, stat_loggers=[RayPrometheusStatLogger])
    
                for i, prompt in enumerate(example_prompts):
                    results = engine.generate(
                        request_id=f"request-id-{i}",
                        prompt=prompt,
                        sampling_params=SamplingParams(max_tokens=10),
                    )
    
                    async for _ in results:
                        pass
    
        # Create the actor and call the async method
        actor = EngineTestActor.remote()  # type: ignore[attr-defined]
>       ray.get(actor.run.remote())

test_ray_metrics.py:60: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/auto_init_hook.py:22: in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/client_mode_hook.py:104: in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py:2861: in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ray._private.worker.Worker object at 0x7570d9a20f50>, object_refs = [ObjectRef(6da3667ad406d6941a7369ad99cc9b077daaf3021e00000001000000)], timeout = None, return_exceptions = False
skip_deserialization = False

    def get_objects(
        self,
        object_refs: list,
        timeout: Optional[float] = None,
        return_exceptions: bool = False,
        skip_deserialization: bool = False,
    ):
        """Get the values in the object store associated with the IDs.
    
        Return the values from the local object store for object_refs. This
        will block until all the values for object_refs have been written to
        the local object store.
    
        Args:
            object_refs: A list of the object refs
                whose values should be retrieved.
            timeout: The maximum amount of time in
                seconds to wait before returning.
            return_exceptions: If any of the objects deserialize to an
                Exception object, whether to return them as values in the
                returned list. If False, then the first found exception will be
                raised.
            skip_deserialization: If true, only the buffer will be released and
                the object associated with the buffer will not be deserialized.
        Returns:
            list: List of deserialized objects or None if skip_deserialization is True.
            bytes: UUID of the debugger breakpoint we should drop
                into or b"" if there is no breakpoint.
        """
        # Make sure that the values are object refs.
        for object_ref in object_refs:
            if not isinstance(object_ref, ObjectRef):
                raise TypeError(
                    f"Attempting to call `get` on the value {object_ref}, "
                    "which is not an ray.ObjectRef."
                )
    
        timeout_ms = (
            int(timeout * 1000) if timeout is not None and timeout != -1 else -1
        )
        data_metadata_pairs: List[
            Tuple[ray._raylet.Buffer, bytes]
        ] = self.core_worker.get_objects(
            object_refs,
            timeout_ms,
        )
    
        debugger_breakpoint = b""
        for data, metadata in data_metadata_pairs:
            if metadata:
                metadata_fields = metadata.split(b",")
                if len(metadata_fields) >= 2 and metadata_fields[1].startswith(
                    ray_constants.OBJECT_METADATA_DEBUG_PREFIX
                ):
                    debugger_breakpoint = metadata_fields[1][
                        len(ray_constants.OBJECT_METADATA_DEBUG_PREFIX) :
                    ]
        if skip_deserialization:
            return None, debugger_breakpoint
    
        values = self.deserialize_objects(data_metadata_pairs, object_refs)
        if not return_exceptions:
            # Raise exceptions instead of returning them to the user.
            for i, value in enumerate(values):
                if isinstance(value, RayError):
                    if isinstance(value, ray.exceptions.ObjectLostError):
                        global_worker.core_worker.dump_object_store_memory_usage()
                    if isinstance(value, RayTaskError):
>                       raise value.as_instanceof_cause()
E                       ray.exceptions.RayTaskError(ValueError): ray::EngineTestActor.run() (pid=137002, ip=10.0.167.199, actor_id=1a7369ad99cc9b077daaf3021e000000, repr=<test_ray_metrics.EngineTestActor object at 0x7950a63aa590>)
E                         File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 449, in result
E                           return self.__get_result()
E                                  ^^^^^^^^^^^^^^^^^^^
E                         File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
E                           raise self._exception
E                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                         File "/home/ray/default/work/vllm/tests/v1/metrics/test_ray_metrics.py", line 55, in run
E                           async for _ in results:
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 315, in generate
E                           out = q.get_nowait() or await q.get()
E                                                   ^^^^^^^^^^^^^
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/output_processor.py", line 51, in get
E                           raise output
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 402, in output_handler
E                           AsyncLLM._record_stats(
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 431, in _record_stats
E                           stat_logger.record(scheduler_stats=scheduler_stats,
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/metrics/loggers.py", line 381, in record
E                           self.gauge_scheduler_running.set(scheduler_stats.num_running_reqs)
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/metrics/ray_wrappers.py", line 50, in set
E                           return self.metric.set(value)
E                                  ^^^^^^^^^^^^^^^^^^^^^^
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/util/metrics.py", line 339, in set
E                           self._record(value, tags)
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/util/metrics.py", line 124, in _record
E                           self._validate_tags(final_tags)
E                         File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/util/metrics.py", line 145, in _validate_tags
E                           raise ValueError(f"Missing value for tag key(s): {','.join(missing_tags)}.")
E                       ValueError: Missing value for tag key(s): model_name,engine.

/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py:949: RayTaskError(ValueError)
============================================================================================== short test summary info ==============================================================================================
FAILED test_ray_metrics.py::test_engine_log_metrics_ray[16-half-distilbert/distilgpt2] - ray.exceptions.RayTaskError(ValueError): ray::EngineTestActor.run() (pid=137002, ip=10.0.167.199, actor_id=1a7369ad99cc9b077daaf3021e000000, repr=<test_ray_metrics.EngineTestActor object at 0x7950a63aa590>)
================================================================================================ 1 failed in 40.71s =================================================================================================
</details>

## Test Plan
```
$ cd tests/v1/metrics
$ pytest -vs test_ray_metrics.py 
INFO 06-03 15:55:30 [__init__.py:243] Automatically detected platform cuda.
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.11.11, pytest-8.4.0, pluggy-1.5.0 -- /home/ray/anaconda3/bin/python
cachedir: .pytest_cache
rootdir: /home/ray/default/work/vllm
configfile: pyproject.toml
plugins: asyncio-1.0.0, anyio-3.7.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                                    

test_ray_metrics.py::test_engine_log_metrics_ray[16-half-distilbert/distilgpt2] 2025-06-03 15:55:34,092INFO worker.py:1735 -- Connecting to existing Ray cluster at address: 10.0.167.199:6379...
2025-06-03 15:55:34,105 INFO worker.py:1920 -- Connected to Ray cluster. View the dashboard at https://session-y3437bvt83zcm1g3tna3q942x8.i.anyscaleuserdata-staging.com 
2025-06-03 15:55:34,109 INFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_7f1b1d640dccb78c5bba6fbba6e333a2e2c7f251.zip' (0.01MiB) to Ray cluster...
2025-06-03 15:55:34,110 INFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_7f1b1d640dccb78c5bba6fbba6e333a2e2c7f251.zip'.
(pid=145905) INFO 06-03 15:55:37 [__init__.py:243] Automatically detected platform cuda.
(EngineTestActor pid=145905) INFO 06-03 15:55:40 [__init__.py:31] Available plugins for group vllm.general_plugins:
(EngineTestActor pid=145905) INFO 06-03 15:55:40 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
(EngineTestActor pid=145905) INFO 06-03 15:55:40 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(EngineTestActor pid=145905) INFO 06-03 15:55:41 [config.py:3131] Downcasting torch.float32 to torch.float16.
(EngineTestActor pid=145905) INFO 06-03 15:55:48 [config.py:793] This model supports multiple tasks: {'score', 'classify', 'generate', 'reward', 'embed'}. Defaulting to 'generate'.
(EngineTestActor pid=145905) WARNING 06-03 15:55:48 [arg_utils.py:1588] Detected VLLM_USE_V1=1 with Engine in background thread. Usage should be considered experimental. Please report any issues on Github.
(EngineTestActor pid=145905) INFO 06-03 15:55:48 [config.py:2118] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineTestActor pid=145905) WARNING 06-03 15:55:49 [utils.py:2531] We must use the `spawn` multiprocessing start method. Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. See https://docs.vllm.ai/en/latest/usage/troubleshooting.html#python-multiprocessing for more information. Reason: In a Ray actor and can only be spawned
(EngineTestActor pid=145905) INFO 06-03 15:55:52 [__init__.py:243] Automatically detected platform cuda.
(EngineTestActor pid=145905) INFO 06-03 15:55:55 [core.py:438] Waiting for init message from front-end.
(EngineTestActor pid=145905) INFO 06-03 15:55:55 [__init__.py:31] Available plugins for group vllm.general_plugins:
(EngineTestActor pid=145905) INFO 06-03 15:55:55 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
(EngineTestActor pid=145905) INFO 06-03 15:55:55 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(EngineTestActor pid=145905) INFO 06-03 15:55:55 [core.py:65] Initializing a V1 LLM engine (v0.9.0.1) with config: model='distilbert/distilgpt2', speculative_config=None, tokenizer='distilbert/distilgpt2', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=1024, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=distilbert/distilgpt2, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level": 3, "custom_ops": ["none"], "splitting_ops": ["vllm.unified_attention", "vllm.unified_attention_with_output"], "compile_sizes": [], "inductor_compile_config": {"enable_auto_functionalized_v2": false}, "use_cudagraph": true, "cudagraph_num_of_warmups": 1, "cudagraph_capture_sizes": [512, 504, 496, 488, 480, 472, 464, 456, 448, 440, 432, 424, 416, 408, 400, 392, 384, 376, 368, 360, 352, 344, 336, 328, 320, 312, 304, 296, 288, 280, 272, 264, 256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176, 168, 160, 152, 144, 136, 128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 4, 2, 1], "max_capture_size": 512}
(EngineTestActor pid=145905) WARNING 06-03 15:55:55 [utils.py:2671] Methods determine_num_available_blocks,device_config,get_cache_block_size_bytes,initialize_cache not implemented in <vllm.v1.worker.gpu_worker.Worker object at 0x79cffa5f00d0>
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [parallel_state.py:1064] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineTestActor pid=145905) WARNING 06-03 15:55:56 [topk_topp_sampler.py:58] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [gpu_model_runner.py:1531] Starting to load model distilbert/distilgpt2...
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [cuda.py:217] Using Flash Attention backend on V1 engine.
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [backends.py:35] Using InductorAdaptor
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [weight_utils.py:291] Using model weights format ['*.safetensors']
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [weight_utils.py:344] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  7.36it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  7.35it/s]
(EngineTestActor pid=145905) 
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [default_loader.py:280] Loading weights took 0.15 seconds
(EngineTestActor pid=145905) INFO 06-03 15:55:56 [gpu_model_runner.py:1549] Model loading took 0.1547 GiB and 0.584980 seconds
(EngineTestActor pid=145905) INFO 06-03 15:55:58 [backends.py:459] Using cache directory: /home/ray/.cache/vllm/torch_compile_cache/1f177a5109/rank_0_0 for vLLM's torch.compile
(EngineTestActor pid=145905) INFO 06-03 15:55:58 [backends.py:469] Dynamo bytecode transform time: 1.23 s
(EngineTestActor pid=145905) INFO 06-03 15:55:58 [backends.py:132] Directly load the compiled graph(s) for shape None from the cache, took 0.483 s
(EngineTestActor pid=145905) INFO 06-03 15:55:58 [monitor.py:33] torch.compile takes 1.23 s in total
(EngineTestActor pid=145905) INFO 06-03 15:55:59 [kv_cache_utils.py:637] GPU KV cache size: 1,099,456 tokens
(EngineTestActor pid=145905) INFO 06-03 15:55:59 [kv_cache_utils.py:640] Maximum concurrency for 1,024 tokens per request: 1073.69x
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [gpu_model_runner.py:1933] Graph capturing finished in 14 secs, took 0.14 GiB
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [core.py:167] init engine (profile, create kv cache, warmup model) took 16.37 seconds
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-0.
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-1.
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-2.
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-3.
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-4.
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-5.
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-6.
(EngineTestActor pid=145905) INFO 06-03 15:56:13 [async_llm.py:261] Added request request-id-7.
(EngineTestActor pid=145905) [rank0]:[W603 15:56:14.336655801 ProcessGroupNCCL.cpp:1476] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
PASSED

================================================================================================ 1 passed in 41.47s =================================================================================================
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
