### PR TITLE
Replace `multiply_add` with `homogeneous_multiply_add` to Address Clang Template Parameter Issue

### DIFF
--- a/csrc/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp
+++ b/csrc/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp
@@ -153,7 +153,7 @@ struct ScaledEpilogueBias
       cutlass::epilogue::threadblock::Sm80EVT<Compute0, ScaleB, Accum>;
 
   using Compute1 = cutlass::epilogue::threadblock::VisitorCompute<
-      cutlass::multiply_add, ElementD, float,
+      cutlass::homogeneous_multiply_add, ElementD, float,
       cutlass::FloatRoundStyle::round_to_nearest>;
 
  public:
@@ -210,7 +210,7 @@ struct ScaledEpilogueBiasAzp
                                               EVTComputeAzp>;
 
   using ComputeScaleBiasA = cutlass::epilogue::threadblock::VisitorCompute<
-      cutlass::multiply_add, ElementD, float,
+      cutlass::homogeneous_multiply_add, ElementD, float,
       cutlass::FloatRoundStyle::round_to_nearest>;
 
  public:
@@ -288,7 +288,7 @@ struct ScaledEpilogueBiasAzpToken
                                               EVTComputeAcc>;
 
   using ComputeScaleBiasA = cutlass::epilogue::threadblock::VisitorCompute<
-      cutlass::multiply_add, ElementD, float,
+      cutlass::homogeneous_multiply_add, ElementD, float,
       cutlass::FloatRoundStyle::round_to_nearest>;
 
  public:

--- a/csrc/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
+++ b/csrc/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
@@ -195,7 +195,7 @@ struct ScaledEpilogueBias
       cutlass::epilogue::fusion::Sm90EVT<Compute0, ScaleB, Accum>;
 
   using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiply_add, ElementD, float,
+      cutlass::homogeneous_multiply_add, ElementD, float,
       cutlass::FloatRoundStyle::round_to_nearest>;
 
  public:
@@ -238,7 +238,7 @@ struct ScaledEpilogueColumnBias
       cutlass::epilogue::fusion::Sm90EVT<Compute0, ScaleB, Accum>;
 
   using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiply_add, ElementD, float,
+      cutlass::homogeneous_multiply_add, ElementD, float,
       cutlass::FloatRoundStyle::round_to_nearest>;
 
  public:
@@ -295,7 +295,7 @@ struct ScaledEpilogueBiasAzp
       cutlass::epilogue::fusion::Sm90EVT<ComputeScaleB, ScaleB, EVTComputeAzp>;
 
   using ComputeScaleBiasA = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiply_add, ElementD, float,
+      cutlass::homogeneous_multiply_add, ElementD, float,
       cutlass::FloatRoundStyle::round_to_nearest>;
 
  public:
@@ -371,7 +371,7 @@ struct ScaledEpilogueBiasAzpToken
       cutlass::epilogue::fusion::Sm90EVT<ComputeScaleB, ScaleB, EVTComputeAcc>;
 
   using ComputeScaleBiasA = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiply_add, ElementD, float,
+      cutlass::homogeneous_multiply_add, ElementD, float,
       cutlass::FloatRoundStyle::round_to_nearest>;
 
  public:


### PR DESCRIPTION
Summary:
Replaced the `multiply_add` template with `homogeneous_multiply_add` in the codebase to address a known Clang issue where template template parameters with one template parameter do not match classes that take multiple template parameters with defaults.

Error:
```
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:155:84: error: template template argument has different template parameters than its corresponding template template parameter
  155 | using Compute1 = cutlass::epilogue::threadblock::template VisitorCompute< cutlass::multiply_add, ElementD, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |                                                                                    ^
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:160:69: error: unknown type name 'Compute1'; did you mean 'Compute0'?
  160 | public: using EVTCompute = cutlass::epilogue::threadblock::Sm80EVT< Compute1, ScaleA, EVTCompute0, Bias> ;
      |                                                                     ^~~~~~~~
      |                                                                     Compute0
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:148:7: note: 'Compute0' declared here
  148 | using Compute0 = cutlass::epilogue::threadblock::VisitorCompute< cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |       ^
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:162:72: error: unknown type name 'Compute1'; did you mean 'Compute0'?
  162 | using ArgumentType = typename cutlass::epilogue::threadblock::Sm80EVT< Compute1, ScaleA, EVTCompute0, Bias> ::Arguments;
      |                                                                        ^~~~~~~~
      |                                                                        Compute0
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:148:7: note: 'Compute0' declared here
  148 | using Compute0 = cutlass::epilogue::threadblock::VisitorCompute< cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |       ^
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:212:93: error: template template argument has different template parameters than its corresponding template template parameter
  212 | using ComputeScaleBiasA = cutlass::epilogue::threadblock::template VisitorCompute< cutlass::multiply_add, ElementD, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |                                                                                             ^
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:217:69: error: unknown type name 'ComputeScaleBiasA'; did you mean 'ComputeScaleB'?
  217 | public: using EVTCompute = cutlass::epilogue::threadblock::Sm80EVT< ComputeScaleBiasA, ScaleA, EVTComputeScaleB, Bias> ;
      |                                                                     ^~~~~~~~~~~~~~~~~
      |                                                                     ComputeScaleB
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:204:7: note: 'ComputeScaleB' declared here
  204 | using ComputeScaleB = cutlass::epilogue::threadblock::VisitorCompute< cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |       ^
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:221:72: error: unknown type name 'ComputeScaleBiasA'; did you mean 'ComputeScaleB'?
  221 | using ArgumentType = typename cutlass::epilogue::threadblock::Sm80EVT< ComputeScaleBiasA, ScaleA, EVTComputeScaleB, Bias> ::Arguments;
      |                                                                        ^~~~~~~~~~~~~~~~~
      |                                                                        ComputeScaleB
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:204:7: note: 'ComputeScaleB' declared here
  204 | using ComputeScaleB = cutlass::epilogue::threadblock::VisitorCompute< cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |       ^
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:290:93: error: template template argument has different template parameters than its corresponding template template parameter
  290 | using ComputeScaleBiasA = cutlass::epilogue::threadblock::template VisitorCompute< cutlass::multiply_add, ElementD, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |                                                                                             ^
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:295:69: error: unknown type name 'ComputeScaleBiasA'; did you mean 'ComputeScaleB'?
  295 | public: using EVTCompute = cutlass::epilogue::threadblock::Sm80EVT< ComputeScaleBiasA, ScaleA, EVTComputeScaleB, Bias> ;
      |                                                                     ^~~~~~~~~~~~~~~~~
      |                                                                     ComputeScaleB
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:282:7: note: 'ComputeScaleB' declared here
  282 | using ComputeScaleB = cutlass::epilogue::threadblock::VisitorCompute< cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |       ^
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:299:72: error: unknown type name 'ComputeScaleBiasA'; did you mean 'ComputeScaleB'?
  299 | using ArgumentType = typename cutlass::epilogue::threadblock::Sm80EVT< ComputeScaleBiasA, ScaleA, EVTComputeScaleB, Bias> ::Arguments;
      |                                                                        ^~~~~~~~~~~~~~~~~
      |                                                                        ComputeScaleB
vllm/__vllm_cpp_lib__/buck-headers/cutlass_extensions/epilogue/scaled_mm_epilogues_c2x.hpp:282:7: note: 'ComputeScaleB' declared here
  282 | using ComputeScaleB = cutlass::epilogue::threadblock::VisitorCompute< cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest> ;
      |       ^
In file included from scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:1:
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:11:5668: error: template template argument has different template parameters than its corresponding template template parameter
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
In file included from scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:1:
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:11:6055: error: expected unqualified-id
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:12:5680: error: template template argument has different template parameters than its corresponding template template parameter
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
In file included from scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:1:
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:12:6068: error: expected unqualified-id
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:13:5691: error: template template argument has different template parameters than its corresponding template template parameter
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
In file included from scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:1:
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:13:6079: error: expected unqualified-id
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:14:5697: error: template template argument has different template parameters than its corresponding template template parameter
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
In file included from scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:1:
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:14:6086: error: expected unqualified-id
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:15:5664: error: template template argument has different template parameters than its corresponding template template parameter
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/functional.h:538:1: note: too many template parameters in template template argument
  538 | template< class A, class B = A, class C = A>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/cutlass-3/__cutlass-3-headers__/buck-headers/cutlass/epilogue/threadblock/fusion/visitor_compute.hpp:56:1: note: previous template template parameter is here
   56 | template< class >  class ComputeFn, class
      | ^~~~~~~~~~~~~~~~~
In file included from scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:1:
vllm/__vllm_cpp_lib__/__action___33__/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu.pic.o.compute_90a.cudafe1.stub.c:15:6047: error: expected unqualified-id
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.

```

Test Plan:
D76353588 all testing passed.

Rollback Plan:

Differential Revision: D76555276


