### PR TITLE
Use the correct torch dtype in topk kernel assertion

### DIFF
--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -530,7 +530,7 @@ void topk_softmax(
             stream);
     }
     else {
-        assert(topk_indices.scalar_type() == at::ScalarType::Int64);
+        assert(topk_indices.scalar_type() == at::ScalarType::Long);
         vllm::moe::topkGatingSoftmaxKernelLauncher(
             gating_output.data_ptr<float>(),
             topk_weights.data_ptr<float>(),


### PR DESCRIPTION
Torch 2.7 doesn't define `ScalarType::Int64` but rather defines `::Long` instead: https://github.com/pytorch/pytorch/blob/release/2.7/c10/core/ScalarType.h#L67

Without this patch, it's impossible to build vllm for (at least) ROCm with an error message like
```
/amd/vadim/vllm/build/temp.linux-x86_64-cpython-310/csrc/moe/topk_softmax_kernels.hip
  /home/amd/vadim/vllm/build/temp.linux-x86_64-cpython-310/csrc/moe/topk_softmax_kernels.hip:535:62: error: no member named 'Int64' in 'c10::ScalarType'
    535 |         assert(topk_indices.scalar_type() == at::ScalarType::Int64);
        |                                              ~~~~~~~~~~~~~~~~^
  /usr/include/assert.h:93:27: note: expanded from macro 'assert'
     93 |      (static_cast <bool> (expr)                                         \
        |                           ^~~~
  1 error generated when compiling for gfx942.

```
