### PR TITLE
Add Nvidia ModelOpt config adaptation

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test ModelOpt quantization method setup and weight loading.
+
+Run `pytest tests/quantization/test_modelopt.py`.
+"""
+
+import pytest
+import torch
+
+from tests.quantization.utils import is_quant_method_supported
+from vllm.platforms import current_platform
+
+
+@pytest.fixture(scope="function", autouse=True)
+def use_v0_only(monkeypatch):
+    """
+    This module relies on V0 internals, so set VLLM_USE_V1=0.
+    """
+    if not current_platform.is_cpu():
+        monkeypatch.setenv('VLLM_USE_V1', '0')
+
+
+@pytest.mark.skipif(not is_quant_method_supported("modelopt"),
+                    reason="ModelOpt FP8 is not supported on this GPU type.")
+def test_modelopt_fp8_checkpoint_setup(vllm_runner):
+    """Test ModelOpt FP8 checkpoint loading and internal structure validation."""
+    # TODO: provide a small publically available test checkpoint
+    model_path = "/home/scratch.omniml_data_1/zhiyu/ckpts/test_ckpts/TinyLlama-1.1B-Chat-v1.0-fp8-0710"
+
+    with vllm_runner(model_path,
+                     quantization="modelopt",
+                     enforce_eager=True) as llm:
+
+        def check_model(model):
+            layer = model.model.layers[0]
+
+            qkv_proj = layer.self_attn.qkv_proj
+            o_proj = layer.self_attn.o_proj
+            gate_up_proj = layer.mlp.gate_up_proj
+            down_proj = layer.mlp.down_proj
+
+            # Check that ModelOpt quantization method is properly applied
+            from vllm.model_executor.layers.quantization.modelopt import ModelOptFp8LinearMethod
+            assert isinstance(qkv_proj.quant_method, ModelOptFp8LinearMethod)
+            assert isinstance(o_proj.quant_method, ModelOptFp8LinearMethod)
+            assert isinstance(gate_up_proj.quant_method, ModelOptFp8LinearMethod)
+            assert isinstance(down_proj.quant_method, ModelOptFp8LinearMethod)
+
+            # Check weight dtype is FP8
+            assert qkv_proj.weight.dtype == torch.float8_e4m3fn
+            assert o_proj.weight.dtype == torch.float8_e4m3fn
+            assert gate_up_proj.weight.dtype == torch.float8_e4m3fn
+            assert down_proj.weight.dtype == torch.float8_e4m3fn
+
+            # Check scales are present and have correct dtype
+            assert hasattr(qkv_proj, 'weight_scale')
+            assert hasattr(qkv_proj, 'input_scale')
+            assert qkv_proj.weight_scale.dtype == torch.float32
+            assert qkv_proj.input_scale.dtype == torch.float32
+
+            assert hasattr(o_proj, 'weight_scale')
+            assert hasattr(o_proj, 'input_scale')
+            assert o_proj.weight_scale.dtype == torch.float32
+            assert o_proj.input_scale.dtype == torch.float32
+
+            assert hasattr(gate_up_proj, 'weight_scale')
+            assert hasattr(gate_up_proj, 'input_scale')
+            assert gate_up_proj.weight_scale.dtype == torch.float32
+            assert gate_up_proj.input_scale.dtype == torch.float32
+
+            assert hasattr(down_proj, 'weight_scale')
+            assert hasattr(down_proj, 'input_scale')
+            assert down_proj.weight_scale.dtype == torch.float32
+            assert down_proj.input_scale.dtype == torch.float32
+
+        llm.apply_model(check_model)
+
+        # Run a simple generation test to ensure the model works
+        output = llm.generate_greedy(["Hello my name is"], max_tokens=20)
+        assert output
+        print(f"ModelOpt FP8 output: {output}")

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -5,6 +5,7 @@
 Run `pytest tests/quantization/test_modelopt.py`.
 """
 
+import os
 import pytest
 import torch
 
@@ -28,6 +29,11 @@ def test_modelopt_fp8_checkpoint_setup(vllm_runner):
     # TODO: provide a small publically available test checkpoint
     model_path = ("/home/scratch.omniml_data_1/zhiyu/ckpts/test_ckpts/"
                   "TinyLlama-1.1B-Chat-v1.0-fp8-0710")
+
+    # Skip test if checkpoint doesn't exist
+    if not os.path.exists(model_path):
+        pytest.skip(f"Test checkpoint not found at {model_path}. "
+                   "This test requires a local ModelOpt FP8 checkpoint.")
 
     with vllm_runner(model_path, quantization="modelopt",
                      enforce_eager=True) as llm:

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -24,12 +24,12 @@ def use_v0_only(monkeypatch):
 @pytest.mark.skipif(not is_quant_method_supported("modelopt"),
                     reason="ModelOpt FP8 is not supported on this GPU type.")
 def test_modelopt_fp8_checkpoint_setup(vllm_runner):
-    """Test ModelOpt FP8 checkpoint loading and internal structure validation."""
+    """Test ModelOpt FP8 checkpoint loading and structure validation."""
     # TODO: provide a small publically available test checkpoint
-    model_path = "/home/scratch.omniml_data_1/zhiyu/ckpts/test_ckpts/TinyLlama-1.1B-Chat-v1.0-fp8-0710"
+    model_path = ("/home/scratch.omniml_data_1/zhiyu/ckpts/test_ckpts/"
+                  "TinyLlama-1.1B-Chat-v1.0-fp8-0710")
 
-    with vllm_runner(model_path,
-                     quantization="modelopt",
+    with vllm_runner(model_path, quantization="modelopt",
                      enforce_eager=True) as llm:
 
         def check_model(model):
@@ -41,10 +41,12 @@ def test_modelopt_fp8_checkpoint_setup(vllm_runner):
             down_proj = layer.mlp.down_proj
 
             # Check that ModelOpt quantization method is properly applied
-            from vllm.model_executor.layers.quantization.modelopt import ModelOptFp8LinearMethod
+            from vllm.model_executor.layers.quantization.modelopt import (
+                ModelOptFp8LinearMethod)
             assert isinstance(qkv_proj.quant_method, ModelOptFp8LinearMethod)
             assert isinstance(o_proj.quant_method, ModelOptFp8LinearMethod)
-            assert isinstance(gate_up_proj.quant_method, ModelOptFp8LinearMethod)
+            assert isinstance(gate_up_proj.quant_method,
+                              ModelOptFp8LinearMethod)
             assert isinstance(down_proj.quant_method, ModelOptFp8LinearMethod)
 
             # Check weight dtype is FP8

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -6,6 +6,7 @@ Run `pytest tests/quantization/test_modelopt.py`.
 """
 
 import os
+
 import pytest
 import torch
 
@@ -33,7 +34,7 @@ def test_modelopt_fp8_checkpoint_setup(vllm_runner):
     # Skip test if checkpoint doesn't exist
     if not os.path.exists(model_path):
         pytest.skip(f"Test checkpoint not found at {model_path}. "
-                   "This test requires a local ModelOpt FP8 checkpoint.")
+                    "This test requires a local ModelOpt FP8 checkpoint.")
 
     with vllm_runner(model_path, quantization="modelopt",
                      enforce_eager=True) as llm:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -904,7 +904,7 @@ class ModelConfig:
         quant_cfg = self._parse_quant_hf_config()
 
         if quant_cfg is not None:
-            # Support both 'quant_library' (preferred) and 'quant_method' (backward compatibility)
+            # Support both 'quant_library' (preferred) and 'quant_method'
             quant_library = quant_cfg.get("quant_library", "").lower()
             if not quant_library:
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -911,8 +911,8 @@ class ModelConfig:
                 quant_library = quant_cfg.get("quant_method", "").lower()
 
             # Normalize library names
-            quant_library = quant_library.replace("compressed_tensors",
-                                                  "compressed-tensors")
+            quant_library = quant_library.replace(
+                "compressed_tensors", "compressed-tensors")
 
             quant_cfg["quant_method"] = quant_library
             quant_method = quant_library

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -928,6 +928,8 @@ class ModelConfig:
                 "awq_marlin",
                 "ipex",
                 "moe_wna16",
+                "modelopt",
+                "modelopt_fp4",
             ]
             quantization_methods = [
                 q for q in supported_quantization if q not in overrides

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -347,11 +347,11 @@ class ModelConfig:
     """Maximum number of data items per modality per prompt. Only applicable
     for multimodal models."""
     interleave_mm_strings: bool = False
-    """Enable fully interleaved support for multimodal prompts, while using 
+    """Enable fully interleaved support for multimodal prompts, while using
     --chat-template-content-format=string. Defaults to False."""
     media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)
-    """Additional args passed to process media inputs, keyed by modalities. 
-    For example, to set num_frames for video, set 
+    """Additional args passed to process media inputs, keyed by modalities.
+    For example, to set num_frames for video, set
     `--media-io-kwargs '{"video": {"num_frames": 40} }'` """
     use_async_output_proc: bool = True
     """Whether to use async output processor."""
@@ -904,18 +904,14 @@ class ModelConfig:
         quant_cfg = self._parse_quant_hf_config()
 
         if quant_cfg is not None:
-            # Support both 'quant_library' (preferred) and 'quant_method'
-            quant_library = quant_cfg.get("quant_library", "").lower()
-            if not quant_library:
-
-                quant_library = quant_cfg.get("quant_method", "").lower()
+            # Use the community standard 'quant_method'
+            quant_method = quant_cfg.get("quant_method", "").lower()
 
             # Normalize library names
-            quant_library = quant_library.replace("compressed_tensors",
-                                                  "compressed-tensors")
+            quant_method = quant_method.replace("compressed_tensors",
+                                                "compressed-tensors")
 
-            quant_cfg["quant_method"] = quant_library
-            quant_method = quant_library
+            quant_cfg["quant_method"] = quant_method
 
             # Quantization methods which are overrides (i.e. they have a
             # `override_quantization_method` method) must be checked in order
@@ -3156,8 +3152,8 @@ class MultiModalConfig:
     """
 
     media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)
-    """Additional args passed to process media inputs, keyed by modalities. 
-    For example, to set num_frames for video, set 
+    """Additional args passed to process media inputs, keyed by modalities.
+    For example, to set num_frames for video, set
     `--media-io-kwargs '{"video": {"num_frames": 40} }'` """
 
     mm_processor_kwargs: Optional[dict[str, object]] = None
@@ -4090,7 +4086,7 @@ class CompilationConfig:
     - True: inductor compilation is used (custom_ops disabled by default).
         One graph for symbolic shape and one graph per size in compile_sizes
         are compiled using configurations in inductor_compile_config.
-        
+
     This setting is ignored if level<PIECEWISE."""
     compile_sizes: Optional[list[Union[int, str]]] = None
     """Sizes to compile for inductor. In addition
@@ -4388,7 +4384,7 @@ class VllmConfig:
 
     As a shorthand, `-O<n>` can be used to directly specify the compilation
     level `n`: `-O3` is equivalent to `-O.level=3` (same as `-O='{"level":3}'`).
-    Currently, -O <n> and -O=<n> are supported as well but this will likely be 
+    Currently, -O <n> and -O=<n> are supported as well but this will likely be
     removed in favor of clearer -O<n> syntax in the future.
 
     NOTE: level 0 is the default level without any optimization. level 1 and 2

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -904,10 +904,17 @@ class ModelConfig:
         quant_cfg = self._parse_quant_hf_config()
 
         if quant_cfg is not None:
-            quant_method = quant_cfg.get("quant_method", "").lower()
-            quant_method = quant_method.replace("compressed_tensors",
-                                                "compressed-tensors")
-            quant_cfg["quant_method"] = quant_method
+            # Support both 'quant_library' (preferred) and 'quant_method' (backward compatibility)
+            quant_library = quant_cfg.get("quant_library", "").lower()
+            if not quant_library:
+
+                quant_library = quant_cfg.get("quant_method", "").lower()
+
+            # Normalize library names
+            quant_library = quant_library.replace("compressed_tensors", "compressed-tensors")
+
+            quant_cfg["quant_method"] = quant_library
+            quant_method = quant_library
 
             # Quantization methods which are overrides (i.e. they have a
             # `override_quantization_method` method) must be checked in order

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -911,8 +911,8 @@ class ModelConfig:
                 quant_library = quant_cfg.get("quant_method", "").lower()
 
             # Normalize library names
-            quant_library = quant_library.replace(
-                "compressed_tensors", "compressed-tensors")
+            quant_library = quant_library.replace("compressed_tensors",
+                                                  "compressed-tensors")
 
             quant_cfg["quant_method"] = quant_library
             quant_method = quant_library

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -911,7 +911,8 @@ class ModelConfig:
                 quant_library = quant_cfg.get("quant_method", "").lower()
 
             # Normalize library names
-            quant_library = quant_library.replace("compressed_tensors", "compressed-tensors")
+            quant_library = quant_library.replace("compressed_tensors",
+                                                  "compressed-tensors")
 
             quant_cfg["quant_method"] = quant_library
             quant_method = quant_library

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -70,7 +70,8 @@ class ModelOptFp8Config(QuantizationConfig):
         return ["hf_quant_config.json"]
 
     @classmethod
-    def override_quantization_method(cls, hf_quant_cfg, user_quant) -> Optional[str]:
+    def override_quantization_method(cls, hf_quant_cfg,
+                                     user_quant) -> Optional[str]:
         """Detect if this ModelOpt config should be used based on quantization config."""
         if hf_quant_cfg is None:
             return None
@@ -87,7 +88,8 @@ class ModelOptFp8Config(QuantizationConfig):
                 if "FP8" in quant_algo:
                     return "modelopt"
             # Also check for compressed-tensors style config with modelopt
-            elif any("FP8" in str(v).upper() for v in hf_quant_cfg.values() if isinstance(v, (str, dict))):
+            elif any("FP8" in str(v).upper() for v in hf_quant_cfg.values()
+                     if isinstance(v, (str, dict))):
                 return "modelopt"
 
         return None
@@ -489,7 +491,8 @@ class ModelOptNvFp4Config(QuantizationConfig):
         return ["hf_quant_config.json"]
 
     @classmethod
-    def override_quantization_method(cls, hf_quant_cfg, user_quant) -> Optional[str]:
+    def override_quantization_method(cls, hf_quant_cfg,
+                                     user_quant) -> Optional[str]:
         """Detect if this ModelOpt FP4 config should be used based on quantization config."""
         if hf_quant_cfg is None:
             return None
@@ -506,7 +509,8 @@ class ModelOptNvFp4Config(QuantizationConfig):
                 if "NVFP4" in quant_algo:
                     return "modelopt_fp4"
             # Also check for compressed-tensors style config with modelopt FP4
-            elif any("FP4" in str(v).upper() for v in hf_quant_cfg.values() if isinstance(v, (str, dict))):
+            elif any("FP4" in str(v).upper() for v in hf_quant_cfg.values()
+                     if isinstance(v, (str, dict))):
                 return "modelopt_fp4"
 
         return None

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -70,8 +70,8 @@ class ModelOptFp8Config(QuantizationConfig):
         return ["hf_quant_config.json"]
 
     @classmethod
-    def override_quantization_method(cls, hf_quant_cfg,
-                                user_quant) -> Optional[QuantizationMethods]:
+    def override_quantization_method(
+            cls, hf_quant_cfg, user_quant) -> Optional[QuantizationMethods]:
         """Detect if this ModelOpt config should be used based on
         quantization config."""
 
@@ -506,8 +506,7 @@ class ModelOptNvFp4Config(QuantizationConfig):
 
     @classmethod
     def override_quantization_method(
-        cls, hf_quant_cfg, user_quant
-    ) -> Optional[QuantizationMethods]:
+            cls, hf_quant_cfg, user_quant) -> Optional[QuantizationMethods]:
         """Detect if this ModelOpt FP4 config should be used based on
         quantization config."""
         if hf_quant_cfg is None:
@@ -561,9 +560,8 @@ class ModelOptNvFp4Config(QuantizationConfig):
             elif isinstance(kv_cache_quant_algo_raw, str):
                 kv_cache_quant_algo = kv_cache_quant_algo_raw
             else:
-                raise ValueError(
-                    f"kv_cache_quant_algo must be a string, got "
-                    f"{type(kv_cache_quant_algo_raw)}")
+                raise ValueError(f"kv_cache_quant_algo must be a string, got "
+                                 f"{type(kv_cache_quant_algo_raw)}")
 
             # Handle group_size with proper type validation
             group_size_raw = quant_config.get("group_size")
@@ -575,15 +573,13 @@ class ModelOptNvFp4Config(QuantizationConfig):
                 try:
                     group_size = int(group_size_raw)
                 except (ValueError, TypeError):
-                    raise ValueError(
-                        f"group_size must be an integer, got "
-                        f"{type(group_size_raw)}") from None
+                    raise ValueError(f"group_size must be an integer, got "
+                                     f"{type(group_size_raw)}") from None
 
             exclude_modules = quant_config.get("exclude_modules", [])
             if not isinstance(exclude_modules, list):
-                raise ValueError(
-                    f"exclude_modules must be a list, got "
-                    f"{type(exclude_modules)}")
+                raise ValueError(f"exclude_modules must be a list, got "
+                                 f"{type(exclude_modules)}")
         else:
             # Compressed-tensors style format:
             # {"quant_algo": "...", "quant_library": "modelopt"}
@@ -597,9 +593,8 @@ class ModelOptNvFp4Config(QuantizationConfig):
             elif isinstance(kv_cache_quant_algo_raw, str):
                 kv_cache_quant_algo = kv_cache_quant_algo_raw
             else:
-                raise ValueError(
-                    f"kv_cache_quant_algo must be a string, got "
-                    f"{type(kv_cache_quant_algo_raw)}")
+                raise ValueError(f"kv_cache_quant_algo must be a string, got "
+                                 f"{type(kv_cache_quant_algo_raw)}")
 
             # Handle group_size with proper type validation
             group_size_raw = config.get("group_size")
@@ -611,15 +606,13 @@ class ModelOptNvFp4Config(QuantizationConfig):
                 try:
                     group_size = int(group_size_raw)
                 except (ValueError, TypeError):
-                    raise ValueError(
-                        f"group_size must be an integer, got "
-                        f"{type(group_size_raw)}") from None
+                    raise ValueError(f"group_size must be an integer, got "
+                                     f"{type(group_size_raw)}") from None
 
             exclude_modules = config.get("exclude_modules", [])
             if not isinstance(exclude_modules, list):
-                raise ValueError(
-                    f"exclude_modules must be a list, got "
-                    f"{type(exclude_modules)}")
+                raise ValueError(f"exclude_modules must be a list, got "
+                                 f"{type(exclude_modules)}")
 
         if quant_method not in QUANT_ALGOS:
             raise ValueError(
@@ -633,10 +626,12 @@ class ModelOptNvFp4Config(QuantizationConfig):
         if is_checkpoint_nvfp4_serialized and "quantization" in config:
             # Check if required fields are present in the quantization config
             quant_config = config["quantization"]
-            required_fields = ["group_size", "kv_cache_quant_algo",
-                              "exclude_modules"]
-            missing_fields = [field for field in required_fields
-                             if field not in quant_config]
+            required_fields = [
+                "group_size", "kv_cache_quant_algo", "exclude_modules"
+            ]
+            missing_fields = [
+                field for field in required_fields if field not in quant_config
+            ]
             if missing_fields:
                 raise ValueError(
                     f"NVFP4 quantization requires the following fields in "

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -78,12 +78,11 @@ class ModelOptFp8Config(QuantizationConfig):
         if hf_quant_cfg is None:
             return None
 
-        quant_library = hf_quant_cfg.get("quant_library", "").lower()
-        if not quant_library:
-            quant_library = hf_quant_cfg.get("quant_method", "").lower()
+        # Use the community standard 'quant_method'
+        quant_method = hf_quant_cfg.get("quant_method", "").lower()
 
-        # Only proceed if the library is explicitly "modelopt"
-        if quant_library != "modelopt":
+        # Only proceed if the method is explicitly "modelopt"
+        if quant_method != "modelopt":
             return None
 
         # Look for ModelOpt-specific config structure
@@ -117,7 +116,7 @@ class ModelOptFp8Config(QuantizationConfig):
             exclude_modules = quant_config.get("exclude_modules")
         else:
             # Compressed-tensors style format:
-            # {"quant_algo": "...", "quant_library": "modelopt"}
+            # {"quant_algo": "...", "quant_method": "modelopt"}
             quant_method = config.get("quant_algo", "")
             kv_cache_quant_method = config.get("kv_cache_quant_algo")
             exclude_modules = config.get("exclude_modules")
@@ -512,12 +511,11 @@ class ModelOptNvFp4Config(QuantizationConfig):
         if hf_quant_cfg is None:
             return None
 
-        quant_library = hf_quant_cfg.get("quant_library", "").lower()
-        if not quant_library:
-            quant_library = hf_quant_cfg.get("quant_method", "").lower()
+        # Use the community standard 'quant_method'
+        quant_method = hf_quant_cfg.get("quant_method", "").lower()
 
-        # Only proceed if the library is explicitly "modelopt"
-        if quant_library != "modelopt":
+        # Only proceed if the method is explicitly "modelopt"
+        if quant_method != "modelopt":
             return None
 
         # Look for ModelOpt-specific config structure
@@ -582,7 +580,7 @@ class ModelOptNvFp4Config(QuantizationConfig):
                                  f"{type(exclude_modules)}")
         else:
             # Compressed-tensors style format:
-            # {"quant_algo": "...", "quant_library": "modelopt"}
+            # {"quant_algo": "...", "quant_method": "modelopt"}
             quant_method = config.get("quant_algo", "")
 
             # Handle kv_cache_quant_algo with proper type validation

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -71,7 +71,7 @@ class ModelOptFp8Config(QuantizationConfig):
 
     @classmethod
     def override_quantization_method(cls, hf_quant_cfg,
-                                     user_quant) -> Optional[str]:
+                                     user_quant) -> Optional[QuantizationMethods]:
         """Detect if this ModelOpt config should be used based on quantization config."""
         if hf_quant_cfg is None:
             return None
@@ -88,7 +88,8 @@ class ModelOptFp8Config(QuantizationConfig):
                 if "FP8" in quant_algo:
                     return "modelopt"
             # Also check for compressed-tensors style config with modelopt
-            elif any("FP8" in str(v).upper() for v in hf_quant_cfg.values()
+            elif any("FP8" in str(v).upper()
+                     for v in hf_quant_cfg.values()
                      if isinstance(v, (str, dict))):
                 return "modelopt"
 
@@ -110,10 +111,11 @@ class ModelOptFp8Config(QuantizationConfig):
             exclude_modules = config.get("exclude_modules")
 
         if quant_method not in QUANT_ALGOS:
-            raise ValueError(f"ModelOpt currently only supports: {QUANT_ALGOS}"
-                             " quantizations in vLLM. Please check the "
-                             "`hf_quant_config.json` file for your model's "
-                             "quant configuration.")
+            raise ValueError(
+                f"ModelOpt currently only supports: {QUANT_ALGOS} "
+                "quantizations in vLLM. Please check the "
+                "`hf_quant_config.json` file for your model's "
+                "quant configuration.")
         is_checkpoint_fp8_serialized = ("FP8" in quant_method)
 
         return cls(is_checkpoint_fp8_serialized, kv_cache_quant_method,
@@ -492,7 +494,7 @@ class ModelOptNvFp4Config(QuantizationConfig):
 
     @classmethod
     def override_quantization_method(cls, hf_quant_cfg,
-                                     user_quant) -> Optional[str]:
+                                     user_quant) -> Optional[QuantizationMethods]:
         """Detect if this ModelOpt FP4 config should be used based on quantization config."""
         if hf_quant_cfg is None:
             return None
@@ -509,7 +511,8 @@ class ModelOptNvFp4Config(QuantizationConfig):
                 if "NVFP4" in quant_algo:
                     return "modelopt_fp4"
             # Also check for compressed-tensors style config with modelopt FP4
-            elif any("FP4" in str(v).upper() for v in hf_quant_cfg.values()
+            elif any("FP4" in str(v).upper()
+                     for v in hf_quant_cfg.values()
                      if isinstance(v, (str, dict))):
                 return "modelopt_fp4"
 
@@ -533,19 +536,21 @@ class ModelOptNvFp4Config(QuantizationConfig):
             exclude_modules = config.get("exclude_modules", [])
 
         if quant_method not in QUANT_ALGOS:
-            raise ValueError(f"ModelOpt currently only supports: {QUANT_ALGOS}"
-                             " quantizations in vLLM. Please check the "
-                             "`hf_quant_config.json` file for your model's "
-                             "quant configuration.")
+            raise ValueError(
+                f"ModelOpt currently only supports: {QUANT_ALGOS} "
+                "quantizations in vLLM. Please check the "
+                "`hf_quant_config.json` file for your model's "
+                "quant configuration.")
         is_checkpoint_nvfp4_serialized = ("NVFP4" in quant_method)
 
         # For FP4, these fields are required
-        if is_checkpoint_nvfp4_serialized and "quantization" in config:
-            if ("group_size" and "kv_cache_quant_algo"
-                    and "exclude_modules") not in config["quantization"]:
-                raise ValueError("NVFP4 quantization requires group size and "
-                                 "kv_cache_quant_algo specified in "
-                                 "hf_quant_config.json")
+        if (is_checkpoint_nvfp4_serialized and "quantization" in config
+            and ("group_size" and "kv_cache_quant_algo"
+                 and "exclude_modules") not in config["quantization"]):
+            raise ValueError(
+                "NVFP4 quantization requires group size and "
+                "kv_cache_quant_algo specified in "
+                "hf_quant_config.json")
 
         return cls(is_checkpoint_nvfp4_serialized, kv_cache_quant_algo,
                    exclude_modules, group_size)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

This PR is to add [Nvidia TensorRT Model Optimizer](https://github.com/NVIDIA/TensorRT-Model-Optimizer) (`modelopt`) config adaptation with auto detection. This is part of the efforts to unify `modelopt`'s config format and `compressed-tensor`'s config format.  

- ~~Update config parsing to look for `quant_library` instead of `quant_method`.~~
- ~~Maintain backward compatibility by checking both field names.~~
- Add `modelopt` config adaptation to handle it as a quant method option.
- Add a unit test for modelopt fp8 checkpoint `test_modelopt.py`

It's essentially format standardization while preserving library-specific functionality.

## Test Plan

```python
from vllm import LLM, SamplingParams
def main():

    model_id = "Llama-3.1-8B-Instruct-FP8"
    sampling_params = SamplingParams(temperature=0.7, top_p=0.9)

    prompts = [
        "Hello, my name is",
        "The president of the United States is",
        "The capital of France is",
        "The future of AI is",
    ]

    llm = LLM(model=model_id, quantization="modelopt")
    outputs = llm.generate(prompts, sampling_params)

    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

if __name__ == "__main__":
    main()
```

`Llama-3.1-8B-Instruct-FP8` is produced by `modelopt` with per-tensor FP8 weights and activations. It can be generated by running the following command under [this directory](https://github.com/NVIDIA/TensorRT-Model-Optimizer/tree/main/examples/llm_ptq).   

`python hf_ptq.py --pyt_ckpt_path meta-llama/Llama-3.1-8B-Instruct --qformat fp8 --export_fmt hf --export_path Llama-3.1-8B-Instruct-FP8 --trust_remote_code`

The quantization config in the exported `config.json` would look like the following:
```yaml
    "quantization_config": {
        "config_groups": {
            "group_0": {
                "input_activations": {
                    "dynamic": false,
                    "num_bits": 8,
                    "type": "float"
                },
                "weights": {
                    "dynamic": false,
                    "num_bits": 8,
                    "type": "float"
                },
                "targets": ["Linear"]
            }
        },
        "ignore": [
            "lm_head"
        ],
        "quant_algo": "FP8",
        "kv_cache_scheme": {
            "dynamic": false,
            "num_bits": 8,
            "type": "float"
        },
        "quant_method": "modelopt",
        "producer": {
            "name": "modelopt",
            "version": "0.33.0"
        }
    }
```

## Test Result
```
Prompt: 'Hello, my name is', Generated text: ' Helen and I am a 6th grade math teacher. I love teaching math'
Prompt: 'The president of the United States is', Generated text: ' the head of the federal government. He is the leader of the country and is'
Prompt: 'The capital of France is', Generated text: ' Paris, a city that has been called the most romantic city in the world.'
Prompt: 'The future of AI is', Generated text: ' not just about technology, but about the people and the world we create with it'
```
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
