### PR TITLE
[CI][PowerPC] Use a more appropriate way to select testcase in tests/models/language/pooling/test_embedding.py

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-cpu-test-ppc64le.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test-ppc64le.sh
@@ -37,7 +37,7 @@ function cpu_tests() {
     pytest -v -s tests/models/language/generation/test_common.py::test_models[False-5-32-facebook/opt-125m]
     pytest -v -s tests/models/language/generation/test_common.py::test_models[False-5-32-google/gemma-1.1-2b-it]
     pytest -v -s tests/models/language/pooling/test_classification.py::test_models[float-jason9693/Qwen2.5-1.5B-apeach]
-    pytest -v -s tests/models/language/pooling/test_embedding.py::test_models[half-BAAI/bge-base-en-v1.5]"
+    pytest -v -s tests/models/language/pooling/test_embedding.py -m cpu_model"
 }
 
 # All of CPU tests are expected to be finished less than 40 mins.


### PR DESCRIPTION
Currently testcase named`tests/models/language/pooling/test_embedding.py::test_models[half-BAAI/bge-base-en-v1.5]` in buildkite job for IBM Power is failing due to:
```
ERROR: not found: /workspace/tests/models/language/pooling/test_embedding.py::test_models[half-BAAI/bge-base-en-v1.5]
(no match in any of [<Module test_embedding.py>])
```
This is happening as dtype is removed from testcase name, name got changed.
After updating the testcase name, it is passing.
