### PR TITLE
[CI/Build] Fix torch nightly CI dependencies part 2

### DIFF
--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -41,6 +41,7 @@ matplotlib # required for qwen-vl test
 num2words # required for smolvlm test
 pqdm
 timm # required for internvl test
+mistral-common==1.6.2
 
 schemathesis==3.39.15  # Required for openai schema test.
 mteb>=1.38.11, <2 # required for mteb test


### PR DESCRIPTION
Summary:
This should fix the last dependency error in the torch nightly CI, the other test failures are other issues. This PR pins mistral-common in the nightly_torch_test.txt to the same version as the requirements/test.txt

Test Plan:
- wait for CI
