### PR TITLE
[Docs] Add Huzaifa Sidhpurwala to vuln mgmt team doc

### DIFF
--- a/docs/contributing/vulnerability_management.md
+++ b/docs/contributing/vulnerability_management.md
@@ -34,6 +34,7 @@ you may contact the following individuals:
 
 - Simon Mo - simon.mo@hey.com
 - Russell Bryant - rbryant@redhat.com
+- Huzaifa Sidhpurwala - huzaifas@redhat.com
 
 ## Slack Discussion
 


### PR DESCRIPTION
Huzaifa has joined the vulnerability management team. He's on the
product security team at Red Hat and has extensive vulnerability
management experience.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
