### PR TITLE
static_scaled_fp8_quant should not run when scale.numel is not 1

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1276,7 +1276,7 @@ def scaled_fp8_quant(
             torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
     else:
         # num_token_padding not implemented for this case
-        assert (scale.numel() == 1 or num_token_padding is None)
+        assert (scale.numel() == 1 and num_token_padding is None)
         torch.ops._C.static_scaled_fp8_quant(output, input, scale)
 
     return output, scale


### PR DESCRIPTION
`static_scaled_fp8_quant` should not run when `scale.numel() > 1`. Right now, when scale is an array of values, `static_scaled_fp8_quant` will just use the first scale and ignore the rest of the array. This shouldn't happen silently, and probably best to fail and inform the user that scale must be of size 1.