### PR TITLE
[Misc] Cleanup compilation tests

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -11,15 +11,6 @@ from vllm.config import (CompilationConfig, CompilationLevel, VllmConfig,
 from .piecewise.test_simple import SillyModel
 
 
-@pytest.fixture(scope="function", autouse=True)
-def use_v1(monkeypatch):
-    """
-    TODO(rzou): The rest of tests/compile runs VLLM_USE_V1=0 right now,
-    I'll switch them over later.
-    """
-    monkeypatch.setenv('VLLM_USE_V1', '1')
-
-
 @pytest.mark.parametrize("enabled", [True, False])
 def test_use_cudagraphs(enabled):
     assert vllm.envs.VLLM_USE_V1


### PR DESCRIPTION
Summary:
After #19302 we no longer need to force VLLM_USE_V1 in tests/compile/test_config.py

Test Plan:
Run the tests (they assert that we are indeed using the V1 engine).

