### PR TITLE
[Minor][UX] Print a message when starting CUDA graph capture

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2169,6 +2169,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 "set -O %s and ensure `use_cudagraph` was not manually set to "
                 "False", CompilationLevel.PIECEWISE)
             return
+        logger.info("Capturing CUDA graphs...")
 
         compilation_counter.num_gpu_runner_capture_triggers += 1
 


### PR DESCRIPTION
Since CUDA graph capture can take a significant amount of time, we should display a message before it starts to inform the user and avoid leaving them wondering what's happening on the vLLM side.

In my opinion, this is crucial for UX.