### PR TITLE
[Bugfix] Mark 'hidden_states' as mutable in moe_forward registration.

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1538,4 +1538,5 @@ direct_register_custom_op(
     mutates_args=["hidden_states"],
     fake_impl=moe_forward_fake,
     dispatch_key=current_platform.dispatch_key,
+    tags=(torch.Tag.needs_fixed_stride_order, ),
 )

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1535,7 +1535,7 @@ def moe_forward_fake(hidden_states: torch.Tensor, router_logits: torch.Tensor,
 direct_register_custom_op(
     op_name="moe_forward",
     op_func=moe_forward,
-    mutates_args=[],
+    mutates_args=["hidden_states"],
     fake_impl=moe_forward_fake,
     dispatch_key=current_platform.dispatch_key,
 )


### PR DESCRIPTION
Mark `hidden_states` as mutable in `moe_forward` registration.  The `inplace` option on `fused_experts` can cause `hidden_states` to sometimes get mutated when calling `moe_forward`.

This fixes a test failure in `tests/models/language/generation/test_common.py::test_models[False-5-32-TitanML/tiny-mixtral]` introduced by https://github.com/vllm-project/vllm/pull/19717.

cc @tlrmchlsmth @tdoublep @varun-sundar-rabindranath @ElizaWszola 