### PR TITLE
Enable ZP Support for Machete

### DIFF
--- a/benchmarks/kernels/benchmark_machete.py
+++ b/benchmarks/kernels/benchmark_machete.py
@@ -234,8 +234,10 @@ def marlin_create_bench_fn(bt: BenchmarkTensors) -> Callable:
 
         fn = lambda: ops.gptq_marlin_gemm(
             a=bt.a,
+            c=None,
             b_q_weight=w_q,
             b_scales=w_s,
+            global_scale=None,
             b_zeros=w_zp,
             g_idx=g_idx,
             perm=sort_indices,

--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -139,7 +139,7 @@ def maybe_convert_zeropoints(zps: Optional[torch.Tensor], s: torch.Tensor):
 
 def group_size_valid(shape: tuple[int, int, int],
                      group_size: Optional[int]) -> bool:
-    return group_size is None or group_size == -1 or group_size % shape[2] == 0
+    return group_size is None or group_size == -1 or shape[2] % group_size == 0
 
 
 def machete_quantize_and_pack(atype: torch.dtype,

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -88,7 +88,7 @@ class MacheteLinearKernel(MPLinearKernel):
             permute_param_layout_(x, input_dim=0, output_dim=1)
             x.data = x.data.contiguous()
             return x
-        
+
         def transform_w_zp(x):
             assert isinstance(x, BasevLLMParameter)
             permute_param_layout_(x, input_dim=0, output_dim=1, packed_dim=1)

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -33,8 +33,6 @@ class MacheteLinearKernel(MPLinearKernel):
             return False, "Act reordering currently not supported by Machete, "\
                           "when the input features are partitioned across "\
                           "devices"
-        if c.zero_points:
-            return False, "Zero points currently not supported by Machete"
 
         if c.weight_type not in query_machete_supported_quant_types(
                 c.zero_points):


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
The Machete kernel already support ZP so enable it in the vLLM frontend. For pre-applying the scales we follow https://github.com/vllm-project/vllm/blob/main/csrc/quantization/machete/Readme.md

## Test Plan
There are already correctness test with zp in `test_machete_mm.py` (under `AWQ style` configs). We test the latency diff with/without zp (using `benchmark_machete.py`) and the e2e correctness (`lm-eval`, sanity check queries). 

We tested on an internal w4a16 asym gs=128 checkpoint (using `compressed-tensors`) based on `CohereLabs/c4ai-command-a-03-2025`. The quant config is
```
  "quantization_config": {
    "config_groups": {
      "group_0": {
        "input_activations": null,
        "output_activations": null,
        "targets": [
          "Linear"
        ],
        "weights": {
          "actorder": "weight",
          "block_structure": null,
          "dynamic": false,
          "group_size": 128,
          "num_bits": 4,
          "observer": "minmax",
          "observer_kwargs": {},
          "strategy": "group",
          "symmetric": false,
          "type": "int"
        }
      }
    },
    "format": "pack-quantized",
    "global_compression_ratio": null,
    "ignore": [
      "lm_head"
    ],
    "kv_cache_scheme": null,
    "quant_method": "compressed-tensors",
    "quantization_status": "compressed"
  },
```

## Test Result
Sanity check query
```
python3       -m vllm.entrypoints.openai.api_server       --model /root/engines/CA-w4a16-gs128-asymm/poseidon --tensor-parallel-size 1 --max-model-len 2048

curl http://localhost:8000/v1/completions     -H "Content-Type: application/json"     -d '{
        "model": "/root/engines/CA-w4a16-gs128-asymm/poseidon",
        "prompt": "San Francisco is a",
        "max_tokens": 25,
        "temperature": 0
    }'
```

completion w/machete
```
"top holiday destination featuring scenic beauty and great ethnic and cultural diversity.\n\nSan Francisco is known for nature, parks, and"
```

completion w/marlin
```
"top holiday destination featuring scenic beauty and great ethnic and cultural diversity.\n\nSan Francisco is known for nature, parks, and"
```

lm-eval (mmlu_pro)
```
machete
mmlu_pro: {'exact_match,custom-extract': np.float64(0.698969414893617), 'exact_match_stderr,custom-extract': np.float64(0.004097131976561064), 'alias': 'mmlu_pro'}

marlin
mmlu_pro: {'exact_match,custom-extract': np.float64(0.6967253989361702), 'exact_match_stderr,custom-extract': np.float64(0.004102789695366856), 'alias': 'mmlu_pro'}
```

latency
```
python3 benchmarks/kernels/benchmark_machete.py \ --act-type bfloat16 \ --group-scale-type bfloat16 \ --out-type bfloat16 \ --group-zero-type bfloat16 \model_bench
```

![Screenshot 2025-06-30 at 1 47 45 PM](https://github.com/user-attachments/assets/56ca5908-5d8c-441b-a66b-58e5e2670545)

the summary is that across the different shapes, with zp is ~1.5% higher latency on average.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
