### PR TITLE
[Llama4] Update `attn_temperature_tuning`

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -148,9 +148,8 @@ class Llama4Attention(nn.Module):
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
-        # TODO: attn_temperature_tuning should be a bool in huggingface
         self.attn_temperature_tuning = self.nope and \
-            config.attn_temperature_tuning > 0
+            config.attn_temperature_tuning
 
         self.floor_scale = getattr(config, "floor_scale", 8192.0)
         self.attn_scale = getattr(config, "attn_scale", 0.1)


### PR DESCRIPTION
## Purpose

Since https://github.com/huggingface/transformers/pull/37501 landed

It's the below on HF now:

```
attn_temperature_tuning (`bool`, *optional*, defaults to `True`):
            Whether to dynamically scale the attention temperature for each query token based on sequence length.
            Recommended for long sequences (e.g., >32k tokens) to maintain stable output results.
```

So we no longer need this comment

## Test Plan

Start the model on TP=8 on H100, loaded fine

Command:

`vllm serve /models/Llama4-Scout-17B --tensor-parallel-size 8`

<!--- pyml disable-next-line no-emphasis-as-heading -->
