### PR TITLE
[Bugfix] Fix modelscope token passed in

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -141,10 +141,11 @@ def list_repo_files(
             if envs.VLLM_USE_MODELSCOPE:
                 from vllm.transformers_utils.utils import (
                     modelscope_list_repo_files)
-                return modelscope_list_repo_files(
-                    repo_id,
-                    revision=revision,
-                    token=os.getenv("MODELSCOPE_API_TOKEN", None))
+                return modelscope_list_repo_files(repo_id,
+                                                  revision=revision,
+                                                  token=os.getenv(
+                                                      "MODELSCOPE_API_TOKEN",
+                                                      None))
             return hf_list_repo_files(repo_id,
                                       revision=revision,
                                       repo_type=repo_type,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -144,7 +144,7 @@ def list_repo_files(
                 return modelscope_list_repo_files(
                     repo_id,
                     revision=revision,
-                    token=os.getenv("MODELSCOPE_API_TOKEN"))
+                    token=os.getenv("MODELSCOPE_API_TOKEN", None))
             return hf_list_repo_files(repo_id,
                                       revision=revision,
                                       repo_type=repo_type,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -141,9 +141,10 @@ def list_repo_files(
             if envs.VLLM_USE_MODELSCOPE:
                 from vllm.transformers_utils.utils import (
                     modelscope_list_repo_files)
-                return modelscope_list_repo_files(repo_id,
-                                                  revision=revision,
-                                                  token=token)
+                return modelscope_list_repo_files(
+                    repo_id,
+                    revision=revision,
+                    token=os.getenv("MODELSCOPE_API_TOKEN"))
             return hf_list_repo_files(repo_id,
                                       revision=revision,
                                       repo_type=repo_type,


### PR DESCRIPTION
When we set env `VLLM_USE_MODELSCOPE`, the token is delivered as HF_TOKEN by mistake, so when should pass the real token or None