### PR TITLE
[Frontend] early return chat format resolution when specified

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -448,6 +448,9 @@ def resolve_chat_template_content_format(
     model_config: ModelConfig,
     trust_remote_code: Optional[bool] = None,
 ) -> _ChatTemplateContentFormat:
+    if given_format != "auto":
+        return given_format
+
     detected_format = _resolve_chat_template_content_format(
         chat_template,
         tools,
@@ -461,7 +464,7 @@ def resolve_chat_template_content_format(
         detected_format=detected_format,
     )
 
-    return detected_format if given_format == "auto" else given_format
+    return detected_format
 
 
 


### PR DESCRIPTION
The auto-detection of content format introduced in https://github.com/vllm-project/vllm/pull/9919 involves Jinja parsing, and it is time-consuming for small models and short max_tokens, such as `Qwen3-0.6B` with `max_tokens=1`. Skipping this auto-detection can provide a 3X RPS boost when using the `--template-content-format string` flag in L20.