### PR TITLE
Fix: Check the type of params to be a Sequence not list.

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1450,15 +1450,15 @@ class LLM:
             prompts = [prompts]
 
         num_requests = len(prompts)
-        if isinstance(params, list) and len(params) != num_requests:
+        if isinstance(params, Sequence) and len(params) != num_requests:
             raise ValueError("The lengths of prompts and params "
                              "must be the same.")
         if isinstance(lora_request,
-                      list) and len(lora_request) != num_requests:
+                      Sequence) and len(lora_request) != num_requests:
             raise ValueError("The lengths of prompts and lora_request "
                              "must be the same.")
 
-        for sp in params if isinstance(params, list) else (params, ):
+        for sp in params if isinstance(params, Sequence) else (params, ):
             if isinstance(sp, SamplingParams):
                 self._add_guided_params(sp, guided_options)
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test commands.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

The method `_validate_and_add_requests` in `llm.py` has the type of `Sequence` for `params` and `lora_request`, but the check is for `list` type. So, it doesn't work for the `tuple` type. Now, it does work for any of the sequence types.

## Test Plan

Passing the `params` or the `lora_request` with a different length than the number of requests.

## Test Result

Now, when the lengths are different, ValueError is successfully thrown.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
