### PR TITLE
[Core] Remove host GPU sync in `merge_multimodal_embeddings`

### DIFF
--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -415,7 +415,10 @@ def _merge_multimodal_embeddings(
             f"Attempted to assign {expr} = {flattened.shape[0]} "
             f"multimodal tokens to {num_expected_tokens} placeholders")
 
-    inputs_embeds[is_multimodal] = flattened
+    # Equivalent to `inputs_embeds[is_multimodal] = flattened`
+    # but without host to GPU sync
+    indices = is_multimodal.nonzero_static(size=num_expected_tokens)
+    inputs_embeds[indices.squeeze(1)] = flattened
     return inputs_embeds
 
 


### PR DESCRIPTION
## Purpose

Indexing (`index_put_`) a GPU tensor with a boolean tensor causes a host/GPU sync since the kernel internally calls `aten::nonzero`.

In the case of `merge_multimodal_embeddings` we've already computed the number of non-zero elements so we can use `nonzero_static` which can be done directly on the GPU removing the host/GPU sync as the tensor has a static size.

I've generated a profile of `gemma3-4b-it` model with multimodal input and one can see that the CPU overhead of `aten::nonzero` is gone and `aten:: _index_put_impl_` is also a tiny bit faster.

```
---------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                             Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg   # of Calls
---------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
   (main)           aten::nonzero         0.04%       1.111ms         0.07%       1.894ms      16.914us      57.570us         0.00%      57.570us       0.514us           112
(this PR)    aten::nonzero_static         0.01%     177.279us         0.02%     451.676us      50.186us      79.582us         0.00%      79.582us       8.842us             9
   (main)  aten::_index_put_impl_         0.04%     978.786us         0.18%       4.783ms      79.714us     418.913us         0.02%     504.228us       8.404us            60
(this PR)  aten::_index_put_impl_         0.04%     918.248us         0.15%       3.915ms      64.179us     423.943us         0.02%     452.073us       7.411us            61
---------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
```

## Test Plan

Covered by existing unittests

## Test Result

See CI
