### PR TITLE
[Bugfix] Don't attempt to use triton if no driver is active

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -13,10 +13,38 @@ HAS_TRITON = (
     or find_spec("pytorch-triton-xpu") is not None  # Not compatible
 )
 if HAS_TRITON:
-    from triton.backends import backends
-    active_triton_drivers = [x.driver for x in backends.values() if x.driver.is_active()]
-    if len(active_triton_drivers) != 1:
+    try:
+        from triton.backends import backends
+        # It's generally expected that x.driver exists and has 
+        # an is_active method.
+        # The `x.driver and` check adds a small layer of safety.
+        active_drivers = [
+            x.driver for x in backends.values()
+            if x.driver and x.driver.is_active()
+        ]
+        if len(active_drivers) != 1:
+            logger.info(
+                "Triton is installed but %d active driver(s) found "
+                "(expected 1). Disabling Triton to prevent runtime errors.",
+                len(active_drivers)
+            )
+            HAS_TRITON = False
+    except ImportError:
+        # This can occur if Triton is partially installed or triton.backends 
+        # is missing.
+        logger.warning(
+            "Triton is installed, but `triton.backends` could not be imported. "
+            "Disabling Triton."
+        )
         HAS_TRITON = False
+    except Exception as e:
+        # Catch any other unexpected errors during the check.
+        logger.warning(
+            "An unexpected error occurred while checking Triton active drivers:"
+            " %s. Disabling Triton.", e
+        )
+        HAS_TRITON = False
+        
 
 if not HAS_TRITON:
     logger.info("Triton not installed or not compatible; certain GPU-related"

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -15,7 +15,8 @@ HAS_TRITON = (
 if HAS_TRITON:
     try:
         from triton.backends import backends
-        # It's generally expected that x.driver exists and has 
+
+        # It's generally expected that x.driver exists and has
         # an is_active method.
         # The `x.driver and` check adds a small layer of safety.
         active_drivers = [
@@ -26,25 +27,21 @@ if HAS_TRITON:
             logger.info(
                 "Triton is installed but %d active driver(s) found "
                 "(expected 1). Disabling Triton to prevent runtime errors.",
-                len(active_drivers)
-            )
+                len(active_drivers))
             HAS_TRITON = False
     except ImportError:
-        # This can occur if Triton is partially installed or triton.backends 
+        # This can occur if Triton is partially installed or triton.backends
         # is missing.
         logger.warning(
             "Triton is installed, but `triton.backends` could not be imported. "
-            "Disabling Triton."
-        )
+            "Disabling Triton.")
         HAS_TRITON = False
     except Exception as e:
         # Catch any other unexpected errors during the check.
         logger.warning(
             "An unexpected error occurred while checking Triton active drivers:"
-            " %s. Disabling Triton.", e
-        )
+            " %s. Disabling Triton.", e)
         HAS_TRITON = False
-        
 
 if not HAS_TRITON:
     logger.info("Triton not installed or not compatible; certain GPU-related"

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -12,6 +12,11 @@ HAS_TRITON = (
     find_spec("triton") is not None
     or find_spec("pytorch-triton-xpu") is not None  # Not compatible
 )
+if HAS_TRITON:
+    from triton.backends import backends
+    active_triton_drivers = [x.driver for x in backends.values() if x.driver.is_active()]
+    if len(active_triton_drivers) != 1:
+        HAS_TRITON = False
 
 if not HAS_TRITON:
     logger.info("Triton not installed or not compatible; certain GPU-related"


### PR DESCRIPTION
Platforms can have triton package installed by external packages (e.g. xgrammar), even if it's unsupported by them and not specified in vLLM requirements. This patch adds additional triton check and prevents non-GPU platforms from autotuning triton flash attention kernels when the package is installed, but incompatible. Example error solved by this PR (importing MLACommonImpl in out-of-tree attention backend, incorrectly attempting to use triton flash attention, because triton package was installed by external dependency):
```
ERROR 06-12 17:46:38 [core.py:515] EngineCore failed to start.
ERROR 06-12 17:46:38 [core.py:515] Traceback (most recent call last):
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/v1/engine/core.py", line 506, in run_engine_core
ERROR 06-12 17:46:38 [core.py:515]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 06-12 17:46:38 [core.py:515]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/v1/engine/core.py", line 390, in __init__
ERROR 06-12 17:46:38 [core.py:515]     super().__init__(vllm_config, executor_class, log_stats,
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/v1/engine/core.py", line 76, in __init__
ERROR 06-12 17:46:38 [core.py:515]     self.model_executor = executor_class(vllm_config)
ERROR 06-12 17:46:38 [core.py:515]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/executor/executor_base.py", line 53, in __init__
ERROR 06-12 17:46:38 [core.py:515]     self._init_executor()
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/executor/uniproc_executor.py", line 46, in _init_executor
ERROR 06-12 17:46:38 [core.py:515]     self.collective_rpc("init_worker", args=([kwargs], ))
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/executor/uniproc_executor.py", line 57, in collective_rpc
ERROR 06-12 17:46:38 [core.py:515]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 06-12 17:46:38 [core.py:515]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/utils.py", line 2680, in run_method
ERROR 06-12 17:46:38 [core.py:515]     return func(*args, **kwargs)
ERROR 06-12 17:46:38 [core.py:515]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/worker/worker_base.py", line 559, in init_worker
ERROR 06-12 17:46:38 [core.py:515]     worker_class = resolve_obj_by_qualname(
ERROR 06-12 17:46:38 [core.py:515]                    ^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/utils.py", line 2248, in resolve_obj_by_qualname
ERROR 06-12 17:46:38 [core.py:515]     module = importlib.import_module(module_name)
ERROR 06-12 17:46:38 [core.py:515]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
ERROR 06-12 17:46:38 [core.py:515]     return _bootstrap._gcd_import(name[level:], package, level)
ERROR 06-12 17:46:38 [core.py:515]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
ERROR 06-12 17:46:38 [core.py:515]   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
ERROR 06-12 17:46:38 [core.py:515]   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
ERROR 06-12 17:46:38 [core.py:515]   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
ERROR 06-12 17:46:38 [core.py:515]   File "<frozen importlib._bootstrap_external>", line 995, in exec_module
ERROR 06-12 17:46:38 [core.py:515]   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm-hpu/vllm_hpu/v1/worker/hpu_worker.py", line 26, in <module>
ERROR 06-12 17:46:38 [core.py:515]     from vllm_hpu.v1.worker.hpu_model_runner import HPUModelRunner, bool_helper
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm-hpu/vllm_hpu/v1/worker/hpu_model_runner.py", line 39, in <module>
ERROR 06-12 17:46:38 [core.py:515]     from vllm_hpu.v1.attention.backends.hpu_attn import HPUAttentionMetadataV1
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm-hpu/vllm_hpu/v1/attention/backends/hpu_attn.py", line 13, in <module>
ERROR 06-12 17:46:38 [core.py:515]     from vllm_hpu.attention.backends.hpu_attn import (HPUAttentionBackend,
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm-hpu/vllm_hpu/attention/backends/hpu_attn.py", line 22, in <module>
ERROR 06-12 17:46:38 [core.py:515]     from vllm.attention.backends.mla.common import MLACommonImpl
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/attention/backends/mla/common.py", line 221, in <module>
ERROR 06-12 17:46:38 [core.py:515]     from vllm.attention.ops.triton_flash_attention import triton_attention
ERROR 06-12 17:46:38 [core.py:515]   File "/software/users/kzawora/vllm-plugin-dev/vllm/vllm/attention/ops/triton_flash_attention.py", line 403, in <module>
ERROR 06-12 17:46:38 [core.py:515]     @triton.autotune(
ERROR 06-12 17:46:38 [core.py:515]      ^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/triton-3.3.1-py3.12-linux-x86_64.egg/triton/runtime/autotuner.py", line 378, in decorator
ERROR 06-12 17:46:38 [core.py:515]     return Autotuner(fn, fn.arg_names, configs, key, reset_to_zero, restore_value, pre_hook=pre_hook,
ERROR 06-12 17:46:38 [core.py:515]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/triton-3.3.1-py3.12-linux-x86_64.egg/triton/runtime/autotuner.py", line 130, in __init__
ERROR 06-12 17:46:38 [core.py:515]     self.do_bench = driver.active.get_benchmarker()
ERROR 06-12 17:46:38 [core.py:515]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/triton-3.3.1-py3.12-linux-x86_64.egg/triton/runtime/driver.py", line 23, in __getattr__
ERROR 06-12 17:46:38 [core.py:515]     self._initialize_obj()
ERROR 06-12 17:46:38 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/triton-3.3.1-py3.12-linux-x86_64.egg/triton/runtime/driver.py", line 20, in _initialize_obj
ERROR 06-12 17:46:38 [core.py:515]     self._obj = self._init_fn()
ERROR 06-12 17:46:38 [core.py:515]                 ^^^^^^^^^^^^^^^
ERROR 06-12 17:46:38 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/triton-3.3.1-py3.12-linux-x86_64.egg/triton/runtime/driver.py", line 8, in _create_driver
ERROR 06-12 17:46:38 [core.py:515]     raise RuntimeError(f"{len(actives)} active drivers ({actives}). There should only be one.")
ERROR 06-12 17:46:38 [core.py:515] RuntimeError: 0 active drivers ([]). There should only be one.
```

CC @simon-mo @youkaichao  @xuechendi 