### PR TITLE
[Misc] Simplify vllm bench cli subcommand implementation

### DIFF
--- a/vllm/entrypoints/cli/__init__.py
+++ b/vllm/entrypoints/cli/__init__.py
@@ -5,8 +5,8 @@ from vllm.entrypoints.cli.benchmark.serve import BenchmarkServingSubcommand
 from vllm.entrypoints.cli.benchmark.throughput import (
     BenchmarkThroughputSubcommand)
 
-__all__ = [
-    BenchmarkLatencySubcommand,
-    BenchmarkServingSubcommand,
-    BenchmarkThroughputSubcommand,
+__all__: list[str] = [
+    "BenchmarkLatencySubcommand",
+    "BenchmarkServingSubcommand",
+    "BenchmarkThroughputSubcommand",
 ]

--- a/vllm/entrypoints/cli/__init__.py
+++ b/vllm/entrypoints/cli/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from vllm.entrypoints.cli.benchmark.latency import BenchmarkLatencySubcommand
+from vllm.entrypoints.cli.benchmark.serve import BenchmarkServingSubcommand
+from vllm.entrypoints.cli.benchmark.throughput import (
+    BenchmarkThroughputSubcommand)
+
+__all__ = [
+    BenchmarkLatencySubcommand,
+    BenchmarkServingSubcommand,
+    BenchmarkThroughputSubcommand,
+]

--- a/vllm/entrypoints/cli/benchmark/base.py
+++ b/vllm/entrypoints/cli/benchmark/base.py
@@ -8,6 +8,8 @@ from vllm.entrypoints.cli.types import CLISubcommand
 class BenchmarkSubcommandBase(CLISubcommand):
     """ The base class of subcommands for vllm bench. """
 
+    help: str
+
     @classmethod
     def add_cli_args(cls, parser: argparse.ArgumentParser) -> None:
         """Add the CLI arguments to the parser."""

--- a/vllm/entrypoints/cli/benchmark/base.py
+++ b/vllm/entrypoints/cli/benchmark/base.py
@@ -3,18 +3,13 @@
 import argparse
 
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.utils import FlexibleArgumentParser
 
 
 class BenchmarkSubcommandBase(CLISubcommand):
     """ The base class of subcommands for vllm bench. """
 
-    @property
-    def help(self) -> str:
-        """The help message of the subcommand."""
-        raise NotImplementedError
-
-    def add_cli_args(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def add_cli_args(cls, parser: argparse.ArgumentParser) -> None:
         """Add the CLI arguments to the parser."""
         raise NotImplementedError
 
@@ -26,14 +21,3 @@ class BenchmarkSubcommandBase(CLISubcommand):
             args: The arguments to the command.
         """
         raise NotImplementedError
-
-    def subparser_init(
-            self,
-            subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
-        parser = subparsers.add_parser(
-            self.name,
-            help=self.help,
-            description=self.help,
-            usage=f"vllm bench {self.name} [options]")
-        self.add_cli_args(parser)
-        return parser

--- a/vllm/entrypoints/cli/benchmark/latency.py
+++ b/vllm/entrypoints/cli/benchmark/latency.py
@@ -4,27 +4,18 @@ import argparse
 
 from vllm.benchmarks.latency import add_cli_args, main
 from vllm.entrypoints.cli.benchmark.base import BenchmarkSubcommandBase
-from vllm.entrypoints.cli.types import CLISubcommand
 
 
 class BenchmarkLatencySubcommand(BenchmarkSubcommandBase):
     """ The `latency` subcommand for vllm bench. """
 
-    def __init__(self):
-        self.name = "latency"
-        super().__init__()
+    name = "latency"
+    help = "Benchmark the latency of a single batch of requests."
 
-    @property
-    def help(self) -> str:
-        return "Benchmark the latency of a single batch of requests."
-
-    def add_cli_args(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def add_cli_args(cls, parser: argparse.ArgumentParser) -> None:
         add_cli_args(parser)
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
         main(args)
-
-
-def cmd_init() -> list[CLISubcommand]:
-    return [BenchmarkLatencySubcommand()]

--- a/vllm/entrypoints/cli/benchmark/main.py
+++ b/vllm/entrypoints/cli/benchmark/main.py
@@ -2,51 +2,44 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import argparse
 
-import vllm.entrypoints.cli.benchmark.latency
-import vllm.entrypoints.cli.benchmark.serve
-import vllm.entrypoints.cli.benchmark.throughput
+from vllm.entrypoints.cli.benchmark.base import BenchmarkSubcommandBase
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.utils import FlexibleArgumentParser
-
-BENCHMARK_CMD_MODULES = [
-    vllm.entrypoints.cli.benchmark.latency,
-    vllm.entrypoints.cli.benchmark.serve,
-    vllm.entrypoints.cli.benchmark.throughput,
-]
 
 
 class BenchmarkSubcommand(CLISubcommand):
     """ The `bench` subcommand for the vLLM CLI. """
 
-    def __init__(self):
-        self.name = "bench"
-        super().__init__()
+    name = "bench"
+    help = "vLLM bench subcommand."
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
         args.dispatch_function(args)
 
     def validate(self, args: argparse.Namespace) -> None:
-        if args.bench_type in self.cmds:
-            self.cmds[args.bench_type].validate(args)
+        pass
 
     def subparser_init(
             self,
             subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
+
         bench_parser = subparsers.add_parser(
-            "bench",
-            help="vLLM bench subcommand.",
-            description="vLLM bench subcommand.",
+            self.name,
+            help=self.help,
+            description=self.help,
             usage="vllm bench <bench_type> [options]")
         bench_subparsers = bench_parser.add_subparsers(required=True,
                                                        dest="bench_type")
-        self.cmds = {}
-        for cmd_module in BENCHMARK_CMD_MODULES:
-            new_cmds = cmd_module.cmd_init()
-            for cmd in new_cmds:
-                cmd.subparser_init(bench_subparsers).set_defaults(
-                    dispatch_function=cmd.cmd)
-                self.cmds[cmd.name] = cmd
+
+        for cmd_cls in BenchmarkSubcommandBase.__subclasses__():
+            cmd_subparser = bench_subparsers.add_parser(
+                cmd_cls.name,
+                help=cmd_cls.help,
+                description=cmd_cls.help,
+            )
+            cmd_subparser.set_defaults(dispatch_function=cmd_cls.cmd)
+            cmd_cls.add_cli_args(cmd_subparser)
         return bench_parser
 
 

--- a/vllm/entrypoints/cli/benchmark/serve.py
+++ b/vllm/entrypoints/cli/benchmark/serve.py
@@ -4,27 +4,18 @@ import argparse
 
 from vllm.benchmarks.serve import add_cli_args, main
 from vllm.entrypoints.cli.benchmark.base import BenchmarkSubcommandBase
-from vllm.entrypoints.cli.types import CLISubcommand
 
 
 class BenchmarkServingSubcommand(BenchmarkSubcommandBase):
     """ The `serve` subcommand for vllm bench. """
 
-    def __init__(self):
-        self.name = "serve"
-        super().__init__()
+    name = "serve"
+    help = "Benchmark the online serving throughput."
 
-    @property
-    def help(self) -> str:
-        return "Benchmark the online serving throughput."
-
-    def add_cli_args(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def add_cli_args(cls, parser: argparse.ArgumentParser) -> None:
         add_cli_args(parser)
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
         main(args)
-
-
-def cmd_init() -> list[CLISubcommand]:
-    return [BenchmarkServingSubcommand()]

--- a/vllm/entrypoints/cli/benchmark/throughput.py
+++ b/vllm/entrypoints/cli/benchmark/throughput.py
@@ -4,27 +4,18 @@ import argparse
 
 from vllm.benchmarks.throughput import add_cli_args, main
 from vllm.entrypoints.cli.benchmark.base import BenchmarkSubcommandBase
-from vllm.entrypoints.cli.types import CLISubcommand
 
 
 class BenchmarkThroughputSubcommand(BenchmarkSubcommandBase):
     """ The `throughput` subcommand for vllm bench. """
 
-    def __init__(self):
-        self.name = "throughput"
-        super().__init__()
+    name = "throughput"
+    help = "Benchmark offline inference throughput."
 
-    @property
-    def help(self) -> str:
-        return "Benchmark offline inference throughput."
-
-    def add_cli_args(self, parser: argparse.ArgumentParser) -> None:
+    @classmethod
+    def add_cli_args(cls, parser: argparse.ArgumentParser) -> None:
         add_cli_args(parser)
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
         main(args)
-
-
-def cmd_init() -> list[CLISubcommand]:
-    return [BenchmarkThroughputSubcommand()]


### PR DESCRIPTION
## Purpose
I found the existing implementation over-complicated:
* every module has to include `cmd_init()`;
*  bench base subcommand has to keep track of a `BENCHMARK_CMD_MODULES` and iterate over it manually;
```
BENCHMARK_CMD_MODULES = [
    vllm.entrypoints.cli.benchmark.latency,
    vllm.entrypoints.cli.benchmark.serve,
    vllm.entrypoints.cli.benchmark.throughput,
]
```
* bench command has to implement it's own subparser_init().

This PR directly iterates over subclasses of `BenchmarkSubcommandBase`, use the `name`, `help`, `add_cli_args` and `cmd` to initialize new parser.
If we'd like to add a new subcommand for bench, we only need to 
1. copy paste ~20 lines like in `vllm/entrypoints/cli/benchmark/throughput.py`
2. add the new module to `__init__.py`.

There's no need to change `vllm/entrypoints/cli/benchmark/main.py` and it'll make the import cleaner.

## Test Plan
1. Check help message
```
vllm bench --help
vllm bench latency --help
vllm bench throughput --help
vllm bench serve --help
```
2. Unit tests
```
pytest -vv tests/benchmarks
```
3. Ran a few commands E2E
```
vllm bench latency --model Qwen/Qwen3-235B-A22B-FP8 --tensor-parallel-size 4 --trust-remote-code --max_num_batched_tokens 40000 --input_len 2000 --output_len 150 --gpu-memory-utilization 0.9
```

## Test Result
1. Help messages
```
➜ vllm bench --help

INFO 06-22 00:34:25 [__init__.py:244] Automatically detected platform cuda.
usage: vllm bench <bench_type> [options]

vLLM bench subcommand.

positional arguments:
  {latency,serve,throughput}
    latency             Benchmark the latency of a single batch of requests.
    serve               Benchmark the online serving throughput.
    throughput          Benchmark offline inference throughput.

options:
  -h, --help            show this help message and exit
```
serve: https://gist.github.com/yeqcharlotte/e82fce865397fa985606fd9ff452a89b
latency: https://gist.github.com/yeqcharlotte/1ab09fb1371eb3bde62e67946c5cabe1
throughput: https://gist.github.com/yeqcharlotte/d3037681ac2b8649b54e77e497f771ba
2. Unit tests
```
tests/benchmarks/test_latency_cli.py::test_bench_latency PASSED                                                     [ 33%]
tests/benchmarks/test_serve_cli.py::test_bench_serve PASSED                                                         [ 66%]
tests/benchmarks/test_throughput_cli.py::test_bench_throughput PASSED                                               [100%]
```
3. E2E latency benchmark runs:
it still functions
```
Warmup iterations: 100%|███████████████████████████████████████████████████████████████████| 10/10 [00:39<00:00,  3.97s/it]
Profiling iterations: 100%|████████████████████████████████████████████████████████████████| 30/30 [01:58<00:00,  3.96s/it]
Avg latency: 3.9597734543960543 seconds
10% percentile latency: 3.9077892663422973 seconds
25% percentile latency: 3.937694176507648 seconds
50% percentile latency: 3.9521696044830605 seconds
75% percentile latency: 3.9949043814558536 seconds
90% percentile latency: 4.012286452157423 seconds
99% percentile latency: 4.026482834450435 seconds
```

## (Optional) Documentation Update

