### PR TITLE
[CI/Build] Fix torch nightly CI dependencies

### DIFF
--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -10,7 +10,7 @@ pytest-timeout
 
 librosa # required by audio tests in entrypoints/openai
 sentence-transformers # required for embedding tests
-transformers==4.51.3
+transformers==4.52.4
 transformers_stream_generator # required for qwen-vl test
 numba == 0.61.2; python_version > '3.9'
 # testing utils
@@ -42,5 +42,5 @@ num2words # required for smolvlm test
 pqdm
 timm # required for internvl test
 
-schemathesis>=3.39.15  # Required for openai schema test.
+schemathesis==3.39.15  # Required for openai schema test.
 mteb>=1.38.11, <2 # required for mteb test


### PR DESCRIPTION
Summary:
I copied over the right dependencies from requirements/test.txt. In the future we should figure out how to autogenerate the torch nightly dependencies file.

Test Plan:
- Wait for CI (verify that the torch nightly job is green)
