### PR TITLE
Feat Dynamic Quantization for MoE Layers in GPTQ Marlin Backend

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -186,8 +186,7 @@ class GPTQMarlinConfig(QuantizationConfig):
                 return MoeWNA16Config.from_config(
                     self.full_config).get_quant_method(layer, prefix)
             return get_moe_quant_method(self,layer, prefix, GPTQMarlinMoEMethod)
-        return get_linear_quant_method(self, layer, prefix,
-                                       GPTQMarlinLinearMethod)
+        return get_linear_quant_method(self, layer, prefix, GPTQMarlinLinearMethod)
 
     @classmethod
     def is_gptq_marlin_compatible(cls, quant_config: dict[str, Any]):

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from copy import deepcopy
 from typing import Any, Callable, Optional, Union
 
 import torch
@@ -9,7 +10,8 @@ import vllm.model_executor.layers.fused_moe  # noqa
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.layer import (
-    FusedMoE, FusedMoEMethodBase, FusedMoeWeightScaleSupported,UnquantizedFusedMoEMethod)
+    FusedMoE, FusedMoEMethodBase, FusedMoeWeightScaleSupported,
+    UnquantizedFusedMoEMethod)
 from vllm.model_executor.layers.linear import (LinearMethodBase,
                                                set_weight_attrs)
 from vllm.model_executor.layers.quantization import QuantizationMethods
@@ -19,7 +21,7 @@ from vllm.model_executor.layers.quantization.kernels.mixed_precision import (
     MPLinearLayerConfig, choose_mp_linear_kernel)
 from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
-    get_linear_quant_method,override_config, get_dynamic_override)
+    get_dynamic_override, get_linear_quant_method, override_config)
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_marlin_supported, check_moe_marlin_supports_layer,
     marlin_make_workspace_new, marlin_moe_permute_scales,
@@ -31,16 +33,16 @@ from vllm.model_executor.parameter import (ChannelQuantScaleParameter,
                                            RowvLLMParameter)
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
-from copy import deepcopy
 
 logger = init_logger(__name__)
 
+
 def get_moe_quant_method(
-        config: QuantizationConfig,
-        layer: torch.nn.Module,
-        prefix: str,
-        moe_method_cls: type,
-    ):
+    config: QuantizationConfig,
+    layer: torch.nn.Module,
+    prefix: str,
+    moe_method_cls: type,
+):
     cloned_config = deepcopy(config)
 
     if isinstance(layer, FusedMoE):
@@ -185,7 +187,7 @@ class GPTQMarlinConfig(QuantizationConfig):
                     "Falling back to Moe WNA16 kernels.")
                 return MoeWNA16Config.from_config(
                     self.full_config).get_quant_method(layer, prefix)
-            return get_moe_quant_method(self,layer, prefix,
+            return get_moe_quant_method(self, layer, prefix,
                                         GPTQMarlinMoEMethod)
         return get_linear_quant_method(self, layer, prefix,
                                        GPTQMarlinLinearMethod)

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -9,7 +9,7 @@ import vllm.model_executor.layers.fused_moe  # noqa
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.layer import (
-    FusedMoE, FusedMoEMethodBase, FusedMoeWeightScaleSupported)
+    FusedMoE, FusedMoEMethodBase, FusedMoeWeightScaleSupported,UnquantizedFusedMoEMethod)
 from vllm.model_executor.layers.linear import (LinearMethodBase,
                                                set_weight_attrs)
 from vllm.model_executor.layers.quantization import QuantizationMethods
@@ -19,7 +19,7 @@ from vllm.model_executor.layers.quantization.kernels.mixed_precision import (
     MPLinearLayerConfig, choose_mp_linear_kernel)
 from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
-    get_linear_quant_method)
+    get_linear_quant_method,override_config, get_dynamic_override)
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_marlin_supported, check_moe_marlin_supports_layer,
     marlin_make_workspace_new, marlin_moe_permute_scales,
@@ -31,9 +31,31 @@ from vllm.model_executor.parameter import (ChannelQuantScaleParameter,
                                            RowvLLMParameter)
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
+from copy import deepcopy
 
 logger = init_logger(__name__)
 
+def get_moe_quant_method(
+        config: QuantizationConfig,
+        layer: torch.nn.Module,
+        prefix: str,
+        moe_method_cls: type,
+    ):
+    cloned_config = deepcopy(config)
+
+    if isinstance(layer, FusedMoE):
+        # False = skip module, None = no override, else = Positive match
+        if get_dynamic_override(  # noqa: E712
+                cloned_config,  # noqa: E712
+                layer_name=prefix) == False:  # noqa: E712
+            return UnquantizedFusedMoEMethod(layer.moe_config)
+
+        if prefix:
+            # Dynamic per module/layer rules may override base config
+            override_config(cloned_config, prefix=prefix)
+
+        return moe_method_cls(cloned_config)
+    return None
 
 class GPTQMarlinConfig(QuantizationConfig):
     """Config class for GPTQ Marlin"""
@@ -163,7 +185,7 @@ class GPTQMarlinConfig(QuantizationConfig):
                     "Falling back to Moe WNA16 kernels.")
                 return MoeWNA16Config.from_config(
                     self.full_config).get_quant_method(layer, prefix)
-            return GPTQMarlinMoEMethod(self)
+            return get_moe_quant_method(self,layer, prefix, GPTQMarlinMoEMethod)
         return get_linear_quant_method(self, layer, prefix,
                                        GPTQMarlinLinearMethod)
 

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -59,6 +59,7 @@ def get_moe_quant_method(
         return moe_method_cls(cloned_config)
     return None
 
+
 class GPTQMarlinConfig(QuantizationConfig):
     """Config class for GPTQ Marlin"""
 

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -185,8 +185,10 @@ class GPTQMarlinConfig(QuantizationConfig):
                     "Falling back to Moe WNA16 kernels.")
                 return MoeWNA16Config.from_config(
                     self.full_config).get_quant_method(layer, prefix)
-            return get_moe_quant_method(self,layer, prefix, GPTQMarlinMoEMethod)
-        return get_linear_quant_method(self, layer, prefix, GPTQMarlinLinearMethod)
+            return get_moe_quant_method(self,layer, prefix,
+                                        GPTQMarlinMoEMethod)
+        return get_linear_quant_method(self, layer, prefix,
+                                       GPTQMarlinLinearMethod)
 
     @classmethod
     def is_gptq_marlin_compatible(cls, quant_config: dict[str, Any]):


### PR DESCRIPTION
dynamic Quantization Does Not Take Effect for MoE Modules with gptq_marlin in vLLM

Problem:
When running Mixture of Experts (MoE) modules using the gptq_marlin backend in vLLM, the dynamic quantization settings from the gptq configuration are not applied.

Root Cause:
In the GPTQMarlinConfig class (defined in gptq_marlin.py), the get_quant_method function uses a utility function called get_linear_quant_method (imported from gptq_utils.py) to handle per-layer dynamic quantization settings for standard linear layers. However, for MoE layers, there is currently no equivalent function in vLLM to process and apply the dynamic flag.

Solution:
To address this, we created a new helper function get_moe_quant_method (currently placed in gptq_marlin.py for simplicity) that mirrors the behavior of get_linear_quant_method, but for MoE layers. This function processes the dynamic quantization setting and returns the appropriate quantization method for each MoE layer.

Following vLLM's existing structure, this helper should ideally be moved to gptq_utils.py (similar to get_linear_quant_method) and imported into gptq_marlin.py.

Validation: 
This fix can be verified using our R1 repository  https://huggingface.co/QuantTrio/DeepSeek-R1-0528-GPTQ-Int4-Int8Mix-Medium