### PR TITLE
[Frontend][Model] Qwen3Rerank API Server backward compatibility

### DIFF
--- a/tests/entrypoints/openai/test_score.py
+++ b/tests/entrypoints/openai/test_score.py
@@ -7,7 +7,7 @@ import requests
 import torch.nn.functional as F
 from torch import tensor
 
-from vllm.entrypoints.openai.protocol import ScoreResponse
+from vllm.entrypoints.openai.protocol import RerankResponse, ScoreResponse
 
 from ...utils import RemoteOpenAIServer
 
@@ -29,11 +29,35 @@ MODELS = [
         "name": "BAAI/bge-base-en-v1.5",
         "is_cross_encoder": False
     },
+    {
+        "name": "Qwen/Qwen3-Reranker-0.6B",
+        "is_cross_encoder": True,
+        "is_qwen3_reranker": True,
+    },
 ]
 DTYPE = "half"
 
 
+def _run_qwen3_reranker_hf(hf_model, text_pairs, instruction):
+    """Helper to run Qwen3 reranker with HF, applying the template."""
+    prefix = '<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
+    suffix = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+
+    formatted_pairs = []
+    for query, doc in text_pairs:
+        q_formatted = f"{prefix}<Instruct>: {instruction}\n<Query>: {query}\n"
+        d_formatted = f"<Document>: {doc}{suffix}"
+        formatted_pairs.append([q_formatted, d_formatted])
+
+    return hf_model.predict(formatted_pairs).tolist()
+
+
 def run_transformers(hf_model, model, text_pairs):
+    if model.get("is_qwen3_reranker"):
+        # The default instruction used in the server fixture.
+        default_instruction = "Given a web search query, retrieve relevant passages that answer the query"
+        return _run_qwen3_reranker_hf(hf_model, text_pairs,
+                                      default_instruction)
     if model["is_cross_encoder"]:
         return hf_model.predict(text_pairs).tolist()
     else:
@@ -53,7 +77,27 @@ def model(request):
 
 @pytest.fixture(scope="class")
 def server(model: dict[str, Any]):
-    args = ["--enforce-eager", "--max-model-len", "100", "--dtype", DTYPE]
+    args = ["--enforce-eager", "--max-model-len", "256", "--dtype", DTYPE]
+    if model.get("is_qwen3_reranker"):
+        import json
+        prefix = '<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
+        suffix = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        default_instruction = "Given a web search query, retrieve relevant passages that answer the query"
+
+        hf_overrides = {
+            "architectures": ["Qwen3ForSequenceClassification"],
+            "classifier_from_token": ["no", "yes"],
+            "is_original_qwen3_reranker": True,
+            "score_template": {
+                "query_template":
+                f"{prefix}<Instruct>: {{instruction}}\n<Query>: {{query}}\n",
+                "document_template": f"<Document>: {{document}}{suffix}",
+                "default_context": {
+                    "instruction": default_instruction
+                }
+            }
+        }
+        args.extend(["--hf-overrides", json.dumps(hf_overrides)])
 
     with RemoteOpenAIServer(model["name"], args) as remote_server:
         yield remote_server
@@ -61,13 +105,23 @@ def server(model: dict[str, Any]):
 
 @pytest.fixture(scope="class")
 def runner(model: dict[str, Any], hf_runner):
-    kwargs = {
-        "dtype": DTYPE,
-        "is_cross_encoder" if model["is_cross_encoder"]\
-              else "is_sentence_transformer": True
-    }
+    model_name = model["name"]
+    kwargs = {"dtype": DTYPE}
+    if model.get("is_qwen3_reranker"):
+        # For the HF reference, use the pre-converted Sequence Classification
+        # model to simplify the runner logic.
+        model_name = "tomaarsen/Qwen3-Reranker-0.6B-seq-cls"
+        hf_runner_kwargs = {
+            "dtype": DTYPE,
+            "is_cross_encoder": True,
+            "trust_remote_code": True,
+        }
+    elif model["is_cross_encoder"]:
+        hf_runner_kwargs = {"dtype": DTYPE, "is_cross_encoder": True}
+    else:
+        hf_runner_kwargs = {"dtype": DTYPE, "is_sentence_transformer": True}
 
-    with hf_runner(model["name"], **kwargs) as hf_model:
+    with hf_runner(model_name, **hf_runner_kwargs) as hf_model:
         yield hf_model
 
 
@@ -191,3 +245,75 @@ class TestModel:
         assert score_response.status_code == 400
         assert "Please, select a smaller truncation size." in \
             score_response.text
+
+    def test_rerank_with_template(self, server: RemoteOpenAIServer,
+                                  model: dict[str, Any], runner):
+        if not model.get("is_qwen3_reranker"):
+            pytest.skip("Test only for Qwen3 Reranker with template support.")
+
+        instruction = "Find the document that is most relevant to the query about national capitals."
+        query = "What is the capital of China?"
+        documents = [
+            "The capital of France is Paris.",
+            "The capital of China is Beijing."
+        ]
+
+        # vLLM run with custom instruction via kwargs
+        rerank_response = requests.post(
+            server.url_for("rerank"),
+            json={
+                "model": model["name"],
+                "query": query,
+                "documents": documents,
+                "score_template_kwargs": {
+                    "instruction": instruction
+                }
+            })
+        rerank_response.raise_for_status()
+        response_data = RerankResponse.model_validate(rerank_response.json())
+        vllm_outputs = {
+            res.document.text: res.relevance_score
+            for res in response_data.results
+        }
+
+        # HF reference run with the same custom instruction
+        text_pairs = [[query, doc] for doc in documents]
+        hf_outputs = _run_qwen3_reranker_hf(runner, text_pairs, instruction)
+
+        for i, doc in enumerate(documents):
+            assert vllm_outputs[doc] == pytest.approx(hf_outputs[i],
+                                                      rel=0.01)
+
+    def test_score_with_template(self, server: RemoteOpenAIServer,
+                                 model: dict[str, Any], runner):
+        if not model.get("is_qwen3_reranker"):
+            pytest.skip("Test only for Qwen3 Reranker with template support.")
+
+        instruction = "Find the document that is most relevant to the query about national capitals."
+        text_1 = "What is the capital of China?"
+        text_2 = [
+            "The capital of France is Paris.",
+            "The capital of China is Beijing."
+        ]
+
+        # vLLM run with custom instruction via kwargs
+        score_response = requests.post(
+            server.url_for("score"),
+            json={
+                "model": model["name"],
+                "text_1": text_1,
+                "text_2": text_2,
+                "score_template_kwargs": {
+                    "instruction": instruction
+                }
+            })
+        score_response.raise_for_status()
+        response_data = ScoreResponse.model_validate(score_response.json())
+        vllm_outputs = [res.score for res in response_data.data]
+
+        # HF reference run with the same custom instruction
+        text_pairs = [[text_1, doc] for doc in text_2]
+        hf_outputs = _run_qwen3_reranker_hf(runner, text_pairs, instruction)
+
+        for i in range(len(vllm_outputs)):
+            assert vllm_outputs[i] == pytest.approx(hf_outputs[i], rel=0.01)

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1194,7 +1194,16 @@ class ScoreRequest(OpenAIBaseModel):
             "default: 0). Any priority other than 0 will raise an error "
             "if the served model does not use priority scheduling."),
     )
-
+    score_template: Optional[dict[str, str]] = Field(
+        default=None,
+        description=("A dictionary containing query_template and "
+                     "document_template to format the scorer input."))
+    score_template_kwargs: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Additional keyword args to pass to the template renderer. "
+            "Will be accessible by the score template."),
+    )
     # --8<-- [end:score-extra-params]
 
     def to_pooling_params(self):
@@ -1220,7 +1229,16 @@ class RerankRequest(OpenAIBaseModel):
             "default: 0). Any priority other than 0 will raise an error "
             "if the served model does not use priority scheduling."),
     )
-
+    rerank_template: Optional[dict[str, str]] = Field(
+        default=None,
+        description=("A dictionary containing query_template and "
+                     "document_template to format the reranker input.")
+    )
+    rerank_template_kwargs: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=("A dictionary of key-value pairs to be formatted into "
+                     "the rerank model's template.")
+    )
     # --8<-- [end:rerank-extra-params]
 
     def to_pooling_params(self):


### PR DESCRIPTION
## Purpose

This PR adds native support for templated inputs in the /score and /rerank endpoints, enabling models such as Qwen3-Reranker to receive the exact prompt format they expect without client-side preprocessing.

## Backward Compatibility
This change is very important because all downstream applications use query+document input instead of instruct input. 
This will make it impossible to directly access the qwen3 Reranker model, and some adapter changes must be made. 
My change allows vllm to support template input from two aspects, mainly referring to `chat_template` and `chat_template_kwargs`:
- Opt-in feature: if no score_template is provided anywhere, the control flow is identical to pre-patch behaviour.
  - ScoreRequest or RerankRequest can pass in score_template or rerank_template, similar to chat_template
  - score_template can also be configured in tokenizer_config.json, which means that in the ideal case, the model comes with its own template. However, the current model does not carry this configuration, which is somewhat different from the ideal. We can use the hf_overrides parameter to make up for it.
- Existing clients and models therefore require zero changes.

PR #19260 reports that the current implementation need client side template format.

## Changes

Area | Change
-- | --
protocol.py | Add optional fields score_template and score_template_kwargs to ScoreRequest / RerankRequest.
serving_score.py | ① Pick template in priority order: request → hf_overrides → model config.json. ② Render the template and pass the fully-formed string to the tokenizer.
Engine init (hf_overrides) | Allow operators to inject a cluster-wide default template without modifying model artifacts.


## Test Plan

New unit tests ensure: 
(a) legacy paths remain identical for untreated models; 
(b) custom template works via API; 
(c) default fallback via hf_overrides succeeds.

## Test Result

encountered dependency issue, solving...
```
(vllm-dev) (vllm-dev) root@873aa6f520cd:/workspaces/vllm# python -c "import torch"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/envs/vllm-dev/lib/python3.11/site-packages/torch/__init__.py", line 409, in <module>
    from torch._C import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
ImportError: /opt/conda/envs/vllm-dev/lib/python3.11/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12: undefined symbol: __nvJitLinkCreate_12_8, version libnvJitLink.so.12
```

## Documentation Update

Add “Templated Score/Rerank” section with curl / Python snippets.

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


<!--- pyml disable-next-line no-emphasis-as-heading -->
