### PR TITLE
[BugFix][Minor] Fix full cuda graph bug when max_num_seqs < 512

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -196,9 +196,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # TODO(woosuk): Provide an option to tune the max cudagraph batch size.
         # The convention is different.
         # self.cudagraph_batch_sizes sorts in ascending order.
-        self.cudagraph_batch_sizes = list(sorted(
-            self.vllm_config.compilation_config.cudagraph_capture_sizes))
-        self.max_cudagraph_batch_size = self.cudagraph_batch_sizes[-1]
+        # The batch sizes in the config are in descending order.
+        self.cudagraph_batch_sizes = list(
+            reversed(
+                self.vllm_config.compilation_config.cudagraph_capture_sizes))
 
         # Cache the device properties.
         self._init_device_properties()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1178,7 +1178,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self._prepare_inputs(scheduler_output))
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         if (self.use_cuda_graph
-                and num_scheduled_tokens <= self.max_cudagraph_batch_size):
+                and num_scheduled_tokens <= self.cudagraph_batch_sizes[-1]):
             # Use piecewise CUDA graphs.
             # Add padding to the batch size.
             num_input_tokens = self.vllm_config.pad_for_cudagraph(


### PR DESCRIPTION
## Purpose

Currently, when the full cuda graph is enabled and `max_num_seqs` happens to be smaller than 512 (max cuda graph size), the following error is raised: 
```
ERROR 06-05 00:47:32 [core.py:396]     self.scheduler_metadata[:n].copy_(scheduler_metadata,
ERROR 06-05 00:47:32 [core.py:396] RuntimeError: The size of tensor a (6) must match the size of tensor b (513) at non-singleton dimension 0
```

This PR fixes this bug.

## Test Plan

## Test Result
