### PR TITLE
Add H20-3e fused MoE kernel tuning configs for DeepSeek-R1/V3

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=256,device_name=NVIDIA_H20-3e,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=256,device_name=NVIDIA_H20-3e,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
H20-3e is H20 GPU with 141G memory. Add Moe tuning configs for DeepSeek-R1/V3

## Test Plan
Tuning command:
```bash
python /mnt/workspace/vllm/benchmarks/kernels/benchmark_moe.py --model /mnt/data/DeepSeek-R1-0528 -tp 8 --dtype fp8_w8a8 --tune 
```

Deploy DeepSeek-R1-0528:
```bash
vllm serve /mnt/data/DeepSeek-R1-0528 --host 0.0.0.0 --port 8000 --root '/' --no-enable-prefix-caching --trust-remote-code --tensor-parallel-size 8 --served-model-name DeepSeek-R1-0528
```

Benchmark:
```bash
python3 -m sglang.bench_serving --tokenizer /mnt/data/DeepSeek-R1-0528 --host 0.0.0.0 --port 8000 --backend vllm --dataset-name random --random-input 1024 --random-output 512 --max-concurrency 8 --num-prompt 200
```


## Test Result

Results without Moe tuning:
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     200       
Benchmark duration (s):                  276.03    
Total input tokens:                      103005    
Total generated tokens:                  53590     
Total generated tokens (retokenized):    53336     
Request throughput (req/s):              0.72      
Input token throughput (tok/s):          373.17    
Output token throughput (tok/s):         194.15    
Total token throughput (tok/s):          567.31    
Concurrency:                             7.80      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   10761.65  
Median E2E Latency (ms):                 10697.00  
---------------Time to First Token----------------
Mean TTFT (ms):                          162.99    
Median TTFT (ms):                        154.33    
P99 TTFT (ms):                           470.98    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           39.88     
Median ITL (ms):                         37.86     
P95 ITL (ms):                            38.65     
P99 ITL (ms):                            123.22    
Max ITL (ms):                            1000.79   
==================================================
```

Results with Moe tuning:
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     200       
Benchmark duration (s):                  238.14    
Total input tokens:                      103005    
Total generated tokens:                  53590     
Total generated tokens (retokenized):    53449     
Request throughput (req/s):              0.84      
Input token throughput (tok/s):          432.55    
Output token throughput (tok/s):         225.04    
Total token throughput (tok/s):          657.58    
Concurrency:                             7.77      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   9255.99   
Median E2E Latency (ms):                 9082.86   
---------------Time to First Token----------------
Mean TTFT (ms):                          157.92    
Median TTFT (ms):                        149.74    
P99 TTFT (ms):                           463.50    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           34.17     
Median ITL (ms):                         32.04     
P95 ITL (ms):                            32.67     
P99 ITL (ms):                            125.23    
Max ITL (ms):                            978.02    
==================================================
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
