### PR TITLE
[CI/Build] Upgrade lm-eval to 0.4.9

### DIFF
--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -27,7 +27,7 @@ mistral_common[opencv] >= 1.6.2 # required for pixtral test
 num2words # required for smolvlm test
 opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
-lm-eval[api]==0.4.8 # required for model evaluation test
+lm-eval[api]==0.4.9 # required for model evaluation test
 mteb>=1.38.11, <2 # required for mteb test
 transformers==4.52.4
 tokenizers==0.21.1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -32,7 +32,7 @@ mistral_common[opencv] >= 1.6.2 # required for pixtral test
 num2words # required for smolvlm test
 opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
-lm-eval[api]==0.4.8 # required for model evaluation test
+lm-eval[api]==0.4.9 # required for model evaluation test
 mteb[bm25s]>=1.38.11, <2 # required for mteb test
 transformers==4.52.4
 tokenizers==0.21.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -282,7 +282,7 @@ librosa==0.10.2.post1
     # via -r requirements/test.in
 llvmlite==0.44.0
     # via numba
-lm-eval==0.4.8
+lm-eval==0.4.9
     # via -r requirements/test.in
 lxml==5.3.0
     # via


### PR DESCRIPTION
## Purpose
Used in https://github.com/vllm-project/vllm/pull/19959.
chartqa is only available in 0.4.9. mmmu_eval has too many categories and is too slow to run. So 

## Test Plan
CI 
Used in https://github.com/vllm-project/vllm/pull/19959
