### PR TITLE
When numa support is found but size is 0, divide by zero exception

### DIFF
--- a/vllm/worker/cpu_worker.py
+++ b/vllm/worker/cpu_worker.py
@@ -417,30 +417,35 @@ class CPUWorker(LocalOrDistributedWorkerBase):
             cpu_count = psutil.cpu_count(logical=False)
             cpus_allow_list = psutil.Process().cpu_affinity()
             numa_size = info.get_num_configured_nodes()
-            cpu_count_per_numa = cpu_count // numa_size
-            num_of_reserved_cpu = min(envs.VLLM_CPU_NUM_OF_RESERVED_CPU,
-                                      cpu_count_per_numa // 2)
-
-            # check allow node_to_cpus list
-            node_to_cpus = []
-            for i in range(numa_size):
-                node_intersect = set(
-                    info.node_to_cpus(i)).intersection(cpus_allow_list)
-                if bool(node_intersect):
-                    node_to_cpus.append(list(node_intersect))
-
-            if world_size > len(node_to_cpus):
-                logger.error(
-                    "Auto thread-binding failed due to "
-                    "world size: %d is larger than "
-                    "allowed NUMA nodes number: %d."
-                    "Please try to bind threads manually.", world_size,
-                    len(node_to_cpus))
+            if numa_size == 0:
+                logger.warning(
+                    "libnuma found but numa size was 0"
+                    "set VLLM_CPU_OMP_THREADS_BIND manually.")
             else:
-                end = cpu_count_per_numa - num_of_reserved_cpu
-                rank_to_cpus_list = node_to_cpus[self.rank][:end]
-                rank_to_cpus = ','.join(str(x) for x in rank_to_cpus_list)
-                logger.info("auto thread-binding list: %s", rank_to_cpus)
+                cpu_count_per_numa = cpu_count // numa_size
+                num_of_reserved_cpu = min(envs.VLLM_CPU_NUM_OF_RESERVED_CPU,
+                                          cpu_count_per_numa // 2)
+
+                # check allow node_to_cpus list
+                node_to_cpus = []
+                for i in range(numa_size):
+                    node_intersect = set(
+                        info.node_to_cpus(i)).intersection(cpus_allow_list)
+                    if bool(node_intersect):
+                        node_to_cpus.append(list(node_intersect))
+
+                if world_size > len(node_to_cpus):
+                    logger.error(
+                        "Auto thread-binding failed due to "
+                        "world size: %d is larger than "
+                        "allowed NUMA nodes number: %d."
+                        "Please try to bind threads manually.", world_size,
+                        len(node_to_cpus))
+                else:
+                    end = cpu_count_per_numa - num_of_reserved_cpu
+                    rank_to_cpus_list = node_to_cpus[self.rank][:end]
+                    rank_to_cpus = ','.join(str(x) for x in rank_to_cpus_list)
+                    logger.info("auto thread-binding list: %s", rank_to_cpus)
         else:
             logger.warning(
                 "Auto thread-binding is not supported due to "


### PR DESCRIPTION
## Purpose
vllm when running on apple silicon through docker desktop divide by zero exception prevents startup. For a reason unclear NUMA information is returned but the numa_size is 0 the application terminates during startup. 

The exception prevents the auto-configuration  that is being attempted. 
## Test Plan
Startup should be normal for all other cases. For this case the application will start

## Test Result
Application is expected to start in this setup.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
