### PR TITLE
[Core] Update error message for Whisper + num-scheduler-steps > 1

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -132,6 +132,10 @@ STR_NOT_IMPL_ENC_DEC_PROMPT_ADAPTER = ("Prompt adapters are not "
                                        "currently supported with encoder/"
                                        "decoder models.")
 
+STR_NOT_IMPL_ENC_DEC_SCHED_STEPS = ("num-scheduler-steps > 1 is not "
+                                    "currently supported with encoder/"
+                                    "decoder models.")
+
 # Efficiently import all enc/dec error strings
 # rather than having to import all of the above
 STR_NOT_IMPL_ENC_DEC_ERR_STRS = {
@@ -146,6 +150,7 @@ STR_NOT_IMPL_ENC_DEC_ERR_STRS = {
     "STR_NOT_IMPL_ENC_DEC_SPEC_DEC": STR_NOT_IMPL_ENC_DEC_SPEC_DEC,
     "STR_NOT_IMPL_ENC_DEC_BACKEND": STR_NOT_IMPL_ENC_DEC_BACKEND,
     "STR_NOT_IMPL_ENC_DEC_PROMPT_ADAPTER": STR_NOT_IMPL_ENC_DEC_PROMPT_ADAPTER,
+    "STR_NOT_IMPL_ENC_DEC_SCHED_STEPS": STR_NOT_IMPL_ENC_DEC_SCHED_STEPS,
 }
 
 # Constants related to forcing the attention backend selection

--- a/vllm/worker/utils.py
+++ b/vllm/worker/utils.py
@@ -44,6 +44,10 @@ def assert_enc_dec_mr_supported_scenario(
         raise NotImplementedError(
             STR_NOT_IMPL_ENC_DEC_ERR_STRS['STR_NOT_IMPL_ENC_DEC_PP'])
 
+    if enc_dec_mr.scheduler_config.num_scheduler_steps > 1:
+        raise NotImplementedError(
+            STR_NOT_IMPL_ENC_DEC_ERR_STRS['STR_NOT_IMPL_ENC_DEC_SCHED_STEPS'])
+
     if enc_dec_mr.scheduler_config.num_lookahead_slots > 0:
         raise NotImplementedError(
             STR_NOT_IMPL_ENC_DEC_ERR_STRS['STR_NOT_IMPL_ENC_DEC_SPEC_DEC'])


### PR DESCRIPTION
Previously, using `--num-scheduler-steps` greater than 1 with an
encoder/decoder model like Whisper would result in the following
misleading error message:

```
ERROR 06-05 19:58:13 [engine.py:448] NotImplementedError: Speculative decoding is not currently supported with encoder/decoder models.
```

The reason is because `num_lookahead_slots` gets set based on the value
of `num-scheduler-steps` when spec decode is not in use. That logic is
here:

https://github.com/vllm-project/vllm/blob/8267f9916f9b4ceace3a8daa908d52824068862b/vllm/engine/arg_utils.py#L1154-L1160

The error message for this case now looks like this:

```
ERROR 06-06 14:20:25 [engine.py:458] NotImplementedError: num-scheduler-steps > 1 is not currently supported with encoder/decoder models.
```

Signed-off-by: Russell Bryant <rbryant@redhat.com>
