### PR TITLE
[Build] Annotate wheel and container path for release workflow

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -56,7 +56,11 @@ steps:
       - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT"
 
   - label: "Annotate release workflow"
-    depends_on: build-release-image, build-wheel-cuda-12-8, build-wheel-cuda-12-6, build-wheel-cuda-11-8, input-release-version
+    depends_on:
+      - build-release-image
+      - build-wheel-cuda-12-8
+      - build-wheel-cuda-12-6
+      - build-wheel-cuda-11-8
     id: annotate-release-workflow
     agents:
       queue: cpu_queue_postmerge
@@ -85,7 +89,7 @@ steps:
     id: input-release-version
     fields:
       - text: "What is the release version?"
-        key: "release-version"
+        key: release-version
 
   - block: "Build CPU release image"
     key: block-cpu-release-image-build

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -1,6 +1,6 @@
 steps:
   - label: "Build wheel - CUDA 12.8"
-    id: build-wheel-cuda-12.8
+    id: build-wheel-cuda-12-8
     agents:
       queue: cpu_queue_postmerge
     commands:
@@ -12,7 +12,7 @@ steps:
       DOCKER_BUILDKIT: "1"
 
   - label: "Build wheel - CUDA 12.6"
-    id: build-wheel-cuda-12.6
+    id: build-wheel-cuda-12-6
     agents:
       queue: cpu_queue_postmerge
     commands:
@@ -30,7 +30,7 @@ steps:
 
   - label: "Build wheel - CUDA 11.8"
     # depends_on: block-build-cu118-wheel
-    id: build-wheel-cuda-11.8
+    id: build-wheel-cuda-11-8
     agents:
       queue: cpu_queue_postmerge
     commands:
@@ -56,7 +56,7 @@ steps:
       - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT"
 
   - label: "Annotate release workflow"
-    depends_on: build-release-image, build-wheel-cuda-12.8, build-wheel-cuda-12.6, build-wheel-cuda-11.8, input-release-version
+    depends_on: build-release-image, build-wheel-cuda-12-8, build-wheel-cuda-12-6, build-wheel-cuda-11-8, input-release-version
     id: annotate-release-workflow
     agents:
       queue: cpu_queue_postmerge

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -1,5 +1,6 @@
 steps:
   - label: "Build wheel - CUDA 12.8"
+    id: build-wheel-cuda-12.8
     agents:
       queue: cpu_queue_postmerge
     commands:
@@ -11,6 +12,7 @@ steps:
       DOCKER_BUILDKIT: "1"
 
   - label: "Build wheel - CUDA 12.6"
+    id: build-wheel-cuda-12.6
     agents:
       queue: cpu_queue_postmerge
     commands:
@@ -28,6 +30,7 @@ steps:
 
   - label: "Build wheel - CUDA 11.8"
     # depends_on: block-build-cu118-wheel
+    id: build-wheel-cuda-11.8
     agents:
       queue: cpu_queue_postmerge
     commands:
@@ -44,12 +47,21 @@ steps:
 
   - label: "Build release image"
     depends_on: block-release-image-build
+    id: build-release-image
     agents:
       queue: cpu_queue_postmerge
     commands:
       - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
       - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.8.1 --tag public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT --target vllm-openai --progress plain -f docker/Dockerfile ."
       - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT"
+
+  - label: "Annotate release workflow"
+    depends_on: build-release-image, build-wheel-cuda-12.8, build-wheel-cuda-12.6, build-wheel-cuda-11.8, input-release-version
+    id: annotate-release-workflow
+    agents:
+      queue: cpu_queue_postmerge
+    commands:
+      - "bash .buildkite/scripts/annotate-release.sh"
 
   - label: "Build and publish TPU release image"
     depends_on: ~
@@ -70,6 +82,7 @@ steps:
       DOCKER_BUILDKIT: "1"
 
   - input: "Provide Release version here"
+    id: input-release-version
     fields:
       - text: "What is the release version?"
         key: "release-version"

--- a/.buildkite/scripts/annotate-release.sh
+++ b/.buildkite/scripts/annotate-release.sh
@@ -10,23 +10,22 @@ if [ -z "$RELEASE_VERSION" ]; then
   exit 1
 fi
 
-# Create the annotation using a here document
 buildkite-agent annotate --style 'info' --context 'release-workflow' << EOF
 To download the wheel:
-```
+\`\`\`
 aws s3 cp s3://vllm-wheels/${RELEASE_VERSION}/vllm-${RELEASE_VERSION}-cp38-abi3-manylinux1_x86_64.whl .
 aws s3 cp s3://vllm-wheels/${RELEASE_VERSION}+cu126/vllm-${RELEASE_VERSION}+cu126-cp38-abi3-manylinux1_x86_64.whl .
 aws s3 cp s3://vllm-wheels/${RELEASE_VERSION}+cu118/vllm-${RELEASE_VERSION}+cu118-cp38-abi3-manylinux1_x86_64.whl . 
-```
+\`\`\`
 
 To download and upload the image:
 
-```
+\`\`\`
 docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${BUILDKITE_COMMIT}
 docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${BUILDKITE_COMMIT} vllm/vllm-openai
 docker tag vllm/vllm-openai vllm/vllm-openai:latest
 docker tag vllm/vllm-openai vllm/vllm-openai:v${RELEASE_VERSION}
 docker push vllm/vllm-openai:latest
 docker push vllm/vllm-openai:v${RELEASE_VERSION}
-```
+\`\`\`
 EOF 

--- a/.buildkite/scripts/annotate-release.sh
+++ b/.buildkite/scripts/annotate-release.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+# Get release version and strip leading 'v' if present
+RELEASE_VERSION=$(buildkite-agent meta-data get release-version | sed 's/^v//')
+
+# Create the annotation using a here document
+buildkite-agent annotate --style 'info' --context 'release-workflow' << EOF
+To download the wheel:
+```
+aws s3 cp s3://vllm-wheels/${RELEASE_VERSION}/vllm-${RELEASE_VERSION}-cp38-abi3-manylinux1_x86_64.whl .
+aws s3 cp s3://vllm-wheels/${RELEASE_VERSION}+cu126/vllm-${RELEASE_VERSION}+cu126-cp38-abi3-manylinux1_x86_64.whl .
+aws s3 cp s3://vllm-wheels/${RELEASE_VERSION}+cu118/vllm-${RELEASE_VERSION}+cu118-cp38-abi3-manylinux1_x86_64.whl . 
+```
+
+To download and upload the image:
+
+```
+docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${BUILDKITE_COMMIT}
+docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${BUILDKITE_COMMIT} vllm/vllm-openai
+docker tag vllm/vllm-openai vllm/vllm-openai:latest
+docker tag vllm/vllm-openai vllm/vllm-openai:v${RELEASE_VERSION}
+docker push vllm/vllm-openai:latest
+docker push vllm/vllm-openai:v${RELEASE_VERSION}
+```
+EOF 

--- a/.buildkite/scripts/annotate-release.sh
+++ b/.buildkite/scripts/annotate-release.sh
@@ -5,6 +5,11 @@ set -ex
 # Get release version and strip leading 'v' if present
 RELEASE_VERSION=$(buildkite-agent meta-data get release-version | sed 's/^v//')
 
+if [ -z "$RELEASE_VERSION" ]; then
+  echo "Error: RELEASE_VERSION is empty. 'release-version' metadata might not be set or is invalid."
+  exit 1
+fi
+
 # Create the annotation using a here document
 buildkite-agent annotate --style 'info' --context 'release-workflow' << EOF
 To download the wheel:


### PR DESCRIPTION
Add a new step to show information like the following on build page:

<img width="967" alt="image" src="https://github.com/user-attachments/assets/d175ff2f-e3b0-41e1-bc23-5cbfef8a266d" />


To download the wheel:
```
aws s3 cp s3://vllm-wheels/0.9.0.1/vllm-0.9.0.1-cp38-abi3-manylinux1_x86_64.whl .
aws s3 cp s3://vllm-wheels/0.9.0.1+cu126/vllm-0.9.0.1+cu126-cp38-abi3-manylinux1_x86_64.whl .
aws s3 cp s3://vllm-wheels/0.9.0.1+cu118/vllm-0.9.0.1+cu118-cp38-abi3-manylinux1_x86_64.whl . 
```

To download and upload the image:

```
docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:5fbbfe9a4c13094ad72ed3d6b4ef208a7ddc0fd7
docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:5fbbfe9a4c13094ad72ed3d6b4ef208a7ddc0fd7 vllm/vllm-openai
docker tag vllm/vllm-openai vllm/vllm-openai:latest
docker tag vllm/vllm-openai vllm/vllm-openai:v0.9.0.1
docker push vllm/vllm-openai:latest
docker push vllm/vllm-openai:v0.9.0.1
```
