### PR TITLE
[Kernel] Add Conch backend for mixed-precision linear layer

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -45,3 +45,4 @@ python-json-logger # Used by logging as per examples/others/logging_configuratio
 scipy # Required for phi-4-multimodal-instruct
 ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
+conch-triton-kernels >= 1.2.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -45,4 +45,3 @@ python-json-logger # Used by logging as per examples/others/logging_configuratio
 scipy # Required for phi-4-multimodal-instruct
 ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
-conch-triton-kernels >= 1.2.1

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -17,3 +17,4 @@ setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 runai-model-streamer==0.11.0
 runai-model-streamer-s3==0.11.0
+conch-triton-kernels==1.2.1

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
@@ -26,8 +26,8 @@ _POSSIBLE_KERNELS: list[type[MPLinearKernel]] = [
     AllSparkLinearKernel,
     MarlinLinearKernel,
     BitBLASLinearKernel,
-    ExllamaLinearKernel,
     ConchLinearKernel,
+    ExllamaLinearKernel,
 ]
 
 

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
@@ -8,6 +8,8 @@ from vllm.model_executor.layers.quantization.kernels.mixed_precision.allspark im
     AllSparkLinearKernel)
 from vllm.model_executor.layers.quantization.kernels.mixed_precision.bitblas import (  # noqa: E501
     BitBLASLinearKernel)
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.conch import (  # noqa: E501
+    ConchLinearKernel)
 from vllm.model_executor.layers.quantization.kernels.mixed_precision.exllama import (  # noqa: E501
     ExllamaLinearKernel)
 from vllm.model_executor.layers.quantization.kernels.mixed_precision.machete import (  # noqa: E501
@@ -25,6 +27,7 @@ _POSSIBLE_KERNELS: list[type[MPLinearKernel]] = [
     MarlinLinearKernel,
     BitBLASLinearKernel,
     ExllamaLinearKernel,
+    ConchLinearKernel,
 ]
 
 

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Final, Optional
+
+import torch
+from conch.ops.quantization.gemm import mixed_precision_gemm
+
+from vllm.model_executor.parameter import (BasevLLMParameter,
+                                           permute_param_layout_)
+from vllm.scalar_type import scalar_types
+
+from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
+
+_CONCH_SUPPORTED_WEIGHT_TYPES: Final = [
+    scalar_types.uint4, scalar_types.uint8, scalar_types.uint4b8,
+    scalar_types.uint8b128
+]
+_CONCH_SUPPORTED_GROUP_SIZES: Final = [-1, 128]
+
+
+class ConchLinearKernel(MPLinearKernel):
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    @classmethod
+    def can_implement(cls,
+                      c: MPLinearLayerConfig) -> tuple[bool, Optional[str]]:
+        if c.weight_type not in _CONCH_SUPPORTED_WEIGHT_TYPES:
+            error_msg = f"Weight type ({c.weight_type}) not supported by "\
+                        "ConchLinearKernel, supported types are: " \
+                        f"{_CONCH_SUPPORTED_WEIGHT_TYPES}"
+            return False, error_msg
+
+        if c.group_size not in _CONCH_SUPPORTED_GROUP_SIZES:
+            error_msg = f"Group size ({c.group_size}) not supported by "\
+                        "ConchLinearKernel, supported group sizes are: " \
+                        f"{_CONCH_SUPPORTED_GROUP_SIZES}"
+            return False, error_msg
+
+        return True, None
+
+    # note assumes that
+    #  `weight_packed` is: {input_dim = 0, output_dim = 1, packed_dim = 0}
+    #  `weight_scale` is: {input_dim = 0, output_dim = 1}
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+
+        def transform_w_q(x):
+            assert isinstance(x, BasevLLMParameter)
+            permute_param_layout_(x, input_dim=0, output_dim=1, packed_dim=0)
+            x.data = x.data.contiguous()
+            return x
+
+        def transform_w_s(x):
+            assert isinstance(x, BasevLLMParameter)
+            permute_param_layout_(x, input_dim=0, output_dim=1)
+            x.data = x.data.contiguous()
+            return x
+
+        self._transform_param(layer, self.w_q_name, transform_w_q)
+        self._transform_param(layer, self.w_s_name, transform_w_s)
+
+    def apply_weights(self,
+                      layer: torch.nn.Module,
+                      x: torch.Tensor,
+                      bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        w_q, w_s, w_zp, _ = self._get_weight_params(layer)
+
+        output = mixed_precision_gemm(
+            x=x,
+            w_q_packed=w_q.data,
+            w_s=w_s.data,
+            w_zp=w_zp.data if w_zp is not None else None,
+            weight_size_bits=self.config.weight_type.size_bits,
+            weight_bias=self.config.weight_type.bias,
+            group_size=self.config.group_size,
+        )
+
+        if bias is not None:
+            output.add_(bias)  # In-place add
+
+        return output

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from importlib.util import find_spec
 from typing import Final, Optional
 
 import torch
-from conch.ops.quantization.gemm import mixed_precision_gemm
 
 from vllm.model_executor.parameter import (BasevLLMParameter,
                                            permute_param_layout_)
@@ -39,6 +40,12 @@ class ConchLinearKernel(MPLinearKernel):
                         f"{_CONCH_SUPPORTED_GROUP_SIZES}"
             return False, error_msg
 
+        if find_spec("conch") is None:
+            error_msg = "conch-triton-kernels is not installed, please "\
+                        "install it via `pip install conch-triton-kernels` "\
+                        "and try again!"
+            return False, error_msg
+
         return True, None
 
     # note assumes that
@@ -65,6 +72,8 @@ class ConchLinearKernel(MPLinearKernel):
                       layer: torch.nn.Module,
                       x: torch.Tensor,
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        from conch.ops.quantization.gemm import mixed_precision_gemm
+
         w_q, w_s, w_zp, _ = self._get_weight_params(layer)
 
         output = mixed_precision_gemm(

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     pack_quantized_values_into_int32, unpack_quantized_values_into_int32)
 from vllm.model_executor.parameter import (BasevLLMParameter,
                                            permute_param_layout_)
+from vllm.platforms import current_platform
 
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
@@ -27,6 +28,9 @@ class MacheteLinearKernel(MPLinearKernel):
     @classmethod
     def can_implement(cls,
                       c: MPLinearLayerConfig) -> tuple[bool, Optional[str]]:
+        # Machete uses CUTLASS, so it can only be compatible with Nvidia
+        if not current_platform.is_cuda():
+            return False, "Machete only supported on CUDA"
 
         if c.has_g_idx and\
             c.partition_weight_shape[0] != c.full_weight_shape[0]:

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_zero_points, query_marlin_supported_quant_types, unpack_cols)
 from vllm.model_executor.parameter import (BasevLLMParameter,
                                            permute_param_layout_)
+from vllm.platforms import current_platform
 
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
@@ -26,6 +27,9 @@ class MarlinLinearKernel(MPLinearKernel):
     @classmethod
     def can_implement(cls,
                       c: MPLinearLayerConfig) -> tuple[bool, Optional[str]]:
+        # Marlin uses inline PTX, so it can only be compatible with Nvidia
+        if not current_platform.is_cuda():
+            return False, "Marlin only supported on CUDA"
 
         quant_types = query_marlin_supported_quant_types(c.zero_points)
         if c.weight_type not in quant_types:


### PR DESCRIPTION
## Purpose

This PR adds a new mixed-precision linear layer (wna16) using [Conch](https://github.com/stackav-oss/conch), for platform-agnostic, Triton-only execution. This is particularly useful for Compressed-Tensors wna16 quantization, which is currently not supported on AMD.

## Test Plan

**Command**

```
VLLM_USE_V1=1 vllm serve ISTA-DASLab/Mistral-Small-3.1-24B-Instruct-2503-GPTQ-4b-128g --max-model-len 8192 --max-seq-len 8192
```

**Before this PR**

```
ERROR 06-18 18:01:16 [core.py:520] EngineCore failed to start.
ERROR 06-18 18:01:16 [core.py:520] Traceback (most recent call last):
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/v1/engine/core.py", line 511, in run_engine_core
ERROR 06-18 18:01:16 [core.py:520]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/v1/engine/core.py", line 395, in __init__
ERROR 06-18 18:01:16 [core.py:520]     super().__init__(vllm_config, executor_class, log_stats,
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/v1/engine/core.py", line 76, in __init__
ERROR 06-18 18:01:16 [core.py:520]     self.model_executor = executor_class(vllm_config)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/executor/executor_base.py", line 53, in __init__
ERROR 06-18 18:01:16 [core.py:520]     self._init_executor()
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/executor/uniproc_executor.py", line 48, in _init_executor
ERROR 06-18 18:01:16 [core.py:520]     self.collective_rpc("load_model")
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/executor/uniproc_executor.py", line 57, in collective_rpc
ERROR 06-18 18:01:16 [core.py:520]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/utils.py", line 2690, in run_method
ERROR 06-18 18:01:16 [core.py:520]     return func(*args, **kwargs)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/v1/worker/gpu_worker.py", line 185, in load_model
ERROR 06-18 18:01:16 [core.py:520]     self.model_runner.load_model()
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/v1/worker/gpu_model_runner.py", line 1633, in load_model
ERROR 06-18 18:01:16 [core.py:520]     self.model = model_loader.load_model(
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/model_executor/model_loader/base_loader.py", line 42, in load_model
ERROR 06-18 18:01:16 [core.py:520]     process_weights_after_loading(model, model_config, target_device)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/model_executor/model_loader/utils.py", line 113, in process_weights_after_loading
ERROR 06-18 18:01:16 [core.py:520]     quant_method.process_weights_after_loading(module)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py", line 595, in process_weights_after_loading
ERROR 06-18 18:01:16 [core.py:520]     layer.scheme.process_weights_after_loading(layer)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py", line 197, in process_weights_after_loading
ERROR 06-18 18:01:16 [core.py:520]     self.kernel.process_weights_after_loading(layer)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py", line 94, in process_weights_after_loading
ERROR 06-18 18:01:16 [core.py:520]     self._transform_param(layer, self.w_q_name, transform_w_q)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py", line 71, in _transform_param
ERROR 06-18 18:01:16 [core.py:520]     new_param = fn(old_param)
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py", line 81, in transform_w_q
ERROR 06-18 18:01:16 [core.py:520]     x.data = ops.machete_prepack_B(x.data.t().contiguous().t(),
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm/vllm/_custom_ops.py", line 1093, in machete_prepack_B
ERROR 06-18 18:01:16 [core.py:520]     return torch.ops._C.machete_prepack_B(b_q_weight, a_type, b_type.id,
ERROR 06-18 18:01:16 [core.py:520]   File "/home/jmanning/vllm_v1/lib/python3.10/site-packages/torch/_ops.py", line 1317, in __getattr__
ERROR 06-18 18:01:16 [core.py:520]     raise AttributeError(
ERROR 06-18 18:01:16 [core.py:520] AttributeError: '_OpNamespace' '_C' object has no attribute 'machete_prepack_B'
Process EngineCore_0:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jmanning/vllm/vllm/v1/engine/core.py", line 524, in run_engine_core
    raise e
  File "/home/jmanning/vllm/vllm/v1/engine/core.py", line 511, in run_engine_core
    engine_core = EngineCoreProc(*args, **kwargs)
  File "/home/jmanning/vllm/vllm/v1/engine/core.py", line 395, in __init__
    super().__init__(vllm_config, executor_class, log_stats,
  File "/home/jmanning/vllm/vllm/v1/engine/core.py", line 76, in __init__
    self.model_executor = executor_class(vllm_config)
  File "/home/jmanning/vllm/vllm/executor/executor_base.py", line 53, in __init__
    self._init_executor()
  File "/home/jmanning/vllm/vllm/executor/uniproc_executor.py", line 48, in _init_executor
    self.collective_rpc("load_model")
  File "/home/jmanning/vllm/vllm/executor/uniproc_executor.py", line 57, in collective_rpc
    answer = run_method(self.driver_worker, method, args, kwargs)
  File "/home/jmanning/vllm/vllm/utils.py", line 2690, in run_method
    return func(*args, **kwargs)
  File "/home/jmanning/vllm/vllm/v1/worker/gpu_worker.py", line 185, in load_model
    self.model_runner.load_model()
  File "/home/jmanning/vllm/vllm/v1/worker/gpu_model_runner.py", line 1633, in load_model
    self.model = model_loader.load_model(
  File "/home/jmanning/vllm/vllm/model_executor/model_loader/base_loader.py", line 42, in load_model
    process_weights_after_loading(model, model_config, target_device)
  File "/home/jmanning/vllm/vllm/model_executor/model_loader/utils.py", line 113, in process_weights_after_loading
    quant_method.process_weights_after_loading(module)
  File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py", line 595, in process_weights_after_loading
    layer.scheme.process_weights_after_loading(layer)
  File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py", line 197, in process_weights_after_loading
    self.kernel.process_weights_after_loading(layer)
  File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py", line 94, in process_weights_after_loading
    self._transform_param(layer, self.w_q_name, transform_w_q)
  File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py", line 71, in _transform_param
    new_param = fn(old_param)
  File "/home/jmanning/vllm/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py", line 81, in transform_w_q
    x.data = ops.machete_prepack_B(x.data.t().contiguous().t(),
  File "/home/jmanning/vllm/vllm/_custom_ops.py", line 1093, in machete_prepack_B
    return torch.ops._C.machete_prepack_B(b_q_weight, a_type, b_type.id,
  File "/home/jmanning/vllm_v1/lib/python3.10/site-packages/torch/_ops.py", line 1317, in __getattr__
    raise AttributeError(
AttributeError: '_OpNamespace' '_C' object has no attribute 'machete_prepack_B'
[rank0]:[W618 18:01:16.289505485 ProcessGroupNCCL.cpp:1536] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
Traceback (most recent call last):
  File "/home/jmanning/vllm_v1/bin/vllm", line 33, in <module>
    sys.exit(load_entry_point('vllm', 'console_scripts', 'vllm')())
  File "/home/jmanning/vllm/vllm/entrypoints/cli/main.py", line 59, in main
    args.dispatch_function(args)
  File "/home/jmanning/vllm/vllm/entrypoints/cli/serve.py", line 58, in cmd
    uvloop.run(run_server(args))
  File "/home/jmanning/vllm_v1/lib/python3.10/site-packages/uvloop/__init__.py", line 82, in run
    return loop.run_until_complete(wrapper())
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/jmanning/vllm_v1/lib/python3.10/site-packages/uvloop/__init__.py", line 61, in wrapper
    return await main
  File "/home/jmanning/vllm/vllm/entrypoints/openai/api_server.py", line 1323, in run_server
    await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
  File "/home/jmanning/vllm/vllm/entrypoints/openai/api_server.py", line 1343, in run_server_worker
    async with build_async_engine_client(args, client_config) as engine_client:
  File "/usr/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/home/jmanning/vllm/vllm/entrypoints/openai/api_server.py", line 155, in build_async_engine_client
    async with build_async_engine_client_from_engine_args(
  File "/usr/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/home/jmanning/vllm/vllm/entrypoints/openai/api_server.py", line 191, in build_async_engine_client_from_engine_args
    async_llm = AsyncLLM.from_vllm_config(
  File "/home/jmanning/vllm/vllm/v1/engine/async_llm.py", line 162, in from_vllm_config
    return cls(
  File "/home/jmanning/vllm/vllm/v1/engine/async_llm.py", line 124, in __init__
    self.engine_core = EngineCoreClient.make_async_mp_client(
  File "/home/jmanning/vllm/vllm/v1/engine/core_client.py", line 93, in make_async_mp_client
    return AsyncMPClient(vllm_config, executor_class, log_stats,
  File "/home/jmanning/vllm/vllm/v1/engine/core_client.py", line 716, in __init__
    super().__init__(
  File "/home/jmanning/vllm/vllm/v1/engine/core_client.py", line 422, in __init__
    self._init_engines_direct(vllm_config, local_only,
  File "/home/jmanning/vllm/vllm/v1/engine/core_client.py", line 491, in _init_engines_direct
    self._wait_for_engine_startup(handshake_socket, input_address,
  File "/home/jmanning/vllm/vllm/v1/engine/core_client.py", line 511, in _wait_for_engine_startup
    wait_for_engine_startup(
  File "/home/jmanning/vllm/vllm/v1/utils.py", line 494, in wait_for_engine_startup
    raise RuntimeError("Engine core initialization failed. "
RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
```

**After this PR**

```
INFO 06-18 18:59:05 [compressed_tensors_wNa16.py:95] Using ConchLinearKernel for CompressedTensorsWNA16
```

## Test Result

None of the other MPLinearKernels work for Compressed-Tensors, mixed-precision on AMD, so I can't compare the performance directly to an AMD baseline. Below are results on H100 w/ Machete vs. Conch and AMD w/ Conch. Conch performance is worse than Machete, but more work could be done to optimize it if there was interest. For now this adds a small feature and gives the opportunity for more platforms to support this kernel via Triton.

```
python benchmarks/benchmark_serving.py   --model ISTA-DASLab/Mistral-Small-3.1-24B-Instruct-2503-GPTQ-4b-128g   --dataset-name random   --ignore-eos   --num-prompts 300   --max-concurrency 300   --random-input-len 500   --random-output-len 500   --seed 1
```

_H100: Baseline_
```
============ Serving Benchmark Result ============
Successful requests:                     300
Benchmark duration (s):                  44.22
Total input tokens:                      149700
Total generated tokens:                  150000
Request throughput (req/s):              6.78
Output token throughput (tok/s):         3392.23
Total Token throughput (tok/s):          6777.67
---------------Time to First Token----------------
Mean TTFT (ms):                          6922.65
Median TTFT (ms):                        7091.84
P99 TTFT (ms):                           12105.54
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          73.60
Median TPOT (ms):                        73.23
P99 TPOT (ms):                           83.55
---------------Inter-token Latency----------------
Mean ITL (ms):                           73.60
Median ITL (ms):                         64.27
P99 ITL (ms):                            617.22
==================================================
```

_H100: Conch_
```
VLLM_DISABLED_KERNELS="AllSparkLinearKernel,MacheteLinearKernel,MarlinLinearKernel,ExllamaLinearKernel,BitBLASLinearKernel"
```

```
============ Serving Benchmark Result ============
Successful requests:                     300
Benchmark duration (s):                  91.12
Total input tokens:                      149700
Total generated tokens:                  150000
Request throughput (req/s):              3.29
Output token throughput (tok/s):         1646.20
Total Token throughput (tok/s):          3289.10
---------------Time to First Token----------------
Mean TTFT (ms):                          19138.15
Median TTFT (ms):                        19689.11
P99 TTFT (ms):                           35436.99
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          142.28
Median TPOT (ms):                        141.27
P99 TPOT (ms):                           173.30
---------------Inter-token Latency----------------
Mean ITL (ms):                           142.28
Median ITL (ms):                         111.71
P99 ITL (ms):                            1868.12
==================================================
```

_MI300X: Conch_
```
============ Serving Benchmark Result ============
Successful requests:                     300
Benchmark duration (s):                  93.09
Total input tokens:                      149700
Total generated tokens:                  150000
Request throughput (req/s):              3.22
Output token throughput (tok/s):         1611.27
Total Token throughput (tok/s):          3219.31
---------------Time to First Token----------------
Mean TTFT (ms):                          18889.63
Median TTFT (ms):                        19425.59
P99 TTFT (ms):                           34731.81
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          145.00
Median TPOT (ms):                        143.99
P99 TPOT (ms):                           174.53
---------------Inter-token Latency----------------
Mean ITL (ms):                           145.00
Median ITL (ms):                         115.35
P99 ITL (ms):                            1799.08
==================================================
```