### PR TITLE
[Core][Model] PrithviMAE Enablement on vLLM v1 engine (superseded by PR 20577)

### DIFF
--- a/examples/offline_inference/prithvi_geospatial_mae.py
+++ b/examples/offline_inference/prithvi_geospatial_mae.py
@@ -144,7 +144,7 @@ class PrithviMAE:
             model=os.path.join(os.path.dirname(__file__), "./model"),
             skip_tokenizer_init=True,
             dtype="float16",
-            enforce_eager=True
+            enforce_eager=True,
         )
 
     def run(self, input_data, location_coords):

--- a/examples/offline_inference/prithvi_geospatial_mae.py
+++ b/examples/offline_inference/prithvi_geospatial_mae.py
@@ -143,7 +143,8 @@ class PrithviMAE:
         self.model = LLM(
             model=os.path.join(os.path.dirname(__file__), "./model"),
             skip_tokenizer_init=True,
-            dtype="float32",
+            dtype="float16",
+            enforce_eager=True
         )
 
     def run(self, input_data, location_coords):

--- a/tests/models/multimodal/pooling/test_prithvi_mae.py
+++ b/tests/models/multimodal/pooling/test_prithvi_mae.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from ....conftest import VllmRunner
+
+def generate_test_mm_data():
+    mm_data = {
+        "pixel_values": torch.full((6, 512, 512), 1.0, dtype=torch.float16),
+        "location_coords": torch.full((1, 2), 1.0, dtype=torch.float16),
+    }
+    return mm_data
+     
+def _run_test(
+    vllm_runner: type[VllmRunner],
+    model: str,
+) -> None:   
+
+    mm_data = generate_test_mm_data()
+    prompt = {
+        # This model deals with no text input
+        "prompt_token_ids": [1],
+        "multi_modal_data": mm_data
+    }
+    with vllm_runner(model, task="embed",
+                    dtype=torch.float16,
+                    enforce_eager=True,
+                    skip_tokenizer_init=True) as vllm_model:
+        output = vllm_model.encode(prompt)
+            
+MODELS=["christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM"]
+@pytest.mark.parametrize("model", MODELS)
+def test_models_image(
+    hf_runner,
+    vllm_runner,
+    image_assets,
+    model: str,
+) -> None:
+    _run_test(
+        vllm_runner,
+        model,
+    )

--- a/tests/models/multimodal/pooling/test_prithvi_mae.py
+++ b/tests/models/multimodal/pooling/test_prithvi_mae.py
@@ -6,17 +6,19 @@ import torch
 
 from ....conftest import VllmRunner
 
+
 def generate_test_mm_data():
     mm_data = {
         "pixel_values": torch.full((6, 512, 512), 1.0, dtype=torch.float16),
         "location_coords": torch.full((1, 2), 1.0, dtype=torch.float16),
     }
     return mm_data
-     
+
+
 def _run_test(
     vllm_runner: type[VllmRunner],
     model: str,
-) -> None:   
+) -> None:
 
     mm_data = generate_test_mm_data()
     prompt = {
@@ -24,13 +26,15 @@ def _run_test(
         "prompt_token_ids": [1],
         "multi_modal_data": mm_data
     }
-    with vllm_runner(model, task="embed",
-                    dtype=torch.float16,
-                    enforce_eager=True,
-                    skip_tokenizer_init=True) as vllm_model:
-        output = vllm_model.encode(prompt)
-            
-MODELS=["christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM"]
+    with vllm_runner(model,
+                     task="embed",
+                     dtype=torch.float16,
+                     enforce_eager=True,
+                     skip_tokenizer_init=True) as vllm_model:
+        vllm_model.encode(prompt)
+
+MODELS = ["christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM"]
+
 @pytest.mark.parametrize("model", MODELS)
 def test_models_image(
     hf_runner,

--- a/tests/models/multimodal/pooling/test_prithvi_mae.py
+++ b/tests/models/multimodal/pooling/test_prithvi_mae.py
@@ -33,7 +33,9 @@ def _run_test(
                      skip_tokenizer_init=True) as vllm_model:
         vllm_model.encode(prompt)
 
+
 MODELS = ["christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM"]
+
 
 @pytest.mark.parametrize("model", MODELS)
 def test_models_image(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -612,8 +612,10 @@ class ModelConfig:
         self.served_model_name = get_served_model_name(self.model,
                                                        self.served_model_name)
         self.multimodal_config = self._init_multimodal_config()
-        self.is_pooling_model = self.registry.is_pooling_model(self.architectures)
-        self.model_supports_multimodal_raw_input = self._init_model_supports_multimodal_raw_input()
+        self.is_pooling_model = self.registry.is_pooling_model(
+            self.architectures)
+        self.model_supports_multimodal_raw_input = (
+            self._init_model_supports_multimodal_raw_input())
         if not self.skip_tokenizer_init:
             self._verify_tokenizer_mode()
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -612,6 +612,7 @@ class ModelConfig:
         self.served_model_name = get_served_model_name(self.model,
                                                        self.served_model_name)
         self.multimodal_config = self._init_multimodal_config()
+        self.model_supports_multimodal_raw_input = self._init_model_supports_multimodal_raw_input()
         if not self.skip_tokenizer_init:
             self._verify_tokenizer_mode()
 
@@ -714,6 +715,9 @@ class ModelConfig:
                              "supported for multimodal models.")
 
         return None
+
+    def _init_model_supports_multimodal_raw_input(self):
+        return self.registry.supports_multimodal_raw_input(self.architectures)
 
     def _get_encoder_config(self):
         return get_sentence_transformer_tokenizer_config(
@@ -1120,10 +1124,10 @@ class ModelConfig:
         return self.get_hf_config_sliding_window()
 
     def get_vocab_size(self) -> int:
-        return self.hf_text_config.vocab_size
+        return getattr(self.hf_text_config, "vocab_size", 0)
 
     def get_hidden_size(self) -> int:
-        return self.hf_text_config.hidden_size
+        return getattr(self.hf_text_config, "hidden_size", 0)
 
     @property
     def is_deepseek_mla(self) -> bool:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -612,8 +612,6 @@ class ModelConfig:
         self.served_model_name = get_served_model_name(self.model,
                                                        self.served_model_name)
         self.multimodal_config = self._init_multimodal_config()
-        self.is_pooling_model = self.registry.is_pooling_model(
-            self.architectures)
         self.model_supports_multimodal_raw_input = (
             self._init_model_supports_multimodal_raw_input())
         if not self.skip_tokenizer_init:
@@ -1424,6 +1422,10 @@ class ModelConfig:
     @property
     def is_multimodal_model(self) -> bool:
         return self.multimodal_config is not None
+    
+    @property
+    def is_pooling_model(self) -> bool: 
+        return self.registry.is_pooling_model(self.architectures)
 
     @property
     def is_cross_encoder(self) -> bool:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -612,6 +612,7 @@ class ModelConfig:
         self.served_model_name = get_served_model_name(self.model,
                                                        self.served_model_name)
         self.multimodal_config = self._init_multimodal_config()
+        self.is_pooling_model = self.registry.is_pooling_model(self.architectures)
         self.model_supports_multimodal_raw_input = self._init_model_supports_multimodal_raw_input()
         if not self.skip_tokenizer_init:
             self._verify_tokenizer_mode()

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -129,6 +129,42 @@ def supports_multimodal(
 
     return isinstance(model, SupportsMultiModal)
 
+@runtime_checkable
+class SupportsMultiModalWithRawInput(SupportsMultiModal, Protocol):
+    """The interface required for all multi-modal models."""
+
+    supports_multimodal_raw_input: ClassVar[Literal[True]] = True
+    """
+    A flag that indicates this model supports multi-modal inputs and processes
+    them in their raw form and not embeddings.
+
+    Note:
+        There is no need to redefine this flag if this class is in the
+        MRO of your model class.
+    """
+
+@runtime_checkable
+class _SupportsMultiModalWithRawInput(Protocol):
+    supports_multimodal_raw_input: ClassVar[Literal[True]]
+
+
+@overload
+def supports_multimodal_raw_input(model: object) -> TypeIs[SupportsMultiModalWithRawInput]:
+    ...
+
+
+@overload
+def supports_multimodal_raw_input(model: type[object]) -> TypeIs[type[SupportsMultiModalWithRawInput]]:
+    ...
+
+
+def supports_multimodal_raw_input(
+    model: Union[type[object], object]
+) -> Union[TypeIs[type[SupportsMultiModalWithRawInput]], TypeIs[SupportsMultiModalWithRawInput]]:
+    if isinstance(model, type):
+        return isinstance(model, _SupportsMultiModalWithRawInput)
+
+    return isinstance(model, SupportsMultiModalWithRawInput)
 
 @runtime_checkable
 class SupportsLoRA(Protocol):

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -129,6 +129,7 @@ def supports_multimodal(
 
     return isinstance(model, SupportsMultiModal)
 
+
 @runtime_checkable
 class SupportsMultiModalWithRawInput(SupportsMultiModal, Protocol):
     """The interface required for all multi-modal models."""
@@ -143,28 +144,33 @@ class SupportsMultiModalWithRawInput(SupportsMultiModal, Protocol):
         MRO of your model class.
     """
 
+
 @runtime_checkable
 class _SupportsMultiModalWithRawInput(Protocol):
     supports_multimodal_raw_input: ClassVar[Literal[True]]
 
 
 @overload
-def supports_multimodal_raw_input(model: object) -> TypeIs[SupportsMultiModalWithRawInput]:
+def supports_multimodal_raw_input(
+        model: object) -> TypeIs[SupportsMultiModalWithRawInput]:
     ...
 
 
 @overload
-def supports_multimodal_raw_input(model: type[object]) -> TypeIs[type[SupportsMultiModalWithRawInput]]:
+def supports_multimodal_raw_input(
+        model: type[object]) -> TypeIs[type[SupportsMultiModalWithRawInput]]:
     ...
 
 
 def supports_multimodal_raw_input(
     model: Union[type[object], object]
-) -> Union[TypeIs[type[SupportsMultiModalWithRawInput]], TypeIs[SupportsMultiModalWithRawInput]]:
+) -> Union[TypeIs[type[SupportsMultiModalWithRawInput]],
+           TypeIs[SupportsMultiModalWithRawInput]]:
     if isinstance(model, type):
         return isinstance(model, _SupportsMultiModalWithRawInput)
 
     return isinstance(model, SupportsMultiModalWithRawInput)
+
 
 @runtime_checkable
 class SupportsLoRA(Protocol):

--- a/vllm/model_executor/models/prithvi_geospatial_mae.py
+++ b/vllm/model_executor/models/prithvi_geospatial_mae.py
@@ -62,8 +62,8 @@ class PrithviGeoSpatialMAEInputBuilder(
         # The size of pixel_values might change in the cases where we resize
         # the input but never exceeds the dimensions below.
         return {
-            "pixel_values": torch.full((1, 6, 512, 512), 1.0),
-            "location_coords": torch.full((1, 2), 1.0),
+            "pixel_values": torch.full((1, 6, 512, 512), 1.0, dtype=torch.float16),
+            "location_coords": torch.full((1, 2), 1.0, dtype=torch.float16),
         }
 
 

--- a/vllm/model_executor/models/prithvi_geospatial_mae.py
+++ b/vllm/model_executor/models/prithvi_geospatial_mae.py
@@ -25,13 +25,14 @@ from transformers import BatchFeature
 
 from vllm.config import VllmConfig
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm.model_executor.models.interfaces import (IsAttentionFree,
-                                                   SupportsMultiModalWithRawInput)
+from vllm.model_executor.models.interfaces import (
+    IsAttentionFree, SupportsMultiModalWithRawInput)
 from vllm.model_executor.models.utils import AutoWeightsLoader
 from vllm.model_executor.pooling_metadata import PoolingMetadata
 from vllm.multimodal import MULTIMODAL_REGISTRY
-from vllm.multimodal.inputs import (MultiModalDataDict, MultiModalFieldConfig, MultiModalFieldElem,
-                                    MultiModalInputs, MultiModalKwargs, MultiModalKwargsItem,
+from vllm.multimodal.inputs import (MultiModalDataDict, MultiModalFieldConfig,
+                                    MultiModalFieldElem, MultiModalInputs,
+                                    MultiModalKwargs, MultiModalKwargsItem,
                                     MultiModalSharedField, PlaceholderRange)
 from vllm.multimodal.parse import MultiModalDataItems
 from vllm.multimodal.processing import (BaseMultiModalProcessor,
@@ -62,7 +63,8 @@ class PrithviGeoSpatialMAEInputBuilder(
         # The size of pixel_values might change in the cases where we resize
         # the input but never exceeds the dimensions below.
         return {
-            "pixel_values": torch.full((6, 512, 512), 1.0, dtype=torch.float16),
+            "pixel_values": torch.full((6, 512, 512), 1.0,
+                                       dtype=torch.float16),
             "location_coords": torch.full((1, 2), 1.0, dtype=torch.float16),
         }
 
@@ -75,8 +77,10 @@ class PrithviGeoSpatialMAEMultiModalProcessor(BaseMultiModalProcessor):
         hf_processor_mm_kwargs: Mapping[str, object],
     ) -> Mapping[str, MultiModalFieldConfig]:
         return dict(
-            pixel_values=MultiModalFieldConfig.shared(batch_size=1, modality="image"),
-            location_coords=MultiModalFieldConfig.shared(batch_size=1, modality="image"),
+            pixel_values=MultiModalFieldConfig.shared(batch_size=1,
+                                                      modality="image"),
+            location_coords=MultiModalFieldConfig.shared(batch_size=1,
+                                                         modality="image"),
         )
 
     def _get_prompt_updates(
@@ -99,15 +103,16 @@ class PrithviGeoSpatialMAEMultiModalProcessor(BaseMultiModalProcessor):
 
         for k, v in mm_data.items():
             mm_kwargs[k] = v
-        mm_place_holders = {
-            "image": [PlaceholderRange(offset=0, length=0)]
-        }
+        mm_place_holders = {"image": [PlaceholderRange(offset=0, length=0)]}
 
         multimodal_kwargs_items = [
-            MultiModalKwargsItem.from_elems(
-                [MultiModalFieldElem(modality="image", key=key, data=data, field=MultiModalSharedField(1))
-                 for key, data in mm_kwargs.items()]
-            )
+            MultiModalKwargsItem.from_elems([
+                MultiModalFieldElem(modality="image",
+                                    key=key,
+                                    data=data,
+                                    field=MultiModalSharedField(1))
+                for key, data in mm_kwargs.items()
+            ])
         ]
 
         return MultiModalInputs(
@@ -124,7 +129,8 @@ class PrithviGeoSpatialMAEMultiModalProcessor(BaseMultiModalProcessor):
     PrithviGeoSpatialMAEMultiModalProcessor,
     info=PrithviGeoSpatialMAEProcessingInfo,
     dummy_inputs=PrithviGeoSpatialMAEInputBuilder)
-class PrithviGeoSpatialMAE(nn.Module, IsAttentionFree, SupportsMultiModalWithRawInput):
+class PrithviGeoSpatialMAE(nn.Module, IsAttentionFree,
+                           SupportsMultiModalWithRawInput):
     """ Prithvi Masked Autoencoder"""
 
     @classmethod
@@ -189,13 +195,14 @@ class PrithviGeoSpatialMAE(nn.Module, IsAttentionFree, SupportsMultiModalWithRaw
             location_coords = None
 
         return pixel_values, location_coords
-    
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
-        # We do not really use any input tokens and therefore no embeddings to be calculated
-        # However, due to the mandatory token ids in the input prompt we pass one token and the
-        # size of the dummy embedding tensors must reflect that.
+        # We do not really use any input tokens and therefore no embeddings
+        # to be calculated. However, due to the mandatory token ids in
+        # the input prompt we pass one token and the size of the dummy
+        #  embedding tensors must reflect that.
         return torch.empty(input_ids.shape)
-    
+
     def forward(
         self,
         input_ids: Optional[torch.Tensor],
@@ -217,7 +224,10 @@ class PrithviGeoSpatialMAE(nn.Module, IsAttentionFree, SupportsMultiModalWithRaw
         hidden_states: torch.Tensor,
         pooling_metadata: PoolingMetadata,
     ) -> Optional[PoolerOutput]:
-        return PoolerOutput([PoolingSequenceGroupOutput(hidden_state) for hidden_state in hidden_states])
+        return PoolerOutput([
+            PoolingSequenceGroupOutput(hidden_state)
+            for hidden_state in hidden_states
+        ])
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/prithvi_geospatial_mae.py
+++ b/vllm/model_executor/models/prithvi_geospatial_mae.py
@@ -62,7 +62,7 @@ class PrithviGeoSpatialMAEInputBuilder(
         # The size of pixel_values might change in the cases where we resize
         # the input but never exceeds the dimensions below.
         return {
-            "pixel_values": torch.full((1, 6, 512, 512), 1.0, dtype=torch.float16),
+            "pixel_values": torch.full((6, 512, 512), 1.0, dtype=torch.float16),
             "location_coords": torch.full((1, 2), 1.0, dtype=torch.float16),
         }
 
@@ -178,7 +178,7 @@ class PrithviGeoSpatialMAE(nn.Module, IsAttentionFree, SupportsMultiModalWithRaw
         if not isinstance(pixel_values, torch.Tensor):
             raise ValueError(f"Incorrect type of pixel_values. "
                              f"Got type: {type(pixel_values)}")
-        pixel_values = torch.unbind(pixel_values, dim=0)[0]
+        # pixel_values = torch.unbind(pixel_values, dim=0)[0]
 
         location_coords = kwargs.pop("location_coords", None)
         if not isinstance(location_coords, torch.Tensor):
@@ -217,7 +217,7 @@ class PrithviGeoSpatialMAE(nn.Module, IsAttentionFree, SupportsMultiModalWithRaw
         hidden_states: torch.Tensor,
         pooling_metadata: PoolingMetadata,
     ) -> Optional[PoolerOutput]:
-        return PoolerOutput([PoolingSequenceGroupOutput(hidden_states[0])])
+        return PoolerOutput([PoolingSequenceGroupOutput(hidden_state) for hidden_state in hidden_states])
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -23,8 +23,9 @@ from vllm.logger import init_logger
 
 from .interfaces import (has_inner_state, has_noops, is_attention_free,
                          is_hybrid, supports_cross_encoding,
-                         supports_multimodal, supports_pp,
-                         supports_transcription, supports_v0_only)
+                         supports_multimodal, supports_multimodal_raw_input,
+                         supports_pp, supports_transcription,
+                         supports_v0_only)
 from .interfaces_base import is_text_generation_model
 
 logger = init_logger(__name__)
@@ -275,6 +276,7 @@ class _ModelInfo:
     is_pooling_model: bool
     supports_cross_encoding: bool
     supports_multimodal: bool
+    supports_multimodal_raw_input: bool
     supports_pp: bool
     has_inner_state: bool
     is_attention_free: bool
@@ -291,6 +293,7 @@ class _ModelInfo:
             is_pooling_model=True,  # Can convert any model into a pooling model
             supports_cross_encoding=supports_cross_encoding(model),
             supports_multimodal=supports_multimodal(model),
+            supports_multimodal_raw_input=supports_multimodal_raw_input(model),
             supports_pp=supports_pp(model),
             has_inner_state=has_inner_state(model),
             is_attention_free=is_attention_free(model),
@@ -527,6 +530,13 @@ class _ModelRegistry:
     ) -> bool:
         model_cls, _ = self.inspect_model_cls(architectures)
         return model_cls.supports_multimodal
+    
+    def supports_multimodal_raw_input(
+        self,
+        architectures: Union[str, list[str]],
+    ) -> bool:
+        model_cls, _ = self.inspect_model_cls(architectures)
+        return model_cls.supports_multimodal_raw_input
 
     def is_pp_supported_model(
         self,

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -24,8 +24,7 @@ from vllm.logger import init_logger
 from .interfaces import (has_inner_state, has_noops, is_attention_free,
                          is_hybrid, supports_cross_encoding,
                          supports_multimodal, supports_multimodal_raw_input,
-                         supports_pp, supports_transcription,
-                         supports_v0_only)
+                         supports_pp, supports_transcription, supports_v0_only)
 from .interfaces_base import is_text_generation_model
 
 logger = init_logger(__name__)
@@ -530,7 +529,7 @@ class _ModelRegistry:
     ) -> bool:
         model_cls, _ = self.inspect_model_cls(architectures)
         return model_cls.supports_multimodal
-    
+
     def supports_multimodal_raw_input(
         self,
         architectures: Union[str, list[str]],

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -266,7 +266,7 @@ class MultiModalRegistry:
         if not model_config.is_multimodal_model:
             raise ValueError(f"{model_config.model} is not a multimodal model")
 
-        if tokenizer is None:
+        if tokenizer is None and not model_config.skip_tokenizer_init:
             tokenizer = cached_tokenizer_from_config(model_config)
         if disable_cache is None:
             mm_config = model_config.get_multimodal_config()

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -63,6 +63,53 @@ class KVCacheBlocks:
         """Creates a new KVCacheBlocks instance with no blocks."""
         return KVCacheBlocks(tuple([] for _ in range(len(self.blocks))))
 
+class DummyKVCacheManager:
+    @property
+    def usage(self) -> float:
+        return 0.0
+
+    def make_prefix_cache_stats(self) -> Optional[PrefixCacheStats]:
+        return None
+
+    def get_computed_blocks(self,
+                            request: Request) -> tuple[KVCacheBlocks, int]:
+        return(KVCacheBlocks([]), 0)
+
+    def allocate_slots(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: Optional[KVCacheBlocks] = None,
+        num_draft_tokens: int = 0,
+        num_lookahead_tokens: int = 0,
+        delay_cache_blocks: bool = False,
+    ) -> Optional[KVCacheBlocks]:
+        #if we do not return a KV cache block requests are unschedulable
+        return KVCacheBlocks([KVCacheBlock(block_id=0)])
+
+    def free(self, request: Request) -> None:
+        pass
+
+    def reset_prefix_cache(self) -> bool:
+        return True
+
+    def get_num_common_prefix_blocks(
+        self,
+        request: Request,
+        num_running_requests: int,
+    ) -> list[int]:
+        return []
+
+    def free_block_hashes(self, request: Request) -> None:
+        pass
+
+    def take_events(self) -> list[KVCacheEvent]:
+        return []
+
+    def get_block_ids(self, request_id: str) -> list[list[int]]:
+        """Get the block ids of a request."""
+        return []
 
 class KVCacheManager:
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -67,6 +67,7 @@ class KVCacheBlocks:
 
 class KVCacheManagerInterface(ABC):
 
+    @property
     @abstractmethod
     def usage(self) -> float:
         raise NotImplementedError

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -63,7 +63,9 @@ class KVCacheBlocks:
         """Creates a new KVCacheBlocks instance with no blocks."""
         return KVCacheBlocks(tuple([] for _ in range(len(self.blocks))))
 
+
 class DummyKVCacheManager:
+
     @property
     def usage(self) -> float:
         return 0.0
@@ -73,7 +75,7 @@ class DummyKVCacheManager:
 
     def get_computed_blocks(self,
                             request: Request) -> tuple[KVCacheBlocks, int]:
-        return(KVCacheBlocks([]), 0)
+        return (KVCacheBlocks([]), 0)
 
     def allocate_slots(
         self,
@@ -110,6 +112,15 @@ class DummyKVCacheManager:
     def get_block_ids(self, request_id: str) -> list[list[int]]:
         """Get the block ids of a request."""
         return []
+
+    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+        """Cache the blocks for the request, if enabled."""
+        pass
+
+    def create_empty_block_list(self) -> KVCacheBlocks:
+        """Creates a new KVCacheBlocks instance with no blocks."""
+        return (KVCacheBlocks([]), 0)
+
 
 class KVCacheManager:
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -493,8 +493,8 @@ class Scheduler(SchedulerInterface):
 
                 if self.lora_config and request.lora_request:
                     scheduled_loras.add(request.lora_request.lora_int_id)
-                req_to_new_block_ids[request.request_id] = (
-                    self.kv_cache_manager.get_block_ids(request.request_id))
+                req_to_new_block_ids[request.request_id] = \
+                    self.kv_cache_manager.get_block_ids(request.request_id)
                 num_scheduled_tokens[request.request_id] = num_new_tokens
                 token_budget -= num_new_tokens
                 request.status = RequestStatus.RUNNING

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -19,7 +19,7 @@ from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.encoder_cache_manager import (EncoderCacheManager,
                                                 compute_encoder_budget)
-from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager, DummyKVCacheManager
+from vllm.v1.core.kv_cache_manager import DummyKVCacheManager, KVCacheManager
 from vllm.v1.core.sched.interface import SchedulerInterface
 from vllm.v1.core.sched.output import (CachedRequestData, NewRequestData,
                                        SchedulerOutput)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -139,23 +139,26 @@ class EngineCore:
             # is attention free.
             kv_cache_specs = []
             kv_cache_configs = [
-                    KVCacheConfig(num_blocks=0, kv_cache_tensors={}, kv_cache_groups=[])
-                ]
+                KVCacheConfig(num_blocks=0,
+                              kv_cache_tensors={},
+                              kv_cache_groups=[])
+            ]
         else:
             # Get all kv cache needed by the model
             kv_cache_specs = self.model_executor.get_kv_cache_specs()
 
             # Profiles the peak memory usage of the model to determine how much
             # memory can be allocated for kv cache.
-            available_gpu_memory = self.model_executor.determine_available_memory()
+            available_gpu_memory = (
+                self.model_executor.determine_available_memory())
 
             assert len(kv_cache_specs) == len(available_gpu_memory)
             # Get the kv cache tensor size
             kv_cache_configs = [
                 get_kv_cache_config(vllm_config, kv_cache_spec_one_worker,
                                     available_gpu_memory_one_worker)
-                for kv_cache_spec_one_worker, available_gpu_memory_one_worker in
-                zip(kv_cache_specs, available_gpu_memory)
+                for kv_cache_spec_one_worker, available_gpu_memory_one_worker
+                in zip(kv_cache_specs, available_gpu_memory)
             ]
 
             # Since we use a shared centralized controller, we need the
@@ -193,7 +196,6 @@ class EngineCore:
             assert request.mm_inputs is not None
             request.mm_inputs = self.mm_input_cache_server.get_and_update_p1(
                 request.mm_inputs, request.mm_hashes)
-
 
         req = Request.from_engine_core_request(request)
         if req.use_structured_output:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -140,7 +140,7 @@ class EngineCore:
             kv_cache_specs = []
             kv_cache_configs = [
                 KVCacheConfig(num_blocks=0,
-                              kv_cache_tensors={},
+                              kv_cache_tensors=[],
                               kv_cache_groups=[])
             ]
         else:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -139,7 +139,7 @@ class EngineCore:
             # is attention free.
             kv_cache_specs = []
             kv_cache_configs = [
-                    KVCacheConfig(num_blocks=0, tensors={}, kv_cache_groups=[])
+                    KVCacheConfig(num_blocks=0, kv_cache_tensors={}, kv_cache_groups=[])
                 ]
         else:
             # Get all kv cache needed by the model

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -82,11 +82,15 @@ class LLMEngine:
             self.dp_group = None
         self.should_execute_dummy_batch = False
 
-        # Tokenizer (+ ensure liveness if running in another process).
-        self.tokenizer = init_tokenizer_from_configs(
-            model_config=vllm_config.model_config,
-            scheduler_config=vllm_config.scheduler_config,
-            lora_config=vllm_config.lora_config)
+        
+        if not self.vllm_config.model_config.skip_tokenizer_init:     
+            # Tokenizer (+ ensure liveness if running in another process).
+            self.tokenizer = init_tokenizer_from_configs(
+                model_config=vllm_config.model_config,
+                scheduler_config=vllm_config.scheduler_config,
+                lora_config=vllm_config.lora_config)
+        else:
+            self.tokenizer = None
 
         # Processor (convert Inputs --> EngineCoreRequests)
         self.processor = Processor(vllm_config=vllm_config,

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -82,8 +82,7 @@ class LLMEngine:
             self.dp_group = None
         self.should_execute_dummy_batch = False
 
-        
-        if not self.vllm_config.model_config.skip_tokenizer_init:     
+        if not self.vllm_config.model_config.skip_tokenizer_init:
             # Tokenizer (+ ensure liveness if running in another process).
             self.tokenizer = init_tokenizer_from_configs(
                 model_config=vllm_config.model_config,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -327,8 +327,11 @@ class OutputProcessor:
         if request_id in self.request_states:
             raise ValueError(f"Request id {request_id} already running.")
 
+        tokenizer = None if not self.tokenizer else \
+            self.tokenizer.get_lora_tokenizer(request.lora_request)
+
         req_state = RequestState.from_new_request(
-            tokenizer=self.tokenizer.get_lora_tokenizer(request.lora_request),
+            tokenizer=tokenizer,
             request=request,
             prompt=prompt,
             parent_req=parent_req,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -336,7 +336,7 @@ class OutputProcessor:
                                                   parent_req=parent_req,
                                                   request_index=request_index,
                                                   queue=queue,
-                                                  log_stats=self.log_stats)
+                                                  log_stats=self.log_stats,)
         self.request_states[request_id] = req_state
         self.lora_states.add_request(req_state)
         if parent_req:

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -330,14 +330,13 @@ class OutputProcessor:
         tokenizer = None if not self.tokenizer else \
             self.tokenizer.get_lora_tokenizer(request.lora_request)
 
-        req_state = RequestState.from_new_request(
-            tokenizer=tokenizer,
-            request=request,
-            prompt=prompt,
-            parent_req=parent_req,
-            request_index=request_index,
-            queue=queue,
-            log_stats=self.log_stats)
+        req_state = RequestState.from_new_request(tokenizer=tokenizer,
+                                                  request=request,
+                                                  prompt=prompt,
+                                                  parent_req=parent_req,
+                                                  request_index=request_index,
+                                                  queue=queue,
+                                                  log_stats=self.log_stats)
         self.request_states[request_id] = req_state
         self.lora_states.add_request(req_state)
         if parent_req:

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -387,9 +387,10 @@ class Processor:
             else:
                 raise ValueError(f"The {prompt_type} prompt cannot be empty")
 
-        if tokenizer:
-            max_input_id = max(prompt_ids, default=0)
-            if max_input_id > tokenizer.max_token_id:
+        if (
+            tokenizer and (max_input_id:=max(prompt_ids, default=0)) > 
+            tokenizer.max_token_id
+        ):
                 raise ValueError(
                     f"Token id {max_input_id} is out of vocabulary")
 

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -390,7 +390,8 @@ class Processor:
         if tokenizer:
             max_input_id = max(prompt_ids, default=0)
             if max_input_id > tokenizer.max_token_id:
-                raise ValueError(f"Token id {max_input_id} is out of vocabulary")
+                raise ValueError(
+                    f"Token id {max_input_id} is out of vocabulary")
 
         max_prompt_len = self.model_config.max_model_len
         if len(prompt_ids) > max_prompt_len:

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -375,7 +375,10 @@ class Processor:
         prompt_type: Literal["encoder", "decoder"],
     ):
         model_config = self.model_config
-        tokenizer = self.tokenizer.get_lora_tokenizer(lora_request)
+        if model_config.skip_tokenizer_init:
+            tokenizer = None
+        else:
+            tokenizer = self.tokenizer.get_lora_tokenizer(lora_request)
 
         prompt_ids = prompt_inputs["prompt_token_ids"]
         if not prompt_ids:
@@ -384,9 +387,10 @@ class Processor:
             else:
                 raise ValueError(f"The {prompt_type} prompt cannot be empty")
 
-        max_input_id = max(prompt_ids, default=0)
-        if max_input_id > tokenizer.max_token_id:
-            raise ValueError(f"Token id {max_input_id} is out of vocabulary")
+        if tokenizer:
+            max_input_id = max(prompt_ids, default=0)
+            if max_input_id > tokenizer.max_token_id:
+                raise ValueError(f"Token id {max_input_id} is out of vocabulary")
 
         max_prompt_len = self.model_config.max_model_len
         if len(prompt_ids) > max_prompt_len:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -124,6 +124,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 cache_config.cache_dtype]
 
         self.is_multimodal_model = model_config.is_multimodal_model
+        self.is_pooling_model = model_config.is_pooling_model
         self.model_supports_multimodal_raw_input = model_config.model_supports_multimodal_raw_input
         self.max_model_len = model_config.max_model_len
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
@@ -557,7 +558,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.input_batch.refresh_metadata()
 
     def _add_multimodal_inputs_to_model_args(self, model_kwargs: dict[str, Any],
-                                             scheduler_output: "SchedulerOutput"):
+                                             scheduler_output: "SchedulerOutput",
+                                             num_reqs: int=-1):
         # Multi-modal data.
         if scheduler_output:
             multi_modal_kwargs_list = []
@@ -569,21 +571,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             multi_modal_kwargs = MultiModalKwargs.batch(multi_modal_kwargs_list)
         else:
             # The only case where SchedulerOtput is None is for a dummy run, let's get some dummy data.
-            dummy_data = self.mm_registry.get_decoder_dummy_data(model_config=self.model_config, seq_len =1)
-            multi_modal_kwargs = MultiModalKwargs.batch([dummy_data.multi_modal_data])
+            dummy_data = [self.mm_registry.get_decoder_dummy_data(model_config=self.model_config, seq_len =1).multi_modal_data for i in range(num_reqs)]
+            # dummy_data = self.mm_registry.get_decoder_dummy_data(model_config=self.model_config, seq_len =1)
+            # multi_modal_kwargs = MultiModalKwargs.batch([dummy_data.multi_modal_data])
+            multi_modal_kwargs = MultiModalKwargs.batch(dummy_data)
             
         model_kwargs.update(multi_modal_kwargs)
 
-    def _maybe_add_model_args(self, num_tokens: int,
+    def _maybe_add_multimodal_kwargs(self,
                               model_kwargs: dict[str,Any], 
-                              scheduler_output: "SchedulerOutput"=None):
-        
-        if self.supports_token_type_ids:
-            model_kwargs["token_type_ids"] =\
-                  self.get_token_type_ids()[:num_tokens]
+                              scheduler_output: "SchedulerOutput"=None,
+                              num_reqs: int=-1):
 
         if self.model_supports_multimodal_raw_input:
-            self._add_multimodal_inputs_to_model_args(model_kwargs, scheduler_output)
+            self._add_multimodal_inputs_to_model_args(model_kwargs, scheduler_output, num_reqs)
 
     def _maybe_compute_attn_prefix(
         self,
@@ -1364,15 +1365,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             mm_embeds = self._gather_mm_embeddings(scheduler_output)
         else:
             mm_embeds = []
-
+        
+        model_kwargs: dict[str, Any] = {}
         if self.is_multimodal_model and get_pp_group().is_first_rank:
             # NOTE(woosuk): To unify token ids and soft tokens (vision
             # embeddings), we always use embeddings (rather than token ids)
             # as input to the multimodal model, even when the input is text.
             input_ids = self.input_ids[:num_scheduled_tokens]
-            self._maybe_add_model_args(num_scheduled_tokens,
-                                       model_kwargs, scheduler_output)
-
+            self._maybe_add_multimodal_kwargs(model_kwargs=model_kwargs,
+                                              scheduler_output=scheduler_output)
             if mm_embeds:
                 inputs_embeds = self.model.get_input_embeddings(
                     input_ids, mm_embeds)
@@ -1388,7 +1389,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # multimodal models, it is not desirable for performance since
             # then the embedding layer is not included in the CUDA graph.
             input_ids = self.input_ids[:num_input_tokens]
-            self._maybe_add_model_args(num_input_tokens, model_kwargs, scheduler_output)
             inputs_embeds = None
         if self.uses_mrope:
             positions = self.mrope_positions[:, :num_input_tokens]
@@ -2076,8 +2076,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                                             num_scheduled_tokens):
             model = self.model
             model_kwargs: dict[str, Any] = {}
-            self._maybe_add_model_args(num_tokens, model_kwargs)
             if self.is_multimodal_model:
+                self._maybe_add_multimodal_kwargs(model_kwargs=model_kwargs,
+                                                  num_reqs=num_reqs)
                 input_ids = None
                 inputs_embeds = self.inputs_embeds[:num_tokens]
             else:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -125,7 +125,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         self.is_multimodal_model = model_config.is_multimodal_model
         self.is_pooling_model = model_config.is_pooling_model
-        self.model_supports_multimodal_raw_input = model_config.model_supports_multimodal_raw_input
+        self.model_supports_multimodal_raw_input = (
+            model_config.model_supports_multimodal_raw_input)
         self.max_model_len = model_config.max_model_len
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
         self.max_num_reqs = scheduler_config.max_num_seqs
@@ -557,9 +558,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Refresh batch metadata with any pending updates.
         self.input_batch.refresh_metadata()
 
-    def _add_multimodal_inputs_to_model_args(self, model_kwargs: dict[str, Any],
-                                             scheduler_output: "SchedulerOutput",
-                                             num_reqs: int=-1):
+    def _add_multimodal_inputs_to_model_args(
+            self,
+            model_kwargs: dict[str, Any],
+            scheduler_output: "SchedulerOutput",
+            num_reqs: int = -1):
         # Multi-modal data.
         if scheduler_output:
             multi_modal_kwargs_list = []
@@ -568,23 +571,30 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 if not isinstance(req_mm_inputs, list):
                     req_mm_inputs = list(req_mm_inputs)
                 multi_modal_kwargs_list.extend(req_mm_inputs)
-            multi_modal_kwargs = MultiModalKwargs.batch(multi_modal_kwargs_list)
+            multi_modal_kwargs = MultiModalKwargs.batch(
+                multi_modal_kwargs_list)
         else:
-            # The only case where SchedulerOtput is None is for a dummy run, let's get some dummy data.
-            dummy_data = [self.mm_registry.get_decoder_dummy_data(model_config=self.model_config, seq_len =1).multi_modal_data for i in range(num_reqs)]
-            # dummy_data = self.mm_registry.get_decoder_dummy_data(model_config=self.model_config, seq_len =1)
-            # multi_modal_kwargs = MultiModalKwargs.batch([dummy_data.multi_modal_data])
+            # The only case where SchedulerOtput is None is for a dummy run,
+            # let's get some dummy data.
+            dummy_data = [
+                self.mm_registry.get_decoder_dummy_data(
+                    model_config=self.model_config, seq_len=1).multi_modal_data
+                for i in range(num_reqs)
+            ]
             multi_modal_kwargs = MultiModalKwargs.batch(dummy_data)
-            
+
         model_kwargs.update(multi_modal_kwargs)
 
-    def _maybe_add_multimodal_kwargs(self,
-                              model_kwargs: dict[str,Any], 
-                              scheduler_output: "SchedulerOutput"=None,
-                              num_reqs: int=-1):
+    def _maybe_add_multimodal_kwargs(
+            self,
+            model_kwargs: dict[str, Any],
+            scheduler_output: "SchedulerOutput" = None,
+            num_reqs: int = -1):
 
         if self.model_supports_multimodal_raw_input:
-            self._add_multimodal_inputs_to_model_args(model_kwargs, scheduler_output, num_reqs)
+            self._add_multimodal_inputs_to_model_args(model_kwargs,
+                                                      scheduler_output,
+                                                      num_reqs)
 
     def _maybe_compute_attn_prefix(
         self,
@@ -1365,15 +1375,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             mm_embeds = self._gather_mm_embeddings(scheduler_output)
         else:
             mm_embeds = []
-        
+
         model_kwargs: dict[str, Any] = {}
         if self.is_multimodal_model and get_pp_group().is_first_rank:
             # NOTE(woosuk): To unify token ids and soft tokens (vision
             # embeddings), we always use embeddings (rather than token ids)
             # as input to the multimodal model, even when the input is text.
             input_ids = self.input_ids[:num_scheduled_tokens]
-            self._maybe_add_multimodal_kwargs(model_kwargs=model_kwargs,
-                                              scheduler_output=scheduler_output)
+            self._maybe_add_multimodal_kwargs(
+                model_kwargs=model_kwargs, scheduler_output=scheduler_output)
             if mm_embeds:
                 inputs_embeds = self.model.get_input_embeddings(
                     input_ids, mm_embeds)
@@ -1425,8 +1435,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 **MultiModalKwargs.as_kwargs(
                     model_kwargs,
                     device=self.device,
-                )
-            )
+                ))
 
             self.maybe_wait_for_kv_save()
             finished_sending, finished_recving = (
@@ -2107,15 +2116,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     self.vllm_config,
                     num_tokens=num_tokens,
                     num_tokens_across_dp=num_tokens_across_dp):
-                outputs = model(
-                    input_ids=input_ids,
-                    positions=positions,
-                    intermediate_tensors=intermediate_tensors,
-                    inputs_embeds=inputs_embeds,
-                    **MultiModalKwargs.as_kwargs(
-                                    model_kwargs,
-                                    device=self.device)
-                )
+                outputs = model(input_ids=input_ids,
+                                positions=positions,
+                                intermediate_tensors=intermediate_tensors,
+                                inputs_embeds=inputs_embeds,
+                                **MultiModalKwargs.as_kwargs(
+                                    model_kwargs, device=self.device))
 
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -330,9 +330,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             scheduler_output: The scheduler output.
         """
         
-        # nothing to be reordered when the mdoel is attention free
+        # nothing to be reordered when the model is attention free
         if self.model_config.is_attention_free:
-            return False
+            return
 
         self.attn_metadata_builders[0].reorder_batch(self.input_batch,
                                                      scheduler_output)
@@ -561,7 +561,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def _maybe_add_multimodal_kwargs(
             self,
             model_kwargs: dict[str, Any],
-            scheduler_output: "SchedulerOutput" = None,
+            scheduler_output: "Optional[SchedulerOutput]" = None,
             num_reqs: int = -1,
     ):
 
@@ -2105,7 +2105,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                                 intermediate_tensors=intermediate_tensors,
                                 inputs_embeds=inputs_embeds,
                                 **MultiModalKwargs.as_kwargs(
-                                    model_kwargs, device=self.device))
+                                    model_kwargs, device=self.device),)
 
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -558,11 +558,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Refresh batch metadata with any pending updates.
         self.input_batch.refresh_metadata()
 
-    def _add_multimodal_inputs_to_model_args(
+    def _maybe_add_multimodal_kwargs(
             self,
             model_kwargs: dict[str, Any],
-            scheduler_output: "SchedulerOutput",
-            num_reqs: int = -1):
+            scheduler_output: "SchedulerOutput" = None,
+            num_reqs: int = -1,
+    ):
+
+        if not self.model_supports_multimodal_raw_input:
+            return
+
         # Multi-modal data.
         if scheduler_output:
             multi_modal_kwargs_list = []
@@ -585,28 +590,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         model_kwargs.update(multi_modal_kwargs)
 
-    def _maybe_add_multimodal_kwargs(
-            self,
-            model_kwargs: dict[str, Any],
-            scheduler_output: "SchedulerOutput" = None,
-            num_reqs: int = -1):
-
-        if self.model_supports_multimodal_raw_input:
-            self._add_multimodal_inputs_to_model_args(model_kwargs,
-                                                      scheduler_output,
-                                                      num_reqs)
-
-    def _maybe_compute_attn_prefix(
-        self,
-        scheduler_output: "SchedulerOutput",
-    ) -> list[int]:
-        return [0] * len(self.kv_cache_config.kv_cache_groups)
-
-    def _maybe_prepare_additional_inputs(self,
-                                         scheduler_output: "SchedulerOutput",
-                                         token_indices: torch.Tensor):
-        pass
-
+ 
     def _get_cumsum_and_arange(
         self,
         num_tokens: np.ndarray,


### PR DESCRIPTION
## Purpose
This PR enables the Prithvi MAE Geospatial model on the vLLM V1 engine. This is a result of pooling/embedding models being enabled in V1.

The main changes in this PR are:
- Adding support for multi-modal models that require the raw multi-modal data in input and not the multi_modal embeddings.
- Improving support for models that use `skip_tokenizer_init=True`
- Improving support for attention-less models by creating a `DummyKVCacheManager` class
- Minor changes to the PrithviMAE model and the example usage script.

## Test Plan
I have added a test script that is only testing the with vLLM runner as this model is not on HF. Therefore it would only check if the inference takes place correctly for the model.

## Test Result
The test is not succeeding at the moment because the pytest process hangs indefinitely while initializing the vlLM engine. The test hangs indefinitely on `wait_for_engine_startup`. The same code tested outside of pytest works just fine. Any help on getting this test running would be much appreciated.

## Documentation Update
Updated examples file.

@DarkLight1337 @maxdebayser @njhill 