### PR TITLE
[doc] add project flag to gcloud TPU command

### DIFF
--- a/docs/getting_started/installation/ai_accelerator/tpu.inc.md
+++ b/docs/getting_started/installation/ai_accelerator/tpu.inc.md
@@ -90,10 +90,10 @@ gcloud alpha compute tpus queued-resources create QUEUED_RESOURCE_ID \
 | RUNTIME_VERSION    | The TPU VM runtime version to use. For example, use `v2-alpha-tpuv6e` for a VM loaded with one or more v6e TPU(s). For more information see [TPU VM images].                                             |
 | SERVICE_ACCOUNT    | The email address for your service account. You can find it in the IAM Cloud Console under *Service Accounts*. For example: `tpu-service-account@<your_project_ID>.iam.gserviceaccount.com`              |
 
-Connect to your TPU using SSH:
+Connect to your TPU VM using SSH:
 
 ```bash
-gcloud compute tpus tpu-vm ssh TPU_NAME --zone ZONE
+gcloud compute tpus tpu-vm ssh TPU_NAME --project PROJECT_ID --zone ZONE
 ```
 
 [TPU versions]: https://cloud.google.com/tpu/docs/runtimes


### PR DESCRIPTION
in case user doesn't have one set in gcloud config which might be result in this error.

```
$ gcloud compute tpus tpu-vm ssh TPU_NAME --zone ZONE
ERROR: (gcloud.compute.tpus.tpu-vm.ssh) The required property [project] is not currently set.
It can be set on a per-command basis by re-running your command with the [--project] flag.

You may set it for your current workspace by running:

  $ gcloud config set project VALUE

or it can be set temporarily by the environment variable [CLOUDSDK_CORE_PROJECT]
```
