### PR TITLE
Add security warning to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/400-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/400-bug-report.yml
@@ -12,7 +12,7 @@ body:
   attributes:
     value: |
       ⚠️ **SECURITY WARNING:** Please review any text you paste to ensure it does not contain sensitive information such as:
-      - API tokens or keys (e.g., HuggingFace tokens, OpenAI API keys)
+      - API tokens or keys (e.g., Hugging Face tokens, OpenAI API keys)
       - Passwords or authentication credentials
       - Private URLs or endpoints
       - Personal or confidential data

--- a/.github/ISSUE_TEMPLATE/400-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/400-bug-report.yml
@@ -8,6 +8,16 @@ body:
   attributes:
     value: >
       #### Before submitting an issue, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/vllm-project/vllm/issues?q=is%3Aissue+sort%3Acreated-desc+).
+- type: markdown
+  attributes:
+    value: |
+      ⚠️ **SECURITY WARNING:** Please review any text you paste to ensure it does not contain sensitive information such as:
+      - API tokens or keys (e.g., HuggingFace tokens, OpenAI API keys)
+      - Passwords or authentication credentials
+      - Private URLs or endpoints
+      - Personal or confidential data
+      
+      Consider redacting or replacing sensitive values with placeholders like `<YOUR_TOKEN_HERE>` when sharing configuration or code examples.
 - type: textarea
   attributes:
     label: Your current environment


### PR DESCRIPTION
This PR adds a prominent security warning to the GitHub bug report template to remind users to review any pasted text for sensitive information before submitting issues. The warning specifically alerts users about API tokens, passwords, private URLs, and other confidential data to prevent accidental exposure in public GitHub issues.