### PR TITLE
[Bugfix] ensure tool_choice is popped when `tool_choice:null` is passed in json payload

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -841,7 +841,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             return data
 
         # if "tool_choice" is specified -- validation
-        if "tool_choice" in data:
+        if "tool_choice" in data and data["tool_choice"] is not None:
 
             # ensure that if "tool choice" is specified, tools are present
             if "tools" not in data or data["tools"] is None:
@@ -853,7 +853,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             if data["tool_choice"] not in [
                     "auto", "required"
             ] and not isinstance(data["tool_choice"], dict):
-                raise NotImplementedError(
+                raise ValueError(
                     f'Invalid value for `tool_choice`: {data["tool_choice"]}! '\
                     'Only named tools, "none", "auto" or "required" '\
                     'are supported.'


### PR DESCRIPTION
When request is made with `"tool_choice":null,"tools":[]` in a json payload, vllm returns a `500 Internal Server Error`.

The minimalist example below triggers the error:
```
curl -X POST  -H "Content-Type: application/json" --url "http://localhost:8003/v1/chat/completions"  --data
 '{"model":"llama33", "messages":[{"role":"user","content":[{"type":"text","text":"tell me a short joke"}]}],"stream":t
rue,"temperature":1.0,"tool_choice":null, tools:[]}'
```
```
INFO:     172.17.0.1:38432 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```


This is due to the fact that the `tool_choice` field is then present on the request, and deserialized as `None`, but this case is not handled, in the current [`check_tool_usage` routine](https://github.com/vllm-project/vllm/blob/dec66d253b6e9c2745940bd4ccda786e7ac975d1/vllm/entrypoints/openai/protocol.py#L671).

This PR fixes the issue. 
