### PR TITLE
[Bugfix] Fix "text_offset" when "--return_tokens_as_token_ids" is enabled

### DIFF
--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -542,6 +542,7 @@ class OpenAIServingCompletion(OpenAIServing):
             step_top_logprobs = top_logprobs[i]
             if step_top_logprobs is None:
                 token = tokenizer.decode(token_id)
+                token_text = token
                 if should_return_as_token_id:
                     token = f"token_id:{token_id}"
 
@@ -556,6 +557,12 @@ class OpenAIServingCompletion(OpenAIServing):
                     token_id,
                     tokenizer,
                     return_as_token_id=should_return_as_token_id,
+                )
+                token_text = self._get_decoded_token(
+                    step_token,
+                    token_id,
+                    tokenizer,
+                    return_as_token_id=False,
                 )
                 token_logprob = max(step_token.logprob, -9999.0)
 
@@ -582,7 +589,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 out_text_offset.append(initial_text_offset)
             else:
                 out_text_offset.append(out_text_offset[-1] + last_token_len)
-            last_token_len = len(token)
+            last_token_len = len(token_text)
 
         return CompletionLogProbs(
             text_offset=out_text_offset,


### PR DESCRIPTION

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fix #19368. The `text_offset` should be calculated by accumulating the length of the actual token text in all cases. The previous code was calculating the length of `f"token_id:{token_id}"`, which cannot be mapped to the actual text sequence.
## Test Plan
A unit test is added in `tests/entrypoints/openai/test_completion.py`
## Test Result
Before: 
```text
FAILED tests/entrypoints/openai/test_completion.py::test_return_tokens_as_token_text_offset - assert [0, 14, 26, 38, 50, 62, ...] == [0, 6, 10, 12, 15, 17, ...]
```
The generated text even only has 20 characters.
After:
The text_offset is correctly aligning with the actual position in `choices[0].text`. The test is now passed.

<!--- pyml disable-next-line no-emphasis-as-heading -->
