### PR TITLE
[Misc] Remove unnecessary fallback to prefill-decode attention

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -171,10 +171,7 @@ class TritonAttentionImpl(AttentionImpl):
         # Whenever making a change in this method, please benchmark the
         # performance to make sure it does not introduce any overhead.
 
-        num_queries_per_kv = query.shape[1] // key.shape[1]
-        num_q_is_pow2 = (num_queries_per_kv & (num_queries_per_kv - 1)) == 0
-        use_prefill_decode_attn = (self.force_prefill_decode_attn
-                                   or not num_q_is_pow2)
+        use_prefill_decode_attn = self.force_prefill_decode_attn
         num_actual_tokens = attn_metadata.num_actual_tokens
 
         if use_prefill_decode_attn:


### PR DESCRIPTION
## Purpose
This PR removes an unnecessary fallback to prefill-decode attention in `vllm/v1/attention/backends/triton_attn.py`. The code currently falls back to prefill-decode attention if the number of queries per key and value is of power 2. This was introduced in #18093 to overcome an issue with unified attention. However,  after the fix in #18100, this condition is not needed anymore.
## Test Plan
Run lm_eval with and without prefill-decode attention using the following commands:
1. With prefill-decode attention
```bash
VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 \
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1\
vllm serve Qwen/Qwen2-7B \
--port 19999 \
--host 0.0.0.0 \
--gpu-memory-utilization 0.90 \
--max-model-len 32768 \
```
2. Without prefill-decode attention
```bash
VLLM_V1_USE_PREFILL_DECODE_ATTENTION=0 \
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1\
vllm serve Qwen/Qwen2-7B \
--port 19999 \
--host 0.0.0.0 \
--gpu-memory-utilization 0.90 \
--max-model-len 32768 \
```

lm_eval

```bash
lm_eval   \
--model local-completions \
--model_args model=Qwen/Qwen2-7B,base_url=http://localhost:19999/v1/completions \
--batch_size auto \
--tasks gsm8k \
--num_fewshot 5 \
--batch_size auto
```

## Test Result
Lm_eval with prefill-decode attention:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7832|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7801|±  |0.0114|

lm_eval without prefill-decode attention:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7786|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7771|±  |0.0115|


