### PR TITLE
feat(model loader): add load format 'prefetch_auto' for parallel mmap…

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1638,6 +1638,7 @@ class TokenizerPoolConfig:
 
 class LoadFormat(str, enum.Enum):
     AUTO = "auto"
+    PREFETCH_AUTO = "prefetch_auto"
     PT = "pt"
     SAFETENSORS = "safetensors"
     NPCACHE = "npcache"
@@ -1662,6 +1663,10 @@ class LoadConfig:
     """The format of the model weights to load:\n
     - "auto" will try to load the weights in the safetensors format and fall
     back to the pytorch bin format if safetensors format is not available.\n
+    - "prefetch_auto" like "auto" but performs concurrent mmap with
+    MAP_POPULATE to prefetch weight files into the page cache.
+    This helps maximize storage bandwidth and improve model loading
+    performance, especially on systems with high disk I/O capacity.
     - "pt" will load the weights in the pytorch bin format.\n
     - "safetensors" will load the weights in the safetensors format.\n
     - "npcache" will load the weights in pytorch format and store a numpy cache

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -485,10 +485,6 @@ def prefetch_weight_files(hf_weights_files: list[str]) -> None:
     local_files = hf_weights_files[rank::world_size]
     mmap_files_concurrently(local_files)
 
-    # synchronize across ranks to ensure all files are prefetched
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
-
 def mmap_files_concurrently(hf_weights_files: list[str]) -> None:
     if len(hf_weights_files) == 0:
         return

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -7,6 +7,9 @@ import hashlib
 import json
 import os
 import tempfile
+import mmap
+import concurrent.futures
+
 import time
 from collections import defaultdict
 from collections.abc import Generator
@@ -471,6 +474,41 @@ def safetensors_weights_iterator(
                 param = f.get_tensor(name)
                 yield name, param
 
+def prefetch_weight_files(hf_weights_files: list[str]) -> None:
+    """Prefetch and mmap weight files in parallel for the current distributed rank."""
+    world_size = 1
+    rank = 0
+    if torch.distributed.is_initialized():
+        world_size = torch.distributed.get_world_size()
+        rank = torch.distributed.get_rank()
+
+    local_files = hf_weights_files[rank::world_size]
+    mmap_files_concurrently(local_files)
+
+    # synchronize across ranks to ensure all files are prefetched
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+def mmap_files_concurrently(hf_weights_files: list[str]) -> None:
+    if len(hf_weights_files) == 0:
+        return
+    max_workers = min(32, len(hf_weights_files))
+    start_time = time.time()
+    logger.info(f"Mmaping {len(hf_weights_files)} files concurrently")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        list(executor.map(_mmap_single_file, hf_weights_files))
+    logger.info(f"Mmaped {len(hf_weights_files)} files, elapsed time: {time.time() - start_time:.2f}s")
+
+def _mmap_single_file(st_file: str) -> None:
+    with open(st_file, "rb") as f:
+        file_size = os.path.getsize(st_file)
+        mm = mmap.mmap(
+            fileno=f.fileno(),
+            length=file_size,
+            prot=mmap.PROT_READ,
+            flags=mmap.MAP_SHARED | mmap.MAP_POPULATE
+        )
+        mm.close()
 
 def runai_safetensors_weights_iterator(
     hf_weights_files: list[str],


### PR DESCRIPTION
Introduce a new load format 'prefetch_auto' that performs concurrent mmap with MAP_POPULATE to prefetch safetensors or bin files into the page cache. This helps maximize storage bandwidth and improve model loading performance, especially on systems with high disk I/O capacity.

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

The purpose of this PR is to optimize the cold start performance of the inference engine when model weights are already stored on the local disk. The current model loading approach fails to fully utilize available disk bandwidth during initial startup, resulting in suboptimal loading speeds. By implementing a disk bandwidth-optimized loading strategy for cold start scenarios, we can significantly accelerate the engine's initialization process. This improvement will directly enhance Pod scaling efficiency and deployment speed in production environments, enabling faster resource provisioning and workload handling capabilities.

## Test Plan
Our test env:
```
#free -h
              total        used        free      shared  buff/cache   available
Mem:           2.0T         23G        1.3T         92M        640G        1.9T
Swap:            0B          0B          0B
```
lsblk result: 
```
NAME            FSTYPE      LABEL    MOUNTPOINT   SIZE MODEL
nvme0n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme0n1p1     LVM2_member                       3.5T
  └─vgdata-data ext4                 /data       10.5T
nvme3n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme3n1p1     ext4                 /home        3.5T
sdb                                             447.1G SAMSUNG MZ7L3480
├─sdb4          iso9660     config-2             64.8M
├─sdb2          ext4                 /boot          1G
├─sdb3          ext4                 /           58.5G
└─sdb1          vfat                 /boot/efi    512M
nvme2n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme2n1p1     LVM2_member                       3.5T
  └─vgdata-data ext4                 /data       10.5T
nvme1n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme1n1p1     LVM2_member                       3.5T
  └─vgdata-data ext4                 /data       10.5T
sda                                             447.1G SAMSUNG MZ7L3480
```
The loaded model is DeepSeek-R1-W8A8, the weight file size:  655GB. All the weight file is mounted in /data. Three 3.5 TB NVMe Samsung MZQL23T8HCLS-00B7C drives are configured in RAID 0 with LVM, mounted to the /data directory, providing a total storage capacity of 10 TB.

We set the `tp=16` in start command.

## Test Result

Module Loader | Load Time (s) | Peak I/O Bandwidth (GB/s) | Average Bandwidth (GB/s)
-- | -- | -- | --
Default Module Loader | 148 | 7.73 | 4.43
Prefetch Auto Module Loader | 50 | 18.38 | 16.36


Time Reduction: The prefetch loader reduces loading time from 148s to 50s (66% improvement).

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
