### PR TITLE
[Core][V1] Support sharded state loading

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1314,12 +1314,6 @@ class EngineArgs:
         #############################################################
         # Unsupported Feature Flags on V1.
 
-        if self.load_format == LoadFormat.SHARDED_STATE.value:
-            _raise_or_fallback(
-                feature_name=f"--load_format {self.load_format}",
-                recommend_to_remove=False)
-            return False
-
         if (self.logits_processor_pattern
                 != EngineArgs.logits_processor_pattern):
             _raise_or_fallback(feature_name="--logits-processor-pattern",


### PR DESCRIPTION
This PR removes the oracles check for sharded state for v1. 

However, it seems like the save sharded weights doesn't work with fp8 checkpoint (I tested with qwen3-235b-a22b) but after removing some of the exception with debug, the models weights seems to be loaded correctly.
So I added a `strict` options to `--model-loader-extra-config` to lax these checks for fp8 checkpoint.

I think this would be a good starting point before adding specific code path for loading quantized weights.

I'm currently in the progress of debugging this, but this should halves the loading time comparing with the default safetensors implementations.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
