### PR TITLE
[Minor] Zero-initialize attn output buffer

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -209,7 +209,7 @@ class Attention(nn.Module):
         if self.use_output:
             output_shape = (output_shape
                             if output_shape is not None else query.shape)
-            output = torch.empty(output_shape,
+            output = torch.zeros(output_shape,
                                  dtype=query.dtype,
                                  device=query.device)
             hidden_size = output_shape[-1]


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Currently, we use `torch.empty` for initializing the attention output buffer. This could cause a numerical issue in the initial memory profiling run, because all the subsequent operators get uninitialized inputs that could contain NaNs. This PR fixes this by using `torch.zeros` instead.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
