### PR TITLE
[Kernel] mark TorchSDPABackend swap_blocks NotImplementedError

### DIFF
--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -65,7 +65,7 @@ class TorchSDPABackend(AttentionBackend):
         dst_kv_cache: torch.Tensor,
         src_to_dst: torch.Tensor,
     ) -> None:
-        PagedAttention.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
+        raise NotImplementedError("Swap is not supported in TorchSDPABackend.")
 
     @staticmethod
     def copy_blocks(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
`TorchSDPABackend` is only used with cpu device and for now and cpu does not support cache swap operations as stated in:
https://github.com/vllm-project/vllm/blob/5a1c2e15d847e30d9c72d60ba1e28dc4b89df23d/vllm/worker/cpu_worker.py#L91-L95

So, `TorchSDPABackend` can raise `NotImplementedError`.
## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
