### PR TITLE
[CI Failure] Fix OOM with test_oot_registration_embedding

### DIFF
--- a/tests/models/test_oot_registration.py
+++ b/tests/models/test_oot_registration.py
@@ -53,7 +53,9 @@ def test_oot_registration_embedding(
     with monkeypatch.context() as m:
         m.setenv("VLLM_PLUGINS", "register_dummy_model")
         prompts = ["Hello, my name is", "The text does not matter"]
-        llm = LLM(model=dummy_gemma2_embedding_path, load_format="dummy")
+        llm = LLM(model=dummy_gemma2_embedding_path,
+                  load_format="dummy",
+                  max_model_len=2048)
         outputs = llm.embed(prompts)
 
         for output in outputs:


### PR DESCRIPTION
## Purpose

FIX https://github.com/vllm-project/vllm/issues/20148

The `models/test_oot_registration.py::test_oot_registration_embedding` test seems to be failing in CI consistently with a context length OOM

https://buildkite.com/vllm/ci/builds/22737/steps/canvas?sid=0197acae-970a-43ee-9fef-108d8a58da0c#0197acae-98db-423d-8af9-eb4eb401f1b4/212-1320

```
[2025-06-26T16:27:15Z] ERROR 06-26 09:27:15 [core.py:519] ValueError: To serve at least one request with the models's max seq len (8192), (2.63 GiB KV cache is needed, which is larger than the available KV cache memory (1.64 GiB). Based on the available memory, the estimated maximum model length is 5088. Try increasing `gpu_memory_utilization` or decreasing `max_model_len` when initializing the engine.
```

## Test Plan

Green CI for this test

## Test Result

https://buildkite.com/vllm/fastcheck/builds/28504/steps/canvas?jid=0197ad94-571b-474d-9172-cb63c661f112