### PR TITLE
[MISC] add cpu_kvcache_space_bytes to CacheConfig

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1506,6 +1506,8 @@ class CacheConfig:
     """This enables dynamic calculation of `k_scale` and `v_scale` when
     kv_cache_dtype is fp8. If `False`, the scales will be loaded from the model
     checkpoint if available. Otherwise, the scales will default to 1.0."""
+    cpu_kvcache_space_bytes: Optional[int] = None
+    """(CPU backend only) CPU key-value cache space."""
 
     # Will be set after profiling.
     num_gpu_blocks: Optional[int] = field(default=None, init=False)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
`cpu_kvcache_space_bytes` is used in `cpu.py` and `cpu_worker.py` files. Such as:
https://github.com/vllm-project/vllm/blob/8b6e1d639c66d5828d03a7df2c3a500030a5c5cd/vllm/worker/cpu_worker.py#L250-L255
https://github.com/vllm-project/vllm/blob/8b6e1d639c66d5828d03a7df2c3a500030a5c5cd/vllm/platforms/cpu.py#L128-L139

But it is not declared in `CacheConfig`.
## Test Plan
NA
## Test Result
NA
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
