### PR TITLE
Fix num_token_padding support for static per-tensor scaled_fp8_quant

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1274,8 +1274,7 @@ def scaled_fp8_quant(
             scale = torch.zeros(1, device=input.device, dtype=torch.float32)
             torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
     else:
-        # num_token_padding not implemented for this case
-        assert (scale.numel() == 1 and num_token_padding is None)
+        assert scale.numel() == 1
         torch.ops._C.static_scaled_fp8_quant(output, input, scale)
 
     return output, scale


### PR DESCRIPTION
## Purpose

FIX https://github.com/vllm-project/vllm/issues/20192

After https://github.com/vllm-project/vllm/pull/20076 fixed the assert to always check for per-tensor scales in the static scaled_fp8_quant case, this test `tests/quantization/test_fp8.py::test_scaled_fp8_quant` started failing
https://buildkite.com/vllm/ci/builds/22749#0197ad88-59ca-41d0-9692-2bb3f5c6dca3

It seems to me that there is no reason why padding wouldn't be supported in this static per-tensor quant case

## Test Plan

Use the existing failing test at
https://github.com/vllm-project/vllm/blob/aafabaa0d5c87c283b366f81fdce55cf91ae980c/tests/quantization/test_fp8.py#L190-L196

## Test Result

```
tests/quantization/test_fp8.py::test_scaled_fp8_quant[dtype0] PASSED
tests/quantization/test_fp8.py::test_scaled_fp8_quant[dtype1] PASSED
```
