### PR TITLE
[Bugfix] Fix Gemma3 weights loading

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -479,8 +479,12 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
             "model.vision_tower.": "vision_tower.",
             "model.multi_modal_projector.": "multi_modal_projector.",
             "lm_head.": "language_model.lm_head.",
-            "vision_tower.vision_model.": "vision_model.",
-        })
+        },
+        orig_to_new_substr={
+            # mapping for llm-compressor quantized checkpoints
+            "vision_model.vision_model.": "vision_model.",
+        },
+    )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Fix https://github.com/vllm-project/llm-compressor/issues/1546#issuecomment-2998918924
- #19643 broke unquantized gemma3 weights loading by mistake, it should map `vision_model.vision_model.` exactly, my bad! 😢 
- This PR corrects the name mapping for Gemma3.

## Test Plan
```
python examples/offline_inference/vision_language.py -m gemma3
```

## Test Result
- Gemma3 loading should work now.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
