### PR TITLE
[BugFix] Add an env to disable moe chunking to work around compile incompatibility

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     VLLM_HOST_IP: str = ""
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_FUSED_MOE_CHUNK_SIZE: int = 64 * 1024
+    VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING: bool = True
     VLLM_USE_RAY_SPMD_WORKER: bool = False
     VLLM_USE_RAY_COMPILED_DAG: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: str = "auto"
@@ -535,6 +536,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_XLA_USE_SPMD", "0"))),
     "VLLM_FUSED_MOE_CHUNK_SIZE":
     lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "32768")),
+    # Control whether to use fused MoE activation chunking. Current chunking 
+    # logic is incompatible with torch.compile and causes IMA. See issue 
+    # https://github.com/vllm-project/vllm/issues/19631.
+    "VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING":
+    lambda: bool(os.getenv("VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING", "1")),
 
     # If set, vllm will skip the deprecation warnings.
     "VLLM_NO_DEPRECATION_WARNING":

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 import sys
 import tempfile
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 if TYPE_CHECKING:
     VLLM_HOST_IP: str = ""
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_FUSED_MOE_CHUNK_SIZE: int = 64 * 1024
-    VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING: bool = True
+    VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING: bool = False
     VLLM_USE_RAY_SPMD_WORKER: bool = False
     VLLM_USE_RAY_COMPILED_DAG: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: str = "auto"
@@ -536,11 +536,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_XLA_USE_SPMD", "0"))),
     "VLLM_FUSED_MOE_CHUNK_SIZE":
     lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "32768")),
-    # Control whether to use fused MoE activation chunking. Current chunking 
-    # logic is incompatible with torch.compile and causes IMA. See issue 
+    # Control whether to use fused MoE activation chunking. Current chunking
+    # logic is incompatible with torch.compile and causes IMA. See issue
     # https://github.com/vllm-project/vllm/issues/19631.
-    "VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING":
-    lambda: bool(os.getenv("VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING", "1")),
+    "VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING":
+    lambda: bool(
+        int(os.getenv("VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING", "0"))),
 
     # If set, vllm will skip the deprecation warnings.
     "VLLM_NO_DEPRECATION_WARNING":

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_FUSED_MOE_CHUNK_SIZE: int = 64 * 1024
-    VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING: bool = False
+    VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING: bool = True
     VLLM_USE_RAY_SPMD_WORKER: bool = False
     VLLM_USE_RAY_COMPILED_DAG: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: str = "auto"
@@ -541,7 +541,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # https://github.com/vllm-project/vllm/issues/19631.
     "VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING":
     lambda: bool(
-        int(os.getenv("VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING", "0"))),
+        int(os.getenv("VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING", "1"))),
 
     # If set, vllm will skip the deprecation warnings.
     "VLLM_NO_DEPRECATION_WARNING":

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -225,6 +225,10 @@ class FusedMoEPermuteExpertsUnpermute(ABC):
         else:
             raise ValueError(f"Unsupported FusedMoe activation: {activation}")
 
+    def enable_chunking(self):
+        return not envs.VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING and \
+          self.supports_chunking()
+
     @abstractmethod
     def apply(
         self,
@@ -400,7 +404,7 @@ class FusedMoEModularKernel(torch.nn.Module):
         else:
             _, M, N, K, top_k = _moe_problem_size(a1q, w1, w2, topk_ids)
 
-            if self.fused_experts.supports_chunking():
+            if self.fused_experts.enable_chunking():
                 CHUNK_SIZE = envs.VLLM_FUSED_MOE_CHUNK_SIZE
                 num_chunks = cdiv(M, CHUNK_SIZE)
             else:

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -226,7 +226,7 @@ class FusedMoEPermuteExpertsUnpermute(ABC):
             raise ValueError(f"Unsupported FusedMoe activation: {activation}")
 
     def enable_chunking(self):
-        return not envs.VLLM_DISABLE_FUSED_MOE_ACTIVATION_CHUNKING and \
+        return envs.VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING and \
           self.supports_chunking()
 
     @abstractmethod


### PR DESCRIPTION
## Purpose
Temp workaround for IMA under high max num batched tokens: https://github.com/vllm-project/vllm/issues/19631

Due to compile incompatibility I feel we shouldn't turn this on by default until we have more comprehensive tests but I'm also open to other options. cc: @zou3519 @bnellnm 

## Test Plan
Turn off chunking w/ inductor: 
```
VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING=0 python3 benchmarks/benchmark_latency.py --model meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --tensor-parallel-size 8 --trust-remote-code --max_num_batched_tokens 40000 --input_len 2000 --output_len 150
```

Turn off inductor w/o inductor: 
```
VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING=0 python3 benchmarks/benchmark_latency.py --model meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --tensor-parallel-size 8 --trust-remote-code --max_num_batched_tokens 40000 --input_len 2000 --output_len 150 --compilation-config '{"use_inductor": false}'
```

## Test Result
Before
```
^[[1;36m(VllmWorker rank=2 pid=3428022)^[[0;0m ERROR 06-13 22:32:19 [multiproc_executor.py:527]   File "/tmp/torchinductor_yeq/y6/cy6oe2twg3y7ikxvey2boducv5ozukmqghzwfjgckbf2c4tatihu.py", line 1282, in call
^[[1;36m(VllmWorker rank=2 pid=3428022)^[[0;0m ERROR 06-13 22:32:19 [multiproc_executor.py:527]     buf52 = empty_strided_cuda(((-32768) + s0, ), (1, ), torch.int32)
^[[1;36m(VllmWorker rank=2 pid=3428022)^[[0;0m ERROR 06-13 22:32:19 [multiproc_executor.py:527]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker rank=2 pid=3428022)^[[0;0m ERROR 06-13 22:32:19 [multiproc_executor.py:527] RuntimeError: Expected result >= 0 to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
```

VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING=0
```
Avg latency: 1.5159119459994448 seconds
10% percentile latency: 1.5085203663096762 seconds
25% percentile latency: 1.5119743127434049 seconds
50% percentile latency: 1.51639746746514 seconds
75% percentile latency: 1.5196820870041847 seconds
90% percentile latency: 1.523688311211299 seconds
99% percentile latency: 1.5265898834553082 seconds
```

VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING=0 + --compilation-config '{"use_inductor": false}'
```
Avg latency: 2.408435560041107 seconds
10% percentile latency: 2.4013032284216025 seconds
25% percentile latency: 2.4030520624946803 seconds
50% percentile latency: 2.408095811493695 seconds
75% percentile latency: 2.4112289877957664 seconds
90% percentile latency: 2.4151853934512473 seconds
99% percentile latency: 2.424483723602025 seconds
```