### PR TITLE
[Core] add remove_seq_from_computed_blocks_tracker to BlockSpaceManager

### DIFF
--- a/vllm/core/interfaces.py
+++ b/vllm/core/interfaces.py
@@ -133,3 +133,7 @@ class BlockSpaceManager(ABC):
     @abstractmethod
     def get_num_cached_tokens(self, seq: Sequence) -> int:
         pass
+
+    @abstractmethod
+    def remove_seq_from_computed_blocks_tracker(self, seq: Sequence) -> None:
+        pass

--- a/vllm/core/placeholder_block_space_manager.py
+++ b/vllm/core/placeholder_block_space_manager.py
@@ -98,3 +98,6 @@ class PlaceholderBlockSpaceManager(BlockSpaceManager):
 
     def get_num_cached_tokens(self, seq: Sequence) -> int:
         return 0
+
+    def remove_seq_from_computed_blocks_tracker(self, seq: Sequence) -> None:
+        return


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/pull/18957#issuecomment-2975836625
#19344  AttributeError: 'PlaceholderBlockSpaceManager' object has no attribute 'remove_seq_from_computed_blocks_tracker'

