### PR TITLE
[Bugfix] Add check_health to v1 async client.

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -362,3 +362,29 @@ async def test_dp_rank_argument(monkeypatch: pytest.MonkeyPatch):
                                            sampling_params=sampling_params,
                                            data_parallel_rank=1):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_check_health(monkeypatch: pytest.MonkeyPatch):
+    """Test that check_health returns normally for healthy engine
+    and raises EngineDeadError when the engine is dead.
+    """
+    from unittest.mock import patch
+    from vllm.v1.engine.exceptions import EngineDeadError
+    
+    with monkeypatch.context() as m, ExitStack() as after:
+        m.setenv("VLLM_USE_V1", "1")
+
+        engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+        after.callback(engine.shutdown)
+
+        # Test 1: Healthy engine should not raise any exception  
+        await engine.check_health()
+
+        # Test 2: Mock the errored property to simulate a dead engine
+        with patch.object(type(engine), 'errored', new_callable=lambda: property(lambda self: True)):
+            with pytest.raises(EngineDeadError):
+                await engine.check_health()
+
+        # Test 3: Verify healthy engine still works after mock
+        await engine.check_health()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -486,6 +486,8 @@ class AsyncLLM(EngineClient):
 
     async def check_health(self) -> None:
         logger.debug("Called check_health.")
+        if self.errored:
+            raise self.dead_error
 
     async def start_profile(self) -> None:
         await self.engine_core.profile_async(True)


### PR DESCRIPTION
This was missed from the V1 migration and we just noticed it when doing fault-tolerance tests on P/D.