### PR TITLE
[V1][TPU] Fix TPU kv sharing tests

### DIFF
--- a/tests/v1/tpu/worker/test_tpu_model_runner.py
+++ b/tests/v1/tpu/worker/test_tpu_model_runner.py
@@ -379,7 +379,6 @@ def test_get_req_paddings():
     assert _get_req_paddings(8, 36) == [8, 16, 32, 36]
 
 
-@pytest.mark.skip(reason="Test is broken on TPU when it's added.")
 def test_init_kv_cache_with_kv_sharing_invalid_target_layer_order(
         model_runner):
     layer_0 = "model.layers.0.self_attn.attn"
@@ -411,7 +410,6 @@ def test_init_kv_cache_with_kv_sharing_invalid_target_layer_order(
         assert fwd_context is not None
 
 
-@pytest.mark.skip(reason="Test is broken on TPU when it's added.")
 def test_init_kv_cache_with_kv_sharing_target_layer_not_exist(model_runner):
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
@@ -442,7 +440,6 @@ def test_init_kv_cache_with_kv_sharing_target_layer_not_exist(model_runner):
         assert fwd_context is not None
 
 
-@pytest.mark.skip(reason="Test is broken on TPU when it's added.")
 def test_init_kv_cache_with_kv_sharing_target_same_as_current(model_runner):
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
@@ -473,7 +470,6 @@ def test_init_kv_cache_with_kv_sharing_target_same_as_current(model_runner):
         assert fwd_context is not None
 
 
-@pytest.mark.skip(reason="Test is broken on TPU when it's added.")
 def test_init_kv_cache_without_kv_sharing():
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
@@ -541,7 +537,6 @@ def test_init_kv_cache_without_kv_sharing():
     assert kv_cache_config.kv_cache_groups[0].layer_names[1] == layer_1
 
 
-@pytest.mark.skip(reason="Test is broken on TPU when it's added.")
 def test_init_kv_cache_with_kv_sharing_valid():
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"

--- a/tests/v1/tpu/worker/test_tpu_model_runner.py
+++ b/tests/v1/tpu/worker/test_tpu_model_runner.py
@@ -31,6 +31,7 @@ pallas_attention_backend_patcher = mock.patch(
     "vllm.v1.worker.tpu_model_runner.PallasAttentionBackend", )
 pallas_attention_backend_patcher.start()
 
+
 def get_vllm_config():
     scheduler_config = SchedulerConfig(
         max_num_seqs=10,
@@ -57,6 +58,8 @@ def get_vllm_config():
         cache_config=cache_config,
         scheduler_config=scheduler_config,
     )
+    return vllm_config
+
 
 def get_model_runner(vllm_config):
     device = "xla:0"  # Mocking TPU device
@@ -64,6 +67,7 @@ def get_model_runner(vllm_config):
          mock.patch("vllm.v1.worker.tpu_model_runner.xm"), \
          mock.patch("vllm.v1.worker.tpu_model_runner.xr"):
         return TPUModelRunner(vllm_config, device)
+
 
 @pytest.fixture
 def model_runner():


### PR DESCRIPTION
fixes TPU tests failures caused by https://github.com/vllm-project/vllm/pull/18212 (soft failures, so it shows up green in CI). note these are currently skipped in CI 

Key differences with GPU runner: 
- pallas attention expects head size to be divisible by 128
- it also makes block size 128 in the test