### PR TITLE
[Easy][Model Registry] Add Llama4ForCausalLM in model registry

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -78,6 +78,7 @@ _TEXT_GENERATION_MODELS = {
     "LlamaForCausalLM": ("llama", "LlamaForCausalLM"),
     # For decapoda-research/llama-*
     "LLaMAForCausalLM": ("llama", "LlamaForCausalLM"),
+    "Llama4ForCausalLM": ("llama4", "Llama4ForCausalLM"),
     "MambaForCausalLM": ("mamba", "MambaForCausalLM"),
     "FalconMambaForCausalLM": ("mamba", "MambaForCausalLM"),
     "FalconH1ForCausalLM":("falcon_h1", "FalconH1ForCausalLM"),


### PR DESCRIPTION
## Purpose
Allow vLLM to run text-only Llama4 model, aka `Llama4ForCausalLM`.

## Test Plan
Run vLLM w/ a text-only Llama4 Maverick checkpoint (vender internal one).

## Test Result
Model successfully recognized and loaded
```
Loading safetensors checkpoint shards:   0% Completed | 0/84 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  10% Completed | 8/84 [00:00<00:00, 77.14it/s]
Loading safetensors checkpoint shards:  19% Completed | 16/84 [00:00<00:01, 48.57it/s]
Loading safetensors checkpoint shards:  29% Completed | 24/84 [00:00<00:01, 53.53it/s]
Loading safetensors checkpoint shards:  36% Completed | 30/84 [00:00<00:00, 55.29it/s]
Loading safetensors checkpoint shards:  43% Completed | 36/84 [00:00<00:00, 49.49it/s]
Loading safetensors checkpoint shards:  50% Completed | 42/84 [00:00<00:01, 39.83it/s]
Loading safetensors checkpoint shards:  67% Completed | 56/84 [00:01<00:00, 56.72it/s]
Loading safetensors checkpoint shards:  77% Completed | 65/84 [00:01<00:00, 57.88it/s]
Loading safetensors checkpoint shards:  88% Completed | 74/84 [00:01<00:00, 64.70it/s]
Loading safetensors checkpoint shards:  96% Completed | 81/84 [00:01<00:00, 56.54it/s]
Loading safetensors checkpoint shards: 100% Completed | 84/84 [00:01<00:00, 56.55it/s]
(VllmWorker rank=0 pid=604590) 
(VllmWorker rank=7 pid=604598) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.72 seconds
(VllmWorker rank=0 pid=604590) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.64 seconds
(VllmWorker rank=2 pid=604593) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.65 seconds
(VllmWorker rank=6 pid=604597) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.62 seconds
(VllmWorker rank=4 pid=604595) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.60 seconds
(VllmWorker rank=5 pid=604596) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.70 seconds
(VllmWorker rank=1 pid=604591) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.71 seconds
(VllmWorker rank=3 pid=604594) INFO 06-12 14:37:50 [default_loader.py:272] Loading weights took 45.71 seconds
(VllmWorker rank=3 pid=604594) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 46.056898 seconds
(VllmWorker rank=0 pid=604590) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 45.984370 seconds
(VllmWorker rank=4 pid=604595) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 45.931201 seconds
(VllmWorker rank=5 pid=604596) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 46.051216 seconds
(VllmWorker rank=1 pid=604591) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 46.056561 seconds
(VllmWorker rank=6 pid=604597) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 45.960544 seconds
(VllmWorker rank=2 pid=604593) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 46.010001 seconds
(VllmWorker rank=7 pid=604598) INFO 06-12 14:37:51 [gpu_model_runner.py:1615] Model loading took 48.8683 GiB and 46.070654 seconds
```

```
Evaluation results on task gsm8k.8_shot.1_gen: em: 0.957500 | f1: 0.957500 | em_maj1@1: 0.957500 | f1_maj1@1: 0.957500
```
