### PR TITLE
[Bugfix] Fix CI bitsandbytes failure

### DIFF
--- a/tests/quantization/test_bitsandbytes.py
+++ b/tests/quantization/test_bitsandbytes.py
@@ -159,6 +159,7 @@ def test_4bit_bnb_embedding_model(
     with vllm_runner(model_name,
                      task="embed",
                      dtype=dtype,
+                     gpu_memory_utilization=0.5,
                      quantization="bitsandbytes") as vllm_model:
         vllm_outputs = vllm_model.encode(example_prompts)
     check_embeddings_close(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
FIX https://github.com/vllm-project/vllm/issues/19964
This OOM issue is probably caused by the recent implementation of V1 support for the embedding model
## Test Plan

## Test Result
The `quantization/test_bitsandbytes.py::test_4bit_bnb_embedding_model[half-intfloat/e5-mistral-7b-instruct-quantize embedding model inflight]` should pass on CI
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
