### PR TITLE
[V1] Use FlashInfer by default on Blackwell GPUs

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -233,7 +233,8 @@ class CudaPlatformBase(Platform):
                 except ImportError:
                     logger.info_once(
                         "FlashInfer failed to import for V1 engine on "
-                        "Blackwell GPU; falling back to other backends.")
+                        "Blackwell (SM 10.0) GPUs; it is recommended to "
+                        "install FlashInfer for better performance.")
                     pass
             if cls.has_device_capability(80):
                 logger.info_once("Using Flash Attention backend on V1 engine.")

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -221,13 +221,13 @@ class CudaPlatformBase(Platform):
                 logger.info_once("Using Triton backend on V1 engine.")
                 return ("vllm.v1.attention.backends."
                         "triton_attn.TritonAttentionBackend")
-            if cls.get_device_capability() == DeviceCapability(10, 0):
-                # Prefer FlashInfer on Blackwell GPUs if installed
+            if cls.is_device_capability(100):
+                # Prefer FlashInfer for V1 on Blackwell GPUs if installed
                 try:
                     import flashinfer  # noqa: F401
                     logger.info_once(
                         "Using FlashInfer backend on V1 engine by default for "
-                        "Blackwell GPUs.")
+                        "Blackwell (SM 10.0) GPUs.")
                     return ("vllm.v1.attention.backends."
                             "flashinfer.FlashInferBackend")
                 except Exception:
@@ -254,16 +254,6 @@ class CudaPlatformBase(Platform):
                 f"with use_v1: {use_v1} use_mla: {use_mla}")
 
         target_backend = _Backend.FLASH_ATTN
-        if cls.has_device_capability(100):
-            try:  # Prefer FlashInfer on Blackwell GPUs if installed
-                import flashinfer  # noqa: F401
-                logger.info(
-                    "Using FlashInfer backend by default on Blackwell GPU.")
-                return "vllm.attention.backends.flashinfer.FlashInferBackend"
-            except Exception:
-                logger.info(
-                    "FlashInfer not installed; falling back to Flash Attention."
-                )
         if not cls.has_device_capability(80):
             # Volta and Turing NVIDIA GPUs.
             logger.info(

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -230,7 +230,10 @@ class CudaPlatformBase(Platform):
                         "Blackwell GPUs.")
                     return ("vllm.v1.attention.backends."
                             "flashinfer.FlashInferBackend")
-                except Exception:
+                except ImportError:
+                    logger.info_once(
+                        "FlashInfer failed to import for V1 engine on "
+                        "Blackwell GPU; falling back to other backends.")
                     pass
             if cls.has_device_capability(80):
                 logger.info_once("Using Flash Attention backend on V1 engine.")

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -227,6 +227,30 @@ class Platform:
         return current_capability.to_int() >= capability
 
     @classmethod
+    def is_device_capability(
+        cls,
+        capability: Union[tuple[int, int], int],
+        device_id: int = 0,
+    ) -> bool:
+        """
+        Test whether this platform has exactly the specified device capability.
+
+        The `capability` argument can either be:
+
+        - A tuple `(major, minor)`.
+        - An integer `<major><minor>`. (See
+        [`DeviceCapability.to_int`][vllm.platforms.interface.DeviceCapability.to_int])
+        """
+        current_capability = cls.get_device_capability(device_id=device_id)
+        if current_capability is None:
+            return False
+
+        if isinstance(capability, tuple):
+            return current_capability == capability
+
+        return current_capability.to_int() == capability
+
+    @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
         """Get the name of a device."""
         raise NotImplementedError


### PR DESCRIPTION
## Purpose

FlashInfer has a specific backend for NVIDIA Blackwell so it is much more performant than FlashAttention2 default in V1 (FA3 is unsupported). If a user has it installed, I think we should choose it by default, which this PR achieves. See this comment for benchmarks https://github.com/vllm-project/vllm/pull/18095#issuecomment-2877849390

This PR also adds `is_device_capability` to the platform interface for exact cc checking since we only want this for SM 10.0

## Test Plan

Test locally on a B200 that FlashInfer is enabled by default

## Test Result

On B200 without flashinfer installed:
```
vllm serve facebook/opt-125m --enforce-eager
...
INFO 06-04 13:16:58 [cuda.py:234] FlashInfer failed to import for V1 engine on Blackwell (SM 10.0) GPUs; it is recommended to install FlashInfer for better performance.
INFO 06-04 13:16:58 [cuda.py:240] Using Flash Attention backend on V1 engine.
```

On B200 with flashinfer installed:
```
uv pip install https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.5%2Bcu128torch2.7-cp38-abi3-linux_x86_64.whl
vllm serve facebook/opt-125m --enforce-eager
...
INFO 06-04 13:15:34 [cuda.py:228] Using FlashInfer backend on V1 engine by default for Blackwell (SM 10.0) GPUs.
```
