### PR TITLE
[Misc] add CLI completion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,6 +150,13 @@ repos:
     types: [python]
     pass_filenames: false
     additional_dependencies: [pathspec, regex]
+  - id: check-cli-completion
+    name: Check if CLI completion script is up to date
+    entry: python scripts/cli_args_completion_generator.py
+    language: python
+    files: ^vllm/entrypoints/cli/|^vllm/engine/arg_utils\.py$|^benchmarks/benchmark_(latency|serving|throughput)\.py$
+    pass_filenames: false
+    additional_dependencies: [regex]
   # Keep `suggestion` last
   - id: suggestion
     name: Suggestion

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -12,6 +12,37 @@ Available Commands:
 vllm {chat,complete,serve,bench,collect-env,run-batch}
 ```
 
+## vLLM CLI completion
+
+To enable vLLM CLI completion, follow these steps:
+
+- Download the completion script
+
+```bash
+curl https://raw.githubusercontent.com/vllm-project/vllm/refs/heads/main/scripts/vllm-completion.bash -o ~/.vllm-completion.bash
+```
+
+- Set it in your shell config (e.g., ~/.bash_profile)
+
+```bash
+cat <<'EOF' >> ~/.bash_profile
+# Enable vLLM CLI completion
+if [ -f ~/.vllm-completion.bash ]; then
+  . ~/.vllm-completion.bash
+fi
+EOF
+```
+
+- If you find that the arguments are outdated, you can use the script to regenerate them automatically.
+
+<gh-file:scripts/cli_args_completion_generator.py>
+
+- Reload the config.
+
+```bash
+source ~/.bash_profile
+```
+
 ## serve
 
 Start the vLLM OpenAI Compatible API server.

--- a/scripts/cli_args_completion_generator.py
+++ b/scripts/cli_args_completion_generator.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+vLLM CLI completion generator.
+
+This script extracts subcommands and CLI arguments from the `vllm` CLI,
+including nested commands and fixed-value options, and uses them to
+populate a bash completion script template.
+
+It supports structured rendering of:
+- Subcommands
+- Arguments for each subcommand
+- Options with fixed value sets (for value completion)
+
+Output is written to a rendered bash file using Jinja-style placeholders.
+
+Usage:
+    python cli_args_completion_generator.py
+
+NOTE: 
+Make sure the template `vllm-completion.template.bash` and the script
+in the same directory.
+"""
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+
+import regex as re
+
+
+def extract_all_options(subcommand: str):
+    """
+    Extracts all CLI options from all sections of `vllm <subcommand> --help`.
+    Handles nested sections like 'Options:', 'ModelConfig:', etc.
+    """
+    try:
+        res = subprocess.run(["vllm"] + subcommand.split() + ["--help"],
+                             capture_output=True,
+                             text=True,
+                             check=True)
+        lines = res.stdout.splitlines()
+    except Exception as e:
+        print(f"# Error: {e}")
+        return []
+
+    options = set()
+    current_section = None
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        # Match section headers like "Options:", "ModelConfig:", etc.
+        if re.match(r"^[\w\s-]+:$", line):
+            current_section = line.rstrip(":")
+            continue
+
+        # Only extract from known parameter lines
+        if current_section:
+            # Extract options like -x, --xxx from lines like:
+            # "-i INPUT, --input-file INPUT"
+            matches = re.findall(
+                r"(?<![\w-])(--[a-zA-Z](?:[\w-]*[a-zA-Z0-9])?|-[a-zA-Z])(?=\s|,|$)",
+                line)
+
+            options.update(matches)
+
+    return options
+
+
+def format_all_subcommand_options(subcommands: list[str]):
+    """
+    Generates a dict mapping subcommand names to quoted,
+    space-separated option strings.
+
+    Returns:
+        dict[str, str]: Keys are like "serve_args", 
+        values are e.g. '"--opt1 --opt2"'
+    """
+    result = {}
+    for sub in subcommands:
+        opts = extract_all_options(sub)
+        key = sub.replace(" ", "_").replace("-", "_") + "_args"
+        result[key] = f'"{" ".join(sorted(opts))}"'
+    return result
+
+
+def extract_subcommands_str(cmd_str: str):
+    """
+    Returns a space-separated string of subcommands from `vllm --help`.
+    Example: "chat complete serve bench collect-env run-batch"
+    """
+    try:
+        parts = cmd_str.split()
+        result = subprocess.run(parts + ["--help"],
+                                capture_output=True,
+                                text=True,
+                                check=True)
+        lines = result.stdout.splitlines()
+    except Exception as e:
+        print(f"# Error running vllm --help: {e}")
+        return ""
+
+    for i, line in enumerate(lines):
+        # Match line like: {chat,complete,serve,...}
+        if (line.strip().lower().startswith("positional arguments:")
+                and i + 1 < len(lines)
+                and (match := re.search(r"\{([^}]+)\}", lines[i + 1]))):
+            subcommands = " ".join(cmd.strip()
+                                   for cmd in match.group(1).split(","))
+            return f'"{subcommands}"'
+
+    return ""
+
+
+def extract_option_value(subcommand: str):
+    """
+    Extracts CLI options that provide a fixed set of values, like:
+        --option {val1,val2,val3}
+    """
+    try:
+        result = subprocess.run(["vllm"] + subcommand.split() + ["--help"],
+                                capture_output=True,
+                                text=True,
+                                check=True)
+        lines = result.stdout.splitlines()
+    except Exception as e:
+        print(f"# Error while fetching help for '{subcommand}': {e}")
+        return {}
+
+    option_values = defaultdict(list)
+
+    for line in lines:
+        line = line.strip()
+
+        # Match pattern like: --option-name {val1,val2,...}
+        match = re.match(r"(--[\w-]+)\s+\{([^}]+)\}", line)
+        if match:
+            option = match.group(1)
+            values = [v.strip() for v in match.group(2).split(",")]
+            option_values[option] = values
+
+    return dict(option_values)
+
+
+def extract_all_option_values(subcommands: list[str]):
+    all_options = {}
+    for sub in subcommands:
+        opt_vals = extract_option_value(sub)
+        for opt, vals in opt_vals.items():
+            if opt in all_options:
+                all_options[opt] = sorted(set(all_options[opt] + vals))
+            else:
+                all_options[opt] = vals
+    return all_options
+
+
+def format_option_value_map(option_value_dict: dict[str, list[str]]):
+    """
+    Format the dictionary into Bash-compatible declare syntax entries.
+    """
+    lines = []
+    for opt, values in sorted(option_value_dict.items()):
+        joined = " ".join(values)
+        lines.append(f'    [{opt}]="{joined}"')
+    return "\n".join(lines)
+
+
+def render_bash_template(template_path: str, output_path: str,
+                         replacements: dict):
+    """
+    Replace placeholders like {{ var }} in a bash template with given values.
+    """
+    with open(template_path, encoding="utf-8") as f:
+        content = f.read()
+
+    for placeholder, value in replacements.items():
+        content = content.replace(placeholder, value)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+if __name__ == "__main__":
+    if shutil.which("vllm") is None:
+        print("Warning: 'vllm' command not found. "
+              "Skipping CLI completion generation.\n"
+              "To enable auto-generation, "
+              "ensure 'vllm' is installed and on your PATH.")
+        sys.exit(0)
+
+    # Used for shell completion of vLLM subcommands
+    print("Generating subcommands...")
+    vllm_subcommands = extract_subcommands_str("vllm")
+    bench_subcommands = extract_subcommands_str("vllm bench")
+
+    # Used for shell completion of CLI options for each vLLM subcommand
+    print("Generating options...")
+    subcommand_list = [
+        "chat", "complete", "collect-env", "serve", "run-batch",
+        "bench latency", "bench throughput", "bench serve"
+    ]
+    all_options = format_all_subcommand_options(subcommand_list)
+
+    # Used for option value completion
+    print("Generating option and value map...")
+    all_opts = extract_all_option_values(subcommand_list)
+    option_value_map = format_option_value_map(all_opts)
+
+    render_bash_template(template_path="scripts/vllm-completion.template.bash",
+                         output_path="scripts/vllm-completion.bash",
+                         replacements={
+                             "{{ subcommands }}":
+                             vllm_subcommands,
+                             "{{ bench_subcommands }}":
+                             bench_subcommands,
+                             "{{ option_value_map_entries }}":
+                             option_value_map,
+                             "{{ chat_args }}":
+                             all_options["chat_args"],
+                             "{{ complete_args }}":
+                             all_options["complete_args"],
+                             "{{ serve_args }}":
+                             all_options["serve_args"],
+                             "{{ run_batch_args }}":
+                             all_options["run_batch_args"],
+                             "{{ bench_latency_args }}":
+                             all_options["bench_latency_args"],
+                             "{{ bench_serve_args }}":
+                             all_options["bench_serve_args"],
+                             "{{ bench_throughput_args }}":
+                             all_options["bench_throughput_args"],
+                         })

--- a/scripts/vllm-completion.bash
+++ b/scripts/vllm-completion.bash
@@ -1,0 +1,116 @@
+# vllm-completion.template.bash
+# 
+# To help auto-generate vllm-completion.bash
+#
+#############################################
+
+_vllm_completions(){
+    local cur prev
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    local subcommands="chat complete serve bench collect-env run-batch"
+
+    # Nested subcommand
+    local bench_subcommands="latency serve throughput"
+
+    # Subcommands args
+    local chat_args="--api-key --help --model-name --quick --system-prompt --url -h -q"
+
+    local complete_args="--api-key --help --model-name --quick --url -h -q"
+
+    local serve_args="--additional-config --allow-credentials --allowed-headers --allowed-local-media-path --allowed-methods --allowed-origins --api-key --api-server-count --block-size --calculate-kv-scales --chat-template --chat-template-content-format --code-revision --collect-detailed-traces --compilation-config --config --config-format --cpu-offload-gb --cuda-graph-sizes --data-parallel-address --data-parallel-backend --data-parallel-rpc-port --data-parallel-size --data-parallel-size-local --data-parallel-start-rank --device --disable-async-output-proc --disable-cascade-attn --disable-chunked-mm-input --disable-custom-all-reduce --disable-fastapi-docs --disable-frontend-multiprocessing --disable-hybrid-kv-cache-manager --disable-log-requests --disable-log-stats --disable-mm-preprocessor-cache --disable-sliding-window --disable-uvicorn-access-log --distributed-executor-backend --download-dir --dtype --enable-auto-tool-choice --enable-chunked-prefill --enable-expert-parallel --enable-lora --enable-lora-bias --enable-multimodal-encoder-data-parallel --enable-prefix-caching --enable-prompt-adapter --enable-prompt-embeds --enable-prompt-tokens-details --enable-reasoning --enable-request-id-headers --enable-server-load-tracking --enable-sleep-mode --enable-ssl-refresh --enforce-eager --fully-sharded-loras --generation-config --gpu-memory-utilization --guided-decoding-backend --guided-decoding-disable-additional-properties --guided-decoding-disable-any-whitespace --guided-decoding-disable-fallback --headless --help --hf-config-path --hf-overrides --hf-token --host --ignore-patterns --json-arg --kv-cache-dtype --kv-events-config --kv-transfer-config --limit-mm-per-prompt --load-format --log-config-file --logits-processor-pattern --long-lora-scaling-factors --long-prefill-token-threshold --lora-dtype --lora-extra-vocab-size --lora-modules --max-cpu-loras --max-log-len --max-logprobs --max-long-partial-prefills --max-lora-rank --max-loras --max-model-len --max-num-batched-tokens --max-num-partial-prefills --max-num-seqs --max-parallel-loading-workers --max-prompt-adapter-token --max-prompt-adapters --max-seq-len-to-capture --middleware --mm-processor-kwargs --model-impl --model-loader-extra-config --multi-step-stream-outputs --no-calculate-kv-scales --no-disable-cascade-attn --no-disable-chunked-mm-input --no-disable-custom-all-reduce --no-disable-hybrid-kv-cache-manager --no-disable-mm-preprocessor-cache --no-disable-sliding-window --no-enable-chunked-prefill --no-enable-expert-parallel --no-enable-lora --no-enable-lora-bias --no-enable-multimodal-encoder-data-parallel --no-enable-prefix-caching --no-enable-prompt-adapter --no-enable-prompt-embeds --no-enable-reasoning --no-enable-sleep-mode --no-enforce-eager --no-fully-sharded-loras --no-guided-decoding-disable-additional-properties --no-guided-decoding-disable-any-whitespace --no-guided-decoding-disable-fallback --no-multi-step-stream-outputs --no-ray-workers-use-nsight --no-skip-tokenizer-init --no-trust-remote-code --no-use-tqdm-on-load --num-gpu-blocks-override --num-lookahead-slots --num-scheduler-steps --otlp-traces-endpoint --override-attention-dtype --override-generation-config --override-neuron-config --override-pooler-config --pipeline-parallel-size --port --preemption-mode --prefix-caching-hash-algo --prompt-adapters --pt-load-map-location --qlora-adapter-name-or-path --quantization --ray-workers-use-nsight --reasoning-parser --response-role --return-tokens-as-token-ids --revision --root-path --rope-scaling --rope-theta --scheduler-cls --scheduler-delay-factor --scheduling-policy --seed --served-model-name --show-hidden-metrics-for-version --skip-tokenizer-init --speculative-config --ssl-ca-certs --ssl-cert-reqs --ssl-certfile --ssl-keyfile --swap-space --task --tensor-parallel-size --tokenizer --tokenizer-mode --tokenizer-pool-extra-config --tokenizer-pool-size --tokenizer-pool-type --tokenizer-revision --tool-call-parser --tool-parser-plugin --trust-remote-code --use-tqdm-on-load --use-v2-block-manager --uvicorn-log-level --worker-cls --worker-extension-cls -O -h -q"
+
+    local run_batch_args="--additional-config --allowed-local-media-path --block-size --calculate-kv-scales --code-revision --collect-detailed-traces --compilation-config --config-format --cpu-offload-gb --cuda-graph-sizes --data-parallel-address --data-parallel-backend --data-parallel-rpc-port --data-parallel-size --data-parallel-size-local --device --disable-async-output-proc --disable-cascade-attn --disable-chunked-mm-input --disable-custom-all-reduce --disable-hybrid-kv-cache-manager --disable-log-requests --disable-log-stats --disable-mm-preprocessor-cache --disable-sliding-window --distributed-executor-backend --download-dir --dtype --enable-chunked-prefill --enable-expert-parallel --enable-lora --enable-lora-bias --enable-metrics --enable-multimodal-encoder-data-parallel --enable-prefix-caching --enable-prompt-adapter --enable-prompt-embeds --enable-prompt-tokens-details --enable-reasoning --enable-sleep-mode --enforce-eager --fully-sharded-loras --generation-config --gpu-memory-utilization --guided-decoding-backend --guided-decoding-disable-additional-properties --guided-decoding-disable-any-whitespace --guided-decoding-disable-fallback --help --hf-config-path --hf-overrides --hf-token --ignore-patterns --input-file --json-arg --kv-cache-dtype --kv-events-config --kv-transfer-config --limit-mm-per-prompt --load-format --logits-processor-pattern --long-lora-scaling-factors --long-prefill-token-threshold --lora-dtype --lora-extra-vocab-size --max-cpu-loras --max-log-len --max-logprobs --max-long-partial-prefills --max-lora-rank --max-loras --max-model-len --max-num-batched-tokens --max-num-partial-prefills --max-num-seqs --max-parallel-loading-workers --max-prompt-adapter-token --max-prompt-adapters --max-seq-len-to-capture --mm-processor-kwargs --model --model-impl --model-loader-extra-config --multi-step-stream-outputs --no-calculate-kv-scales --no-disable-cascade-attn --no-disable-chunked-mm-input --no-disable-custom-all-reduce --no-disable-hybrid-kv-cache-manager --no-disable-mm-preprocessor-cache --no-disable-sliding-window --no-enable-chunked-prefill --no-enable-expert-parallel --no-enable-lora --no-enable-lora-bias --no-enable-multimodal-encoder-data-parallel --no-enable-prefix-caching --no-enable-prompt-adapter --no-enable-prompt-embeds --no-enable-reasoning --no-enable-sleep-mode --no-enforce-eager --no-fully-sharded-loras --no-guided-decoding-disable-additional-properties --no-guided-decoding-disable-any-whitespace --no-guided-decoding-disable-fallback --no-multi-step-stream-outputs --no-ray-workers-use-nsight --no-skip-tokenizer-init --no-trust-remote-code --no-use-tqdm-on-load --num-gpu-blocks-override --num-lookahead-slots --num-scheduler-steps --otlp-traces-endpoint --output-file --output-tmp-dir --override-attention-dtype --override-generation-config --override-neuron-config --override-pooler-config --pipeline-parallel-size --port --preemption-mode --prefix-caching-hash-algo --pt-load-map-location --qlora-adapter-name-or-path --quantization --ray-workers-use-nsight --reasoning-parser --response-role --revision --rope-scaling --rope-theta --scheduler-cls --scheduler-delay-factor --scheduling-policy --seed --served-model-name --show-hidden-metrics-for-version --skip-tokenizer-init --speculative-config --swap-space --task --tensor-parallel-size --tokenizer --tokenizer-mode --tokenizer-pool-extra-config --tokenizer-pool-size --tokenizer-pool-type --tokenizer-revision --trust-remote-code --url --use-tqdm-on-load --use-v2-block-manager --worker-cls --worker-extension-cls -O -h -i -o -q"
+
+    local bench_latency_args="--additional-config --allowed-local-media-path --batch-size --block-size --calculate-kv-scales --code-revision --collect-detailed-traces --compilation-config --config-format --cpu-offload-gb --cuda-graph-sizes --data-parallel-address --data-parallel-backend --data-parallel-rpc-port --data-parallel-size --data-parallel-size-local --device --disable-async-output-proc --disable-cascade-attn --disable-chunked-mm-input --disable-custom-all-reduce --disable-detokenize --disable-hybrid-kv-cache-manager --disable-log-stats --disable-mm-preprocessor-cache --disable-sliding-window --distributed-executor-backend --download-dir --dtype --enable-chunked-prefill --enable-expert-parallel --enable-lora --enable-lora-bias --enable-multimodal-encoder-data-parallel --enable-prefix-caching --enable-prompt-adapter --enable-prompt-embeds --enable-reasoning --enable-sleep-mode --enforce-eager --fully-sharded-loras --generation-config --gpu-memory-utilization --guided-decoding-backend --guided-decoding-disable-additional-properties --guided-decoding-disable-any-whitespace --guided-decoding-disable-fallback --help --hf-config-path --hf-overrides --hf-token --ignore-patterns --input-len --json-arg --kv-cache-dtype --kv-events-config --kv-transfer-config --limit-mm-per-prompt --load-format --logits-processor-pattern --long-lora-scaling-factors --long-prefill-token-threshold --lora-dtype --lora-extra-vocab-size --max-cpu-loras --max-logprobs --max-long-partial-prefills --max-lora-rank --max-loras --max-model-len --max-num-batched-tokens --max-num-partial-prefills --max-num-seqs --max-parallel-loading-workers --max-prompt-adapter-token --max-prompt-adapters --max-seq-len-to-capture --mm-processor-kwargs --model --model-impl --model-loader-extra-config --multi-step-stream-outputs --n --no-calculate-kv-scales --no-disable-cascade-attn --no-disable-chunked-mm-input --no-disable-custom-all-reduce --no-disable-hybrid-kv-cache-manager --no-disable-mm-preprocessor-cache --no-disable-sliding-window --no-enable-chunked-prefill --no-enable-expert-parallel --no-enable-lora --no-enable-lora-bias --no-enable-multimodal-encoder-data-parallel --no-enable-prefix-caching --no-enable-prompt-adapter --no-enable-prompt-embeds --no-enable-reasoning --no-enable-sleep-mode --no-enforce-eager --no-fully-sharded-loras --no-guided-decoding-disable-additional-properties --no-guided-decoding-disable-any-whitespace --no-guided-decoding-disable-fallback --no-multi-step-stream-outputs --no-ray-workers-use-nsight --no-skip-tokenizer-init --no-trust-remote-code --no-use-tqdm-on-load --num-gpu-blocks-override --num-iters --num-iters-warmup --num-lookahead-slots --num-scheduler-steps --otlp-traces-endpoint --output-json --output-len --override-attention-dtype --override-generation-config --override-neuron-config --override-pooler-config --pipeline-parallel-size --preemption-mode --prefix-caching-hash-algo --profile --pt-load-map-location --qlora-adapter-name-or-path --quantization --ray-workers-use-nsight --reasoning-parser --revision --rope-scaling --rope-theta --scheduler-cls --scheduler-delay-factor --scheduling-policy --seed --served-model-name --show-hidden-metrics-for-version --skip-tokenizer-init --speculative-config --swap-space --task --tensor-parallel-size --tokenizer --tokenizer-mode --tokenizer-pool-extra-config --tokenizer-pool-size --tokenizer-pool-type --tokenizer-revision --trust-remote-code --use-beam-search --use-tqdm-on-load --use-v2-block-manager --worker-cls --worker-extension-cls -O -h -q"
+
+    local bench_serve_args="--append-result --base-url --burstiness --custom-output-len --custom-skip-chat-template --dataset-name --dataset-path --disable-tqdm --endpoint --endpoint-type --goodput --help --hf-output-len --hf-split --hf-subset --host --ignore-eos --label --logprobs --lora-modules --max-concurrency --metadata --metric-percentiles --min-p --model --num-prompts --percentile-metrics --port --profile --random-input-len --random-output-len --random-prefix-len --random-range-ratio --request-rate --result-dir --result-filename --save-detailed --save-result --seed --served-model-name --sharegpt-output-len --sonnet-input-len --sonnet-output-len --sonnet-prefix-len --temperature --tokenizer --tokenizer-mode --top-k --top-p --trust-remote-code --use-beam-search -h"
+
+    local bench_throughput_args="--additional-config --allowed-local-media-path --async-engine --backend --block-size --calculate-kv-scales --code-revision --collect-detailed-traces --compilation-config --config-format --cpu-offload-gb --cuda-graph-sizes --data-parallel-address --data-parallel-backend --data-parallel-rpc-port --data-parallel-size --data-parallel-size-local --dataset --dataset-name --dataset-path --device --disable-async-output-proc --disable-cascade-attn --disable-chunked-mm-input --disable-custom-all-reduce --disable-detokenize --disable-frontend-multiprocessing --disable-hybrid-kv-cache-manager --disable-log-requests --disable-log-stats --disable-mm-preprocessor-cache --disable-sliding-window --distributed-executor-backend --download-dir --dtype --enable-chunked-prefill --enable-expert-parallel --enable-lora --enable-lora-bias --enable-multimodal-encoder-data-parallel --enable-prefix-caching --enable-prompt-adapter --enable-prompt-embeds --enable-reasoning --enable-sleep-mode --enforce-eager --fully-sharded-loras --generation-config --gpu-memory-utilization --guided-decoding-backend --guided-decoding-disable-additional-properties --guided-decoding-disable-any-whitespace --guided-decoding-disable-fallback --help --hf-config-path --hf-max-batch-size --hf-overrides --hf-split --hf-subset --hf-token --ignore-patterns --input-len --json-arg --kv-cache-dtype --kv-events-config --kv-transfer-config --limit-mm-per-prompt --load-format --logits-processor-pattern --long-lora-scaling-factors --long-prefill-token-threshold --lora-dtype --lora-extra-vocab-size --lora-path --max-cpu-loras --max-logprobs --max-long-partial-prefills --max-lora-rank --max-loras --max-model-len --max-num-batched-tokens --max-num-partial-prefills --max-num-seqs --max-parallel-loading-workers --max-prompt-adapter-token --max-prompt-adapters --max-seq-len-to-capture --mm-processor-kwargs --model --model-impl --model-loader-extra-config --multi-step-stream-outputs --n --no-calculate-kv-scales --no-disable-cascade-attn --no-disable-chunked-mm-input --no-disable-custom-all-reduce --no-disable-hybrid-kv-cache-manager --no-disable-mm-preprocessor-cache --no-disable-sliding-window --no-enable-chunked-prefill --no-enable-expert-parallel --no-enable-lora --no-enable-lora-bias --no-enable-multimodal-encoder-data-parallel --no-enable-prefix-caching --no-enable-prompt-adapter --no-enable-prompt-embeds --no-enable-reasoning --no-enable-sleep-mode --no-enforce-eager --no-fully-sharded-loras --no-guided-decoding-disable-additional-properties --no-guided-decoding-disable-any-whitespace --no-guided-decoding-disable-fallback --no-multi-step-stream-outputs --no-ray-workers-use-nsight --no-skip-tokenizer-init --no-trust-remote-code --no-use-tqdm-on-load --num-gpu-blocks-override --num-lookahead-slots --num-prompts --num-scheduler-steps --otlp-traces-endpoint --output-json --output-len --override-attention-dtype --override-generation-config --override-neuron-config --override-pooler-config --pipeline-parallel-size --preemption-mode --prefix-caching-hash-algo --prefix-len --pt-load-map-location --qlora-adapter-name-or-path --quantization --random-range-ratio --ray-workers-use-nsight --reasoning-parser --revision --rope-scaling --rope-theta --scheduler-cls --scheduler-delay-factor --scheduling-policy --seed --served-model-name --show-hidden-metrics-for-version --skip-tokenizer-init --speculative-config --swap-space --task --tensor-parallel-size --tokenizer --tokenizer-mode --tokenizer-pool-extra-config --tokenizer-pool-size --tokenizer-pool-type --tokenizer-revision --trust-remote-code --use-tqdm-on-load --use-v2-block-manager --worker-cls --worker-extension-cls -O -h -q"
+
+    # Option value completion mapping (centralized definition)
+    declare -A option_value_map=(
+            [--backend]="vllm hf mii vllm-chat"
+    [--block-size]="1 128 16 32 64 8"
+    [--chat-template-content-format]="auto string openai"
+    [--collect-detailed-traces]="None all model worker"
+    [--config-format]="auto hf mistral"
+    [--dataset-name]="burstgpt custom hf random sharegpt sonnet"
+    [--device]="auto cpu cuda hpu neuron tpu xpu"
+    [--distributed-executor-backend]="None external_launcher mp ray uni"
+    [--dtype]="auto bfloat16 float float16 float32 half"
+    [--endpoint-type]="vllm openai openai-chat openai-audio"
+    [--guided-decoding-backend]="auto guidance lm-format-enforcer outlines xgrammar"
+    [--kv-cache-dtype]="auto fp8 fp8_e4m3 fp8_e5m2"
+    [--load-format]="auto bitsandbytes dummy fastsafetensors gguf mistral npcache pt runai_streamer runai_streamer_sharded safetensors sharded_state tensorizer"
+    [--lora-dtype]="auto bfloat16 float16"
+    [--model-impl]="auto transformers vllm"
+    [--preemption-mode]="None recompute swap"
+    [--prefix-caching-hash-algo]="builtin sha256"
+    [--quantization]="None aqlm auto-round awq awq_marlin bitblas bitsandbytes compressed-tensors deepspeedfp experts_int8 fbgemm_fp8 fp8 gguf gptq gptq_bitblas gptq_marlin gptq_marlin_24 hqq ipex marlin modelopt modelopt_fp4 moe_wna16 neuron_quant ptpc_fp8 qqq quark torchao tpu_int8"
+    [--reasoning-parser]="deepseek_r1 granite qwen3"
+    [--scheduling-policy]="fcfs priority"
+    [--task]="auto classify draft embed embedding generate reward score transcription"
+    [--tokenizer-mode]="auto custom mistral slow"
+    [--tool-call-parser]="deepseek_v3 granite-20b-fc granite hermes internlm jamba llama4_pythonic llama4_json llama3_json mistral phi4_mini_json pythonic"
+    [--uvicorn-log-level]="debug info warning error critical trace"
+    )
+
+    if [[ -n "${option_value_map[$prev]}" ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${option_value_map[$prev]}" -- "$cur")
+        return 0
+    fi
+
+    # Top-level subcommands
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${subcommands}" -- "$cur")
+        return 0
+    fi
+
+    # Second-level handling
+    case "${COMP_WORDS[1]}" in
+        bench)
+            if [[ ${COMP_CWORD} -eq 2 ]]; then
+                mapfile -t COMPREPLY < <(compgen -W "${bench_subcommands}" -- "$cur")
+                return 0
+            fi
+
+            # bench subcommands （latency, serve, throughput）
+            local bench_sub=${COMP_WORDS[2]}
+            case "$bench_sub" in
+                latency)
+                    mapfile -t COMPREPLY < <(compgen -W "${bench_latency_args}" -- "$cur")
+                    ;;
+                serve)
+                    mapfile -t COMPREPLY < <(compgen -W "${bench_serve_args}" -- "$cur")
+                    ;;
+                throughput)
+                    mapfile -t COMPREPLY < <(compgen -W "${bench_throughput_args}" -- "$cur")
+                    ;;
+            esac
+            return 0
+            ;;
+        chat)
+            mapfile -t COMPREPLY < <(compgen -W "${chat_args}" -- "$cur")
+            return 0
+            ;;
+        complete)
+            mapfile -t COMPREPLY < <(compgen -W "${complete_args}" -- "$cur")
+            return 0
+            ;;
+        serve)
+            mapfile -t COMPREPLY < <(compgen -W "${serve_args}" -- "$cur")
+            return 0
+            ;;
+        run-batch)
+            mapfile -t COMPREPLY < <(compgen -W "${run_batch_args}" -- "$cur")
+            return 0
+            ;;
+        *)
+            ;;
+    esac
+}
+
+complete -F _vllm_completions vllm

--- a/scripts/vllm-completion.template.bash
+++ b/scripts/vllm-completion.template.bash
@@ -1,0 +1,93 @@
+# vllm-completion.template.bash
+# 
+# To help auto-generate vllm-completion.bash
+#
+#############################################
+
+_vllm_completions(){
+    local cur prev
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    local subcommands={{ subcommands }}
+
+    # Nested subcommand
+    local bench_subcommands={{ bench_subcommands }}
+
+    # Subcommands args
+    local chat_args={{ chat_args }}
+
+    local complete_args={{ complete_args }}
+
+    local serve_args={{ serve_args }}
+
+    local run_batch_args={{ run_batch_args }}
+
+    local bench_latency_args={{ bench_latency_args }}
+
+    local bench_serve_args={{ bench_serve_args }}
+
+    local bench_throughput_args={{ bench_throughput_args }}
+
+    # Option value completion mapping (centralized definition)
+    declare -A option_value_map=(
+        {{ option_value_map_entries }}
+    )
+
+    if [[ -n "${option_value_map[$prev]}" ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${option_value_map[$prev]}" -- "$cur")
+        return 0
+    fi
+
+    # Top-level subcommands
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${subcommands}" -- "$cur")
+        return 0
+    fi
+
+    # Second-level handling
+    case "${COMP_WORDS[1]}" in
+        bench)
+            if [[ ${COMP_CWORD} -eq 2 ]]; then
+                mapfile -t COMPREPLY < <(compgen -W "${bench_subcommands}" -- "$cur")
+                return 0
+            fi
+
+            # bench subcommands （latency, serve, throughput）
+            local bench_sub=${COMP_WORDS[2]}
+            case "$bench_sub" in
+                latency)
+                    mapfile -t COMPREPLY < <(compgen -W "${bench_latency_args}" -- "$cur")
+                    ;;
+                serve)
+                    mapfile -t COMPREPLY < <(compgen -W "${bench_serve_args}" -- "$cur")
+                    ;;
+                throughput)
+                    mapfile -t COMPREPLY < <(compgen -W "${bench_throughput_args}" -- "$cur")
+                    ;;
+            esac
+            return 0
+            ;;
+        chat)
+            mapfile -t COMPREPLY < <(compgen -W "${chat_args}" -- "$cur")
+            return 0
+            ;;
+        complete)
+            mapfile -t COMPREPLY < <(compgen -W "${complete_args}" -- "$cur")
+            return 0
+            ;;
+        serve)
+            mapfile -t COMPREPLY < <(compgen -W "${serve_args}" -- "$cur")
+            return 0
+            ;;
+        run-batch)
+            mapfile -t COMPREPLY < <(compgen -W "${run_batch_args}" -- "$cur")
+            return 0
+            ;;
+        *)
+            ;;
+    esac
+}
+
+complete -F _vllm_completions vllm


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

vllm has somes subcommands, but each with numerous arguments,
which makes CLI usage difficult without references. So adds Bash completion support for the vllm CLI.
- Supports subcommand and option auto-completion (e.g., serve, chat, bench, etc.).
- Greatly improves usability by helping users discover and use available CLI options more easily.
- Makes working with long and complex arguments faster and less error-prone.
- add a script `cli_args_completion_generator.py` to auto-generate it with the template
```
$ vllm[double-tabs]
bench        chat         collect-env  complete     run-batch    serve

$ vllm bench[double-tabs]
latency     serve       throughput

$ vllm serve --d[double-tabs]
--data-parallel-address             --disable-fastapi-docs
--data-parallel-backend             --disable-frontend-multiprocessing
--data-parallel-rpc-port            --disable-hybrid-kv-cache-manager
--data-parallel-size                --disable-log-requests
--data-parallel-size-local          --disable-log-stats
--data-parallel-start-rank          --disable-mm-preprocessor-cache
--device                            --disable-sliding-window
--disable-async-output-proc         --disable-uvicorn-access-log
--disable-cascade-attn              --distributed-executor-backend
--disable-chunked-mm-input          --download-dir
--disable-custom-all-reduce         --dtype

```


## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
