### PR TITLE
[Config] Make prefix cache metrics interval configurable

### DIFF
--- a/tests/test_prefix_cache_metrics_config.py
+++ b/tests/test_prefix_cache_metrics_config.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import ObservabilityConfig, VllmConfig
+from vllm.v1.core.kv_cache_utils import PrefixCachingMetrics
+from vllm.v1.metrics.loggers import LoggingStatLogger
+
+
+def test_observability_config_prefix_cache_metrics_validation():
+    """Test that ObservabilityConfig validates
+    prefix_cache_metrics_max_requests."""
+    # Test valid values
+    config = ObservabilityConfig(prefix_cache_metrics_max_requests=500)
+    assert config.prefix_cache_metrics_max_requests == 500
+
+    config = ObservabilityConfig(prefix_cache_metrics_max_requests=1000)
+    assert config.prefix_cache_metrics_max_requests == 1000
+
+    # Test default value
+    config = ObservabilityConfig()
+    assert config.prefix_cache_metrics_max_requests == 1000
+
+    # Test invalid values
+    with pytest.raises(ValueError, match="must be between 1 and 100000"):
+        ObservabilityConfig(prefix_cache_metrics_max_requests=0)
+
+    with pytest.raises(ValueError, match="must be between 1 and 100000"):
+        ObservabilityConfig(prefix_cache_metrics_max_requests=-1)
+
+    with pytest.raises(ValueError, match="must be between 1 and 100000"):
+        ObservabilityConfig(prefix_cache_metrics_max_requests=100001)
+
+
+def test_prefix_caching_metrics_configurable_interval():
+    """Test that PrefixCachingMetrics respects the configurable interval."""
+    # Test with custom interval
+    metrics = PrefixCachingMetrics(max_recent_requests=500)
+    assert metrics.max_recent_requests == 500
+
+    # Test with default interval
+    metrics = PrefixCachingMetrics()
+    assert metrics.max_recent_requests == 1000
+
+
+def test_logging_stat_logger_uses_config():
+    """Test that LoggingStatLogger uses the configured prefix cache metrics
+    interval."""
+    # Create VllmConfig with custom observability config
+    observability_config = ObservabilityConfig(
+        prefix_cache_metrics_max_requests=2000)
+    vllm_config = VllmConfig(observability_config=observability_config)
+
+    # Create logger
+    logger = LoggingStatLogger(vllm_config)
+
+    # Verify it uses the configured value
+    assert logger.prefix_caching_metrics.max_recent_requests == 2000
+
+    # Test with None observability config (should use default)
+    vllm_config_none = VllmConfig(observability_config=None)
+    logger_none = LoggingStatLogger(vllm_config_none)
+    assert logger_none.prefix_caching_metrics.max_recent_requests == 1000

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3567,6 +3567,11 @@ class ObservabilityConfig:
     you migrate to new metrics. The metric is likely to be removed completely
     in an upcoming release."""
 
+    prefix_cache_metrics_max_requests: int = 1000
+    """Maximum number of recent requests to track for prefix cache hit rate
+    metrics. Higher values provide more stable metrics but use more memory.
+    Must be a positive integer."""
+
     @cached_property
     def show_hidden_metrics(self) -> bool:
         """Check if the hidden metrics should be shown."""
@@ -3631,6 +3636,11 @@ class ObservabilityConfig:
                 "OpenTelemetry is not available. Unable to configure "
                 "'otlp_traces_endpoint'. Ensure OpenTelemetry packages are "
                 f"installed. Original error:\n{otel_import_error_traceback}")
+
+        if not (1 <= self.prefix_cache_metrics_max_requests <= 100000):
+            raise ValueError(
+                f"prefix_cache_metrics_max_requests must be between 1 and "
+                f"100000, got: {self.prefix_cache_metrics_max_requests}")
 
     def _parse_collect_detailed_traces(self):
         assert isinstance(self.collect_detailed_traces, list)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -408,6 +408,8 @@ class EngineArgs:
         ObservabilityConfig.otlp_traces_endpoint
     collect_detailed_traces: Optional[list[DetailedTraceModules]] = \
         ObservabilityConfig.collect_detailed_traces
+    prefix_cache_metrics_max_requests: int = \
+        ObservabilityConfig.prefix_cache_metrics_max_requests
     disable_async_output_proc: bool = not ModelConfig.use_async_output_proc
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: Union[str, Type[object]] = SchedulerConfig.scheduler_cls
@@ -800,6 +802,9 @@ class EngineArgs:
         observability_group.add_argument(
             "--otlp-traces-endpoint",
             **observability_kwargs["otlp_traces_endpoint"])
+        observability_group.add_argument(
+            "--prefix-cache-metrics-max-requests",
+            **observability_kwargs["prefix_cache_metrics_max_requests"])
         # TODO: generalise this special case
         choices = observability_kwargs["collect_detailed_traces"]["choices"]
         metavar = f"{{{','.join(choices)}}}"
@@ -1224,6 +1229,8 @@ class EngineArgs:
             show_hidden_metrics_for_version,
             otlp_traces_endpoint=self.otlp_traces_endpoint,
             collect_detailed_traces=self.collect_detailed_traces,
+            prefix_cache_metrics_max_requests=self.
+            prefix_cache_metrics_max_requests,
         )
 
         config = VllmConfig(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -55,8 +55,11 @@ class LoggingStatLogger(StatLoggerBase):
         self._reset(time.monotonic())
         self.last_scheduler_stats = SchedulerStats()
         # Prefix cache metrics. This cannot be reset.
-        # TODO: Make the interval configurable.
-        self.prefix_caching_metrics = PrefixCachingMetrics()
+        max_requests = (
+            vllm_config.observability_config.prefix_cache_metrics_max_requests
+            if vllm_config.observability_config else 1000)
+        self.prefix_caching_metrics = PrefixCachingMetrics(
+            max_recent_requests=max_requests)
         self.spec_decoding_logging = SpecDecodingLogging()
         self.last_prompt_throughput: float = 0.0
         self.last_generation_throughput: float = 0.0


### PR DESCRIPTION
## Purpose

Resolves TODO left by @comaniac in vllm/v1/metrics/loggers.py:58 - makes the prefix cache metrics interval configurable instead of hardcoded to 1000 requests.

The prefix cache metrics currently use a hardcoded limit of 1000 recent requests to calculate hit rates. This adds a configurable parameter to let users adjust this based on their memory vs stability preferences.

## Changes

- Add `prefix_cache_metrics_max_requests` to ObservabilityConfig (default: 1000)
- Add `--prefix-cache-metrics-max-requests` CLI argument  
- Validate range 1-100000 to prevent excessive memory usage
- Update LoggingStatLogger to respect the configured value
- Add comprehensive tests for validation and integration

Higher values give more stable hit rate metrics but use more memory.
Lower values are more memory-efficient but metrics may be noisier.

## Test Plan

```bash
# Test default behavior (should use 1000)
python -c "from vllm.config import ObservabilityConfig; print(ObservabilityConfig().prefix_cache_metrics_max_requests)"

# Test custom value via config
python -c "from vllm.config import ObservabilityConfig; print(ObservabilityConfig(prefix_cache_metrics_max_requests=2000).prefix_cache_metrics_max_requests)"

# Test validation - should fail
python -c "from vllm.config import ObservabilityConfig; ObservabilityConfig(prefix_cache_metrics_max_requests=0)"

# Test CLI argument (when serving)
vllm serve model_name --prefix-cache-metrics-max-requests=2000

# Run the new tests
pytest tests/test_prefix_cache_metrics_config.py -v
```

## Test Results

✅ **Default value (1000)**: Works correctly, maintains backward compatibility  
✅ **Custom values**: Accepted and properly used by PrefixCachingMetrics  
✅ **Validation**: Invalid values (0, negative, >100000) properly rejected with clear error messages  
✅ **Integration**: LoggingStatLogger correctly uses configured value or falls back to 1000  
✅ **All tests pass**: 3 test functions covering validation, metrics behavior, and end-to-end integration

Example usage: `--prefix-cache-metrics-max-requests=2000`