### PR TITLE
[P/D][Bugfix]: Fix the issue where the remote KVCache cannot be loaded when PP > 1

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -259,10 +259,9 @@ class EngineCore:
         # Note that this is not blocking.
         if not self.batch_queue.full():
             scheduler_output = self.scheduler.schedule()
-            if scheduler_output.total_num_scheduled_tokens > 0:
-                future = self.model_executor.execute_model(scheduler_output)
-                self.batch_queue.put_nowait(
-                    (future, scheduler_output))  # type: ignore
+            future = self.model_executor.execute_model(scheduler_output)
+            self.batch_queue.put_nowait(
+                (future, scheduler_output))  # type: ignore
 
         scheduled_batch = (scheduler_output is not None
                            and scheduler_output.total_num_scheduled_tokens > 0)


### PR DESCRIPTION
When the  PD disagg , the remote KVCache cannot be loaded if PP > 1.

we need to execute `self.model_executor.execute_model` to start loading the KV cache.
