### PR TITLE
[Fix] Fall back to Gloo when NCCL backend is unavailable

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -938,6 +938,13 @@ def init_distributed_environment(
         assert distributed_init_method is not None, (
             "distributed_init_method must be provided when initializing "
             "distributed environment")
+        if not torch.distributed.is_backend_available(backend):
+            logger.warning(
+                "Distributed backend %s is not available; "
+                "falling back to gloo.", backend)
+            assert torch.distributed.is_gloo_available(), (
+                "Fallback Gloo backend is not available.")
+            backend = "gloo"
         # this backend is used for WORLD
         torch.distributed.init_process_group(
             backend=backend,


### PR DESCRIPTION
## Purpose
vLLM refuses to launch with CUDA device on systems without NCCL support (i.e. Jetson):
```
RuntimeError: Distributed package doesn't have NCCL built in
```
Previously I have been running vLLM on Jetson by doing a find-replace for `nccl` -> `gloo` in `vllm/distributed/parallel_state.py`, but submitting a proper patch seems more appropriate.

When Torch's NCCL distributed backend isn't available, this will simply print a warning and fall back to using Gloo.

## Test Plan
1. Ensure installed Torch doesn't have NCCL support
2. Run vLLM
3. Observe warning: `Distributed backend nccl is not available; falling back to gloo.`
4. vLLM works as expected

## Test Result
OK