### PR TITLE
Add tps metrics in PrometheusStatLogger

### DIFF
--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -223,7 +223,7 @@ class Metrics:
             documentation="Number of emitted tokens.",
             labelnames=labelnames))
 
-        # Tokens metrics
+        # Tokens throughput metrics
         self.gauge_prompt_throughput = self._gauge_cls(
             name="vllm:prompt_token_throughput",
             documentation="Prompt token throughput (tokens/sec).",


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

- To expose (almost) real-time prompt/generation token throughput metrics in `PrometheusStatLogger`, which are currently available in `LoggingStatLogger`

## Test Plan

- Do vLLM serve and make inference tasks to vLLM engine
- Get tps metrics via /metrics, and compare with stdout logs made by `LoggingStatLogger`

## Test Result

- No needed

<!--- pyml disable-next-line no-emphasis-as-heading -->
