### PR TITLE
[Bugfix] Skip loading extra parameters for modelopt Qwen3 MoE model

### DIFF
--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -386,6 +386,7 @@ class Qwen3MoeModel(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
+        # Skip loading extra parameters for GPTQ/modelopt models.
         ignore_suffixes = (".bias", "_bias", ".k_scale", "_k_scale",
                            ".v_scale", "_v_scale", ".weight_scale",
                            "_weight_scale", ".input_scale", "_input_scale")
@@ -415,7 +416,7 @@ class Qwen3MoeModel(nn.Module):
                     continue
                 name = name.replace(weight_name, param_name)
 
-                # Skip loading extra bias for GPTQ/modelopt models.
+                # Skip loading extra parameters for GPTQ/modelopt models.
                 if name.endswith(ignore_suffixes) and name not in params_dict:
                     continue
 
@@ -438,7 +439,7 @@ class Qwen3MoeModel(nn.Module):
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name, self):
                         continue
-                    # Skip loading extra bias for GPTQ/modelopt models.
+                    # Skip loading extra parameters for GPTQ/modelopt models.
                     if name.endswith(
                             ignore_suffixes) and name not in params_dict:
                         continue
@@ -451,7 +452,7 @@ class Qwen3MoeModel(nn.Module):
                                   expert_id=expert_id)
                     break
                 else:
-                    # Skip loading extra bias for GPTQ/modelopt models.
+                    # Skip loading extra parameters for GPTQ/modelopt models.
                     if name.endswith(
                             ignore_suffixes) and name not in params_dict:
                         continue

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -386,7 +386,7 @@ class Qwen3MoeModel(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
-        ignore_suffixes = (".bias", "_bias", ".k_scale", "_k_scale", ".weight_scale", "_weight_scale", ".input_scale", "_input_scale")
+        ignore_suffixes = (".bias", "_bias", ".k_scale", "_k_scale", ".v_scale", "_v_scale", ".weight_scale", "_weight_scale", ".input_scale", "_input_scale")
                                                      
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -386,8 +386,10 @@ class Qwen3MoeModel(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
-        ignore_suffixes = (".bias", "_bias", ".k_scale", "_k_scale", ".v_scale", "_v_scale", ".weight_scale", "_weight_scale", ".input_scale", "_input_scale")
-                                                     
+        ignore_suffixes = (".bias", "_bias", ".k_scale", "_k_scale",
+                           ".v_scale", "_v_scale", ".weight_scale",
+                           "_weight_scale", ".input_scale", "_input_scale")
+
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
         expert_params_mapping = FusedMoE.make_expert_params_mapping(
@@ -412,11 +414,11 @@ class Qwen3MoeModel(nn.Module):
                 if "mlp.experts" in name:
                     continue
                 name = name.replace(weight_name, param_name)
-              
+
                 # Skip loading extra bias for GPTQ/modelopt models.
                 if name.endswith(ignore_suffixes) and name not in params_dict:
                     continue
-                  
+
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -437,7 +439,8 @@ class Qwen3MoeModel(nn.Module):
                     if is_pp_missing_parameter(name, self):
                         continue
                     # Skip loading extra bias for GPTQ/modelopt models.
-                    if name.endswith(ignore_suffixes) and name not in params_dict:
+                    if name.endswith(
+                            ignore_suffixes) and name not in params_dict:
                         continue
                     param = params_dict[name]
                     weight_loader = param.weight_loader
@@ -449,7 +452,8 @@ class Qwen3MoeModel(nn.Module):
                     break
                 else:
                     # Skip loading extra bias for GPTQ/modelopt models.
-                    if name.endswith(ignore_suffixes) and name not in params_dict:
+                    if name.endswith(
+                            ignore_suffixes) and name not in params_dict:
                         continue
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name, self):

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -386,6 +386,8 @@ class Qwen3MoeModel(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
+        ignore_suffixes = (".bias", "_bias", ".k_scale", "_k_scale", ".weight_scale", "_weight_scale", ".input_scale", "_input_scale")
+                                                     
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
         expert_params_mapping = FusedMoE.make_expert_params_mapping(
@@ -410,10 +412,11 @@ class Qwen3MoeModel(nn.Module):
                 if "mlp.experts" in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if ((name.endswith(".bias") or name.endswith("_bias"))
-                        and name not in params_dict):
+              
+                # Skip loading extra bias for GPTQ/modelopt models.
+                if name.endswith(ignore_suffixes) and name not in params_dict:
                     continue
+                  
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -433,9 +436,8 @@ class Qwen3MoeModel(nn.Module):
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name, self):
                         continue
-                    # Skip loading extra bias for GPTQ models.
-                    if ((name.endswith(".bias") or name.endswith("_bias"))
-                            and name not in params_dict):
+                    # Skip loading extra bias for GPTQ/modelopt models.
+                    if name.endswith(ignore_suffixes) and name not in params_dict:
                         continue
                     param = params_dict[name]
                     weight_loader = param.weight_loader
@@ -446,9 +448,8 @@ class Qwen3MoeModel(nn.Module):
                                   expert_id=expert_id)
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if ((name.endswith(".bias") or name.endswith("_bias"))
-                            and name not in params_dict):
+                    # Skip loading extra bias for GPTQ/modelopt models.
+                    if name.endswith(ignore_suffixes) and name not in params_dict:
                         continue
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name, self):


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fixes https://github.com/vllm-project/vllm/issues/15784

## Test Plan
add the following to the `quantization_config` field of config.json
```
"quant_method": "fp8",
"activation_scheme": "static",
```

and then serve with
```
vllm serve {modelopt_quantized_model}
```

## Test Result

(AS-IS)
```
ERROR 06-13 14:37:58 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/qwen3_moe.py", line 535, in load_weights
ERROR 06-13 14:37:58 [core.py:515]     return loader.load_weights(weights)
ERROR 06-13 14:37:58 [core.py:515]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-13 14:37:58 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/utils.py", line 278, in load_weights
ERROR 06-13 14:37:58 [core.py:515]     autoloaded_weights = set(self._load_module("", self.module, weights))
ERROR 06-13 14:37:58 [core.py:515]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-13 14:37:58 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/utils.py", line 236, in _load_module
ERROR 06-13 14:37:58 [core.py:515]     yield from self._load_module(prefix,
ERROR 06-13 14:37:58 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/utils.py", line 209, in _load_module
ERROR 06-13 14:37:58 [core.py:515]     loaded_params = module_load_weights(weights)
ERROR 06-13 14:37:58 [core.py:515]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-13 14:37:58 [core.py:515]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/qwen3_moe.py", line 469, in load_weights
ERROR 06-13 14:37:58 [core.py:515]     param = params_dict[name]
ERROR 06-13 14:37:58 [core.py:515]             ~~~~~~~~~~~^^^^^^
ERROR 06-13 14:37:58 [core.py:515] KeyError: 'layers.40.self_attn.qkqkv_proj.k_scale'
```

(TO-BE)
- loads the model successfully

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
