### PR TITLE
[PERF] Speedup of MRoPE prepare inputs

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -26,6 +26,7 @@
 import math
 from typing import Any, Optional, Union
 
+import numpy as np
 import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
@@ -1467,6 +1468,18 @@ class MRotaryEmbedding(RotaryEmbedding):
             mrope_position_delta + context_len,
             mrope_position_delta + seq_len,
         ).expand(3, -1)
+
+    # Faster version of `get_next_input_positions_tensor`
+    @staticmethod
+    def mrope_assign_next_input_positions(out: np.ndarray, out_offset: int,
+                                          mrope_position_delta: int,
+                                          context_len: int,
+                                          num_new_tokens: int):
+
+        for dim in range(3):
+            for idx in range(num_new_tokens):
+                out[dim, out_offset +
+                    idx] = mrope_position_delta + context_len + idx
 
     @classmethod
     def omni_get_updates_use_audio_in_video(

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -1476,10 +1476,10 @@ class MRotaryEmbedding(RotaryEmbedding):
                                           context_len: int,
                                           num_new_tokens: int):
 
-        for dim in range(3):
-            for idx in range(num_new_tokens):
-                out[dim, out_offset +
-                    idx] = mrope_position_delta + context_len + idx
+        values = np.arange(mrope_position_delta + context_len,
+                           mrope_position_delta + context_len + num_new_tokens,
+                           dtype=out.dtype)
+        out[:, out_offset:out_offset + num_new_tokens] = values
 
     @classmethod
     def omni_get_updates_use_audio_in_video(

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -1459,22 +1459,9 @@ class MRotaryEmbedding(RotaryEmbedding):
         ]
 
     @staticmethod
-    def get_next_input_positions_tensor(
-        mrope_position_delta: int,
-        context_len: int,
-        seq_len: int,
-    ) -> torch.Tensor:
-        return torch.arange(
-            mrope_position_delta + context_len,
-            mrope_position_delta + seq_len,
-        ).expand(3, -1)
-
-    # Faster version of `get_next_input_positions_tensor`
-    @staticmethod
-    def mrope_assign_next_input_positions(out: np.ndarray, out_offset: int,
-                                          mrope_position_delta: int,
-                                          context_len: int,
-                                          num_new_tokens: int):
+    def get_next_input_positions_tensor(out: np.ndarray, out_offset: int,
+                                        mrope_position_delta: int,
+                                        context_len: int, num_new_tokens: int):
 
         values = np.arange(mrope_position_delta + context_len,
                            mrope_position_delta + context_len + num_new_tokens,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -261,6 +261,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 dtype=torch.int64,
                 device="cpu",
                 pin_memory=self.pin_memory)
+            self.mrope_positions_np = self.mrope_positions_cpu.numpy()
 
         # Only relevant for models using ALiBi (e.g, MPT)
         self.use_alibi = check_use_alibi(model_config)
@@ -888,15 +889,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 dst_start = mrope_pos_ptr
                 dst_end = mrope_pos_ptr + completion_part_len
 
-                self.mrope_positions_cpu[:, dst_start:dst_end] = \
-                    MRotaryEmbedding.get_next_input_positions_tensor(
-                        req.mrope_position_delta,
-                        context_len=num_computed_tokens +
-                        prompt_part_len,
-                        seq_len=num_computed_tokens +
-                        prompt_part_len +
-                        completion_part_len,
-                    )
+                MRotaryEmbedding.mrope_assign_next_input_positions(
+                    out=self.mrope_positions_np,
+                    out_offset=dst_start,
+                    mrope_position_delta=req.mrope_position_delta,
+                    context_len=num_computed_tokens + prompt_part_len,
+                    num_new_tokens=completion_part_len,
+                )
 
                 mrope_pos_ptr += completion_part_len
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -889,7 +889,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 dst_start = mrope_pos_ptr
                 dst_end = mrope_pos_ptr + completion_part_len
 
-                MRotaryEmbedding.mrope_assign_next_input_positions(
+                MRotaryEmbedding.get_next_input_positions_tensor(
                     out=self.mrope_positions_np,
                     out_offset=dst_start,
                     mrope_position_delta=req.mrope_position_delta,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

## Purpose
Speedup of MRoPE prepare inputs. 
#16881 got stuck for a while. I combined parts of #16881 and #17617 to minimize changes and brings sufficient speedup.
`MRotaryEmbedding.get_next_input_positions_tensor` takes a lot of time. Use numpy to speedup it. 


## Performance Test Result
I used
`vllm serve Qwen/Qwen2.5-VL-3B-Instruct --disable-log-requests --no-enable-prefix-caching` 
as a server and 
`fib benchmark -rps 50 --input-token-distribution uniform 250 300     --output-token-distribution uniform 150 250 --num-of-imgs-per-req 1     --img-ratios-per-req 512x512 -n 1000 --base-url http://localhost:8000     --endpoint v1/chat/completions --backend openai-chat
`
to make workload (send 50 requests per sec with one 512x512 image per request). 

I decorated `GPUModelRunner._prepare_inputs` with nvtx to measure the time. 
`_prepare_inputs` average time
Before: 3.869 ms
With this PR: 1.487 ms (speedup 2.6x)
For info, with #17617: 2.511 ms

E2E performance improvement on Qwen2.5-VL-3B-Instruct with high load is around 1.5%.

cc @imkero @ywang96 @simon-mo 


