### PR TITLE
[Bugfix] Enforce contiguous input for dynamic_per_token FP8/INT8 quant

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1267,7 +1267,7 @@ def scaled_fp8_quant(
                                 device=input.device,
                                 dtype=torch.float32)
             torch.ops._C.dynamic_per_token_scaled_fp8_quant(
-                output, input, scale, scale_ub)
+                output, input.contiguous(), scale, scale_ub)
         else:
             scale = torch.zeros(1, device=input.device, dtype=torch.float32)
             torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
@@ -1376,8 +1376,8 @@ def scaled_int8_quant(
                                dtype=torch.float32)
     input_azp = None if symmetric else torch.empty_like(input_scales,
                                                         dtype=torch.int32)
-    torch.ops._C.dynamic_scaled_int8_quant(output, input, input_scales,
-                                           input_azp)
+    torch.ops._C.dynamic_scaled_int8_quant(output, input.contiguous(),
+                                           input_scales, input_azp)
     return output, input_scales, input_azp
 
 


### PR DESCRIPTION
## Purpose

We require that the inputs are contiguous for both the `dynamic_per_token_scaled_fp8_quant` and `dynamic_scaled_int8_quant` kernels. This PR enforces that as I ran into an error when evaluating a deepseek model.

## Test Plan

Tested using FP8-dynamic DeepSeek V2 Lite (per token and per channel)

## Test Result

Before:
```
lm_eval --model vllm --model_args pretrained=nm-testing/DeepSeek-Coder-V2-Lite-Instruct-FP8-dynamic --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto 
...
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py", line 145, in apply_weights
    return self.fp8_linear.apply(input=x,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/utils/w8a8_utils.py", line 351, in apply
    qinput, x_scale = ops.scaled_fp8_quant(
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/home/mgoin/code/vllm/vllm/_custom_ops.py", line 1269, in scaled_fp8_quant
    torch.ops._C.dynamic_per_token_scaled_fp8_quant(
  File "/home/mgoin/venvs/vllm/lib/python3.12/site-packages/torch/_ops.py", line 1158, in __call__
    return self._op(*args, **(kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected input.is_contiguous() to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
```

After:
```
lm_eval --model vllm --model_args pretrained=nm-testing/DeepSeek-Coder-V2-Lite-Instruct-FP8-dynamic --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto 
vllm (pretrained=nm-testing/DeepSeek-Coder-V2-Lite-Instruct-FP8-dynamic,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7528|±  |0.0119|
|     |       |strict-match    |     5|exact_match|↑  |0.7362|±  |0.0121|
```
