### PR TITLE
buildkite release pipeline: add torch_cuda_arch_list including 12.0 to the Docker "Build release image" build args in order to enable Blackwell SM120 support

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -52,7 +52,7 @@ steps:
       queue: cpu_queue_postmerge
     commands:
       - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
-      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.8.1 --tag public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT --target vllm-openai --progress plain -f docker/Dockerfile ."
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.8.1 --build-arg torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 10.1 12.0+PTX' --tag public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT --target vllm-openai --progress plain -f docker/Dockerfile ."
       - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT"
 
   - label: "Annotate release workflow"

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -52,7 +52,7 @@ steps:
       queue: cpu_queue_postmerge
     commands:
       - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
-      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.8.1 --build-arg torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 10.1 12.0+PTX' --tag public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT --target vllm-openai --progress plain -f docker/Dockerfile ."
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.8.1 --build-arg torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 10.1 12.0+PTX' --build-arg RUN_WHEEL_CHECK=false --tag public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT --target vllm-openai --progress plain -f docker/Dockerfile ."
       - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT"
 
   - label: "Annotate release workflow"


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

## Purpose
We need Nvidia Blackwell SM120 support. There are a lot of issues regarding it.
1. Some tried to use the vLLM pypi wheels - which we **unfortunately can't update to SM120 at the moment** since we're restricted by the pypi's 400 MB limit and even building for SM120-only results in a 548 MB wheel, and building for all arches results in a 922 MB wheel which even exceeds the proposed 800 MB new limit (see [here](https://github.com/vllm-project/vllm/issues/13306#issuecomment-2940556134))
  - https://github.com/vllm-project/vllm/issues/16901
  - https://github.com/vllm-project/vllm/issues/18835
2. Some want to start vLLM via docker - **this is what this Pullrequest is solving**:
  - https://github.com/vllm-project/vllm/issues/13306
  - https://github.com/vllm-project/vllm/issues/14452
  - https://github.com/vllm-project/vllm/issues/16652
  - https://github.com/vllm-project/vllm/issues/18916
  - https://github.com/vllm-project/vllm/issues/18995

There are two alternative solutions for solving Number 2 (proving a SM 120 capable Docker image), see https://github.com/vllm-project/vllm/issues/13306#issuecomment-2940556134

> So in order to get SM120 Blackwell support at least in the Docker AWS image, the workaround would be to:
> 
> 1. either add `--build-arg torch_cuda_arch_list='7.0 7.5 8.0 8.9 9.0+PTX'` to [Build wheel - CUDA 12.8](https://github.com/vllm-project/vllm/blob/c48c6c4008ab3ba0a2ab2d9c04b285a5d6a58b88/.buildkite/release-pipeline.yaml#L7) (to keep wheelsize small) and add `12.0` to the [Dockerfile](https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile) to make it the new default
> 2. or add `--build-arg torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 10.1 12.0+PTX'` to the Docker [Build release image](https://github.com/vllm-project/vllm/blob/c48c6c4008ab3ba0a2ab2d9c04b285a5d6a58b88/.buildkite/release-pipeline.yaml#L55) args which only affect the Docker image being pushed to AWS and not the wheels

This is the PR for alternative 2 since I didn't want to touch the defaults.

Besides adding `--build-arg torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 10.1 12.0+PTX'` I needed to add `--build-arg RUN_WHEEL_CHECK=false` too of course. This shouldn't be a problem since AWS does not have the same size restrictions as pypi's wheel size limits.

## Test Plan
1. Make a test build, very similar to the line I've touched in this pullrequest:
```
DOCKER_BUILDKIT=1 sudo docker build \
  --build-arg max_jobs=96 \
  --build-arg USE_SCCACHE=0 \
  --build-arg GIT_REPO_CHECK=1 \
  --build-arg CUDA_VERSION=12.8.1 \
  --build-arg torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 10.1 12.0+PTX' \
  --build-arg RUN_WHEEL_CHECK=false \
  --tag public.ecr.aws/q9t5s3a7/vllm-release-repo:dev \
  --target vllm-openai \
  --progress plain \
  -f docker/Dockerfile .
```
2. Push this image to Dockerhub under the following image name and tag: `wurstdeploy/vllm:dev`
3. Run this image using 1x RTX 6000 Pro and in another test using 1x RTX 4090

## Test Result
1. I've built it succesfully using an Azure `Standard E96s v6 (96 vcpus, 768 GiB memory)` machine. The build took ~1 hour, max system memory usage, including OS: 181125 MiB RAM. This build is based on the following commit:
```
# After cloing the repo via git clone https://github.com/vllm-project/vllm
azureuser@buildtest:~/vllm$ git log -1
commit ccd7c050898cfea4b6b0de16446dcc47fa02a399 (HEAD -> main, origin/main, origin/HEAD)
Author: jvlunteren <161835099+jvlunteren@users.noreply.github.com>
Date:   Tue Jun 17 12:45:07 2025 +0200

    [Kernel] Add Split-KV Support to Unified Triton Attention Kernel (#19152)

    Signed-off-by: Jan van Lunteren <jvl@zurich.ibm.com>

```
2. Image is now available at Docker Hub on `wurstdeploy/vllm:dev`. I did it as follows:
```
sudo docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:dev wurstdeploy/vllm:dev
sudo docker login
sudo docker push wurstdeploy/vllm:dev
```
3. Both tests ran successful, using `TinyLlama/TinyLlama-1.1B-Chat-v1.0` and a test prompt. Screenshots: [[1]](https://github.com/user-attachments/assets/d402aac6-2855-4e76-b617-ed8b52d017da), [[2]](https://github.com/user-attachments/assets/2bf3b628-498a-4357-bb47-0506671f7266), [[3]](https://github.com/user-attachments/assets/e2564b02-694a-4d20-8185-b21e26468bf9) edit: but it only works with the docker environment variable `-e VLLM_USE_FLASHINFER_SAMPLER=0` being set, else I get a kernel error. Investigation follows in the comments

