### PR TITLE
Use w8a8 quantized matmul Pallas kernel

### DIFF
--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -18,9 +18,9 @@ setuptools==78.1.0
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.9.0.dev20250703
-torchvision==0.24.0.dev20250703
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250703-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250703-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250703-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
+torch==2.9.0.dev20250710
+torchvision==0.24.0.dev20250710
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250710-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250710-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250710-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
 

--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -18,9 +18,9 @@ setuptools==78.1.0
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.9.0.dev20250710
-torchvision==0.24.0.dev20250710
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250710-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250710-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250710-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
+torch==2.9.0.dev20250711
+torchvision==0.24.0.dev20250711
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.9.0.dev20250711-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.9.0.dev20250711-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.9.0.dev20250711-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
 

--- a/tests/tpu/test_quantization_accuracy.py
+++ b/tests/tpu/test_quantization_accuracy.py
@@ -14,7 +14,7 @@ RTOL = 0.03
 @dataclass
 class GSM8KAccuracyTestConfig:
     model_name: str
-    excepted_value: float
+    expected_value: float
 
     def get_model_args(self) -> str:
         return (f"pretrained={self.model_name},"
@@ -25,13 +25,13 @@ class GSM8KAccuracyTestConfig:
 ACCURACY_CONFIGS = [
     GSM8KAccuracyTestConfig(
         model_name="neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w8a8",
-        excepted_value=0.76),  # no bias
+        expected_value=0.76),  # no bias
     # NOTE(rob): We cannot re-initialize vLLM in the same process for TPU,
     # so only one of these tests can run in a single call to pytest. As
     # a follow up, move this into the LM-EVAL section of the CI.
     # GSM8KAccuracyTestConfig(
     #     model_name="neuralmagic/Qwen2-7B-Instruct-quantized.w8a8",
-    #     excepted_value=0.66),  # bias in QKV layers
+    #     expected_value=0.66),  # bias in QKV layers
 ]
 
 
@@ -45,7 +45,7 @@ def test_gsm8k_correctness(config: GSM8KAccuracyTestConfig):
         batch_size="auto",
     )
 
-    EXPECTED_VALUE = config.excepted_value
+    EXPECTED_VALUE = config.expected_value
     measured_value = results["results"][TASK][FILTER]
     assert (measured_value - RTOL < EXPECTED_VALUE
             and measured_value + RTOL > EXPECTED_VALUE

--- a/tests/v1/tpu/test_basic.py
+++ b/tests/v1/tpu/test_basic.py
@@ -70,6 +70,7 @@ def test_basic(
 @pytest.mark.skip(reason="Temporarily disabled due to timeout")
 @pytest.mark.skipif(not current_platform.is_tpu(),
                     reason="This is a basic test for TPU only")
+<<<<<<< HEAD
 @pytest.mark.parametrize("max_tokens", [8])
 @pytest.mark.parametrize("max_num_seqs", [16])
 def test_phi3(
@@ -90,10 +91,25 @@ def test_phi3(
     ]
     # test head dim = 96
     model = "microsoft/Phi-3-mini-128k-instruct"
+=======
+def test_w8a8_quantization(
+    vllm_runner: type[VllmRunner],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = "neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+    max_tokens = 5
+    tensor_parallel_size = 1
+    max_num_seqs = 4
+
+    prompt = "The next numbers of the sequence " + ", ".join(
+        str(i) for i in range(1024)) + " are:"
+    example_prompts = [prompt]
+>>>>>>> 2699b90f5 (add a tests that runs faster. Start using the kernel)
 
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")
 
+<<<<<<< HEAD
         with vllm_runner(model,
                          max_num_batched_tokens=256,
                          max_num_seqs=max_num_seqs) as vllm_model:
@@ -103,6 +119,20 @@ def test_phi3(
         for output, answer in zip(vllm_outputs, answers):
             generated_text = output[1]
             assert answer in generated_text
+=======
+        with vllm_runner(
+                model,
+                max_num_batched_tokens=64,
+                max_model_len=4096,
+                gpu_memory_utilization=0.7,
+                max_num_seqs=max_num_seqs,
+                tensor_parallel_size=tensor_parallel_size) as vllm_model:
+            vllm_outputs = vllm_model.generate_greedy(example_prompts,
+                                                      max_tokens)
+        output = vllm_outputs[0][1]
+
+        assert "1024" in output or "0, 1" in output
+>>>>>>> 2699b90f5 (add a tests that runs faster. Start using the kernel)
 
 
 TP_SIZE_8 = 8

--- a/tests/v1/tpu/test_basic.py
+++ b/tests/v1/tpu/test_basic.py
@@ -70,7 +70,6 @@ def test_basic(
 @pytest.mark.skip(reason="Temporarily disabled due to timeout")
 @pytest.mark.skipif(not current_platform.is_tpu(),
                     reason="This is a basic test for TPU only")
-<<<<<<< HEAD
 @pytest.mark.parametrize("max_tokens", [8])
 @pytest.mark.parametrize("max_num_seqs", [16])
 def test_phi3(
@@ -91,25 +90,10 @@ def test_phi3(
     ]
     # test head dim = 96
     model = "microsoft/Phi-3-mini-128k-instruct"
-=======
-def test_w8a8_quantization(
-    vllm_runner: type[VllmRunner],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    model = "neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
-    max_tokens = 5
-    tensor_parallel_size = 1
-    max_num_seqs = 4
-
-    prompt = "The next numbers of the sequence " + ", ".join(
-        str(i) for i in range(1024)) + " are:"
-    example_prompts = [prompt]
->>>>>>> 2699b90f5 (add a tests that runs faster. Start using the kernel)
 
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")
 
-<<<<<<< HEAD
         with vllm_runner(model,
                          max_num_batched_tokens=256,
                          max_num_seqs=max_num_seqs) as vllm_model:
@@ -119,20 +103,6 @@ def test_w8a8_quantization(
         for output, answer in zip(vllm_outputs, answers):
             generated_text = output[1]
             assert answer in generated_text
-=======
-        with vllm_runner(
-                model,
-                max_num_batched_tokens=64,
-                max_model_len=4096,
-                gpu_memory_utilization=0.7,
-                max_num_seqs=max_num_seqs,
-                tensor_parallel_size=tensor_parallel_size) as vllm_model:
-            vllm_outputs = vllm_model.generate_greedy(example_prompts,
-                                                      max_tokens)
-        output = vllm_outputs[0][1]
-
-        assert "1024" in output or "0, 1" in output
->>>>>>> 2699b90f5 (add a tests that runs faster. Start using the kernel)
 
 
 TP_SIZE_8 = 8
@@ -175,3 +145,35 @@ def test_gemma3_27b_with_text_input_and_tp(
         for output, answer in zip(vllm_outputs, answers):
             generated_text = output[1]
             assert answer in generated_text
+
+
+@pytest.mark.skipif(not current_platform.is_tpu(),
+                    reason="This is a basic test for TPU only")
+def test_w8a8_quantization(
+    vllm_runner: type[VllmRunner],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = "neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+    max_tokens = 5
+    tensor_parallel_size = 1
+    max_num_seqs = 4
+
+    prompt = "The next numbers of the sequence " + ", ".join(
+        str(i) for i in range(1024)) + " are:"
+    example_prompts = [prompt]
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+
+        with vllm_runner(
+                model,
+                max_num_batched_tokens=64,
+                max_model_len=4096,
+                gpu_memory_utilization=0.7,
+                max_num_seqs=max_num_seqs,
+                tensor_parallel_size=tensor_parallel_size) as vllm_model:
+            vllm_outputs = vllm_model.generate_greedy(example_prompts,
+                                                      max_tokens)
+        output = vllm_outputs[0][1]
+
+        assert "1024" in output or "0, 1" in output

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
@@ -5,6 +5,8 @@ import warnings
 from typing import Optional
 
 import torch
+# Required to register custom ops.
+import torch_xla.experimental.custom_kernel  # noqa: F401
 from functorch.experimental.control_flow import cond  # noqa: F401
 
 from vllm.model_executor.layers.quantization.utils import replace_parameter
@@ -90,16 +92,24 @@ class XLAScaledMMLinearKernel(ScaledMMLinearKernel):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         w_q, w_s, _, _, _ = self._get_weight_params(layer)
 
-        import torch_xla.experimental.xla_quantized_matmul  # noqa: F401
-        out = torch.ops.xla.quantized_matmul(x,
-                                             w_q,
-                                             w_s,
-                                             zero_point=None,
-                                             block_size=-1,
-                                             int4_weight=False,
-                                             quantize_activation=True)
-        # `quantized_matmul` output is fp32, cast it down to bf16 for perf
-        out = out.to(x.dtype)
+        # import torch_xla.experimental.xla_quantized_matmul  # noqa: F401
+        # out = torch.ops.xla.quantized_matmul(x,
+        #                                      w_q,
+        #                                      w_s,
+        #                                      zero_point=None,
+        #                                      block_size=-1,
+        #                                      int4_weight=False,
+        #                                      quantize_activation=True)
+        # # `quantized_matmul` output is fp32, cast it down to bf16 for perf
+        # out = out.to(x.dtype)
+
+        out = torch.ops.xla.quantized_matmul_int8(
+            x,
+            w_q,
+            w_s,
+            quantize_activation=True,
+        )
+
         # Explicitly capture control flow to make dynamo happy.
         # https://pytorch.org/docs/main/generated/exportdb/index.html#cond-branch-class-method # noqa: E501
         return cond(bias is None, self.no_add_bias, self.add_bias, [out, bias])

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
@@ -5,8 +5,6 @@ import warnings
 from typing import Optional
 
 import torch
-# Required to register custom ops.
-import torch_xla.experimental.custom_kernel  # noqa: F401
 from functorch.experimental.control_flow import cond  # noqa: F401
 
 from vllm.model_executor.layers.quantization.utils import replace_parameter
@@ -92,6 +90,8 @@ class XLAScaledMMLinearKernel(ScaledMMLinearKernel):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         w_q, w_s, _, _, _ = self._get_weight_params(layer)
 
+        # Required to register custom ops.
+        import torch_xla.experimental.custom_kernel  # noqa: F401
         out = torch.ops.xla.quantized_matmul_int8(
             x,
             w_q,

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
@@ -92,22 +92,12 @@ class XLAScaledMMLinearKernel(ScaledMMLinearKernel):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         w_q, w_s, _, _, _ = self._get_weight_params(layer)
 
-        # import torch_xla.experimental.xla_quantized_matmul  # noqa: F401
-        # out = torch.ops.xla.quantized_matmul(x,
-        #                                      w_q,
-        #                                      w_s,
-        #                                      zero_point=None,
-        #                                      block_size=-1,
-        #                                      int4_weight=False,
-        #                                      quantize_activation=True)
-        # # `quantized_matmul` output is fp32, cast it down to bf16 for perf
-        # out = out.to(x.dtype)
-
         out = torch.ops.xla.quantized_matmul_int8(
             x,
             w_q,
             w_s,
             quantize_activation=True,
+            vmem_limit_bytes=96 * 1024 * 1024,
         )
 
         # Explicitly capture control flow to make dynamo happy.

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
@@ -99,6 +99,8 @@ class XLAScaledMMLinearKernel(ScaledMMLinearKernel):
             quantize_activation=True,
             vmem_limit_bytes=96 * 1024 * 1024,
         )
+        if out.dtype != x.dtype:
+            out = out.to(x.dtype)
 
         # Explicitly capture control flow to make dynamo happy.
         # https://pytorch.org/docs/main/generated/exportdb/index.html#cond-branch-class-method # noqa: E501

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
@@ -97,7 +97,6 @@ class XLAScaledMMLinearKernel(ScaledMMLinearKernel):
             w_q,
             w_s,
             quantize_activation=True,
-            vmem_limit_bytes=96 * 1024 * 1024,
         )
 
         # Explicitly capture control flow to make dynamo happy.

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/xla.py
@@ -99,8 +99,6 @@ class XLAScaledMMLinearKernel(ScaledMMLinearKernel):
             quantize_activation=True,
             vmem_limit_bytes=96 * 1024 * 1024,
         )
-        if out.dtype != x.dtype:
-            out = out.to(x.dtype)
 
         # Explicitly capture control flow to make dynamo happy.
         # https://pytorch.org/docs/main/generated/exportdb/index.html#cond-branch-class-method # noqa: E501

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -106,9 +106,6 @@ class TPUWorker:
         # ring, the xla tpu compiler flag
         # `xla_tpu_force_1d_allreduce_at_chunk_count` is a temporary solution to
         # fix this. It will be removed after the bug in XLA compiler is fixed.
-        # os.environ["LIBTPU_INIT_ARGS"] = (
-        #     "--xla_tpu_force_1d_allreduce_at_chunk_count=1
-        #  --xla_jf_conv_input_fusion=False")
         os.environ["LIBTPU_INIT_ARGS"] = (
             os.environ.get("LIBTPU_INIT_ARGS", "") +
             " --xla_tpu_force_1d_allreduce_at_chunk_count=1"

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -106,6 +106,9 @@ class TPUWorker:
         # ring, the xla tpu compiler flag
         # `xla_tpu_force_1d_allreduce_at_chunk_count` is a temporary solution to
         # fix this. It will be removed after the bug in XLA compiler is fixed.
+        # os.environ["LIBTPU_INIT_ARGS"] = (
+        #     "--xla_tpu_force_1d_allreduce_at_chunk_count=1
+        #  --xla_jf_conv_input_fusion=False")
         os.environ["LIBTPU_INIT_ARGS"] = (
             os.environ.get("LIBTPU_INIT_ARGS", "") +
             " --xla_tpu_force_1d_allreduce_at_chunk_count=1"


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

This PR uses a custom Pallas kernel to do w8a8 quantized matmul in lieu of XLA's matmul. This results in much better performance for w8a8 models:

by using neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w8a8 with TP=1 and RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w8a8 with TP=8, I got the following e2e benchmark:

| case | tp=1 throughput | tp=8 throughput | 
|------|------|------|
| baseline (non quantized) | 8.09 | 6.30 |
| quantized via XLA with the flag --xla_jf_conv_input_fusion=False | 9.26 | 6.07 |
| quantized via kernel | 9.69 | 6.77 |



## Test Plan
- VLLM_USE_V1=1 pytest -s -vv tests/v1/tpu/test_basic.py -k test_w8a8_quantization
- VLLM_USE_V1=1 pytest -s -v tests/tpu/test_quantization_accuracy.py

## Test Result

Note, need to install `lm-eval==0.4.8`. Without specifying the version, lm-eval=0.4.9 will be installed and running `test_quantization_accuracy.py` fails with an [error](https://gist.github.com/vanbasten23/045ef20a29e1d2fcf3a13b6ad1c2582f) 
<!--- pyml disable-next-line no-emphasis-as-heading -->
