### PR TITLE
Add cache to cuda get_device_capability

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -6,7 +6,7 @@ pynvml. However, it should not initialize cuda context.
 
 import os
 from datetime import timedelta
-from functools import lru_cache, wraps
+from functools import cache, wraps
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 
 import torch
@@ -389,7 +389,7 @@ class CudaPlatformBase(Platform):
 class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
-    @lru_cache(maxsize=8)
+    @cache
     @with_nvml_context
     def get_device_capability(cls,
                               device_id: int = 0
@@ -487,7 +487,7 @@ class NvmlCudaPlatform(CudaPlatformBase):
 class NonNvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
-    @lru_cache(maxsize=8)
+    @cache
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
         major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major=major, minor=minor)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -389,8 +389,8 @@ class CudaPlatformBase(Platform):
 class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
-    @with_nvml_context
     @lru_cache(maxsize=8)
+    @with_nvml_context
     def get_device_capability(cls,
                               device_id: int = 0
                               ) -> Optional[DeviceCapability]:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -6,7 +6,7 @@ pynvml. However, it should not initialize cuda context.
 
 import os
 from datetime import timedelta
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 
 import torch
@@ -390,6 +390,7 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     @with_nvml_context
+    @lru_cache(maxsize=8)
     def get_device_capability(cls,
                               device_id: int = 0
                               ) -> Optional[DeviceCapability]:
@@ -486,6 +487,7 @@ class NvmlCudaPlatform(CudaPlatformBase):
 class NonNvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
+    @lru_cache(maxsize=8)
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
         major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major=major, minor=minor)


### PR DESCRIPTION
## Purpose

I worry that current_platform.get_device_capability and has_device_capability are called on the hot path in situations like runtime kernel selection (CUTLASS or DeepGEMM kernels) so I want to change these results to be cached for the num of devices. I think there are generally only a max of 8 devices per process/host, although this may change with GB200 NVL72.

This is already present in `rocm.py` as a precedent: https://github.com/vllm-project/vllm/blob/da9b523ce1fd5c27bfd18921ba0388bf2e8e4618/vllm/platforms/rocm.py#L229-L235

## Test Plan

Green CI

## Test Result
