### PR TITLE
Mark invariant normalizer in Gemma as non-persistent

### DIFF
--- a/tests/models/language/generation/test_gemma.py
+++ b/tests/models/language/generation/test_gemma.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import numpy as np
+
+
+MODELS = [
+    "google/gemma-2b",
+    "google/gemma-2-2b",
+    "google/gemma-3-4b-it"
+]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_dummy_loader(vllm_runner, model: str) -> None:
+    with vllm_runner(
+            model,
+            load_format="dummy",
+    ) as llm:
+        normalizers = llm.collective_rpc(
+            lambda self: self.worker.model_runner.model.model.normalizer.cpu().item()
+        )
+        assert np.allclose(
+            normalizers,
+            llm.llm_engine.model_config.hf_config.hidden_size**0.5,
+            rtol=1e-3
+        )

--- a/tests/models/language/generation/test_gemma.py
+++ b/tests/models/language/generation/test_gemma.py
@@ -1,14 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import pytest
 import numpy as np
+import pytest
 
-
-MODELS = [
-    "google/gemma-2b",
-    "google/gemma-2-2b",
-    "google/gemma-3-4b-it"
-]
+MODELS = ["google/gemma-2b", "google/gemma-2-2b", "google/gemma-3-4b-it"]
 
 
 @pytest.mark.parametrize("model", MODELS)
@@ -17,11 +12,9 @@ def test_dummy_loader(vllm_runner, model: str) -> None:
             model,
             load_format="dummy",
     ) as llm:
-        normalizers = llm.collective_rpc(
-            lambda self: self.worker.model_runner.model.model.normalizer.cpu().item()
-        )
+        normalizers = llm.collective_rpc(lambda self: self.worker.model_runner.
+                                         model.model.normalizer.cpu().item())
         assert np.allclose(
             normalizers,
             llm.llm_engine.model_config.hf_config.hidden_size**0.5,
-            rtol=1e-3
-        )
+            rtol=1e-3)

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -281,7 +281,9 @@ class GemmaModel(nn.Module):
         # data type such as bfloat16, not float32.
         # See https://github.com/huggingface/transformers/pull/29402
         normalizer = self.config.hidden_size**0.5
-        self.register_buffer("normalizer", torch.tensor(normalizer))
+        self.register_buffer(
+            "normalizer", torch.tensor(normalizer), persistent=False
+        )
         self.make_empty_intermediate_tensors = (
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -281,9 +281,9 @@ class GemmaModel(nn.Module):
         # data type such as bfloat16, not float32.
         # See https://github.com/huggingface/transformers/pull/29402
         normalizer = self.config.hidden_size**0.5
-        self.register_buffer(
-            "normalizer", torch.tensor(normalizer), persistent=False
-        )
+        self.register_buffer("normalizer",
+                             torch.tensor(normalizer),
+                             persistent=False)
         self.make_empty_intermediate_tensors = (
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -267,7 +267,9 @@ class Gemma2Model(nn.Module):
         # data type such as bfloat16, not float32.
         # See https://github.com/huggingface/transformers/pull/29402
         normalizer = self.config.hidden_size**0.5
-        self.register_buffer("normalizer", torch.tensor(normalizer))
+        self.register_buffer(
+            "normalizer", torch.tensor(normalizer), persistent=False
+        )
         self.make_empty_intermediate_tensors = (
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -267,9 +267,9 @@ class Gemma2Model(nn.Module):
         # data type such as bfloat16, not float32.
         # See https://github.com/huggingface/transformers/pull/29402
         normalizer = self.config.hidden_size**0.5
-        self.register_buffer(
-            "normalizer", torch.tensor(normalizer), persistent=False
-        )
+        self.register_buffer("normalizer",
+                             torch.tensor(normalizer),
+                             persistent=False)
         self.make_empty_intermediate_tensors = (
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -371,7 +371,9 @@ class Gemma3Model(nn.Module):
         # data type such as bfloat16, not float32.
         # See https://github.com/huggingface/transformers/pull/29402
         normalizer = self.config.hidden_size**0.5
-        self.register_buffer("normalizer", torch.tensor(normalizer))
+        self.register_buffer(
+            "normalizer", torch.tensor(normalizer), persistent=False
+        )
         self.make_empty_intermediate_tensors = (
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -371,9 +371,9 @@ class Gemma3Model(nn.Module):
         # data type such as bfloat16, not float32.
         # See https://github.com/huggingface/transformers/pull/29402
         normalizer = self.config.hidden_size**0.5
-        self.register_buffer(
-            "normalizer", torch.tensor(normalizer), persistent=False
-        )
+        self.register_buffer("normalizer",
+                             torch.tensor(normalizer),
+                             persistent=False)
         self.make_empty_intermediate_tensors = (
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))


### PR DESCRIPTION
Prevents the Gemma embedding normalizer, which is a model invariant, from being scrambled by the dummy weight loader.

This is a quick fix for the problem when a vLLM Gemma model keeps producing gibberish in an RLHF setup (similar to the [RLHF example](https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/rlhf.py)) if it was initially loaded with dummy weights, _even after_ we send in the real weights. It is due to the dummy weight loader [traversing `state_dict` rather than `named_parameters`](https://github.com/vllm-project/vllm/blob/d4629dc43f92c189e90a3e2f2f8a52648aed4d9d/vllm/model_executor/model_loader/weight_utils.py#L689) and inadvertently randomizing the normalizer, which is a model invariant rather than a trainable weight.

A quick scan of the model registry indicates that other models register similar invariant buffers with `persistent=False`, thus not triggering this issue.

A long-term solution would be to provide an API for marking a buffer as invariant, e.g.
```
def register_invariant(self, name, tensor):
    tensor._no_dummy_init = True
    self.register_buffer(name, tensor)
```
and have `initialize_dummy_weights` respect that flag.