### PR TITLE
[Bugfix] Properly reject requests with empty list guided_choice

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -173,6 +173,12 @@ class Processor:
             params.guided_decoding.backend = engine_level_backend
 
         # Request content validation
+        if (isinstance(params.guided_decoding.choice, list)
+                and not params.guided_decoding.choice):
+            # It is invalid for choice to be an empty list
+            raise ValueError(f"Choice '{params.guided_decoding.choice}' "
+                             "cannot be an empty list")
+
         if engine_level_backend.startswith("xgrammar"):
             # xgrammar with no fallback
             validate_xgrammar_grammar(params)


### PR DESCRIPTION
## Purpose

Improve the error message and properly raise a ValueError when receiving a request specifying empty "choice" for structured outputs.

## Test Plan

Server:
```
vllm serve Qwen/Qwen3-0.6B --enforce-eager
```

Client:
```python
from openai import OpenAI

client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")

chat_response = client.chat.completions.create(
    model=client.models.list().data[0].id,
    messages=[{
        "role": "user",
        "content": [{"type": "text", "text": "Who are you?"}],
    }],
    extra_body={
        "guided_choice": []
    }
)
```

## Test Result

Before (the server would crash):
```
INFO 06-27 17:12:40 [async_llm.py:270] Added request chatcmpl-5e577b9ff48c43b391a6a74fc22d15da.
ERROR 06-27 17:12:40 [backend_xgrammar.py:113] Validation should have already occurred. Please file an issue.
ERROR 06-27 17:12:41 [core.py:521] EngineCore encountered a fatal error.
ERROR 06-27 17:12:41 [core.py:521] Traceback (most recent call last):
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 512, in run_engine_core
ERROR 06-27 17:12:41 [core.py:521]     engine_core.run_busy_loop()
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 539, in run_busy_loop
ERROR 06-27 17:12:41 [core.py:521]     self._process_engine_step()
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 564, in _process_engine_step
ERROR 06-27 17:12:41 [core.py:521]     outputs, model_executed = self.step_fn()
ERROR 06-27 17:12:41 [core.py:521]                               ^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 234, in step
ERROR 06-27 17:12:41 [core.py:521]     scheduler_output = self.scheduler.schedule()
ERROR 06-27 17:12:41 [core.py:521]                        ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/core/sched/scheduler.py", line 361, in schedule
ERROR 06-27 17:12:41 [core.py:521]     if structured_output_req and structured_output_req.grammar:
ERROR 06-27 17:12:41 [core.py:521]                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/structured_output/request.py", line 45, in grammar
ERROR 06-27 17:12:41 [core.py:521]     completed = self._check_grammar_completion()
ERROR 06-27 17:12:41 [core.py:521]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/structured_output/request.py", line 33, in _check_grammar_completion
ERROR 06-27 17:12:41 [core.py:521]     self._grammar = self._grammar.result(timeout=0.0001)
ERROR 06-27 17:12:41 [core.py:521]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/.local/share/uv/python/cpython-3.12.4-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 456, in result
ERROR 06-27 17:12:41 [core.py:521]     return self.__get_result()
ERROR 06-27 17:12:41 [core.py:521]            ^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/.local/share/uv/python/cpython-3.12.4-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
ERROR 06-27 17:12:41 [core.py:521]     raise self._exception
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/.local/share/uv/python/cpython-3.12.4-linux-x86_64-gnu/lib/python3.12/concurrent/futures/thread.py", line 58, in run
ERROR 06-27 17:12:41 [core.py:521]     result = self.fn(*self.args, **self.kwargs)
ERROR 06-27 17:12:41 [core.py:521]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/structured_output/__init__.py", line 109, in _async_create_grammar
ERROR 06-27 17:12:41 [core.py:521]     return self.backend.compile_grammar(request_type, grammar_spec)
ERROR 06-27 17:12:41 [core.py:521]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [core.py:521]   File "/home/mgoin/code/vllm/vllm/v1/structured_output/backend_xgrammar.py", line 116, in compile_grammar
ERROR 06-27 17:12:41 [core.py:521]     raise ValueError(
ERROR 06-27 17:12:41 [core.py:521] ValueError: grammar is not of valid supported types. (StructuredOutputOptions.CHOICE)
ERROR 06-27 17:12:41 [async_llm.py:419] AsyncLLM output_handler failed.
ERROR 06-27 17:12:41 [async_llm.py:419] Traceback (most recent call last):
ERROR 06-27 17:12:41 [async_llm.py:419]   File "/home/mgoin/code/vllm/vllm/v1/engine/async_llm.py", line 378, in output_handler
ERROR 06-27 17:12:41 [async_llm.py:419]     outputs = await engine_core.get_output_async()
ERROR 06-27 17:12:41 [async_llm.py:419]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 06-27 17:12:41 [async_llm.py:419]   File "/home/mgoin/code/vllm/vllm/v1/engine/core_client.py", line 809, in get_output_async
ERROR 06-27 17:12:41 [async_llm.py:419]     raise self._format_exception(outputs) from None
ERROR 06-27 17:12:41 [async_llm.py:419] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
INFO 06-27 17:12:41 [async_llm.py:345] Request chatcmpl-5e577b9ff48c43b391a6a74fc22d15da failed (engine dead).
INFO:     127.0.0.1:55444 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```

After:
```
Client:
Traceback (most recent call last):
  File "/home/mgoin/code/t.py", line 9, in <module>
    chat_response = client.chat.completions.create(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mgoin/venvs/vllm/lib/python3.12/site-packages/openai/_utils/_utils.py", line 287, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/mgoin/venvs/vllm/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py", line 925, in create
    return self._post(
           ^^^^^^^^^^^
  File "/home/mgoin/venvs/vllm/lib/python3.12/site-packages/openai/_base_client.py", line 1239, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mgoin/venvs/vllm/lib/python3.12/site-packages/openai/_base_client.py", line 1034, in request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'object': 'error', 'message': "Choice '[]' cannot be an empty list", 'type': 'BadRequestError', 'param': None, 'code': 400}

Server:
INFO:     127.0.0.1:40160 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
```
