### PR TITLE
[Bugfix] fix sampling seeding being off when sequences are prempted

### DIFF
--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -273,7 +273,9 @@ def _prepare_seq_groups(
         do_sample = seq_group_metadata.do_sample
 
         if seq_group_metadata.is_prompt:
-            if sampling_params.seed is not None:
+            if seq_group_metadata.request_id in generators:
+                generator = generators[seq_group_metadata.request_id]
+            elif sampling_params.seed is not None:
                 generator = torch.Generator(device=device).manual_seed(
                     sampling_params.seed)
                 if generators is not None:


### PR DESCRIPTION
## Purpose
This PR fixes a bug where sequences being preempted in v0 will cause the sampling seeding behaviour to be wrong.
This happens because the `_prepare_seq_groups` will recreate the `torch.Generator` for any prefills, including prefills that are from a preempted sequence returning to the running.

The fix is to distinguish the preemption prefills from the prompt prefills by checking if a generator already exists for the seq_id. If it does, we know it is a preemption prefill and can use the generator that was already created for it. Otherwise, it is a prompt prefill and we create a new generator. 

## Test Plan
The way I tested it locally was to override the sampler to output the 9th int of the generator state instead of the actual token. The correct behavior should be that the generator counts up. However, without this fix, the generator will be reset when the sequence is preempted.

This test can be added to the test suite.

## Test Result
TBD

## (Optional) Documentation Update
Not needed as it is bugfix.

<!--- pyml disable-next-line no-emphasis-as-heading -->
