### PR TITLE
[Fix][V1] Remove --scheduling-policy oracle

### DIFF
--- a/tests/v1/test_oracle.py
+++ b/tests/v1/test_oracle.py
@@ -77,12 +77,6 @@ def test_unsupported_configs(monkeypatch):
         with pytest.raises(NotImplementedError):
             AsyncEngineArgs(
                 model=MODEL,
-                scheduling_policy="priority",
-            ).create_engine_config()
-
-        with pytest.raises(NotImplementedError):
-            AsyncEngineArgs(
-                model=MODEL,
                 num_scheduler_steps=5,
             ).create_engine_config()
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1289,11 +1289,6 @@ class EngineArgs:
                                recommend_to_remove=True)
             return False
 
-        if self.scheduling_policy != SchedulerConfig.policy:
-            _raise_or_fallback(feature_name="--scheduling-policy",
-                               recommend_to_remove=False)
-            return False
-
         if self.num_scheduler_steps != SchedulerConfig.num_scheduler_steps:
             _raise_or_fallback(feature_name="--num-scheduler-steps",
                                recommend_to_remove=True)


### PR DESCRIPTION
The previously merged PR #[19057](https://github.com/vllm-project/vllm/pull/19057) failed to disable the exception when --scheduling-policy was defined while running V1.