### PR TITLE
[Bugfix] Respect num-gpu-blocks-override in v1

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -900,3 +900,19 @@ def test_get_kv_cache_config():
     with pytest.raises(NotImplementedError):
         get_kv_cache_config(vllm_config, kv_cache_specs_hybrid,
                             mem_per_block_per_layer * 2 * 32)
+
+    # Test num_gpu_blocks_override
+    vllm_config.cache_config.num_gpu_blocks_override = 16
+    kv_cache_config_override_blocks = get_kv_cache_config(
+        vllm_config, kv_cache_specs_full, mem_per_block_per_layer * 2 * 32)
+    assert kv_cache_config_override_blocks == KVCacheConfig(
+        num_blocks=16,
+        kv_cache_tensors=[
+            KVCacheTensor(size=mem_per_block_per_layer * 16,
+                          shared_by=["layer_1"]),
+            KVCacheTensor(size=mem_per_block_per_layer * 16,
+                          shared_by=["layer_2"]),
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer_1", "layer_2"], new_kv_cache_spec())
+        ])

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -660,6 +660,7 @@ def get_num_blocks(vllm_config: VllmConfig, num_layers: int,
         logger.info(
             "Overriding num_gpu_blocks=%d with "
             "num_gpu_blocks_override=%d", num_blocks, num_gpu_blocks_override)
+        return num_gpu_blocks_override
     return num_blocks
 
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -660,7 +660,7 @@ def get_num_blocks(vllm_config: VllmConfig, num_layers: int,
         logger.info(
             "Overriding num_gpu_blocks=%d with "
             "num_gpu_blocks_override=%d", num_blocks, num_gpu_blocks_override)
-        return num_gpu_blocks_override
+        num_blocks = num_gpu_blocks_override
     return num_blocks
 
 


### PR DESCRIPTION
## Purpose
This PR ensures that `--num-gpu-blocks-override` is respected in v1. This option is useful for testing preemption and CPU KV cache offloading via a custom KV connector.

## Test Plan
Added test case to `tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_config`:
```
pytest -s -vv tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_config
```

Also, run `vllm serve` with `--num-gpu-blocks-override 100` and custom CPU KV cache connector.

## Test Result
Unit test `tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_config` passes.

vLLM logs now reflect correct GPU KV cache size, and CPU KV cache kicks in within just a few requests, as expected.

Before:
```
(VllmWorker rank=0 pid=3947788) INFO 06-11 10:47:43 [gpu_worker.py:227] Available KV cache memory: 81.38 GiB                             
INFO 06-11 10:47:44 [kv_cache_utils.py:660] Overriding num_gpu_blocks=333325 with num_gpu_blocks_override=100                             INFO 06-11 10:47:44 [kv_cache_utils.py:715] GPU KV cache size: 5,333,200 tokens                              
INFO 06-11 10:47:44 [kv_cache_utils.py:719] Maximum concurrency for 131,072 tokens per request: 40.69x                                    INFO 06-11 10:47:44 [kv_cache_utils.py:660] Overriding num_gpu_blocks=333325 with num_gpu_blocks_override=100
INFO 06-11 10:47:44 [kv_cache_utils.py:715] GPU KV cache size: 5,333,200 tokens                                                           INFO 06-11 10:47:44 [kv_cache_utils.py:719] Maximum concurrency for 131,072 tokens per request: 40.69x                                    
```

After:
```
(VllmWorker rank=1 pid=125313) INFO 06-11 10:55:07 [gpu_worker.py:227] Available KV cache memory: 81.38 GiB
INFO 06-11 10:55:07 [kv_cache_utils.py:660] Overriding num_gpu_blocks=333325 with num_gpu_blocks_override=100                            
INFO 06-11 10:55:07 [kv_cache_utils.py:716] GPU KV cache size: 1,600 tokens                                                              
INFO 06-11 10:55:07 [kv_cache_utils.py:720] Maximum concurrency for 131,072 tokens per request: 0.01x                                     INFO 06-11 10:55:07 [kv_cache_utils.py:660] Overriding num_gpu_blocks=333325 with num_gpu_blocks_override=100
INFO 06-11 10:55:07 [kv_cache_utils.py:716] GPU KV cache size: 1,600 tokens                                                               INFO 06-11 10:55:07 [kv_cache_utils.py:720] Maximum concurrency for 131,072 tokens per request: 0.01x
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
