### PR TITLE
[NixlConnector] Drop `num_blocks` check 

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -703,8 +703,6 @@ class NixlConnectorWorker:
         assert self.block_size == remote_block_size, "Remote P worker with " \
         "different block size is not supported"
 
-        assert self.num_blocks >= nixl_agent_meta.num_blocks
-
         # Create dst descs and xfer side handles. TP workers have same #blocks.
         if engine_id in self.dst_num_blocks:
             assert self.dst_num_blocks[engine_id] == nixl_agent_meta.num_blocks


### PR DESCRIPTION
This check is too strict. 
Let's drop it for now and come up with a more sensible lower bound later.