### PR TITLE
Create initial AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# vllm-project/vllm Overview
+
+This document provides a high-level overview of the vLLM repository structure for new contributors working on the codebase.
+Given the rapid development of the codebase, this document focuses on aspects that are less likely to change frequently.
+
+## Core Directories
+
+- `vllm/`: The main Python package for vLLM. This is where the core inference engine, model implementations, and utilities reside. Key subdirectories:
+    - `attention/`: Attention mechanism implementations
+    - `compilation/`: Manages `torch.compile` integration and custom fusion
+    - `distributed/`: Multi-device/node distribution logic
+    - `engine/`: Core inference engine (`LLMEngine`, `AsyncLLMEngine`)
+    - `entrypoints/`: API interfaces (CLI, OpenAI API, `LLM` class for offline inference)
+    - `executor/`: Responsible for executing the model on one device, or it can be a distributed executor that can execute the model on multiple devices
+    - `lora/`: Multi-LoRA batching support
+    - `model_executor/`: Model definitions (`models/`), weight loading (`model_loader/`), and layer definitions (`layers/`)
+    - `multimodal/`: Image/video/audio-language model support
+    - `platforms/`: Hardware-specific utilities
+    - `worker/`: Hardware-specific execution classes (`ModelRunner`, `Worker`)
+
+- `csrc/`: Contains C++/CUDA source code compiled for performance-critical kernels and operations. Most compilation is specified in `CMakeLists.txt` Important subdirectories:
+    - `attention/`: Attention operations
+    - `core/`: Core utilities
+    - `cpu/`: CPU-specific kernels
+    - `mamba/`: Kernels for state-space models
+    - `moe/`: Mixture of Experts operations
+    - `quantization/`: Quantization kernels
+    - `rocm/`: ROCm-specific kernels
+    - `torch_bindings.cpp` and `ops.h` are where compiled operations are registered to PyTorch
+
+- `docker/`: Dockerfiles for building vLLM wheels and containers. Used for CI and release.
+
+- `docs/`: Project documentation, including API references, tutorials, and design documents.
+
+- `tests/`: Pytest-based test suite organized by component. Execution of most CI tests are defined in `.buildkite/test-pipeline.yaml`


### PR DESCRIPTION
## Purpose

As more LLM agents are being used to develop vLLM (Copilot, Gemini Code Assist, Codex) I thought it would be interesting to start working on an LLM-specific guide for development. There isn't a standard yet - Codex uses `AGENTS.md`, Claude Code uses `CLAUDE.md`, Cursor uses `.cursor/rules` - but `AGENTS.md` sounds like the most neutral general starting point to me.

This PR is my idea to keep it simple and structural at first, but consider this PR fully open to your contribution and feel free to suggest changes.

For context here is the snippet from the [Codex blog](https://openai.com/index/introducing-codex/): 
> Codex can be guided by AGENTS.md files placed within your repository. These are text files, akin to README.md, where you can inform Codex how to navigate your codebase, which commands to run for testing, and how best to adhere to your project's standard practices. Like human developers, Codex agents perform best when provided with configured dev environments, reliable testing setups, and clear documentation. 

