### PR TITLE
Add ModelOpt Qwen3 nvfp4 support

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -772,6 +772,10 @@ def maybe_remap_kv_scale_name(name: str, params_dict: dict) -> Optional[str]:
     qkv_proj_scale_names = [
         ".self_attn.qkv_proj.k_scale", ".self_attn.qkv_proj.v_scale"
     ]
+    # Handle Qwen3 MoE models naming
+    qkqkv_proj_scale_names = [
+        ".self_attn.qkqkv_proj.k_scale", ".self_attn.qkqkv_proj.v_scale"
+    ]
     for scale_name in possible_scale_names:
         if name.endswith(scale_name):
             if any(mo_scale_name in name
@@ -784,6 +788,12 @@ def maybe_remap_kv_scale_name(name: str, params_dict: dict) -> Optional[str]:
                 # Handle qkv_proj scale parameters
                 remapped_name = name.replace(
                     f".self_attn.qkv_proj{scale_name}",
+                    f".self_attn.attn{scale_name}")
+            elif any(qkqkv_scale_name in name
+                     for qkqkv_scale_name in qkqkv_proj_scale_names):
+                # Handle qkqkv_proj scale parameters
+                remapped_name = name.replace(
+                    f".self_attn.qkqkv_proj{scale_name}",
                     f".self_attn.attn{scale_name}")
             else:
                 remapped_name = name.replace(scale_name, f".attn{scale_name}")

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -764,49 +764,41 @@ def maybe_remap_kv_scale_name(name: str, params_dict: dict) -> Optional[str]:
             return None
         return remapped_name
 
-    possible_scale_names = [".k_scale", ".v_scale"]
-    modelopt_scale_names = [
-        ".self_attn.k_proj.k_scale", ".self_attn.v_proj.v_scale"
+    # Define scale name mapping patterns in order of precedence
+    scale_mapping_patterns = [
+        # ModelOpt format: .self_attn.{k,v}_proj.{k,v}_scale ->
+        # .self_attn.attn.{k,v}_scale
+        (r"\.self_attn\.([kv])_proj\.([kv])_scale$",
+         r".self_attn.attn.\2_scale"),
+        # QKV proj format: .self_attn.qkv_proj.{k,v}_scale ->
+        # .self_attn.attn.{k,v}_scale
+        (r"\.self_attn\.qkv_proj\.([kv])_scale$", r".self_attn.attn.\1_scale"),
+        # Qwen3 MoE format: .self_attn.qkqkv_proj.{k,v}_scale ->
+        # .self_attn.attn.{k,v}_scale
+        (r"\.self_attn\.qkqkv_proj\.([kv])_scale$", r".self_attn.attn.\1_scale"
+         ),
+        # Default format: .{k,v}_scale -> .attn.{k,v}_scale
+        (r"\.([kv])_scale$", r".attn.\1_scale"),
     ]
-    # Also support qkv_proj scale parameters (from stacked parameter processing)
-    qkv_proj_scale_names = [
-        ".self_attn.qkv_proj.k_scale", ".self_attn.qkv_proj.v_scale"
-    ]
-    # Handle Qwen3 MoE models naming
-    qkqkv_proj_scale_names = [
-        ".self_attn.qkqkv_proj.k_scale", ".self_attn.qkqkv_proj.v_scale"
-    ]
-    for scale_name in possible_scale_names:
-        if name.endswith(scale_name):
-            if any(mo_scale_name in name
-                   for mo_scale_name in modelopt_scale_names):
-                remapped_name = name.replace(
-                    f".self_attn.{scale_name[1]}_proj{scale_name}",
-                    f".self_attn.attn{scale_name}")
-            elif any(qkv_scale_name in name
-                     for qkv_scale_name in qkv_proj_scale_names):
-                # Handle qkv_proj scale parameters
-                remapped_name = name.replace(
-                    f".self_attn.qkv_proj{scale_name}",
-                    f".self_attn.attn{scale_name}")
-            elif any(qkqkv_scale_name in name
-                     for qkqkv_scale_name in qkqkv_proj_scale_names):
-                # Handle qkqkv_proj scale parameters
-                remapped_name = name.replace(
-                    f".self_attn.qkqkv_proj{scale_name}",
-                    f".self_attn.attn{scale_name}")
-            else:
-                remapped_name = name.replace(scale_name, f".attn{scale_name}")
-            if remapped_name not in params_dict:
-                logger.warning_once(
-                    "Found %s in the checkpoint (e.g. %s), but not found the expected name in the model (e.g. %s). %s is not loaded.",  # noqa: E501
-                    scale_name,
-                    name,
-                    remapped_name,
-                    scale_name,
-                )
-                return None
-            return remapped_name
+
+    # Check if name ends with k_scale or v_scale
+    if name.endswith((".k_scale", ".v_scale")):
+        import re
+
+        for pattern, replacement in scale_mapping_patterns:
+            if re.search(pattern, name):
+                remapped_name = re.sub(pattern, replacement, name)
+                if remapped_name not in params_dict:
+                    scale_type = name.split(".")[-1]
+                    logger.warning_once(
+                        "Found %s in the checkpoint (e.g. %s), but not found the expected name in the model (e.g. %s). %s is not loaded.",  # noqa: E501
+                        scale_type,
+                        name,
+                        remapped_name,
+                        scale_type,
+                    )
+                    return None
+                return remapped_name
 
     # If there were no matches, return the untouched param name
     return name

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -783,7 +783,7 @@ def maybe_remap_kv_scale_name(name: str, params_dict: dict) -> Optional[str]:
 
     # Check if name ends with k_scale or v_scale
     if name.endswith((".k_scale", ".v_scale")):
-        import re
+        import regex as re
 
         for pattern, replacement in scale_mapping_patterns:
             if re.search(pattern, name):

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -48,7 +48,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 
@@ -471,12 +471,21 @@ class Qwen3MoeModel(nn.Module):
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
+                if name.endswith("scale"):
+                    # Remapping the name of FP8 kv-scale.
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
                 if name not in params_dict:
                     continue
 
                 param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                if weight_loader == default_weight_loader:
+                    weight_loader(param, loaded_weight)
+                else:
+                    weight_loader(param, loaded_weight, shard_id)
                 break
             else:
                 is_expert_weight = False

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -48,7 +48,8 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader, maybe_remap_kv_scale_name)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

Enable ModelOpt Qwen3 (both non-MoE and MoE) nvfp4 checkpoint deployment in vLLM. It seems only minor changes are required.

The ModelOpt Qwen3 MoE nvfp4 checkpoint `Qwen3-30B-A3B-fp4` can be generated with the following command under [ModelOpt's examples/llm_ptq](https://github.com/NVIDIA/TensorRT-Model-Optimizer/tree/main/examples/llm_ptq) directory.

```
python hf_ptq.py --pyt_ckpt_path Qwen/Qwen3-30B-A3B --qformat nvfp4 --export_fmt hf --export_path Qwen3-30B-A3B-fp4 --trust_remote_code
```
With this PR, Qwen2.5/QwQ-32B nvfp4 models will be also supported.

Tested on Qwen2.5-1.5B-Instruct-fp4, QwQ-32B-fp4, Qwen3-1.7B-fp4 as well.

## Purpose

## Test Plan
Run the following test script:
```
from vllm import LLM, SamplingParams
def main():

    model_id = "Qwen3-30B-A3B-fp4"
    sampling_params = SamplingParams(temperature=0.8, top_p=0.9)

    prompts = [
        "Hello, my name is",
        "The president of the United States is",
        "The capital of France is",
        "The future of AI is",
    ]

    llm = LLM(model=model_id, quantization="modelopt_fp4", tensor_parallel_size=1)
    outputs = llm.generate(prompts, sampling_params)

    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

if __name__ == "__main__":
    main()
```

## Test Result
The generated outputs:
```
Prompt: ‘Hello, my name is’, Generated text: ” Mary. I am a 23-year-old woman, and I’m looking”
Prompt: ‘The president of the United States is’, Generated text: ' the commander-in-chief of the armed forces, and the vice president is the second’
Prompt: ‘The capital of France is’, Generated text: ” Paris, right? Yes, that’s correct. But I want to know more”
Prompt: ‘The future of AI is’, Generated text: ' not in the hands of the big tech companies alone, but in the hands of’
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
