### PR TITLE
[Perf][CLI] Improve overall startup time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,11 @@ repos:
     entry: python tools/check_spdx_header.py
     language: python
     types: [python]
+  - id: check-root-lazy-imports
+    name: Check root lazy imports
+    entry: python tools/check_init_lazy_imports.py
+    language: python
+    types: [python]
   - id: check-filenames
     name: Check for spaces in all filenames
     entry: bash

--- a/tools/check_init_lazy_imports.py
+++ b/tools/check_init_lazy_imports.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Ensure we perform lazy loading in vllm/__init__.py.
+i.e: appears only within the ``if typing.TYPE_CHECKING:`` guard,
+**except** for a short whitelist.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+from collections.abc import Iterable
+from typing import Final
+
+REPO_ROOT: Final = pathlib.Path(__file__).resolve().parent.parent
+INIT_PATH: Final = REPO_ROOT / "vllm" / "__init__.py"
+
+# If you need to add items to whitelist, do it here.
+ALLOWED_IMPORTS: Final[frozenset[str]] = frozenset({
+    "vllm.env_override",
+})
+ALLOWED_FROM_MODULES: Final[frozenset[str]] = frozenset({
+    ".version",
+})
+
+
+def _is_internal(name: str | None, *, level: int = 0) -> bool:
+    if level > 0:
+        return True
+    if name is None:
+        return False
+    return name.startswith("vllm.") or name == "vllm"
+
+
+def _fail(violations: Iterable[tuple[int, str]]) -> None:
+    print("ERROR: Disallowed eager imports in vllm/__init__.py:\n",
+          file=sys.stderr)
+    for lineno, msg in violations:
+        print(f"  Line {lineno}: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    source = INIT_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(INIT_PATH))
+
+    violations: list[tuple[int, str]] = []
+
+    class Visitor(ast.NodeVisitor):
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._in_type_checking = False
+
+        def visit_If(self, node: ast.If) -> None:
+            guard_is_type_checking = False
+            test = node.test
+            if isinstance(test, ast.Attribute) and isinstance(
+                    test.value, ast.Name):
+                guard_is_type_checking = (test.value.id == "typing"
+                                          and test.attr == "TYPE_CHECKING")
+            elif isinstance(test, ast.Name):
+                guard_is_type_checking = test.id == "TYPE_CHECKING"
+
+            if guard_is_type_checking:
+                prev = self._in_type_checking
+                self._in_type_checking = True
+                for child in node.body:
+                    self.visit(child)
+                self._in_type_checking = prev
+                for child in node.orelse:
+                    self.visit(child)
+            else:
+                self.generic_visit(node)
+
+        def visit_Import(self, node: ast.Import) -> None:
+            if self._in_type_checking:
+                return
+            for alias in node.names:
+                module_name = alias.name
+                if _is_internal(
+                        module_name) and module_name not in ALLOWED_IMPORTS:
+                    violations.append((
+                        node.lineno,
+                        f"import '{module_name}' must be inside typing.TYPE_CHECKING",  # noqa: E501
+                    ))
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            if self._in_type_checking:
+                return
+            module_as_written = ("." * node.level) + (node.module or "")
+            if _is_internal(
+                    node.module, level=node.level
+            ) and module_as_written not in ALLOWED_FROM_MODULES:
+                violations.append((
+                    node.lineno,
+                    f"from '{module_as_written}' import ... must be inside typing.TYPE_CHECKING",  # noqa: E501
+                ))
+
+    Visitor().visit(tree)
+
+    if violations:
+        _fail(violations)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -1,29 +1,71 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """vLLM: a high-throughput and memory-efficient inference engine for LLMs"""
+
 # The version.py should be independent library, and we always import the
 # version library first.  Such assumption is critical for some customization.
 from .version import __version__, __version_tuple__  # isort:skip
 
+import typing
+
 # The environment variables override should be imported before any other
 # modules to ensure that the environment variables are set before any
 # other modules are imported.
-import vllm.env_override  # isort:skip  # noqa: F401
+import vllm.env_override  # noqa: F401
 
-from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
-from vllm.engine.async_llm_engine import AsyncLLMEngine
-from vllm.engine.llm_engine import LLMEngine
-from vllm.entrypoints.llm import LLM
-from vllm.executor.ray_utils import initialize_ray_cluster
-from vllm.inputs import PromptType, TextPrompt, TokensPrompt
-from vllm.model_executor.models import ModelRegistry
-from vllm.outputs import (ClassificationOutput, ClassificationRequestOutput,
-                          CompletionOutput, EmbeddingOutput,
-                          EmbeddingRequestOutput, PoolingOutput,
-                          PoolingRequestOutput, RequestOutput, ScoringOutput,
-                          ScoringRequestOutput)
-from vllm.pooling_params import PoolingParams
-from vllm.sampling_params import SamplingParams
+MODULE_ATTRS = {
+    "AsyncEngineArgs": ".engine.arg_utils:AsyncEngineArgs",
+    "EngineArgs": ".engine.arg_utils:EngineArgs",
+    "AsyncLLMEngine": ".engine.async_llm_engine:AsyncLLMEngine",
+    "LLMEngine": ".engine.llm_engine:LLMEngine",
+    "LLM": ".entrypoints.llm:LLM",
+    "initialize_ray_cluster": ".executor.ray_utils:initialize_ray_cluster",
+    "PromptType": ".inputs:PromptType",
+    "TextPrompt": ".inputs:TextPrompt",
+    "TokensPrompt": ".inputs:TokensPrompt",
+    "ModelRegistry": ".model_executor.models:ModelRegistry",
+    "SamplingParams": ".sampling_params:SamplingParams",
+    "PoolingParams": ".pooling_params:PoolingParams",
+    "ClassificationOutput": ".outputs:ClassificationOutput",
+    "ClassificationRequestOutput": ".outputs:ClassificationRequestOutput",
+    "CompletionOutput": ".outputs:CompletionOutput",
+    "EmbeddingOutput": ".outputs:EmbeddingOutput",
+    "EmbeddingRequestOutput": ".outputs:EmbeddingRequestOutput",
+    "PoolingOutput": ".outputs:PoolingOutput",
+    "PoolingRequestOutput": ".outputs:PoolingRequestOutput",
+    "RequestOutput": ".outputs:RequestOutput",
+    "ScoringOutput": ".outputs:ScoringOutput",
+    "ScoringRequestOutput": ".outputs:ScoringRequestOutput",
+}
+
+if typing.TYPE_CHECKING:
+    from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
+    from vllm.engine.async_llm_engine import AsyncLLMEngine
+    from vllm.engine.llm_engine import LLMEngine
+    from vllm.entrypoints.llm import LLM
+    from vllm.executor.ray_utils import initialize_ray_cluster
+    from vllm.inputs import PromptType, TextPrompt, TokensPrompt
+    from vllm.model_executor.models import ModelRegistry
+    from vllm.outputs import (ClassificationOutput,
+                              ClassificationRequestOutput, CompletionOutput,
+                              EmbeddingOutput, EmbeddingRequestOutput,
+                              PoolingOutput, PoolingRequestOutput,
+                              RequestOutput, ScoringOutput,
+                              ScoringRequestOutput)
+    from vllm.pooling_params import PoolingParams
+    from vllm.sampling_params import SamplingParams
+else:
+
+    def __getattr__(name: str) -> typing.Any:
+        if name in MODULE_ATTRS:
+            from importlib import import_module
+            module_name, attr_name = MODULE_ATTRS[name].split(":")
+            module = import_module(module_name, __package__)
+            return getattr(module, attr_name)
+        else:
+            raise AttributeError(
+                f'module {__package__} has no attribute {name}')
+
 
 __all__ = [
     "__version__",

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -57,8 +57,9 @@ if typing.TYPE_CHECKING:
 else:
 
     def __getattr__(name: str) -> typing.Any:
+        from importlib import import_module
+
         if name in MODULE_ATTRS:
-            from importlib import import_module
             module_name, attr_name = MODULE_ATTRS[name].split(":")
             module = import_module(module_name, __package__)
             return getattr(module, attr_name)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1971,7 +1971,7 @@ class ParallelConfig:
 
         if not current_platform.use_custom_allreduce():
             self.disable_custom_all_reduce = True
-            logger.info(
+            logger.debug(
                 "Disabled the custom all-reduce kernel because it is not "
                 "supported on current platform.")
         if self.ray_workers_use_nsight and not self.use_ray:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1971,7 +1971,7 @@ class ParallelConfig:
 
         if not current_platform.use_custom_allreduce():
             self.disable_custom_all_reduce = True
-            logger.debug(
+            logger.info(
                 "Disabled the custom all-reduce kernel because it is not "
                 "supported on current platform.")
         if self.ray_workers_use_nsight and not self.use_ray:

--- a/vllm/entrypoints/cli/benchmark/main.py
+++ b/vllm/entrypoints/cli/benchmark/main.py
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
 import argparse
+import typing
 
 from vllm.entrypoints.cli.benchmark.base import BenchmarkSubcommandBase
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.utils import FlexibleArgumentParser
+
+if typing.TYPE_CHECKING:
+    from vllm.utils import FlexibleArgumentParser
 
 
 class BenchmarkSubcommand(CLISubcommand):
@@ -23,7 +29,6 @@ class BenchmarkSubcommand(CLISubcommand):
     def subparser_init(
             self,
             subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
-
         bench_parser = subparsers.add_parser(
             self.name,
             help=self.help,

--- a/vllm/entrypoints/cli/collect_env.py
+++ b/vllm/entrypoints/cli/collect_env.py
@@ -1,19 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 import argparse
+import typing
 
 from vllm.collect_env import main as collect_env_main
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.utils import FlexibleArgumentParser
+
+if typing.TYPE_CHECKING:
+    from vllm.utils import FlexibleArgumentParser
 
 
 class CollectEnvSubcommand(CLISubcommand):
     """The `collect-env` subcommand for the vLLM CLI. """
-
-    def __init__(self):
-        self.name = "collect-env"
-        super().__init__()
+    name = "collect-env"
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
@@ -23,12 +25,11 @@ class CollectEnvSubcommand(CLISubcommand):
     def subparser_init(
             self,
             subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
-        collect_env_parser = subparsers.add_parser(
+        return subparsers.add_parser(
             "collect-env",
             help="Start collecting environment information.",
             description="Start collecting environment information.",
             usage="vllm collect-env")
-        return collect_env_parser
 
 
 def cmd_init() -> list[CLISubcommand]:

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -1,26 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+'''The CLI entrypoints of vLLM
 
-# The CLI entrypoint to vLLM.
+Note that all future modules must be lazily loaded within main
+to avoid certain eager import breakage.'''
+from __future__ import annotations
+
+import importlib.metadata
 import signal
 import sys
-
-import vllm.entrypoints.cli.benchmark.main
-import vllm.entrypoints.cli.collect_env
-import vllm.entrypoints.cli.openai
-import vllm.entrypoints.cli.run_batch
-import vllm.entrypoints.cli.serve
-import vllm.version
-from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG, cli_env_setup
-from vllm.utils import FlexibleArgumentParser
-
-CMD_MODULES = [
-    vllm.entrypoints.cli.openai,
-    vllm.entrypoints.cli.serve,
-    vllm.entrypoints.cli.benchmark.main,
-    vllm.entrypoints.cli.collect_env,
-    vllm.entrypoints.cli.run_batch,
-]
 
 
 def register_signal_handlers():
@@ -33,16 +21,34 @@ def register_signal_handlers():
 
 
 def main():
+    import vllm.entrypoints.cli.benchmark.main
+    import vllm.entrypoints.cli.collect_env
+    import vllm.entrypoints.cli.openai
+    import vllm.entrypoints.cli.run_batch
+    import vllm.entrypoints.cli.serve
+    from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG, cli_env_setup
+    from vllm.utils import FlexibleArgumentParser
+
+    CMD_MODULES = [
+        vllm.entrypoints.cli.openai,
+        vllm.entrypoints.cli.serve,
+        vllm.entrypoints.cli.benchmark.main,
+        vllm.entrypoints.cli.collect_env,
+        vllm.entrypoints.cli.run_batch,
+    ]
+
     cli_env_setup()
 
     parser = FlexibleArgumentParser(
         description="vLLM CLI",
         epilog=VLLM_SUBCMD_PARSER_EPILOG,
     )
-    parser.add_argument('-v',
-                        '--version',
-                        action='version',
-                        version=vllm.version.__version__)
+    parser.add_argument(
+        '-v',
+        '--version',
+        action='version',
+        version=importlib.metadata.version('vllm'),
+    )
     subparsers = parser.add_subparsers(required=False, dest="subparser")
     cmds = {}
     for cmd_module in CMD_MODULES:

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -2,20 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Commands that act as an interactive OpenAI API client
 
-from __future__ import annotations
-
 import argparse
 import os
 import signal
 import sys
-import typing
+from typing import TYPE_CHECKING, Optional
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 
 from vllm.entrypoints.cli.types import CLISubcommand
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from vllm.utils import FlexibleArgumentParser
 
 
@@ -46,7 +44,8 @@ def _interactive_cli(args: argparse.Namespace) -> tuple[str, OpenAI]:
     return model_name, openai_client
 
 
-def chat(system_prompt: str | None, model_name: str, client: OpenAI) -> None:
+def chat(system_prompt: Optional[str], model_name: str,
+         client: OpenAI) -> None:
     conversation: list[ChatCompletionMessageParam] = []
     if system_prompt is not None:
         conversation.append({"role": "system", "content": system_prompt})

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-# Commands that act as an interactive OpenAI API client
+
+from __future__ import annotations
 
 import argparse
 import os
 import signal
 import sys
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
@@ -44,8 +45,7 @@ def _interactive_cli(args: argparse.Namespace) -> tuple[str, OpenAI]:
     return model_name, openai_client
 
 
-def chat(system_prompt: Optional[str], model_name: str,
-         client: OpenAI) -> None:
+def chat(system_prompt: str | None, model_name: str, client: OpenAI) -> None:
     conversation: list[ChatCompletionMessageParam] = []
     if system_prompt is not None:
         conversation.append({"role": "system", "content": system_prompt})

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -2,17 +2,21 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Commands that act as an interactive OpenAI API client
 
+from __future__ import annotations
+
 import argparse
 import os
 import signal
 import sys
-from typing import Optional
+import typing
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.utils import FlexibleArgumentParser
+
+if typing.TYPE_CHECKING:
+    from vllm.utils import FlexibleArgumentParser
 
 
 def _register_signal_handlers():
@@ -42,8 +46,7 @@ def _interactive_cli(args: argparse.Namespace) -> tuple[str, OpenAI]:
     return model_name, openai_client
 
 
-def chat(system_prompt: Optional[str], model_name: str,
-         client: OpenAI) -> None:
+def chat(system_prompt: str | None, model_name: str, client: OpenAI) -> None:
     conversation: list[ChatCompletionMessageParam] = []
     if system_prompt is not None:
         conversation.append({"role": "system", "content": system_prompt})
@@ -92,10 +95,7 @@ def _add_query_options(
 
 class ChatCommand(CLISubcommand):
     """The `chat` subcommand for the vLLM CLI. """
-
-    def __init__(self):
-        self.name = "chat"
-        super().__init__()
+    name = "chat"
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
@@ -157,10 +157,7 @@ class ChatCommand(CLISubcommand):
 
 class CompleteCommand(CLISubcommand):
     """The `complete` subcommand for the vLLM CLI. """
-
-    def __init__(self):
-        self.name = "complete"
-        super().__init__()
+    name = 'complete'
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:

--- a/vllm/entrypoints/cli/run_batch.py
+++ b/vllm/entrypoints/cli/run_batch.py
@@ -6,14 +6,15 @@ from __future__ import annotations
 import argparse
 import asyncio
 import importlib.metadata
+import typing
 
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.openai.run_batch import main as run_batch_main
-from vllm.entrypoints.openai.run_batch import make_arg_parser
 from vllm.entrypoints.utils import (VLLM_SUBCMD_PARSER_EPILOG,
                                     show_filtered_argument_or_group_from_help)
 from vllm.logger import init_logger
-from vllm.utils import FlexibleArgumentParser
+
+if typing.TYPE_CHECKING:
+    from vllm.utils import FlexibleArgumentParser
 
 logger = init_logger(__name__)
 
@@ -24,6 +25,8 @@ class RunBatchSubcommand(CLISubcommand):
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
+        from vllm.entrypoints.openai.run_batch import main as run_batch_main
+
         logger.info("vLLM batch processing API version %s",
                     importlib.metadata.version("vllm"))
         logger.info("args: %s", args)
@@ -44,6 +47,8 @@ class RunBatchSubcommand(CLISubcommand):
     def subparser_init(
             self,
             subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
+        from vllm.entrypoints.openai.run_batch import make_arg_parser
+
         run_batch_parser = subparsers.add_parser(
             "run-batch",
             help="Run batch prompts and write results to file.",

--- a/vllm/entrypoints/cli/run_batch.py
+++ b/vllm/entrypoints/cli/run_batch.py
@@ -1,37 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 import argparse
 import asyncio
-
-from prometheus_client import start_http_server
+import importlib.metadata
 
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.logger import logger
 from vllm.entrypoints.openai.run_batch import main as run_batch_main
 from vllm.entrypoints.openai.run_batch import make_arg_parser
 from vllm.entrypoints.utils import (VLLM_SUBCMD_PARSER_EPILOG,
                                     show_filtered_argument_or_group_from_help)
+from vllm.logger import init_logger
 from vllm.utils import FlexibleArgumentParser
-from vllm.version import __version__ as VLLM_VERSION
+
+logger = init_logger(__name__)
 
 
 class RunBatchSubcommand(CLISubcommand):
     """The `run-batch` subcommand for vLLM CLI."""
-
-    def __init__(self):
-        self.name = "run-batch"
-        super().__init__()
+    name = "run-batch"
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
-        logger.info("vLLM batch processing API version %s", VLLM_VERSION)
+        logger.info("vLLM batch processing API version %s",
+                    importlib.metadata.version("vllm"))
         logger.info("args: %s", args)
 
         # Start the Prometheus metrics server.
         # LLMEngine uses the Prometheus client
         # to publish metrics at the /metrics endpoint.
         if args.enable_metrics:
+            from prometheus_client import start_http_server
+
             logger.info("Prometheus metrics enabled")
             start_http_server(port=args.port, addr=args.url)
         else:

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -9,8 +9,8 @@ import sys
 import uvloop
 import zmq
 
+import vllm
 import vllm.envs as envs
-from vllm import AsyncEngineArgs
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.openai.api_server import (run_server, run_server_worker,
                                                 setup_server)
@@ -112,7 +112,7 @@ def run_headless(args: argparse.Namespace):
         raise ValueError("api_server_count can't be set in headless mode")
 
     # Create the EngineConfig.
-    engine_args = AsyncEngineArgs.from_cli_args(args)
+    engine_args = vllm.AsyncEngineArgs.from_cli_args(args)
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
 
@@ -172,7 +172,7 @@ def run_multi_api_server(args: argparse.Namespace):
 
     listen_address, sock = setup_server(args)
 
-    engine_args = AsyncEngineArgs.from_cli_args(args)
+    engine_args = vllm.AsyncEngineArgs.from_cli_args(args)
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
     model_config = vllm_config.model_config

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -38,10 +38,7 @@ logger = init_logger(__name__)
 
 class ServeSubcommand(CLISubcommand):
     """The `serve` subcommand for the vLLM CLI. """
-
-    def __init__(self):
-        self.name = "serve"
-        super().__init__()
+    name = "serve"
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:

--- a/vllm/entrypoints/cli/types.py
+++ b/vllm/entrypoints/cli/types.py
@@ -20,7 +20,8 @@ class CLISubcommand:
         raise NotImplementedError("Subclasses should implement this method")
 
     def validate(self, args: argparse.Namespace) -> None:
-        ...
+        # No validation by default
+        pass
 
     def subparser_init(
             self,

--- a/vllm/entrypoints/cli/types.py
+++ b/vllm/entrypoints/cli/types.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import argparse
+from __future__ import annotations
 
-from vllm.utils import FlexibleArgumentParser
+import argparse
+import typing
+
+if typing.TYPE_CHECKING:
+    from vllm.utils import FlexibleArgumentParser
 
 
 class CLISubcommand:
@@ -16,8 +20,7 @@ class CLISubcommand:
         raise NotImplementedError("Subclasses should implement this method")
 
     def validate(self, args: argparse.Namespace) -> None:
-        # No validation by default
-        pass
+        ...
 
     def subparser_init(
             self,

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from vllm.engine.arg_utils import AsyncEngineArgs, optional_type
 from vllm.engine.async_llm_engine import AsyncLLMEngine
-from vllm.entrypoints.logger import RequestLogger, logger
+from vllm.entrypoints.logger import RequestLogger
 # yapf: disable
 from vllm.entrypoints.openai.protocol import (BatchRequestInput,
                                               BatchRequestOutput,
@@ -29,9 +29,12 @@ from vllm.entrypoints.openai.serving_embedding import OpenAIServingEmbedding
 from vllm.entrypoints.openai.serving_models import (BaseModelPath,
                                                     OpenAIServingModels)
 from vllm.entrypoints.openai.serving_score import ServingScores
+from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import FlexibleArgumentParser, random_uuid
 from vllm.version import __version__ as VLLM_VERSION
+
+logger = init_logger(__name__)
 
 
 def make_arg_parser(parser: FlexibleArgumentParser):
@@ -201,13 +204,16 @@ async def upload_data(output_url: str, data_or_file: str,
         except Exception as e:
             if attempt < max_retries:
                 logger.error(
-                    f"Failed to upload data (attempt {attempt}). "
-                    f"Error message: {str(e)}.\nRetrying in {delay} seconds..."
+                    "Failed to upload data (attempt %d). Error message: %s.\nRetrying in %d seconds...",  # noqa: E501
+                    attempt,
+                    e,
+                    delay,
                 )
                 await asyncio.sleep(delay)
             else:
-                raise Exception(f"Failed to upload data (attempt {attempt}). "
-                                f"Error message: {str(e)}.") from e
+                raise Exception(
+                    f"Failed to upload data (attempt {attempt}). Error message: {str(e)}."  # noqa: E501
+                ) from e
 
 
 async def write_file(path_or_url: str, batch_outputs: list[BatchRequestOutput],

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -74,10 +74,6 @@ class TritonPlaceholder(types.ModuleType):
         self.heuristics = self._dummy_decorator("heuristics")
         self.Config = self._dummy_decorator("Config")
         self.language = TritonLanguagePlaceholder()
-        logger.warning_once(
-            "Triton is not installed. Using dummy decorators. "
-            "Install it via `pip install triton` to enable kernel"
-            " compilation.")
 
     def _dummy_decorator(self, name):
 

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -74,6 +74,10 @@ class TritonPlaceholder(types.ModuleType):
         self.heuristics = self._dummy_decorator("heuristics")
         self.Config = self._dummy_decorator("Config")
         self.language = TritonLanguagePlaceholder()
+        logger.warning_once(
+            "Triton is not installed. Using dummy decorators. "
+            "Install it via `pip install triton` to enable kernel"
+            " compilation.")
 
     def _dummy_decorator(self, name):
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -67,9 +67,6 @@ from torch.library import Library
 from typing_extensions import Never, ParamSpec, TypeIs, assert_never
 
 import vllm.envs as envs
-# NOTE: import triton_utils to make TritonPlaceholderModule work
-#       if triton is unavailable
-import vllm.triton_utils  # noqa: F401
 from vllm.logger import enable_trace_function_call, init_logger
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This PR performs lazy loading for importing vllm, where it tries to cleanup a lot of eager heavy imports to help improve general CLI startup experience

This PR does:
- Lazy load imports `vllm/__init__.py` to avoid unwanted side-effect. I have checked that most of these imports will be run during serve/engine initialization
- Move a lot of the configuration validator into `@model_validator` hooks
- Cached the compute kwargs in `arg_utils.py`, given that these are currently being called multiples times (we only need this for CLI, so most of the time, it is safe to have this cache. I used a lru_cache size of 30 preemptively to make sure we have enough room for future configuration if needed)
- Lazy load all CLI imports, given that we don't need to setup eagerly during startup.
- remove triton_utils side effect in utils, given that this doesn't seem to do anything (for all of the vllm.triton_utils import, it should validate HAS_TRITON accordingly).

With this PR, it reduces the vllm CLI by around 2 seconds which we still have a lot of room for improvement (a part of #19824 to improve general startup UX)

Here is the hyperfine for `vllm -h`. Python 3.11, 8xH100 instances on LambdaLabs:

with this PR

```bash
➜ hyperfine 'vllm -h' --warmup 3 --runs 100
Benchmark 1: vllm -h
  Time (mean ± σ):      6.705 s ±  0.016 s    [User: 14.560 s, System: 0.571 s]
  Range (min … max):    6.676 s …  6.798 s    100 runs

➜ hyperfine 'python -c "import vllm"' --warmup 3 --runs 100
Benchmark 1: python -c "import vllm"
  Time (mean ± σ):      1.344 s ±  0.004 s    [User: 9.608 s, System: 0.181 s]
  Range (min … max):    1.336 s …  1.356 s    100 runs
```

On current [main](https://github.com/vllm-project/vllm/commit/4c409cabc2c1c432ba670029990bd59e6bbf1479)

```bash
➜ hyperfine 'vllm -h' --warmup 3 --runs 100
Benchmark 1: vllm -h
  Time (mean ± σ):      8.635 s ±  0.020 s    [User: 16.423 s, System: 0.637 s]
  Range (min … max):    8.544 s …  8.730 s    100 runs

➜ hyperfine 'python -c "import vllm"' --warmup 3 --runs 100
Benchmark 1: python -c "import vllm"
  Time (mean ± σ):      5.194 s ±  0.060 s    [User: 13.067 s, System: 0.552 s]
  Range (min … max):    5.139 s …  5.568 s    100 runs
```

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>

