### PR TITLE
Fix FA2 fallback for Blackwell V1

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -255,7 +255,7 @@ class CudaPlatformBase(Platform):
                         "install FlashInfer for better performance.")
                     pass
             # FlashAttention is the default for SM 8.0+ GPUs
-            elif cls.has_device_capability(80):
+            if cls.has_device_capability(80):
                 logger.info_once("Using Flash Attention backend on V1 engine.")
                 return ("vllm.v1.attention.backends."
                         "flash_attn.FlashAttentionBackend")


### PR DESCRIPTION
`elif` was not the right choice, as we want FA2 to be a constant fallback on V1 so we can use it for Blackwell when FlashInfer isn't installed