### PR TITLE
[Misc] Fix skipped max-model-len validation when deriving max model length from tokenizer config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -438,3 +438,31 @@ def test_load_config_pt_load_map_location(pt_load_map_location):
     config = VllmConfig(load_config=load_config)
 
     assert config.load_config.pt_load_map_location == pt_load_map_location
+
+
+@pytest.mark.parametrize(
+    ("model_id", "max_model_len", "expected_max_len", "should_raise"), [
+        ("BAAI/bge-reranker-base", None, 512, False),
+        ("BAAI/bge-reranker-base", 256, 256, False),
+        ("BAAI/bge-reranker-base", 513, 512, True),
+    ])
+def test_get_and_verify_max_len(model_id, max_model_len, expected_max_len,
+                                should_raise):
+    """Test get_and_verify_max_len with different configurations."""
+    model_config = ModelConfig(
+        model_id,
+        task="auto",
+        tokenizer=model_id,
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        seed=0,
+        dtype="float16",
+        revision=None,
+    )
+
+    if should_raise:
+        with pytest.raises(ValueError):
+            model_config.get_and_verify_max_len(max_model_len)
+    else:
+        actual_max_len = model_config.get_and_verify_max_len(max_model_len)
+        assert actual_max_len == expected_max_len


### PR DESCRIPTION
## Purpose
`_get_and_verify_max_len` attempts to derive max_model_len from a few HF configs then applies a bunch of validation.
Overriding max_model_len through tokenizer after the validation is already done causes some validation to be skipped. 

Hence, moving that logic to happen before we execute the logic around none of the max-model-len key is found inside `_get_and_verify_max_len`.

Introduced in https://github.com/vllm-project/vllm/pull/19201.

## Test Plan
Added unit tests

E2E edge case:
```
vllm serve BAAI/bge-reranker-base --max-model-len 513
```

## Test Result

unit tests passed

max-model-len would throw now while previously it got silently overriden.
```
File "/home/yeq/uv_env/dsvllm/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 123, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
  Value error, User-specified max_model_len (513) is greater than the derived max_model_len (max_position_embeddings=512 or model_max_length=None in model's config.json). This may lead to incorrect model outputs or CUDA errors. To allow overriding this maximum, set the env var VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 [type=value_error, input_value=ArgsKwargs((), {'model': ...attention_dtype': None}), input_type=ArgsKwargs]
  ```