### PR TITLE
use base version for version comparison

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -31,7 +31,7 @@ logger = init_logger(__name__)
 def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
     if compilation_config.use_inductor:
         if envs.VLLM_USE_STANDALONE_COMPILE and is_torch_equal_or_newer(
-                "2.8.0"):
+                "2.8.0a"):
             logger.debug("Using InductorStandaloneAdaptor")
             return InductorStandaloneAdaptor()
         else:

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -44,14 +44,14 @@ class TorchAOConfig(QuantizationConfig):
         """
         # TorchAO quantization relies on tensor subclasses. In order,
         # to enable proper caching this needs standalone compile
-        if is_torch_equal_or_newer("2.8.0"):
+        if is_torch_equal_or_newer("2.8.0a"):
             os.environ["VLLM_TEST_STANDALONE_COMPILE"] = "1"
             logger.info(
                 "Using TorchAO: Setting VLLM_TEST_STANDALONE_COMPILE=1")
 
         # TODO: remove after the torch dependency is updated to 2.8
         if is_torch_equal_or_newer(
-                "2.7.0") and not is_torch_equal_or_newer("2.8.0"):
+                "2.7.0") and not is_torch_equal_or_newer("2.8.0a"):
             os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
             logger.info("Using TorchAO: Setting VLLM_DISABLE_COMPILE_CACHE=1")
         """

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2905,10 +2905,6 @@ def sha256(input) -> int:
 def is_torch_equal_or_newer(target: str) -> bool:
     """Check if the installed torch version is >= the target version.
 
-    This function uses base_version for comparison such that pre release
-    versions are considered to be older than the target version. For example,
-    torch version 2.8.0a0+git093fd47 is considered to be older than 2.8.0.
-
     Args:
         target: a version string, like "2.6.0".
 
@@ -2917,8 +2913,7 @@ def is_torch_equal_or_newer(target: str) -> bool:
     """
     try:
         torch_version = version.parse(str(torch.__version__))
-        base_version = version.parse(torch_version.base_version)
-        return base_version >= version.parse(target)
+        return torch_version >= version.parse(target)
     except Exception:
         # Fallback to PKG-INFO to load the package info, needed by the doc gen.
         return Version(importlib.metadata.version('torch')) >= Version(target)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2905,6 +2905,10 @@ def sha256(input) -> int:
 def is_torch_equal_or_newer(target: str) -> bool:
     """Check if the installed torch version is >= the target version.
 
+    This function uses base_version for comparison such that pre release
+    versions are considered to be older than the target version. For example,
+    torch version 2.8.0a0+git093fd47 is considered to be older than 2.8.0.
+
     Args:
         target: a version string, like "2.6.0".
 
@@ -2913,7 +2917,8 @@ def is_torch_equal_or_newer(target: str) -> bool:
     """
     try:
         torch_version = version.parse(str(torch.__version__))
-        return torch_version >= version.parse(target)
+        base_version = version.parse(torch_version.base_version)
+        return base_version >= version.parse(target)
     except Exception:
         # Fallback to PKG-INFO to load the package info, needed by the doc gen.
         return Version(importlib.metadata.version('torch')) >= Version(target)


### PR DESCRIPTION
#18846 turns standalone_compile on by default via `is_torch_equal_or_newer("2.8.0")`. One major motivation is to use standalone_compile for vllm x torch nightly CI tests.

However, it has no effect yet. The current torch nightly gives `2.8.0a0+...` which is a pre-release and is considered to be less than `2.8.0`. This PR fixes the issue by comparing with `2.8.0a`.
<img width="533" alt="image" src="https://github.com/user-attachments/assets/6ccfcd6c-5321-424c-bde7-e653d258f9eb" />
