### PR TITLE
[Frontend] Add optional token-level progress bar to `LLM.beam_search`

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -606,7 +606,7 @@ class LLM:
 
         token_iter = range(max_tokens)
         if use_tqdm:
-            token_iter = tqdm(range(max_tokens),
+            token_iter = tqdm(token_iter,
                               desc="Beam search",
                               unit="token",
                               unit_scale=False)

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -613,8 +613,7 @@ class LLM:
             logger.warning(
                 "The progress bar shows the upper bound on token steps and "
                 "may finish early due to stopping conditions. It does not "
-                "reflect instance-level progress.",
-            )
+                "reflect instance-level progress.")
 
         for _ in token_iter:
             all_beams: list[BeamSearchSequence] = list(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -604,13 +604,19 @@ class LLM:
                     **mm_kwargs,
                 ), )
 
-        token_iter = tqdm(range(max_tokens), desc="Beam search", unit="token", unit_scale=False)
-        warnings.warn(
-            "The progress bar shows the upper bound on token steps and "
-            "may finish early due to stopping conditions. It does not "
-            "reflect instance-level progress.",
-            stacklevel=2,
-        )          
+        token_iter = range(max_tokens)
+        if use_tqdm:
+            token_iter = tqdm(range(max_tokens),
+                              desc="Beam search",
+                              unit="token",
+                              unit_scale=False)
+            warnings.warn(
+                "The progress bar shows the upper bound on token steps and "
+                "may finish early due to stopping conditions. It does not "
+                "reflect instance-level progress.",
+                stacklevel=2,
+            )
+
         for _ in token_iter:
             all_beams: list[BeamSearchSequence] = list(
                 sum((instance.beams for instance in instances), []))

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -610,11 +610,10 @@ class LLM:
                               desc="Beam search",
                               unit="token",
                               unit_scale=False)
-            warnings.warn(
+            logger.warning(
                 "The progress bar shows the upper bound on token steps and "
                 "may finish early due to stopping conditions. It does not "
                 "reflect instance-level progress.",
-                stacklevel=2,
             )
 
         for _ in token_iter:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -531,6 +531,7 @@ class LLM:
         prompts: list[Union[TokensPrompt, TextPrompt]],
         params: BeamSearchParams,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
+        use_tqdm: bool = False,
     ) -> list[BeamSearchOutput]:
         """
         Generate sequences using beam search.
@@ -602,7 +603,19 @@ class LLM:
                     **mm_kwargs,
                 ), )
 
-        for _ in range(max_tokens):
+        token_iter = range(max_tokens)
+        if use_tqdm:
+            token_iter = tqdm(range(max_tokens, desc="Beam Searching"))
+            warnings.warn(
+                "The progress bar shows the upper bound on token steps and "
+                "may finish early due to stopping conditions. It does not "
+                "reflect instance-level progress.",
+                stacklevel=2,
+                unit="token",
+                unit_scale=False,
+            )
+          
+        for _ in token_iter:
             all_beams: list[BeamSearchSequence] = list(
                 sum((instance.beams for instance in instances), []))
             pos = [0] + list(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -541,6 +541,7 @@ class LLM:
                 of token IDs.
             params: The beam search parameters.
             lora_request: LoRA request to use for generation, if any.
+            use_tqdm: Whether to use tqdm to display the progress bar.
         """
         # TODO: how does beam search work together with length penalty,
         # frequency, penalty, and stopping criteria, etc.?

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -604,18 +604,13 @@ class LLM:
                     **mm_kwargs,
                 ), )
 
-        token_iter = range(max_tokens)
-        if use_tqdm:
-            token_iter = tqdm(range(max_tokens, desc="Beam Searching"))
-            warnings.warn(
-                "The progress bar shows the upper bound on token steps and "
-                "may finish early due to stopping conditions. It does not "
-                "reflect instance-level progress.",
-                stacklevel=2,
-                unit="token",
-                unit_scale=False,
-            )
-          
+        token_iter = tqdm(range(max_tokens), desc="Beam search", unit="token", unit_scale=False)
+        warnings.warn(
+            "The progress bar shows the upper bound on token steps and "
+            "may finish early due to stopping conditions. It does not "
+            "reflect instance-level progress.",
+            stacklevel=2,
+        )          
         for _ in token_iter:
             all_beams: list[BeamSearchSequence] = list(
                 sum((instance.beams for instance in instances), []))


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
This PR adds an optional token-level progress bar to the `LLM.beam_search()` method using `tqdm`. It addresses a recurring usability issue: when running beam search inference, users have no visibility into how long generation will take or how far along the process is.

This PR resolves the feature request described in https://github.com/vllm-project/vllm/issues/19300#issue-3125976266.

This feature:
- Wraps the `range(max_tokens)` loop with `tqdm` if `use_tqdm=True`,
- Adds a `use_tqdm` argument (default: False) to preserve backward compatibility,
- Emits a warning explaining that the progress bar shows an upper bound on token steps (not per-instance progress),
- Labels the tqdm output with "Beam search" and shows progress in tokens (e.g., 40/128 tokens),

This proposal was also previously requested by users https://github.com/vllm-project/vllm/issues/11835, and this PR revives the functionality in a clean, optional, and informative manner.

## Test Plan

Enable the progress bar in a script or notebook:
```
outputs = llm.beam_search(
    prompts=["Translate this sentence."],
    sampling_params=sampling_params,
    use_tqdm=True,  # Enables progress bar
)
```
Observe the terminal for:
- The tqdm bar output like `Beam Searching: 39%|█  | 25/64 tokens`,
- The log warning about token-level estimation.

## Test Result

```
WARNING vllm: The progress bar shows the upper bound on token steps and may finish early due to stopping conditions. It does not reflect instance-level progress.
Beam search:  36%|███████████████████▏                  | 36/100 tokens
```
- Progress bar is visible, responsive, and terminates early if generation stops.
- No side effects when use_tqdm=False or when tqdm is not available.

<!--- pyml disable-next-line no-emphasis-as-heading -->
