### PR TITLE
[Fix] import regex instead of re

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/xlam_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/xlam_tool_parser.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # ruff: noqa
 import json
-import re
 from collections.abc import Sequence
 from typing import Any, Dict, List, Optional, Union
+
+import regex as re
 
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               DeltaFunctionCall, DeltaMessage,


### PR DESCRIPTION
The pre-commits checks are currently failing on main because `xlam_tool_parser.py` is using `import re`. This is a quick and tiny fix. 