### PR TITLE
[BUGFIX] AttributeError: 'Future' object has no attribute 'sampled_token_ids'

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -233,6 +233,8 @@ class EngineCore:
             return {}, False
         scheduler_output = self.scheduler.schedule()
         model_output = self.execute_model(scheduler_output)
+        if isinstance(model_output, Future):
+            model_output = model_output.result()
         engine_core_outputs = self.scheduler.update_from_output(
             scheduler_output, model_output)  # type: ignore
 


### PR DESCRIPTION

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

Bugfix when using pipeline parallel and multiprocess disabled, reproduce:

```
import os
os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0" 

from vllm import LLM
llm = LLM("facebook/opt-350m", 
    # tensor_parallel_size=2, 
    pipeline_parallel_size=2, 
    enforce_eager=False,
    max_model_len=2048,
)
output = llm.generate("San Franciso is a")
print(output)
```

bug output:
```
Traceback (most recent call last):
  File "./test_vllm2.py", line 11, in <module>
    output = llm.generate("San Franciso is a")
  File "env/lib/python3.10/site-packages/vllm/utils.py", line 1274, in inner
    return fn(*args, **kwargs)
  File "env/lib/python3.10/site-packages/vllm/entrypoints/llm.py", line 495, in generate
    outputs = self._run_engine(use_tqdm=use_tqdm)
  File "env/lib/python3.10/site-packages/vllm/entrypoints/llm.py", line 1551, in _run_engine
    step_outputs = self.llm_engine.step()
  File "env/lib/python3.10/site-packages/vllm/v1/engine/llm_engine.py", line 233, in step
    outputs = self.engine_core.get_output()
  File "env/lib/python3.10/site-packages/vllm/v1/engine/core_client.py", line 226, in get_output
    outputs, _ = self.engine_core.step()
  File "env/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 238, in step
    engine_core_outputs = self.scheduler.update_from_output(
  File "env/lib/python3.10/site-packages/vllm/v1/core/sched/scheduler.py", line 733, in update_from_output
    sampled_token_ids = model_runner_output.sampled_token_ids
AttributeError: 'Future' object has no attribute 'sampled_token_ids'
```

## Test Plan

```
import os
os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0" 

from vllm import LLM
llm = LLM("facebook/opt-350m", 
    # tensor_parallel_size=2, 
    pipeline_parallel_size=2, 
    enforce_eager=False,
    max_model_len=2048,
)
output = llm.generate("San Franciso is a")
print(output)
```

## Test Result

```
Processed prompts: 100%|█| 1/1 [00:00<00:00,  7.41it/s, est. speed input: 44.57 toks/s, output: 1
[RequestOutput(request_id=0, prompt='San Franciso is a', prompt_token_ids=[2, 16033, 5075, 139, 16, 10], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' large island in the Latin Atlantic region that is believed to be the largest island on', token_ids=[739, 2946, 11, 5, 5862, 5038, 976, 14, 16, 2047, 7, 28, 5, 1154, 2946, 15], cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})]
```

Possible related issue: https://github.com/vllm-project/vllm/issues/19063
