### PR TITLE
[Misc] Minor refactor of NIXL background handshake

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -515,6 +515,37 @@ class NixlConnectorWorker:
         # Remote rank -> agent name.
         return {p_remote_rank: handshake(path, p_remote_rank)}
 
+    def _background_nixl_handshake(self, req_id: str,
+                                   remote_engine_id: EngineId, meta: ReqMeta):
+        # Do NIXL handshake in background and add to _ready_requests when done.
+        with self._handshake_lock:
+            if remote_engine_id not in self._remote_agents:
+                fut = self._handshake_futures.get(remote_engine_id)
+                if fut is None:
+                    fut = self._handshake_initiation_executor.submit(
+                        self._nixl_handshake, meta.remote_host,
+                        meta.remote_port)
+                    self._handshake_futures[remote_engine_id] = fut
+
+                    def done_callback(f: Future[dict[int, str]],
+                                      eid=remote_engine_id):
+                        with self._handshake_lock:
+                            del self._handshake_futures[eid]
+                            try:
+                                self._remote_agents[eid] = f.result()
+                            except Exception:
+                                logger.exception("Handshake with %s failed",
+                                                 eid)
+
+                    fut.add_done_callback(done_callback)
+
+                # TODO: handle failure state of future in the
+                # callback, we want to fail the request in this case.
+                def request_ready(_f: Future[Any], entry=(req_id, meta)):
+                    self._ready_requests.put(entry)
+
+                fut.add_done_callback(request_ready)
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""
 
@@ -902,38 +933,11 @@ class NixlConnectorWorker:
                 remote_engine_id, len(meta.local_block_ids),
                 len(meta.remote_block_ids))
             if remote_engine_id not in self._remote_agents:
-                # Being optimistic to assume engine is usually ready, apply
-                # lock only when the optimistic check fails.
-                with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
-                        fut = self._handshake_futures.get(remote_engine_id)
-                        if fut is None:
-                            fut = self._handshake_initiation_executor.submit(
-                                self._nixl_handshake, meta.remote_host,
-                                meta.remote_port, meta.tp_size)
-                            self._handshake_futures[remote_engine_id] = fut
-
-                            def done_callback(f: Future[dict[int, str]],
-                                              eid=remote_engine_id):
-                                with self._handshake_lock:
-                                    del self._handshake_futures[eid]
-                                    try:
-                                        self._remote_agents[eid] = f.result()
-                                    except Exception:
-                                        logger.exception(
-                                            "Handshake with %s failed", eid)
-
-                            fut.add_done_callback(done_callback)
-
-                        # TODO: handle failure state of future in the
-                        # callback, we want to fail the request in this case.
-                        def request_ready(_f: Future[Any],
-                                          entry=(req_id, meta)):
-                            self._ready_requests.put(entry)
-
-                        fut.add_done_callback(request_ready)
-                        continue
-            self._read_blocks_for_req(req_id, meta)
+                # Initiate handshake with remote engine to exchange metadata.
+                self._background_nixl_handshake(req_id, remote_engine_id, meta)
+            else:
+                # Handshake already completed, start async read xfer.
+                self._read_blocks_for_req(req_id, meta)
 
         # Start transfers for requests whose handshakes have now finished.
         while not self._ready_requests.empty():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -518,33 +518,29 @@ class NixlConnectorWorker:
     def _background_nixl_handshake(self, req_id: str,
                                    remote_engine_id: EngineId, meta: ReqMeta):
         # Do NIXL handshake in background and add to _ready_requests when done.
-        with self._handshake_lock:
-            if remote_engine_id not in self._remote_agents:
-                fut = self._handshake_futures.get(remote_engine_id)
-                if fut is None:
-                    fut = self._handshake_initiation_executor.submit(
-                        self._nixl_handshake, meta.remote_host,
-                        meta.remote_port, meta.tp_size)
-                    self._handshake_futures[remote_engine_id] = fut
+        fut = self._handshake_futures.get(remote_engine_id)
+        if fut is None:
+            fut = self._handshake_initiation_executor.submit(
+                self._nixl_handshake, meta.remote_host, meta.remote_port,
+                meta.tp_size)
+            self._handshake_futures[remote_engine_id] = fut
 
-                    def done_callback(f: Future[dict[int, str]],
-                                      eid=remote_engine_id):
-                        with self._handshake_lock:
-                            del self._handshake_futures[eid]
-                            try:
-                                self._remote_agents[eid] = f.result()
-                            except Exception:
-                                logger.exception("Handshake with %s failed",
-                                                 eid)
+            def done_callback(f: Future[dict[int, str]], eid=remote_engine_id):
+                with self._handshake_lock:
+                    del self._handshake_futures[eid]
+                    try:
+                        self._remote_agents[eid] = f.result()
+                    except Exception:
+                        logger.exception("Handshake with %s failed", eid)
 
-                    fut.add_done_callback(done_callback)
+            fut.add_done_callback(done_callback)
 
-                # TODO: handle failure state of future in the
-                # callback, we want to fail the request in this case.
-                def request_ready(_f: Future[Any], entry=(req_id, meta)):
-                    self._ready_requests.put(entry)
+        # TODO: handle failure state of future in the
+        # callback, we want to fail the request in this case.
+        def request_ready(_f: Future[Any], entry=(req_id, meta)):
+            self._ready_requests.put(entry)
 
-                fut.add_done_callback(request_ready)
+        fut.add_done_callback(request_ready)
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""
@@ -934,10 +930,14 @@ class NixlConnectorWorker:
                 len(meta.remote_block_ids))
             if remote_engine_id not in self._remote_agents:
                 # Initiate handshake with remote engine to exchange metadata.
-                self._background_nixl_handshake(req_id, remote_engine_id, meta)
-            else:
-                # Handshake already completed, start async read xfer.
-                self._read_blocks_for_req(req_id, meta)
+                with self._handshake_lock:
+                    if remote_engine_id not in self._remote_agents:
+                        self._background_nixl_handshake(
+                            req_id, remote_engine_id, meta)
+                        continue
+
+            # Handshake already completed, start async read xfer.
+            self._read_blocks_for_req(req_id, meta)
 
         # Start transfers for requests whose handshakes have now finished.
         while not self._ready_requests.empty():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -522,7 +522,8 @@ class NixlConnectorWorker:
             fut = self._handshake_futures.get(remote_engine_id)
             if fut is None:
                 fut = self._handshake_initiation_executor.submit(
-                    self._nixl_handshake, meta.remote_host, meta.remote_port)
+                    self._nixl_handshake, meta.remote_host, meta.remote_port,
+                    meta.tp_size)
                 self._handshake_futures[remote_engine_id] = fut
 
                 def done_callback(f: Future[dict[int, str]],

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -519,30 +519,32 @@ class NixlConnectorWorker:
                                    remote_engine_id: EngineId, meta: ReqMeta):
         # Do NIXL handshake in background and add to _ready_requests when done.
         with self._handshake_lock:
-            fut = self._handshake_futures.get(remote_engine_id)
-            if fut is None:
-                fut = self._handshake_initiation_executor.submit(
-                    self._nixl_handshake, meta.remote_host, meta.remote_port,
-                    meta.tp_size)
-                self._handshake_futures[remote_engine_id] = fut
+            if remote_engine_id not in self._remote_agents:
+                fut = self._handshake_futures.get(remote_engine_id)
+                if fut is None:
+                    fut = self._handshake_initiation_executor.submit(
+                        self._nixl_handshake, meta.remote_host,
+                        meta.remote_port, meta.tp_size)
+                    self._handshake_futures[remote_engine_id] = fut
 
-                def done_callback(f: Future[dict[int, str]],
-                                  eid=remote_engine_id):
-                    with self._handshake_lock:
-                        del self._handshake_futures[eid]
-                        try:
-                            self._remote_agents[eid] = f.result()
-                        except Exception:
-                            logger.exception("Handshake with %s failed", eid)
+                    def done_callback(f: Future[dict[int, str]],
+                                      eid=remote_engine_id):
+                        with self._handshake_lock:
+                            del self._handshake_futures[eid]
+                            try:
+                                self._remote_agents[eid] = f.result()
+                            except Exception:
+                                logger.exception("Handshake with %s failed",
+                                                 eid)
 
-                fut.add_done_callback(done_callback)
+                    fut.add_done_callback(done_callback)
 
-            # TODO: handle failure state of future in the
-            # callback, we want to fail the request in this case.
-            def request_ready(_f: Future[Any], entry=(req_id, meta)):
-                self._ready_requests.put(entry)
+                # TODO: handle failure state of future in the
+                # callback, we want to fail the request in this case.
+                def request_ready(_f: Future[Any], entry=(req_id, meta)):
+                    self._ready_requests.put(entry)
 
-            fut.add_done_callback(request_ready)
+                fut.add_done_callback(request_ready)
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""


### PR DESCRIPTION
I believe having futures-handling logic in `register_kv_caches` hurts readability unnecessarily.
This PR just moves that logic into its own function. 
It should also make future edits a bit easier, since the handshake path is under active development and we still haven't settled on a definitive way of doing exchanges, hence it would be wise to keep things isolated.