### PR TITLE
fix: Properly set engine_id when using multi connector in dynamo

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -47,7 +47,10 @@ class MultiConnector(KVConnectorBase_V1):
         assert ktcs is not None
         for ktc in ktcs:
             temp_config = copy.copy(vllm_config)
-            temp_config.kv_transfer_config = KVTransferConfig(**ktc)
+            engine_id = vllm_config.kv_transfer_config.engine_id if ktc.get(
+                "engine_id") is None else ktc.get("engine_id")
+            temp_config.kv_transfer_config = KVTransferConfig(
+                **ktc, engine_id=engine_id)
             self._connectors.append(
                 KVConnectorFactory.create_connector_v1(temp_config, role))
 


### PR DESCRIPTION
Currently, when NixlConnector is used in MultiConnector, the NixlConnectorScheduler and NixlConnectorWorker on the same node will be set to different engine_ids, resulting in the corresponding engine_id being unable to be found during transmission.This fixes it.

![image](https://github.com/user-attachments/assets/255aa345-8f91-4540-933b-323b4ee3fca5)

dynamo config:

```yaml
Common:
  model: /model/QwQ-32B-ppt_refine_distill_230k-gptq-int4
  block-size: 16
  served_model_name: QwQ-32B
  kv-transfer-config: '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"SharedStorageConnector","kv_role":"kv_both","kv_connector_extra_config":{"shared_storage_path":"local_storage"}}]}}'

Frontend:
  endpoint: dynamo.SimpleLoadBalancer.generate_disagg
  port: 8000
  served_model_name: QwQ-32B 

SimpleLoadBalancer:
  enable_disagg: true
  common-configs: [model, block-size, kv-transfer-config, served_model_name]

VllmPrefillWorker:
  enforce-eager: true
  ServiceArgs:
    workers: 1
    resources:
      gpu: 1
  common-configs: [model, block-size, kv-transfer-config, served_model_name]

VllmDecodeWorker:
  enforce-eager: true
  ServiceArgs:
    workers: 1
    resources:
      gpu: 1
  common-configs: [model, block-size, kv-transfer-config, served_model_name]
```

dynamo serve graphs.disagg:Frontend -f configs/test_disagg.yaml

vllm version: 0.9.0.1
dynamo version: 0.3.0