### PR TITLE
[Docs] Update transcriptions API to use openai client with `stream=True` 

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1750,12 +1750,11 @@ class TranscriptionRequest(OpenAIBaseModel):
     timestamps incurs additional latency.
     """
 
-    # --8<-- [start:transcription-extra-params]
     stream: Optional[bool] = False
-    """Custom field not present in the original OpenAI definition. When set,
-    it will enable output to be streamed in a similar fashion as the Chat
-    Completion endpoint.
+    """When set, it will enable output to be streamed in a similar fashion 
+    as the Chat Completion endpoint.
     """
+    # --8<-- [start:transcription-extra-params]
     # Flattened stream option to simplify form data.
     stream_include_usage: Optional[bool] = False
     stream_continuous_usage_stats: Optional[bool] = False


### PR DESCRIPTION
Since https://github.com/openai/openai-python/pull/2260 OpenAI official api client correctly handles the stream option for the audio.transcription api.
This PR simply adjusts the Docs to reflect that change.

I don't think there's a strong enough reason to update the `requirements/common.txt` list, but let me know in case you want me to bump that version too.
