### PR TITLE
[TPU] update torch_xla pin

### DIFF
--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -18,9 +18,9 @@ setuptools==78.1.0
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.8.0.dev20250529
-torchvision==0.22.0.dev20250529
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250529-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250529-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250529-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
+torch==2.8.0.dev20250605
+torchvision==0.23.0.dev20250605
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250605-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250605-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250605-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
 

--- a/tests/tpu/test_moe_pallas.py
+++ b/tests/tpu/test_moe_pallas.py
@@ -27,7 +27,7 @@ TOP_KS = [2, 6]
 # The Pallas GMM kernel requires num_tokens * topk to be a multiple of 16
 @pytest.mark.parametrize("m", [8, 16, 64, 2048])
 @pytest.mark.parametrize("n", [128, 1024, 2048])
-@pytest.mark.parametrize("k", [128, 512, 1024])
+@pytest.mark.parametrize("k", [128, 511, 1024])
 @pytest.mark.parametrize("e", NUM_EXPERTS)
 @pytest.mark.parametrize("topk", TOP_KS)
 @pytest.mark.parametrize("ep_size", EP_SIZE)

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -101,8 +101,7 @@ class TPUWorker:
         # fix this. It will be removed after the bug in XLA compiler is fixed.
         os.environ["LIBTPU_INIT_ARGS"] = (
             os.environ.get("LIBTPU_INIT_ARGS", "") +
-            " --xla_tpu_force_1d_allreduce_at_chunk_count=1"
-        )
+            " --xla_tpu_force_1d_allreduce_at_chunk_count=1")
         torch.set_grad_enabled(False)
         torch.set_default_dtype(self.model_config.dtype)
 

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -100,8 +100,8 @@ class TPUWorker:
         # `xla_tpu_force_1d_allreduce_at_chunk_count` is a temporary solution to
         # fix this. It will be removed after the bug in XLA compiler is fixed.
         os.environ["LIBTPU_INIT_ARGS"] = (
-            os.environ.get("LIBTPU_INIT_ARGS", "")
-            + " --xla_tpu_force_1d_allreduce_at_chunk_count=1"
+            os.environ.get("LIBTPU_INIT_ARGS", "") +
+            " --xla_tpu_force_1d_allreduce_at_chunk_count=1"
         )
         torch.set_grad_enabled(False)
         torch.set_default_dtype(self.model_config.dtype)

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -100,7 +100,9 @@ class TPUWorker:
         # `xla_tpu_force_1d_allreduce_at_chunk_count` is a temporary solution to
         # fix this. It will be removed after the bug in XLA compiler is fixed.
         os.environ["LIBTPU_INIT_ARGS"] = (
-            "--xla_tpu_force_1d_allreduce_at_chunk_count=1")
+            os.environ.get("LIBTPU_INIT_ARGS", "")
+            + " --xla_tpu_force_1d_allreduce_at_chunk_count=1"
+        )
         torch.set_grad_enabled(False)
         torch.set_default_dtype(self.model_config.dtype)
 


### PR DESCRIPTION
## Purpose
To integrate the MoE gmm kernel update in torch_xla repo. We can observe a lot of performance gain on Mixtral model. Also it modified the pallas gmm kernel test a bit to prove that it can support irregular dimension size.

Before the update:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  121.44    
Total input tokens:                      1672653   
Total generated tokens:                  128000    
Request throughput (req/s):              8.23      
Output token throughput (tok/s):         1054.00   
Total Token throughput (tok/s):          14827.30  
---------------Time to First Token----------------
Mean TTFT (ms):                          57163.68  
Median TTFT (ms):                        56839.68  
P99 TTFT (ms):                           113953.49 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          116.61    
Median TPOT (ms):                        121.36    
P99 TPOT (ms):                           122.98    
---------------Inter-token Latency----------------
Mean ITL (ms):                           116.61    
Median ITL (ms):                         126.01    
P99 ITL (ms):                            127.24    
==================================================
```


After the update:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  83.38     
Total input tokens:                      1672653   
Total generated tokens:                  128000    
Request throughput (req/s):              11.99     
Output token throughput (tok/s):         1535.22   
Total Token throughput (tok/s):          21596.85  
---------------Time to First Token----------------
Mean TTFT (ms):                          39235.74  
Median TTFT (ms):                        38956.00  
P99 TTFT (ms):                           78323.49  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          80.03     
Median TPOT (ms):                        83.56     
P99 TPOT (ms):                           84.11     
---------------Inter-token Latency----------------
Mean ITL (ms):                           80.03     
Median ITL (ms):                         86.29     
P99 ITL (ms):                            87.79     
==================================================
```


## Test Plan

```
pytest -s -v tests/tpu/test_moe_pallas.py
```

## Test Result

passed.