### PR TITLE
[Chore] Clarifying log messages for KV Connector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -98,8 +98,9 @@ def get_kv_connector_cache_layout():
     vllm_config = get_current_vllm_config()
     kv_config = vllm_config.kv_transfer_config
     if vllm_config.model_config is None or kv_config is None:
-        logger.warning_once("Unable to detect current VLLM config. " \
-        "Defaulting to NHD kv cache layout.")
+        logger.warning_once(
+            "Unable to detect current config for KV Cache connector layout. Defaulting to NHD kv cache layout."  # noqa: E501
+        )
     else:
         use_mla = vllm_config.model_config.use_mla
         if not use_mla and kv_config.kv_connector == "NixlConnector":


### PR DESCRIPTION
This PR clarifies some of the warning for KV Cache layout, given that this is showing up on log traces as "utils.py", which is ambiguous.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
