### PR TITLE
[Quantization] Add compressed-tensors emulations support for NVFP4

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -133,6 +133,7 @@ if TYPE_CHECKING:
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_KV_CACHE_LAYOUT: Optional[str] = None
     VLLM_COMPUTE_NANS_IN_LOGITS: bool = False
+    VLLM_USE_NVFP4_CT_EMULATIONS: bool = False
 
 
 def get_default_cache_root():
@@ -918,6 +919,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # or bad hardware but it may add compute overhead.
     "VLLM_COMPUTE_NANS_IN_LOGITS":
     lambda: bool(int(os.getenv("VLLM_COMPUTE_NANS_IN_LOGITS", "0"))),
+    
+    # Controls whether or not emulations are used for NVFP4
+    # generations on machines < 100 for compressed-tensors
+    # models
+    "VLLM_USE_NVFP4_CT_EMULATIONS":
+    lambda: bool(int(os.getenv("VLLM_USE_NVFP4_CT_EMULATIONS", "0")))
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -919,7 +919,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # or bad hardware but it may add compute overhead.
     "VLLM_COMPUTE_NANS_IN_LOGITS":
     lambda: bool(int(os.getenv("VLLM_COMPUTE_NANS_IN_LOGITS", "0"))),
-    
+
     # Controls whether or not emulations are used for NVFP4
     # generations on machines < 100 for compressed-tensors
     # models

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import os
 from contextlib import suppress
 from typing import Any, Literal, Optional, cast
 
@@ -14,6 +13,7 @@ from compressed_tensors.quantization import (QuantizationArgs,
                                              QuantizationType)
 from pydantic import BaseModel
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
@@ -376,7 +376,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         if is_activation_quantization_format(self.quant_format):
             if self._is_fp4a4_nvfp4(weight_quant, input_quant):
                 if CompressedTensorsW4A4Fp4.cutlass_fp4_supported(
-                ) or os.environ.get("USE_NVFP4_CT_EMULATIONS", "0") == "1":
+                ) or envs.VLLM_USE_NVFP4_CT_EMULATIONS:
                     return CompressedTensorsW4A4Fp4()
                 else:
                     logger.warning_once(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import suppress
 from typing import Any, Literal, Optional, cast
 
@@ -374,7 +375,8 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         if is_activation_quantization_format(self.quant_format):
             if self._is_fp4a4_nvfp4(weight_quant, input_quant):
-                if CompressedTensorsW4A4Fp4.cutlass_fp4_supported():
+                if CompressedTensorsW4A4Fp4.cutlass_fp4_supported(
+                ) or os.environ.get("USE_NVFP4_CT_EMULATIONS") == "1":
                     return CompressedTensorsW4A4Fp4()
                 else:
                     logger.warning_once(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -376,7 +376,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         if is_activation_quantization_format(self.quant_format):
             if self._is_fp4a4_nvfp4(weight_quant, input_quant):
                 if CompressedTensorsW4A4Fp4.cutlass_fp4_supported(
-                ) or os.environ.get("USE_NVFP4_CT_EMULATIONS") == "1":
+                ) or os.environ.get("USE_NVFP4_CT_EMULATIONS", "0") == "1":
                     return CompressedTensorsW4A4Fp4()
                 else:
                     logger.warning_once(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -137,7 +137,6 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
         if USE_NVFP4_CT_EMULATIONS == "1":
-            print("running emulations")
             return run_nvfp4_emulations(
                 x=x,
                 input_global_scale=layer.input_global_scale,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -31,6 +31,8 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
 
     @classmethod
     def get_min_capability(cls) -> int:
+        if USE_NVFP4_CT_EMULATIONS == "1":
+            return 80
         return 100
 
     @classmethod
@@ -135,11 +137,12 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
         if USE_NVFP4_CT_EMULATIONS == "1":
+            print("running emulations")
             return run_nvfp4_emulations(
                 x=x,
                 input_global_scale=layer.input_global_scale,
                 weight=layer.weight,
-                weight_scale_swizzles=layer.weight_scale_swizzled,
+                weight_scale_swizzled=layer.weight_scale_swizzled,
                 weight_global_scale=layer.weight_global_scale)
 
         output_dtype = x.dtype

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -137,12 +137,15 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
         if USE_NVFP4_CT_EMULATIONS == "1":
-            return run_nvfp4_emulations(
+            out = run_nvfp4_emulations(
                 x=x,
                 input_global_scale=layer.input_global_scale,
                 weight=layer.weight,
                 weight_scale_swizzled=layer.weight_scale_swizzled,
                 weight_global_scale=layer.weight_global_scale)
+            if bias is not None:
+                out = out + bias
+            return out
 
         output_dtype = x.dtype
         output_shape = [x.shape[0], layer.weight.shape[0]]

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-import os
 from typing import Callable, Optional
 
 import torch
 from torch.nn.parameter import Parameter
 
+import vllm.envs as envs
 from vllm._custom_ops import (cutlass_scaled_fp4_mm,
                               cutlass_scaled_mm_supports_fp4, scaled_fp4_quant)
 from vllm.logger import init_logger
@@ -21,8 +21,6 @@ logger = init_logger(__name__)
 
 __all__ = ["CompressedTensorsW4A4Fp4"]
 
-USE_NVFP4_CT_EMULATIONS = os.environ.get("USE_NVFP4_CT_EMULATIONS", '0')
-
 
 class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
 
@@ -31,7 +29,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        if USE_NVFP4_CT_EMULATIONS == "1":
+        if envs.VLLM_USE_NVFP4_CT_EMULATIONS:
             return 80
         return 100
 
@@ -136,7 +134,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                       x: torch.Tensor,
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
-        if USE_NVFP4_CT_EMULATIONS == "1":
+        if envs.VLLM_USE_NVFP4_CT_EMULATIONS:
             out = run_nvfp4_emulations(
                 x=x,
                 input_global_scale=layer.input_global_scale,


### PR DESCRIPTION
## Purpose
- Enable an option to run emulations when running NVFP4 on a non-b200 machine instead of falling back to always use marlin
- Now if the user sets `VLLM_USE_NVFP4_CT_EMULATIONS` to `1`, emulations will be used for nvfp4 as opposed to nvfp4a16

## Test Plan
- All exisiting tests pass; setting `VLLM_USE_NVFP4_CT_EMULATIONS` uses emulations 
