### PR TITLE
[BUGFIX][DEEPSEEK][MODEL_LOAD] fix w13, w2 weight not initialized assert

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -889,6 +889,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
                                             expert_id=expert_id,
                                             return_success=True)
                     if success:
+                        name = name_mapped
                         break
                 else:
                     if is_expert_weight:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fix issue when loading deepseek model, current error log
Failing is introduced by https://github.com/vllm-project/vllm/pull/18343

```
		INFO 06-27 21:12:49 [default_loader.py:272] Loading weights took 7.88 seconds
		ERROR 06-27 21:12:49 [core.py:519] EngineCore failed to start.
		ERROR 06-27 21:12:49 [core.py:519] Traceback (most recent call last):
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/v1/engine/core.py", line 510, in run_engine_core
		ERROR 06-27 21:12:49 [core.py:519]     engine_core = EngineCoreProc(*args, **kwargs)
		ERROR 06-27 21:12:49 [core.py:519]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/v1/engine/core.py", line 394, in __init__
		ERROR 06-27 21:12:49 [core.py:519]     super().__init__(vllm_config, executor_class, log_stats,
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/v1/engine/core.py", line 75, in __init__
		ERROR 06-27 21:12:49 [core.py:519]     self.model_executor = executor_class(vllm_config)
		ERROR 06-27 21:12:49 [core.py:519]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/executor/executor_base.py", line 53, in __init__
		ERROR 06-27 21:12:49 [core.py:519]     self._init_executor()
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/executor/uniproc_executor.py", line 48, in _init_executor
		ERROR 06-27 21:12:49 [core.py:519]     self.collective_rpc("load_model")
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/executor/uniproc_executor.py", line 57, in collective_rpc
		ERROR 06-27 21:12:49 [core.py:519]     answer = run_method(self.driver_worker, method, args, kwargs)
		ERROR 06-27 21:12:49 [core.py:519]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/utils.py", line 2687, in run_method
		ERROR 06-27 21:12:49 [core.py:519]     return func(*args, **kwargs)
		ERROR 06-27 21:12:49 [core.py:519]            ^^^^^^^^^^^^^^^^^^^^^
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm-gaudi/vllm_hpu/v1/worker/hpu_worker.py", line 112, in load_model
		ERROR 06-27 21:12:49 [core.py:519]     self.model_runner.load_model()
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm-gaudi/vllm_hpu/v1/worker/hpu_model_runner.py", line 1688, in load_model
		ERROR 06-27 21:12:49 [core.py:519]     self.model = get_model(vllm_config=self.vllm_config)
		ERROR 06-27 21:12:49 [core.py:519]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/model_executor/model_loader/__init__.py", line 59, in get_model
		ERROR 06-27 21:12:49 [core.py:519]     return loader.load_model(vllm_config=vllm_config,
		ERROR 06-27 21:12:49 [core.py:519]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/model_executor/model_loader/base_loader.py", line 41, in load_model
		ERROR 06-27 21:12:49 [core.py:519]     self.load_weights(model, model_config)
		ERROR 06-27 21:12:49 [core.py:519]   File "/workspace/vllm/vllm/model_executor/model_loader/default_loader.py", line 281, in load_weights
		ERROR 06-27 21:12:49 [core.py:519]     raise ValueError("Following weights were not initialized from "
ERROR 06-27 21:12:49 [core.py:519] ValueError: Following weights were not initialized from checkpoint: {'model.layers.1.mlp.experts.w13_weight', 'model.layers.6.mlp.experts.w2_weight', 'model.layers.18.mlp.experts.w13_weight', 'model.layers.24.mlp.experts.w13_weight', 'model.layers.5.mlp.experts.w13_weight', 'model.layers.12.mlp.experts.w13_weight', 'model.layers.21.mlp.experts.w13_weight', 'model.layers.7.mlp.experts.w2_weight', 'model.layers.18.mlp.experts.w2_weight', 'model.layers.3.mlp.experts.w13_weight', 'model.layers.22.mlp.experts.w13_weight', 'model.layers.25.mlp.experts.w2_weight', 'model.layers.16.mlp.experts.w2_weight', 'model.layers.9.mlp.experts.w2_weight', 'model.layers.11.mlp.experts.w2_weight', 'model.layers.4.mlp.experts.w2_weight', 'model.layers.17.mlp.experts.w2_weight', 'model.layers.13.mlp.experts.w2_weight', 'model.layers.15.mlp.experts.w13_weight', 'model.layers.9.mlp.experts.w13_weight', 'model.layers.12.mlp.experts.w2_weight', 'model.layers.19.mlp.experts.w13_weight', 'model.layers.8.mlp.experts.w13_weight', 'model.layers.23.mlp.experts.w2_weight', 'model.layers.6.mlp.experts.w13_weight', 'model.layers.26.mlp.experts.w13_weight', 'model.layers.10.mlp.experts.w2_weight', 'model.layers.5.mlp.experts.w2_weight', 'model.layers.14.mlp.experts.w13_weight', 'model.layers.20.mlp.experts.w13_weight', 'model.layers.2.mlp.experts.w2_weight', 'model.layers.10.mlp.experts.w13_weight', 'model.layers.21.mlp.experts.w2_weight', 'model.layers.22.mlp.experts.w2_weight', 'model.layers.26.mlp.experts.w2_weight', 'model.layers.23.mlp.experts.w13_weight', 'model.layers.25.mlp.experts.w13_weight', 'model.layers.1.mlp.experts.w2_weight', 'model.layers.11.mlp.experts.w13_weight', 'model.layers.16.mlp.experts.w13_weight', 'model.layers.3.mlp.experts.w2_weight', 'model.layers.24.mlp.experts.w2_weight', 'model.layers.4.mlp.experts.w13_weight', 'model.layers.15.mlp.experts.w2_weight', 'model.layers.17.mlp.experts.w13_weight', 'model.layers.13.mlp.experts.w13_weight', 'model.layers.8.mlp.experts.w2_weight', 'model.layers.2.mlp.experts.w13_weight', 'model.layers.20.mlp.experts.w2_weight', 'model.layers.7.mlp.experts.w13_weight', 'model.layers.19.mlp.experts.w2_weight', 'model.layers.14.mlp.experts.w2_weight'}
```

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
