### PR TITLE
[Frontend] Support image object in llm.chat

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -101,6 +101,49 @@ To substitute multiple images inside the same text prompt, you can pass in a lis
 
 Full example: <gh-file:examples/offline_inference/vision_language_multi_image.py>
 
+If using the [LLM.chat](https://docs.vllm.ai/en/stable/models/generative_models.html#llmchat) method, you can pass images directly in the message content using various formats: image URLs, PIL Image objects, or pre-computed embeddings:
+
+```python
+from vllm import LLM
+from vllm.assets.image import ImageAsset
+
+llm = LLM(model="llava-hf/llava-1.5-7b-hf")
+image_url = "https://picsum.photos/id/32/512/512"
+image_pil = ImageAsset('cherry_blossom').pil_image
+image_embeds = torch.load(...)
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant"},
+    {"role": "user", "content": "Hello"},
+    {"role": "assistant", "content": "Hello! How can I assist you today?"},
+    {
+        "role": "user",
+        "content": [{
+            "type": "image_url",
+            "image_url": {
+                "url": image_url
+            }
+        },{
+            "type": "image_pil",
+            "image_pil": image_pil
+        }, {
+            "type": "image_embeds",
+            "image_embeds": image_embeds
+        }, {
+            "type": "text",
+            "text": "What's in these images?"
+        }],
+    },
+]
+
+# Perform inference and log output.
+outputs = llm.chat(conversation)
+
+for o in outputs:
+    generated_text = o.outputs[0].text
+    print(generated_text)
+```
+
 Multi-image input can be extended to perform video captioning. We show this with [Qwen2-VL](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct) as it supports videos:
 
 ??? Code

--- a/examples/offline_inference/mistral-small.py
+++ b/examples/offline_inference/mistral-small.py
@@ -6,6 +6,7 @@ import argparse
 
 from vllm import LLM
 from vllm.sampling_params import SamplingParams
+from vllm.assets.image import ImageAsset
 
 # This script is an offline demo for running Mistral-Small-3.1
 #
@@ -71,14 +72,16 @@ def run_simple_demo(args: argparse.Namespace):
     )
 
     prompt = "Describe this image in one sentence."
-    image_url = "https://picsum.photos/id/237/200/300"
 
     messages = [
         {
             "role": "user",
             "content": [
                 {"type": "text", "text": prompt},
-                {"type": "image_url", "image_url": {"url": image_url}},
+                {
+                    "type": "image_pil",
+                    "image_pil": ImageAsset("cherry_blossom").pil_image,
+                },
             ],
         },
     ]

--- a/examples/offline_inference/mistral-small.py
+++ b/examples/offline_inference/mistral-small.py
@@ -6,7 +6,6 @@ import argparse
 
 from vllm import LLM
 from vllm.sampling_params import SamplingParams
-from vllm.assets.image import ImageAsset
 
 # This script is an offline demo for running Mistral-Small-3.1
 #
@@ -56,7 +55,7 @@ from vllm.assets.image import ImageAsset
 
 
 def run_simple_demo(args: argparse.Namespace):
-    model_name = "mistral-community/pixtral-12b"
+    model_name = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
     sampling_params = SamplingParams(max_tokens=8192)
 
     llm = LLM(
@@ -67,7 +66,7 @@ def run_simple_demo(args: argparse.Namespace):
         limit_mm_per_prompt={"image": 1},
         max_model_len=4096,
         max_num_seqs=2,
-        tensor_parallel_size=1,
+        tensor_parallel_size=2,
         disable_mm_preprocessor_cache=args.disable_mm_preprocessor_cache,
     )
 
@@ -79,7 +78,7 @@ def run_simple_demo(args: argparse.Namespace):
             "role": "user",
             "content": [
                 {"type": "text", "text": prompt},
-                {"type": "image", "image": ImageAsset('cherry_blossom').pil_image},
+                {"type": "image_url", "image_url": {"url": image_url}},
             ],
         },
     ]
@@ -90,7 +89,7 @@ def run_simple_demo(args: argparse.Namespace):
 
 
 def run_advanced_demo(args: argparse.Namespace):
-    model_name = "mistral-community/pixtral-12b"
+    model_name = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
     max_img_per_msg = 3
     max_tokens_per_img = 4096
 

--- a/examples/offline_inference/mistral-small.py
+++ b/examples/offline_inference/mistral-small.py
@@ -6,6 +6,7 @@ import argparse
 
 from vllm import LLM
 from vllm.sampling_params import SamplingParams
+from vllm.assets.image import ImageAsset
 
 # This script is an offline demo for running Mistral-Small-3.1
 #
@@ -55,7 +56,7 @@ from vllm.sampling_params import SamplingParams
 
 
 def run_simple_demo(args: argparse.Namespace):
-    model_name = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+    model_name = "mistral-community/pixtral-12b"
     sampling_params = SamplingParams(max_tokens=8192)
 
     llm = LLM(
@@ -66,7 +67,7 @@ def run_simple_demo(args: argparse.Namespace):
         limit_mm_per_prompt={"image": 1},
         max_model_len=4096,
         max_num_seqs=2,
-        tensor_parallel_size=2,
+        tensor_parallel_size=1,
         disable_mm_preprocessor_cache=args.disable_mm_preprocessor_cache,
     )
 
@@ -78,7 +79,7 @@ def run_simple_demo(args: argparse.Namespace):
             "role": "user",
             "content": [
                 {"type": "text", "text": prompt},
-                {"type": "image_url", "image_url": {"url": image_url}},
+                {"type": "image", "image": ImageAsset('cherry_blossom').pil_image},
             ],
         },
     ]
@@ -89,7 +90,7 @@ def run_simple_demo(args: argparse.Namespace):
 
 
 def run_advanced_demo(args: argparse.Namespace):
-    model_name = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+    model_name = "mistral-community/pixtral-12b"
     max_img_per_msg = 3
     max_tokens_per_img = 4096
 

--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -136,8 +136,10 @@ def test_parse_chat_messages_single_image(
             "role":
             "user",
             "content": [{
-                "type": "image",
-                "image_url": image_url
+                "type": "image_url",
+                "image_url": {
+                    "url": image_url
+                }
             }, {
                 "type": "text",
                 "text": "What's in the image?"
@@ -152,6 +154,7 @@ def test_parse_chat_messages_single_image(
         "role": "user",
         "content": "<|image_1|>\nWhat's in the image?"
     }]
+    print('mm data', mm_data)
     _assert_mm_data_is_image_input(mm_data, 1)
 
 
@@ -226,8 +229,10 @@ async def test_parse_chat_messages_single_image_async(
             "role":
             "user",
             "content": [{
-                "type": "image",
-                "image": ImageAsset('cherry_blossom').pil_image
+                "type": "image_url",
+                "image_url": {
+                    "url": image_url
+                }
             }, {
                 "type": "text",
                 "text": "What's in the image?"

--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -136,10 +136,8 @@ def test_parse_chat_messages_single_image(
             "role":
             "user",
             "content": [{
-                "type": "image_url",
-                "image_url": {
-                    "url": image_url
-                }
+                "type": "image",
+                "image_url": image_url
             }, {
                 "type": "text",
                 "text": "What's in the image?"
@@ -228,10 +226,8 @@ async def test_parse_chat_messages_single_image_async(
             "role":
             "user",
             "content": [{
-                "type": "image_url",
-                "image_url": {
-                    "url": image_url
-                }
+                "type": "image",
+                "image": ImageAsset('cherry_blossom').pil_image
             }, {
                 "type": "text",
                 "text": "What's in the image?"
@@ -264,10 +260,8 @@ def test_parse_chat_messages_multiple_images(
                     "url": image_url
                 }
             }, {
-                "type": "image_url",
-                "image_url": {
-                    "url": image_url
-                }
+                "type": "image",
+                "image": ImageAsset('cherry_blossom').pil_image
             }, {
                 "type": "text",
                 "text": "What's in these images?"
@@ -303,10 +297,8 @@ async def test_parse_chat_messages_multiple_images_async(
                     "url": image_url
                 }
             }, {
-                "type": "image_url",
-                "image_url": {
-                    "url": image_url
-                }
+                "type": "image",
+                "image": ImageAsset('cherry_blossom').pil_image
             }, {
                 "type": "text",
                 "text": "What's in these images?"

--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -154,7 +154,6 @@ def test_parse_chat_messages_single_image(
         "role": "user",
         "content": "<|image_1|>\nWhat's in the image?"
     }]
-    print('mm data', mm_data)
     _assert_mm_data_is_image_input(mm_data, 1)
 
 

--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -264,8 +264,8 @@ def test_parse_chat_messages_multiple_images(
                     "url": image_url
                 }
             }, {
-                "type": "image",
-                "image": ImageAsset('cherry_blossom').pil_image
+                "type": "image_pil",
+                "image_pil": ImageAsset('cherry_blossom').pil_image
             }, {
                 "type": "text",
                 "text": "What's in these images?"
@@ -301,8 +301,8 @@ async def test_parse_chat_messages_multiple_images_async(
                     "url": image_url
                 }
             }, {
-                "type": "image",
-                "image": ImageAsset('cherry_blossom').pil_image
+                "type": "image_pil",
+                "image_pil": ImageAsset('cherry_blossom').pil_image
             }, {
                 "type": "text",
                 "text": "What's in these images?"

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -627,6 +627,10 @@ class BaseMultiModalContentParser(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def parse_direct_image(self, image: object) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
     def parse_image_embeds(self,
                            image_embeds: Union[str, dict[str, str]]) -> None:
         raise NotImplementedError
@@ -663,7 +667,6 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder(placeholder)
 
     def parse_direct_image(self, image: object) -> None:  
-        # Directly add the PIL image without URL processing  
         placeholder = self._tracker.add("image", image)  
         self._add_placeholder(placeholder)  
 
@@ -718,6 +721,13 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
 
         placeholder = self._tracker.add("image", image_coro)
         self._add_placeholder(placeholder)
+
+    def parse_direct_image(self, image: object) -> None:  
+        future: asyncio.Future[object] = asyncio.Future()  
+        future.set_result(image)  
+        
+        placeholder = self._tracker.add("image", future) 
+        self._add_placeholder(placeholder)  
 
     def parse_image_embeds(self,
                            image_embeds: Union[str, dict[str, str]]) -> None:

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -8,7 +8,6 @@ from collections import defaultdict, deque
 from collections.abc import Awaitable, Iterable
 from functools import cached_property, lru_cache, partial
 from pathlib import Path
-from PIL import Image
 from typing import (Any, Callable, Generic, Literal, Optional, TypeVar, Union,
                     cast)
 
@@ -29,7 +28,8 @@ from openai.types.chat import (ChatCompletionMessageToolCallParam,
                                ChatCompletionToolMessageParam)
 from openai.types.chat.chat_completion_content_part_input_audio_param import (
     InputAudio)
-from pydantic import TypeAdapter, ConfigDict, BaseModel
+from PIL import Image
+from pydantic import BaseModel, ConfigDict, TypeAdapter
 # yapf: enable
 from transformers import (PreTrainedTokenizer, PreTrainedTokenizerFast,
                           ProcessorMixin)
@@ -95,9 +95,9 @@ class ChatCompletionContentPartVideoParam(TypedDict, total=False):
 class PILImage(BaseModel):
     """
     A PIL.Image.Image object.
-    """       
+    """
     image: Image.Image
-    model_config = ConfigDict(arbitrary_types_allowed=True) 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class CustomChatCompletionContentPILImageParam(TypedDict, total=False):
@@ -702,9 +702,9 @@ class MultiModalContentParser(BaseMultiModalContentParser):
 
         self._add_placeholder(placeholder)
 
-    def parse_pil_image(self, image: Image.Image) -> None:  
-        placeholder = self._tracker.add("image", image)  
-        self._add_placeholder(placeholder)  
+    def parse_pil_image(self, image: Image.Image) -> None:
+        placeholder = self._tracker.add("image", image)
+        self._add_placeholder(placeholder)
 
     def parse_audio(self, audio_url: str) -> None:
         audio = self._connector.fetch_audio(audio_url)
@@ -762,12 +762,12 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         placeholder = self._tracker.add("image_embeds", future)
         self._add_placeholder(placeholder)
 
-    def parse_pil_image(self, image: Image.Image) -> None:  
-        future: asyncio.Future[Image.Image] = asyncio.Future()  
-        future.set_result(image)  
-        
-        placeholder = self._tracker.add("image", future) 
-        self._add_placeholder(placeholder)  
+    def parse_pil_image(self, image: Image.Image) -> None:
+        future: asyncio.Future[Image.Image] = asyncio.Future()
+        future.set_result(image)
+
+        placeholder = self._tracker.add("image", future)
+        self._add_placeholder(placeholder)
 
     def parse_audio(self, audio_url: str) -> None:
         audio_coro = self._connector.fetch_audio_async(audio_url)
@@ -906,7 +906,7 @@ MM_PARSER_MAP: dict[
     lambda part: _ImageParser(part).get("image_url", {}).get("url", None),
     "image_embeds":
     lambda part: _ImageEmbedsParser(part).get("image_embeds", None),
-    "image": lambda part: _PILImageParser(part).get("image", None),  
+    "image": lambda part: _PILImageParser(part).get("image", None),
     "audio_url":
     lambda part: _AudioParser(part).get("audio_url", {}).get("url", None),
     "input_audio":
@@ -1048,9 +1048,9 @@ def _parse_chat_message_content_part(
             return str_content
 
     if part_type == "image":
-        image_content = cast(Image.Image, content)  
-        mm_parser.parse_pil_image(image_content)  
-        return {'type': 'image'} if wrap_dicts else None  
+        image_content = cast(Image.Image, content)
+        mm_parser.parse_pil_image(image_content)
+        return {'type': 'image'} if wrap_dicts else None
     if part_type == "image_url":
         str_content = cast(str, content)
         mm_parser.parse_image(str_content)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -96,7 +96,7 @@ class PILImage(BaseModel):
     """
     A PIL.Image.Image object.
     """
-    image: Image.Image
+    image_pil: Image.Image
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -8,6 +8,7 @@ from collections import defaultdict, deque
 from collections.abc import Awaitable, Iterable
 from functools import cached_property, lru_cache, partial
 from pathlib import Path
+from PIL import Image
 from typing import (Any, Callable, Generic, Literal, Optional, TypeVar, Union,
                     cast)
 
@@ -28,7 +29,7 @@ from openai.types.chat import (ChatCompletionMessageToolCallParam,
                                ChatCompletionToolMessageParam)
 from openai.types.chat.chat_completion_content_part_input_audio_param import (
     InputAudio)
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ConfigDict, BaseModel
 # yapf: enable
 from transformers import (PreTrainedTokenizer, PreTrainedTokenizerFast,
                           ProcessorMixin)
@@ -91,6 +92,25 @@ class ChatCompletionContentPartVideoParam(TypedDict, total=False):
     """The type of the content part."""
 
 
+class PILImage(BaseModel):
+    """
+    A PIL.Image.Image object.
+    """       
+    image: Image.Image
+    model_config = ConfigDict(arbitrary_types_allowed=True) 
+
+
+class CustomChatCompletionContentPILImageParam(TypedDict, total=False):
+    """A simpler version of the param that only accepts a PIL image.
+
+    Example:
+    {
+        "image": ImageAsset('cherry_blossom').pil_image
+    }
+    """
+    image: Required[PILImage]
+
+
 class CustomChatCompletionContentSimpleImageParam(TypedDict, total=False):
     """A simpler version of the param that only accepts a plain image_url.
     This is supported by OpenAI API, although it is not documented.
@@ -129,6 +149,7 @@ ChatCompletionContentPartParam: TypeAlias = Union[
     OpenAIChatCompletionContentPartParam, ChatCompletionContentPartAudioParam,
     ChatCompletionContentPartInputAudioParam,
     ChatCompletionContentPartVideoParam, ChatCompletionContentPartRefusalParam,
+    CustomChatCompletionContentPILImageParam,
     CustomChatCompletionContentSimpleImageParam,
     ChatCompletionContentPartImageEmbedsParam,
     CustomChatCompletionContentSimpleAudioParam,
@@ -632,7 +653,7 @@ class BaseMultiModalContentParser(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def parse_image_object(self, image: object) -> None:
+    def parse_pil_image(self, image: Image.Image) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -681,7 +702,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
 
         self._add_placeholder(placeholder)
 
-    def parse_image_object(self, image: object) -> None:  
+    def parse_pil_image(self, image: Image.Image) -> None:  
         placeholder = self._tracker.add("image", image)  
         self._add_placeholder(placeholder)  
 
@@ -741,8 +762,8 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         placeholder = self._tracker.add("image_embeds", future)
         self._add_placeholder(placeholder)
 
-    def parse_image_object(self, image: object) -> None:  
-        future: asyncio.Future[object] = asyncio.Future()  
+    def parse_pil_image(self, image: Image.Image) -> None:  
+        future: asyncio.Future[Image.Image] = asyncio.Future()  
         future.set_result(image)  
         
         placeholder = self._tracker.add("image", future) 
@@ -866,12 +887,13 @@ _TextParser = partial(cast, ChatCompletionContentPartTextParam)
 _ImageEmbedsParser = partial(cast, ChatCompletionContentPartImageEmbedsParam)
 _InputAudioParser = partial(cast, ChatCompletionContentPartInputAudioParam)
 _RefusalParser = partial(cast, ChatCompletionContentPartRefusalParam)
+_PILImageParser = partial(cast, CustomChatCompletionContentPILImageParam)
 # Need to validate url objects
 _ImageParser = TypeAdapter(ChatCompletionContentPartImageParam).validate_python
 _AudioParser = TypeAdapter(ChatCompletionContentPartAudioParam).validate_python
 _VideoParser = TypeAdapter(ChatCompletionContentPartVideoParam).validate_python
 
-_ContentPart: TypeAlias = Union[str, dict[str, str], InputAudio]
+_ContentPart: TypeAlias = Union[str, dict[str, str], InputAudio, PILImage]
 
 # Define a mapping from part types to their corresponding parsing functions.
 MM_PARSER_MAP: dict[
@@ -884,7 +906,7 @@ MM_PARSER_MAP: dict[
     lambda part: _ImageParser(part).get("image_url", {}).get("url", None),
     "image_embeds":
     lambda part: _ImageEmbedsParser(part).get("image_embeds", None),
-    "image": lambda part: part.get("image", None),  
+    "image": lambda part: _PILImageParser(part).get("image", None),  
     "audio_url":
     lambda part: _AudioParser(part).get("audio_url", {}).get("url", None),
     "input_audio":
@@ -1025,6 +1047,10 @@ def _parse_chat_message_content_part(
         else:
             return str_content
 
+    if part_type == "image":
+        image_content = cast(Image.Image, content)  
+        mm_parser.parse_pil_image(image_content)  
+        return {'type': 'image'} if wrap_dicts else None  
     if part_type == "image_url":
         str_content = cast(str, content)
         mm_parser.parse_image(str_content)
@@ -1033,10 +1059,6 @@ def _parse_chat_message_content_part(
         content = cast(Union[str, dict[str, str]], content)
         mm_parser.parse_image_embeds(content)
         return {'type': 'image'} if wrap_dicts else None
-    if part_type == "image":
-        image_content = cast(object, content)  # PIL image or similar  
-        mm_parser.parse_image_object(image_content)  
-        return {'type': 'image'} if wrap_dicts else None  
     if part_type == "audio_url":
         str_content = cast(str, content)
         mm_parser.parse_audio(str_content)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -662,6 +662,11 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         placeholder = self._tracker.add("image", image)
         self._add_placeholder(placeholder)
 
+    def parse_direct_image(self, image: object) -> None:  
+        # Directly add the PIL image without URL processing  
+        placeholder = self._tracker.add("image", image)  
+        self._add_placeholder(placeholder)  
+
     def parse_image_embeds(self,
                            image_embeds: Union[str, dict[str, str]]) -> None:
         if isinstance(image_embeds, dict):
@@ -869,6 +874,7 @@ MM_PARSER_MAP: dict[
     lambda part: _ImageParser(part).get("image_url", {}).get("url", None),
     "image_embeds":
     lambda part: _ImageEmbedsParser(part).get("image_embeds", None),
+    "image": lambda part: part.get("image", None),  
     "audio_url":
     lambda part: _AudioParser(part).get("audio_url", {}).get("url", None),
     "input_audio":
@@ -938,7 +944,7 @@ def _parse_chat_message_content_mm_part(
 
 
 VALID_MESSAGE_CONTENT_MM_PART_TYPES = ("text", "refusal", "image_url",
-                                       "image_embeds",
+                                       "image_embeds", "image",
                                        "audio_url", "input_audio", "video_url")
 
 
@@ -1017,6 +1023,10 @@ def _parse_chat_message_content_part(
         content = cast(Union[str, dict[str, str]], content)
         mm_parser.parse_image_embeds(content)
         return {'type': 'image'} if wrap_dicts else None
+    if part_type == "image":
+        image_content = cast(object, content)  # PIL image or similar  
+        mm_parser.parse_direct_image(image_content)  
+        return {'type': 'image'} if wrap_dicts else None  
     if part_type == "audio_url":
         str_content = cast(str, content)
         mm_parser.parse_audio(str_content)


### PR DESCRIPTION
## Purpose

Fix [17551](https://github.com/vllm-project/vllm/issues/17551)

## Test Plan
Unit test:  
```
pytest tests/entrypoints/test_chat_utils.py
```

Manual test: 
Run a multimodal llm chat with hardcoded image object 
```
python examples/offline_inference/mistral-small.py simple --format hf
```