### PR TITLE
[Docs] Fix a bullet list in usage/security.md

### DIFF
--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -31,6 +31,7 @@ refer to the [PyTorch Security
 Guide](https://github.com/pytorch/pytorch/security/policy#using-distributed-features).
 
 Key points from the PyTorch security guide:
+
 - PyTorch Distributed features are intended for internal communication only
 - They are not built for use in untrusted environments or networks
 - No authorization protocol is included for performance reasons


### PR DESCRIPTION
A bullet list is occasionally failed to render on [the security page](https://docs.vllm.ai/en/latest/usage/security.html?h=security#notes-on-pytorch-distributed) as shown below:

![image](https://github.com/user-attachments/assets/94367428-374f-4c8d-b829-ff6dce670328)
