### PR TITLE
[Bugfix] Fix faulty triton importing logic when using Ray for DP

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 import types
 from importlib.util import find_spec
 
@@ -23,7 +24,22 @@ if HAS_TRITON:
             x.driver for x in backends.values()
             if x.driver and x.driver.is_active()
         ]
-        if len(active_drivers) != 1:
+
+        # Check if we're in a distributed environment where CUDA_VISIBLE_DEVICES
+        # might be temporarily empty (e.g., Ray sets it to "" during actor init)
+        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+        is_distributed_env = (cuda_visible_devices is not None
+                              and len(cuda_visible_devices.strip()) == 0)
+
+        # Apply lenient driver check for distributed environments
+        if is_distributed_env and len(active_drivers) == 0:
+            # Allow 0 drivers in distributed environments - they may become
+            # active later when CUDA context is properly initialized
+            logger.debug(
+                "Triton found 0 active drivers in distributed environment. "
+                "This is expected during initialization.")
+        elif not is_distributed_env and len(active_drivers) != 1:
+            # Strict check for non-distributed environments
             logger.info(
                 "Triton is installed but %d active driver(s) found "
                 "(expected 1). Disabling Triton to prevent runtime errors.",


### PR DESCRIPTION
## Purpose

FIX https://github.com/vllm-project/vllm/issues/19731

In the `DPEngineCoreActor`, Ray sets `CUDA_VISIBLE_DEVICES` to an empty string, and then the code deletes it to properly initialize data parallel groups. 
https://github.com/vllm-project/vllm/blob/aed8468642740c9a8486d6dde334d9a4e80a687f/vllm/v1/engine/core.py#L922-L925

However, this happens after the Triton driver check has already run during the module import.
The key issue is the timing:
1. When the Ray actor is created, the `vllm.triton_utils.importing` module is imported first
2. During import, it runs the driver check when `CUDA_VISIBLE_DEVICES` is set to empty string by Ray
3. This causes Triton to see 0 active drivers and disables Triton
4. Later, the `DPEngineCoreActor.__init__()` method deletes the problematic `CUDA_VISIBLE_DEVICES` environment variable

## Test Plan

Manually verify `TP_SIZE=1 DP_SIZE=2 pytest -s -v "v1/test_async_llm_dp.py::test_load[ray-RequestOutputKind.DELTA]"` works now.

## Test Result

Passed!