### PR TITLE
[CI] Disable failing GGUF model test

### DIFF
--- a/tests/models/quantization/test_gguf.py
+++ b/tests/models/quantization/test_gguf.py
@@ -79,7 +79,7 @@ DOLPHIN_CONFIG = GGUFTestConfig(
 )
 
 MODELS = [
-    # LLAMA_CONFIG, # broken
+    # LLAMA_CONFIG, # broken: https://github.com/vllm-project/vllm/issues/19458
     QWEN2_CONFIG,
     PHI3_CONFIG,
     GPT2_CONFIG,

--- a/tests/models/quantization/test_gguf.py
+++ b/tests/models/quantization/test_gguf.py
@@ -79,7 +79,7 @@ DOLPHIN_CONFIG = GGUFTestConfig(
 )
 
 MODELS = [
-    LLAMA_CONFIG,
+    # LLAMA_CONFIG, # broken
     QWEN2_CONFIG,
     PHI3_CONFIG,
     GPT2_CONFIG,


### PR DESCRIPTION
This specific Llama 1B GGUF model test has been failing consistently in multiple PRs https://buildkite.com/vllm/ci/builds/21800/steps/waterfall?jid=01975af4-f581-4d43-a1e5-7175d960b2b7#01975af4-f581-4d43-a1e5-7175d960b2b7/212-6971

I propose we disable it for now to ignore as there are still tests passing the Qwen2, Phi3, etc

Tracking issue https://github.com/vllm-project/vllm/issues/19458