### PR TITLE
[Chore] debloat some initial logs

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -538,10 +538,10 @@ class ModelConfig:
                                self.code_revision, self.config_format)
 
         if hf_overrides_kw:
-            logger.info("Overriding HF config with %s", hf_overrides_kw)
+            logger.debug("Overriding HF config with %s", hf_overrides_kw)
             hf_config.update(hf_overrides_kw)
         if hf_overrides_fn:
-            logger.info("Overriding HF config with %s", hf_overrides_fn)
+            logger.debug("Overriding HF config with %s", hf_overrides_fn)
             hf_config = hf_overrides_fn(hf_config)
 
         self.hf_config = hf_config
@@ -1938,8 +1938,8 @@ class ParallelConfig:
                         if get_current_placement_group():
                             backend = "ray"
             self.distributed_executor_backend = backend
-            logger.info("Defaulting to use %s for distributed inference",
-                        backend)
+            logger.debug("Defaulting to use %s for distributed inference",
+                         backend)
 
         if self.distributed_executor_backend is None and self.world_size == 1:
             self.distributed_executor_backend = "uni"

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -306,7 +306,7 @@ def log_non_default_args(args: argparse.Namespace):
     for arg, default in vars(parser.parse_args([])).items():
         if default != getattr(args, arg):
             non_default_args[arg] = getattr(args, arg)
-    logger.info("non-default args: %s", non_default_args)
+    logger.debug("non-default args: %s", non_default_args)
 
 
 def create_parser_for_docs() -> FlexibleArgumentParser:

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -306,7 +306,7 @@ def log_non_default_args(args: argparse.Namespace):
     for arg, default in vars(parser.parse_args([])).items():
         if default != getattr(args, arg):
             non_default_args[arg] = getattr(args, arg)
-    logger.debug("non-default args: %s", non_default_args)
+    logger.info("non-default args: %s", non_default_args)
 
 
 def create_parser_for_docs() -> FlexibleArgumentParser:


### PR DESCRIPTION
This PR moves a few log lines onto debug mode

```bash
INFO 06-10 17:32:33 [cli_args.py:309] non-default args: ...
INFO 06-10 17:32:38 [config.py:1946] Defaulting to use mp for distributed inference
INFO 06-10 17:32:39 [config.py:536] Overriding HF config with ...
```

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
