### PR TITLE
feat: offload weights to cpu before fp8 online quant

### DIFF
--- a/docs/features/quantization/fp8.md
+++ b/docs/features/quantization/fp8.md
@@ -135,4 +135,4 @@ print(result[0].outputs[0].text)
 ```
 
 !!! warning
-    Currently, we load the model at original precision before quantizing down to 8-bits, so you need enough memory to load the whole model.
+    Currently, by default we load the model at original precision before quantizing down to 8-bits, so you need enough memory to load the whole model. To avoid this, adding `VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1` can allow offloading weights to cpu before quantization and quantized weights will be kept in device.

--- a/tests/quantization/test_cpu_offload.py
+++ b/tests/quantization/test_cpu_offload.py
@@ -13,6 +13,16 @@ from ..utils import compare_two_settings
 
 @pytest.mark.skipif(not is_quant_method_supported("fp8"),
                     reason="fp8 is not supported on this GPU type.")
+def test_offload_weights_before_quant_fp8():
+    # Test quantization of an unquantized checkpoint
+    compare_two_settings("meta-llama/Llama-3.2-1B-Instruct",
+                         ["--quantization", "fp8"], ["--quantization", "fp8"],
+                         {"VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT": "1"},
+                         max_wait_seconds=480)
+
+
+@pytest.mark.skipif(not is_quant_method_supported("fp8"),
+                    reason="fp8 is not supported on this GPU type.")
 def test_cpu_offload_fp8():
     # Test quantization of an unquantized checkpoint
     compare_two_settings("meta-llama/Llama-3.2-1B-Instruct",

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1560,6 +1560,10 @@ class CacheConfig:
             raise ValueError("CPU offload space must be non-negative"
                              f", but got {self.cpu_offload_gb}")
 
+        if self.cpu_offload_gb > 0 and envs.VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT:
+            raise ValueError("CPU offload can't work together with"
+                             "OFFLOAD_WEIGHTS_BEFORE_QUANT")
+
         if self.gpu_memory_utilization > 1.0:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -135,6 +135,7 @@ if TYPE_CHECKING:
     VLLM_KV_CACHE_LAYOUT: Optional[str] = None
     VLLM_COMPUTE_NANS_IN_LOGITS: bool = False
     VLLM_USE_NVFP4_CT_EMULATIONS: bool = False
+    VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT: bool = False
 
 
 def get_default_cache_root():
@@ -927,7 +928,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # generations on machines < 100 for compressed-tensors
     # models
     "VLLM_USE_NVFP4_CT_EMULATIONS":
-    lambda: bool(int(os.getenv("VLLM_USE_NVFP4_CT_EMULATIONS", "0")))
+    lambda: bool(int(os.getenv("VLLM_USE_NVFP4_CT_EMULATIONS", "0"))),
+
+    # Offload model weights to cpu before online fp8 quantization
+    "VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT":
+    lambda: os.environ.get("VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT", "0") == "1",
 }
 
 # --8<-- [end:env-vars-definition]


### PR DESCRIPTION
We offload weights to cpu before online quantization so that device doesn't need to hold whole model weights, which fix the limitation mentioned in upstream [fp8 quantization](https://docs.vllm.ai/en/latest/features/quantization/fp8.html#online-dynamic-quantization). Note that, this option can't work together with `cpu_offload_gb` to avoid obscure behaviors.

This feature controlled by env variable `VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT`, example command:
```
VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 VLLM_MLA_DISABLE=1 python3 examples/offline_inference/basic/generate.py --model deepseek-ai/DeepSeek-v2-lite  --enforce-eager --dtype=float16 --block-size=64 --max_model_len=2048 --gpu-memory-utilization=0.8 --quantization fp8 --trust-remote-code
```
