### PR TITLE
[PD][Nixl] Remote consumer READ timeout for clearing request blocks 

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -9,13 +9,13 @@ from unittest.mock import patch
 
 import pytest
 
+from vllm import LLM
 from vllm.config import KVTransferConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
     KVConnectorRole, NixlAgentMetadata, NixlConnector, NixlConnectorMetadata,
     NixlConnectorWorker)
 from vllm.forward_context import ForwardContext
-from vllm.llm_engine.llm_engine import LLM
-from vllm.llm_engine.scheduler.scheduler import SamplingParams
+from vllm.sampling_params import SamplingParams
 
 from .utils import create_request, create_scheduler, create_vllm_config
 

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -44,9 +44,9 @@ def test_basic_interface():
     assert kv_connector_metadata is not None
     assert isinstance(kv_connector_metadata, NixlConnectorMetadata)
 
-    assert len(kv_connector_metadata.requests) == 1
-    assert request_id in kv_connector_metadata.requests
-    req_meta = kv_connector_metadata.requests[request_id]
+    assert len(kv_connector_metadata.reqs_to_recv) == 1
+    assert request_id in kv_connector_metadata.reqs_to_recv
+    req_meta = kv_connector_metadata.reqs_to_recv[request_id]
 
     for block_id, block in zip(
             req_meta.local_block_ids, scheduler.kv_cache_manager.coordinator.
@@ -81,7 +81,7 @@ def test_prompt_less_than_block_size():
     kv_connector_metadata = scheduler_output.kv_connector_metadata
     assert kv_connector_metadata is not None
     assert isinstance(kv_connector_metadata, NixlConnectorMetadata)
-    assert len(kv_connector_metadata.requests) == 0
+    assert len(kv_connector_metadata.reqs_to_recv) == 0
 
     # This request should be scheduled regularly.
     assert len(scheduler_output.scheduled_new_reqs) == 1

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -376,6 +376,9 @@ class TestNixlHandshake:
         raise TimeoutError("Took too long to complete async handshake.")
 
 
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.NixlWrapper",
+    FakeNixlWrapper)
 def test_abort_timeout_on_prefiller(monkeypatch):
     """
     Test lifecycle of an aborted Remote Prefill request hitting the timeout.

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -162,9 +162,16 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
 
     REMOTE_ENGINE_ID = "remote_engine"
 
-    def __init__(self, *args, hand_shake_latency: float = 1.8, **kwargs):
+    def __init__(self,
+                 *args,
+                 hand_shake_latency: float = 1.8,
+                 remote_agent_time_offset: float = 0.0,
+                 **kwargs):
         super().__init__(*args, **kwargs)
         self._hand_shake_latency = hand_shake_latency
+        self._remote_agent_time_offsets = {
+            self.REMOTE_ENGINE_ID: remote_agent_time_offset
+        }
 
     def _nixl_handshake(self, host: str, port: int,
                         remote_tp_size: int) -> dict[int, str]:
@@ -374,6 +381,125 @@ class TestNixlHandshake:
                 if cnt_finished_reqs == total_reqs:
                     return
         raise TimeoutError("Took too long to complete async handshake.")
+
+    @patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.NixlWrapper",
+        FakeNixlWrapper)
+    def test_ttl_expiration_on_decoder(self, dist_init):
+        """
+        Test that decoder-side TTL expiration works correctly.
+        
+        This test verifies that:
+        1. Requests with expired TTL are not processed for KV transfer (no _read_blocks called)
+        2. Expired requests are automatically marked as finished
+        3. Clock synchronization offset is properly handled (remote is N seconds ahead)
+        """ #noqa: E501
+        # Remote is 100 seconds ahead.
+        remote_agent_time_offset = 100.0
+        vllm_config = create_vllm_config()
+
+        # Test worker role in decode server
+        connector = NixlConnector(vllm_config, KVConnectorRole.WORKER)
+
+        class TTLTestNixlConnectorWorker(FakeNixlConnectorWorker):
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._read_blocks_called = set()
+
+            def _read_blocks(self, local_block_ids, remote_block_ids,
+                             dst_engine_id, request_id):
+                # Override to track if _read_blocks was called but don't
+                # actually read blocks
+                self._read_blocks_called.add(request_id)
+
+        connector.connector_worker = TTLTestNixlConnectorWorker(
+            vllm_config,
+            connector.engine_id,
+            remote_agent_time_offset=remote_agent_time_offset)
+
+        # Ensure the remote agent is already registered (skip handshake)
+        connector.connector_worker._remote_agents[
+            FakeNixlConnectorWorker.REMOTE_ENGINE_ID] = {
+                0: "test_agent"
+            }
+
+        current_time = time.perf_counter()
+
+        # Test Case 1: Request with expired TTL
+        expired_request_id = "expired_req"
+        expired_ttl = current_time  # TTL expired (remote is ahead)
+
+        metadata_expired = NixlConnectorMetadata()
+        metadata_expired.add_new_req(
+            request_id=expired_request_id,
+            local_block_ids=[1, 2, 3],
+            kv_transfer_params={
+                "remote_block_ids": [4, 5, 6],
+                "remote_engine_id": FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
+                "remote_host": "localhost",
+                "remote_port": 1234,
+                "tp_size": 1,
+                "request_ttl": expired_ttl,
+            })
+
+        # Test Case 2: Request with valid TTL
+        valid_request_id = "valid_req"
+        # 200 seconds from now
+        valid_ttl = current_time + remote_agent_time_offset + 200
+
+        metadata_valid = NixlConnectorMetadata()
+        metadata_valid.add_new_req(
+            request_id=valid_request_id,
+            local_block_ids=[7, 8, 9],
+            kv_transfer_params={
+                "remote_block_ids": [10, 11, 12],
+                "remote_engine_id": FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
+                "remote_host": "localhost",
+                "remote_port": 1234,
+                "tp_size": 1,
+                "request_ttl": valid_ttl,
+            })
+
+        # Process expired request
+        connector.bind_connector_metadata(metadata_expired)
+        connector.start_load_kv(
+            ForwardContext(
+                no_compile_layers={},
+                attn_metadata={},
+                virtual_engine=0,
+            ))
+
+        # Check that expired request was added to _reqs_expired_ttl
+        assert expired_request_id in \
+            connector.connector_worker._reqs_expired_ttl
+
+        # Check that _read_blocks was NOT called for expired request
+        assert expired_request_id not in \
+            connector.connector_worker._read_blocks_called
+
+        # Check that expired request is marked as finished
+        _, done_recving = connector.get_finished(finished_req_ids=set())
+        assert expired_request_id in done_recving
+        assert expired_request_id not in \
+            connector.connector_worker._reqs_expired_ttl  # Should be removed
+
+        # Process valid request
+        connector.bind_connector_metadata(metadata_valid)
+        connector.start_load_kv(
+            ForwardContext(
+                no_compile_layers={},
+                attn_metadata={},
+                virtual_engine=0,
+            ))
+
+        # Check that valid request was NOT added to _reqs_expired_ttl
+        assert valid_request_id not in \
+            connector.connector_worker._reqs_expired_ttl
+
+        # Check that _read_blocks WAS called for valid request
+        assert valid_request_id in \
+            connector.connector_worker._read_blocks_called
 
 
 def test_abort_timeout_on_prefiller(monkeypatch):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -826,6 +826,19 @@ class NixlConnectorWorker:
                 "and %s requests done recving", self.tp_rank,
                 len(done_sending), len(done_recving))
 
+        # Handle timeout
+        # now = time.perf_counter()
+        # for req_id, finish_time in self._reqs_to_send.items():
+        #     if finish_time == -1:
+        #         # Request just finished, start timeout.
+        #         self._reqs_to_send[req_id] = now
+        #     elif now - finish_time >= envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT:
+        #         # Timeout exceed, abort request and clear.
+        #         aborted_req_ids.add(req_id)
+        # if req_id in self._done_sending_count:
+        # self._done_sending_count[req_id] += self.world_size
+        # del self._reqs_to_send[req_id]
+
         if self.world_size == 1:
             return done_sending, done_recving
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -845,7 +845,7 @@ class NixlConnectorWorker:
         now = time.monotonic()
         while self._reqs_to_send:
             req_id, expires = next(iter(self._reqs_to_send.items()))
-            # Sorted dict, oldest request are put first so we can exit early.
+            # Sorted dict, oldest requests are put first so we can exit early.
             if now < expires:
                 break
             del self._reqs_to_send[req_id]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -837,7 +837,7 @@ class NixlConnectorWorker:
                 len(done_sending), len(done_recving))
 
         # Handle timeout to avoid stranding blocks on remote.
-        now = time.perf_counter()
+        now = time.monotonic()
         timed_out_requests: list[str] = []
         for req_id, finish_time in self._reqs_to_send.items():
             if finish_time < 0:
@@ -1081,8 +1081,7 @@ class NixlConnectorWorker:
 
         # Use handle to check completion in future step().
         # TODO (NickLucche) surface xfer elapsed time
-        self._recving_transfers[request_id].append(
-            (handle, time.perf_counter()))
+        self._recving_transfers[request_id].append((handle, time.monotonic()))
 
     def _get_block_descs_ids(self,
                              engine_id: str,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -64,7 +64,6 @@ class NixlAgentMetadata(
     num_blocks: int
     block_len: int
     attn_backend_name: str
-    remote_node_time: Optional[float] = None
 
 
 @dataclass
@@ -75,7 +74,6 @@ class ReqMeta:
     remote_port: int
     remote_engine_id: str
     tp_size: int
-    request_ttl: float
 
 
 class NixlConnectorMetadata(KVConnectorMetadata):
@@ -98,7 +96,6 @@ class NixlConnectorMetadata(KVConnectorMetadata):
             remote_port=kv_transfer_params["remote_port"],
             # P workers don't need to receive tp_size from proxy here.
             tp_size=kv_transfer_params.get("tp_size", 1),
-            request_ttl=kv_transfer_params.get("request_ttl", -1),
         )
 
 
@@ -334,10 +331,12 @@ class NixlConnectorScheduler:
         # If prompt < block_size, no xfer so free blocks immediately.
         delay_free_blocks = len(computed_block_ids) > 0
 
-        if delay_free_blocks:
+        if delay_free_blocks and params.get("do_remote_decode"):
+            now = time.monotonic()
             # Prefill request on remote. It will be read from D upon completion
-            self._reqs_need_send[request.request_id] = (
-                time.perf_counter() + envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT)
+            self._reqs_need_send[
+                request.
+                request_id] = now + envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,
@@ -346,8 +345,7 @@ class NixlConnectorScheduler:
             remote_engine_id=self.engine_id,
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
-            tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
-            request_ttl=self._reqs_need_send.get(request.request_id, -1))
+            tp_size=self.vllm_config.parallel_config.tensor_parallel_size)
 
 
 class NixlConnectorWorker:
@@ -459,10 +457,6 @@ class NixlConnectorWorker:
         # finish reading before safely freeing the blocks.
         self.consumer_notification_counts_by_req = defaultdict[ReqId, int](int)
 
-        # Map of remote agent name -> time offset to keep clocks synced.
-        self._remote_agent_time_offsets: dict[str, float] = {}
-        self._reqs_expired_ttl: set[ReqId] = set()
-
     def __del__(self):
         """Cleanup background threads on destruction."""
         self._handshake_initiation_executor.shutdown(wait=False)
@@ -494,15 +488,13 @@ class NixlConnectorWorker:
                 if msg != GET_META_MSG:
                     logger.warning(
                         "Connection listener got unexpected message %s", msg)
-
-                # Add current node time to the metadata for clock sync with D.
-                metadata.remote_node_time = time.perf_counter()
-                encoded_data = encoder.encode(metadata)
                 sock.send_multipart((identity, b"", encoded_data))
 
     def _nixl_handshake(self, host: str, port: int,
                         remote_tp_size: int) -> dict[int, str]:
         """Do a NIXL handshake with a remote instance."""
+
+        start_time = time.perf_counter()
 
         # NOTE(rob): we need each rank to have a unique port. This is
         # a hack to keep us moving. We will switch when moving to etcd
@@ -511,18 +503,11 @@ class NixlConnectorWorker:
         def handshake(path: str, rank: int) -> str:
             # Send query for the request.
             with zmq_ctx(zmq.REQ, path) as sock:
-                start_time = time.perf_counter()
                 sock.send(GET_META_MSG)
                 metadata_bytes = sock.recv()
                 decoder = msgspec.msgpack.Decoder(NixlAgentMetadata)
-                metadata: NixlAgentMetadata = decoder.decode(metadata_bytes)
+                metadata = decoder.decode(metadata_bytes)
                 got_metadata_time = time.perf_counter()
-
-                # "Sync" clocks between local and remote by registering offset.
-                rtt = got_metadata_time - start_time
-                assert metadata.remote_node_time
-                self._remote_agent_time_offsets[metadata.engine_id] = (
-                    metadata.remote_node_time + rtt / 2 - got_metadata_time)
 
                 # Register Remote agent.
                 remote_agent_name = self.add_remote_agent(
@@ -857,7 +842,7 @@ class NixlConnectorWorker:
                 len(done_sending), len(done_recving))
 
         # Handle timeout to avoid stranding blocks on remote.
-        now = time.perf_counter()
+        now = time.monotonic()
         while self._reqs_to_send:
             req_id, expires = next(iter(self._reqs_to_send.items()))
             # Sorted dict, oldest requests are put first so we can exit early.
@@ -865,12 +850,6 @@ class NixlConnectorWorker:
                 break
             del self._reqs_to_send[req_id]
             done_sending.add(req_id)
-
-        # Handle remote requests with expired TTL without attempting to read.
-        while self._reqs_expired_ttl:
-            req_id = next(iter(self._reqs_expired_ttl))
-            done_recving.add(req_id)
-            self._reqs_expired_ttl.remove(req_id)
 
         if self.world_size == 1:
             return done_sending, done_recving
@@ -970,6 +949,11 @@ class NixlConnectorWorker:
         """
         for req_id, meta in metadata.reqs_to_recv.items():
             remote_engine_id = meta.remote_engine_id
+            logger.debug(
+                "start_load_kv for request %s from remote engine %s. "
+                "Num local_block_ids: %s. Num remote_block_ids: %s. ", req_id,
+                remote_engine_id, len(meta.local_block_ids),
+                len(meta.remote_block_ids))
             if remote_engine_id not in self._remote_agents:
                 # Initiate handshake with remote engine to exchange metadata.
                 with self._handshake_lock:
@@ -989,20 +973,9 @@ class NixlConnectorWorker:
         self._reqs_to_send.update(metadata.reqs_to_send)
 
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
-        # Make sure request TTL is not expired before reading.
-        assert self._remote_agent_time_offsets[
-            meta.remote_engine_id] is not None
-        remote_offset = self._remote_agent_time_offsets[meta.remote_engine_id]
-        if time.perf_counter() + remote_offset > meta.request_ttl:
-            logger.warning("Request remote TTL expired for request %s", req_id)
-            self._reqs_expired_ttl.add(req_id)
-            return
-
         logger.debug(
-            "start_load_kv for request %s from remote engine %s. "
-            "Num local_block_ids: %s. Num remote_block_ids: %s. ", req_id,
-            meta.remote_engine_id, len(meta.local_block_ids),
-            len(meta.remote_block_ids))
+            "Remote agent %s available, calling _read_blocks for req %s",
+            meta.remote_engine_id, req_id)
         self._read_blocks(
             request_id=req_id,
             dst_engine_id=meta.remote_engine_id,
@@ -1103,8 +1076,7 @@ class NixlConnectorWorker:
 
         # Use handle to check completion in future step().
         # TODO (NickLucche) surface xfer elapsed time
-        self._recving_transfers[request_id].append(
-            (handle, time.perf_counter()))
+        self._recving_transfers[request_id].append((handle, time.monotonic()))
 
     def _get_block_descs_ids(self,
                              engine_id: str,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -138,6 +138,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: str = "NONE"
     VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16: bool = True
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: Optional[int] = None
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: int = 120
 
 
 def get_default_cache_root():
@@ -953,7 +954,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # generations on machines < 100 for compressed-tensors
     # models
     "VLLM_USE_NVFP4_CT_EMULATIONS":
-    lambda: bool(int(os.getenv("VLLM_USE_NVFP4_CT_EMULATIONS", "0")))
+    lambda: bool(int(os.getenv("VLLM_USE_NVFP4_CT_EMULATIONS", "0"))),
+
+    # Time (in seconds) after which the KV cache on the producer side is
+    # automatically cleared if no READ notification is received from the
+    # consumer. This is only applicable when using NixlConnector in a
+    # disaggregated decode-prefill setup.
+    "VLLM_NIXL_ABORT_REQUEST_TIMEOUT":
+    lambda: int(os.getenv("VLLM_NIXL_ABORT_REQUEST_TIMEOUT", "120"))
 }
 
 # --8<-- [end:env-vars-definition]


### PR DESCRIPTION
With https://github.com/vllm-project/vllm/pull/19223, we're addressing most of the cases where P request blocks may be left starving.
However, there are still cases where if the router fails to communicate request abortion for whatever reason (eg in-flight request lost, router down..) while the request has not yet reached D or D fails to communicate the abortion to P, where the remote producer may be left with blocks that won't be cleared.

This PR addresses these final edge-cases by attaching a simple TTL to every request that needs to be read from local(D)<-remote (P).  

cc @njhill 