### PR TITLE
[Bugfix] Fix processor initialization in transformers 4.53.0

### DIFF
--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import torch
 from packaging.version import Version
-from packaging.version import __version__ as TRANSFORMERS_VERSION
 from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
+from transformers import __version__ as TRANSFORMERS_VERSION
 from typing_extensions import TypeVar
 
 from vllm.jsontree import JSONTree, json_map_leaves

--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import torch
+from packaging.version import Version
+from packaging.version import __version__ as TRANSFORMERS_VERSION
 from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
 from typing_extensions import TypeVar
 
@@ -128,9 +130,16 @@ class InputProcessingContext(InputContext):
         /,
         **kwargs: object,
     ) -> _P:
+        # Transformers 4.53.0 has issue with passing tokenizer to
+        # initialize processor. We disable it for this version.
+        # See: https://github.com/vllm-project/vllm/issues/20224
+        if Version(TRANSFORMERS_VERSION) == Version("4.53.0"):
+            tokenizer = None
+        else:
+            tokenizer = self.tokenizer
         return super().get_hf_processor(
             typ,
-            tokenizer=self.tokenizer,
+            tokenizer=tokenizer,
             **kwargs,
         )
 

--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -133,13 +133,10 @@ class InputProcessingContext(InputContext):
         # Transformers 4.53.0 has issue with passing tokenizer to
         # initialize processor. We disable it for this version.
         # See: https://github.com/vllm-project/vllm/issues/20224
-        if Version(TRANSFORMERS_VERSION) == Version("4.53.0"):
-            tokenizer = None
-        else:
-            tokenizer = self.tokenizer
+        if Version(TRANSFORMERS_VERSION) != Version("4.53.0"):
+            kwargs["tokenizer"] = self.tokenizer
         return super().get_hf_processor(
             typ,
-            tokenizer=tokenizer,
             **kwargs,
         )
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Fix #20224
- Disable tokenizer overrides when initialize hf_processor since `Transformers` v4.53.0 has issues about this.

## Test Plan
```
python examples/offline_inference/audio_language.py -m whisper
```
## Test Result
It should work with `Transformers` v4.53.0 now.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
