### PR TITLE
[Wheel Size] Only build FA2 8.0+PTX

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,7 +38,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 8798f27777fb57f447070301bf33a9f9c607f491
+          GIT_TAG 61f1cfbf303884e131632626e7349912d784726c
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,7 +38,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 61f1cfbf303884e131632626e7349912d784726c
+          GIT_TAG 763ad155a1c826f71ff318f41edb1e4e5e376ddb
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION
## Purpose

Reduce wheel size by only building FA2 8.0+PTX instead of 8.0,9.0,10.0 etc.

376.35 MB -> 339.32 MB

This does cause a slowdown in the initial runs on a machine while the PTX is JIT compiled

```
(vllm) lwilkinson@gpu66:~/code/vllm$ vllm bench throughput --model RedHatAI/Meta-Llama-3.1-8B-FP8 --load-format dummy --input-len 10000 --output-len 200 --num-prompts 100
...
Throughput: 1.27 requests/s, 12954.78 total tokens/s, 254.02 output tokens/s
```

subsequent runs:
```
(vllm) lwilkinson@gpu66:~/code/vllm$ vllm bench throughput --model RedHatAI/Meta-Llama-3.1-8B-FP8 --load-format dummy --input-len 10000 --output-len 200 --num-prompts 100
...
Throughput: 4.15 requests/s, 42355.56 total tokens/s, 830.50 output tokens/s
```

## Test Plan

CI

## Test Result

CI passing