### PR TITLE
[v1] Add fp32 support to v1 engine through flex attn

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -183,6 +183,34 @@ def test_env(
                     assert backend.get_name() == expected
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("use_v1", [True, False])
+def test_fp32_fallback(
+    device: str,
+    use_v1: bool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test attention backend selection with fp32."""
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1" if use_v1 else "0")
+
+        if device == "cpu":
+            with patch("vllm.attention.selector.current_platform",
+                       CpuPlatform()):
+                backend = get_attn_backend(16, torch.float32, torch.float32,
+                                           16, False)
+            assert (backend.get_name() == "TORCH_SDPA_VLLM_V1"
+                    if use_v1 else "TORCH_SDPA")
+
+        elif device == "cuda":
+            with patch("vllm.attention.selector.current_platform",
+                       CudaPlatform()):
+                backend = get_attn_backend(16, torch.float32, torch.float32,
+                                           16, False)
+            assert (backend.get_name() == "FLEX_ATTENTION"
+                    if use_v1 else "XFORMERS")
+
+
 def test_flash_attn(monkeypatch: pytest.MonkeyPatch):
     """Test FlashAttn validation."""
     # TODO: When testing for v1, pipe in `use_v1` as an argument to

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -4,6 +4,7 @@
 import random
 
 import pytest
+import torch
 
 from vllm.attention import Attention
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
@@ -399,6 +400,7 @@ def test_load_model_weights_inplace(dist_init, model_runner, model_runner_2):
 
 
 def test_init_kv_cache_with_kv_sharing_invalid_target_layer_order():
+    torch.set_default_dtype(torch.float16)
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
     error_msg = f"{layer_1} must come before the current layer"
@@ -427,6 +429,7 @@ def test_init_kv_cache_with_kv_sharing_invalid_target_layer_order():
 
 
 def test_init_kv_cache_with_kv_sharing_target_layer_not_exist():
+    torch.set_default_dtype(torch.float16)
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
     invalid_layer = "model.layers.0.cross_attn.attn"
@@ -455,6 +458,7 @@ def test_init_kv_cache_with_kv_sharing_target_layer_not_exist():
 
 
 def test_init_kv_cache_with_kv_sharing_target_same_as_current():
+    torch.set_default_dtype(torch.float16)
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
     error_msg = f"{layer_1} cannot be the same as the current layer"
@@ -483,6 +487,7 @@ def test_init_kv_cache_with_kv_sharing_target_same_as_current():
 
 
 def test_init_kv_cache_without_kv_sharing():
+    torch.set_default_dtype(torch.float16)
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
     vllm_config = get_vllm_config()
@@ -550,6 +555,7 @@ def test_init_kv_cache_without_kv_sharing():
 
 
 def test_init_kv_cache_with_kv_sharing_valid():
+    torch.set_default_dtype(torch.float16)
     layer_0 = "model.layers.0.self_attn.attn"
     layer_1 = "model.layers.1.self_attn.attn"
     vllm_config = get_vllm_config()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1337,13 +1337,6 @@ class EngineArgs:
                                recommend_to_remove=False)
             return False
 
-        # Only Fp16 and Bf16 dtypes since we only support FA.
-        V1_SUPPORTED_DTYPES = [torch.bfloat16, torch.float16]
-        if model_config.dtype not in V1_SUPPORTED_DTYPES:
-            _raise_or_fallback(feature_name=f"--dtype {model_config.dtype}",
-                               recommend_to_remove=False)
-            return False
-
         # No Embedding Models so far.
         if model_config.task not in ["generate"]:
             _raise_or_fallback(feature_name=f"--task {model_config.task}",

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -233,6 +233,10 @@ class CudaPlatformBase(Platform):
                 logger.info_once("Using Triton backend on V1 engine.")
                 return ("vllm.v1.attention.backends."
                         "triton_attn.TritonAttentionBackend")
+            if dtype not in (torch.float16, torch.bfloat16):
+                logger.info_once(
+                    f"Using FlexAttenion backend for {dtype} on V1 engine.")
+                return "vllm.v1.attention.backends.flex_attention.FlexAttentionBackend"  # noqa: E501
             if cls.is_device_capability(100):
                 # Prefer FlashInfer for V1 on Blackwell GPUs if installed
                 try:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
- After FlexAttention PR landed, we can use it for fp32 inference.
- This PR adds fp32 support for v1 engine through enabling FlexAttention backend.

## Test Plan
```
python examples/offline_inference/basic/generate.py --model facebook/opt-125m --dtype float32
```

## Test Result
```
INFO 06-07 15:48:36 [cuda.py:237] Using FlexAttenion backend for torch.float32 on V1 engine.
INFO 06-07 15:48:36 [weight_utils.py:292] Using model weights format ['*.bin']
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.93it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.93it/s]

INFO 06-07 15:48:37 [default_loader.py:272] Loading weights took 0.53 seconds
INFO 06-07 15:48:37 [gpu_model_runner.py:1618] Model loading took 0.4678 GiB and 0.814874 seconds
INFO 06-07 15:48:40 [backends.py:462] Using cache directory: /root/.cache/vllm/torch_compile_cache/815e1a20d0/rank_0_0 for vLLM's torch.compile
INFO 06-07 15:48:40 [backends.py:472] Dynamo bytecode transform time: 3.35 s
INFO 06-07 15:48:42 [backends.py:135] Directly load the compiled graph(s) for shape None from the cache, took 1.047 s
INFO 06-07 15:48:42 [monitor.py:34] torch.compile takes 3.35 s in total
INFO 06-07 15:48:43 [kv_cache_utils.py:715] GPU KV cache size: 176,464 tokens
INFO 06-07 15:48:43 [kv_cache_utils.py:719] Maximum concurrency for 2,048 tokens per request: 86.16x
INFO 06-07 15:49:02 [gpu_model_runner.py:2012] Graph capturing finished in 19 secs, took 0.22 GiB
INFO 06-07 15:49:02 [core.py:171] init engine (profile, create kv cache, warmup model) took 24.91 seconds
Adding requests: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 862.85it/s]
Processed prompts: 100%|██████████████████████████████████████████████████| 4/4 [00:05<00:00,  1.39s/it, est. speed input: 4.66 toks/s, output: 11.47 toks/s]
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Joel, I am a BYU lecturer and I would love to talk about your class'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: " stuck painting the country like it's 70 years old again, with behind-the"
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: " directly behind Germany's winning bid for elections as French business and French defence leaders fired"
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' predicted according to the 2020 report by a economists\nAI stand to be in the'
--------------------------------------------------
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
