### PR TITLE
Fix Typo in Documentation and Function Name

### DIFF
--- a/tests/kernels/attention/test_encoder_decoder_attn.py
+++ b/tests/kernels/attention/test_encoder_decoder_attn.py
@@ -99,7 +99,7 @@ class TestResources(NamedTuple):
     Attributes:
 
     * scale: 1/sqrt(d) scale factor for attn
-    * attn_backend: implementatino of abstraction
+    * attn_backend: implementations of abstraction
                     attention interface using
                     a particular kernel library
                     i.e. XFormers

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -28,7 +28,7 @@ def reset_default_device():
     torch.set_default_device(original_device)
 
 
-def test_topk_impl_equivalance():
+def test_topk_impl_equivalence():
 
     torch.set_default_device(DEVICE)
     generator = Generator(device=DEVICE).manual_seed(33)


### PR DESCRIPTION


Description:  
This pull request addresses two minor issues:
1. Corrects a typo in the documentation of `attn_backend` in `test_encoder_decoder_attn.py` by changing "implementation" to "implementations".
2. Fixes a typo in the function name `test_topk_impl_equivalance` to `test_topk_impl_equivalence` in `test_topk_topp_sampler.py`.

These changes improve code readability and maintain consistency in naming conventions. No functional code was altered.