### PR TITLE
[Bugfix] Fix port handling in make_zmq_path

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2461,7 +2461,7 @@ def make_zmq_path(scheme: str, host: str, port: Optional[int] = None) -> str:
     Returns:
         A properly formatted ZMQ path string.
     """
-    if not port:
+    if port is None:
         return f"{scheme}://{host}"
     if is_valid_ipv6_address(host):
         return f"{scheme}://[{host}]:{port}"


### PR DESCRIPTION
## Summary
- fix `make_zmq_path` so port 0 is handled correctly

## Testing
- `pytest -q tests/test_utils.py::test_make_zmq_path -k 'make_zmq_path' -vv`

> Note: this is my first try using Codex - see https://chatgpt.com/codex/tasks/task_e_683f807db26083299b8fd1339771b942