### PR TITLE
[V1] [ROCm] Enable EP with AITER Fused MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -635,13 +635,13 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             indices_type=self.topk_indices_dtype)
 
         if self.rocm_aiter_moe_enabled:
-            assert expert_map is None
             return self.rocm_aiter_fused_experts(
                 hidden_states=x,
                 w1=layer.w13_weight,
                 w2=layer.w2_weight,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
+                expert_map=expert_map,
                 activation=activation,
                 apply_router_weight_on_input=apply_router_weight_on_input)
         else:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -633,7 +633,8 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
                 a1_scale=layer.w13_input_scale,
-                a2_scale=layer.w2_input_scale)
+                a2_scale=layer.w2_input_scale,
+                expert_map=expert_map)
         if self.use_marlin:
             assert activation == "silu", (
                 f"{activation} not supported for Marlin MoE.")

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -434,6 +434,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     """
 
     def __init__(self, quant_config: Fp8Config):
+
         from vllm.model_executor.layers.fused_moe import fused_experts
         self.quant_config = quant_config
         self.block_quant = self.quant_config.weight_block_size is not None
@@ -871,7 +872,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                           if self.block_quant else layer.w2_weight_scale),
                 a1_scale=layer.w13_input_scale,
                 a2_scale=layer.w2_input_scale,
-                block_shape=self.quant_config.weight_block_size)
+                block_shape=self.quant_config.weight_block_size,
+                expert_map=expert_map)
         elif self.use_marlin:
             assert activation == "silu", (
                 f"{activation} not supported for Marlin MoE.")


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Enable AITER Fused MoE expert parallelism feature.


## Test Plan
Perform lm_eval on gsm8k_cot dataset.

Example test command

```
HF_HUB_OFFLINE=1 \
VLLM_USE_V1=1 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_LINEAR=0 \
VLLM_USE_TRITON_FLASH_ATTN=0 \
VLLM_ROCM_USE_AITER_RMSNORM=0 \
VLLM_ROCM_USE_AITER_MHA=0 \
VLLM_ROCM_USE_AITER_MOE=1 \
VLLM_ROCM_USE_AITER_PAGED_ATTN=0 \
VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 \
SAFETENSORS_FAST_GPU=1 \
lm_eval --model vllm --model_args pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,max_model_len=10000 --trust_remote_code --tasks gsm8k_cot --num_fewshot 8 --batch_size 250 --seed 1234
```

## Test Result


1.  deepseek-ai/DeepSeek-R1 V0 Engine TP8 EP8

vllm (pretrained=deepseek-ai/DeepSeek-R1,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,block_size=1,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.9303|±  |0.0070|
|         |       |strict-match    |     8|exact_match|↑  |0.9280|±  |0.0071|


2. deepseek-ai/DeepSeek-R1 V1 Engine TP8 EP8


vllm (pretrained=deepseek-ai/DeepSeek-R1,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,block_size=1,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.9386|±  |0.0066|
|         |       |strict-match    |     8|exact_match|↑  |0.9272|±  |0.0072|



3. Qwen/Qwen3-235B-A22B-FP8 V0 Engine TP8 EP8

vllm (pretrained=Qwen/Qwen3-235B-A22B-FP8,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.8992|±  |0.0083|
|         |       |strict-match    |     8|exact_match|↑  |0.8332|±  |0.0103|


4. Qwen/Qwen3-235B-A22B-FP8 V1 Engine TP8 EP8

vllm (pretrained=Qwen/Qwen3-235B-A22B-FP8,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.9098|±  |0.0079|
|         |       |strict-match    |     8|exact_match|↑  |0.8302|±  |0.0103|


5. RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic V1 Engine TP8 EP8 (Without AITER)

vllm (pretrained=RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.7369|±  |0.0121|
|         |       |strict-match    |     8|exact_match|↑  |0.9325|±  |0.0069|

6. RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic V1 TP8 EP8 (AITER tkw1)

vllm (pretrained=RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.7854|±  |0.0113|
|         |       |strict-match    |     8|exact_match|↑  |0.9333|±  |0.0069|

7. meta-llama/Llama-4-Scout-17B-16E-Instruct V1 Engine TP8 EP8 (Without AITER)

vllm (pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.7741|±  |0.0115|
|         |       |strict-match    |     8|exact_match|↑  |0.9325|±  |0.0069|

8. meta-llama/Llama-4-Scout-17B-16E-Instruct V1 Engine TP8 EP8 (AITER Fused MoE)

vllm (pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 250
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.7597|±  |0.0118|
|         |       |strict-match    |     8|exact_match|↑  |0.9295|±  |0.0071|

## Performance Gain
Dataset: Random
ISL:OSL= 1000:1000
Number of prompts: 500
Concurrency: 64
vLLM Engine Version: V1 Engine
Tensor Parallelism: 8
Expert Parallelism: 8

Comparison Scenarios: AITER Fused MoE only vs No AITER

- Notes on DeepSeek-R1 benchmark: in V1 Engine, There is only AITER MLA backend, so the DeepSeek-R1 benchmark is AITER MLA + AITER Fused MoE (with aiter.biased_grouped_topk kernel) vs AITER MLA

- Notes on Llama4 models benchmark. The flags for the other models:
`VLLM_ROCM_USE_AITER_LINEAR=0 VLLM_ROCM_USE_AITER_RMSNORM=0 VLLM_ROCM_USE_AITER_MHA=0`


### DeepSeek-R1
| Metric | No AITER | AITER | Gain |
|--------|----------|-------|------|
| Request throughput (req/s) | 1.56 | 2.90 | **+85.9%** |
| Output token throughput (tok/s) | 486.26 | 891.14 | **+83.3%** |
| Total token throughput (tok/s) | 2040.52 | 3784.11 | **+85.4%** |
| Mean TTFT (ms) | 2432.53 | 1572.64 | **-35.3%** (better) |
| Mean TPOT (ms) | 542.99 | 352.58 | **-35.1%** (better) |
| Mean ITL (ms) | 105.39 | 56.84 | **-46.1%** (better) |

### Llama-4-Scout-17B-16E-Instruct
| Metric | No AITER | AITER | Gain |
|--------|----------|-------|------|
| Request throughput (req/s) | 3.57 | 5.56 | **+55.7%** |
| Output token throughput (tok/s) | 1019.63 | 1605.34 | **+57.4%** |
| Total token throughput (tok/s) | 4582.81 | 7153.24 | **+56.1%** |
| Mean TTFT (ms) | 536.00 | 323.43 | **-39.7%** (better) |
| Mean TPOT (ms) | 51.91 | 33.55 | **-35.4%** (better) |
| Mean ITL (ms) | 50.50 | 32.56 | **-35.5%** (better) |

### Llama-4-Maverick-17B-128E-Instruct-FP8
| Metric | No AITER | AITER | Gain |
|--------|----------|-------|------|
| Request throughput (req/s) | 3.54 | 5.62 | **+58.8%** |
| Output token throughput (tok/s) | 1026.57 | 1587.21 | **+54.6%** |
| Total token throughput (tok/s) | 4563.25 | 7198.01 | **+57.7%** |
| Mean TTFT (ms) | 539.02 | 331.61 | **-38.5%** (better) |
| Mean TPOT (ms) | 51.32 | 34.13 | **-33.5%** (better) |
| Mean ITL (ms) | 50.05 | 32.85 | **-34.4%** (better) |


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
