### PR TITLE
[Core][V1] Expose num_scheduled_tokens in NewRequestData

### DIFF
--- a/tests/v1/tpu/worker/test_tpu_model_runner.py
+++ b/tests/v1/tpu/worker/test_tpu_model_runner.py
@@ -74,6 +74,7 @@ def _schedule_new_request(*req_ids: str) -> SchedulerOutput:
                 block_ids=([0], ),  # block_ids should be tuple[list[int]]
                 num_computed_tokens=0,
                 lora_request=None,
+                num_scheduled_tokens=3,
             ))
         num_scheduled_tokens[req_id] = 3
         total_num_scheduled_tokens += num_scheduled_tokens[req_id]
@@ -103,7 +104,7 @@ def _is_req_added(model_runner, req_id: str) -> bool:
 
 def _is_req_state_block_table_match(model_runner, req_id: str) -> bool:
     """Check if the request state block IDs match the block table.
-    
+
     This function handles both legacy BlockTable and new MultiGroupBlockTable
     structures for backward compatibility.
     """

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -125,6 +125,7 @@ def _schedule_new_request(*req_ids: str) -> SchedulerOutput:
                 block_ids=([0], ),
                 num_computed_tokens=0,
                 lora_request=None,
+                num_scheduled_tokens=3,
             ))
         num_scheduled_tokens[req_id] = 3
         total_num_scheduled_tokens += num_scheduled_tokens[req_id]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -30,12 +30,14 @@ class NewRequestData:
     block_ids: tuple[list[int], ...]
     num_computed_tokens: int
     lora_request: Optional[LoRARequest]
+    num_scheduled_tokens: int
 
     @classmethod
     def from_request(
         cls,
         request: Request,
         block_ids: tuple[list[int], ...],
+        num_scheduled_tokens: int,
     ) -> NewRequestData:
         return cls(
             req_id=request.request_id,
@@ -47,6 +49,7 @@ class NewRequestData:
             block_ids=block_ids,
             num_computed_tokens=request.num_computed_tokens,
             lora_request=request.lora_request,
+            num_scheduled_tokens=num_scheduled_tokens,
         )
 
     def __repr__(self):
@@ -59,7 +62,8 @@ class NewRequestData:
                 f"sampling_params={self.sampling_params},"
                 f"block_ids={self.block_ids},"
                 f"num_computed_tokens={self.num_computed_tokens},"
-                f"lora_request={self.lora_request}"
+                f"lora_request={self.lora_request},"
+                f"num_scheduled_tokens={self.num_scheduled_tokens}"
                 ")")
 
     # Version of __repr__ with the prompt data obfuscated
@@ -73,7 +77,8 @@ class NewRequestData:
                 f"sampling_params={self.sampling_params},"
                 f"block_ids={self.block_ids},"
                 f"num_computed_tokens={self.num_computed_tokens},"
-                f"lora_request={self.lora_request}"
+                f"lora_request={self.lora_request},"
+                f"num_scheduled_tokens={self.num_scheduled_tokens}"
                 ")")
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -516,7 +516,8 @@ class Scheduler(SchedulerInterface):
         # Construct the scheduler output.
         new_reqs_data = [
             NewRequestData.from_request(req,
-                                        req_to_new_block_ids[req.request_id])
+                                        req_to_new_block_ids[req.request_id],
+                                        num_scheduled_tokens[req.request_id])
             for req in scheduled_new_reqs
         ]
         resumed_reqs_data = [


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
This changes exposes `num_scheduled_tokens` as a field in `NewRequestData`. This makes it much easier for some v1 KV connectors (in my case, a custom CPU KV cache connector) to understand when a block is fully computed. Example (assume block size 16):
- New request with 50-token prompt arrives; assume 0-length hit in GPU/CPU prefix cache.
- Scheduler only has budget to compute 13 tokens for this request.
- How does KV connector know this block should not be copied from GPU to CPU KV cache in this step? This is easy to decide if KV connector knows `num_scheduled_tokens` is 13 and not 16.

## Test Plan
Ensure builds and tests pass. (From vLLM's perspective, this change merely exposes a field in a struct, and involves no logic changes based on the value of this field.)

Also integrated this change with internal CPU KV cache connector and found GPU-to-CPU write-back logic is much simpler.

## Test Result
Builds and tests pass

<!--- pyml disable-next-line no-emphasis-as-heading -->
