### PR TITLE
[Bugfix] Register reducer even if transformers_modules not available

### DIFF
--- a/tests/config/test_mp_reducer.py
+++ b/tests/config/test_mp_reducer.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import sys
+from unittest.mock import patch
+
+from vllm.config import VllmConfig
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.v1.engine.async_llm import AsyncLLM
+
+
+def test_mp_reducer(monkeypatch):
+    """
+    Test that _reduce_config reducer is registered when AsyncLLM is instantiated
+    without transformers_modules. This is a regression test for
+    https://github.com/vllm-project/vllm/pull/18640.
+    """
+
+    # Use V1 AsyncLLM which calls maybe_register_config_serialize_by_value
+    monkeypatch.setenv('VLLM_USE_V1', '1')
+
+    # Ensure transformers_modules is not in sys.modules
+    if 'transformers_modules' in sys.modules:
+        del sys.modules['transformers_modules']
+
+    with patch('multiprocessing.reducer.register') as mock_register:
+        engine_args = AsyncEngineArgs(
+            model="facebook/opt-125m",
+            max_model_len=32,
+            gpu_memory_utilization=0.1,
+            disable_log_stats=True,
+            disable_log_requests=True,
+        )
+
+        async_llm = AsyncLLM.from_engine_args(
+            engine_args,
+            start_engine_loop=False,
+        )
+
+        assert mock_register.called, (
+            "multiprocessing.reducer.register should have been called")
+
+        vllm_config_registered = False
+        for call_args in mock_register.call_args_list:
+            # Verify that a reducer for VllmConfig was registered
+            if len(call_args[0]) >= 2 and call_args[0][0] == VllmConfig:
+                vllm_config_registered = True
+
+                reducer_func = call_args[0][1]
+                assert callable(
+                    reducer_func), "Reducer function should be callable"
+                break
+
+        assert vllm_config_registered, (
+            "VllmConfig should have been registered to multiprocessing.reducer"
+        )
+
+        async_llm.shutdown()

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -639,33 +639,34 @@ def maybe_register_config_serialize_by_value() -> None:
     """ # noqa
     try:
         import transformers_modules
+        transformers_modules_available = True
     except ImportError:
-        # the config does not need trust_remote_code
-        return
+        transformers_modules_available = False
 
     try:
-        import cloudpickle
-        cloudpickle.register_pickle_by_value(transformers_modules)
-
-        # ray vendors its own version of cloudpickle
-        from vllm.executor.ray_utils import ray
-        if ray:
-            ray.cloudpickle.register_pickle_by_value(transformers_modules)
-
-        # multiprocessing uses pickle to serialize arguments when using spawn
-        # Here we get pickle to use cloudpickle to serialize config objects
-        # that contain instances of the custom config class to avoid
-        # serialization problems if the generated module (and model) has a `.`
-        # in its name
         import multiprocessing
         import pickle
 
+        import cloudpickle
+
         from vllm.config import VllmConfig
 
+        # Register multiprocessing reducers to handle cross-process
+        # serialization of VllmConfig objects that may contain custom configs
+        # from transformers_modules
         def _reduce_config(config: VllmConfig):
             return (pickle.loads, (cloudpickle.dumps(config), ))
 
         multiprocessing.reducer.register(VllmConfig, _reduce_config)
+
+        # Register transformers_modules with cloudpickle if available
+        if transformers_modules_available:
+            cloudpickle.register_pickle_by_value(transformers_modules)
+
+            # ray vendors its own version of cloudpickle
+            from vllm.executor.ray_utils import ray
+            if ray:
+                ray.cloudpickle.register_pickle_by_value(transformers_modules)
 
     except Exception as e:
         logger.warning(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fix crash due to pickle serialization error, regression from #18640.

Reproducer:
```
from ray import serve
from ray.serve.llm import LLMConfig, build_openai_app

llm_config = LLMConfig(
    model_loading_config=dict(
        model_id="deepseek",
        model_source="deepseek-ai/DeepSeek-V2-Lite",
    ),
    runtime_env=dict(
        env_vars={"VLLM_USE_V1": "1"}
    ),
    deployment_config=dict(
        autoscaling_config=dict(min_replicas=1, max_replicas=1),
    ),
    engine_kwargs=dict(
        tensor_parallel_size=2,
        pipeline_parallel_size=2,
        gpu_memory_utilization=0.92,
        dtype="auto",
        max_num_seqs=40,
        max_model_len=16384,
        enable_chunked_prefill=True,
        enable_prefix_caching=True,
        trust_remote_code=True,
    ),
)

app = build_openai_app({"llm_configs": [llm_config]})
serve.run(app, blocking=True)
```

Logs:
```
(base) ray@ip-10-0-187-137:~/default/test$ python serve.py 
INFO 06-11 13:15:22 [__init__.py:243] Automatically detected platform cuda.
2025-06-11 13:15:26,248 INFO worker.py:1736 -- Connecting to existing Ray cluster at address: 10.0.187.137:6379...
2025-06-11 13:15:26,260 INFO worker.py:1907 -- Connected to Ray cluster. View the dashboard at https://session-wt3bx4gfx89xq279ieluvgpthx.i.anyscaleuserdata.com 
2025-06-11 13:15:26,261 INFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_9ff90b59d6f4660e7f58c35c2920d87d050382c3.zip' (0.00MiB) to Ray cluster...
2025-06-11 13:15:26,262 INFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_9ff90b59d6f4660e7f58c35c2920d87d050382c3.zip'.
INFO 2025-06-11 13:15:26,367 serve 60859 -- Connecting to existing Serve app in namespace "serve". New http options will not be applied.
(ServeController pid=45327) INFO 2025-06-11 13:15:26,392 controller 45327 -- Deploying new version of Deployment(name='LLMDeploymentdeepseek', app='default') (initial target replicas: 1).
(ServeController pid=45327) INFO 2025-06-11 13:15:26,393 controller 45327 -- Deploying new version of Deployment(name='LLMRouter', app='default') (initial target replicas: 2).
(ServeController pid=45327) INFO 2025-06-11 13:15:26,497 controller 45327 -- Adding 1 replica to Deployment(name='LLMDeploymentdeepseek', app='default').
(ServeController pid=45327) INFO 2025-06-11 13:15:26,500 controller 45327 -- Stopping 1 replicas of Deployment(name='LLMRouter', app='default') with outdated versions.
(ServeController pid=45327) INFO 2025-06-11 13:15:26,500 controller 45327 -- Adding 1 replica to Deployment(name='LLMRouter', app='default').
(ServeController pid=45327) INFO 2025-06-11 13:15:26,637 controller 45327 -- Replica(id='xwtag3zo', deployment='LLMRouter', app='default') did not shut down after grace period, force-killing it. 
(ServeController pid=45327) INFO 2025-06-11 13:15:26,742 controller 45327 -- Replica(id='xwtag3zo', deployment='LLMRouter', app='default') is stopped.
(ServeReplica:default:LLMDeploymentdeepseek pid=61051) INFO 06-11 13:15:30 [__init__.py:243] Automatically detected platform cuda.
(ServeReplica:default:LLMDeploymentdeepseek pid=61051) INFO 2025-06-11 13:15:33,682 default_LLMDeploymentdeepseek 03l9rrsq -- Running tasks to download model files on worker nodes
(download_model_files pid=61269) No cloud storage mirror configured
(ServeReplica:default:LLMDeploymentdeepseek pid=61051) You are using a model of type deepseek_v2 to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
(ServeReplica:default:LLMDeploymentdeepseek pid=61051) You are using a model of type deepseek_v2 to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
(pid=61380) INFO 06-11 13:15:40 [__init__.py:243] Automatically detected platform cuda. [repeated 2x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)
(_get_vllm_engine_config pid=61380) INFO 06-11 13:15:43 [__init__.py:31] Available plugins for group vllm.general_plugins:
(_get_vllm_engine_config pid=61380) INFO 06-11 13:15:43 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
(_get_vllm_engine_config pid=61380) INFO 06-11 13:15:43 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(_get_vllm_engine_config pid=61380) INFO 06-11 13:15:43 [config.py:213] Replacing legacy 'type' key with 'rope_type'
(ServeController pid=45327) WARNING 2025-06-11 13:15:45,277 controller 45327 -- Deployment 'LLMRouter' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=45327) This may be caused by a slow __init__ or reconfigure method.
(ServeReplica:default:LLMDeploymentdeepseek pid=61051) INFO 2025-06-11 13:15:50,960 default_LLMDeploymentdeepseek 03l9rrsq -- Using executor class: <class 'vllm.v1.executor.ray_distributed_executor.RayDistributedExecutor'>
(_get_vllm_engine_config pid=61380) INFO 06-11 13:15:50 [config.py:793] This model supports multiple tasks: {'classify', 'score', 'generate', 'embed', 'reward'}. Defaulting to 'generate'.
(_get_vllm_engine_config pid=61380) INFO 06-11 13:15:50 [config.py:2118] Chunked prefill is enabled with max_num_batched_tokens=2048.
(ServeController pid=45327) ERROR 2025-06-11 13:15:51,444 controller 45327 -- Exception in Replica(id='03l9rrsq', deployment='LLMDeploymentdeepseek', app='default'), the replica will be stopped.
(ServeController pid=45327) Traceback (most recent call last):
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/deployment_state.py", line 718, in check_ready
(ServeController pid=45327)     ) = ray.get(self._ready_obj_ref)
(ServeController pid=45327)         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
(ServeController pid=45327)     return fn(*args, **kwargs)
(ServeController pid=45327)            ^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
(ServeController pid=45327)     return func(*args, **kwargs)
(ServeController pid=45327)            ^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 2847, in get
(ServeController pid=45327)     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
(ServeController pid=45327)                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 947, in get_objects
(ServeController pid=45327)     raise value.as_instanceof_cause()
(ServeController pid=45327) ray.exceptions.RayTaskError(RuntimeError): ray::ServeReplica:default:LLMDeploymentdeepseek.initialize_and_get_metadata() (pid=61051, ip=10.0.187.137, actor_id=1a881caf72ab8c176d3b7ca002000000, repr=<ray.serve._private.replica.ServeReplica:default:LLMDeploymentdeepseek object at 0x777a863fc510>)
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 449, in result
(ServeController pid=45327)     return self.__get_result()
(ServeController pid=45327)            ^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
(ServeController pid=45327)     raise self._exception
(ServeController pid=45327)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1022, in initialize_and_get_metadata
(ServeController pid=45327)     await self._replica_impl.initialize(deployment_config)
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 730, in initialize
(ServeController pid=45327)     raise RuntimeError(traceback.format_exc()) from None
(ServeController pid=45327) RuntimeError: Traceback (most recent call last):
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 703, in initialize
(ServeController pid=45327)     self._user_callable_asgi_app = await asyncio.wrap_future(
(ServeController pid=45327)                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1442, in initialize_callable
(ServeController pid=45327)     await self._call_func_or_gen(
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1388, in _call_func_or_gen
(ServeController pid=45327)     result = await result
(ServeController pid=45327)              ^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 442, in __init__
(ServeController pid=45327)     await asyncio.wait_for(self._start_engine(), timeout=ENGINE_START_TIMEOUT_S)
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/asyncio/tasks.py", line 489, in wait_for
(ServeController pid=45327)     return fut.result()
(ServeController pid=45327)            ^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 488, in _start_engine
(ServeController pid=45327)     await self.engine.start()
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 280, in start
(ServeController pid=45327)     self.engine = await self._start_engine()
(ServeController pid=45327)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 337, in _start_engine
(ServeController pid=45327)     return await self._start_engine_v1()
(ServeController pid=45327)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 405, in _start_engine_v1
(ServeController pid=45327)     return self._start_async_llm_engine(
(ServeController pid=45327)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 528, in _start_async_llm_engine
(ServeController pid=45327)     engine = vllm.engine.async_llm_engine.AsyncLLMEngine(
(ServeController pid=45327)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 123, in __init__
(ServeController pid=45327)     self.engine_core = core_client_class(
(ServeController pid=45327)                        ^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 738, in __init__
(ServeController pid=45327)     super().__init__(
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 408, in __init__
(ServeController pid=45327)     self.resources.local_engine_manager = CoreEngineProcManager(
(ServeController pid=45327)                                           ^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/utils.py", line 142, in __init__
(ServeController pid=45327)     proc.start()
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/process.py", line 121, in start
(ServeController pid=45327)     self._popen = self._Popen(self)
(ServeController pid=45327)                   ^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/context.py", line 288, in _Popen
(ServeController pid=45327)     return Popen(process_obj)
(ServeController pid=45327)            ^^^^^^^^^^^^^^^^^^
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 32, in __init__
(ServeController pid=45327)     super().__init__(process_obj)
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_fork.py", line 19, in __init__
(ServeController pid=45327)     self._launch(process_obj)
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 47, in _launch
(ServeController pid=45327)     reduction.dump(process_obj, fp)
(ServeController pid=45327)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/reduction.py", line 60, in dump
(ServeController pid=45327)     ForkingPickler(file, protocol).dump(obj)
(ServeController pid=45327) _pickle.PicklingError: Can't pickle <class 'transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek.DeepseekV2Config'>: import of module 'transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek' failed
(ServeController pid=45327) INFO 2025-06-11 13:15:51,447 controller 45327 -- Adding 1 replica to Deployment(name='LLMDeploymentdeepseek', app='default').
(ServeReplica:default:LLMDeploymentdeepseek pid=61051) WARNING 06-11 13:15:51 [utils.py:2531] We must use the `spawn` multiprocessing start method. Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. See https://docs.vllm.ai/en/latest/usage/troubleshooting.html#python-multiprocessing for more information. Reason: In a Ray actor and can only be spawned
(ServeController pid=45327) INFO 2025-06-11 13:15:51,558 controller 45327 -- Replica(id='03l9rrsq', deployment='LLMDeploymentdeepseek', app='default') is stopped.
(ServeReplica:default:LLMDeploymentdeepseek pid=61784) INFO 06-11 13:15:56 [__init__.py:243] Automatically detected platform cuda.
(ServeReplica:default:LLMDeploymentdeepseek pid=61784) INFO 2025-06-11 13:15:58,952 default_LLMDeploymentdeepseek c123c9hd -- Running tasks to download model files on worker nodes
(download_model_files pid=61905) No cloud storage mirror configured
(ServeReplica:default:LLMDeploymentdeepseek pid=61784) You are using a model of type deepseek_v2 to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
(ServeReplica:default:LLMDeploymentdeepseek pid=61784) You are using a model of type deepseek_v2 to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
(pid=62013) INFO 06-11 13:16:05 [__init__.py:243] Automatically detected platform cuda.
(_get_vllm_engine_config pid=62013) INFO 06-11 13:16:08 [__init__.py:31] Available plugins for group vllm.general_plugins:
(_get_vllm_engine_config pid=62013) INFO 06-11 13:16:08 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
(_get_vllm_engine_config pid=62013) INFO 06-11 13:16:08 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(_get_vllm_engine_config pid=62013) INFO 06-11 13:16:08 [config.py:213] Replacing legacy 'type' key with 'rope_type'
^CTraceback (most recent call last):
  File "/home/ray/default/test/serve.py", line 29, in <module>
    serve.run(app, blocking=True)
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/api.py", line 721, in run
    handle = _run(
             ^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/api.py", line 631, in _run
    return _run_many(
           ^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/api.py", line 609, in _run_many
    return client.deploy_applications(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/client.py", line 53, in check
    return f(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/client.py", line 312, in deploy_applications
    self._wait_for_application_running(app.name)
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/client.py", line 244, in _wait_for_application_running
    time.sleep(CLIENT_POLLING_INTERVAL_S)
KeyboardInterrupt
```
## Test Plan

## Test Result
The exception is not seen when running the reproducer script.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
