### PR TITLE
[Bugfix] Fix TP inference for Flex attention backend

### DIFF
--- a/tests/v1/engine/test_engine_core.py
+++ b/tests/v1/engine/test_engine_core.py
@@ -403,8 +403,12 @@ def test_engine_core_tp(monkeypatch: pytest.MonkeyPatch):
                                      executor_class=executor_class,
                                      log_stats=True)
 
-        def get_worker_num_gpu_blocks(worker):
-            return worker.cache_config.num_gpu_blocks
+        def get_worker_cache_config_field(worker, key: str):
+            return getattr(worker.cache_config, key)
 
-        num_gpu_blocks = engine_core.collective_rpc(get_worker_num_gpu_blocks)
+        num_gpu_blocks = engine_core.collective_rpc(
+            get_worker_cache_config_field, args=("num_gpu_blocks", ))
+        num_cpu_blocks = engine_core.collective_rpc(
+            get_worker_cache_config_field, args=("num_cpu_blocks", ))
         assert all(x is not None for x in num_gpu_blocks)
+        assert all(x is not None for x in num_cpu_blocks)

--- a/tests/v1/engine/test_engine_core.py
+++ b/tests/v1/engine/test_engine_core.py
@@ -19,7 +19,7 @@ from vllm.v1.executor.abstract import Executor, UniProcExecutor
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import ModelRunnerOutput
 
-from ...utils import create_new_process_for_each_test
+from ...utils import create_new_process_for_each_test, multi_gpu_test
 
 if not current_platform.is_cuda():
     pytest.skip(reason="V1 currently only supported on CUDA.",
@@ -378,3 +378,33 @@ def test_engine_core_concurrent_batches(monkeypatch: pytest.MonkeyPatch):
                 # Odd steps schedules a new batch.
                 assert output is None
             step += 1
+
+
+@multi_gpu_test(num_gpus=2)
+def test_engine_core_tp(monkeypatch: pytest.MonkeyPatch):
+    """
+    Test engine can initialize worker in tp properly
+    """
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+        """Setup the EngineCore."""
+        engine_args = EngineArgs(
+            model=MODEL_NAME,
+            tensor_parallel_size=2,
+            # Reduce startup time.
+            enforce_eager=True,
+        )
+        vllm_config = engine_args.create_engine_config()
+        executor_class = Executor.get_class(vllm_config)
+
+        with set_default_torch_num_threads(1):
+            engine_core = EngineCore(vllm_config=vllm_config,
+                                     executor_class=executor_class,
+                                     log_stats=True)
+
+        def get_worker_num_gpu_blocks(worker):
+            return worker.cache_config.num_gpu_blocks
+
+        num_gpu_blocks = engine_core.collective_rpc(get_worker_num_gpu_blocks)
+        assert all(x is not None for x in num_gpu_blocks)

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -13,6 +13,7 @@ from torch.nn.attention.flex_attention import (BlockMask, _mask_mod_signature,
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionMetadata, AttentionType,
                                               is_quantized_kv_cache)
+from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import (AttentionMetadataBuilder,
@@ -236,7 +237,12 @@ class FlexAttentionMetadata:
 
     def build_block_mask(self) -> BlockMask:
         assert self.mask_mod is not None
-        return create_block_mask_compiled(
+        # FIXME: With TP>1, create_block_mask_compiled will raise
+        # CUDA error: an illegal memory access was encountered
+        create_block_mask_fn = (create_block_mask_compiled
+                                if get_tensor_model_parallel_world_size() == 1
+                                else create_block_mask)
+        return create_block_mask_fn(
             self.mask_mod,
             None,
             None,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -84,6 +84,8 @@ class EngineCore:
 
         vllm_config.cache_config.num_gpu_blocks = num_gpu_blocks
         vllm_config.cache_config.num_cpu_blocks = num_cpu_blocks
+        self.collective_rpc("initialize_cache",
+                            args=(num_gpu_blocks, num_cpu_blocks))
 
         self.structured_output_manager = StructuredOutputManager(vllm_config)
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -112,6 +112,11 @@ class Worker(WorkerBase):
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
 
+    def initialize_cache(self, num_gpu_blocks: int,
+                         num_cpu_blocks: int) -> None:
+        self.cache_config.num_gpu_blocks = num_gpu_blocks
+        self.cache_config.num_cpu_blocks = num_cpu_blocks
+
     def init_device(self):
         if self.device_config.device.type == "cuda":
             # torch.distributed.all_reduce does not free the input tensor until

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -93,6 +93,11 @@ class TPUWorker:
         if self.model_config.seed is None:
             self.model_config.seed = 0
 
+    def initialize_cache(self, num_gpu_blocks: int,
+                         num_cpu_blocks: int) -> None:
+        self.cache_config.num_gpu_blocks = num_gpu_blocks
+        self.cache_config.num_cpu_blocks = num_cpu_blocks
+
     def init_device(self):
         os.environ["PJRT_DEVICE"] = "TPU"
         # Note: Currently the XLA compiler wrongly uses 2D ring strategy on 1D


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Flex Attention doesn't work with tensor parallel currently because `num_gpu_blocks` is not updated in `cache_config` properly:
```
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]   File "/kaggle/working/vllm/vllm/v1/worker/gpu_model_runner.py", line 1211, in execute_model
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]     spec_decode_metadata) = (self._prepare_inputs(scheduler_output))
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]   File "/kaggle/working/vllm/vllm/v1/worker/gpu_model_runner.py", line 706, in _prepare_inputs
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]     attn_metadata_i = (builder.build(
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]                        ^^^^^^^^^^^^^^
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]   File "/kaggle/working/vllm/vllm/v1/attention/backends/flex_attention.py", line 301, in build
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]     total_cache_tokens = (self.runner.cache_config.num_gpu_blocks *
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=1 pid=2540) ERROR 06-15 05:58:54 [multiproc_executor.py:527] TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```
- This PR fixes this issue to make Flex Attention work with TP.

## Test Plan
```shell
VLLM_ATTENTION_BACKEND=FLEX_ATTENTION python examples/offline_inference/basic/generate.py --model facebook/opt-125m -tp 2
```

## Test Result
```
(VllmWorker rank=1 pid=5600) INFO 06-15 06:06:11 [gpu_model_runner.py:2083] Graph capturing finished in 26 secs, took 0.20 GiB
(VllmWorker rank=0 pid=5599) INFO 06-15 06:06:11 [gpu_model_runner.py:2083] Graph capturing finished in 26 secs, took 0.20 GiB
INFO 06-15 06:06:11 [core.py:173] init engine (profile, create kv cache, warmup model) took 48.53 seconds
Adding requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 776.08it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████████████████| 4/4 [00:11<00:00,  2.92s/it, est. speed input: 2.23 toks/s, output: 5.49 toks/s]
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Joel, I am a BYU lecturer and I would love to talk about your class'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: " stuck painting the country like it's 70 years old again, with behind-the"
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: " directly behind Germany's winning bid for elections as French business and French defence leaders fired"
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' predicted according to the 2020 report by a economists\nAI stand to be in the'
--------------------------------------------------
```

## (Optional) Documentation Update
no need

<!--- pyml disable-next-line no-emphasis-as-heading -->
