### PR TITLE
[BugFix][CPU] Fix CPU CI by ignore collecting test_pixtral

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-cpu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test.sh
@@ -43,7 +43,10 @@ function cpu_tests() {
     pytest -v -s tests/kernels/attention/test_mla_decode_cpu.py -m cpu_model
     pytest -v -s tests/models/language/generation -m cpu_model
     pytest -v -s tests/models/language/pooling -m cpu_model
-    pytest -v -s tests/models/multimodal/generation --ignore=tests/models/multimodal/generation/test_mllama.py -m cpu_model"
+    pytest -v -s tests/models/multimodal/generation \
+                --ignore=tests/models/multimodal/generation/test_mllama.py \
+                --ignore=tests/models/multimodal/generation/test_pixtral.py \
+                -m cpu_model"
 
   # Run compressed-tensor test
   docker exec cpu-test-"$NUMA_NODE" bash -c "


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

CPU CI is broken when collecting multimodal tests:

```bash
_____ ERROR collecting tests/models/multimodal/generation/test_pixtral.py ______
--
  | tests/models/multimodal/generation/test_pixtral.py:114: in <module>
  | _create_engine_inputs(IMG_URLS[:1]),
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | tests/models/multimodal/generation/test_pixtral.py:73: in _create_engine_inputs
  | tokenizer = MistralTokenizer.from_model("pixtral")
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | /opt/venv/lib/python3.12/site-packages/mistral_common/tokens/tokenizers/mistral.py:189: in from_model
  | return tokenizer_cls()
  | ^^^^^^^^^^^^^^^
  | /opt/venv/lib/python3.12/site-packages/mistral_common/tokens/tokenizers/mistral.py:362: in <lambda>
  | "pixtral": lambda: MistralTokenizer.v3(is_tekken=True, is_mm=True),
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | /opt/venv/lib/python3.12/site-packages/mistral_common/tokens/tokenizers/mistral.py:142: in v3
  | return cls.from_file(str(cls._data_path() / tokenizer_name), mode=ValidationMode.test)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | /opt/venv/lib/python3.12/site-packages/mistral_common/tokens/tokenizers/mistral.py:239: in from_file
  | raise TokenizerException(f"Unrecognized tokenizer file: {tokenizer_filename}")
  | E   mistral_common.exceptions.TokenizerException: Unrecognized tokenizer file: /opt/venv/lib/python3.12/site-packages/mistral_common/data/tekken_240911.json
```

Not sure about the root cause, ignore this file to fix this problem as there has no CPU tests.

## Test Plan

CI pipeline

## Test Result

CPU CI recovered in fast-check

## (Optional) Documentation Update
