### PR TITLE
[BugFix] Force registration of w8a8_block_fp8_matmul_deepgemm via lazy import

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -143,6 +143,7 @@ def apply_w8a8_block_fp8_linear(
             column_major_scales=True,
         )
 
+        import vllm.model_executor.layers.quantization.deepgemm  # noqa: F401
         output = torch.ops.vllm.w8a8_block_fp8_matmul_deepgemm(
             q_input,
             weight,


### PR DESCRIPTION
## Purpose
```
VLLM_ALL2ALL_BACKEND="deepep_low_latency" VLLM_USE_DEEP_GEMM=1  vllm serve Qwen/Qwen3-30B-A3B-FP8  --trust-remote-code  --data-parallel-size 2 --enable-expert-parallel --port 9010  --no-enable-prefix-caching --enforce-eager
```
fails with
```
...
(EngineCore_1 pid=3742336)     output_parallel = self.quant_method.apply(self, input_, bias)
(EngineCore_1 pid=3742336)   File "/home/varun/code/vllm/vllm/model_executor/layers/quantization/fp8.py", line 406, in apply
(EngineCore_1 pid=3742336)     return torch.ops.vllm.apply_w8a8_block_fp8_linear(
(EngineCore_1 pid=3742336)   File "/home/varun/code/vllm/vllm-test/lib/python3.10/site-packages/torch/_ops.py", line 1158, in __call__
(EngineCore_1 pid=3742336)     return self._op(*args, **(kwargs or {}))
(EngineCore_1 pid=3742336)   File "/home/varun/code/vllm/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 146, in apply_w8a8_block_fp8_linear
(EngineCore_1 pid=3742336)     output = torch.ops.vllm.w8a8_block_fp8_matmul_deepgemm(
(EngineCore_1 pid=3742336)   File "/home/varun/code/vllm/vllm-test/lib/python3.10/site-packages/torch/_ops.py", line 1267, in __getattr__
(EngineCore_1 pid=3742336)     raise AttributeError(
(EngineCore_1 pid=3742336) AttributeError: '_OpNamespace' 'vllm' object has no attribute 'w8a8_block_fp8_matmul_deepgemm'
```
It happens also without `--enforce-eager`

Fix: 
  Import `vllm.model_executor.layers.quantization.deepgemm` before the call so the op `w8a8_block_fp8_matmul_deepgemm` is registered.

## Test Plan
Tested server startup locally on H100

## Test Result
