### PR TITLE
[Misc][ROCm] Enforce no unused variable in ROCm C++ files

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -122,6 +122,7 @@ function (get_torch_gpu_compiler_flags OUT_GPU_FLAGS GPU_LANG)
       "-DENABLE_FP8"
       "-U__HIP_NO_HALF_CONVERSIONS__"
       "-U__HIP_NO_HALF_OPERATORS__"
+      "-Werror=unused-variable"
       "-fno-gpu-rdc")
 
   endif()


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
Ensure there is no unused variable in the ROCm C++ files. Follow up of https://github.com/vllm-project/vllm/pull/19609

## Test Plan
Local test
python setup.py develop

## Test Result
[Expect to fail and failed] With some unused variable ttt
/home/lufang/gitrepos/vllm/build/temp.linux-x86_64-cpython-310/csrc/rocm/attention.hip:3521:7: error: unused variable 'ttt' [-Werror,-Wunused-variable]
 3521 |   int ttt = 0;

[Expect to build and built] Without unused variables
Using /home/lufang/gitrepos/vllm/.venv/lib/python3.10/site-packages
Finished processing dependencies for vllm==0.9.2.dev137+g3c0e9e7cb.rocm631

## (Optional) Documentation Update
N/A
