### PR TITLE
[Benchmark][Bugfix] Fix Dataset Length Calculation

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -353,7 +353,7 @@ class RandomDataset(BenchmarkDataset):
                 : input_lens[i]
             ]
             prompt = tokenizer.decode(re_encoded_sequence)
-            total_input_len = prefix_len + int(input_lens[i])
+            total_input_len = len(re_encoded_sequence)
             requests.append(
                 SampleRequest(
                     prompt=prompt,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

- fix dataset

## Test Plan
- launch server
```
vllm serve RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
```

- run an example sweep

```bash
CONCURRENCIES=(1 25 50 100 150 200)

INPUT_LEN=650
OUTPUT_LEN=150
PREFIX_LEN=500
CC_MULT=30
MODEL=${MODEL:-RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic}
TOKENIZER=${TOKENIZER:-RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic}


for CONCURRENCY in "${CONCURRENCIES[@]}";
do
    NUM_PROMPTS=$(($CC_MULT * $CONCURRENCY))
    
    echo ""
    echo "===== RUNNING $MODEL FOR $NUM_PROMPTS PROMPTS WITH CONCURRENCY $CONCURRENCY ====="
    echo ""

    python3 ../benchmarks/benchmark_serving.py \
        --served-model-name $MODEL \
        --model $TOKENIZER \
        --dataset-name random \
        --random-prefix-len $PREFIX_LEN \
        --random-input-len $INPUT_LEN \
        --random-output-len $OUTPUT_LEN \
        --max-concurrency $CONCURRENCY \
        --num-prompts $NUM_PROMPTS \
        --seed $(date +%s) \
        --percentile-metrics ttft,tpot,itl,e2el \
        --metric-percentiles 90,95,99 \
        --ignore-eos

done
```

## Test Result

I get the proper output length reported.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
