### PR TITLE
Add NotImplementedError to v1 cpu runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.envrc
 
 # Spyder project settings
 .spyderproject

--- a/tests/v1/worker/test_cpu_model_runner.py
+++ b/tests/v1/worker/test_cpu_model_runner.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+
+from vllm.v1.worker.cpu_model_runner import CPUModelRunner
+from vllm.config import (ModelConfig, SchedulerConfig, CacheConfig,
+                         ParallelConfig, VllmConfig, DeviceConfig)
+
+DEVICE = torch.device("cpu")
+
+def get_vllm_config():
+    model_config = ModelConfig(
+        model="facebook/opt-125m",
+        tokenizer="facebook/opt-125m",
+    )
+    device_config = DeviceConfig(
+        device="cpu",
+    )
+    cache_config = CacheConfig()
+    scheduler_config = SchedulerConfig()
+    parallel_config = ParallelConfig()
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        cache_config=cache_config,
+        scheduler_config=scheduler_config,
+        parallel_config=parallel_config,
+        device_config=device_config,
+    )
+    return vllm_config
+
+@pytest.fixture
+def model_runner():
+    return CPUModelRunner(get_vllm_config(), DEVICE)
+
+def test_execute_model(model_runner: CPUModelRunner):
+    with pytest.raises(NotImplementedError):
+        model_runner.execute_model(None)

--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -74,7 +74,7 @@ class CPUModelRunner(GPUModelRunner):
     @torch.inference_mode()
     def execute_model(
         self,
-        scheduler_output: "SchedulerOutput",
+        scheduler_output,
         intermediate_tensors: Optional[IntermediateTensors] = None,
     ) -> Union[ModelRunnerOutput, IntermediateTensors]:
         raise NotImplementedError

--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from contextlib import contextmanager
-from typing import Any
+from typing import  Any, Optional, Union
 
 import torch
 
@@ -8,6 +8,8 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader import get_model
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm.sequence import IntermediateTensors
+from vllm.v1.outputs import  ModelRunnerOutput
 
 logger = init_logger(__name__)
 
@@ -69,6 +71,13 @@ class CPUModelRunner(GPUModelRunner):
     def _sync_device(self) -> None:
         pass
 
+    @torch.inference_mode()
+    def execute_model(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+    ) -> Union[ModelRunnerOutput, IntermediateTensors]:
+        raise NotImplementedError
 
 @contextmanager
 def _set_global_compilation_settings():


### PR DESCRIPTION
add v1 cpu runner not implemented error

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
This is my first commit to the repo. The purpose is to familiarize the codebase with minimal changes. 

This PR is only aim to make the error more verbose while running the example on a CPU machine so that it doesnt fall to the GPU implementation
```
VLLM_USE_V1=1 python examples/offline_inference/basic/basic.py        
```
## Test Plan

Unit test and example

## Test Result
```
pytest tests/v1/worker/test_cpu_model_runner.py
```
```
=========================================================================== warnings summary ============================================================================
../../.venv/lib/python3.12/site-packages/schemathesis/generation/coverage.py:305
  /Users/fredchan/.venv/lib/python3.12/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================== 1 passed, 1 warning in 12.78s =====================================================================
```
