### PR TITLE
[CI Fix] Try fixing eagle e2e test OOM by reducing block allocation

### DIFF
--- a/tests/spec_decode/e2e/test_eagle_correctness.py
+++ b/tests/spec_decode/e2e/test_eagle_correctness.py
@@ -370,6 +370,10 @@ def test_llama2_eagle_e2e_greedy_correctness(vllm_runner, common_llm_kwargs,
 @pytest.mark.parametrize(
     "common_llm_kwargs",
     [{
+        # 2 for small prompt, 256//16 for generated.
+        "num_gpu_blocks_override": 2 + 256 // 16,
+        "max_model_len": (2 + 256 // 16) * 16,
+
         # Skip cuda graph recording for fast test.
         "enforce_eager": True,
 
@@ -420,6 +424,10 @@ def test_llama3_eagle_e2e_greedy_correctness(vllm_runner, common_llm_kwargs,
 @pytest.mark.parametrize(
     "common_llm_kwargs",
     [{
+        # 2 for small prompt, 256//16 for generated.
+        "num_gpu_blocks_override": 2 + 256 // 16,
+        "max_model_len": (2 + 256 // 16) * 16,
+
         # Skip cuda graph recording for fast test.
         "enforce_eager": True,
 


### PR DESCRIPTION
## Purpose

FIX https://github.com/vllm-project/vllm/issues/20214

The constantly failing test in CI seems to be an OOM during kv cache allocation, so maybe we can get through by just manually specifying the kv cache blocks for now. I'm not sure if it is a memory profiling issue or just a small GPU issue since the tests have failed for weeks at this point.

## Test Plan

See if the spec decode test is green in CI, see https://github.com/vllm-project/vllm/issues/20214


## Test Result