### PR TITLE
[Bugfix] Fix bnb 8bit model weights loading

### DIFF
--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -577,10 +577,10 @@ def dequantize_dq(quant_states: dict) -> None:
     thereby avoiding this computational overhead during inference. This comes 
     at the cost of increased memory usage.
     """
-    from bitsandbytes.functional import dequantize_blockwise
+    from bitsandbytes.functional import QuantState, dequantize_blockwise
     for _, quant_state in quant_states.items():
         # Copied from: https://github.com/bitsandbytes-foundation/bitsandbytes/blob/0.45.3/bitsandbytes/functional.py#L1352-#L1356
-        if quant_state.nested:
+        if isinstance(quant_state, QuantState) and quant_state.nested:
             absmax = dequantize_blockwise(quant_state.absmax,
                                           quant_state.state2)
             absmax += quant_state.offset


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Fix error when loading BNB 8bit pre-quant models introduced in #19742:
```
[rank0]:   File "/kaggle/working/vllm/vllm/model_executor/model_loader/__init__.py", line 59, in get_model
[rank0]:     return loader.load_model(vllm_config=vllm_config,
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/kaggle/working/vllm/vllm/model_executor/model_loader/base_loader.py", line 41, in load_model
[rank0]:     self.load_weights(model, model_config)
[rank0]:   File "/kaggle/working/vllm/vllm/model_executor/model_loader/bitsandbytes_loader.py", line 547, in load_weights
[rank0]:     dequantize_dq(quant_states)
[rank0]:   File "/kaggle/working/vllm/vllm/model_executor/model_loader/bitsandbytes_loader.py", line 583, in dequantize_dq
[rank0]:     if quant_state.nested:
[rank0]:        ^^^^^^^^^^^^^^^^^^
[rank0]: AttributeError: 'Tensor' object has no attribute 'nested'. Did you mean: 'is_nested'?
```

## Test Plan
```
python examples/offline_inference/basic/generate.py --model JohnConnor123/Llama-3.2-3B-Instruct-BNB-8bit --max-model-len 1024
```
```
pytest -s -v tests/quantization/test_bitsandbytes.py -k test_load_8bit_bnb_model
```

## Test Result
The offline generation should run successfully and bnb 8bit tests should pass now. 

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
