### PR TITLE
[V1][Kernel] Flashinfer HND KV cache layout

### DIFF
--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
-import os
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -50,8 +49,7 @@ if TYPE_CHECKING:
     from vllm.worker.model_runner import (ModelInputForGPUBuilder,
                                           ModelInputForGPUWithSamplingMetadata)
 
-FLASHINFER_KV_CACHE_LAYOUT: str = os.getenv("FLASHINFER_KV_CACHE_LAYOUT",
-                                            "NHD").upper()
+FLASHINFER_KV_CACHE_LAYOUT: str = envs.VLLM_KV_CACHE_LAYOUT or "NHD"
 
 
 class FlashInferBackend(AttentionBackend):

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -98,12 +98,12 @@ def get_kv_connector_cache_layout():
     vllm_config = get_current_vllm_config()
     kv_config = vllm_config.kv_transfer_config
     if vllm_config.model_config is None or kv_config is None:
-        logger.warning("Unable to detect current VLLM config. " \
+        logger.warning_once("Unable to detect current VLLM config. " \
         "Defaulting to NHD kv cache layout.")
     else:
         use_mla = vllm_config.model_config.use_mla
         if not use_mla and kv_config.kv_connector == "NixlConnector":
-            logger.info("NixlConnector detected. Setting KV cache " \
+            logger.info_once("NixlConnector detected. Setting KV cache " \
             "layout to HND for better xfer performance.")
             return "HND"
     return "NHD"

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -3,7 +3,6 @@
 """
 KV cache helper for store.
 """
-
 import torch
 
 import vllm.envs as envs
@@ -94,9 +93,11 @@ class model_aware_kv_ops_helper:
 
 
 def get_kv_connector_cache_layout():
+    # NOTE (NickLucche) When running disaggregated PD with NIXL, HND layout is
+    # used for faster transfer.
     vllm_config = get_current_vllm_config()
     kv_config = vllm_config.kv_transfer_config
-    if vllm_config.model_config is None:
+    if vllm_config.model_config is None or kv_config is None:
         logger.warning("Unable to detect current VLLM config. " \
         "Defaulting to NHD kv cache layout.")
     else:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_SLEEP_WHEN_IDLE: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
+    VLLM_KV_CACHE_LAYOUT: Optional[str] = None
 
 
 def get_default_cache_root():
@@ -879,6 +880,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # processes via zmq.
     "VLLM_MQ_MAX_CHUNK_BYTES_MB":
     lambda: int(os.getenv("VLLM_MQ_MAX_CHUNK_BYTES_MB", "16")),
+
+    # KV Cache layout used throughout vllm.
+    # Some common values are:
+    # - NHD
+    # - HND
+    # Where N=num_blocks, H=num_heads and D=head_size. The default value will
+    # leave the layout choice to the backend. Mind that backends may only
+    # implement and support a subset of all possible layouts.
+    "VLLM_KV_CACHE_LAYOUT":
+    lambda: os.getenv("VLLM_KV_CACHE_LAYOUT", None)
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -16,13 +16,12 @@ from vllm.attention.ops.merge_attn_states import merge_attn_states
 from vllm.attention.utils.fa_utils import (flash_attn_supports_fp8,
                                            get_flash_attn_version)
 from vllm.config import VllmConfig, get_layers_from_vllm_config
-from vllm.distributed.kv_transfer.kv_connector.utils import (
-    get_kv_connector_cache_layout)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils import cdiv
 from vllm.v1.attention.backends.utils import (AttentionMetadataBuilder,
-                                              CommonAttentionMetadata)
+                                              CommonAttentionMetadata,
+                                              get_kv_cache_layout)
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.block_table import BlockTable
 
@@ -75,7 +74,7 @@ class FlashAttentionBackend(AttentionBackend):
     def get_kv_cache_stride_order() -> tuple[int, ...]:
         # `stride_order` indicates the permutation that gets
         # us from `get_kv_cache_shape` to the actual memory layout we want.
-        cache_layout = get_kv_connector_cache_layout()
+        cache_layout = get_kv_cache_layout()
         if cache_layout == "NHD":
             stride_order = (0, 1, 2, 3, 4)
         elif cache_layout == "HND":

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -73,8 +73,7 @@ class FlashAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_kv_cache_stride_order() -> tuple[int, ...]:
-        # NOTE When running disaggregated PD with NIXL, HND layout is used for
-        # faster transfer. `stride_order` indicates the permutation that gets
+        # `stride_order` indicates the permutation that gets
         # us from `get_kv_cache_shape` to the actual memory layout we want.
         cache_layout = get_kv_connector_cache_layout()
         if cache_layout == "NHD":
@@ -82,7 +81,7 @@ class FlashAttentionBackend(AttentionBackend):
         elif cache_layout == "HND":
             stride_order = (0, 1, 3, 2, 4)
         else:
-            raise ValueError("Unknown cache layout format %s.", cache_layout)
+            raise ValueError(f"Unknown cache layout format {cache_layout}.")
         return stride_order
 
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import functools
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -33,8 +32,6 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE = 256 * 1024 * 1024
-FLASHINFER_KV_CACHE_LAYOUT: str = os.getenv("FLASHINFER_KV_CACHE_LAYOUT",
-                                            "").upper()
 
 logger = init_logger(__name__)
 
@@ -42,8 +39,8 @@ logger = init_logger(__name__)
 @functools.lru_cache
 def get_flashinfer_kv_cache_layout():
     # Override with format specified by the user.
-    cache_layout = FLASHINFER_KV_CACHE_LAYOUT
-    if not cache_layout:
+    cache_layout = envs.VLLM_KV_CACHE_LAYOUT
+    if cache_layout is None:
         cache_layout = get_kv_connector_cache_layout()
     else:
         logger.info("`FLASHINFER_KV_CACHE_LAYOUT` environment variable " \

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -45,6 +45,10 @@ def get_flashinfer_kv_cache_layout():
     cache_layout = FLASHINFER_KV_CACHE_LAYOUT
     if not cache_layout:
         cache_layout = get_kv_connector_cache_layout()
+    else:
+        logger.info("`FLASHINFER_KV_CACHE_LAYOUT` environment variable " \
+        "detected. Setting KV cache layout to %s.", cache_layout)
+
     return cache_layout
 
 
@@ -91,7 +95,7 @@ class FlashInferBackend(AttentionBackend):
         elif cache_layout == "HND":
             stride_order = (0, 1, 3, 2, 4)
         else:
-            raise ValueError("Unknown cache layout format %s.", cache_layout)
+            raise ValueError(f"Unknown cache layout format {cache_layout}.")
         return stride_order
 
 
@@ -304,7 +308,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._num_prefills = num_prefills
         self._num_decode_tokens = num_decode_tokens
         self._num_prefill_tokens = num_prefill_tokens
-        self._kv_cache_layout = None
 
         return modified_batch
 
@@ -316,15 +319,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 device=self.runner.device)
         return self._workspace_buffer
 
-    def get_kv_cache_layout(self):
-        if self._kv_cache_layout is None:
-            self._kv_cache_layout = get_flashinfer_kv_cache_layout()
-        return self._kv_cache_layout
-
     def _get_prefill_wrapper(self):
         if self._prefill_wrapper is None:
             self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
-                self._get_workspace_buffer(), self.get_kv_cache_layout())
+                self._get_workspace_buffer(), get_flashinfer_kv_cache_layout())
         return self._prefill_wrapper
 
     def _get_decode_wrapper(self):
@@ -337,14 +335,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 num_qo_heads // num_kv_heads > 4)
             self._decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
-                self.get_kv_cache_layout(),
+                get_flashinfer_kv_cache_layout(),
                 use_tensor_cores=use_tensor_cores)
         return self._decode_wrapper
 
     def _get_cascade_wrapper(self):
         if self._cascade_wrapper is None:
             self._cascade_wrapper = MultiLevelCascadeAttentionWrapper(
-                2, self._get_workspace_buffer(), self.get_kv_cache_layout())
+                2, self._get_workspace_buffer(),
+                get_flashinfer_kv_cache_layout())
         return self._cascade_wrapper
 
     def _plan(self, attn_metadata: FlashInferMetadata):
@@ -568,7 +567,6 @@ class FlashInferImpl(AttentionImpl):
 
         assert self.num_heads % self.num_kv_heads == 0
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
-        self.stride_order = FlashInferBackend.get_kv_cache_stride_order()
 
         if attn_type != AttentionType.DECODER:
             raise NotImplementedError("Encoder self-attention and "
@@ -656,6 +654,7 @@ class FlashInferImpl(AttentionImpl):
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_prefill_tokens = attn_metadata.num_prefill_tokens
 
+        stride_order = FlashInferBackend.get_kv_cache_stride_order()
         # Regular attention (common case).
         # Decodes are at the front and prefills are at the back,
         # according to reorder_batch()
@@ -670,7 +669,7 @@ class FlashInferImpl(AttentionImpl):
             assert prefill_wrapper._sm_scale == self.scale
             prefill_wrapper.run(
                 prefill_query,
-                kv_cache.permute(*self.stride_order),
+                kv_cache.permute(*stride_order),
                 k_scale=layer._k_scale_float,
                 v_scale=layer._v_scale_float,
                 out=output[num_decode_tokens:],
@@ -686,7 +685,7 @@ class FlashInferImpl(AttentionImpl):
             assert decode_wrapper._sm_scale == self.scale
             decode_wrapper.run(
                 decode_query,
-                kv_cache.permute(*self.stride_order),
+                kv_cache.permute(*stride_order),
                 k_scale=layer._k_scale_float,
                 v_scale=layer._v_scale_float,
                 out=output[:num_decode_tokens],

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import abc
 from abc import abstractmethod
+import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
@@ -11,6 +12,12 @@ import torch
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.worker.gpu_input_batch import InputBatch
+import vllm.envs as envs
+from vllm.distributed.kv_transfer.kv_connector.utils import (
+    get_kv_connector_cache_layout)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -119,3 +126,16 @@ def validate_kv_sharing_target(current_layer_name, target_layer_name,
         raise ValueError(
             error_msg +
             f"must be the same type as the current layer ({expected}).")
+
+
+@functools.lru_cache
+def get_kv_cache_layout():
+    # Override with format specified by the user.
+    cache_layout = envs.VLLM_KV_CACHE_LAYOUT
+    if cache_layout is None:
+        cache_layout = get_kv_connector_cache_layout()
+    else:
+        logger.info("`FLASHINFER_KV_CACHE_LAYOUT` environment variable " \
+        "detected. Setting KV cache layout to %s.", cache_layout)
+
+    return cache_layout

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import abc
-from abc import abstractmethod
 import functools
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
@@ -12,6 +12,7 @@ import torch
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.worker.gpu_input_batch import InputBatch
+
 import vllm.envs as envs
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     get_kv_connector_cache_layout)
@@ -135,7 +136,7 @@ def get_kv_cache_layout():
     if cache_layout is None:
         cache_layout = get_kv_connector_cache_layout()
     else:
-        logger.info("`FLASHINFER_KV_CACHE_LAYOUT` environment variable " \
+        logger.info_once("`FLASHINFER_KV_CACHE_LAYOUT` environment variable " \
         "detected. Setting KV cache layout to %s.", cache_layout)
 
     return cache_layout


### PR DESCRIPTION
Follow up PR to https://github.com/vllm-project/vllm/pull/18775, again porting over functionality from V0 (ref https://github.com/vllm-project/vllm/pull/16605).

This PR will enable the use of FlashInfer with a HND cache layout in V1. 
Among the most immediate benefits, this PR is a prerequisite to enabling heterogeneous TP support for disaggregated prefill-decode setup, optimizing the layout for xfers.

Test with:
```
FLASHINFER_KV_CACHE_LAYOUT=HND VLLM_ATTENTION_BACKEND=FLASHINFER vllm serve Qwen/Qwen3-0.6B  
```   

A simple benchmark:
```
# FLASHINFER_KV_CACHE_LAYOUT=HND  VLLM_ATTENTION_BACKEND=FLASHINFER vllm serve Qwen/Qwen3-14B --disable-log-requests

NHD

============ Serving Benchmark Result ============
Successful requests:                     982       
Benchmark duration (s):                  94.63     
Total input tokens:                      1745235   
Total generated tokens:                  125696    
Request throughput (req/s):              10.38     
Output token throughput (tok/s):         1328.26   
Total Token throughput (tok/s):          19770.61  
---------------Time to First Token----------------
Mean TTFT (ms):                          45294.13  
Median TTFT (ms):                        46790.26  
P99 TTFT (ms):                           91790.54  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          106.51    
Median TPOT (ms):                        113.65    
P99 TPOT (ms):                           131.63    
---------------Inter-token Latency----------------
Mean ITL (ms):                           106.51    
Median ITL (ms):                         30.62     
P99 ITL (ms):                            378.72    
==================================================

HDN (this PR)

============ Serving Benchmark Result ============
Successful requests:                     982       
Benchmark duration (s):                  95.03     
Total input tokens:                      1745219   
Total generated tokens:                  125696    
Request throughput (req/s):              10.33     
Output token throughput (tok/s):         1322.67   
Total Token throughput (tok/s):          19687.22  
---------------Time to First Token----------------
Mean TTFT (ms):                          45028.82  
Median TTFT (ms):                        46518.14  
P99 TTFT (ms):                           92111.68  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          106.67    
Median TPOT (ms):                        111.74    
P99 TPOT (ms):                           132.01    
---------------Inter-token Latency----------------
Mean ITL (ms):                           106.67    
Median ITL (ms):                         30.41     
P99 ITL (ms):                            378.99    
==================================================
```

cc @mgoin 