### PR TITLE
[Perf][Frontend] Cached resolution for resolving chat templates

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -293,6 +293,7 @@ def _try_extract_ast(chat_template: str) -> Optional[jinja2.nodes.Template]:
         return None
 
 
+@lru_cache(maxsize=32)
 def _detect_content_format(
     chat_template: str,
     *,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR is indented to fix performance for repetitive calls of `resolve_chat_template_content_format`, which is currently called on each prompt to `v1/chat/completions`. 
Internally, this function uses `_detect_content_format` which loads Jinja template and iterates over it. It's turned out that in tput benchmark mode when we send 1000 requests to OpenAI server, it internally calls this function 1000 times which results in 6-8 seconds delay before prompts actually are started to process.

As a solution, we can just cache invocation of `_detect_content_format` function, since chat templates are not often changed from request to request. In a simple case, when users don't override chat template and default one is used, we call `_detect_content_format` only one.

## Test Plan
Not required

## Test Result
6-8 seconds improvement on tput benchmark with 1000 prompts on meta-llama/Llama-3.1-8B-Instruct

## (Optional) Documentation Update

