### PR TITLE
[Benchmark][Bug] Fix multiple bugs in bench and add args to spec_decode offline

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -350,8 +350,9 @@ class RandomDataset(BenchmarkDataset):
             # To avoid uncontrolled change of the prompt length,
             # the encoded sequence is truncated before being decode again.
             total_input_len = prefix_len + int(input_lens[i])
-            re_encoded_sequence = tokenizer.encode(
-                prompt, add_special_tokens=False)[:total_input_len]
+            re_encoded_sequence = tokenizer.encode(prompt, add_special_tokens=False)[
+                :total_input_len
+            ]
             prompt = tokenizer.decode(re_encoded_sequence)
             requests.append(
                 SampleRequest(

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -354,6 +354,7 @@ class RandomDataset(BenchmarkDataset):
                 :total_input_len
             ]
             prompt = tokenizer.decode(re_encoded_sequence)
+            total_input_len = len(re_encoded_sequence)
             requests.append(
                 SampleRequest(
                     prompt=prompt,

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -349,11 +349,10 @@ class RandomDataset(BenchmarkDataset):
             # [1650, 939, 486] -> ['Ġcall', 'sh', 'ere']
             # To avoid uncontrolled change of the prompt length,
             # the encoded sequence is truncated before being decode again.
-            re_encoded_sequence = tokenizer.encode(prompt, add_special_tokens=False)[
-                : input_lens[i]
-            ]
+            total_input_len = prefix_len + int(input_lens[i])
+            re_encoded_sequence = tokenizer.encode(
+                prompt, add_special_tokens=False)[:total_input_len]
             prompt = tokenizer.decode(re_encoded_sequence)
-            total_input_len = len(re_encoded_sequence)
             requests.append(
                 SampleRequest(
                     prompt=prompt,

--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -49,7 +49,7 @@ def main():
     args = parse_args()
     args.endpoint_type = "openai-chat"
 
-    model_dir = args.model_dir 
+    model_dir = args.model_dir
     if args.model_dir is None:
         model_dir = "meta-llama/Llama-3.1-8B-Instruct"
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
@@ -62,13 +62,11 @@ def main():
 
     if args.method == "eagle" or args.method == "eagle3":
         eagle_dir = args.eagle_dir
-        if args.method == "eagle":
-            if eagle_dir is None:
-                eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
+        if args.method == "eagle" and eagle_dir is None:
+            eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
 
-        elif args.method == "eagle3":
-            if eagle_dir is None:
-                eagle_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
+        elif args.method == "eagle3" and eagle_dir is None:
+            eagle_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
         speculative_config = {
             "method": args.method,
             "model": eagle_dir,

--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -39,6 +39,9 @@ def parse_args():
     parser.add_argument("--top-k", type=int, default=-1)
     parser.add_argument("--print-output", action="store_true")
     parser.add_argument("--output-len", type=int, default=256)
+    parser.add_argument("--model-dir", type=str, default=None)
+    parser.add_argument("--eagle-dir", type=str, default=None)
+    parser.add_argument("--max-model-len", type=int, default=2048)
     return parser.parse_args()
 
 
@@ -46,9 +49,10 @@ def main():
     args = parse_args()
     args.endpoint_type = "openai-chat"
 
-    model_dir = "meta-llama/Llama-3.1-8B-Instruct"
+    model_dir = args.model_dir 
+    if args.model_dir is None:
+        model_dir = "meta-llama/Llama-3.1-8B-Instruct"
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
-    max_model_len = 2048
 
     prompts = get_samples(args, tokenizer)
     # add_special_tokens is False to avoid adding bos twice when using chat templates
@@ -57,16 +61,20 @@ def main():
     ]
 
     if args.method == "eagle" or args.method == "eagle3":
+        eagle_dir = args.eagle_dir
         if args.method == "eagle":
-            eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
+            if eagle_dir is None:
+                eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
+
         elif args.method == "eagle3":
-            eagle_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
+            if eagle_dir is None:
+                eagle_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
         speculative_config = {
             "method": args.method,
             "model": eagle_dir,
             "num_speculative_tokens": args.num_spec_tokens,
             "draft_tensor_parallel_size": args.draft_tp,
-            "max_model_len": max_model_len,
+            "max_model_len": args.max_model_len,
         }
     elif args.method == "ngram":
         speculative_config = {
@@ -74,7 +82,7 @@ def main():
             "num_speculative_tokens": args.num_spec_tokens,
             "prompt_lookup_max": args.prompt_lookup_max,
             "prompt_lookup_min": args.prompt_lookup_min,
-            "max_model_len": max_model_len,
+            "max_model_len": args.max_model_len,
         }
     else:
         raise ValueError(f"unknown method: {args.method}")
@@ -86,7 +94,7 @@ def main():
         enable_chunked_prefill=args.enable_chunked_prefill,
         max_num_batched_tokens=args.max_num_batched_tokens,
         enforce_eager=args.enforce_eager,
-        max_model_len=max_model_len,
+        max_model_len=args.max_model_len,
         max_num_seqs=args.max_num_seqs,
         gpu_memory_utilization=0.8,
         speculative_config=speculative_config,

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -382,6 +382,7 @@ class RandomDataset(BenchmarkDataset):
             re_encoded_sequence = tokenizer.encode(
                 prompt, add_special_tokens=False)[:total_input_len]
             prompt = tokenizer.decode(re_encoded_sequence)
+            total_input_len = len(re_encoded_sequence)
             requests.append(
                 SampleRequest(
                     prompt=prompt,

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -320,6 +320,8 @@ class RandomDataset(BenchmarkDataset):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        random.seed(self.random_seed)
+        np.random.seed(self.random_seed)
 
     def sample(
         self,
@@ -692,7 +694,8 @@ def get_samples(args, tokenizer) -> list[SampleRequest]:
                                     dataset_path=args.dataset_path).
             sample(tokenizer=tokenizer, num_requests=args.num_prompts),
             "random":
-            lambda: RandomDataset(dataset_path=args.dataset_path).sample(
+            lambda: RandomDataset(random_seed=args.seed,
+                                  dataset_path=args.dataset_path).sample(
                 tokenizer=tokenizer,
                 num_requests=args.num_prompts,
                 prefix_len=args.random_prefix_len,

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -378,10 +378,10 @@ class RandomDataset(BenchmarkDataset):
             # [1650, 939, 486] -> ['Ġcall', 'sh', 'ere']
             # To avoid uncontrolled change of the prompt length,
             # the encoded sequence is truncated before being decode again.
-            re_encoded_sequence = tokenizer.encode(
-                prompt, add_special_tokens=False)[:input_lens[i]]
-            prompt = tokenizer.decode(re_encoded_sequence)
             total_input_len = prefix_len + int(input_lens[i])
+            re_encoded_sequence = tokenizer.encode(
+                prompt, add_special_tokens=False)[:total_input_len]
+            prompt = tokenizer.decode(re_encoded_sequence)
             requests.append(
                 SampleRequest(
                     prompt=prompt,

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -632,6 +632,12 @@ def add_cli_args(parser: argparse.ArgumentParser):
         "the endpoint type will be used as the label.",
     )
     parser.add_argument(
+        "--backend",
+        type=str,
+        default="vllm",
+        choices=list(ASYNC_REQUEST_FUNCS.keys()),
+    )
+    parser.add_argument(
         "--base-url",
         type=str,
         default=None,


### PR DESCRIPTION
1. add random seed in random dataset. This is needed if we want to simulate prompt caching and ttft analysis
2. fix random dataset bug: https://github.com/vllm-project/vllm/blob/0d06b533a0fcca7a62603c868df68235659d6935/vllm/benchmarks/datasets.py#L380 Currently it picks 1st input len num of tokens which means if prefix len is 32k and input len is 32k then it will pick 1st 32k tokens which is all the prefix len instead of all 64k. This leads to ~98% prefix cache hit. Similar bug was fixed in https://github.com/vllm-project/vllm/pull/19868 but the original intention of RandomDataset is to have prefix and input len independent of each other so that context length can be sampled from `[input_len * (1 - range_ratio), input_len * (1 + range_ratio)]` as per [this](https://github.com/vllm-project/vllm/blob/8359f4c8d840d409fe698d9bf428ecd2f7e85b75/vllm/benchmarks/datasets.py#L562-L570)
3. add --backend in serve.py for cases when sampling params are passed
4. add model config, eagle dir in offline inference 