### PR TITLE
[CI/Build][Bugfix] Fix deadlock on v1 engine test CI

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -383,7 +383,8 @@ async def test_check_health(monkeypatch: pytest.MonkeyPatch):
     with monkeypatch.context() as m, ExitStack() as after:
         m.setenv("VLLM_USE_V1", "1")
 
-        engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+        with set_default_torch_num_threads(1):
+            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
         after.callback(engine.shutdown)
 
         # Test 1: Healthy engine should not raise any exception


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- This PR fixes the deadlock in `tests/v1/engine/test_async_llm.py`, which caused the v1 test timeout on main.

## Test Plan
```
pytest -v -s v1/engine
```

## Test Result
- The test should pass now.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
