### PR TITLE
[Bugfix][V1] Allow manual FlashAttention for Blackwell

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -233,7 +233,7 @@ class CudaPlatformBase(Platform):
                 logger.info_once("Using Triton backend on V1 engine.")
                 return ("vllm.v1.attention.backends."
                         "triton_attn.TritonAttentionBackend")
-            elif selected_backend in _Backend.FLASH_ATTN:
+            elif selected_backend == _Backend.FLASH_ATTN:
                 logger.info_once("Using Flash Attention backend on V1 engine.")
                 return ("vllm.v1.attention.backends."
                         "flash_attn.FlashAttentionBackend")

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -226,15 +226,21 @@ class CudaPlatformBase(Platform):
             if selected_backend == _Backend.FLASHINFER:
                 logger.info_once("Using FlashInfer backend on V1 engine.")
                 return "vllm.v1.attention.backends.flashinfer.FlashInferBackend"
-            if selected_backend == _Backend.FLEX_ATTENTION:
+            elif selected_backend == _Backend.FLEX_ATTENTION:
                 logger.info("Using FlexAttenion backend on V1 engine.")
                 return "vllm.v1.attention.backends.flex_attention.FlexAttentionBackend"  # noqa: E501
-            if selected_backend == _Backend.TRITON_ATTN_VLLM_V1:
+            elif selected_backend == _Backend.TRITON_ATTN_VLLM_V1:
                 logger.info_once("Using Triton backend on V1 engine.")
                 return ("vllm.v1.attention.backends."
                         "triton_attn.TritonAttentionBackend")
+            elif selected_backend in _Backend.FLASH_ATTN:
+                logger.info_once("Using Flash Attention backend on V1 engine.")
+                return ("vllm.v1.attention.backends."
+                        "flash_attn.FlashAttentionBackend")
+
+            # Default backends for V1 engine
+            # Prefer FlashInfer for Blackwell GPUs if installed
             if cls.is_device_capability(100):
-                # Prefer FlashInfer for V1 on Blackwell GPUs if installed
                 try:
                     import flashinfer  # noqa: F401
                     logger.info_once(
@@ -248,10 +254,13 @@ class CudaPlatformBase(Platform):
                         "Blackwell (SM 10.0) GPUs; it is recommended to "
                         "install FlashInfer for better performance.")
                     pass
-            if cls.has_device_capability(80):
+            # FlashAttention is the default for SM 8.0+ GPUs
+            elif cls.has_device_capability(80):
                 logger.info_once("Using Flash Attention backend on V1 engine.")
                 return ("vllm.v1.attention.backends."
                         "flash_attn.FlashAttentionBackend")
+
+        # Backends for V0 engine
         if selected_backend == _Backend.FLASHINFER:
             logger.info("Using FlashInfer backend.")
             return "vllm.attention.backends.flashinfer.FlashInferBackend"


### PR DESCRIPTION
## Purpose

In the previous PR to use FlashInfer by default (https://github.com/vllm-project/vllm/pull/19118), this inadventantly prevents FlashAttention from being used if FlashInfer is installed since we don't have an explicit case to check for the selected_backend to be FA.

## Test Plan

Test locally on a B200

## Test Result

Before (main):
```
VLLM_ATTENTION_BACKEND=FLASH_ATTN vllm serve meta-llama/Llama-3.1-8B-Instruct
...
INFO 06-11 10:42:28 [cuda.py:240] Using FlashInfer backend on V1 engine by default for Blackwell (SM 10.0) GPUs.
```

After (PR):
```
VLLM_ATTENTION_BACKEND=FLASH_ATTN vllm serve meta-llama/Llama-3.1-8B-Instruct
...
INFO 06-11 10:41:12 [cuda.py:237] Using Flash Attention backend on V1 engine.
```