### PR TITLE
Support no privileged mode on CPU for docker and kubernetes deployments

### DIFF
--- a/csrc/cpu/utils.cpp
+++ b/csrc/cpu/utils.cpp
@@ -54,8 +54,7 @@ std::string init_cpu_threads_env(const std::string& cpu_ids) {
     *(src_mask->maskp) = *(src_mask->maskp) ^ *(mask->maskp);
     int page_num = numa_migrate_pages(pid, src_mask, mask);
     if (page_num == -1) {
-      TORCH_CHECK(false,
-                  "numa_migrate_pages failed. errno: " + std::to_string(errno));
+      TORCH_WARN("numa_migrate_pages failed. errno: " + std::to_string(errno));
     }
 
     // restrict memory allocation node.


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
To enable no privileged mode run for both docker and kubernetes environment.
We don't error out an numa_migrate_pages call, but just give warning instead.

Without changes in the PR, we will have this issue.
![image](https://github.com/user-attachments/assets/a9076316-d534-41bd-bcbb-7abf9a3cc9b0)

After the changes, it only gives warning and  it will bind CPU cores successfully .
![image](https://github.com/user-attachments/assets/f659378c-dadd-4626-a3c6-8f5a5432b3cf)


## Test Plan

normal perf tests.

## Test Result

it could run without privileged mode, and performance numbers are similar. 

Indeed saw 5% more for remote NUMA access, but no huge increase after the change.
before the change.
![image](https://github.com/user-attachments/assets/21d50f64-7149-4485-a63b-4fa7fef98cda)
after the change
![image](https://github.com/user-attachments/assets/57b6e2a5-441a-46f7-8fc1-ab07d19a7688)


<!--- pyml disable-next-line no-emphasis-as-heading -->
