### PR TITLE
Only build CUTLASS MoE kernels on Hopper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,10 +542,10 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
 
   # CUTLASS MoE kernels
 
-  # The MoE kernel cutlass_moe_mm requires CUDA 12.3 or later (and only works
+  # The MoE kernel cutlass_moe_mm requires CUDA 12.3 or later (and ONLY works
   # on Hopper). get_cutlass_(pplx_)moe_mm_data should only be compiled
   # if it's possible to compile MoE kernels that use its output.
-  cuda_archs_loose_intersection(SCALED_MM_ARCHS "9.0a;10.0a" "${CUDA_ARCHS}")
+  cuda_archs_loose_intersection(SCALED_MM_ARCHS "9.0a" "${CUDA_ARCHS}")
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.3 AND SCALED_MM_ARCHS)
     set(SRCS "csrc/quantization/cutlass_w8a8/moe/grouped_mm_c3x.cu"
              "csrc/quantization/cutlass_w8a8/moe/moe_data.cu")


### PR DESCRIPTION
## Purpose

Fix https://github.com/vllm-project/vllm/issues/18841 and unblock 0.9.2 release

`10.0` was added by https://github.com/vllm-project/vllm/pull/16362, but the kernels only work on `9.0` Hopper 

## Test Plan

Rebuild vLLM locally and load `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` on a 8xH100 server

```
from vllm import LLM

LLM(
    model="meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
    tensor_parallel_size=8,
    max_model_len=8192,
)
```

## Test Result

The model is loaded successfully instead of failing with `CUDA error: no kernel image is available for execution on the device`

cc @simon-mo @houseroad 
