### PR TITLE
use .dev for version comparison with pytorch nightly release

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -5,6 +5,15 @@ import pytest
 import vllm
 from vllm.compilation.counter import compilation_counter
 from vllm.config import VllmConfig
+from vllm.utils import _is_torch_equal_or_newer
+
+
+def test_version():
+    assert _is_torch_equal_or_newer('2.8.0.dev20250624+cu128', '2.8.0.dev')
+    assert _is_torch_equal_or_newer('2.8.0a0+gitc82a174', '2.8.0.dev')
+    assert _is_torch_equal_or_newer('2.8.0', '2.8.0.dev')
+    assert _is_torch_equal_or_newer('2.8.1', '2.8.0.dev')
+    assert not _is_torch_equal_or_newer('2.7.1', '2.8.0.dev')
 
 
 def test_use_cudagraphs_dynamic(monkeypatch):

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -32,7 +32,7 @@ logger = init_logger(__name__)
 def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
     if compilation_config.use_inductor:
         if envs.VLLM_USE_STANDALONE_COMPILE and is_torch_equal_or_newer(
-                "2.8.0a"):
+                "2.8.0.dev"):
             logger.debug("Using InductorStandaloneAdaptor")
             return InductorStandaloneAdaptor()
         else:

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -44,14 +44,14 @@ class TorchAOConfig(QuantizationConfig):
         """
         # TorchAO quantization relies on tensor subclasses. In order,
         # to enable proper caching this needs standalone compile
-        if is_torch_equal_or_newer("2.8.0a"):
+        if is_torch_equal_or_newer("2.8.0.dev"):
             os.environ["VLLM_TEST_STANDALONE_COMPILE"] = "1"
             logger.info(
                 "Using TorchAO: Setting VLLM_TEST_STANDALONE_COMPILE=1")
 
         # TODO: remove after the torch dependency is updated to 2.8
         if is_torch_equal_or_newer(
-                "2.7.0") and not is_torch_equal_or_newer("2.8.0a"):
+                "2.7.0") and not is_torch_equal_or_newer("2.8.0.dev"):
             os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
             logger.info("Using TorchAO: Setting VLLM_DISABLE_COMPILE_CACHE=1")
         """

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2919,8 +2919,13 @@ def is_torch_equal_or_newer(target: str) -> bool:
         Whether the condition meets.
     """
     try:
-        torch_version = version.parse(str(torch.__version__))
-        return torch_version >= version.parse(target)
+        return _is_torch_equal_or_newer(str(torch.__version__), target)
     except Exception:
         # Fallback to PKG-INFO to load the package info, needed by the doc gen.
         return Version(importlib.metadata.version('torch')) >= Version(target)
+
+
+# Helper function used in testing.
+def _is_torch_equal_or_newer(torch_version: str, target: str) -> bool:
+    torch_version = version.parse(torch_version)
+    return torch_version >= version.parse(target)


### PR DESCRIPTION
#19587 tried to use `2.8.0.a` for enabling standalone_compile in vllm x torch nightly CI tests.

There is an issue that local pytorch build gives `2.8.0.a`, but pytorch nightly release gives `2.8.0.dev`. To save build time the ci tests uses pytorch nightly release instead of local pytorch build. Since `2.8.0.dev` < `2.8.0.a`, this pr uses `.dev` instead.