### PR TITLE
[Bug Fix] Fix address/port already in use error for pplx test

### DIFF
--- a/tests/kernels/moe/deepep_utils.py
+++ b/tests/kernels/moe/deepep_utils.py
@@ -5,9 +5,7 @@ DeepEP test utilities
 import dataclasses
 import importlib
 import os
-import socket
 import traceback
-from contextlib import closing
 from typing import Callable, Optional
 
 import torch
@@ -15,6 +13,8 @@ from torch.distributed import ProcessGroup
 from torch.multiprocessing import (
     spawn)  # pyright: ignore[reportPrivateImportUsage]
 from typing_extensions import Concatenate, ParamSpec
+
+from vllm.model_executor.layers.fused_moe.utils import find_free_port
 
 has_deep_ep = importlib.util.find_spec("deep_ep") is not None
 if has_deep_ep:
@@ -80,13 +80,6 @@ def _worker_parallel_launch(
         raise
     finally:
         torch.distributed.destroy_process_group()
-
-
-def find_free_port():
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(('', 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
 
 
 def parallel_launch(

--- a/tests/kernels/moe/deepep_utils.py
+++ b/tests/kernels/moe/deepep_utils.py
@@ -4,6 +4,7 @@ DeepEP test utilities
 """
 import dataclasses
 import importlib
+import os
 import socket
 import traceback
 from contextlib import closing
@@ -101,7 +102,7 @@ def parallel_launch(
             world_size,
             world_size,
             0,
-            f"tcp://localhost:{find_free_port()}",
+            f"tcp://{os.getenv('LOCALHOST', 'localhost')}:{find_free_port()}",
             worker,
         ) + args,
         nprocs=world_size,

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import socket
+from contextlib import closing
 from math import prod
 from typing import Optional
 
@@ -96,3 +98,10 @@ def _fp8_perm(m: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
         return m.view(dtype=torch.uint8)[idx, ...].view(dtype=m.dtype)
     else:
         return m[idx, ...]
+
+
+def find_free_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]


### PR DESCRIPTION
## Purpose

Fix address/port already in use error

```bash
>       raise ProcessRaisedException(msg, error_index, failed_process.pid)
E       torch.multiprocessing.spawn.ProcessRaisedException: 
E       
E       -- Process 0 terminated with the following error:
E       Traceback (most recent call last):
E         File "/home/wentao/.wentao_env/lib/python3.12/site-packages/torch/multiprocessing/spawn.py", line 90, in _wrap
E           fn(i, *args)
E         File "/home/wentao/vllm-source/tests/kernels/moe/utils.py", line 51, in _worker_parallel_launch
E           torch.distributed.init_process_group(
E         File "/home/wentao/.wentao_env/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
E           return func(*args, **kwargs)
E                  ^^^^^^^^^^^^^^^^^^^^^
E         File "/home/wentao/.wentao_env/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 95, in wrapper
E           func_return = func(*args, **kwargs)
E                         ^^^^^^^^^^^^^^^^^^^^^
E         File "/home/wentao/.wentao_env/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 1710, in init_process_group
E           store, rank, world_size = next(rendezvous_iterator)
E                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
E         File "/home/wentao/.wentao_env/lib/python3.12/site-packages/torch/distributed/rendezvous.py", line 230, in _tcp_rendezvous_handler
E           store = _create_c10d_store(
E                   ^^^^^^^^^^^^^^^^^^^
E         File "/home/wentao/.wentao_env/lib/python3.12/site-packages/torch/distributed/rendezvous.py", line 198, in _create_c10d_store
E           return TCPStore(
E                  ^^^^^^^^^
E       torch.distributed.DistNetworkError: The server socket has failed to listen on any local network address. port: 29500, useIpv6: false, code: -98, name: EADDRINUSE, message: address already in use

../../../../.wentao_env/lib/python3.12/site-packages/torch/multiprocessing/spawn.py:215: ProcessRaisedException
------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------
INFO 06-25 15:21:43 [__init__.py:244] Automatically detected platform cuda.
INFO 06-25 15:21:43 [__init__.py:244] Automatically detected platform cuda.
------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------
W0625 15:21:48.812000 100212 torch/multiprocessing/spawn.py:169] Terminating process 114296 via signal SIGTERM
================================================================ short test summary info =================================================================
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-8-mnk0] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-8-mnk1] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-8-mnk2] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-8-mnk3] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-64-mnk0] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-64-mnk1] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-64-mnk2] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-1-64-mnk3] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-8-mnk0] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-8-mnk1] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-8-mnk2] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-8-mnk3] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-64-mnk0] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-64-mnk1] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-64-mnk2] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-2-64-mnk3] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-6-8-mnk0] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-6-8-mnk1] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-6-8-mnk2] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-6-8-mnk3] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-6-64-mnk0] - torch.multiprocessing.spawn.ProcessRaisedException: 
FAILED test_pplx_moe.py::test_pplx_prepare_finalize[False-world_dp_size0-dtype0-6-64-mnk1] - torch.multiprocessing.spawn.ProcessRaisedException: 
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/usr/lib/python3.12/selectors.py:415: KeyboardInterrupt
(to show a full traceback on KeyboardInterrupt use --full-trace)
======================================================= 22 failed, 216 passed in 264.29s (0:04:24) =======================================================
```

## Test

![image](https://github.com/user-attachments/assets/9ac59b9b-fdf0-48b2-963f-b3289c35b331)
