### PR TITLE
[BugFix] Destroy nccl Comm to fix cuda memory leak of `destroy_model_parallel`

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -107,6 +107,10 @@ class PyNcclCommunicator:
             stream.synchronize()
             del data
 
+    def __del__(self):
+        with torch.cuda.device(self.device):
+            self.nccl.ncclCommDestroy(self.comm)
+
     def all_reduce(self,
                    in_tensor: torch.Tensor,
                    op: ReduceOp = ReduceOp.SUM,

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -108,8 +108,9 @@ class PyNcclCommunicator:
             del data
 
     def __del__(self):
-        with torch.cuda.device(self.device):
-            self.nccl.ncclCommDestroy(self.comm)
+        if hasattr(self, "comm"):
+            with torch.cuda.device(self.device):
+                self.nccl.ncclCommDestroy(self.comm)
 
     def all_reduce(self,
                    in_tensor: torch.Tensor,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

to fix the bug of cuda memory leak when call `cleanup_dist_env_and_memory` and `destroy_model_parallel`

## Test Plan
```py
# filename: test_pynccl_memory_leak.py
import gc
import time
import torch
import torch.distributed as dist
import torch.multiprocessing as mp

def get_gpu_memory_usage(device_id: int) -> tuple[float, float]:
    torch.cuda.set_device(device_id)
    torch.cuda.synchronize()
    free, total = torch.cuda.mem_get_info(device_id)
    return total - free

def test_pynccl_memory_leak(rank: int, world_size: int, iterations: int = 10):
    import os
    os.environ['MASTER_ADDR'] = '127.0.0.1'
    os.environ['MASTER_PORT'] = '29500'
    
    dist.init_process_group(
        backend='gloo',
        rank=rank,
        world_size=world_size
    )
    
    device = torch.device(f"cuda:{rank}")
    torch.cuda.set_device(device)
    
    used = get_gpu_memory_usage(rank)
    print(f"[Rank {rank}] init memory usage: {used / 1024**2:.2f}MB")
    
    from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
    
    cpu_group = dist.group.WORLD
    
    for i in range(iterations):
        pynccl_comm = PyNcclCommunicator(
                group=cpu_group,
                device=device
            )
        del pynccl_comm
        gc.collect()
        torch.cuda.empty_cache()
        time.sleep(0.1)
        used = get_gpu_memory_usage(rank)
        print(f"[Rank {rank}] {i+1}-th new & del pynccl communicator, memory usage: {used / 1024**2:.2f}MB")
        
    dist.destroy_process_group()

def main():
    if not torch.cuda.is_available():
        print("❌ CUDA is not available, cannot test")
        return
    
    world_size = torch.cuda.device_count()
    if world_size < 2:
        print("❌ need at least 2 GPUs to test NCCL communication, current available GPUs:", world_size)
        print("hint: use CUDA_VISIBLE_DEVICES=0,1 python test_pynccl_memory_leak.py")
        return
    
    print(f"test with {world_size} GPUs...")
    
    mp.spawn(
        test_pynccl_memory_leak,
        args=(world_size, 5),
        nprocs=world_size,
        join=True
    )

if __name__ == "__main__":
    main() 
```

run this script on a machine with multi GPUs via

```shell
CUDA_VISIBLE_DEVICES=0,1,2,3 VLLM_LOGGING_LEVEL=ERROR \
python test_pynccl_memory_leak.py
```

## Test Result

my machine is nVidia A100 * 8.

before fix it, the results were
```
test with 4 GPUs...
[Rank 1] init memory usage: 420.81MB
[Rank 2] init memory usage: 420.81MB
[Rank 0] init memory usage: 420.81MB
[Rank 3] init memory usage: 420.81MB
[Rank 0] 1-th new & del pynccl communicator, memory usage: 1026.81MB
[Rank 1] 1-th new & del pynccl communicator, memory usage: 1122.81MB
[Rank 2] 1-th new & del pynccl communicator, memory usage: 1122.81MB
[Rank 3] 1-th new & del pynccl communicator, memory usage: 1026.81MB
[Rank 3] 2-th new & del pynccl communicator, memory usage: 1442.81MB
[Rank 0] 2-th new & del pynccl communicator, memory usage: 1442.81MB
[Rank 2] 2-th new & del pynccl communicator, memory usage: 1634.81MB
[Rank 1] 2-th new & del pynccl communicator, memory usage: 1634.81MB
[Rank 0] 3-th new & del pynccl communicator, memory usage: 1860.81MB
[Rank 1] 3-th new & del pynccl communicator, memory usage: 2148.81MB
[Rank 2] 3-th new & del pynccl communicator, memory usage: 2148.81MB
[Rank 3] 3-th new & del pynccl communicator, memory usage: 1860.81MB
[Rank 0] 4-th new & del pynccl communicator, memory usage: 2276.81MB
[Rank 2] 4-th new & del pynccl communicator, memory usage: 2660.81MB
[Rank 1] 4-th new & del pynccl communicator, memory usage: 2660.81MB
[Rank 3] 4-th new & del pynccl communicator, memory usage: 2276.81MB
[Rank 0] 5-th new & del pynccl communicator, memory usage: 2692.81MB
[Rank 1] 5-th new & del pynccl communicator, memory usage: 3172.81MB
[Rank 2] 5-th new & del pynccl communicator, memory usage: 3172.81MB
[Rank 3] 5-th new & del pynccl communicator, memory usage: 2692.81MB
```

after fix it, the results are 

```
test with 4 GPUs...
[Rank 1] init memory usage: 420.81MB
[Rank 2] init memory usage: 420.81MB
[Rank 0] init memory usage: 420.81MB
[Rank 3] init memory usage: 420.81MB
[Rank 1] 1-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 3] 1-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 2] 1-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 0] 1-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 3] 2-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 2] 2-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 0] 2-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 1] 2-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 3] 3-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 2] 3-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 0] 3-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 1] 3-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 3] 4-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 2] 4-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 0] 4-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 1] 4-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 3] 5-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 0] 5-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 2] 5-th new & del pynccl communicator, memory usage: 608.81MB
[Rank 1] 5-th new & del pynccl communicator, memory usage: 608.81MB
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
