### PR TITLE
Fix test_max_model_len in tests/entrypoints/llm/test_generate.py

### DIFF
--- a/tests/entrypoints/llm/test_generate.py
+++ b/tests/entrypoints/llm/test_generate.py
@@ -125,4 +125,7 @@ def test_max_model_len():
     for output in outputs:
         num_total_tokens = len(output.prompt_token_ids) + len(
             output.outputs[0].token_ids)
-        assert num_total_tokens == max_model_len
+        # Total tokens must not exceed max_model_len.
+        # It can be less if generation finishes due to other reasons (e.g., EOS)
+        # before reaching the absolute model length limit.
+        assert num_total_tokens <= max_model_len


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
The original test didn't consider cases that we exit earlier. So we should relax the test to <= from ==

Some failing example: https://buildkite.com/vllm/fastcheck/builds/26960#01975b5c-44fe-43b0-88b4-272b80a8263f

## Test Plan
pytest tests/entrypoints/llm/test_generate.py

## Test Result
The test passed.

## (Optional) Documentation Update
N/A
