### PR TITLE
[Build] Add upper limit for transformers version

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.51.1
+transformers >= 4.51.1, <= 4.53.0 # Upper limit because of issue #20224
 huggingface-hub[hf_xet] >= 0.33.0  # Required for Xet downloads.
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.


### PR DESCRIPTION
This change adds an upper limit for the `transformers` package version
because Whisper fails to load with the latest version (4.53.0). I'm not
sure if the problem affects other models yet.

Issue #20224

Signed-off-by: Russell Bryant <rbryant@redhat.com>
