### PR TITLE
[Chore] dedup logs

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1968,7 +1968,7 @@ class ParallelConfig:
 
         if not current_platform.use_custom_allreduce():
             self.disable_custom_all_reduce = True
-            logger.info(
+            logger.debug(
                 "Disabled the custom all-reduce kernel because it is not "
                 "supported on current platform.")
         if self.ray_workers_use_nsight and not self.use_ray:

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -74,10 +74,6 @@ class TritonPlaceholder(types.ModuleType):
         self.heuristics = self._dummy_decorator("heuristics")
         self.Config = self._dummy_decorator("Config")
         self.language = TritonLanguagePlaceholder()
-        logger.warning_once(
-            "Triton is not installed. Using dummy decorators. "
-            "Install it via `pip install triton` to enable kernel"
-            " compilation.")
 
     def _dummy_decorator(self, name):
 


### PR DESCRIPTION
This PR dedups triton logs given that we are already warning about this during eager import check.

Also moves the custom all-reduce warning to debug, given that this is not useful for end-users (only for debugging purposes here.)

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
