### PR TITLE
[Minor] Allow redirecting model path for HfRunner in test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from vllm.inputs import (ExplicitEncoderDecoderPrompt, TextPrompt,
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams
+from vllm.transformers_utils.utils import maybe_model_redirect
 from vllm.utils import cuda_device_count_stateless
 
 logger = init_logger(__name__)
@@ -318,6 +319,7 @@ class HfRunner:
         skip_tokenizer_init: bool = False,
         auto_cls: type[_BaseAutoModelClass] = AutoModelForCausalLM,
     ) -> None:
+        model_name = maybe_model_redirect(model_name)
         self.model_name = model_name
 
         self.config = AutoConfig.from_pretrained(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- https://github.com/vllm-project/vllm/pull/14116 introduced local model redirect for non-standard paths.
- Currently when running test with `VLLM_MODEL_REDIRECT_PATH` set up, only `VllmRunner` will be redirected to corresponding local model path, while `HfRunner` is still using remote HF model repo, causing test failing on machine without connection to HF.

## Test Plan
```
VLLM_MODEL_REDIRECT_PATH="/data/redirect.json" pytest -s -v tests/models/multimodal/generation/test_common.py -k qwen2_vl
```

## Test Result
- The above test can pass with local model redirection on a machine without HF connection.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
