### PR TITLE
Use PyTorch util for traced files instead of monkey-patching inline_call()

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -408,7 +408,8 @@ class VllmBackend:
             #    it mainly summarizes how the model is used in forward pass)
             from torch._dynamo.utils import get_traced_code
 
-            forward_code_files = sorted(list(set(c.co_filename for c in get_traced_code())))
+            forward_code_files = sorted(
+                list(set(c.co_filename for c in get_traced_code())))
             logger.debug(
                 "Traced files (to be considered for compilation cache):\n%s",
                 "\n".join(forward_code_files))

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -406,9 +406,9 @@ class VllmBackend:
 
             # 2. factors come from the code files that are traced by Dynamo (
             #    it mainly summarizes how the model is used in forward pass)
-            forward_code_files = list(
-                sorted(self.compilation_config.traced_files))
-            self.compilation_config.traced_files.clear()
+            from torch._dynamo.utils import get_traced_code
+
+            forward_code_files = sorted(list(set(c.co_filename for c in get_traced_code())))
             logger.debug(
                 "Traced files (to be considered for compilation cache):\n%s",
                 "\n".join(forward_code_files))

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -3,11 +3,9 @@
 
 import inspect
 from typing import Callable, Optional, TypeVar, Union, overload
-from unittest.mock import patch
 
 import torch
 import torch.nn as nn
-from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -214,29 +214,7 @@ def _support_torch_compile(
             torch._dynamo.eval_frame.remove_from_cache(
                 self.original_code_object)
 
-            # collect all relevant files traced by Dynamo,
-            # so that the compilation cache can trigger re-compilation
-            # properly when any of these files change.
-
-            # 1. the file containing the top-level forward function
-            self.vllm_config.compilation_config.traced_files.add(
-                self.original_code_object.co_filename)
-
-            # 2. every time Dynamo sees a function call, it will inline
-            # the function by calling InliningInstructionTranslator.inline_call
-            # we hijack this function to know all the functions called
-            # during Dynamo tracing, and their corresponding files
-            inline_call = InliningInstructionTranslator.inline_call
-
-            def patched_inline_call(parent, func, args, kwargs):
-                code = func.get_code()
-                self.vllm_config.compilation_config.traced_files.add(
-                    code.co_filename)
-                return inline_call(parent, func, args, kwargs)
-
-            with patch.object(InliningInstructionTranslator, 'inline_call',
-                              patched_inline_call):
-                output = self.compiled_callable(*args, **kwargs)
+            output = self.compiled_callable(*args, **kwargs)
             return output
 
         # usually, capturing the model once is enough, and then we can

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3964,7 +3964,7 @@ class CompilationConfig:
     """custom ops that are enabled"""
     disabled_custom_ops: Counter[str] = field(default_factory=Counter,
                                               init=False)
-    """files that are traced for compilation"""
+    """custom ops that are disabled"""
     compilation_time: float = field(default=0.0, init=False)
     """time taken for compilation"""
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3964,8 +3964,6 @@ class CompilationConfig:
     """custom ops that are enabled"""
     disabled_custom_ops: Counter[str] = field(default_factory=Counter,
                                               init=False)
-    """custom ops that are disabled"""
-    traced_files: set[str] = field(default_factory=set, init=False)
     """files that are traced for compilation"""
     compilation_time: float = field(default=0.0, init=False)
     """time taken for compilation"""
@@ -4007,7 +4005,6 @@ class CompilationConfig:
             "compilation_time",
             "bs_to_padded_graph_size",
             "pass_config",
-            "traced_files",
         }
         # The cast to string is necessary because Pydantic is mocked in docs
         # builds and sphinx-argparse doesn't know the return type of decode()


### PR DESCRIPTION
## Purpose

Make code more future-proof by utilizing a PyTorch util to get the set of traced filenames instead of relying on Dynamo implementation details (i.e. monkey-patching `inline_call()`).

Note that this relies on https://github.com/pytorch/pytorch/pull/155249, which will only be available in the PyTorch nightlies until 2.8.

## Test Plan

I saw that existing tests exercise this logic (e.g. `tests/compile/piecewise/test_toy_llama.py`), but I'll take any insights into better ways to verify this change.
