### PR TITLE
[Fix] Remove unused opentelemetry-semantic-conventions-ai dependency

### DIFF
--- a/examples/online_serving/opentelemetry/README.md
+++ b/examples/online_serving/opentelemetry/README.md
@@ -7,7 +7,6 @@
       'opentelemetry-sdk>=1.26.0,<1.27.0' \
       'opentelemetry-api>=1.26.0,<1.27.0' \
       'opentelemetry-exporter-otlp>=1.26.0,<1.27.0' \
-      'opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0'
     ```
 
 1. Start Jaeger in a docker container:

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -47,4 +47,3 @@ ninja # Required for xgrammar, rocm, tpu, xpu
 opentelemetry-sdk>=1.26.0  # vllm.tracing
 opentelemetry-api>=1.26.0  # vllm.tracing
 opentelemetry-exporter-otlp>=1.26.0  # vllm.tracing
-opentelemetry-semantic-conventions-ai>=0.4.1  # vllm.tracing


### PR DESCRIPTION
## Purpose
#12007 removed all uses of `opentelemetry-semantic-conventions-ai`, but it is still present in the requirements.
It should not be required again, as once the API is stabilized it will be imported from `opentelemetry-python` instead.

## Test Plan

## Test Result

<!--- pyml disable-next-line no-emphasis-as-heading -->
