### PR TITLE
[Doc] uses absolute links for structured outputs

### DIFF
--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -149,7 +149,7 @@ completion = client.chat.completions.create(
 print(completion.choices[0].message.content)
 ```
 
-See also: [full example](../../examples/online_serving/structured_outputs)
+See also: [full example](https://docs.vllm.ai/en/latest/examples/online_serving/structured_outputs.html)
 
 ## Reasoning Outputs
 
@@ -190,7 +190,7 @@ print("reasoning_content: ", completion.choices[0].message.reasoning_content)
 print("content: ", completion.choices[0].message.content)
 ```
 
-See also: [full example](../../examples/online_serving/structured_outputs)
+See also: [full example](https://docs.vllm.ai/en/latest/examples/online_serving/structured_outputs.html)
 
 ## Experimental Automatic Parsing (OpenAI API)
 
@@ -311,4 +311,4 @@ outputs = llm.generate(
 print(outputs[0].outputs[0].text)
 ```
 
-See also: [full example](../../examples/online_serving/structured_outputs)
+See also: [full example](https://docs.vllm.ai/en/latest/examples/online_serving/structured_outputs.html)

--- a/examples/online_serving/structured_outputs/README.md
+++ b/examples/online_serving/structured_outputs/README.md
@@ -22,7 +22,7 @@ If you want to run this script standalone with `uv`, you can use the following:
 uvx --from git+https://github.com/vllm-project/vllm#subdirectory=examples/online_serving/structured_outputs structured-output
 ```
 
-See [feature docs](../../../features/structured_outputs.md) for more information.
+See [feature docs](https://docs.vllm.ai/en/latest/features/structured_outputs.html) for more information.
 
 !!! tip
     If vLLM is running remotely, then set `OPENAI_BASE_URL=<remote_url>` before running the script.


### PR DESCRIPTION
This PR updates the absolute links for all structured outputs examples with features page.

I don't think relative links are being resolved correctly here.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
