### PR TITLE
[V1] Reuse V0's memory_profiling util for gpu worker memory profiling

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2269,6 +2269,8 @@ def kill_process_tree(pid: int):
 class MemorySnapshot:
     """Memory snapshot."""
     torch_peak: int = 0
+    free_memory: int = 0
+    total_memory: int = 0
     cuda_memory: int = 0
     torch_memory: int = 0
     non_torch_memory: int = 0
@@ -2288,8 +2290,8 @@ class MemorySnapshot:
         self.torch_peak = torch.cuda.memory_stats().get(
             "allocated_bytes.all.peak", 0)
 
-        self.cuda_memory = torch.cuda.mem_get_info(
-        )[1] - torch.cuda.mem_get_info()[0]
+        self.free_memory, self.total_memory = torch.cuda.mem_get_info()
+        self.cuda_memory = self.total_memory - self.free_memory
 
         # torch.cuda.memory_reserved() is how many bytes
         # PyTorch gets from cuda (by calling cudaMalloc, etc.)
@@ -2302,6 +2304,8 @@ class MemorySnapshot:
     def __sub__(self, other: MemorySnapshot) -> MemorySnapshot:
         return MemorySnapshot(
             torch_peak=self.torch_peak - other.torch_peak,
+            free_memory=self.free_memory - other.free_memory,
+            total_memory=self.total_memory - other.free_memory,
             cuda_memory=self.cuda_memory - other.cuda_memory,
             torch_memory=self.torch_memory - other.torch_memory,
             non_torch_memory=self.non_torch_memory - other.non_torch_memory,
@@ -2322,6 +2326,14 @@ class MemoryProfilingResult:
     before_profile: MemorySnapshot = field(default_factory=MemorySnapshot)
     after_profile: MemorySnapshot = field(default_factory=MemorySnapshot)
     profile_time: float = 0.0
+
+    def __repr__(self) -> str:
+        return (f"Memory profiling takes {self.profile_time:.2f} seconds. "
+                f"Weights memory: {(self.weights_memory / GiB_bytes):.2f}GiB; "
+                f"Non-torch forward increase memory: "
+                f"{(self.non_torch_increase / GiB_bytes):.2f}GiB; "
+                f"Torch peak memory: "
+                f"{(self.torch_peak_increase / GiB_bytes):.2f}GiB.")
 
 
 @contextlib.contextmanager

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2330,9 +2330,9 @@ class MemoryProfilingResult:
     def __repr__(self) -> str:
         return (f"Memory profiling takes {self.profile_time:.2f} seconds. "
                 f"Weights memory: {(self.weights_memory / GiB_bytes):.2f}GiB; "
-                f"Non-torch forward increase memory: "
+                f"non-torch forward increase memory: "
                 f"{(self.non_torch_increase / GiB_bytes):.2f}GiB; "
-                f"Torch peak memory: "
+                f"torch peak memory: "
                 f"{(self.torch_peak_increase / GiB_bytes):.2f}GiB.")
 
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2329,11 +2329,13 @@ class MemoryProfilingResult:
 
     def __repr__(self) -> str:
         return (f"Memory profiling takes {self.profile_time:.2f} seconds. "
-                f"Weights memory: {(self.weights_memory / GiB_bytes):.2f}GiB; "
+                f"Total non KV cache memory: "
+                f"{(self.non_kv_cache_memory / GiB_bytes):.2f}GiB; "
+                f"torch peak memory increase: "
+                f"{(self.torch_peak_increase / GiB_bytes):.2f}GiB; "
                 f"non-torch forward increase memory: "
                 f"{(self.non_torch_increase / GiB_bytes):.2f}GiB; "
-                f"torch peak memory: "
-                f"{(self.torch_peak_increase / GiB_bytes):.2f}GiB.")
+                f"weights memory: {(self.weights_memory / GiB_bytes):.2f}GiB.")
 
 
 @contextlib.contextmanager

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2305,7 +2305,7 @@ class MemorySnapshot:
         return MemorySnapshot(
             torch_peak=self.torch_peak - other.torch_peak,
             free_memory=self.free_memory - other.free_memory,
-            total_memory=self.total_memory - other.free_memory,
+            total_memory=self.total_memory - other.total_memory,
             cuda_memory=self.cuda_memory - other.cuda_memory,
             torch_memory=self.torch_memory - other.torch_memory,
             non_torch_memory=self.non_torch_memory - other.non_torch_memory,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -218,8 +218,9 @@ class Worker(WorkerBase):
 
         logger.debug(
             "Initial free memory: %.2f GiB, free memory: %.2f GiB, "
-            "total GPU memory: %.2f GiB", GiB(self.init_snapshot.free_memory),
-            GiB(free_gpu_memory), GiB(self.init_snapshot.total_memory))
+            "requested GPU memory: %.2f GiB",
+            GiB(self.init_snapshot.free_memory), GiB(free_gpu_memory),
+            GiB(self.requested_memory))
         logger.debug(profile_result)
         logger.info("Available KV cache memory: %.2f GiB",
                     GiB(available_kv_cache_memory))

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -201,7 +201,7 @@ class Worker(WorkerBase):
         with memory_profiling(
                 self.init_snapshot,
                 weights_memory=int(
-                    self.model_runner.model_memory_usage)) as result:
+                    self.model_runner.model_memory_usage)) as profile_result:
             self.model_runner.profile_run()
 
         free_gpu_memory, _ = torch.cuda.mem_get_info()
@@ -214,13 +214,13 @@ class Worker(WorkerBase):
             f"This happens when the GPU memory was not properly cleaned up "
             f"before initializing the vLLM instance.")
         available_kv_cache_memory = self.requested_memory \
-            - result.non_kv_cache_memory
+            - profile_result.non_kv_cache_memory
 
         logger.debug(
             "Initial free memory: %.2f GiB, free memory: %.2f GiB, "
             "total GPU memory: %.2f GiB", GiB(self.init_snapshot.free_memory),
             GiB(free_gpu_memory), GiB(self.init_snapshot.total_memory))
-        logger.debug(result)
+        logger.debug(profile_result)
         logger.info("Available KV cache memory: %.2f GiB",
                     GiB(available_kv_cache_memory))
         gc.collect()


### PR DESCRIPTION
## Purpose
Update: Rebase on top of https://github.com/vllm-project/vllm/pull/18974. Clean up duplicated calls, improve code readability and logging.

Follow-up PRs to reduce OOMs:
- [ ] Account for CUDA graph memory
- [ ] torch memory snapshot capture for profiling
- [ ] max-model-len auto for long ctx model

---
old context before rebase:
V1's memory profiling incorrectly counts memory used by other processes as non_torch_allocations. This means, if you try to start 2 vllm servers -- one uses 70% hbm, the other uses 20%, it'll complain about not having enough memory. 

This seems to bother quite a few users in the V0 deprecation RFC: https://github.com/vllm-project/vllm/issues/18571#issuecomment-2907534785.

So reattempt https://github.com/vllm-project/vllm/pull/14419 by leveraging V0's memory profiling util to address that as @youkaichao suggested.


## Test Plan
1. Unit test -- it's already covered by the following test which is broken on main
```
pytest -vv tests/entrypoints/llm/test_gpu_utilization.py
```

2. E2E test
Starting 2 servers as below:
```
CUDA_VISIBLE_DEVICES=0 wp vllm serve "meta-llama/Llama-3.2-1B" \
    --gpu-memory-utilization 0.7
```

```
VLLM_LOGGING_LEVEL=DEBUG CUDA_VISIBLE_DEVICES=0 wp python3 benchmarks/benchmark_latency.py \
    --model "meta-llama/Llama-3.2-1B" \
    --tensor-parallel-size 1 \
    --trust-remote-code \
    --gpu-memory-utilization 0.2
```   

## Test Result
before
```
DEBUG 06-09 00:54:11 [gpu_worker.py:237] Initial free memory: 40.32 GiB, free memory: 37.74 GiB, total GPU memory: 139.72 GiB
DEBUG 06-09 00:54:11 [gpu_worker.py:241] Peak torch memory: 7.07 GiB, non-torch forward-pass memory: 0.17 GiB, available KVCache memory: 20.70 GiB
```

after
```
DEBUG 06-09 01:03:28 [gpu_worker.py:221] Initial free memory: 40.32 GiB, free memory: 37.74 GiB, requested GPU memory: 27.94 GiB
DEBUG 06-09 01:03:28 [gpu_worker.py:225] Memory profiling takes 6.13 seconds. Total non KV cache memory: 7.16GiB; torch peak memory increase: 4.69GiB; non-torch forward increase memory: 0.15GiB; weights memory: 2.32GiB.
INFO 06-09 01:03:28 [gpu_worker.py:226] Available KV cache memory: 20.78 GiB
```

---
old test before rebase:

1. Unit test

before
```
ValueError: No available memory for the cache blocks. Try increasing `gpu_memory_utilization` when initializing the engine.
================================================ short test summary info =================================================
FAILED tests/entrypoints/llm/test_gpu_utilization.py::test_gpu_memory_utilization - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
```
after
```
tests/entrypoints/llm/test_gpu_utilization.py::test_gpu_memory_utilization PASSED                                  [100%]
```

2. E2E test

before
```
ERROR 06-03 03:14:47 [core.py:508]     check_enough_kv_cache_memory(vllm_config, kv_cache_spec, available_memory)
ERROR 06-03 03:14:47 [core.py:508]   File "/data/users/yeq/gitrepos/vllm/vllm/v1/core/kv_cache_utils.py", line 532, in check_enough_kv_cache_memory
ERROR 06-03 03:14:47 [core.py:508]     raise ValueError("No available memory for the cache blocks. "
ERROR 06-03 03:14:47 [core.py:508] ValueError: No available memory for the cache blocks. Try increasing `gpu_memory_utilization` when initializing the engine.
```
after
```
INFO 06-06 23:28:31 [gpu_worker.py:224] Memory profiling takes 6.20 seconds
INFO 06-06 23:28:31 [gpu_worker.py:224] the current vLLM instance can use total_gpu_memory (139.72GiB) x gpu_memory_utilization (0.20) = 27.94GiB
INFO 06-06 23:28:31 [gpu_worker.py:224] model weights take 2.32GiB; non_torch_memory takes 0.15GiB; PyTorch activation peak memory takes 4.69GiB; the rest of the memory reserved for KV Cache is 20.78GiB.
INFO 06-06 23:28:31 [kv_cache_utils.py:638] GPU KV cache size: 681,040 tokens
INFO 06-06 23:28:31 [kv_cache_utils.py:641] Maximum concurrency for 131,072 tokens per request: 5.20x
...
Avg latency: 0.2802899726356069 seconds

```