### PR TITLE
Reduce debug logging when DeepGEMM is disabled due to problem size

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -55,11 +55,8 @@ def _valid_deep_gemm(hidden_states: torch.Tensor, w1: torch.Tensor,
     if (w1.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn):
         return False
 
-    if (not hidden_states.is_contiguous() or not w1.is_contiguous()
-            or not w2.is_contiguous()):
-        return False
-
-    return True
+    return (hidden_states.is_contiguous() and w1.is_contiguous()
+            and w2.is_contiguous())
 
 
 class DeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -50,17 +50,13 @@ def _valid_deep_gemm(hidden_states: torch.Tensor, w1: torch.Tensor,
     M = hidden_states.size(0)
     _, K, N = w2.size()
     if not _valid_deep_gemm_shape(M, N, K):
-        logger.debug("DeepGemm disabled: unaligned problem size.")
         return False
 
     if (w1.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn):
-        logger.debug("DeepGemm disabled: invalid weight dtype(s).")
         return False
 
     if (not hidden_states.is_contiguous() or not w1.is_contiguous()
             or not w2.is_contiguous()):
-        logger.debug(
-            "DeepGemm disabled: weights or activations not contiguous.")
         return False
 
     return True


### PR DESCRIPTION
## Purpose
With `VLLM_LOGGING_LEVEL="debug"` the logging for disabling DeepGemm is very spammy. This breaks up the checks and doesn't log for the check against `M`.

## Test Plan
try it

## Test Result
