### PR TITLE
[TPU] Skip hanging tests

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-tpu-v1-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-tpu-v1-test.sh
@@ -150,7 +150,7 @@ run_and_track_test 9 "test_multimodal.py" \
 run_and_track_test 10 "test_pallas.py" \
     "python3 -m pytest -s -v /workspace/vllm/tests/v1/tpu/test_pallas.py"
 run_and_track_test 11 "test_struct_output_generate.py" \
-    "python3 -m pytest -s -v /workspace/vllm/tests/v1/entrypoints/llm/test_struct_output_generate.py"
+    "python3 -m pytest -s -v /workspace/vllm/tests/v1/entrypoints/llm/test_struct_output_generate.py -k 'not test_structured_output_with_reasoning_matrices'"
 run_and_track_test 12 "test_moe_pallas.py" \
     "python3 -m pytest -s -v /workspace/vllm/tests/tpu/test_moe_pallas.py"
 run_and_track_test 13 "test_lora.py" \

--- a/tests/v1/tpu/test_spmd_model_weight_loading.py
+++ b/tests/v1/tpu/test_spmd_model_weight_loading.py
@@ -45,11 +45,14 @@ def _get_spmd_mesh():
     return MESH
 
 
-@pytest.mark.parametrize("model", [
-    "Qwen/Qwen2-1.5B-Instruct",
-    "meta-llama/Llama-3.1-8B-Instruct",
-    "meta-llama/Llama-3.1-70B-Instruct",
-])
+@pytest.mark.parametrize(
+    "model",
+    [
+        "Qwen/Qwen2-1.5B-Instruct",
+        # Skip large models due to CI runner disk space limitations
+        # "meta-llama/Llama-3.1-8B-Instruct",
+        # "meta-llama/Llama-3.1-70B-Instruct",
+    ])
 def test_tpu_model_loader(model):
     # Skip the 70B test if there are less than 8 chips
     # TODO: Query using torch xla API, the query API is not working


### PR DESCRIPTION
Somehow the test have been hanging. Buildkite [log](https://buildkite.com/vllm/ci/builds/21358#01973746-adda-4d48-a361-e3ca7647ca76)

This makes each TPU CI run take 4 hr, disable it to unblock CI.

```

tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output_with_reasoning_matrices[Qwen/Qwen3-1.7B-xgrammar-auto-deepseek_r1-None] INFO 06-03 22:27:53 [config.py:822] This model supports multiple tasks: {'embed', 'classify', 'reward', 'generate', 'score'}. Defaulting to 'generate'.
--
  | INFO 06-03 22:27:53 [config.py:1967] Disabled the custom all-reduce kernel because it is not supported on current platform.
  | INFO 06-03 22:27:53 [config.py:2176] Chunked prefill is enabled with max_num_batched_tokens=8192.
  | INFO 06-03 22:27:53 [tpu.py:105] [TPU] Forcing DYNAMO_ONCE compilation level
  | huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
  | To disable this warning, you can either:
  | - Avoid using `tokenizers` before the fork if possible
  | - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true \| false)
  | INFO 06-03 22:27:55 [core.py:455] Waiting for init message from front-end.
  | INFO 06-03 22:27:55 [tpu.py:105] [TPU] Forcing DYNAMO_ONCE compilation level
  | INFO 06-03 22:27:55 [core.py:70] Initializing a V1 LLM engine (v0.9.1.dev143+gfa98d7777) with config: model='Qwen/Qwen3-1.7B', speculative_config=None, tokenizer='Qwen/Qwen3-1.7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=1024, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=None, decoding_config=DecodingConfig(backend='xgrammar', disable_fallback=False, disable_any_whitespace=True, disable_additional_properties=False, reasoning_backend='deepseek_r1'), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=Qwen/Qwen3-1.7B, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=False, pooler_config=None, compilation_config={"level":2,"debug_dump_path":"","cache_dir":"","backend":"openxla","custom_ops":["none"],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":1,"cudagraph_capture_sizes":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":512,"local_cache_dir":null}
  | INFO 06-03 22:27:55 [tpu_worker.py:294] tpu_commons not found, using vLLM's TPUWorker.
  | [Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
  | INFO 06-03 22:27:55 [parallel_state.py:1065] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
  | WARNING 06-03 22:28:01 [tpu.py:178] Pin memory is not supported on TPU.
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1574] Using exponential token paddings:
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     16
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     32
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     64
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     128
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     256
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     512
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     1024
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     2048
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     4096
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1576]     8192
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1540] Preparing request paddings:
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1547]     8
  | INFO 06-03 22:28:01 [tpu_model_runner.py:1547]     16
  | INFO 06-03 22:28:01 [tpu_model_runner.py:969] Loading model from scratch...
  | INFO 06-03 22:28:01 [tpu.py:51] Cannot use None backend on TPU.
  | INFO 06-03 22:28:01 [tpu.py:54] Using Pallas V1 backend.
  | INFO 06-03 22:28:02 [weight_utils.py:292] Using model weights format ['*.safetensors']


```