### PR TITLE
[Feat][CLI] enforce-include-usage

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1190,6 +1190,7 @@ async def init_app_state(
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
+        enable_force_include_usage=args.enable_force_include_usage,
     ) if model_config.runner_type == "generate" else None
     state.openai_serving_completion = OpenAIServingCompletion(
         engine_client,
@@ -1197,6 +1198,7 @@ async def init_app_state(
         state.openai_serving_models,
         request_logger=request_logger,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
+        enable_force_include_usage=args.enable_force_include_usage,
     ) if model_config.runner_type == "generate" else None
     state.openai_serving_pooling = OpenAIServingPooling(
         engine_client,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -273,6 +273,11 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         default=False,
         help="If set to True, enable prompt_tokens_details in usage.")
     parser.add_argument(
+        "--enable-force-include-usage",
+        action='store_true',
+        default=False,
+        help="If set to True, including usage on every request.")
+    parser.add_argument(
         "--enable-server-load-tracking",
         action='store_true',
         default=False,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -132,7 +132,7 @@ RequestT = TypeVar("RequestT", bound=AnyRequest)
 
 class RequestProcessingMixin(BaseModel):
     """
-    Mixin for request processing, 
+    Mixin for request processing,
     handling prompt preparation and engine input.
     """
     request_prompts: Optional[Sequence[RequestPrompt]] = []
@@ -144,7 +144,7 @@ class RequestProcessingMixin(BaseModel):
 
 class ResponseGenerationMixin(BaseModel):
     """
-    Mixin for response generation, 
+    Mixin for response generation,
     managing result generators and final batch results.
     """
     result_generator: Optional[AsyncGenerator[tuple[int, Union[
@@ -208,6 +208,7 @@ class OpenAIServing:
         *,
         request_logger: Optional[RequestLogger],
         return_tokens_as_token_ids: bool = False,
+        enable_force_include_usage: bool = False,
     ):
         super().__init__()
 
@@ -219,6 +220,7 @@ class OpenAIServing:
 
         self.request_logger = request_logger
         self.return_tokens_as_token_ids = return_tokens_as_token_ids
+        self.enable_force_include_usage = enable_force_include_usage
 
         self._tokenizer_executor = ThreadPoolExecutor(max_workers=1)
 


### PR DESCRIPTION
Currently, when streaming the usage is always null. This prevents the usage of limits per user and is a bit unexpected as without using streaming, the usage is always returned.

This can be used, if vllm is between a router, such as vllm-router or litellm and serves many users and is important to detect abuse, divide costs etc.

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Always returns tokens which can be used by various systems for:
* Detecting abuse by users
* Billing or dividing cost company internally

In addition this align the behavior with the `non-streaming` mode where the usage is always returned

## Test Plan

1. Setup this commit and run vllm
2. Send the follow request and notice how usage is returned in the last segment
```sh
curl --request POST \
  --url https://yourhost.example.com/llm/v1/completions \
  --header 'apikey: {{token}}' \
  --header 'content-type: application/json' \
  --data '{
  "model": "qwen3-30b-a3b",
  "max_tokens": 100,
  "presence_penalty": 0,
  "frequency_penalty": 0,
  "temperature": 0.1,
  "prompt": "def write_hello():",
  "stream": true
}'
```

---

```sh
data: {"id":"cmpl-ef83ad46-8ca3-49dc-8371-790f281f60a1#8733163","object":"text_completion","created":1750142471,"model":"qwen3-30b-a3b","choices":[],"usage":{"prompt_tokens":4,"total_tokens":104,"completion_tokens":100}}
```

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
