### PR TITLE
[custom_op][vllm-plugin] update custom_op class to use op_registry

### DIFF
--- a/tests/plugins/vllm_add_dummy_platform/setup.py
+++ b/tests/plugins/vllm_add_dummy_platform/setup.py
@@ -10,5 +10,7 @@ setup(
     entry_points={
         'vllm.platform_plugins': [
             "dummy_platform_plugin = vllm_add_dummy_platform:dummy_platform_plugin"  # noqa
-        ]
+        ],
+        "vllm.general_plugins":
+        ["dummy_custom_ops = vllm_add_dummy_platform:register_ops"],
     })

--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/__init__.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/__init__.py
@@ -6,3 +6,7 @@ from typing import Optional
 
 def dummy_platform_plugin() -> Optional[str]:
     return "vllm_add_dummy_platform.dummy_platform.DummyPlatform"
+
+
+def register_ops():
+    import vllm_add_dummy_platform.dummy_custom_ops  # noqa

--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_attention_backend.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_attention_backend.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from vllm.attention.backends.flash_attn import FlashAttentionBackend
+from vllm.attention.backends.placeholder_attn import (
+    PlaceholderAttentionBackend)
 
 
-class DummyAttentionBackend(FlashAttentionBackend):
+class DummyAttentionBackend(PlaceholderAttentionBackend):
 
     @staticmethod
     def get_name() -> str:

--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_custom_ops.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_custom_ops.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Optional
+
+import torch
+
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+
+
+@CustomOp.register("RotaryEmbedding", is_oot_custom_op=True)
+class DummyRotaryEmbedding(RotaryEmbedding):
+    """Original rotary positional embedding."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.addition_config = True
+
+    def forward_oot(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        offsets: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return super().forward_oot(positions, query, key, offsets)

--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_custom_ops.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_custom_ops.py
@@ -4,11 +4,16 @@ from typing import Optional
 
 import torch
 
-from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 
 
-@CustomOp.register("RotaryEmbedding", is_oot_custom_op=True)
+# Register CustomRotaryEmbedding to CustomOP.
+# Using either way as below works
+# Example 1:
+# - @CustomOp.register_oot("RotaryEmbedding")
+# Example 2:
+# - @RotaryEmbedding.register_oot()
+@RotaryEmbedding.register_oot()
 class DummyRotaryEmbedding(RotaryEmbedding):
     """Original rotary positional embedding."""
 

--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_custom_ops.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_custom_ops.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Optional
 
 import torch
 
@@ -8,12 +7,7 @@ from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 
 
 # Register CustomRotaryEmbedding to CustomOP.
-# Using either way as below works
-# Example 1:
-# - @CustomOp.register_oot("RotaryEmbedding")
-# Example 2:
-# - @RotaryEmbedding.register_oot()
-@RotaryEmbedding.register_oot()
+@RotaryEmbedding.register_oot
 class DummyRotaryEmbedding(RotaryEmbedding):
     """Original rotary positional embedding."""
 
@@ -21,11 +15,6 @@ class DummyRotaryEmbedding(RotaryEmbedding):
         super().__init__(*args, **kwargs)
         self.addition_config = True
 
-    def forward_oot(
-        self,
-        positions: torch.Tensor,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        offsets: Optional[torch.Tensor] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        return super().forward_oot(positions, query, key, offsets)
+    def forward_oot(self, *args,
+                    **kwargs) -> tuple[torch.Tensor, torch.Tensor]:
+        return super().forward_oot(*args, **kwargs)

--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_platform.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_platform.py
@@ -1,11 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import TYPE_CHECKING
 
-from vllm.platforms.cuda import CudaPlatform
+from vllm.platforms.interface import Platform, PlatformEnum
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+else:
+    VllmConfig = None
+from vllm import envs
 
 
-class DummyPlatform(CudaPlatform):
+class DummyPlatform(Platform):
+    _enum = PlatformEnum.OOT
     device_name = "DummyDevice"
+    device_type: str = "privateuseone"
+    dispatch_key: str = "PrivateUse1"
+
+    @classmethod
+    def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        if envs.VLLM_USE_V1:
+            compilation_config = vllm_config.compilation_config
+            # Activate custom ops for v1.
+            compilation_config.custom_ops = ["all"]
 
     def get_attn_backend_cls(self, backend_name, head_size, dtype,
                              kv_cache_dtype, block_size, use_v1, use_mla):

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -18,7 +18,7 @@ class CustomOp(nn.Module):
 
     def __new__(cls, *args, **kwargs):
         try:
-            op_name = cls.name
+            op_name = cls.__name__
         except AttributeError:
             raise TypeError(
                 f"Cannot instantiate '{cls.__name__}': its 'name' attribute "
@@ -30,6 +30,8 @@ class CustomOp(nn.Module):
             op_cls_to_instantiate = cls
         else:
             op_cls_to_instantiate = cls.op_registry_oot[op_name]
+            logger.debug("Instantiating custom op: %s using %s", op_name,
+                         str(op_cls_to_instantiate))
         return super().__new__(op_cls_to_instantiate)
 
     def __init__(self):

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -159,6 +159,13 @@ class CustomOp(nn.Module):
     op_registry_oot: dict[str, type['CustomOp']] = {}
 
     # Decorator to register custom ops.
+    # For OOT custom ops:
+    #   if in-tree layer class is registered with an oot_custom_op layer,
+    #   the oot_custom_op layer will be used instead.
+    #   use `name=<In-Tree Layer class Name>` and `is_oot_custom_op=True`
+    # Examples:
+    # - @CustomOp.register("UnquantizedFusedMoEMethod", is_oot_custom_op=True)
+    # - @CustomOp.register("RMSNorm", is_oot_custom_op=True)
     @classmethod
     def register(cls, name: str, is_oot_custom_op=False):
 

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -160,10 +160,10 @@ class CustomOp(nn.Module):
 
     # Decorator to register custom ops.
     @classmethod
-    def register(cls, name: str, custom_op=False):
+    def register(cls, name: str, is_oot_custom_op=False):
 
         def decorator(op_cls):
-            if custom_op:
+            if is_oot_custom_op:
                 assert name not in cls.op_registry_oot, \
                     f"Duplicate op name: {name}"
                 op_cls.name = name

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Optional
+
 import torch.nn as nn
 
 from vllm.config import get_current_vllm_config
@@ -181,7 +183,7 @@ class CustomOp(nn.Module):
     # - @UnquantizedFusedMoEMethod.register_oot()
     #   class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod)
     @classmethod
-    def register_oot(cls, name: str = None):
+    def register_oot(cls, name: Optional[str] = None):
 
         def decorator(op_cls):
             reg_name = name if name is not None else cls.__name__


### PR DESCRIPTION
Co-Authored with @kzawora-intel 

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

POC for https://github.com/vllm-project/vllm/issues/19161

Problem:

- Existing implementation of CustomOP doesn't use op_regitry[class_name] for initialization.
- For vllm-plugin custom op, only monkey patch works for updating exiting op impl, including process_weight_after_loading, forward_oot

Solution:

- In this PR, propose to use op_regitry by init from op_regitry[class_name] instead of original one

## Test Plan

Verfied by a poc hpu plugin
```
entry_points={
        "vllm.platform_plugins": ["hpu = vllm_hpu:register"],
        "vllm.general_plugins": ["hpu_custom_ops = vllm_hpu:register_ops"],
    },
```

``` vllm_hpu.__init__.py
def register_ops():
    """Register custom ops for the HPU platform."""

    from vllm_hpu.ops.hpu_fused_moe import HPUUnquantizedFusedMoEMethod # noqa: F401
```

``` hpu_fused_moe.py
from typing import Callable, Optional

import torch
from vllm.model_executor.layers.quantization.base_config import (
    QuantizationConfig)
from vllm.model_executor.layers.fused_moe.layer import \
    UnquantizedFusedMoEMethod, FusedMoE
from vllm.model_executor.custom_op import CustomOp

@UnquantizedFusedMoEMethod.register_oot
class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
    """MoE method without quantization."""

    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
        super().process_weights_after_loading(layer)
        
        # custom handling for HPU
        num_experts = layer.local_num_experts
        ep_shift = layer.ep_rank * num_experts
        quant_config = layer.quant_config
        moe_op = VllmMixtureOfExpertsOp(
                num_experts,
                experts_min,
                experts_max,
        )
        layer.moe_op = moe_op

        for expert_id in range(layer.local_num_experts):
            layer.moe_op.w13_list[expert_id].set_weight(
                layer.w13_weight.data[expert_id])
            layer.moe_op.w2_list[expert_id].set_weight(
                layer.w2_weight.data[expert_id])

    def forward_oot(
        self,
        ...
        **kwargs,
    ):
        input_shape = x.shape
        x = x.view(-1, x.shape[-1])
        topk_weights, topk_ids = FusedMoE.select_experts(
                hidden_states=x,
                router_logits=router_logits,
                use_grouped_topk=use_grouped_topk,
                top_k=top_k,
                renormalize=renormalize,
                topk_group=topk_group,
                num_expert_group=num_expert_group,
                custom_routing_function=custom_routing_function,
                scoring_func=scoring_func,
                e_score_correction_bias=e_score_correction_bias)
       
        topk_ids = topk_ids.view(*x.shape[:-1], -1)
        topk_weights = topk_weights.view(*x.shape[:-1], -1)
        
        return layer.moe_op(
            x,
            topk_ids.to(torch.int64),
            topk_weights.to(x.dtype),
            permuted_weights=True,
            activation=activation,
        ).view(*input_shape)

```

## Test Result

Verified that HPUUnquantizedFusedMoEMethod in hpu plugin is called.

```
INFO 06-05 01:12:17 [__init__.py:31] Available plugins for group vllm.platform_plugins:
INFO 06-05 01:12:17 [__init__.py:33] - hpu -> vllm_hpu:register
INFO 06-05 01:12:17 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-05 01:12:17 [__init__.py:234] Platform plugin hpu is activated
WARNING 06-05 01:12:18 [_custom_ops.py:21] Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
INFO 06-05 01:12:19 [__init__.py:31] Available plugins for group vllm.general_plugins:
INFO 06-05 01:12:19 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
INFO 06-05 01:12:19 [__init__.py:33] - **hpu_custom_ops -> vllm_hpu:register_ops**
INFO 06-05 01:12:19 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-05 01:12:27 [config.py:793] This model supports multiple tasks: {'embed', 'generate', 'classify', 'score', 'reward'}. Defaulting to 'generate'.
INFO 06-05 01:12:27 [arg_utils.py:1594] hpu is experimental on VLLM_USE_V1=1. Falling back to V0 Engine.
INFO 06-05 01:12:27 [config.py:1909] Disabled the custom all-reduce kernel because it is not supported on current platform.
INFO 06-05 01:12:27 [llm_engine.py:230] Initializing a V0 LLM engine (v0.9.1.dev172+gd459fae0a.d20250604) with config: model='Qwen3/Qwen3-30B-A3B/', 
Adding requests:   0%|          | 0/4 [00:00<?, ?it/s]
Adding requests: 100%|██████████| 4/4 [00:00<00:00, 1987.35it/s]

Processed prompts:   0%|          | 0/4 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]Configuration: ('prompt', 4, 128) was not warmed-up!
...
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
