### PR TITLE
[Build] Add Benchmark dependencies to requirements/common.txt

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,3 +48,5 @@ opentelemetry-sdk>=1.26.0  # vllm.tracing
 opentelemetry-api>=1.26.0  # vllm.tracing
 opentelemetry-exporter-otlp>=1.26.0  # vllm.tracing
 opentelemetry-semantic-conventions-ai>=0.4.1  # vllm.tracing
+pandas  # needed for benchmarks module
+datasets  # needed for benchmarks module


### PR DESCRIPTION
## Summary
- add pandas and datasets to common requirements for benchmark support otherwise a clean install will fail

------
https://chatgpt.com/codex/tasks/task_e_68404dbc92f4832985a94abfa89e8fe9