### PR TITLE
[V1] [Metrics] Hide deprecated metrics.

### DIFF
--- a/tests/entrypoints/openai/test_metrics.py
+++ b/tests/entrypoints/openai/test_metrics.py
@@ -229,9 +229,12 @@ EXPECTED_METRICS = [
 EXPECTED_METRICS_V1 = [
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
-    "vllm:gpu_cache_usage_perc",
-    "vllm:gpu_prefix_cache_queries",
-    "vllm:gpu_prefix_cache_hits",
+    "vllm:gpu_cache_usage_perc", # deprecated
+    "vllm:cache_usage_perc",
+    "vllm:gpu_prefix_cache_queries", # deprecated
+    "vllm:prefix_cache_queries",
+    "vllm:gpu_prefix_cache_hits",  # deprecated
+    "vllm:prefix_cache_hits",
     "vllm:num_preemptions_total",
     "vllm:prompt_tokens_total",
     "vllm:generation_tokens_total",
@@ -273,7 +276,11 @@ EXPECTED_METRICS_V1 = [
     "vllm:request_decode_time_seconds_count",
 ]
 
-HIDDEN_DEPRECATED_METRICS: list[str] = []
+HIDDEN_DEPRECATED_METRICS: list[str] = [
+    "vllm:gpu_cache_usage_perc",
+    "vllm:gpu_prefix_cache_queries",
+    "vllm:gpu_prefix_cache_hits",
+]
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_metrics.py
+++ b/tests/entrypoints/openai/test_metrics.py
@@ -229,9 +229,9 @@ EXPECTED_METRICS = [
 EXPECTED_METRICS_V1 = [
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
-    "vllm:gpu_cache_usage_perc", # deprecated
+    "vllm:gpu_cache_usage_perc",  # deprecated
     "vllm:cache_usage_perc",
-    "vllm:gpu_prefix_cache_queries", # deprecated
+    "vllm:gpu_prefix_cache_queries",  # deprecated
     "vllm:prefix_cache_queries",
     "vllm:gpu_prefix_cache_hits",  # deprecated
     "vllm:prefix_cache_hits",

--- a/tests/entrypoints/openai/test_metrics.py
+++ b/tests/entrypoints/openai/test_metrics.py
@@ -295,9 +295,15 @@ async def test_metrics_exist(server: RemoteOpenAIServer,
     response = requests.get(server.url_for("metrics"))
     assert response.status_code == HTTPStatus.OK
 
-    for metric in (EXPECTED_METRICS_V1 if use_v1 else EXPECTED_METRICS):
-        if (not server.show_hidden_metrics
-                and metric not in HIDDEN_DEPRECATED_METRICS):
+    metrics_list = EXPECTED_METRICS_V1 if use_v1 else EXPECTED_METRICS
+    if not server.show_hidden_metrics:
+        for metric in HIDDEN_DEPRECATED_METRICS:
+            assert metric not in response.text
+        for metric in metrics_list:
+            if metric not in HIDDEN_DEPRECATED_METRICS:
+                assert metric in response.text
+    else:
+        for metric in metrics_list:
             assert metric in response.text
 
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -194,25 +194,26 @@ class PrometheusStatLogger(StatLoggerBase):
                     "GPU KV-cache usage. 1 means 100 percent usage."
                     "DEPRECATED: Use vllm:kv_cache_usage_perc instead."),
                 multiprocess_mode="mostrecent",
-            labelnames=labelnames).labels(*labelvalues)
+                labelnames=labelnames).labels(*labelvalues)
 
             # Deprecated in 0.9 - Renamed as vllm:prefix_cache_queries
             # Hidden in 0.10, due to be removed in 0.11
             self.counter_gpu_prefix_cache_queries = self._counter_cls(
                 name="vllm:gpu_prefix_cache_queries",
-                documentation=
-                ("GPU prefix cache queries, in terms of number of queried tokens."
-             "DEPRECATED: Use vllm:prefix_cache_queries instead."),
-            labelnames=labelnames).labels(*labelvalues)
+                documentation=(
+                    "GPU prefix cache queries, in terms of number of "
+                    "queried tokens."
+                    "DEPRECATED: Use vllm:prefix_cache_queries instead."),
+                labelnames=labelnames).labels(*labelvalues)
 
             # Deprecated in 0.9 - Renamed as vllm:prefix_cache_hits
             # Hidden in 0.10, due to be removed in 0.11
             self.counter_gpu_prefix_cache_hits = self._counter_cls(
                 name="vllm:gpu_prefix_cache_hits",
-                documentation=(
-                    "GPU prefix cache hits, in terms of number of cached tokens."
-                "DEPRECATED: Use vllm:prefix_cache_hits instead."),
-            labelnames=labelnames).labels(*labelvalues)
+                documentation=
+                ("GPU prefix cache hits, in terms of number of cached tokens."
+                 "DEPRECATED: Use vllm:prefix_cache_hits instead."),
+                labelnames=labelnames).labels(*labelvalues)
 
         self.gauge_kv_cache_usage = self._gauge_cls(
             name="vllm:kv_cache_usage_perc",

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -183,33 +183,34 @@ class PrometheusStatLogger(StatLoggerBase):
             labelnames=labelnames).labels(*labelvalues)
 
         #
-        # GPU cache
+        # Cache
         #
-        # Deprecated in 0.9 - Renamed as vllm:kv_cache_usage_perc
-        # TODO: in 0.10, only enable if show_hidden_metrics=True
-        self.gauge_gpu_cache_usage = self._gauge_cls(
-            name="vllm:gpu_cache_usage_perc",
-            documentation=(
-                "GPU KV-cache usage. 1 means 100 percent usage."
-                "DEPRECATED: Use vllm:kv_cache_usage_perc instead."),
-            multiprocess_mode="mostrecent",
+        if self.show_hidden_metrics:
+            # Deprecated in 0.9 - Renamed as vllm:kv_cache_usage_perc
+            # Hidden in 0.10, due to be removed in 0.11
+            self.gauge_gpu_cache_usage = self._gauge_cls(
+                name="vllm:gpu_cache_usage_perc",
+                documentation=(
+                    "GPU KV-cache usage. 1 means 100 percent usage."
+                    "DEPRECATED: Use vllm:kv_cache_usage_perc instead."),
+                multiprocess_mode="mostrecent",
             labelnames=labelnames).labels(*labelvalues)
 
-        # Deprecated in 0.9 - Renamed as vllm:prefix_cache_queries
-        # TODO: in 0.10, only enable if show_hidden_metrics=True
-        self.counter_gpu_prefix_cache_queries = self._counter_cls(
-            name="vllm:gpu_prefix_cache_queries",
-            documentation=
-            ("GPU prefix cache queries, in terms of number of queried tokens."
+            # Deprecated in 0.9 - Renamed as vllm:prefix_cache_queries
+            # Hidden in 0.10, due to be removed in 0.11
+            self.counter_gpu_prefix_cache_queries = self._counter_cls(
+                name="vllm:gpu_prefix_cache_queries",
+                documentation=
+                ("GPU prefix cache queries, in terms of number of queried tokens."
              "DEPRECATED: Use vllm:prefix_cache_queries instead."),
             labelnames=labelnames).labels(*labelvalues)
 
-        # Deprecated in 0.9 - Renamed as vllm:prefix_cache_hits
-        # TODO: in 0.10, only enable if show_hidden_metrics=True
-        self.counter_gpu_prefix_cache_hits = self._counter_cls(
-            name="vllm:gpu_prefix_cache_hits",
-            documentation=(
-                "GPU prefix cache hits, in terms of number of cached tokens."
+            # Deprecated in 0.9 - Renamed as vllm:prefix_cache_hits
+            # Hidden in 0.10, due to be removed in 0.11
+            self.counter_gpu_prefix_cache_hits = self._counter_cls(
+                name="vllm:gpu_prefix_cache_hits",
+                documentation=(
+                    "GPU prefix cache hits, in terms of number of cached tokens."
                 "DEPRECATED: Use vllm:prefix_cache_hits instead."),
             labelnames=labelnames).labels(*labelvalues)
 
@@ -427,14 +428,14 @@ class PrometheusStatLogger(StatLoggerBase):
             self.gauge_scheduler_running.set(scheduler_stats.num_running_reqs)
             self.gauge_scheduler_waiting.set(scheduler_stats.num_waiting_reqs)
 
-            self.gauge_gpu_cache_usage.set(scheduler_stats.kv_cache_usage)
+            if self.show_hidden_metrics:
+                self.gauge_gpu_cache_usage.set(scheduler_stats.kv_cache_usage)
+                self.counter_gpu_prefix_cache_queries.inc(
+                    scheduler_stats.prefix_cache_stats.queries)
+                self.counter_gpu_prefix_cache_hits.inc(
+                    scheduler_stats.prefix_cache_stats.hits)
+
             self.gauge_kv_cache_usage.set(scheduler_stats.kv_cache_usage)
-
-            self.counter_gpu_prefix_cache_queries.inc(
-                scheduler_stats.prefix_cache_stats.queries)
-            self.counter_gpu_prefix_cache_hits.inc(
-                scheduler_stats.prefix_cache_stats.hits)
-
             self.counter_prefix_cache_queries.inc(
                 scheduler_stats.prefix_cache_stats.queries)
             self.counter_prefix_cache_hits.inc(


### PR DESCRIPTION
Hide the following metrics that were deprecated in 0.9:

- `gpu_cache_usage`
-  `gpu_prefix_cache_queries` 
- `gpu_prefix_cache_hits`

