### PR TITLE
[Misc] Correct broken docs link

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -95,10 +95,9 @@ class ServeSubcommand(CLISubcommand):
             type=str,
             default='',
             required=False,
-            help="Read CLI options from a config file."
-            "Must be a YAML with the following options:"
-            "https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#cli-reference"
-        )
+            help="Read CLI options from a config file. "
+            "Must be a YAML with the following options: "
+            "https://docs.vllm.ai/en/latest/configuration/serve_args.html")
 
         serve_parser = make_arg_parser(serve_parser)
         show_filtered_argument_or_group_from_help(serve_parser, "serve")


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

This PR fixes an incorrect documentation link in the help text for the `--config` option when using `vllm serve`.

## Test Plan

```bash
vllm serve --help | grep \\--config -A4
```

## Test Result

> AS-IS

```bash
  --config CONFIG       Read CLI options from a config file.Must be a YAML
                        with the following options:https://docs.vllm.ai/en/lat
                        est/serving/openai_compatible_server.html#cli-
                        reference (default: )
```

> TO-BE

```bash
  --config CONFIG       Read CLI options from a config file. Must be a YAML
                        with the following options: https://docs.vllm.ai/en/la
                        test/configuration/serve_args.html (default: )
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
