### PR TITLE
[Benchmark] Added benchmark support for Unsloth Vision Datasets

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,6 +59,12 @@ become available.
       <td><code>AI-MO/aimo-validation-aime</code> , <code>AI-MO/NuminaMath-1.5</code>, <code>AI-MO/NuminaMath-CoT</code></td>
     </tr>
     <tr>
+      <td><strong>HuggingFace-Unsloth</strong></td>
+      <td style="text-align: center;">✅</td>
+      <td style="text-align: center;">✅</td>
+      <td><code>unsloth/LaTeX_OCR</code>, <code>unsloth/Radiology_mini</code></td>
+    </tr>
+    <tr>
       <td><strong>HuggingFace-Other</strong></td>
       <td style="text-align: center;">✅</td>
       <td style="text-align: center;">✅</td>
@@ -255,6 +261,34 @@ python3 vllm/benchmarks/benchmark_serving.py \
     --num-prompts 80
 ```
 
+**`unsloth/LaTeX_OCR`**
+
+``` bash
+python3 vllm/benchmarks/benchmark_serving.py \
+  --backend openai-chat \
+  --model Qwen/Qwen2-VL-7B-Instruct \
+  --endpoint /v1/chat/completions \
+  --dataset-name hf \
+  --dataset-path unsloth/LaTeX_OCR \
+  --hf-split train \
+  --hf-output-len 256 \
+  --num-prompts 1000
+```
+
+**`unsloth/Radiology_mini`**
+
+``` bash
+python3 vllm/benchmarks/benchmark_serving.py \
+  --backend openai-chat \
+  --model Qwen/Qwen2-VL-7B-Instruct \
+  --endpoint /v1/chat/completions \
+  --dataset-name hf \
+  --dataset-path unsloth/Radiology_mini \
+  --hf-split train \
+  --hf-output-len 256 \
+  --num-prompts 1000
+```
+
 **Running With Sampling Parameters**
 
 When using OpenAI-compatible backends such as `vllm`, optional sampling
@@ -392,6 +426,30 @@ python3 benchmarks/benchmark_throughput.py \
   --dataset-path AI-MO/aimo-validation-aime \
   --hf-split train \
   --num-prompts 10
+```
+
+**`unsloth/LaTeX_OCR`**
+
+```bash
+python3 vllm/benchmarks/benchmark_throughput.py \
+  --model Qwen/Qwen2-VL-7B-Instruct \
+  --backend vllm-chat \
+  --dataset-name hf \
+  --dataset-path unsloth/LaTeX_OCR \
+  --hf-split train \
+  --num-prompts 1000
+```
+
+**`unsloth/Radiology_mini`**
+
+```bash
+python3 vllm/benchmarks/benchmark_throughput.py \
+  --model Qwen/Qwen2-VL-7B-Instruct \
+  --backend vllm-chat \
+  --dataset-name hf \
+  --dataset-path unsloth/Radiology_mini \
+  --hf-split train \
+  --num-prompts 1000
 ```
 
 **Benchmark with LoRA Adapters**

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -264,15 +264,28 @@ python3 vllm/benchmarks/benchmark_serving.py \
 **`unsloth/LaTeX_OCR`**
 
 ``` bash
+# Serve the model
+vllm serve unsloth/Qwen2-VL-2B-Instruct \
+    --dtype bfloat16 \
+    --max-model-len 4096 \
+    --max-num-seqs 5 \
+    --limit-mm-per-prompt "image=1,video=0" \
+    --max-seq-len-to-capture 4096 \
+    --mm-processor-kwargs '{"min_pixels": 784, "max_pixels": 1003520}'
+```
+
+``` bash
 python3 vllm/benchmarks/benchmark_serving.py \
   --backend openai-chat \
-  --model Qwen/Qwen2-VL-7B-Instruct \
+  --request-rate 5 \
+  --max-concurrency 5 \
+  --model unsloth/Qwen2-VL-2B-Instruct \
   --endpoint /v1/chat/completions \
   --dataset-name hf \
   --dataset-path unsloth/LaTeX_OCR \
   --hf-split train \
   --hf-output-len 256 \
-  --num-prompts 1000
+  --num-prompts 1000 
 ```
 
 **`unsloth/Radiology_mini`**
@@ -280,7 +293,9 @@ python3 vllm/benchmarks/benchmark_serving.py \
 ``` bash
 python3 vllm/benchmarks/benchmark_serving.py \
   --backend openai-chat \
-  --model Qwen/Qwen2-VL-7B-Instruct \
+  --request-rate 5 \
+  --max-concurrency 5 \
+  --model unsloth/Qwen2-VL-2B-Instruct \
   --endpoint /v1/chat/completions \
   --dataset-name hf \
   --dataset-path unsloth/Radiology_mini \
@@ -432,19 +447,19 @@ python3 benchmarks/benchmark_throughput.py \
 
 ```bash
 python3 vllm/benchmarks/benchmark_throughput.py \
-  --model Qwen/Qwen2-VL-7B-Instruct \
+  --model unsloth/Qwen2-VL-2B-Instruct \
   --backend vllm-chat \
   --dataset-name hf \
   --dataset-path unsloth/LaTeX_OCR \
   --hf-split train \
-  --num-prompts 1000
+  --num-prompts 1000 
 ```
 
 **`unsloth/Radiology_mini`**
 
 ```bash
 python3 vllm/benchmarks/benchmark_throughput.py \
-  --model Qwen/Qwen2-VL-7B-Instruct \
+  --model unsloth/Qwen2-VL-2B-Instruct \
   --backend vllm-chat \
   --dataset-name hf \
   --dataset-path unsloth/Radiology_mini \

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -834,6 +834,67 @@ class VisionArenaDataset(HuggingFaceDataset):
 
 
 # -----------------------------------------------------------------------------
+# UnSloth Vision Dataset Implementation
+# -----------------------------------------------------------------------------
+
+
+class UnSlothVisionDataset(HuggingFaceDataset):
+    """
+    UnSloth Vision Dataset.
+    """
+
+    DEFAULT_OUTPUT_LEN = 256
+    SUPPORTED_DATASET_PATHS = {
+        "unsloth/LaTeX_OCR": lambda x: (
+            "Write the LaTeX representation for this image.",
+            x["image"]
+        ),
+        "unsloth/Radiology_mini": lambda x: (
+            "You are an expert radiographer. Describe accurately what you see in this image.",
+            x["image"]
+        ),
+    }
+    IS_MULTIMODAL = True
+
+    def sample(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        num_requests: int,
+        output_len: Optional[int] = None,
+        enable_multimodal_chat: bool = False,
+        **kwargs,
+    ) -> list:
+        output_len = output_len if output_len is not None else self.DEFAULT_OUTPUT_LEN
+        sampled_requests = []
+
+        parser_fn = self.SUPPORTED_DATASET_PATHS.get(self.dataset_path)
+        if parser_fn is None:
+            raise ValueError(f"Unsupported dataset path: {self.dataset_path}")
+
+        for item in self.data:
+            if len(sampled_requests) >= num_requests:
+                break            
+            prompt, mm_content = parser_fn(item)
+            mm_content = process_image(mm_content)
+            prompt_len = len(tokenizer(prompt).input_ids)
+            if enable_multimodal_chat:
+                # Note: when chat is enabled the request prompt_len is no longer
+                # accurate and we will be using request output to count the
+                # actual prompt len
+                prompt = self.apply_multimodal_chat_transformation(
+                    prompt, mm_content)
+            sampled_requests.append(
+                SampleRequest(
+                    prompt=prompt,
+                    prompt_len=prompt_len,
+                    expected_output_len=output_len,
+                    multi_modal_data=mm_content,
+                ))
+        self.maybe_oversample_requests(sampled_requests, num_requests)
+        return sampled_requests
+
+
+# -----------------------------------------------------------------------------
 # Instruct Coder Dataset Implementation
 # -----------------------------------------------------------------------------
 

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -834,13 +834,12 @@ class VisionArenaDataset(HuggingFaceDataset):
 
 
 # -----------------------------------------------------------------------------
-# UnSloth Vision Dataset Implementation
+# Unsloth Vision Dataset Implementation
 # -----------------------------------------------------------------------------
 
-
-class UnSlothVisionDataset(HuggingFaceDataset):
+class UnslothVisionDataset(HuggingFaceDataset):
     """
-    UnSloth Vision Dataset.
+    Unsloth Vision Dataset.
     """
 
     DEFAULT_OUTPUT_LEN = 256

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -70,6 +70,7 @@ from benchmark_dataset import (
     SampleRequest,
     ShareGPTDataset,
     SonnetDataset,
+    UnSlothVisionDataset,
     VisionArenaDataset,
 )
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
@@ -795,6 +796,10 @@ def main(args: argparse.Namespace):
         elif args.dataset_path in ASRDataset.SUPPORTED_DATASET_PATHS:
             dataset_class = ASRDataset
             args.hf_split = "train"
+        elif args.dataset_path in UnSlothVisionDataset.SUPPORTED_DATASET_PATHS:
+            dataset_class = UnSlothVisionDataset
+            args.hf_split = "train"
+            args.hf_subset = None
         else:
             supported_datasets = set(
                 [

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -70,7 +70,7 @@ from benchmark_dataset import (
     SampleRequest,
     ShareGPTDataset,
     SonnetDataset,
-    UnSlothVisionDataset,
+    UnslothVisionDataset,
     VisionArenaDataset,
 )
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
@@ -796,8 +796,8 @@ def main(args: argparse.Namespace):
         elif args.dataset_path in ASRDataset.SUPPORTED_DATASET_PATHS:
             dataset_class = ASRDataset
             args.hf_split = "train"
-        elif args.dataset_path in UnSlothVisionDataset.SUPPORTED_DATASET_PATHS:
-            dataset_class = UnSlothVisionDataset
+        elif args.dataset_path in UnslothVisionDataset.SUPPORTED_DATASET_PATHS:
+            dataset_class = UnslothVisionDataset
             args.hf_split = "train"
             args.hf_subset = None
         else:

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -534,7 +534,7 @@ def validate_args(args):
         if args.dataset_path in (
             VisionArenaDataset.SUPPORTED_DATASET_PATHS.keys()
             | ConversationDataset.SUPPORTED_DATASET_PATHS
-            | UnslothVisionDataset.SUPPORTED_DATASET_PATHS
+            | UnslothVisionDataset.SUPPORTED_DATASET_PATHS.keys()
         ):
             assert args.backend == "vllm-chat", (
                 f"{args.dataset_path} needs to use vllm-chat as the backend."

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -25,7 +25,7 @@ from benchmark_dataset import (
     SampleRequest,
     ShareGPTDataset,
     SonnetDataset,
-    UnSlothVisionDataset,
+    UnslothVisionDataset,
     VisionArenaDataset,
 )
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
@@ -374,8 +374,8 @@ def get_requests(args, tokenizer):
             dataset_cls = AIMODataset
             common_kwargs["dataset_subset"] = None
             common_kwargs["dataset_split"] = "train"
-        elif args.dataset_path in UnSlothVisionDataset.SUPPORTED_DATASET_PATHS:
-            dataset_cls = UnSlothVisionDataset
+        elif args.dataset_path in UnslothVisionDataset.SUPPORTED_DATASET_PATHS:
+            dataset_cls = UnslothVisionDataset
             common_kwargs['dataset_subset'] = None
             common_kwargs['dataset_split'] = args.hf_split
             sample_kwargs["enable_multimodal_chat"] = True
@@ -534,7 +534,7 @@ def validate_args(args):
         if args.dataset_path in (
             VisionArenaDataset.SUPPORTED_DATASET_PATHS.keys()
             | ConversationDataset.SUPPORTED_DATASET_PATHS
-            | UnSlothVisionDataset.SUPPORTED_DATASET_PATHS
+            | UnslothVisionDataset.SUPPORTED_DATASET_PATHS
         ):
             assert args.backend == "vllm-chat", (
                 f"{args.dataset_path} needs to use vllm-chat as the backend."

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -25,6 +25,7 @@ from benchmark_dataset import (
     SampleRequest,
     ShareGPTDataset,
     SonnetDataset,
+    UnSlothVisionDataset,
     VisionArenaDataset,
 )
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
@@ -373,6 +374,12 @@ def get_requests(args, tokenizer):
             dataset_cls = AIMODataset
             common_kwargs["dataset_subset"] = None
             common_kwargs["dataset_split"] = "train"
+        elif args.dataset_path in UnSlothVisionDataset.SUPPORTED_DATASET_PATHS:
+            dataset_cls = UnSlothVisionDataset
+            common_kwargs['dataset_subset'] = None
+            common_kwargs['dataset_split'] = args.hf_split
+            sample_kwargs["enable_multimodal_chat"] = True
+        
     else:
         raise ValueError(f"Unknown dataset name: {args.dataset_name}")
     # Remove None values
@@ -527,6 +534,7 @@ def validate_args(args):
         if args.dataset_path in (
             VisionArenaDataset.SUPPORTED_DATASET_PATHS.keys()
             | ConversationDataset.SUPPORTED_DATASET_PATHS
+            | UnSlothVisionDataset.SUPPORTED_DATASET_PATHS
         ):
             assert args.backend == "vllm-chat", (
                 f"{args.dataset_path} needs to use vllm-chat as the backend."


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
This PR adds support for two Hugging Face datasets from Unsloth for vision benchmarking tasks:  ```unsloth/LaTeX_OCR``` and ```unsloth/Radiology_mini``` .

## Test Plan

1. Benchmark Serving
```
# Serve the model
vllm serve unsloth/Qwen2-VL-2B-Instruct \
    --dtype bfloat16 \
    --max-model-len 4096 \
    --max-num-seqs 5 \
    --limit-mm-per-prompt "image=1,video=0" \
    --max-seq-len-to-capture 4096 \
    --mm-processor-kwargs '{"min_pixels": 784, "max_pixels": 1003520}'
```
```
# Benchmark
python3 vllm/benchmarks/benchmark_serving.py \
  --backend openai-chat \
  --request-rate 5 \
  --max-concurrency 5 \
  --model unsloth/Qwen2-VL-2B-Instruct \
  --endpoint /v1/chat/completions \
  --dataset-name hf \
  --dataset-path unsloth/LaTeX_OCR \
  --hf-split train \
  --hf-output-len 256 \
  --num-prompts 1000 
```

2. Benchmark throughput
```
python3 vllm/benchmarks/benchmark_throughput.py \
  --model unsloth/Qwen2-VL-2B-Instruct \
  --backend vllm-chat \
  --dataset-name hf \
  --dataset-path unsloth/LaTeX_OCR \
  --hf-split train \
  --num-prompts 1000 
```


## Test Result

1. Benchmark serving
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  201.35    
Total input tokens:                      8000      
Total generated tokens:                  73002     
Request throughput (req/s):              4.97      
Output token throughput (tok/s):         362.57    
Total Token throughput (tok/s):          402.30    
---------------Time to First Token----------------
Mean TTFT (ms):                          44.91     
Median TTFT (ms):                        42.01     
P99 TTFT (ms):                           72.49     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          5.50      
Median TPOT (ms):                        5.40      
P99 TPOT (ms):                           7.38      
---------------Inter-token Latency----------------
Mean ITL (ms):                           5.43      
Median ITL (ms):                         4.69      
P99 ITL (ms):                            32.08     
==================================================
```
3. Benchmark throughput
```
Throughput: 40.87 requests/s, 12228.12 total tokens/s, 10461.48 output tokens/s
Total num prompt tokens:  43231
Total num output tokens:  256000
```

## (Optional) Documentation Update

Updated benchmark README

<!--- pyml disable-next-line no-emphasis-as-heading -->
