### PR TITLE
[Bugfix] default set cuda_graph_sizes to max_num_seqs for v1 engine

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2203,6 +2203,7 @@ class SchedulerConfig:
                 self.max_num_partial_prefills, self.max_long_partial_prefills,
                 self.long_prefill_token_threshold)
 
+        # If cuda_graph_sizes is not specified, default set to [max_num_seqs].
         if self.cuda_graph_sizes is None:
             self.cuda_graph_sizes = [self.max_num_seqs]
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2033,7 +2033,7 @@ class SchedulerConfig:
     NOTE: This will be replaced by speculative config in the future; it is
     present to enable correctness tests until then."""
 
-    cuda_graph_sizes: list[int] = None  # type: ignore
+    cuda_graph_sizes: Optional[list[int]] = None  # type: ignore
     """Cuda graph capture sizes
     1. if none provided, then default set to [max_num_seqs]
     2. if one value is provided, then the capture list would follow the

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2033,7 +2033,7 @@ class SchedulerConfig:
     NOTE: This will be replaced by speculative config in the future; it is
     present to enable correctness tests until then."""
 
-    cuda_graph_sizes: list[int] = field(default_factory=lambda: [])
+    cuda_graph_sizes: list[int] = field(default_factory=list)
     """Cuda graph capture sizes
     1. if none provided, then default set to [max_num_seqs]
     2. if one value is provided, then the capture list would follow the

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2033,11 +2033,12 @@ class SchedulerConfig:
     NOTE: This will be replaced by speculative config in the future; it is
     present to enable correctness tests until then."""
 
-    cuda_graph_sizes: list[int] = field(default_factory=lambda: [512])
-    """Cuda graph capture sizes, default is 512.
-    1. if one value is provided, then the capture list would follow the
+    cuda_graph_sizes: list[int] = None  # type: ignore
+    """Cuda graph capture sizes
+    1. if none provided, then default set to [max_num_seqs]
+    2. if one value is provided, then the capture list would follow the
     pattern: [1, 2, 4] + [i for i in range(8, cuda_graph_sizes + 1, 8)]
-    2. more than one value (e.g. 1 2 128) is provided, then the capture list
+    3. more than one value (e.g. 1 2 128) is provided, then the capture list
     will follow the provided list."""
 
     delay_factor: float = 0.0
@@ -2201,6 +2202,9 @@ class SchedulerConfig:
                 "long_prefill_token_threshold=%d",
                 self.max_num_partial_prefills, self.max_long_partial_prefills,
                 self.long_prefill_token_threshold)
+
+        if self.cuda_graph_sizes is None:
+            self.cuda_graph_sizes = [self.max_num_seqs]
 
     @model_validator(mode='after')
     def _verify_args(self) -> Self:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2033,7 +2033,7 @@ class SchedulerConfig:
     NOTE: This will be replaced by speculative config in the future; it is
     present to enable correctness tests until then."""
 
-    cuda_graph_sizes: Optional[list[int]] = None  # type: ignore
+    cuda_graph_sizes: list[int] = field(default_factory=lambda: [])
     """Cuda graph capture sizes
     1. if none provided, then default set to [max_num_seqs]
     2. if one value is provided, then the capture list would follow the
@@ -2204,7 +2204,7 @@ class SchedulerConfig:
                 self.long_prefill_token_threshold)
 
         # If cuda_graph_sizes is not specified, default set to [max_num_seqs].
-        if self.cuda_graph_sizes is None:
+        if not self.cuda_graph_sizes:
             self.cuda_graph_sizes = [self.max_num_seqs]
 
     @model_validator(mode='after')

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -303,8 +303,8 @@ class EngineArgs:
     kv_cache_dtype: CacheDType = CacheConfig.cache_dtype
     seed: Optional[int] = ModelConfig.seed
     max_model_len: Optional[int] = ModelConfig.max_model_len
-    cuda_graph_sizes: Optional[list[int]] = get_field(SchedulerConfig,
-                                                      "cuda_graph_sizes")
+    cuda_graph_sizes: list[int] = get_field(SchedulerConfig,
+                                            "cuda_graph_sizes")
     # Note: Specifying a custom executor backend by passing a class
     # is intended for expert use only. The API may change without
     # notice.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -303,8 +303,8 @@ class EngineArgs:
     kv_cache_dtype: CacheDType = CacheConfig.cache_dtype
     seed: Optional[int] = ModelConfig.seed
     max_model_len: Optional[int] = ModelConfig.max_model_len
-    cuda_graph_sizes: list[int] = get_field(SchedulerConfig,
-                                            "cuda_graph_sizes")
+    cuda_graph_sizes: Optional[list[int]] = get_field(SchedulerConfig,
+                                                      "cuda_graph_sizes")
     # Note: Specifying a custom executor backend by passing a class
     # is intended for expert use only. The API may change without
     # notice.


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

I noticed that in the V1 engine, the default `cuda-graph-sizes` is a fixed number `512`. This may create a performance problem if a user sets `max_num_seqs` to a larger value, because not all batch sizes will be covered by the CUDA graphs.

To fix this, this PR makes the default `cuda-graph_sizes` align with `max_num_seqs` when the user doesn't provide it.