### PR TITLE
[Frontend] Add prompt/generation token throughput gauge to PrometheusStatLogger

### DIFF
--- a/docs/design/v1/metrics.md
+++ b/docs/design/v1/metrics.md
@@ -30,6 +30,8 @@ In v0, the following metrics are exposed via a Prometheus-compatible `/metrics` 
 - `vllm:cpu_prefix_cache_hit_rate` (Gauge)
 - `vllm:prompt_tokens_total` (Counter)
 - `vllm:generation_tokens_total` (Counter)
+- `vllm:prompt_throughput_toks_per_s` (Gauge)
+- `vllm:generation_throughput_toks_per_s` (Gauge)
 - `vllm:request_success_total` (Counter)
 - `vllm:request_prompt_tokens` (Histogram)
 - `vllm:request_generation_tokens` (Histogram)

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -223,6 +223,22 @@ class Metrics:
             documentation="Number of emitted tokens.",
             labelnames=labelnames))
 
+        # Latest token throughput stats
+        self.gauge_prompt_throughput_toks_per_s = self._gauge_cls(
+            name="vllm:prompt_throughput_toks_per_s",
+            documentation=(
+                "Number of prompt tokens processed per second over the "
+                "logging interval."),
+            labelnames=labelnames,
+            multiprocess_mode="sum")
+        self.gauge_generation_throughput_toks_per_s = self._gauge_cls(
+            name="vllm:generation_throughput_toks_per_s",
+            documentation=(
+                "Number of generation tokens processed per second over "
+                "the logging interval."),
+            labelnames=labelnames,
+            multiprocess_mode="sum")
+
 
 # --8<-- [end:metrics-definitions]
 
@@ -600,6 +616,17 @@ class PrometheusStatLogger(StatLoggerBase):
                 self._log_counter(
                     self.metrics.counter_spec_decode_num_emitted_tokens,
                     self.spec_decode_metrics.emitted_tokens)
+
+            self._log_gauge(
+                self.metrics.gauge_prompt_throughput_toks_per_s,
+                get_throughput(self.num_prompt_tokens,
+                               now=stats.now,
+                               last_log=self.last_local_log))
+            self._log_gauge(
+                self.metrics.gauge_generation_throughput_toks_per_s,
+                get_throughput(self.num_generation_tokens,
+                               now=stats.now,
+                               last_log=self.last_local_log))
 
             # Reset tracked stats for next interval.
             self.num_prompt_tokens = []


### PR DESCRIPTION
## Purpose
Adds prompt/generation tokens throughput metrics in `PrometheusStatLogger._log_prometheus()`, just like `LoggingStatLoger.log()` do, to expose tokens throughput in `/metrics` endpoint.

FIX https://github.com/vllm-project/vllm/issues/19119, the purpose of work is effectively copied from there

## Test Plan

New test case ran with:
`pytest tests/metrics/test_metrics.py::test_metric_throughput_gauges`