### PR TITLE
[Fix] Support cls pooling in ModernBertPooler

### DIFF
--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -258,6 +258,7 @@ class ModernBertPooler(nn.Module):
         super().__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size,
                                config.classifier_bias)
+        self.pooling_type = config.classifier_pooling
         self.act = nn.GELU()
         self.norm = nn.LayerNorm(config.hidden_size,
                                  eps=config.norm_eps,
@@ -265,7 +266,12 @@ class ModernBertPooler(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         pooled_output = hidden_states
-        pooled_output = pooled_output.mean(dim=0, keepdim=False)
+        if self.pooling_type == "mean":
+            pooled_output = pooled_output.mean(dim=0, keepdim=False)
+        elif self.pooling_type == "cls":
+            pooled_output = pooled_output[0, :]
+        else:
+            raise ValueError(f"Pooling type should be either `cls` or `mean`, but got {self.pooling_type}")
         pooled_output = self.norm(self.act(self.dense(pooled_output)))
         return pooled_output
 

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -271,10 +271,8 @@ class ModernBertPooler(nn.Module):
         elif self.pooling_type == "cls":
             pooled_output = pooled_output[0, :]
         else:
-            raise ValueError(
-                "Pooling type should be either `cls` or `mean`, "
-                f"but got {self.pooling_type}"
-            )
+            raise ValueError("Pooling type should be either `cls` or `mean`, "
+                             f"but got {self.pooling_type}")
         pooled_output = self.norm(self.act(self.dense(pooled_output)))
         return pooled_output
 

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -271,7 +271,9 @@ class ModernBertPooler(nn.Module):
         elif self.pooling_type == "cls":
             pooled_output = pooled_output[0, :]
         else:
-            raise ValueError(f"Pooling type should be either `cls` or `mean`, but got {self.pooling_type}")
+            raise ValueError(
+                f"Pooling type should be either `cls` or `mean`, but got {self.pooling_type}"
+            )
         pooled_output = self.norm(self.act(self.dense(pooled_output)))
         return pooled_output
 

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -272,7 +272,8 @@ class ModernBertPooler(nn.Module):
             pooled_output = pooled_output[0, :]
         else:
             raise ValueError(
-                f"Pooling type should be either `cls` or `mean`, but got {self.pooling_type}"
+                "Pooling type should be either `cls` or `mean`, "
+                f"but got {self.pooling_type}"
             )
         pooled_output = self.norm(self.act(self.dense(pooled_output)))
         return pooled_output


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

#16648 implemented ModernBERT. However, it supported only mean pooling, causing some models implemented with cls pooling don't work properly.

This PR fixes the issue by loading pooling method from the model config, and then apply it in `ModernBertPooler`.

Note that I implement only `cls` and `mean` pooling, as huggingface transformers' implementation doesn't support choices other than `cls` and `mean`. (https://github.com/huggingface/transformers/blob/f4fc42216cd56ab6b68270bf80d811614d8d59e4/src/transformers/models/modernbert/configuration_modernbert.py#L93)

## Test Plan

Test cases are designed with reference to https://github.com/vllm-project/vllm/pull/16648#issuecomment-2983265912.

<details>

<summary>test code</summary>

```python
import pytest
import torch
from sentence_transformers import CrossEncoder

from vllm import LLM


def test_modernbert_reranker(model_name):
    st_model = CrossEncoder(model_name, model_kwargs={"torch_dtype": torch.float32})
    vllm_model = LLM(model_name, task="score", dtype="float32")

    sentences = [
        ("ping", "pong"),
        ("ping", "pong" * 16),
        ("ping", "pong" * 24),
        ("ping", "pong" * 32),
        ("ping", "pong" * 48),
        ("ping", "pong" * 64),
        ("ping", "pong" * 128),
    ]

    st_scores = st_model.predict(sentences)

    texts_1 = [x[0] for x in sentences]
    texts_2 = [x[1] for x in sentences]
    outputs = vllm_model.score(texts_1, texts_2)
    vllm_scores = [output.outputs.score for output in outputs]

    def test_close(s1, s2):
        return float(s1) == pytest.approx(float(s2), rel=0.01)

    print(
        model_name,
        ":\t",
        [test_close(st_scores[i], vllm_scores[i]) for i in range(len(st_scores))],
    )


if __name__ == "__main__":
    model_names = [
        "Alibaba-NLP/gte-reranker-modernbert-base",  # mean pooling
        "cl-nagoya/ruri-v3-reranker-310m",  # cls pooling
    ]
    for model_name in model_names:
        test_modernbert_reranker(model_name)

```

</details>

## Test Result
Before this PR:
```
Alibaba-NLP/gte-reranker-modernbert-base :       [True, True, True, True, False, False, False]
cl-nagoya/ruri-v3-reranker-310m :        [False, False, False, False, False, False, False]
```

After this PR:
```
Alibaba-NLP/gte-reranker-modernbert-base :       [True, True, True, True, False, False, False]
cl-nagoya/ruri-v3-reranker-310m :        [True, True, True, True, True, False, False]
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
