### PR TITLE
[CI/Build] Add new CI job to validate Hybrid Models for every PR 

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -509,6 +509,17 @@ steps:
     - pip freeze | grep -E 'torch'
     - pytest -v -s models/language -m core_model
 
+- label: Language Models Test (Hybrid) # TBD min
+  mirror_hardwares: [amdexperimental]
+  torch_nightly: true
+  source_file_dependencies:
+  - vllm/
+  - tests/models/language/generation
+  commands:
+    # Install causal-conv1d for plamo2 models here, as it is not compatible with pip-compile.
+    - pip install 'git+https://github.com/Dao-AILab/causal-conv1d@v1.5.0.post8'
+    - pytest -v -s models/language/generation -m hybrid_model
+
 - label: Language Models Test (Extended Generation) # 1hr20min
   mirror_hardwares: [amdexperimental]
   optional: true
@@ -518,7 +529,7 @@ steps:
   commands:
     # Install causal-conv1d for plamo2 models here, as it is not compatible with pip-compile.
     - pip install 'git+https://github.com/Dao-AILab/causal-conv1d@v1.5.0.post8'
-    - pytest -v -s models/language/generation -m 'not core_model'
+    - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
 
 - label: Language Models Test (Extended Pooling)  # 36min
   mirror_hardwares: [amdexperimental]

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -509,7 +509,7 @@ steps:
     - pip freeze | grep -E 'torch'
     - pytest -v -s models/language -m core_model
 
-- label: Language Models Test (Hybrid) # TBD min
+- label: Language Models Test (Hybrid) # 35 min
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
   source_file_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ skip_gitignore = true
 markers = [
     "skip_global_cleanup",
     "core_model: enable this model test in each PR instead of only nightly",
-    "hybrid_model: models that contain mamba layers",
+    "hybrid_model: models that contain mamba layers (including pure SSM and hybrid architectures)",
     "cpu_model: enable this model test in CPU tests",
     "split: run this test as part of a split",
     "distributed: run this test only in distributed GPU tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ skip_gitignore = true
 markers = [
     "skip_global_cleanup",
     "core_model: enable this model test in each PR instead of only nightly",
+    "hybrid_model: models that contain mamba layers",
     "cpu_model: enable this model test in CPU tests",
     "split: run this test as part of a split",
     "distributed: run this test only in distributed GPU tests",

--- a/tests/models/language/generation/test_hybrid.py
+++ b/tests/models/language/generation/test_hybrid.py
@@ -9,6 +9,9 @@ from vllm.sampling_params import SamplingParams
 
 from ...utils import check_logprobs_close, check_outputs_equal
 
+# Mark all tests as hybrid
+pytestmark = pytest.mark.hybrid_model
+
 # NOTE: The first model in each list is taken as the primary model,
 # meaning that it will be used in all tests in this file
 # The rest of the models will only be tested by test_models
@@ -44,7 +47,6 @@ V1_SUPPORTED_MODELS = [
 MAX_NUM_SEQS = 4
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", SSM_MODELS + HYBRID_MODELS)
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])
@@ -98,7 +100,6 @@ def test_models(
         )
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", SSM_MODELS + HYBRID_MODELS)
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])
@@ -128,7 +129,6 @@ def test_batching(
     )
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("num_logprobs", [5])
@@ -165,7 +165,6 @@ def test_chunked_prefill(
     )
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [10])
 def test_chunked_prefill_with_parallel_sampling(
@@ -198,7 +197,6 @@ def test_chunked_prefill_with_parallel_sampling(
         vllm_model.generate(example_prompts, sampling_params)
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [20])
 def test_mamba_cache_cg_padding(
@@ -228,7 +226,6 @@ def test_mamba_cache_cg_padding(
             "Could be related to mamba cache not padded correctly")
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [20])
 def test_models_preemption_recompute(
@@ -257,7 +254,6 @@ def test_models_preemption_recompute(
     )
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 def test_fail_upon_inc_requests_and_finished_requests_lt_available_blocks(
     vllm_runner,
@@ -281,7 +277,6 @@ def test_fail_upon_inc_requests_and_finished_requests_lt_available_blocks(
                     "steps finished requests registered unnecessarily ")
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 def test_state_cleanup(
     vllm_runner,
@@ -303,7 +298,6 @@ def test_state_cleanup(
                     "could be related to finished_requests_ids")
 
 
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [64])
 def test_multistep_correctness(
@@ -331,7 +325,6 @@ def test_multistep_correctness(
 
 
 @multi_gpu_test(num_gpus=2)
-@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])

--- a/tests/models/language/generation/test_hybrid.py
+++ b/tests/models/language/generation/test_hybrid.py
@@ -44,6 +44,7 @@ V1_SUPPORTED_MODELS = [
 MAX_NUM_SEQS = 4
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", SSM_MODELS + HYBRID_MODELS)
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])
@@ -97,6 +98,7 @@ def test_models(
         )
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", SSM_MODELS + HYBRID_MODELS)
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])
@@ -126,6 +128,7 @@ def test_batching(
     )
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("num_logprobs", [5])
@@ -162,6 +165,7 @@ def test_chunked_prefill(
     )
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [10])
 def test_chunked_prefill_with_parallel_sampling(
@@ -194,6 +198,7 @@ def test_chunked_prefill_with_parallel_sampling(
         vllm_model.generate(example_prompts, sampling_params)
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [20])
 def test_mamba_cache_cg_padding(
@@ -223,6 +228,7 @@ def test_mamba_cache_cg_padding(
             "Could be related to mamba cache not padded correctly")
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [20])
 def test_models_preemption_recompute(
@@ -251,6 +257,7 @@ def test_models_preemption_recompute(
     )
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 def test_fail_upon_inc_requests_and_finished_requests_lt_available_blocks(
     vllm_runner,
@@ -274,6 +281,7 @@ def test_fail_upon_inc_requests_and_finished_requests_lt_available_blocks(
                     "steps finished requests registered unnecessarily ")
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 def test_state_cleanup(
     vllm_runner,
@@ -295,6 +303,7 @@ def test_state_cleanup(
                     "could be related to finished_requests_ids")
 
 
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [64])
 def test_multistep_correctness(
@@ -322,6 +331,7 @@ def test_multistep_correctness(
 
 
 @multi_gpu_test(num_gpus=2)
+@pytest.mark.hybrid_model
 @pytest.mark.parametrize("model", [SSM_MODELS[0], HYBRID_MODELS[0]])
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])


### PR DESCRIPTION
Hybrid models that mix mamba and attention layers (Bamba, Nemotron-H, Granite 4.0, Zamba2,  Falcon H1) are becoming increasingly important to multiple different stakeholders. Currently, vLLM's support for these models is not verified as part of PR builds. The only way to test them in CI is to trigger the optional `Language Models Test (Extended Generation)` job. This job takes a long time (more than an hour) and contains a lot of flaky test (as one would expect for a job that is not run frequently on this codebase). 

This PR proposes to add a new CI stage that runs by default for every PR and verifies that vLLM works well for the family of hybrid models. 

Hopefully this job will run when I open this PR and I add a comment re: how long it takes to run after I observe it. 
