### PR TITLE
[BugFix][FlashInfer] Fix attention backend interface mismatch with unexpected keyword `use_irope`

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -48,7 +48,6 @@ class Attention(nn.Module):
         blocksparse_params: Optional[Dict[str, Any]] = None,
         logits_soft_cap: Optional[float] = None,
         per_layer_sliding_window: Optional[int] = None,
-        use_irope: bool = False,
         use_mla: bool = False,
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
@@ -101,7 +100,6 @@ class Attention(nn.Module):
         self._k_scale_float = 1.0
         self._v_scale_float = 1.0
 
-        self.use_irope = use_irope
         self.use_mla = use_mla
         self.num_heads = num_heads
         self.head_size = head_size

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -48,6 +48,7 @@ class Attention(nn.Module):
         blocksparse_params: Optional[Dict[str, Any]] = None,
         logits_soft_cap: Optional[float] = None,
         per_layer_sliding_window: Optional[int] = None,
+        use_irope: bool = False,
         use_mla: bool = False,
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
@@ -100,6 +101,7 @@ class Attention(nn.Module):
         self._k_scale_float = 1.0
         self._v_scale_float = 1.0
 
+        self.use_irope = use_irope
         self.use_mla = use_mla
         self.num_heads = num_heads
         self.head_size = head_size

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -510,6 +510,10 @@ class FlashInferImpl(AttentionImpl):
         kv_sharing_target_layer_name: Optional[int] = None,
         use_irope: bool = False,
     ) -> None:
+        if use_irope:
+            logger.warning_once(
+                "Using irope in FlashInfer is not supported yet, it will fall"
+                " back to global attention for long context.")
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
@@ -524,7 +528,6 @@ class FlashInferImpl(AttentionImpl):
         self.kv_cache_dtype = kv_cache_dtype
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
-        self.use_irope = use_irope
 
         assert self.num_heads % self.num_kv_heads == 0
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -508,6 +508,7 @@ class FlashInferImpl(AttentionImpl):
         logits_soft_cap: Optional[float] = None,
         attn_type: AttentionType = AttentionType.DECODER,
         kv_sharing_target_layer_name: Optional[int] = None,
+        use_irope: bool = False,
     ) -> None:
         self.num_heads = num_heads
         self.head_size = head_size
@@ -523,6 +524,7 @@ class FlashInferImpl(AttentionImpl):
         self.kv_cache_dtype = kv_cache_dtype
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+        self.use_irope = use_irope
 
         assert self.num_heads % self.num_kv_heads == 0
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
Fix the interface mismatch for FlashInfer attention backend for `use_irope`.

Error:

```
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]   File "/home/guorachel/venv/vllm/vllm/model_executor/models/llama4.py", line 262, in __init__
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]     self.self_attn = Llama4Attention(
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]                      ^^^^^^^^^^^^^^^^
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]   File "/home/guorachel/venv/vllm/vllm/model_executor/models/llama4.py", line 195, in __init__
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]     self.attn = Attention(
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]                 ^^^^^^^^^^
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]   File "/home/guorachel/venv/vllm/vllm/attention/layer.py", line 134, in __init__
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]     self.impl = impl_cls(num_heads, head_size, scale, num_kv_heads,
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=5 pid=2407942) ERROR 06-03 14:44:28 [multiproc_executor.py:486] TypeError: FlashInferImpl.__init__() got an unexpected keyword argument 'use_irope'
```

## Test Plan

```
VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER vllm serve meta-llama/Llama-4-Scout-17B-16E-Instruct --disable-log-requests -tp 8 --max-num-seqs 64 --no-enable-prefix-caching --max_num_batched_tokens=81920 --max-model-len=32768
```

Accuracy eval:

```
FLASHINFER_ENABLE_AOT=1 VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER lm_eval --model vllm --model_args "pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=8,max_model_len=32768" --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto
```


Flashinfer on H100 (with this diff:)

FlashInfer:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9196|±  |0.0075|
|     |       |strict-match    |     5|exact_match|↑  |0.9052|±  |0.0081|

Flashinfer on B200 (with this diff:)

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9219|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9037|±  |0.0081|


## Test Result

After this interface fix, the server command starts successfully.

<!--- pyml disable-next-line no-emphasis-as-heading -->
