### PR TITLE
[New Model] Support `StableLMAlphaForCausalLM`

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -113,6 +113,7 @@ _TEXT_GENERATION_MODELS = {
     "RWForCausalLM": ("falcon", "FalconForCausalLM"),
     "StableLMEpochForCausalLM": ("stablelm", "StablelmForCausalLM"),
     "StableLmForCausalLM": ("stablelm", "StablelmForCausalLM"),
+    "StableLMAlphaForCausalLM": ("stablelm_alpha", "StableLMAlphaForCausalLM"),
     "Starcoder2ForCausalLM": ("starcoder2", "Starcoder2ForCausalLM"),
     "SolarForCausalLM": ("solar", "SolarForCausalLM"),
     "TeleChat2ForCausalLM": ("telechat2", "TeleChat2ForCausalLM"),

--- a/vllm/model_executor/models/stablelm_alpha.py
+++ b/vllm/model_executor/models/stablelm_alpha.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright 2023 Stability AI, EleutherAI, and The HuggingFace Inc. team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This code is based off the following work:
+# https://huggingface.co/stabilityai/stablelm-base-alpha-3b/blob/main/modeling_stablelm_alpha.py
+"""Inference-only StableLM-Alpha model compatible with HuggingFace weights."""
+from collections.abc import Iterable
+from typing import Optional, Union, cast
+
+import torch
+from torch import nn
+
+from vllm.attention import Attention
+from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.linear import (MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.configs.stablelm_alpha import StableLMAlphaConfig
+
+from .interfaces import SupportsPP
+from .utils import (AutoWeightsLoader, is_pp_missing_parameter,
+                    make_empty_intermediate_tensors_factory, make_layers,
+                    maybe_prefix)
+
+
+class StableLMAlphaMLP(nn.Module):
+
+    def __init__(self,
+                 config: StableLMAlphaConfig,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 prefix: str = "") -> None:
+        super().__init__()
+        self.config = config
+        hidden_size = config.hidden_size
+
+        # Calculate intermediate size using StableLM-Alpha's specific logic
+        multiple_of = 256
+        ff_dim = int(8 * hidden_size / 3)
+        intermediate_size = multiple_of * (
+            (ff_dim + multiple_of - 1) // multiple_of)
+
+        # Gate projection outputs 2 * intermediate_size, then gets chunked
+        self.gate_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size, intermediate_size],  # ff and ff_gate
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_proj")
+
+        self.out_proj = RowParallelLinear(intermediate_size,
+                                          hidden_size,
+                                          bias=False,
+                                          quant_config=quant_config,
+                                          prefix=f"{prefix}.out_proj")
+
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.out_proj(x)
+        return x
+
+
+class StableLMAlphaAttention(nn.Module):
+
+    def __init__(self,
+                 config: StableLMAlphaConfig,
+                 cache_config: Optional[CacheConfig] = None,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 prefix: str = "") -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+
+        self.total_num_heads = config.num_attention_heads
+        self.num_heads = self.total_num_heads // tp_size
+
+        self.total_num_key_value_heads = config.num_key_value_heads
+        if self.total_num_key_value_heads >= tp_size:
+            # Number of KV heads is greater than TP size, so we partition
+            # the KV heads across multiple tensor parallel GPUs.
+            assert self.total_num_key_value_heads % tp_size == 0
+        else:
+            # Number of KV heads is less than TP size, so we replicate
+            # the KV heads across multiple tensor parallel GPUs.
+            assert tp_size % self.total_num_key_value_heads == 0
+        self.num_key_value_heads = max(
+            1, self.total_num_key_value_heads // tp_size)
+
+        self.head_dim = self.hidden_size // self.total_num_heads
+        self.max_position_embeddings = config.max_position_embeddings
+
+        # Partial rotary embeddings
+        self.rotary_ndims = int(self.head_dim * config.rotary_pct)
+
+        self.scaling = self.head_dim**-0.5
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_key_value_heads * self.head_dim
+
+        if (self.head_dim * self.num_heads * tp_size) != self.hidden_size:
+            raise ValueError(f"hidden_size must be divisible by num_heads "
+                             f"(got `hidden_size`: {self.hidden_size}"
+                             f" and `num_heads`: {self.num_heads}).")
+
+        self.qkv_proj = QKVParallelLinear(self.hidden_size,
+                                          self.head_dim,
+                                          self.total_num_heads,
+                                          self.total_num_key_value_heads,
+                                          bias=config.use_qkv_bias,
+                                          quant_config=quant_config,
+                                          prefix=f"{prefix}.qkv_proj")
+
+        self.out_proj = RowParallelLinear(self.total_num_heads * self.head_dim,
+                                          self.hidden_size,
+                                          bias=False,
+                                          quant_config=quant_config,
+                                          prefix=f"{prefix}.out_proj")
+
+        # Rotary embedding with partial rotary support
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.rotary_ndims,
+            max_position=self.config.max_position_embeddings,
+            base=self.config.rotary_emb_base,
+        )
+
+        self.attn = Attention(self.num_heads,
+                              self.head_dim,
+                              self.scaling,
+                              num_kv_heads=self.num_key_value_heads,
+                              cache_config=cache_config,
+                              quant_config=quant_config,
+                              prefix=f"{prefix}.attn")
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v)
+        output, _ = self.out_proj(attn_output)
+        return output
+
+
+class StableLMAlphaDecoderLayer(nn.Module):
+
+    def __init__(
+        self,
+        config: StableLMAlphaConfig,
+        cache_config: Optional[CacheConfig] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        self.norm = nn.LayerNorm(config.hidden_size, eps=config.norm_eps)
+
+        self.attention = StableLMAlphaAttention(config,
+                                                cache_config,
+                                                quant_config,
+                                                prefix=f"{prefix}.attention")
+
+        self.mlp = StableLMAlphaMLP(config,
+                                    quant_config,
+                                    prefix=f"{prefix}.mlp")
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Pre-norm: apply normalization once and use for both attention and MLP
+        residual = hidden_states
+        hidden_states = self.norm(hidden_states)
+
+        # Self-attention
+        attn_output = self.attention(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+
+        # Feed-forward (using the same normalized input)
+        mlp_output = self.mlp(hidden_states)
+
+        # Residual connection: residual + attn_output + mlp_output
+        hidden_states = residual + attn_output + mlp_output
+
+        return hidden_states, residual
+
+
+class StableLMAlphaModel(nn.Module):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+
+        config = vllm_config.model_config.hf_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
+        )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            lambda prefix: StableLMAlphaDecoderLayer(cast(
+                StableLMAlphaConfig, config),
+                                                     cache_config,
+                                                     quant_config,
+                                                     prefix=prefix),
+            prefix=f"{prefix}.layers",
+        )
+
+        self.final_norm = nn.LayerNorm(config.hidden_size, eps=config.norm_eps)
+
+        self.make_empty_intermediate_tensors = (
+            make_empty_intermediate_tensors_factory(["hidden_states"],
+                                                    config.hidden_size))
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors],
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.get_input_embeddings(input_ids)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        for layer in self.layers[self.start_layer:self.end_layer]:
+            hidden_states, residual = layer(positions, hidden_states)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        hidden_states = self.final_norm(hidden_states)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_proj", "gate_proj", 0),
+            ("gate_proj", "up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            # Handle standard parameter mappings
+            for (param_name, weight_name, shard_id) in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class StableLMAlphaForCausalLM(nn.Module, SupportsPP):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+        self.quant_config = quant_config
+
+        self.model = StableLMAlphaModel(vllm_config=vllm_config,
+                                        prefix=maybe_prefix(prefix, "model"))
+
+        self.lm_head = ParallelLMHead(config.vocab_size,
+                                      config.hidden_size,
+                                      quant_config=quant_config,
+                                      prefix=f"{prefix}.lm_head")
+
+        if getattr(self.config, "tie_word_embeddings", False):
+            self.lm_head.weight = self.model.embed_tokens.weight
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+        # Create a callable for make_empty_intermediate_tensors
+        def _make_empty_intermediate_tensors(
+                batch_size: int, dtype: torch.dtype,
+                device: torch.device) -> IntermediateTensors:
+            return self.model.make_empty_intermediate_tensors(
+                batch_size, dtype, device)
+
+        self.make_empty_intermediate_tensors = _make_empty_intermediate_tensors
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        *,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        hidden_states = self.model(input_ids, positions, intermediate_tensors,
+                                   inputs_embeds)
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[torch.Tensor]:
+        logits = self.logits_processor(self.lm_head, hidden_states,
+                                       sampling_metadata)
+        return logits
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm/model_executor/models/stablelm_alpha.py
+++ b/vllm/model_executor/models/stablelm_alpha.py
@@ -133,7 +133,7 @@ class StableLMAlphaAttention(nn.Module):
                                           self.head_dim,
                                           self.total_num_heads,
                                           self.total_num_key_value_heads,
-                                          bias=config.use_qkv_bias,
+                                          bias=False,
                                           quant_config=quant_config,
                                           prefix=f"{prefix}.qkv_proj")
 

--- a/vllm/model_executor/models/stablelm_alpha.py
+++ b/vllm/model_executor/models/stablelm_alpha.py
@@ -99,10 +99,10 @@ class StableLMAlphaAttention(nn.Module):
         self.hidden_size = config.hidden_size
         tp_size = get_tensor_model_parallel_world_size()
 
-        self.total_num_heads = config.num_attention_heads
+        self.total_num_heads = config.num_heads
         self.num_heads = self.total_num_heads // tp_size
 
-        self.total_num_key_value_heads = config.num_key_value_heads
+        self.total_num_key_value_heads = config.num_heads
         if self.total_num_key_value_heads >= tp_size:
             # Number of KV heads is greater than TP size, so we partition
             # the KV heads across multiple tensor parallel GPUs.

--- a/vllm/model_executor/models/stablelm_alpha.py
+++ b/vllm/model_executor/models/stablelm_alpha.py
@@ -280,10 +280,18 @@ class StableLMAlphaModel(nn.Module):
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
+        # StableLM-Alpha weight name mappings
+        weight_name_mappings = {
+            "embed.weight": "embed_tokens.weight",
+        }
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
+            # Apply weight name mappings
+            if name in weight_name_mappings:
+                name = weight_name_mappings[name]
+            
             # Skip loading extra bias for GPTQ models.
             if name.endswith(".bias") and name not in params_dict:
                 continue

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -42,6 +42,7 @@ from vllm.transformers_utils.configs import (ChatGLMConfig, Cohere2Config,
                                              NemotronConfig, NVLM_D_Config,
                                              OvisConfig, RWConfig,
                                              SkyworkR1VChatConfig, SolarConfig,
+                                             StableLMAlphaConfig,
                                              Telechat2Config, UltravoxConfig)
 # yapf: enable
 from vllm.transformers_utils.utils import check_gguf_file
@@ -83,6 +84,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = {
     "ovis": OvisConfig,
     "solar": SolarConfig,
     "skywork_chat": SkyworkR1VChatConfig,
+    "stablelm_alpha": StableLMAlphaConfig,
     "telechat": Telechat2Config,
     "ultravox": UltravoxConfig,
     **_CONFIG_REGISTRY_OVERRIDE_HF

--- a/vllm/transformers_utils/configs/__init__.py
+++ b/vllm/transformers_utils/configs/__init__.py
@@ -28,6 +28,7 @@ from vllm.transformers_utils.configs.nvlm_d import NVLM_D_Config
 from vllm.transformers_utils.configs.ovis import OvisConfig
 from vllm.transformers_utils.configs.skyworkr1v import SkyworkR1VChatConfig
 from vllm.transformers_utils.configs.solar import SolarConfig
+from vllm.transformers_utils.configs.stablelm_alpha import StableLMAlphaConfig
 from vllm.transformers_utils.configs.telechat2 import Telechat2Config
 from vllm.transformers_utils.configs.ultravox import UltravoxConfig
 
@@ -56,6 +57,7 @@ __all__ = [
     "OvisConfig",
     "SkyworkR1VChatConfig",
     "SolarConfig",
+    "StableLMAlphaConfig",
     "Telechat2Config",
     "UltravoxConfig",
 ]

--- a/vllm/transformers_utils/configs/stablelm_alpha.py
+++ b/vllm/transformers_utils/configs/stablelm_alpha.py
@@ -89,43 +89,42 @@ class StableLMAlphaConfig(PretrainedConfig):
 
     def __init__(
         self,
-        vocab_size=50257,
-        hidden_size=4096,
-        intermediate_size=11008,
+        vocab_size=50432,
+        hidden_size=2560,
         num_hidden_layers=32,
-        num_attention_heads=32,
-        num_key_value_heads=None,
-        max_position_embeddings=2048,
+        num_heads=32,
+        max_position_embeddings=4096,
         initializer_range=0.02,
         norm_eps=1e-5,
-        rotary_pct=1.0,
+        hidden_act="silu",
+        rotary_pct=0.25,
         rotary_emb_base=10000,
+        rotary_scaling_factor=1.0,
         use_qkv_bias=False,
         tie_word_embeddings=False,
         use_cache=True,
         pad_token_id=None,
-        bos_token_id=1,
-        eos_token_id=2,
+        bos_token_id=0,
+        eos_token_id=0,
         **kwargs,
     ):
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
-        self.intermediate_size = intermediate_size
         self.num_hidden_layers = num_hidden_layers
-        self.num_attention_heads = num_attention_heads
-
-        # for backward compatibility
-        if num_key_value_heads is None:
-            num_key_value_heads = num_attention_heads
-
-        self.num_key_value_heads = num_key_value_heads
+        self.num_heads = num_heads
         self.max_position_embeddings = max_position_embeddings
         self.initializer_range = initializer_range
         self.norm_eps = norm_eps
+        self.hidden_act = hidden_act
         self.rotary_pct = rotary_pct
         self.rotary_emb_base = rotary_emb_base
+        self.rotary_scaling_factor = rotary_scaling_factor
         self.use_qkv_bias = use_qkv_bias
         self.use_cache = use_cache
+
+        # For compatibility with vLLM, provide these attributes
+        self.num_attention_heads = num_heads
+        self.num_key_value_heads = num_heads  # StableLM-Alpha uses MHA
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/vllm/transformers_utils/configs/stablelm_alpha.py
+++ b/vllm/transformers_utils/configs/stablelm_alpha.py
@@ -131,3 +131,8 @@ class StableLMAlphaConfig(PretrainedConfig):
             tie_word_embeddings=tie_word_embeddings,
             **kwargs,
         )
+
+
+# Register the config class with transformers for the StableLM-Alpha model type
+from transformers import CONFIG_MAPPING
+CONFIG_MAPPING.register("stablelm_alpha", StableLMAlphaConfig)

--- a/vllm/transformers_utils/configs/stablelm_alpha.py
+++ b/vllm/transformers_utils/configs/stablelm_alpha.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright 2023 Stability AI, EleutherAI, and The HuggingFace Inc. team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""StableLM-Alpha model configuration"""
+# ruff: noqa: E501
+from transformers import PretrainedConfig
+
+
+class StableLMAlphaConfig(PretrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of a [`StableLMAlphaModel`]. It is used to instantiate
+    a StableLM-Alpha model according to the specified arguments, defining the model architecture. Instantiating a
+    configuration with the defaults will yield a similar configuration to that of the StableLM-Alpha
+    [stabilityai/stablelm-base-alpha-3b](https://huggingface.co/stabilityai/stablelm-base-alpha-3b) architecture.
+
+    Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PretrainedConfig`] for more information.
+
+    Args:
+        vocab_size (`int`, *optional*, defaults to 50257):
+            Vocabulary size of the StableLM-Alpha model. Defines the number of different tokens that can be represented
+            by the `inputs_ids` passed when calling [`StableLMAlphaModel`].
+        hidden_size (`int`, *optional*, defaults to 4096):
+            Dimension of the hidden representations.
+        intermediate_size (`int`, *optional*, defaults to 11008):
+            Dimension of the MLP representations.
+        num_hidden_layers (`int`, *optional*, defaults to 32):
+            Number of hidden layers in the Transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 32):
+            Number of attention heads for each attention layer in the Transformer encoder.
+        num_key_value_heads (`int`, *optional*):
+            This is the number of key_value heads that should be used to implement Grouped Query Attention. If
+            `num_key_value_heads=num_attention_heads`, the model will use Multi Head Attention (MHA), if
+            `num_key_value_heads=1` the model will use Multi Query Attention (MQA) otherwise GQA is used. When
+            converting a multi-head checkpoint to a GQA checkpoint, each group key and value head should be constructed
+            by meanpooling all the original heads within that group. For more details checkout [this
+            paper](https://arxiv.org/pdf/2305.13245.pdf). If it is not specified, will default to
+            `num_attention_heads`.
+        max_position_embeddings (`int`, *optional*, defaults to 2048):
+            The maximum sequence length that this model might ever be used with. Typically set this to something large
+            just in case (e.g., 512 or 1024 or 2048).
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
+        norm_eps (`float`, *optional*, defaults to 1e-5):
+            The epsilon used by the normalization layers.
+        rotary_pct (`float`, *optional*, defaults to 1.0):
+            The percentage of the hidden size to use for rotary position embeddings.
+        rotary_emb_base (`int`, *optional*, defaults to 10000):
+            The base period of the RoPE embeddings.
+        use_qkv_bias (`bool`, *optional*, defaults to `False`):
+            Whether to use bias in the query, key, and value projection layers.
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether to tie weight embeddings
+        use_cache (`bool`, *optional*, defaults to `True`):
+            Whether or not the model should return the last key/values attentions (not used by all models). Only
+            relevant if `config.is_decoder=True`.
+
+    Example:
+
+    ```python
+    >>> from transformers import StableLMAlphaModel, StableLMAlphaConfig
+
+    >>> # Initializing a StableLM-Alpha stablelm-base-alpha-3b style configuration
+    >>> configuration = StableLMAlphaConfig()
+
+    >>> # Initializing a model from the stablelm-base-alpha-3b style configuration
+    >>> model = StableLMAlphaModel(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```"""
+
+    model_type = "stablelm_alpha"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size=50257,
+        hidden_size=4096,
+        intermediate_size=11008,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        num_key_value_heads=None,
+        max_position_embeddings=2048,
+        initializer_range=0.02,
+        norm_eps=1e-5,
+        rotary_pct=1.0,
+        rotary_emb_base=10000,
+        use_qkv_bias=False,
+        tie_word_embeddings=False,
+        use_cache=True,
+        pad_token_id=None,
+        bos_token_id=1,
+        eos_token_id=2,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+
+        # for backward compatibility
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+
+        self.num_key_value_heads = num_key_value_heads
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.norm_eps = norm_eps
+        self.rotary_pct = rotary_pct
+        self.rotary_emb_base = rotary_emb_base
+        self.use_qkv_bias = use_qkv_bias
+        self.use_cache = use_cache
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/vllm/transformers_utils/configs/stablelm_alpha.py
+++ b/vllm/transformers_utils/configs/stablelm_alpha.py
@@ -100,7 +100,6 @@ class StableLMAlphaConfig(PretrainedConfig):
         rotary_pct=0.25,
         rotary_emb_base=10000,
         rotary_scaling_factor=1.0,
-        use_qkv_bias=False,
         tie_word_embeddings=False,
         use_cache=True,
         pad_token_id=None,
@@ -119,7 +118,6 @@ class StableLMAlphaConfig(PretrainedConfig):
         self.rotary_pct = rotary_pct
         self.rotary_emb_base = rotary_emb_base
         self.rotary_scaling_factor = rotary_scaling_factor
-        self.use_qkv_bias = use_qkv_bias
         self.use_cache = use_cache
 
         # For compatibility with vLLM, provide these attributes

--- a/vllm/transformers_utils/configs/stablelm_alpha.py
+++ b/vllm/transformers_utils/configs/stablelm_alpha.py
@@ -133,6 +133,3 @@ class StableLMAlphaConfig(PretrainedConfig):
         )
 
 
-# Register the config class with transformers for the StableLM-Alpha model type
-from transformers import CONFIG_MAPPING
-CONFIG_MAPPING.register("stablelm_alpha", StableLMAlphaConfig)


### PR DESCRIPTION
## Purpose

Support the `StableLMAlphaForCausalLM` architecture. Note that `stabilityai/stablelm-base-alpha-3b-v2` isn't supported on V1, since the `head_dim` = 80, of `hidden_size` (2560) / `num_heads` (32) isn't supported due to FlashAttention & Flashinfer incompatibility with dimension 80.

- Fix #15046

## Test Plan and Results

### Evaluate `gsm8k`

`lm_eval --model hf --model_args pretrained=stabilityai/stablelm-base-alpha-7b-v2,trust_remote_code=True --tasks gsm8k --num_fewshot 5 --limit 250 --batch_size auto`

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.052|±  |0.0141|
|     |       |strict-match    |     5|exact_match|↑  |0.040|±  |0.0124|

`lm_eval --model vllm --model_args pretrained=stabilityai/stablelm-base-alpha-7b-v2
,trust_remote_code=True --tasks gsm8k --num_fewshot 5 --limit 250 --batch_size auto`

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.052|±  |0.0139|
|     |       |strict-match    |     5|exact_match|↑  |0.040|±  |0.0122|

## (Optional) Documentation Update

TODO: Occasionally there is garbled output, like below.

<details>
<summary>Request</summary>

```bash
curl http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "stabilityai/stablelm-base-alpha-7b-v2",
    "prompt": "San Francisco is a",
    "max_tokens": 7,
    "temperature": 0
}'
```

</details>

<details>
<summary>Response</summary>

```json
{
  "id": "cmpl-c1260c8243f041d6818b0914ba1a7af0",
  "object": "text_completion",
  "created": 1750789759,
  "model": "stabilityai/stablelm-base-alpha-7b-v2",
  "choices": [
    {
      "index": 0,
      "text": "—A,A,A,",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "prompt_logprobs": null
    }
  ],
  "usage": {
    "prompt_tokens": 4,
    "completion_tokens": 7,
    "total_tokens": 11,
    "prompt_tokens_details": null
  },
  "kv_transfer_params": null
}
```

</details>

TODO: Add to the supported models doc.

<!--- pyml disable-next-line no-emphasis-as-heading -->
