### PR TITLE
enable torchao for AMD

### DIFF
--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -6,21 +6,47 @@ import importlib.util
 import pytest
 import torch
 
+from vllm.platforms import current_platform
+
 DTYPE = ["bfloat16"]
 
 TORCHAO_AVAILABLE = importlib.util.find_spec("torchao") is not None
 
 
 @pytest.mark.skipif(not TORCHAO_AVAILABLE, reason="torchao is not available")
+@pytest.mark.skipif(
+    current_platform.is_fp8_fnuz(), reason="only fnuz FP8 is supported"
+)
 def test_pre_quantized_model(vllm_runner):
-    with vllm_runner("drisspg/fp8-opt-125m",
-                     quantization="torchao",
-                     dtype="bfloat16",
-                     enforce_eager=True) as llm:
-        output = llm.generate_greedy(["The capital of France is"],
-                                     max_tokens=32)
+    with vllm_runner(
+        "drisspg/fp8-opt-125m",
+        quantization="torchao",
+        dtype="bfloat16",
+        enforce_eager=True,
+    ) as llm:
+        output = llm.generate_greedy(
+            ["The capital of France is"], max_tokens=32
+        )
     assert output
     print(output)
+
+
+@pytest.mark.skipif(not TORCHAO_AVAILABLE, reason="torchao is not available")
+@pytest.mark.skipif(
+    not current_platform.is_fp8_fnuz(), reason="only fnuz FP8 is supported"
+)
+def test_pre_quantized_model_fnuz(vllm_runner):
+    torch._dynamo.reset()
+    model_name = "jcaip/fp8fnuz-opt-125m"
+    with vllm_runner(
+        model_name=model_name, quantization="torchao", dtype="bfloat16"
+    ) as llm:
+        output = llm.generate_greedy(
+            ["The capital of France is"], max_tokens=32
+        )
+
+        assert output
+        print(output)
 
 
 @pytest.mark.skipif(not TORCHAO_AVAILABLE, reason="torchao is not available")
@@ -29,17 +55,22 @@ def test_pre_quantized_model(vllm_runner):
     [
         "cuda:0",
         # {"": "cuda"},
-    ])
-def test_opt_125m_int8wo_model_loading_with_params(vllm_runner,
-                                                   pt_load_map_location):
+    ],
+)
+def test_opt_125m_int8wo_model_loading_with_params(
+    vllm_runner, pt_load_map_location
+):
     torch._dynamo.reset()
     model_name = "jerryzh168/opt-125m-int8wo-partial-quant"
-    with vllm_runner(model_name=model_name,
-                     quantization="torchao",
-                     dtype="bfloat16",
-                     pt_load_map_location=pt_load_map_location) as llm:
-        output = llm.generate_greedy(["The capital of France is"],
-                                     max_tokens=32)
+    with vllm_runner(
+        model_name=model_name,
+        quantization="torchao",
+        dtype="bfloat16",
+        pt_load_map_location=pt_load_map_location,
+    ) as llm:
+        output = llm.generate_greedy(
+            ["The capital of France is"], max_tokens=32
+        )
 
         assert output
         print(output)
@@ -49,12 +80,15 @@ def test_opt_125m_int8wo_model_loading_with_params(vllm_runner,
 def test_opt_125m_int4wo_model_per_module_quant(vllm_runner):
     torch._dynamo.reset()
     model_name = "jerryzh168/opt-125m-int4wo-per-module"
-    with vllm_runner(model_name=model_name,
-                     quantization="torchao",
-                     dtype="bfloat16",
-                     pt_load_map_location="cuda:0") as llm:
-        output = llm.generate_greedy(["The capital of France is"],
-                                     max_tokens=32)
+    with vllm_runner(
+        model_name=model_name,
+        quantization="torchao",
+        dtype="bfloat16",
+        pt_load_map_location="cuda:0",
+    ) as llm:
+        output = llm.generate_greedy(
+            ["The capital of France is"], max_tokens=32
+        )
 
         assert output
         print(output)
@@ -64,12 +98,15 @@ def test_opt_125m_int4wo_model_per_module_quant(vllm_runner):
 def test_qwenvl_int8wo_model_loading_with_params(vllm_runner):
     torch._dynamo.reset()
     model_name = "mobicham/Qwen2.5-VL-3B-Instruct_int8wo_ao"
-    with vllm_runner(model_name=model_name,
-                     quantization="torchao",
-                     dtype="bfloat16",
-                     pt_load_map_location="cuda:0") as llm:
-        output = llm.generate_greedy(["The capital of France is"],
-                                     max_tokens=32)
+    with vllm_runner(
+        model_name=model_name,
+        quantization="torchao",
+        dtype="bfloat16",
+        pt_load_map_location="cuda:0",
+    ) as llm:
+        output = llm.generate_greedy(
+            ["The capital of France is"], max_tokens=32
+        )
 
         assert output
         print(output)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -168,7 +168,7 @@ class RocmPlatform(Platform):
 
     supported_quantization: list[str] = [
         "awq", "gptq", "fp8", "compressed-tensors", "fbgemm_fp8", "gguf",
-        "quark", "ptpc_fp8"
+        "quark", "ptpc_fp8", "torchao"
     ]
 
     @classmethod


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR enables torchao as a supported quanitzation technique for AMD. 

I see the following speedups when running `run-performance-benchmarks.sh` on a MI300X:

```
# Latency tests

- Input length: 32 tokens.
- Output length: 128 tokens.
- Batch size: fixed (1).
- Models: llama-3.1 8B, llama-3 70B, mixtral 8x7B.
- Evaluation metrics: end-to-end latency (mean, median, p99).

| Test name                                | GPU        |   Mean latency (ms) |   Median latency (ms) |   P99 latency (ms) |
|:-----------------------------------------|:-----------|--------------------:|----------------------:|-------------------:|
| latency_llama70B_tp1                     | 1xMI300X-O |             1040.38 |               1043.81 |            1066.25 |
| latency_llama70B_tp1_float8dq-per-row    | 1xMI300X-O |             1068.96 |               1075.82 |            1093.81 |
| latency_llama70B_tp1_float8dq-per-tensor | 1xMI300X-O |             1104.17 |               1109.92 |            1126.08 |
| latency_llama70B_tp1_int4wo-hqq          | 1xMI300X-O |             1112.85 |               1118.15 |            1136.43 |

## Throughput tests

- Input length: randomly sample 200 prompts from ShareGPT dataset (with fixed random seed).
- Output length: the corresponding output length of these 200 prompts.
- Batch size: dynamically determined by vllm to achieve maximum throughput.
- Models: llama-3.1 8B, llama-3 70B, mixtral 8x7B.
- Evaluation metrics: throughput.

| Test name                                  | GPU        |   Tput (req/s) |
|:-------------------------------------------|:-----------|---------------:|
| throughput_llama8B_tp1                     | 1xMI300X-O |        17.2457 |
| throughput_llama8B_tp1_float8dq_per_row    | 1xMI300X-O |        20.2053 |
| throughput_llama8B_tp1_float8dq_per_tensor | 1xMI300X-O |        18.4371 |
```

## Test Plan

You can test with 
```
pytest tests/quantization/test_torchao.py 
```

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
