### PR TITLE
[BugFix] Fix docker build cpu-dev image error

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -98,6 +98,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     VLLM_TARGET_DEVICE=cpu python3 setup.py develop 
 
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,src=requirements/test.in,target=requirements/test.in \
+    cp requirements/test.in requirements/test-cpu.in && \
+    sed -i '/mamba_ssm/d' requirements/test-cpu.in && \
+    uv pip compile requirements/test-cpu.in -o requirements/test.txt && \
     uv pip install -r requirements/dev.txt && \
     pre-commit install --hook-type pre-commit --hook-type commit-msg
 


### PR DESCRIPTION

## Purpose

- Fix the Issue: #19392 

## Test Plan

```bash
docker build -f docker/Dockerfile.cpu --target vllm-dev -t vllm-cpu-dev .  
```


## Test Result

Build successfully.

```bash
 => [vllm-dev 1/5] WORKDIR /workspace/vllm                                            0.1s
 => [vllm-dev 2/5] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked       10.6s
 => [vllm-dev 3/5] RUN --mount=type=cache,target=/root/.cache/uv     uv pip install   2.1s
 => [vllm-dev 4/5] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=c  47.5s
 => [vllm-dev 5/5] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=b  44.7s
 => exporting to image                                                                6.7s
 => => exporting layers                                                               6.7s
 => => writing image sha256:6434627be7803b4b9f94fc0ee868ae6fe739d49b27b970e9569fc2dd  0.0s
 => => naming to docker.io/library/vllm-cpu-dev   
```

