### PR TITLE
[Doc] Fix description in the Automatic Prefix Caching design doc

### DIFF
--- a/docs/design/v1/prefix_caching.md
+++ b/docs/design/v1/prefix_caching.md
@@ -144,7 +144,7 @@ As a result, we will have the following components when the KV cache manager is 
 
 **Running request:** Workflow for the scheduler to schedule a running request with KV cache block allocation:
 
-1. The scheduler calls `kv_cache_manager.append_slots()`. It does the following steps:  
+1. The scheduler calls `kv_cache_manager.allocate_slots()`. It does the following steps:  
    1. Compute the number of new required blocks, and return if there are no sufficient blocks to allocate.  
    2. Allocate new blocks by popping the heads of the free queue. If the head block is a cached block, this also “evicts” the block so that no other requests can reuse it anymore from now on.  
    3. Append token IDs to the slots in existing blocks as well as the new blocks. If a block is full, we add it to the Cache Block to cache it.


### PR DESCRIPTION
## Purpose

The function name is incorrect, the scheduler calls [allocate_slots](https://github.com/vllm-project/vllm/blob/v0.9.0/vllm/v1/core/kv_cache_manager.py#L171) to allocate the KV cache block.

## Test Plan

## Test Result

<!--- pyml disable-next-line no-emphasis-as-heading -->
