### PR TITLE
[Misc] Fix  misleading ROCm warning

### DIFF
--- a/vllm/attention/ops/triton_flash_attention.py
+++ b/vllm/attention/ops/triton_flash_attention.py
@@ -25,8 +25,13 @@ Not currently supported:
 import torch
 
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx1x
 from vllm.triton_utils import tl, triton
+
+# Avoid misleading ROCm warning.
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_gfx1x
+else:
+    on_gfx1x = lambda *args, **kwargs: False
 
 torch_dtype: tl.constexpr = torch.float16
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Importing [rocm](https://github.com/vllm-project/vllm/blob/v0.9.1/vllm/attention/ops/triton_flash_attention.py#L28 ) causes the following log output, and this PR is to avoid this.
```shell
WARNING 06-11 08:09:14 [rocm.py:28] Failed to import from amdsmi with ModuleNotFoundError("No module named 'amdsmi'")
WARNING 06-11 08:09:14 [rocm.py:39] Failed to import from vllm._rocm_C with ModuleNotFoundError("No module named 'vllm._rocm_C'")
```
## Test Plan

```python
import os
from vllm import LLM

os.environ["VLLM_USE_V1"] = "0"
llm = LLM(
    model="deepseek-ai/DeepSeek-V2-Lite-Chat",
)

```
## Test Result
The above logs should not be output"
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
