### PR TITLE
Update compatible packaging version

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -13,7 +13,7 @@ RUN apt-get update -q -y && apt-get install -q -y \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
     apt-transport-https ca-certificates wget curl
 # Remove sccache    
-RUN python3 -m pip install --upgrade pip && pip install setuptools_scm
+RUN python3 -m pip install --upgrade pip
 RUN apt-get purge -y sccache; python3 -m pip uninstall -y sccache; rm -f "$(which sccache)"
 ARG COMMON_WORKDIR
 WORKDIR ${COMMON_WORKDIR}

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -12,7 +12,8 @@ ray>=2.10.0,<2.45.0
 peft
 pytest-asyncio
 tensorizer>=2.9.0
-setuptools-scm>=8
+packaging>=24.2
 setuptools>=77.0.3,<80.0.0
+setuptools-scm>=8
 runai-model-streamer==0.11.0
 runai-model-streamer-s3==0.11.0


### PR DESCRIPTION
This PR contains two changes
1.
This will remove below error
Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.

rocm-build.txt has correct but rocm.txt is missing
2. remove redundant from dockerfile which is already present in *.txt file pip install setuptools_scm


<!--- pyml disable-next-line no-emphasis-as-heading -->
