### PR TITLE
cmake: Add support for `HIPCC_COMPILE_FLAGS_APPEND`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,15 @@ endif()
 #
 get_torch_gpu_compiler_flags(VLLM_GPU_FLAGS ${VLLM_GPU_LANG})
 
+# Show additional HIP flags status for ROCm builds
+if(VLLM_GPU_LANG STREQUAL "HIP")
+  if(HIPCC_COMPILE_FLAGS_APPEND)
+    message(STATUS "Additional HIP flags: ${HIPCC_COMPILE_FLAGS_APPEND}")
+  else()
+    message(STATUS "Additional HIP flags: NONE (set via -DHIPCC_COMPILE_FLAGS_APPEND=\"flag1;flag2\" or HIPCC_COMPILE_FLAGS_APPEND=\"flag1 flag2\")")
+  endif()
+endif()
+
 #
 # Set nvcc parallelism.
 #


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

This commit introduces a new CMake variable, `HIPCC_COMPILE_FLAGS_APPEND`, which allows users to
pass additional compiler flags specifically for ROCm builds.

The `HIPCC_COMPILE_FLAGS_APPEND` can be set via:
- CMake command-line: `-DHIPCC_COMPILE_FLAGS_APPEND="flag1;flag2"`
- Environment variable: `HIPCC_COMPILE_FLAGS_APPEND="flag1 flag2"`

These flags are appended to the existing HIP compiler flags retrieved from `torch`.

Also, a status message is now displayed during CMake configuration to indicate
whether additional HIP flags are being used.

## Test Plan

TBD

## Test Result

TBD

Fixes #19284
Signed-off-by: Emilien Macchi <emacchi@redhat.com>
