### PR TITLE
Fixes IMA for TP w/ flex-attention

### DIFF
--- a/tests/kernels/test_flex_attention.py
+++ b/tests/kernels/test_flex_attention.py
@@ -51,7 +51,6 @@ def test_flex_attention_vs_default_backend(monkeypatch):
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")
         m.setenv("VLLM_ATTENTION_BACKEND", "FLEX_ATTENTION")
-        m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 
         set_seed(seed)
 
@@ -66,7 +65,6 @@ def test_flex_attention_vs_default_backend(monkeypatch):
     # Run with default backend
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")
-        m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
         set_seed(seed)
         llm_default = LLM(
             model_name,


### PR DESCRIPTION
# FlexAttention Backend Fix

So I have been using this file for testing: https://gist.github.com/drisspg/3050c61f587030f09b96d86e14b10711
I am on the latest PyTorch Nightly, and I found that it it is working even before this fix:


So I am not sure, that being said people have ran into the create-block mask problem before w/ compile so this was a mistake on my end
```Shell
INFO 06-16 13:44:24 [kv_cache_utils.py:720] Maximum concurrency for 32,768 tokens per request: 1.00x
(VllmWorker rank=3 pid=1989317) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
(VllmWorker rank=0 pid=1989313) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
(VllmWorker rank=1 pid=1989314) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
(VllmWorker rank=5 pid=1989319) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
(VllmWorker rank=7 pid=1989323) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
(VllmWorker rank=6 pid=1989321) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
(VllmWorker rank=4 pid=1989318) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
(VllmWorker rank=2 pid=1989315) INFO 06-16 13:44:24 [cuda.py:230] Using FlexAttenion backend on V1 engine.
Capturing CUDA graphs:   0%|                                                                                                                 | 0/67 [00:00<?, ?it/s]Capturing CUDA graphs:   0%|                                                                                                                 | 0/67 [00:00<?, ?it/s]Capturing CUDA graphs:   0%|                                                                                                                 | 0/67 [00:00<?, ?it/s]Capturing CUDA graphs:   0%|                                                                                                                 | 0/67 [00:00<?, ?it/s]Capturing CUDA graphs:   0%|                                                                                                                 | 0/67 [00:00<?, ?it/s]Capturing CUDA graphs:   0%|                                                                                                                 | 0/67 [00:00<?, ?it/s]Capturing CUDA graphs:   0%|                                                                                                                 | 0/67 [00:00<?, ?it/s]Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:27<00:00,  2.40it/s]
(VllmWorker rank=4 pid=1989318) INFO 06-16 13:44:52 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:28<00:00,  2.33it/s]
(VllmWorker rank=5 pid=1989319) INFO 06-16 13:44:53 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:29<00:00,  2.25it/s]
(VllmWorker rank=0 pid=1989313) INFO 06-16 13:44:54 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:30<00:00,  2.23it/s]
Capturing CUDA graphs:  91%|██████████████████████████████████████████████████████████████████████████████████████████████▋         | 61/67 [00:30<00:02,  2.05it/s](VllmWorker rank=6 pid=1989321) INFO 06-16 13:44:54 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:30<00:00,  2.20it/s]
(VllmWorker rank=1 pid=1989314) INFO 06-16 13:44:54 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:31<00:00,  2.16it/s]
(VllmWorker rank=7 pid=1989323) INFO 06-16 13:44:55 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:32<00:00,  2.07it/s]
(VllmWorker rank=2 pid=1989315) INFO 06-16 13:44:56 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
Capturing CUDA graphs: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:33<00:00,  2.03it/s]
(VllmWorker rank=3 pid=1989317) INFO 06-16 13:44:57 [custom_all_reduce.py:196] Registering 2211 cuda graph addresses
(VllmWorker rank=0 pid=1989313) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 33 secs, took 0.97 GiB
(VllmWorker rank=6 pid=1989321) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 33 secs, took 0.97 GiB
(VllmWorker rank=1 pid=1989314) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 33 secs, took 0.97 GiB
(VllmWorker rank=4 pid=1989318) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 33 secs, took 0.97 GiB
(VllmWorker rank=7 pid=1989323) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 33 secs, took 0.97 GiB
(VllmWorker rank=2 pid=1989315) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 33 secs, took 0.97 GiB
(VllmWorker rank=5 pid=1989319) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 33 secs, took 0.97 GiB
(VllmWorker rank=3 pid=1989317) INFO 06-16 13:44:57 [gpu_model_runner.py:2083] Graph capturing finished in 34 secs, took 0.97 GiB
INFO 06-16 13:44:57 [core.py:173] init engine (profile, create kv cache, warmup model) took 40.78 seconds

Generating responses...
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 188.23it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████| 4/4 [00:04<00:00,  1.17s/it, est. speed input: 5.57 toks/s, output: 109.62 toks/s]

Results:
--------------------------------------------------------------------------------
Prompt: Hello, my name is
Generated:  Kristi and I am so excited to be here today. I have been a homeschool mom for 17 years and am married to my best friend, Jonathan. We have two children, Hannah and Ben. We are also expecting our third child in June! We have been in our current house since 2014. I love the feeling of being surrounded by my family, friends, and community.
My husband and I are both alumni of Spring Hill College and I am a graduate of the University of Alabama. I am also a wife of a pastor and have been a member of the church for 15 years. I have been a member of
--------------------------------------------------------------------------------
Prompt: The president of the United States is
Generated:  responsible for the government of the United States. The president serves a four-year term and is elected by popular vote. The United States has a parliamentary government, which means that the president and the members of the legislative branch work together to create a law.
The United States was established as a republic in 1776. It is an example of a democracy, which means that the citizens of the United States choose their leaders. The president is the head of state. He or she is elected for a term of four years. The vice president is the second highest-ranking official in the United States. He or she is elected for a term of four
--------------------------------------------------------------------------------
Prompt: The capital of France is
Generated:  Paris, the country’s fashion capital, home to some of the world’s most famous fashion houses. Travel to the south of France and visit the poppy fields of Provence and the French Riviera. Savor the culinary delights of Paris, watch the world’s greatest artists at the Louvre and enjoy a luxurious cruise along the Rhone River.
Welcome to Paris, the capital of France and a fashion capital of the world. Take some time to explore the city’s many museums, including the Louvre, the Musée d’Orsay and the Orangerie. You’ll also enjoy a cruise along the Seine River. Head
--------------------------------------------------------------------------------
Prompt: The future of AI is
Generated:  in the hands of students
The future of artificial intelligence is in the hands of college students, according to IBM’s latest report on the state of artificial intelligence.
In the report, the IBM Watson Group released a survey of 1,500 college students from around the world, including students in the U.S. and the United Kingdom.
Students were asked to rate their level of interest in AI on a scale of one to five, with five being the highest.
Students were also asked how much they believed AI was a threat to their jobs, and how much they believed AI was a tool to help them find a better job.
The report found
--------------------------------------------------------------------------------
```


## Files Changed
- `tests/kernels/test_flex_attention.py`
- `vllm/v1/attention/backends/flex_attention.py`

## Changes
- **Tests**: Removed `VLLM_ENABLE_V1_MULTIPROCESSING=0` env var
- **Backend**: Fixed TP>1 CUDA memory errors by always using `create_block_mask_compiled`
- **Backend**: Added explicit device parameter
- **Backend**: Removed unused TP world size import

## Result
FlexAttention now works with multi-GPU tensor parallel setups without CUDA errors.

<!--- pyml disable-next-line no-emphasis-as-heading -->
