### PR TITLE
Workaround for an integer overflow with large CHUNK_SIZE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -350,7 +350,7 @@ def fused_moe_kernel(
         return
     offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(
         tl.int64)
-    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id).to(tl.int64)
     token_mask = offs_token < num_valid_tokens
 
     off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
@@ -455,7 +455,7 @@ def fused_moe_kernel(
         accumulator = accumulator.to(compute_type)
     # -----------------------------------------------------------
     # Write back the block of the output
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_cn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)).to(tl.int64)
     c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[
         None, :]
     c_mask = token_mask[:, None] & (offs_cn[None, :] < N)


### PR DESCRIPTION
I've noticed that vllm started to crash a few weeks ago with DeepSeek-V3, because the default value of VLLM_FUSED_MOE_CHUNK_SIZE was raised from 32k to 64k, resulting in an int32 overflow during address calculation in fused_moe_kernel.  