### PR TITLE
enable multiple ssm groups duplication

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -152,7 +152,7 @@ def extra_groups_for_head_shards(ngroups: int, tp_size: int):
         return 0
 
     # for n_groups == 1 or tp_size % ngroups == 0, 
-    # this is exactly tp_size - n_groups
+    #  this is exactly tp_size - n_groups
     return tp_size - ngroups
 
 

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -195,7 +195,8 @@ def mamba_v2_sharded_weight_loader(
             else:
                 assert (
                     tp_size % n_groups == 0
-                ), "num groups must divide TP size if TP size does not divide n_groups and n_groups is not equal to 1."
+                ), "num groups must divide TP size if TP size does not divide n_groups"
+                " and n_groups is not equal to 1."
                 rank = tp_rank // n_groups
             # - leftmost boundary index into loaded weight.
             loaded_skip = rank * shard_size

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -157,7 +157,7 @@ def extra_groups_for_head_shards(ngroups: int, tp_size: int):
 
 
 def mamba_v2_sharded_weight_loader(
-    shard_spec: list[tuple[int, int, float]],
+    shard_spec: list[tuple[int, int, int, bool]],
     tp_size: int,
     tp_rank: int,
 ) -> LoaderFunction:

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -151,7 +151,8 @@ def extra_groups_for_head_shards(ngroups: int, tp_size: int):
     if ngroups % tp_size == 0:
         return 0
 
-    # for n_groups == 1 or tp_size % ngroups == 0, this is exactly tp_size - n_groups
+    # for n_groups == 1 or tp_size % ngroups == 0, 
+    # this is exactly tp_size - n_groups
     return tp_size - ngroups
 
 
@@ -194,8 +195,8 @@ def mamba_v2_sharded_weight_loader(
             else:
                 assert (
                     tp_size % n_groups == 0
-                ), "num groups must divide TP size if TP size does not divide n_groups"
-                " and n_groups is not equal to 1."
+                ), "num groups must divide TP size if TP size does not divide"
+                " n_groups and n_groups is not equal to 1."
                 rank = tp_rank // n_groups
             # - leftmost boundary index into loaded weight.
             loaded_skip = rank * shard_size

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -189,11 +189,13 @@ def mamba_v2_sharded_weight_loader(
             # in the case where num_groups == 1 or num_groups divides tp size
             rank = 0 if duplicate_groups else tp_rank
             if duplicate_groups:
-                 rank = 0
-            elif n_groups % tp_size==0:
+                rank = 0
+            elif n_groups % tp_size == 0:
                 rank = tp_rank
             else:
-                assert(tp_size % n_groups == 0), "num groups must divide TP size if TP size does not divide n_groups and n_groups is not equal to 1."
+                assert (
+                    tp_size % n_groups == 0
+                ), "num groups must divide TP size if TP size does not divide n_groups and n_groups is not equal to 1."
                 rank = tp_rank // n_groups
             # - leftmost boundary index into loaded weight.
             loaded_skip = rank * shard_size
@@ -324,7 +326,7 @@ class MambaMixer2(CustomOp):
             self.n_groups * self.ssm_state_size,  # expected model size
             (self.n_groups - n_groups) *
             self.ssm_state_size,  # extra dims assigned
-            n_groups, # original n_groups to check for multi-groups duplication
+            n_groups,  # original n_groups to check for multi-groups duplication
             n_groups == 1,  # if there was only one group
         )
         intermediate_settings = (intermediate_size, 0, 0, False)

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -82,7 +82,6 @@ class Mixer2RMSNormGated(CustomOp):
         x = x * nn.functional.silu(gate.to(torch.float32))
         if not self.use_rms_norm:
             return x.to(input_dtype)
-
         if self.n_groups == 1:
             if self.tp_size > 1:
                 # Compute local sum and then reduce to obtain global sum


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)". Add mamba multi group duplication 
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
This PR enable the duplication of multiple groups for Mamba models . Before, the groups duplication was only enabled when n_groups == 1. If n_groups divides tp_size, we can duplicate each groups tp_size/n_groups times so that each group can take its rank

For example, this enables Falcon-H1-34B to support TP4 instead of only TP2
## Test Plan
Can be tested on gsm8k for Bamba-9B/ Falcon-H1-7B and Falcon-H1-34B
## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
