### PR TITLE
[Fix] The zip function in Python 3.9 does not have the strict argument

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3,7 +3,6 @@
 
 import copy
 import gc
-import sys
 import time
 import weakref
 from contextlib import contextmanager
@@ -67,11 +66,15 @@ from .utils import (gather_mm_placeholders, initialize_kv_cache_for_kv_sharing,
 
 if TYPE_CHECKING:
     import xgrammar as xgr
+    import xgrammar.kernels.apply_token_bitmask_inplace_torch_compile as xgr_torch_compile  # noqa: E501
 
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
     from vllm.v1.core.sched.output import SchedulerOutput
 else:
     xgr = LazyLoader("xgr", globals(), "xgrammar")
+    xgr_torch_compile = LazyLoader(
+        "xgr_torch_compile", globals(),
+        "xgrammar.kernels.apply_token_bitmask_inplace_torch_compile")
 
 logger = init_logger(__name__)
 
@@ -463,21 +466,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     req_data.new_token_ids[-num_new_tokens:])
             # Update the block IDs.
             if not req_data.resumed_from_preemption:
-                if sys.version_info >= (3, 10):
-                    # Append the new blocks to the existing block IDs.
-                    for block_ids, new_block_ids in zip(req_state.block_ids,
-                                                        req_data.new_block_ids,
-                                                        strict=True):
-                        block_ids.extend(new_block_ids)
-                else:
-                    # The argument 'strict' is not support until 3.10
-                    if len(req_state.block_ids) != len(req_data.new_block_ids):
-                        raise ValueError(
-                            "The number of block IDs does not match the "
-                            "number of new block IDs.")
-                    for block_ids, new_block_ids in zip(
-                            req_state.block_ids, req_data.new_block_ids):
-                        block_ids.extend(new_block_ids)
+                # Append the new blocks to the existing block IDs.
+                for block_ids, new_block_ids in zip(req_state.block_ids,
+                                                    req_data.new_block_ids):
+                    block_ids.extend(new_block_ids)
             else:
                 # The request is resumed from preemption.
                 # Replace the existing block IDs with the new ones.
@@ -1113,7 +1105,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # so we receive it in that format.
         grammar_bitmask = torch.from_numpy(grammar_bitmask)
 
-        xgr.apply_token_bitmask_inplace(
+        # Force use of the torch.compile implementation from xgrammar to work
+        # around issues with the Triton kernel in concurrent structured output
+        # scenarios. See PR #19565 and issues #19493, #18376 for details.
+        xgr_torch_compile.apply_token_bitmask_inplace_torch_compile(
             logits,
             grammar_bitmask.to(self.device, non_blocking=True),
             indices=out_indices,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -476,7 +476,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         raise ValueError(
                             "The number of block IDs does not match the "
                             "number of new block IDs.")
-                    for block_ids, new_block_ids in zip(  # type: ignore[call-overload]
+                    for block_ids, new_block_ids in zip(
                             req_state.block_ids, req_data.new_block_ids):
                         block_ids.extend(new_block_ids)
             else:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -465,10 +465,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if not req_data.resumed_from_preemption:
                 if sys.version_info >= (3, 10):
                     # Append the new blocks to the existing block IDs.
-                    for block_ids, new_block_ids in zip(  # type: ignore[call-overload]
-                            req_state.block_ids,
-                            req_data.new_block_ids,
-                            strict=True):
+                    for block_ids, new_block_ids in zip(req_state.block_ids,
+                                                        req_data.new_block_ids,
+                                                        strict=True):
                         block_ids.extend(new_block_ids)
                 else:
                     # The argument 'strict' is not support until 3.10

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -472,6 +472,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         block_ids.extend(new_block_ids)
                 else:
                     # The argument 'strict' is not support until 3.10
+                    if len(req_state.block_ids) != len(req_data.new_block_ids):
+                        raise ValueError(
+                            "The number of block IDs does not match the "
+                            "number of new block IDs.")
                     for block_ids, new_block_ids in zip(  # type: ignore[call-overload]
                             req_state.block_ids, req_data.new_block_ids):
                         block_ids.extend(new_block_ids)

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -425,7 +425,7 @@ class TPUModelRunner(LoRAModelRunnerMixin):
                         raise ValueError(
                             "The number of block IDs does not match the "
                             "number of new block IDs.")
-                    for block_ids, new_block_ids in zip(  # type: ignore[call-overload]
+                    for block_ids, new_block_ids in zip(
                             req_state.block_ids, req_data.new_block_ids):
                         block_ids.extend(new_block_ids)
             else:

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -422,6 +422,10 @@ class TPUModelRunner(LoRAModelRunnerMixin):
                         block_ids.extend(new_block_ids)
                 else:
                     # The argument 'strict' is not support until 3.10
+                    if len(req_state.block_ids) != len(req_data.new_block_ids):
+                        raise ValueError(
+                            "The number of block IDs does not match the "
+                            "number of new block IDs.")
                     for block_ids, new_block_ids in zip(  # type: ignore[call-overload]
                             req_state.block_ids, req_data.new_block_ids):
                         block_ids.extend(new_block_ids)

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -415,10 +415,9 @@ class TPUModelRunner(LoRAModelRunnerMixin):
             if not req_data.resumed_from_preemption:
                 if sys.version_info >= (3, 10):
                     # Append the new blocks to the existing block IDs.
-                    for block_ids, new_block_ids in zip(  # type: ignore[call-overload]
-                            req_state.block_ids,
-                            req_data.new_block_ids,
-                            strict=True):
+                    for block_ids, new_block_ids in zip(req_state.block_ids,
+                                                        req_data.new_block_ids,
+                                                        strict=True):
                         block_ids.extend(new_block_ids)
                 else:
                     # The argument 'strict' is not support until 3.10

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import bisect
 import gc
-import sys
 import time
 from typing import TYPE_CHECKING, Optional, cast
 from unittest.mock import patch
@@ -413,21 +412,10 @@ class TPUModelRunner(LoRAModelRunnerMixin):
             # Update the cached states.
             req_state.num_computed_tokens = req_data.num_computed_tokens
             if not req_data.resumed_from_preemption:
-                if sys.version_info >= (3, 10):
-                    # Append the new blocks to the existing block IDs.
-                    for block_ids, new_block_ids in zip(req_state.block_ids,
-                                                        req_data.new_block_ids,
-                                                        strict=True):
-                        block_ids.extend(new_block_ids)
-                else:
-                    # The argument 'strict' is not support until 3.10
-                    if len(req_state.block_ids) != len(req_data.new_block_ids):
-                        raise ValueError(
-                            "The number of block IDs does not match the "
-                            "number of new block IDs.")
-                    for block_ids, new_block_ids in zip(
-                            req_state.block_ids, req_data.new_block_ids):
-                        block_ids.extend(new_block_ids)
+                # Append the new blocks to the existing block IDs.
+                for block_ids, new_block_ids in zip(req_state.block_ids,
+                                                    req_data.new_block_ids):
+                    block_ids.extend(new_block_ids)
             else:
                 # The request is resumed from preemption.
                 # Replace the existing block IDs with the new ones.


### PR DESCRIPTION
## Purpose
Fix #19432 
## Test Plan
Run the command:
```
uv venv -p 3.9 --seed
source .venv/bin/activate
uv pip install -U vllm \
    --torch-backend=auto \
    --extra-index-url https://wheels.vllm.ai/nightly
# vllm==0.9.1rc2
vllm serve facebook/opt-125m --port 30303
```

```
curl http://localhost:30303/v1/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -d '{"model": "facebook/opt-125m", "prompt": "Say this is a test", "temperature": 0, "max_tokens": 7}'
```

## Test Result
Check the python version and start the server:

<img width="1393" alt="Screenshot 2025-06-12 at 7 40 12 PM" src="https://github.com/user-attachments/assets/bf74bdbd-98e0-4e9d-a22f-acc28c46f819" />
<img width="1383" alt="Screenshot 2025-06-12 at 7 40 37 PM" src="https://github.com/user-attachments/assets/41328a83-4f75-490f-9673-7534b4e18762" />

Execution result:

<img width="1383" alt="Screenshot 2025-06-12 at 7 41 02 PM" src="https://github.com/user-attachments/assets/8780e19f-011f-402e-99df-4814c48f3e7b" />

