### PR TITLE
[Kernel] Change reshape_and_cache_flash to torch.compile()

### DIFF
--- a/tests/model_executor/test_kv_cache.py
+++ b/tests/model_executor/test_kv_cache.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import random
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.kv_cache import ReshapeAndCacheFlash
+from vllm.platforms import current_platform
+from vllm.utils import create_kv_caches_with_random_flash
+
+DTYPES = [torch.half, torch.bfloat16, torch.float]
+NUM_TOKENS = [42]  # Arbitrary values for testing
+NUM_HEADS = [8]  # Arbitrary values for testing
+HEAD_SIZES = [64, 80, 120, 256]
+BLOCK_SIZES = [8, 16, 32]
+CACHE_LAYOUTS = ["NHD", "HND"]
+
+# Arbitrary values for testing
+# don't make it too large. e.g. [1024, 36000] will OOM
+NUM_BLOCKS = [1024, 10000]
+
+SEEDS = [0]
+CUDA_DEVICES = [
+    f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)
+]
+
+# We assume fp8 is always enabled for testing.
+KV_CACHE_DTYPE = ["auto", "fp8"]
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
+@pytest.mark.parametrize("kv_cache_layout", CACHE_LAYOUTS)
+@torch.inference_mode()
+def test_reshape_and_cache_flash(
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    kv_cache_dtype: str,
+    kv_cache_layout: str,
+) -> None:
+    current_platform.seed_everything(seed)
+    torch.set_default_device(device)
+
+    # fp8 conversion requires continugous memory buffer. Reduce the number of
+    # blocks and tokens to consume less memory.
+    num_tokens = num_tokens // 2
+    num_blocks = num_blocks // 2
+    # Create a random slot mapping.
+    num_slots = block_size * num_blocks
+    slot_mapping_lst = random.sample(range(num_slots), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping_lst,
+                                dtype=torch.long,
+                                device=device)
+    qkv = torch.randn(num_tokens,
+                      3,
+                      num_heads,
+                      head_size,
+                      dtype=dtype,
+                      device=device)
+    _, key, value = qkv.unbind(dim=1)
+
+    # Create the KV caches.
+    key_caches, value_caches = create_kv_caches_with_random_flash(
+        num_blocks,
+        block_size,
+        1,
+        num_heads,
+        head_size,
+        kv_cache_dtype,
+        dtype,
+        device=device,
+        cache_layout=kv_cache_layout,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+    del key_caches
+    del value_caches
+
+    k_scale = (key.amax() / 64.0).to(torch.float32)
+    v_scale = (value.amax() / 64.0).to(torch.float32)
+
+    def permute_and_compact(x):
+        y = x if kv_cache_layout == "NHD" else x.permute(0, 2, 1, 3)
+        return y.contiguous()
+
+    key_cache_compact = permute_and_compact(key_cache)
+    value_cache_compact = permute_and_compact(value_cache)
+
+    # Clone the KV caches.
+    if kv_cache_dtype == "fp8":
+        cloned_key_cache = torch.empty_like(key_cache_compact,
+                                            dtype=torch.float16)
+        ops.convert_fp8(cloned_key_cache, key_cache_compact, k_scale.item(),
+                        kv_cache_dtype)
+        cloned_value_cache = torch.empty_like(value_cache_compact,
+                                              dtype=torch.float16)
+        ops.convert_fp8(cloned_value_cache, value_cache_compact,
+                        v_scale.item(), kv_cache_dtype)
+    else:
+        cloned_key_cache = key_cache_compact.clone()
+        cloned_value_cache = value_cache_compact.clone()
+
+    reshape_and_cache_flash = ReshapeAndCacheFlash(kv_cache_dtype)
+    reshape_and_cache_flash(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        k_scale,
+        v_scale,
+    )
+
+    key_cache_compact = permute_and_compact(key_cache)
+    value_cache_compact = permute_and_compact(value_cache)
+
+    if kv_cache_dtype == "fp8":
+        result_key_cache = torch.empty_like(key_cache_compact,
+                                            dtype=torch.float16)
+        ops.convert_fp8(result_key_cache,
+                        key_cache_compact,
+                        k_scale.item(),
+                        kv_dtype=kv_cache_dtype)
+        result_value_cache = torch.empty_like(value_cache_compact,
+                                              dtype=torch.float16)
+        ops.convert_fp8(result_value_cache,
+                        value_cache_compact,
+                        v_scale.item(),
+                        kv_dtype=kv_cache_dtype)
+
+    # Run the reference implementation.
+    block_indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
+    block_indices_lst = block_indices.cpu().tolist()
+    block_offsets = slot_mapping % block_size
+    block_offsets_lst = block_offsets.cpu().tolist()
+    for i in range(num_tokens):
+        block_idx = block_indices_lst[i]
+        block_offset = block_offsets_lst[i]
+        if kv_cache_layout == "NHD":
+            cloned_key_cache[block_idx, block_offset, :, :] = key[i]
+            cloned_value_cache[block_idx, block_offset, :, :] = value[i]
+        else:
+            cloned_key_cache[block_idx, :, block_offset, :] = key[i]
+            cloned_value_cache[block_idx, :, block_offset, :] = value[i]
+
+    if kv_cache_dtype == "fp8":
+        torch.testing.assert_close(result_key_cache,
+                                   cloned_key_cache,
+                                   atol=0.001,
+                                   rtol=0.1)
+        torch.testing.assert_close(result_value_cache,
+                                   cloned_value_cache,
+                                   atol=0.001,
+                                   rtol=0.1)
+    else:
+        torch.testing.assert_close(key_cache_compact, cloned_key_cache)
+        torch.testing.assert_close(value_cache_compact, cloned_value_cache)

--- a/vllm/model_executor/layers/kv_cache.py
+++ b/vllm/model_executor/layers/kv_cache.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KV Cache operations."""
+
+import torch
+
+from vllm.attention.backends.abstract import is_quantized_kv_cache
+from vllm.model_executor.custom_op import CustomOp
+from vllm.platforms import current_platform
+
+
+@CustomOp.register("reshape_and_cache_flash")
+class ReshapeAndCacheFlash(CustomOp):
+    """Reshape_and_cache, Flash Attn KV Cache format."""
+
+    def __init__(
+        self,
+        kv_cache_dtype: str,
+    ) -> None:
+        super().__init__()
+        self.fp8_dtype = current_platform.fp8_dtype() if is_quantized_kv_cache(
+            kv_cache_dtype) else None
+
+    @staticmethod
+    def forward_static(
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        k_scale: torch.Tensor,
+        v_scale: torch.Tensor,
+        fp8_dtype: torch.dtype | None,
+    ) -> None:
+        """PyTorch implementation of reshape_and_cache_flash, to be compiled.
+
+        Args:
+            key: New key vectors, shape:
+                 (num_tokens, num_kv_heads, head_size).
+            value: New value vectors, shape:
+                   (num_tokens, num_kv_heads, head_size).
+            key_cache: Key cache, shape:
+                       (num_pages, cache_block_size, num_kv_heads, head_size).
+            value_cache: Value cache, shape:
+                         (num_pages, cache_block_size, num_kv_heads, head_size).
+            slot_mapping: Tensor listing what slots in the cache each key/value
+                          vector should be placed in, shape: (num_tokens,).
+            kv_cache_dtype: String datatype of kv cache elements.
+            k_scale: Fp8 scaling factor for k.
+            v_scale: Fp8 scaling factor for v.
+            fp8_dtype: (Optional) FP8 dtype, pass if scaling should be applied.
+        """
+        num_tokens = slot_mapping.size(0)
+        _, block_size, _, _ = key_cache.shape
+
+        if fp8_dtype:
+            key = (key / k_scale).to(fp8_dtype).view(key_cache.dtype)
+            value = (value / v_scale).to(fp8_dtype).view(value_cache.dtype)
+
+        block_indicies = torch.floor_divide(slot_mapping, block_size)
+        block_offsets = slot_mapping % block_size
+        key_cache[block_indicies, block_offsets, :, :] = key[:num_tokens]
+        value_cache[block_indicies, block_offsets, :, :] = value[:num_tokens]
+
+    def forward_native(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        k_scale: torch.Tensor,
+        v_scale: torch.Tensor,
+    ) -> None:
+        self.forward_static(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            k_scale,
+            v_scale,
+            self.fp8_dtype,
+        )
+
+    def forward_cuda(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        k_scale: torch.Tensor,
+        v_scale: torch.Tensor,
+    ) -> None:
+        self.forward_native(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            k_scale,
+            v_scale,
+        )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -17,6 +17,7 @@ from vllm.attention.utils.fa_utils import (flash_attn_supports_fp8,
                                            get_flash_attn_version)
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.logger import init_logger
+from vllm.model_executor.layers.kv_cache import ReshapeAndCacheFlash
 from vllm.platforms import current_platform
 from vllm.utils import cdiv
 from vllm.v1.attention.backends.utils import (
@@ -371,6 +372,8 @@ class FlashAttentionImpl(AttentionImpl):
         else:
             self.sliding_window = (sliding_window - 1, 0)
         self.kv_cache_dtype = kv_cache_dtype
+        self.reshape_and_cache_flash = ReshapeAndCacheFlash(
+            self.kv_cache_dtype)
         if logits_soft_cap is None:
             # In flash-attn, setting logits_soft_cap as 0 means no soft cap.
             logits_soft_cap = 0
@@ -454,13 +457,12 @@ class FlashAttentionImpl(AttentionImpl):
             # and value[:num_actual_tokens] because the reshape_and_cache_flash
             # op uses the slot_mapping's shape to determine the number of
             # actual tokens.
-            torch.ops._C_cache_ops.reshape_and_cache_flash(
+            self.reshape_and_cache_flash(
                 key,
                 value,
                 key_cache,
                 value_cache,
                 attn_metadata.slot_mapping,
-                self.kv_cache_dtype,
                 layer._k_scale,
                 layer._v_scale,
             )


### PR DESCRIPTION
## Purpose

This PR adds a pure-PyTorch implementation of `reshape_and_cache_flash` that can be used with `torch.compile()` instead of the existing CUDA kernel.

## Test Plan

### Microbenchmarks

We measure the performance of 1) the PyTorch implementation (no compilation), 2) the PyTorch implementation with compilation and 3) the vLLM CUDA implementation of the kernel. The benchmark source code can be found [here](https://github.com/stackav-oss/conch/tree/feature/jmanning/compile-reshape-and-cache).

### End-to-end

```
VLLM_USE_V1=1 VLLM_LOGGING_LEVEL=DEBUG VLLM_WORKER_MULTIPROC_METHOD=spawn   vllm serve meta-llama/Llama-3.1-8B-Instruct     --trust-remote-code     --max-model-len=2048     --block-size=128     --max-num-seqs=128     --gpu_memory_utilization=0.90     --data-parallel-size 1     --disable-log-requests  --port 8002
```

```
python benchmarks/benchmark_serving.py --model meta-llama/Llama-3.1-8B-Instruct --dataset-name random --ignore-eos --num-prompts 3000 --max-concurrency 3000 --random-input-len 500 --random-output-len 500 --seed 1 --port 8002
```

## Test Result

### Microbenchmarks

**H100**

```
Parameters: {'head_dim': 256, 'num_tokens': 64, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=90548, min=0.021 ms, max=6.640 ms, mean=0.022 ms, median=0.022 ms
PyTorch (compiled? True): num_iterations=77802, min=0.005 ms, max=0.447 ms, mean=0.008 ms, median=0.006 ms
CUDA Baseline: num_iterations=97980, min=0.007 ms, max=0.063 ms, mean=0.008 ms, median=0.008 ms

Parameters: {'head_dim': 256, 'num_tokens': 128, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=89716, min=0.021 ms, max=1.167 ms, mean=0.022 ms, median=0.022 ms
PyTorch (compiled? True): num_iterations=63144, min=0.006 ms, max=4.090 ms, mean=0.009 ms, median=0.007 ms
CUDA Baseline: num_iterations=95635, min=0.008 ms, max=0.056 ms, mean=0.008 ms, median=0.008 ms

Parameters: {'head_dim': 256, 'num_tokens': 512, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=83498, min=0.030 ms, max=1.322 ms, mean=0.031 ms, median=0.031 ms
PyTorch (compiled? True): num_iterations=78054, min=0.008 ms, max=1.131 ms, mean=0.009 ms, median=0.009 ms
CUDA Baseline: num_iterations=94200, min=0.010 ms, max=0.059 ms, mean=0.011 ms, median=0.011 ms

Parameters: {'head_dim': 256, 'num_tokens': 2048, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=65297, min=0.063 ms, max=0.076 ms, mean=0.065 ms, median=0.065 ms
PyTorch (compiled? True): num_iterations=73315, min=0.018 ms, max=0.198 ms, mean=0.018 ms, median=0.018 ms
CUDA Baseline: num_iterations=84041, min=0.023 ms, max=0.028 ms, mean=0.024 ms, median=0.024 ms

Parameters: {'head_dim': 256, 'num_tokens': 8192, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=33738, min=0.205 ms, max=0.216 ms, mean=0.208 ms, median=0.208 ms
PyTorch (compiled? True): num_iterations=61214, min=0.051 ms, max=0.177 ms, mean=0.053 ms, median=0.053 ms
CUDA Baseline: num_iterations=58767, min=0.072 ms, max=0.077 ms, mean=0.073 ms, median=0.073 ms

Parameters: {'head_dim': 256, 'num_tokens': 32768, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=11540, min=0.776 ms, max=0.780 ms, mean=0.778 ms, median=0.778 ms
PyTorch (compiled? True): num_iterations=32969, min=0.187 ms, max=0.190 ms, mean=0.188 ms, median=0.189 ms
CUDA Baseline: num_iterations=27723, min=0.264 ms, max=0.269 ms, mean=0.266 ms, median=0.266 ms
```

**MI300X**

```
Parameters: {'head_dim': 256, 'num_tokens': 64, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=112091, min=0.021 ms, max=10.802 ms, mean=0.040 ms, median=0.039 ms
PyTorch (compiled? True): num_iterations=93598, min=0.006 ms, max=3.219 ms, mean=0.021 ms, median=0.020 ms
CUDA Baseline: num_iterations=191139, min=0.006 ms, max=14.431 ms, mean=0.007 ms, median=0.007 ms

Parameters: {'head_dim': 256, 'num_tokens': 128, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=116550, min=0.022 ms, max=10.819 ms, mean=0.041 ms, median=0.040 ms
PyTorch (compiled? True): num_iterations=99883, min=0.007 ms, max=0.196 ms, mean=0.021 ms, median=0.019 ms
CUDA Baseline: num_iterations=189140, min=0.006 ms, max=0.043 ms, mean=0.007 ms, median=0.007 ms

Parameters: {'head_dim': 256, 'num_tokens': 512, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=106815, min=0.026 ms, max=10.834 ms, mean=0.038 ms, median=0.037 ms
PyTorch (compiled? True): num_iterations=105649, min=0.007 ms, max=10.792 ms, mean=0.021 ms, median=0.020 ms
CUDA Baseline: num_iterations=187549, min=0.008 ms, max=0.283 ms, mean=0.009 ms, median=0.009 ms

Parameters: {'head_dim': 256, 'num_tokens': 2048, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=79845, min=0.042 ms, max=0.250 ms, mean=0.045 ms, median=0.045 ms
PyTorch (compiled? True): num_iterations=107404, min=0.011 ms, max=10.776 ms, mean=0.020 ms, median=0.019 ms
CUDA Baseline: num_iterations=145981, min=0.014 ms, max=0.024 ms, mean=0.017 ms, median=0.017 ms

Parameters: {'head_dim': 256, 'num_tokens': 8192, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=43990, min=0.127 ms, max=0.151 ms, mean=0.141 ms, median=0.141 ms
PyTorch (compiled? True): num_iterations=72710, min=0.049 ms, max=9.743 ms, mean=0.052 ms, median=0.052 ms
CUDA Baseline: num_iterations=97484, min=0.046 ms, max=0.340 ms, mean=0.055 ms, median=0.055 ms

Parameters: {'head_dim': 256, 'num_tokens': 32768, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
PyTorch (compiled? False): num_iterations=16903, min=0.464 ms, max=15.049 ms, mean=0.485 ms, median=0.484 ms
PyTorch (compiled? True): num_iterations=33605, min=0.162 ms, max=0.178 ms, mean=0.167 ms, median=0.167 ms
CUDA Baseline: num_iterations=45260, min=0.171 ms, max=13.653 ms, mean=0.182 ms, median=0.180 ms
```

The `torch.compile()`'d kernel offers favorable performance to the CUDA baseline on H100 for all input sizes. Interestingly, for small input sizes on MI300X, the HIP-ified implementation is faster (the reason for this is unclear).

### End-to-end

**H100**

_Before_

```
============ Serving Benchmark Result ============
Successful requests:                     990
Benchmark duration (s):                  83.25
Total input tokens:                      492905
Total generated tokens:                  495000
Request throughput (req/s):              11.89
Output token throughput (tok/s):         5945.80
Total Token throughput (tok/s):          11866.44
---------------Time to First Token----------------
Mean TTFT (ms):                          41568.94
Median TTFT (ms):                        38606.37
P99 TTFT (ms):                           74914.72
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.91
Median TPOT (ms):                        18.26
P99 TPOT (ms):                           18.53
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.17
Median ITL (ms):                         15.38
P99 ITL (ms):                            199.59
==================================================
```

_After_

```
============ Serving Benchmark Result ============
Successful requests:                     990
Benchmark duration (s):                  85.61
Total input tokens:                      492905
Total generated tokens:                  495000
Request throughput (req/s):              11.56
Output token throughput (tok/s):         5782.27
Total Token throughput (tok/s):          11540.07
---------------Time to First Token----------------
Mean TTFT (ms):                          42511.00
Median TTFT (ms):                        39430.18
P99 TTFT (ms):                           76065.76
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.41
Median TPOT (ms):                        18.76
P99 TPOT (ms):                           19.04
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.67
Median ITL (ms):                         15.87
P99 ITL (ms):                            202.83
==================================================
```

**MI300X**

_Before_

```
============ Serving Benchmark Result ============
Successful requests:                     3000
Benchmark duration (s):                  277.36
Total input tokens:                      1494883
Total generated tokens:                  1500000
Request throughput (req/s):              10.82
Output token throughput (tok/s):         5408.09
Total Token throughput (tok/s):          10797.72
---------------Time to First Token----------------
Mean TTFT (ms):                          136364.69
Median TTFT (ms):                        134695.71
P99 TTFT (ms):                           267242.84
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.88
Median TPOT (ms):                        22.06
P99 TPOT (ms):                           22.52
---------------Inter-token Latency----------------
Mean ITL (ms):                           22.35
Median ITL (ms):                         18.14
P99 ITL (ms):                            288.39
==================================================
```

_After_

```
============ Serving Benchmark Result ============
Successful requests:                     3000
Benchmark duration (s):                  292.15
Total input tokens:                      1494883
Total generated tokens:                  1500000
Request throughput (req/s):              10.27
Output token throughput (tok/s):         5134.39
Total Token throughput (tok/s):          10251.26
---------------Time to First Token----------------
Mean TTFT (ms):                          144315.83
Median TTFT (ms):                        142238.36
P99 TTFT (ms):                           281056.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.82
Median TPOT (ms):                        22.88
P99 TPOT (ms):                           25.08
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.24
Median ITL (ms):                         18.90
P99 ITL (ms):                            292.87
==================================================
```

Oddly, we see a small reduction in throughput on both H100 and MI300X with the compiled `reshape_and_cache_flash` kernel, despite generally better microbenchmark performance. I believe that, because this kernel is inside of the attention op, that it may not be correctly compiled.

## Next Steps

I would appreciate any insight from the team on how to proceed. I believe that if we can ensure that this operation is correctly compiled that we could get a small performance gain (and eliminate the need to maintain a CUDA kernel for this relatively simple operation). Another option would be to add the kernel/test but not enable it for backends (i.e. remove the 2nd commit in this PR).