### PR TITLE
[Bugfix] fix xgrammar not installed on macOS

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ lm-format-enforcer >= 0.10.11, < 0.11
 llguidance >= 0.7.11, < 0.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64"
 outlines == 0.1.11
 lark == 1.2.2
-xgrammar == 0.1.19; platform_machine == "x86_64" or platform_machine == "aarch64"
+xgrammar == 0.1.19; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

Fix https://github.com/vllm-project/vllm/issues/19676

## Purpose

Ensure that xgrammar is installed by default on macOS for arm

## Test Plan
 
Reinstall with `pip install -e .` on macOS.

## Test Result

`Successfully installed compressed-tensors-0.10.1 mistral_common-1.6.2 vllm-0.9.1.dev558+g0ba139d47 xgrammar-0.1.19`

