### PR TITLE
Fix tensor shapes for DeepEP and DeepGEMM assertions

### DIFF
--- a/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
@@ -120,6 +120,8 @@ class BatchedDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         a2q = a2q.view(E, max_num_tokens, -1)
         a2q_scale = a2q_scale.view(E, max_num_tokens, -1)
 
+        output = output.view(E, max_num_tokens, -1)
+
         dg.m_grouped_gemm_fp8_fp8_bf16_nt_masked((a2q, a2q_scale),
                                                  (w2, w2_scale),
                                                  out=output,

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -174,6 +174,11 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             # weights have already been applied.
             combine_topk_weights = torch.ones_like(topk_weights)
 
+        _, _, num_max_dispatch_tokens_per_rank, _, num_experts = self.handle
+        fused_expert_output = fused_expert_output.view(
+            num_experts // self.buffer.group_size,
+            self.buffer.group_size * num_max_dispatch_tokens_per_rank, -1)
+
         # TODO (varun) : Enable zero copy mode
         _, event, hook = self.buffer.low_latency_combine(
             fused_expert_output,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

When running DEP16 DSR1 on 2x8xH100 with `VLLM_ALL2ALL_BACKEND="deepep_low_latency"` and `VLLM_USE_DEEP_GEMM=1` there were 2 separate assertion errors.

In DeepGEMM [m_grouped_gemm_fp8_fp8_bf16_nt_masked](https://github.com/deepseek-ai/DeepGEMM/blob/main/deep_gemm/jit_kernels/m_grouped_gemm.py#L142) and in DeepEP [low_latency_combine](https://github.com/deepseek-ai/DeepEP/blob/main/csrc/deep_ep.cpp#L1183).

Both of those can be solved by simply changing the view of the tensor to match the expected shapes by the kernels.


## Purpose

Fix assertion errors.

## Test Plan

Node 0:
```bash
vllm serve deepseek-ai/DeepSeek-R1 --data_parallel_size 16 --data_parallel_size_local 8 --data_parallel_address <node 0 ip> --data_parallel_rpc_port 13345  --max-model-len 10240 --enable-expert-parallel --trust-remote-code
```

Node 1:
```bash
vllm serve  deepseek-ai/DeepSeek-R1 --data_parallel_size 16 --data_parallel_size_local 8 --data_parallel_address <node 0 ip>  --data_parallel_rpc_port 13345  --max-model-len 10240 --enable-expert-parallel --trust-remote-code  --data_parallel_start_rank 8 --headless
```

## Test Result

No errors during model initialization, correct completion outputs.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
