### PR TITLE
[v1][P/D] Fix a edge case in kv cache schedule

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1006,6 +1006,8 @@ class Scheduler(SchedulerInterface):
         # Now that the blocks are ready, actually cache them.
         block_ids = self.kv_cache_manager.get_block_ids(request.request_id)[0]
         num_computed_tokens = len(block_ids) * self.block_size
+        # Handle the case where num request tokens less then one block.
+        num_computed_tokens = min(num_computed_tokens, request.num_tokens)
         if num_computed_tokens == request.num_tokens:
             num_computed_tokens -= 1
         self.kv_cache_manager.single_type_manager.cache_blocks(


### PR DESCRIPTION
## Purpose
Fix the edge case in async kv load, where the request tokens left for compute are less then one block. Current implementation will still use 1 block and cache_block will fail. 
## Test Plan
Tested with customized implementation with prompt: "The capitol of France is ", which only has 7 tokens, while 1 block size is 16.

## Test Result
Will return response successfully

<!--- pyml disable-next-line no-emphasis-as-heading -->
