### PR TITLE
[Misc][Frontend] passthrough `bad_words`

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -272,7 +272,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
     prompt_logprobs: Optional[int] = None
     allowed_token_ids: Optional[list[int]] = None
-    bad_words: list[str] = []
+    bad_words: list[str] = Field(default_factory=list)
     # --8<-- [end:chat-completion-sampling-params]
 
     # --8<-- [start:chat-completion-extra-params]

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -272,6 +272,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
     prompt_logprobs: Optional[int] = None
     allowed_token_ids: Optional[list[int]] = None
+    bad_words: list[str] = []
     # --8<-- [end:chat-completion-sampling-params]
 
     # --8<-- [start:chat-completion-extra-params]
@@ -550,6 +551,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 else RequestOutputKind.FINAL_ONLY,
             guided_decoding=guided_decoding,
             logit_bias=self.logit_bias,
+            bad_words= self.bad_words,
             allowed_token_ids=self.allowed_token_ids,
             extra_args=({"kv_transfer_params": self.kv_transfer_params}
                         if self.kv_transfer_params else None))


### PR DESCRIPTION


## ✅ PR Description Checklist

* [x] **Purpose** – Clearly states what the PR addresses and links related issues.
* [x] **Test Plan** – Provides example commands and context to validate the change.
* [x] **Test Results** – Demonstrates expected behavior after the change.
* [x] **Documentation Update** – Not required in this case, but mentioned for completeness.

---

## Purpose

This PR enables support for the `bad_words` sampling parameter when using `vllm serve`. Currently, this parameter is supported by the offline API but not the online serving interface, which limits feature parity between the two modes.

Attempts to use `bad_words` in a `vllm serve` request are silently ignored, and the following warning is emitted:

```text
[protocol.py:58] The following fields were present in the request but ignored: {'bad_words'}
```

Furthermore, using `extra_body` (which some old [documentation](https://docs.vllm.ai/en/v0.8.3/serving/openai_compatible_server.html) mentions as a workaround) also does not work as expected.

This change aligns the behavior of the serving API with the offline API by enabling the `bad_words` field in `ChatCompletionRequest` and `SamplingParams.from_optional`.

Although this adds functionality not supported in OpenAI's API (thus slightly diverging from compatibility), it is non-breaking and opt-in.

---

## Test Plan

Reproduce the issue by starting the server and making a request with the `bad_words` parameter:

1. Start the server:

```bash
vllm serve "HuggingFaceTB/SmolLM2-135M-Instruct"
```

2. Make a request:

```bash
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "HuggingFaceTB/SmolLM2-135M-Instruct",
        "messages": [
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": "Where is the capital of Italy?"}
        ],
        "bad_words": ["Italy", "italy", "Rome", "rome"]
    }'
```

After the patch, the server should respect the `bad_words` parameter and filter out specified terms in the output.

For comparison, here's the offline version that already works:

```python
from vllm import LLM, SamplingParams
sampling_params = SamplingParams(
    temperature=1,
    bad_words=["Italy", "italy", "Rome", "rome"]
)
llm = LLM(model="HuggingFaceTB/SmolLM2-135M-Instruct")
res = llm.chat([{"role": "user", "content": "Where is the capital of Italy?"}], sampling_params)
print(res)
```

---

## Test Results

* **Before:** `bad_words` is ignored in serving mode, and a warning is logged.
* **After:** The server honors the `bad_words` parameter and excludes the specified terms from the response.
* **Compatibility:** Offline API behavior is unchanged. OpenAI API compatibility is slightly diverged, but this is clearly documented.
