### PR TITLE
[Core] Add Support for Default Modality Specific LoRAs [generate / chat completions]

### DIFF
--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -272,3 +272,80 @@ The new format of `--lora-modules` is mainly to support the display of parent mo
         ]
     }
     ```
+
+## Default LoRA Models For Multimodal Models
+
+Some models, e.g., Granite Speech and Phi 4 multimodal, contain LoRA adapter(s) that are expected to always be applied when a given modality is present. This can be a bit tedious to manage with the above approaches, as it requires the user to send the `LoRARequest` (offline) or to filter requests between the base model and LoRA model (server) depending on the content of the request's multimodal data.
+
+To this end, we allow registration of default multimodal LoRAs to handle this automatically, where users can map each modality to a LoRA adapter to automatically apply it when the corresponding inputs are present. Note that currently, we only allow one LoRA per prompt; if several modalities are provided, each of which are registered to a given modality, none of them will be applied.
+
+Example usage for offline inference:
+
+```python
+from transformers import AutoTokenizer
+from vllm import LLM, SamplingParams
+from vllm.assets.audio import AudioAsset
+
+model_id = "ibm-granite/granite-speech-3.3-2b"
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+def get_prompt(question: str, has_audio: bool):
+    """Build the input prompt to send to vLLM."""
+    if has_audio:
+        question = f"<|audio|>{question}"
+    chat = [
+        {
+            "role": "user",
+            "content": question
+        }
+    ]
+    return tokenizer.apply_chat_template(chat, tokenize=False)
+
+
+model = LLM(
+    model=model_id,
+    enable_lora=True,
+    max_lora_rank=64,
+    max_model_len=2048,
+    limit_mm_per_prompt={"audio": 1},
+    # Will always pass a `LoRARequest` with the `model_id`
+    # whenever audio is contained in the request data.
+    default_mm_loras = {"audio": model_id},
+    enforce_eager=True,
+)
+
+question = "can you transcribe the speech into a written format?"
+prompt_with_audio = get_prompt(
+    question=question,
+    has_audio=True,
+)
+audio = AudioAsset("mary_had_lamb").audio_and_sample_rate
+
+inputs = {
+    "prompt": prompt_with_audio,
+    "multi_modal_data": {
+        "audio": audio,
+    }
+}
+
+
+outputs = model.generate(
+    inputs,
+    sampling_params=SamplingParams(
+        temperature=0.2,
+        max_tokens=64,
+    ),
+)
+```
+
+You can also pass a json dictionary of `--default_mm_loras` mapping modalities to LoRA model IDs. For example, when starting the server:
+
+```bash
+vllm serve ibm-granite/granite-speech-3.3-2b \
+    --max-model-len 2048 \
+    --enable-lora \
+    --default_mm_loras '{"audio":"ibm-granite/granite-speech-3.3-2b"}' \
+    --max-lora-rank 64
+```
+
+Note: Default multimodal LoRAs are currently only available for `.generate` and chat completions.

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -275,7 +275,7 @@ The new format of `--lora-modules` is mainly to support the display of parent mo
 
 ## Default LoRA Models For Multimodal Models
 
-Some models, e.g., Granite Speech and Phi 4 multimodal, contain LoRA adapter(s) that are expected to always be applied when a given modality is present. This can be a bit tedious to manage with the above approaches, as it requires the user to send the `LoRARequest` (offline) or to filter requests between the base model and LoRA model (server) depending on the content of the request's multimodal data.
+Some models, e.g., [Granite Speech](https://huggingface.co/ibm-granite/granite-speech-3.3-8b) and [Phi-4-multimodal-instruct](https://huggingface.co/microsoft/Phi-4-multimodal-instruct) multimodal, contain LoRA adapter(s) that are expected to always be applied when a given modality is present. This can be a bit tedious to manage with the above approaches, as it requires the user to send the `LoRARequest` (offline) or to filter requests between the base model and LoRA model (server) depending on the content of the request's multimodal data.
 
 To this end, we allow registration of default multimodal LoRAs to handle this automatically, where users can map each modality to a LoRA adapter to automatically apply it when the corresponding inputs are present. Note that currently, we only allow one LoRA per prompt; if several modalities are provided, each of which are registered to a given modality, none of them will be applied.
 
@@ -338,13 +338,13 @@ outputs = model.generate(
 )
 ```
 
-You can also pass a json dictionary of `--default_mm_loras` mapping modalities to LoRA model IDs. For example, when starting the server:
+You can also pass a json dictionary of `--default-mm-loras` mapping modalities to LoRA model IDs. For example, when starting the server:
 
 ```bash
 vllm serve ibm-granite/granite-speech-3.3-2b \
     --max-model-len 2048 \
     --enable-lora \
-    --default_mm_loras '{"audio":"ibm-granite/granite-speech-3.3-2b"}' \
+    --default-mm-loras '{"audio":"ibm-granite/granite-speech-3.3-2b"}' \
     --max-lora-rank 64
 ```
 

--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -3,7 +3,6 @@
 
 # imports for guided decoding tests
 import json
-import os
 from typing import Optional
 
 import jsonschema
@@ -13,22 +12,14 @@ import pytest_asyncio
 import regex as re
 import requests
 import torch
-from huggingface_hub import snapshot_download
 from openai import BadRequestError, OpenAI
 
-from ...conftest import AudioTestAssets
 from ...utils import RemoteOpenAIServer
 from .test_completion import zephyr_lora_added_tokens_files  # noqa: F401
 from .test_completion import zephyr_lora_files  # noqa: F401
 
 # any model with a chat template should work here
 MODEL_NAME = "HuggingFaceH4/zephyr-7b-beta"
-# Contains a modality specific lora alongside the base model
-MULTIMODAL_MODEL_NAME = snapshot_download(
-    "microsoft/Phi-4-multimodal-instruct")
-AUDIO_LORA_PATH = os.path.join(MULTIMODAL_MODEL_NAME, "speech-lora")
-
-ACTIVE_MM_LORA_RESPONSE = "Spoken text: The first words I spoke in the original chronograph, a little piece of practical poetry. Mary had a little lamb, it slept with quite a snow, and everywhere that Mary went, the lamb was sure to go."  # noqa: E501
 
 
 @pytest.fixture(scope="module")
@@ -73,38 +64,6 @@ def server(
         yield remote_server
 
 
-@pytest.fixture(scope="module", params=[False, True])
-def multimodal_server(request, monkeypatch_module):  # noqa: F811
-
-    use_v1 = request.param
-    monkeypatch_module.setenv('VLLM_USE_V1', '1' if use_v1 else '0')
-
-    args = [
-        # use half precision for speed and memory savings in CI environment
-        "--dtype",
-        "half",
-        "--max-model-len",
-        "12800",
-        "--enforce-eager",
-        # lora config below
-        "--enable-lora",
-        "--lora-modules",
-        f"speech={AUDIO_LORA_PATH}",
-        "--max-lora-rank",
-        "320",
-        "--max-num-seqs",
-        "2",
-        "--trust-remote-code",
-        "--gpu-memory-utilization",
-        "0.8",
-        "--default-mm-loras",
-        f"{{\"audio\": \"{AUDIO_LORA_PATH}\"}}",
-    ]
-
-    with RemoteOpenAIServer(MULTIMODAL_MODEL_NAME, args) as remote_server:
-        yield remote_server
-
-
 @pytest.fixture
 def is_v1_server(server):
     import os
@@ -116,50 +75,6 @@ def is_v1_server(server):
 async def client(server):
     async with server.get_async_client() as async_client:
         yield async_client
-
-
-@pytest_asyncio.fixture
-async def multi_modal_client(multimodal_server):
-    async with multimodal_server.get_async_client() as async_client:
-        yield async_client
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    # base model with default lora should give the same response as lora model
-    "model_name",
-    [MULTIMODAL_MODEL_NAME, "speech"],
-)
-async def test_default_mm_lora_chat_completions(
-    model_name: str,
-    multi_modal_client: openai.AsyncOpenAI,
-    audio_assets: AudioTestAssets,
-):
-    messages = [{
-        "role":
-        "user",
-        "content": [{
-            "type": "text",
-            "text": "Can you transcribe this audio?",
-        }, {
-            "type": "audio_url",
-            "audio_url": {
-                "url": audio_assets[0].url
-            },
-        }]
-    }]
-
-    chat_completion = await multi_modal_client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_completion_tokens=128,
-        temperature=0.0)
-
-    assert len(chat_completion.choices) > 0
-
-    message = chat_completion.choices[0].message
-    assert message.content is not None and len(message.content) >= 0
-    assert message.content == ACTIVE_MM_LORA_RESPONSE
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_default_mm_loras.py
+++ b/tests/entrypoints/openai/test_default_mm_loras.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import openai  # use the official client for correctness check
+import os
+import pytest
+import pytest_asyncio
+from huggingface_hub import snapshot_download
+from ...conftest import AudioTestAssets
+
+from ...conftest import AudioTestAssets
+from ...utils import RemoteOpenAIServer
+
+# NOTE - the tests in this module are currently analogous to test_chat, but are
+# separated to avoid OOM killing due to module-scoped servers, since we currently
+# need a multimodal model for these tests.
+
+# Contains a modality specific lora alongside the base model
+MULTIMODAL_MODEL_NAME = snapshot_download(
+    "microsoft/Phi-4-multimodal-instruct")
+AUDIO_LORA_PATH = os.path.join(MULTIMODAL_MODEL_NAME, "speech-lora")
+
+ACTIVE_MM_LORA_RESPONSE = "Spoken text: The first words I spoke in the original chronograph, a little piece of practical poetry. Mary had a little lamb, it slept with quite a snow, and everywhere that Mary went, the lamb was sure to go."  # noqa: E501
+
+@pytest.fixture(scope="module")
+def monkeypatch_module():
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
+@pytest.fixture(scope="module", params=[False, True])
+def multimodal_server(request, monkeypatch_module):  # noqa: F811
+
+    use_v1 = request.param
+    monkeypatch_module.setenv('VLLM_USE_V1', '1' if use_v1 else '0')
+
+    args = [
+        # use half precision for speed and memory savings in CI environment
+        "--dtype",
+        "half",
+        "--max-model-len",
+        "12800",
+        "--enforce-eager",
+        # lora config below
+        "--enable-lora",
+        "--lora-modules",
+        f"speech={AUDIO_LORA_PATH}",
+        "--max-lora-rank",
+        "320",
+        "--max-num-seqs",
+        "2",
+        "--trust-remote-code",
+        "--gpu-memory-utilization",
+        "0.8",
+        "--default-mm-loras",
+        f"{{\"audio\": \"{AUDIO_LORA_PATH}\"}}",
+    ]
+
+    with RemoteOpenAIServer(MULTIMODAL_MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest_asyncio.fixture
+async def multi_modal_client(multimodal_server):
+    async with multimodal_server.get_async_client() as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # base model with default lora should give the same response as lora model
+    "model_name",
+    [MULTIMODAL_MODEL_NAME, "speech"],
+)
+async def test_default_mm_lora_chat_completions(
+    model_name: str,
+    multi_modal_client: openai.AsyncOpenAI,
+    audio_assets: AudioTestAssets,
+):
+    messages = [{
+        "role":
+        "user",
+        "content": [{
+            "type": "text",
+            "text": "Can you transcribe this audio?",
+        }, {
+            "type": "audio_url",
+            "audio_url": {
+                "url": audio_assets[0].url
+            },
+        }]
+    }]
+
+    chat_completion = await multi_modal_client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_completion_tokens=128,
+        temperature=0.0)
+
+    assert len(chat_completion.choices) > 0
+
+    message = chat_completion.choices[0].message
+    assert message.content is not None and len(message.content) >= 0
+    assert message.content == ACTIVE_MM_LORA_RESPONSE

--- a/tests/entrypoints/openai/test_default_mm_loras.py
+++ b/tests/entrypoints/openai/test_default_mm_loras.py
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import openai  # use the official client for correctness check
 import os
+
+import openai  # use the official client for correctness check
 import pytest
 import pytest_asyncio
 from huggingface_hub import snapshot_download
-from ...conftest import AudioTestAssets
 
 from ...conftest import AudioTestAssets
 from ...utils import RemoteOpenAIServer
 
 # NOTE - the tests in this module are currently analogous to test_chat, but are
-# separated to avoid OOM killing due to module-scoped servers, since we currently
+# separated to avoid OOM killing due to module-scoped servers, since we
 # need a multimodal model for these tests.
 
 # Contains a modality specific lora alongside the base model
@@ -22,12 +22,14 @@ AUDIO_LORA_PATH = os.path.join(MULTIMODAL_MODEL_NAME, "speech-lora")
 
 ACTIVE_MM_LORA_RESPONSE = "Spoken text: The first words I spoke in the original chronograph, a little piece of practical poetry. Mary had a little lamb, it slept with quite a snow, and everywhere that Mary went, the lamb was sure to go."  # noqa: E501
 
+
 @pytest.fixture(scope="module")
 def monkeypatch_module():
     from _pytest.monkeypatch import MonkeyPatch
     mpatch = MonkeyPatch()
     yield mpatch
     mpatch.undo()
+
 
 @pytest.fixture(scope="module", params=[False, True])
 def multimodal_server(request, monkeypatch_module):  # noqa: F811

--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for applying default registered multimodal loras.
+"""
+
+import pytest
+
+from vllm.lora.request import LoRARequest
+
+from ..conftest import AudioTestAssets, VllmRunner
+
+MODEL = "ibm-granite/granite-speech-3.3-2b"
+AUDIO_PROMPT = "<|start_of_role|>system<|end_of_role|>Knowledge Cutoff Date: April 2024.\nToday's Date: December 19, 2024.\nYou are Granite, developed by IBM. You are a helpful AI assistant<|end_of_text|>\n<|start_of_role|>user<|end_of_role|><|audio|>can you transcribe the speech into a written format?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>"  # noqa: E501
+
+# Responses are greedy decoded; we just check the end of
+# the generated text. If the lora is inactive, this model
+# generates commentary on the transcription.
+RESPONSE_SUFFIX_WITH_LORA = "the first words i spoke in the original chorus a little piece of practical poetry mary had a little lamb its fleece was white as snow and everywhere that mary went the lamb would surely go"  # noqa: E501
+RESPONSE_SUFFIX_WITHOUT_LORA = "This is a simplified transcription of the given text, which appears to be a poetic description or narrative."  # noqa: E501
+
+
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
+
+
+VLLM_RUNNER_BASE_KWARGS = {
+    "model_name": MODEL,
+    "dtype": "half",
+    "enable_lora": "True",
+    "max_lora_rank": 64,
+    "max_model_len": 2048,
+    "limit_mm_per_prompt": {
+        "audio": 1
+    },
+    "enforce_eager": True,
+}
+
+
+def run_test(vllm_runner, audio_assets, lora_request, expected_suffix,
+             **kwargs):
+    inputs = [([AUDIO_PROMPT], [audio_assets[0].audio_and_sample_rate[0]])]
+
+    # Apply any additional kwargs as overrides to the base kwargs
+    vllm_runner_kwargs = {**VLLM_RUNNER_BASE_KWARGS, **kwargs}
+
+    with vllm_runner(**vllm_runner_kwargs) as vllm_model:
+        vllm_outputs_with_default_lora = [
+            vllm_model.generate_greedy(
+                prompts,
+                max_tokens=128,
+                audios=audios,
+                lora_request=lora_request,
+            ) for prompts, audios in inputs
+        ]
+        assert vllm_outputs_with_default_lora[-1][-1][-1].endswith(
+            expected_suffix)
+
+
+def test_active_default_mm_lora(
+    vllm_runner: type[VllmRunner],
+    audio_assets: AudioTestAssets,
+):
+    """Ensure that we can use the default audio lora."""
+    run_test(
+        vllm_runner,
+        audio_assets,
+        lora_request=None,
+        default_mm_loras={"audio": LoRARequest("speech", 1, MODEL)},
+        expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
+    )
+
+
+def test_inactive_default_mm_lora(
+    vllm_runner: type[VllmRunner],
+    audio_assets: AudioTestAssets,
+):
+    """Ensure that modalities are filtered properly."""
+    run_test(
+        vllm_runner,
+        audio_assets,
+        lora_request=None,
+        default_mm_loras={"image": LoRARequest("vision", 1, MODEL)},
+        expected_suffix=RESPONSE_SUFFIX_WITHOUT_LORA,
+    )
+
+
+def test_default_mm_lora_succeeds_with_redundant_lora_request(
+    vllm_runner: type[VllmRunner],
+    audio_assets: AudioTestAssets,
+):
+    """Ensure that redundantly providing the lora works."""
+    run_test(
+        vllm_runner,
+        audio_assets,
+        lora_request=LoRARequest("speech", 1, MODEL),
+        default_mm_loras={"audio": LoRARequest("speech", 1, MODEL)},
+        expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
+    )
+
+
+def test_default_mm_lora_fails_with_overridden_lora_request(
+    vllm_runner: type[VllmRunner],
+    audio_assets: AudioTestAssets,
+):
+    """Ensure that if the lora_request conflicts with default_mm_loras,
+    we use the lora_request."""
+    run_test(
+        vllm_runner,
+        audio_assets,
+        lora_request=LoRARequest("speech", 2, MODEL),
+        default_mm_loras={"audio": LoRARequest("something", 1, "never used")},
+        expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
+    )

--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -69,7 +69,7 @@ def test_active_default_mm_lora(
         vllm_runner,
         audio_assets,
         lora_request=None,
-        default_mm_loras={"audio": LoRARequest("speech", 1, MODEL)},
+        default_mm_loras={"audio": MODEL},
         expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
     )
 
@@ -83,7 +83,7 @@ def test_inactive_default_mm_lora(
         vllm_runner,
         audio_assets,
         lora_request=None,
-        default_mm_loras={"image": LoRARequest("vision", 1, MODEL)},
+        default_mm_loras={"image": MODEL},
         expected_suffix=RESPONSE_SUFFIX_WITHOUT_LORA,
     )
 
@@ -96,8 +96,8 @@ def test_default_mm_lora_succeeds_with_redundant_lora_request(
     run_test(
         vllm_runner,
         audio_assets,
-        lora_request=LoRARequest("speech", 1, MODEL),
-        default_mm_loras={"audio": LoRARequest("speech", 1, MODEL)},
+        lora_request=LoRARequest("audio", 1, MODEL),
+        default_mm_loras={"audio": MODEL},
         expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
     )
 
@@ -112,6 +112,6 @@ def test_default_mm_lora_fails_with_overridden_lora_request(
         vllm_runner,
         audio_assets,
         lora_request=LoRARequest("speech", 2, MODEL),
-        default_mm_loras={"audio": LoRARequest("something", 1, "never used")},
+        default_mm_loras={"audio": "this path is overridden"},
         expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
     )

--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -3,20 +3,26 @@
 Tests for applying default registered multimodal loras.
 """
 
+import os
+
 import pytest
+from huggingface_hub import snapshot_download
 
 from vllm.lora.request import LoRARequest
 
 from ..conftest import AudioTestAssets, VllmRunner
 
-MODEL = "ibm-granite/granite-speech-3.3-2b"
-AUDIO_PROMPT = "<|start_of_role|>system<|end_of_role|>Knowledge Cutoff Date: April 2024.\nToday's Date: December 19, 2024.\nYou are Granite, developed by IBM. You are a helpful AI assistant<|end_of_text|>\n<|start_of_role|>user<|end_of_role|><|audio|>can you transcribe the speech into a written format?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>"  # noqa: E501
+MODEL_PATH = snapshot_download("microsoft/Phi-4-multimodal-instruct")
+AUDIO_LORA_PATH = os.path.join(MODEL_PATH, "speech-lora")
+IMAGE_LORA_PATH = os.path.join(MODEL_PATH, "vision-lora")
+
+AUDIO_PROMPT = "<|user|><|audio_1|>Can you transcribe this audio?<|end|><|assistant|>"  # noqa: E501
 
 # Responses are greedy decoded; we just check the end of
 # the generated text. If the lora is inactive, this model
 # generates commentary on the transcription.
-RESPONSE_SUFFIX_WITH_LORA = "the first words i spoke in the original chorus a little piece of practical poetry mary had a little lamb its fleece was white as snow and everywhere that mary went the lamb would surely go"  # noqa: E501
-RESPONSE_SUFFIX_WITHOUT_LORA = "This is a simplified transcription of the given text, which appears to be a poetic description or narrative."  # noqa: E501
+RESPONSE_SUFFIX_WITH_LORA = "Spoken text: The first words I spoke in the original chronograph, a little piece of practical poetry. Mary had a little lamb, it slept with quite a snow, and everywhere that Mary went, the lamb was sure to go."  # noqa: E501
+RESPONSE_SUFFIX_WITHOUT_LORA = "Certainly! Here is the transcription of the audio you provided:\n\nThe first words I spoke in the original phonograph record: A little piece of practical poetry. Mary had a little lamb; its fleece was white as snow, and everywhere that Mary went, the lamb was sure to go."  # noqa: E501
 
 
 @pytest.fixture(autouse=True)
@@ -28,11 +34,13 @@ def v1(run_with_both_engines_lora):
 
 
 VLLM_RUNNER_BASE_KWARGS = {
-    "model_name": MODEL,
+    "model_name": MODEL_PATH,
     "dtype": "half",
     "enable_lora": "True",
-    "max_lora_rank": 64,
-    "max_model_len": 2048,
+    "max_num_seqs": 2,
+    "max_lora_rank": 320,
+    "max_model_len": 12800,
+    "gpu_memory_utilization": 0.8,
     "limit_mm_per_prompt": {
         "audio": 1
     },
@@ -56,6 +64,7 @@ def run_test(vllm_runner, audio_assets, lora_request, expected_suffix,
                 lora_request=lora_request,
             ) for prompts, audios in inputs
         ]
+
         assert vllm_outputs_with_default_lora[-1][-1][-1].endswith(
             expected_suffix)
 
@@ -69,7 +78,7 @@ def test_active_default_mm_lora(
         vllm_runner,
         audio_assets,
         lora_request=None,
-        default_mm_loras={"audio": MODEL},
+        default_mm_loras={"audio": AUDIO_LORA_PATH},
         expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
     )
 
@@ -79,11 +88,12 @@ def test_inactive_default_mm_lora(
     audio_assets: AudioTestAssets,
 ):
     """Ensure that modalities are filtered properly."""
+    # Default image lora won't be active since we only pass audio
     run_test(
         vllm_runner,
         audio_assets,
         lora_request=None,
-        default_mm_loras={"image": MODEL},
+        default_mm_loras={"image": IMAGE_LORA_PATH},
         expected_suffix=RESPONSE_SUFFIX_WITHOUT_LORA,
     )
 
@@ -96,8 +106,8 @@ def test_default_mm_lora_succeeds_with_redundant_lora_request(
     run_test(
         vllm_runner,
         audio_assets,
-        lora_request=LoRARequest("audio", 1, MODEL),
-        default_mm_loras={"audio": MODEL},
+        lora_request=LoRARequest("audio", 1, AUDIO_LORA_PATH),
+        default_mm_loras={"audio": AUDIO_LORA_PATH},
         expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
     )
 
@@ -111,7 +121,7 @@ def test_default_mm_lora_fails_with_overridden_lora_request(
     run_test(
         vllm_runner,
         audio_assets,
-        lora_request=LoRARequest("speech", 2, MODEL),
-        default_mm_loras={"audio": "this path is overridden"},
+        lora_request=LoRARequest("speech", 2, AUDIO_LORA_PATH),
+        default_mm_loras={"audio": IMAGE_LORA_PATH},
         expected_suffix=RESPONSE_SUFFIX_WITH_LORA,
     )

--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Tests for applying default registered multimodal loras.
 """
 
 import os
 
-import pytest
 from huggingface_hub import snapshot_download
 
 from vllm.lora.request import LoRARequest
@@ -23,15 +23,6 @@ AUDIO_PROMPT = "<|user|><|audio_1|>Can you transcribe this audio?<|end|><|assist
 # generates commentary on the transcription.
 RESPONSE_SUFFIX_WITH_LORA = "Spoken text: The first words I spoke in the original chronograph, a little piece of practical poetry. Mary had a little lamb, it slept with quite a snow, and everywhere that Mary went, the lamb was sure to go."  # noqa: E501
 RESPONSE_SUFFIX_WITHOUT_LORA = "Certainly! Here is the transcription of the audio you provided:\n\nThe first words I spoke in the original phonograph record: A little piece of practical poetry. Mary had a little lamb; its fleece was white as snow, and everywhere that Mary went, the lamb was sure to go."  # noqa: E501
-
-
-@pytest.fixture(autouse=True)
-def v1(run_with_both_engines_lora):
-    # Simple autouse wrapper to run both engines for each test
-    # This can be promoted up to conftest.py to run for every
-    # test in a package
-    pass
-
 
 VLLM_RUNNER_BASE_KWARGS = {
     "model_name": MODEL_PATH,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -33,10 +33,7 @@ import vllm.envs as envs
 from vllm import version
 from vllm.compilation.inductor_pass import CallableInductorPass, InductorPass
 from vllm.logger import init_logger
-from vllm.model_executor.layers.quantization import (QUANTIZATION_METHODS,
-                                                     QuantizationMethods,
-                                                     get_quantization_config)
-from vllm.model_executor.models import ModelRegistry
+from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.platforms import current_platform
 from vllm.transformers_utils.config import (
     ConfigFormat, get_config, get_hf_image_processor_config,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2994,13 +2994,14 @@ class LoRAConfig:
     trained with those scaling factors to be used at the same time. If not
     specified, only adapters trained with the base model scaling factor are
     allowed."""
-    mm_loras: Optional[dict[str, LoRARequest]] = None
+    default_mm_loras: Optional[dict[str, LoRARequest]] = None
     """Dictionary mapping specific modalities to LoRA adapters; this field
     is only applicable to multimodal models and should be leveraged when
     a model always expects a LoRA to be active when a given modality is
     provided. Note that currently, if a request provides multiple additional
-    modalities, each of which have their own lora, we do NOT apply the mm_loras
-    because we currently only support one lora adapter per prompt.
+    modalities, each of which have their own lora, we do NOT apply
+    default_mm_loras because we currently only support one lora adapter
+    per prompt.
     """
     bias_enabled: bool = False
     """Enable bias for LoRA adapters."""

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -33,7 +33,6 @@ import vllm.envs as envs
 from vllm import version
 from vllm.compilation.inductor_pass import CallableInductorPass, InductorPass
 from vllm.logger import init_logger
-from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.quantization import (QUANTIZATION_METHODS,
                                                      QuantizationMethods,
                                                      get_quantization_config)
@@ -2994,15 +2993,16 @@ class LoRAConfig:
     trained with those scaling factors to be used at the same time. If not
     specified, only adapters trained with the base model scaling factor are
     allowed."""
-    default_mm_loras: Optional[dict[str, LoRARequest]] = None
-    """Dictionary mapping specific modalities to LoRA adapters; this field
-    is only applicable to multimodal models and should be leveraged when
-    a model always expects a LoRA to be active when a given modality is
-    provided. Note that currently, if a request provides multiple additional
-    modalities, each of which have their own lora, we do NOT apply
+    default_mm_loras: Optional[dict[str, str]] = None
+    """Dictionary mapping specific modalities to LoRA model paths; this field
+    is only applicable to multimodal models and should be leveraged when a
+    model always expects a LoRA to be active when a given modality is present.
+    Note that currently, if a request provides multiple additional
+    modalities, each of which have their own LoRA, we do NOT apply
     default_mm_loras because we currently only support one lora adapter
-    per prompt.
-    """
+    per prompt. When run in offline mode, the lora IDs for n modalities
+    will be automatically assigned to 1-n with the names of the modalities
+    in alphabetic order."""
     bias_enabled: bool = False
     """Enable bias for LoRA adapters."""
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -33,6 +33,11 @@ import vllm.envs as envs
 from vllm import version
 from vllm.compilation.inductor_pass import CallableInductorPass, InductorPass
 from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
+from vllm.model_executor.layers.quantization import (QUANTIZATION_METHODS,
+                                                     QuantizationMethods,
+                                                     get_quantization_config)
+from vllm.model_executor.models import ModelRegistry
 from vllm.platforms import current_platform
 from vllm.transformers_utils.config import (
     ConfigFormat, get_config, get_hf_image_processor_config,
@@ -2989,6 +2994,14 @@ class LoRAConfig:
     trained with those scaling factors to be used at the same time. If not
     specified, only adapters trained with the base model scaling factor are
     allowed."""
+    mm_loras: Optional[dict[str, LoRARequest]] = None
+    """Dictionary mapping specific modalities to LoRA adapters; this field
+    is only applicable to multimodal models and should be leveraged when
+    a model always expects a LoRA to be active when a given modality is
+    provided. Note that currently, if a request provides multiple additional
+    modalities, each of which have their own lora, we do NOT apply the mm_loras
+    because we currently only support one lora adapter per prompt.
+    """
     bias_enabled: bool = False
     """Enable bias for LoRA adapters."""
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1292,6 +1292,11 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager,
         )
 
+        if not model_config.is_multimodal_model and self.default_mm_loras:
+            raise ValueError(
+                "Default modality-specific LoRA(s) were provided for a "
+                "non multimodal model")
+
         lora_config = LoRAConfig(
             bias_enabled=self.enable_lora_bias,
             max_lora_rank=self.max_lora_rank,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -35,7 +35,6 @@ from vllm.config import (BlockSize, CacheConfig, CacheDType, CompilationConfig,
                          VllmConfig, get_attr_docs, get_field)
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
-from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.plugins import load_general_plugins
@@ -386,7 +385,7 @@ class EngineArgs:
     enable_lora_bias: bool = LoRAConfig.bias_enabled
     max_loras: int = LoRAConfig.max_loras
     max_lora_rank: int = LoRAConfig.max_lora_rank
-    default_mm_loras: Optional[Dict[str, LoRARequest]] = \
+    default_mm_loras: Optional[Dict[str, str]] = \
         LoRAConfig.default_mm_loras
     fully_sharded_loras: bool = LoRAConfig.fully_sharded_loras
     max_cpu_loras: Optional[int] = LoRAConfig.max_cpu_loras
@@ -800,6 +799,8 @@ class EngineArgs:
                                 **lora_kwargs["max_cpu_loras"])
         lora_group.add_argument("--fully-sharded-loras",
                                 **lora_kwargs["fully_sharded_loras"])
+        lora_group.add_argument("--default-mm-loras",
+                                **lora_kwargs["default_mm_loras"])
 
         # PromptAdapter related configs
         prompt_adapter_kwargs = get_kwargs(PromptAdapterConfig)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -35,6 +35,7 @@ from vllm.config import (BlockSize, CacheConfig, CacheDType, CompilationConfig,
                          VllmConfig, get_attr_docs, get_field)
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.plugins import load_general_plugins
@@ -385,6 +386,7 @@ class EngineArgs:
     enable_lora_bias: bool = LoRAConfig.bias_enabled
     max_loras: int = LoRAConfig.max_loras
     max_lora_rank: int = LoRAConfig.max_lora_rank
+    mm_loras: Optional[Dict[str, LoRARequest]] = LoRAConfig.mm_loras
     fully_sharded_loras: bool = LoRAConfig.fully_sharded_loras
     max_cpu_loras: Optional[int] = LoRAConfig.max_cpu_loras
     lora_dtype: Optional[Union[str, torch.dtype]] = LoRAConfig.lora_dtype
@@ -1292,6 +1294,7 @@ class EngineArgs:
             bias_enabled=self.enable_lora_bias,
             max_lora_rank=self.max_lora_rank,
             max_loras=self.max_loras,
+            mm_loras=self.mm_loras,
             fully_sharded_loras=self.fully_sharded_loras,
             lora_extra_vocab_size=self.lora_extra_vocab_size,
             long_lora_scaling_factors=self.long_lora_scaling_factors,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -386,7 +386,8 @@ class EngineArgs:
     enable_lora_bias: bool = LoRAConfig.bias_enabled
     max_loras: int = LoRAConfig.max_loras
     max_lora_rank: int = LoRAConfig.max_lora_rank
-    mm_loras: Optional[Dict[str, LoRARequest]] = LoRAConfig.mm_loras
+    default_mm_loras: Optional[Dict[str, LoRARequest]] = \
+        LoRAConfig.default_mm_loras
     fully_sharded_loras: bool = LoRAConfig.fully_sharded_loras
     max_cpu_loras: Optional[int] = LoRAConfig.max_cpu_loras
     lora_dtype: Optional[Union[str, torch.dtype]] = LoRAConfig.lora_dtype
@@ -1294,7 +1295,7 @@ class EngineArgs:
             bias_enabled=self.enable_lora_bias,
             max_lora_rank=self.max_lora_rank,
             max_loras=self.max_loras,
-            mm_loras=self.mm_loras,
+            default_mm_loras=self.default_mm_loras,
             fully_sharded_loras=self.fully_sharded_loras,
             lora_extra_vocab_size=self.lora_extra_vocab_size,
             long_lora_scaling_factors=self.long_lora_scaling_factors,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -566,7 +566,7 @@ class LLM:
                 " used by a single prompt consuming several modalities; "
                 " currently we only support one lora per request; as such,"
                 " lora(s) registered with modalities: %s"
-                " will be skipped.", intersection)
+                " will be skipped", intersection)
             return lora_request
 
         # Build the LoRA request; the ID of the default mm lora is the
@@ -575,12 +575,14 @@ class LLM:
         modality_lora_path = default_mm_loras[modality_name]
         modality_lora_id = sorted(default_mm_loras).index(modality_name) + 1
 
-        if (lora_request is not None
-                and lora_request.lora_int_id != modality_lora_id):
-            logger.warning(
-                "A modality with a registered lora and a lora_request "
-                "with a different ID were provided; falling back to the "
-                "lora_request as we only apply one LoRARequest per prompt.")
+        # If we have a collision, warn if there is a collision,
+        # but always send the explicitly provided request.
+        if lora_request:
+            if lora_request.lora_int_id != modality_lora_id:
+                logger.warning(
+                    "A modality with a registered lora and a lora_request "
+                    "with a different ID were provided; falling back to the "
+                    "lora_request as we only apply one LoRARequest per prompt")
             return lora_request
 
         return LoRARequest(

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1483,7 +1483,9 @@ async def init_app_state(
                     resolved_chat_template, args.model)
 
     # Merge default_mm_loras into the static lora_modules
-    default_mm_loras = vllm_config.lora_config.default_mm_loras
+    default_mm_loras = (vllm_config.lora_config.default_mm_loras
+                        if vllm_config.lora_config is not None else {})
+
     lora_modules = args.lora_modules
     if default_mm_loras:
         default_mm_lora_paths = [

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -87,6 +87,7 @@ from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.entrypoints.openai.serving_embedding import OpenAIServingEmbedding
 from vllm.entrypoints.openai.serving_engine import OpenAIServing
 from vllm.entrypoints.openai.serving_models import (BaseModelPath,
+                                                    LoRAModulePath,
                                                     OpenAIServingModels)
 from vllm.entrypoints.openai.serving_pooling import OpenAIServingPooling
 from vllm.entrypoints.openai.serving_responses import OpenAIServingResponses
@@ -1481,11 +1482,26 @@ async def init_app_state(
                     "This discrepancy may lead to performance degradation.",
                     resolved_chat_template, args.model)
 
+    # Merge default_mm_loras into the static lora_modules
+    default_mm_loras = vllm_config.lora_config.default_mm_loras
+    lora_modules = args.lora_modules
+    if default_mm_loras:
+        default_mm_lora_paths = [
+            LoRAModulePath(
+                name=modality,
+                path=lora_path,
+            ) for modality, lora_path in default_mm_loras.items()
+        ]
+        if args.lora_modules is None:
+            lora_modules = default_mm_lora_paths
+        else:
+            lora_modules += default_mm_lora_paths
+
     state.openai_serving_models = OpenAIServingModels(
         engine_client=engine_client,
         model_config=model_config,
         base_model_paths=base_model_paths,
-        lora_modules=args.lora_modules,
+        lora_modules=lora_modules,
         prompt_adapters=args.prompt_adapters,
     )
     await state.openai_serving_models.init_static_loras()

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -153,7 +153,8 @@ class OpenAIServingChat(OpenAIServing):
             (
                 lora_request,
                 prompt_adapter_request,
-            ) = self._maybe_get_adapters(request)
+            ) = self._maybe_get_adapters(request,
+                                         supports_default_mm_loras=True)
 
             model_name = self._get_model_name(request.model, lora_request)
 

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -458,24 +458,46 @@ class OpenAIServing:
             err_type="NotFoundError",
             status_code=HTTPStatus.NOT_FOUND)
 
-    def _maybe_get_adapters(
-        self, request: AnyRequest
-    ) -> Union[tuple[None, None], tuple[LoRARequest, None], tuple[
-            None, PromptAdapterRequest]]:
-        # NOTE - we check the lora adapters prior to checking if the model is
-        # directly supported in case we have multimodal loras active by default
-        # that are initialized in our static loras.
-        message_types = self._get_message_types(request.messages)
+    def _get_active_default_mm_loras(
+            self, request: AnyRequest) -> Optional[LoRARequest]:
+        """Determine if there are any active default multimodal loras."""
+        # TODO: Currently this is only enabled for chat completions
+        # to be better aligned with only being enabled for .generate
+        # when run offline. It would be nice to support additional
+        # tasks types in the future.
+        message_types = self._get_message_types(request)
+        default_mm_loras = set()
 
         for lora in self.models.lora_requests.values():
-            if request.model == lora.lora_name:
-                return lora, None
             # Best effort match for default multimodal lora adapters;
             # There is probably a better way to do this, but currently
             # this matches against the set of 'types' in any content lists
             # up until '_', e.g., to match audio_url -> audio
             if lora.lora_name in message_types:
+                default_mm_loras.add(lora)
+
+        # Currently only support default modality specific loras if
+        # we have exactly one lora matched on the request.
+        if len(default_mm_loras) == 1:
+            return default_mm_loras.pop()
+
+    def _maybe_get_adapters(
+        self,
+        request: AnyRequest,
+        supports_default_mm_loras: bool = False,
+    ) -> Union[tuple[None, None], tuple[LoRARequest, None], tuple[
+            None, PromptAdapterRequest]]:
+
+        for lora in self.models.lora_requests:
+            if request.model == lora.lora_name:
                 return lora, None
+
+        # Currently only support default modality specific loras
+        # if we have exactly one lora matched on the request.
+        if supports_default_mm_loras:
+            default_mm_lora = self._get_active_default_mm_loras(request)
+            if default_mm_lora is not None:
+                return default_mm_lora, None
 
         if self._is_model_supported(request.model):
             return None, None
@@ -486,13 +508,17 @@ class OpenAIServing:
         # if _check_model has been called earlier, this will be unreachable
         raise ValueError(f"The model `{request.model}` does not exist.")
 
-    def get_message_types(self, messages: AnyRequest) -> set[str]:
-        """Retrieve the set of types up from content dicts up until `_`;
-        we use this to match potential multimodal data with default per
-        modality loras.
+    def _get_message_types(self, request: AnyRequest) -> set[str]:
+        """Retrieve the set of types from message content dicts up
+        until `_`; we use this to match potential multimodal data
+        with default per modality loras.
         """
         message_types = set()
-        for message in messages:
+
+        if not hasattr(request, "messages"):
+            return message_types
+
+        for message in request.messages:
             if (isinstance(message, dict) and "content" in message
                     and isinstance(message["content"], list)):
                 for content_dict in message["content"]:

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -480,6 +480,7 @@ class OpenAIServing:
         # we have exactly one lora matched on the request.
         if len(default_mm_loras) == 1:
             return default_mm_loras.pop()
+        return None
 
     def _maybe_get_adapters(
         self,
@@ -513,7 +514,7 @@ class OpenAIServing:
         until `_`; we use this to match potential multimodal data
         with default per modality loras.
         """
-        message_types = set()
+        message_types: set[str] = set()
 
         if not hasattr(request, "messages"):
             return message_types

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -489,9 +489,8 @@ class OpenAIServing:
     ) -> Union[tuple[None, None], tuple[LoRARequest, None], tuple[
             None, PromptAdapterRequest]]:
 
-        for lora in self.models.lora_requests:
-            if request.model == lora.lora_name:
-                return lora, None
+        if request.model in self.models.lora_requests:
+            return self.models.lora_requests[request.model], None
 
         # Currently only support default modality specific loras
         # if we have exactly one lora matched on the request.

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -462,15 +462,43 @@ class OpenAIServing:
         self, request: AnyRequest
     ) -> Union[tuple[None, None], tuple[LoRARequest, None], tuple[
             None, PromptAdapterRequest]]:
+        # NOTE - we check the lora adapters prior to checking if the model is
+        # directly supported in case we have multimodal loras active by default
+        # that are initialized in our static loras.
+        message_types = self._get_message_types(request.messages)
+
+        for lora in self.models.lora_requests.values():
+            if request.model == lora.lora_name:
+                return lora, None
+            # Best effort match for default multimodal lora adapters;
+            # There is probably a better way to do this, but currently
+            # this matches against the set of 'types' in any content lists
+            # up until '_', e.g., to match audio_url -> audio
+            if lora.lora_name in message_types:
+                return lora, None
+
         if self._is_model_supported(request.model):
             return None, None
-        if request.model in self.models.lora_requests:
-            return self.models.lora_requests[request.model], None
+
         for prompt_adapter in self.models.prompt_adapter_requests:
             if request.model == prompt_adapter.prompt_adapter_name:
                 return None, prompt_adapter
         # if _check_model has been called earlier, this will be unreachable
         raise ValueError(f"The model `{request.model}` does not exist.")
+
+    def get_message_types(self, messages: AnyRequest) -> set[str]:
+        """Retrieve the set of types up from content dicts up until `_`;
+        we use this to match potential multimodal data with default per
+        modality loras.
+        """
+        message_types = set()
+        for message in messages:
+            if (isinstance(message, dict) and "content" in message
+                    and isinstance(message["content"], list)):
+                for content_dict in message["content"]:
+                    if "type" in content_dict:
+                        message_types.add(content_dict["type"].split("_")[0])
+        return message_types
 
     async def _normalize_prompt_text_to_input(
         self,


### PR DESCRIPTION
## Purpose
Fixes https://github.com/vllm-project/vllm/issues/16994

This PR adds support for default modality specific Lora adapters - this is useful for models like granite speech and phi4mm, where it's bundled with its own LoRA, but currently needs the user to remember to pass the `LoRARequest` with every offline call containing audio, or send the request to the LoRA model name when running online.

Note that generally this should be applicable for most request types that can take LoRAs, but the initial implementation only adds it for `.generate` for offline and `chat_completions` for online.

## Test Plan

```python
from transformers import AutoTokenizer
from vllm import LLM, SamplingParams
from vllm.assets.audio import AudioAsset

model_id = "ibm-granite/granite-speech-3.3-2b"
tokenizer = AutoTokenizer.from_pretrained(model_id)

def get_prompt(question: str, has_audio: bool):
    """Build the input prompt to send to vLLM."""
    if has_audio:
        question = f"<|audio|>{question}"
    chat = [
        {
            "role": "user",
            "content": question
        }
    ]
    return tokenizer.apply_chat_template(chat, tokenize=False)


model = LLM(
    model=model_id,
    enable_lora=True,
    max_lora_rank=64,
    max_model_len=2048,
    limit_mm_per_prompt={"audio": 1},
    # Will always pass a `LoRARequest` with the `model_id`
    # whenever audio is contained in the request data.
    default_mm_loras = {"audio": model_id},
    enforce_eager=True,
)

question = "can you transcribe the speech into a written format?"
prompt_with_audio = get_prompt(
    question=question,
    has_audio=True,
)
audio = AudioAsset("mary_had_lamb").audio_and_sample_rate

inputs = {
    "prompt": prompt_with_audio,
    "multi_modal_data": {
        "audio": audio,
    }
}

outputs = model.generate(
    inputs,
    sampling_params=SamplingParams(
        temperature=0.2,
        max_tokens=64,
    ),
)

print(f"Audio Example - Question: {question}")
for output in outputs:
    print("------")
    print(output.outputs[0].text)
```

In the case of the server, you can pass the mapping from the command line as a JSON object.
```bash
vllm serve ibm-granite/granite-speech-3.3-2b \
    --max-model-len 2048 \
    --enable-lora \
    --default_mm_loras '{"audio":"ibm-granite/granite-speech-3.3-2b"}' \
    --max-lora-rank 64
```

## Test Result
Running the audio example correctly applies the lora and produces a transcription.

CC @jeejeelee @DarkLight1337 

<!--- pyml disable-next-line no-emphasis-as-heading -->
