### PR TITLE
Revert "Fix(models/siglip): Add compatibility for Gemma models quantized by llm-compressor"

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -479,7 +479,6 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
             "model.vision_tower.": "vision_tower.",
             "model.multi_modal_projector.": "multi_modal_projector.",
             "lm_head.": "language_model.lm_head.",
-            "vision_tower.vision_model.": "vision_model.",
         })
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):


### PR DESCRIPTION
Reverts vllm-project/vllm#19643

- It's reported that #19643 broke unquantized Gemma3 models loading, my bad! 😢 
- Revert it until proper fix is submitted by @Flink-ddd: https://github.com/vllm-project/llm-compressor/issues/1546#issuecomment-3000303239