### PR TITLE
Disable "Forbid direct 'import triton'" check for `vllm/triton_utils/importing.py` in an extensible way

### DIFF
--- a/tools/check_triton_import.py
+++ b/tools/check_triton_import.py
@@ -14,10 +14,14 @@ ALLOWED_LINES = {
     "from vllm.triton_utils import tl, triton",
 }
 
+ALLOWED_FILES = {"vllm/triton_utils/importing.py"}
+
+
+def is_allowed_file(current_file: str) -> bool:
+    return current_file in ALLOWED_FILES
+
 
 def is_forbidden_import(line: str) -> bool:
-    if "# triton-import-ok" in line:
-        return False
     stripped = line.strip()
     return bool(
         FORBIDDEN_IMPORT_RE.match(stripped)) and stripped not in ALLOWED_LINES
@@ -27,10 +31,14 @@ def parse_diff(diff: str) -> list[str]:
     violations = []
     current_file = None
     current_lineno = None
+    skip_allowed_file = False
 
     for line in diff.splitlines():
         if line.startswith("+++ b/"):
             current_file = line[6:]
+            skip_allowed_file = is_allowed_file(current_file)
+        elif skip_allowed_file:
+            continue
         elif line.startswith("@@"):
             match = re.search(r"\+(\d+)", line)
             if match:

--- a/tools/check_triton_import.py
+++ b/tools/check_triton_import.py
@@ -16,6 +16,8 @@ ALLOWED_LINES = {
 
 
 def is_forbidden_import(line: str) -> bool:
+    if "# triton-import-ok" in line:
+        return False
     stripped = line.strip()
     return bool(
         FORBIDDEN_IMPORT_RE.match(stripped)) and stripped not in ALLOWED_LINES

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -15,7 +15,7 @@ HAS_TRITON = (
 )
 if HAS_TRITON:
     try:
-        from triton.backends import backends  # triton-import-ok
+        from triton.backends import backends
 
         # It's generally expected that x.driver exists and has
         # an is_active method.

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -15,7 +15,7 @@ HAS_TRITON = (
 )
 if HAS_TRITON:
     try:
-        from triton.backends import backends
+        from triton.backends import backends  # triton-import-ok
 
         # It's generally expected that x.driver exists and has
         # an is_active method.


### PR DESCRIPTION
## Purpose

The purpose is to prevent unnecessary "Forbid direct 'import triton'" pre-commit failures. Specifically, I have another PR ( #16862 ) which makes no changes to `vllm/triton_utils/importing.py`, but is nonetheless receiving a "Forbid direct 'import triton'" pre-commit failure for the line

```
from triton.backends import backends
```

However, I hesistate to replace `triton` with `vllm.triton_utils.triton` because *`importing.py` is the file which defines the placeholder classes which `vllm.triton_utils.triton` relies on*, so this would be a circular import.

So instead I tweaked the pre-commit check to have an allow-list which consists for the time being of just `vllm/triton_utils/importing.py`, but which could be extended with other files in the future. Files in the allow list cannot fail the "Forbid direct 'import triton'" pre-commit check.

## Test Plan

A quick manual test: I added `import triton` to `gpu_input_batch.py`.

## Test Result

I confirmed that "Forbid direct 'import triton'" still catches the bogus `import triton` in `gpu_input_batch.py`; however, "Forbid direct 'import triton'" does not catch the line in `vllm/triton_utils/importing.py`, as intended.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
