### PR TITLE
[full_graph] Fix query_start_loc padding

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -655,7 +655,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Fill unused with -1. Needed for reshape_and_cache
         self.seq_lens[num_reqs:].fill_(0)
-        self.query_start_loc[num_reqs + 1:].fill_(-1)
+        # Note: pad query_start_loc to be non-decreasing, as kernels
+        # like FlashAttention requires that
+        self.query_start_loc[num_reqs + 1:].fill_(
+            self.query_start_loc_cpu[num_reqs].item())
 
         query_start_loc = self.query_start_loc[:num_reqs + 1]
         seq_lens = self.seq_lens[:num_reqs]


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
When do full graph compilation, we capture the graph with a max shaped persistent buffer for various attention metadata, one of which is `query_start_loc`. And we pad that based on actual input shape, but for `query_start_loc`, padding `-1` leads to incorrect result in compilation mode (eager is fine). Because for FlashAttention kernel, `query_start_loc` corresponds to `cu_seqlens_q` and FA kernel requires it to be non-decreasing (thanks @ipiszy for figuring this our and proposing the fix). So we pad the last element of current `query_start_loc` request size which makes it work. 

It's possible that different attention backend requires different padding. For example, there is FlashMLA https://github.com/vllm-project/vllm/pull/18581 work on going and I haven't checked the flashinfer backend requirement. Possibly we need this to be backend specific. 

## Test Plan
https://gist.github.com/yinghai/4d72cb67a056a033a7a86e59d8051d90 shows a minimal repro of the issue. 

Adding `cu_seqlens_q[bsz+1:].fill_(cu_seqlens_q0[-1])` after https://gist.github.com/yinghai/4d72cb67a056a033a7a86e59d8051d90#file-repro-py-L131 will fix the issue which is what the change in vllm here is about. 
