### PR TITLE
[BugFix] Allow use_cudagraph to work with dynamic VLLM_USE_V1

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -11,6 +11,16 @@ from vllm.config import (CompilationConfig, CompilationLevel, VllmConfig,
 from .piecewise.test_simple import SillyModel
 
 
+def test_use_cudagraphs_dynamic(monkeypatch):
+    assert vllm.envs.VLLM_USE_V1
+    vllm_config = VllmConfig()
+    assert vllm_config.compilation_config.use_cudagraph
+
+    monkeypatch.setenv('VLLM_USE_V1', '0')
+    vllm_config = VllmConfig()
+    assert not vllm_config.compilation_config.use_cudagraph
+
+
 @pytest.mark.parametrize("enabled", [True, False])
 def test_use_cudagraphs(enabled):
     assert vllm.envs.VLLM_USE_V1

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3931,7 +3931,7 @@ class CompilationConfig:
     constructor, e.g. `CompilationConfig(inductor_passes={"a": func})`."""
 
     # CudaGraph compilation
-    use_cudagraph: bool = envs.VLLM_USE_V1
+    use_cudagraph: bool = field(default_factory=lambda: envs.VLLM_USE_V1)
     """Whether to use cudagraph inside compilation.
     - False: cudagraph inside compilation is not used.
     - True: cudagraph inside compilation is used. It requires


### PR DESCRIPTION
Summary:
If a test dynamically changes VLLM_USE_V1, the default value of use_cudagraph doesn't get updated. This PR fixes that by setting a default factory for use_cudagraph. I'm not sure if this is relevant in real life but it is definitely relevant during testing (we dynamically set VLLM_USE_V1 all the time in tests).

Test Plan:
- added new test (`pytest tests/compile/test_config.py -v -k "use_cudagraphs_dynamic"`)
