### PR TITLE
[TPU] Temporary fix vmem oom for long model len by reducing page size

### DIFF
--- a/vllm/v1/attention/backends/pallas.py
+++ b/vllm/v1/attention/backends/pallas.py
@@ -84,9 +84,12 @@ class PallasAttentionBackend(AttentionBackend):
     # can spill SREGs easily which leads to bad performance. The strategy we
     # apply here is trying to split max-model-len to 16 pages which make the
     # spill less likely. Meanwhile we make sure the page size is in [16, 256].
-    # For long model length, we use 16 pages to avoid too much VMEM spill.
     @staticmethod
     def get_page_size(vllm_config: VllmConfig) -> int:
+        # TODO: This is a temporary fix for vmem OOM.
+        # For long model length, we use 16 page-size to avoid too much
+        # VMEM spill. A more robust solution should be implemented to
+        # handle VREG spills.
         if vllm_config.model_config.max_model_len > 8192:
             return 16
         page_size = next_power_of_2(

--- a/vllm/v1/attention/backends/pallas.py
+++ b/vllm/v1/attention/backends/pallas.py
@@ -84,8 +84,11 @@ class PallasAttentionBackend(AttentionBackend):
     # can spill SREGs easily which leads to bad performance. The strategy we
     # apply here is trying to split max-model-len to 16 pages which make the
     # spill less likely. Meanwhile we make sure the page size is in [16, 256].
+    # For long model length, we use 16 pages to avoid too much VMEM spill.
     @staticmethod
     def get_page_size(vllm_config: VllmConfig) -> int:
+        if vllm_config.model_config.max_model_len > 8192:
+            return 16
         page_size = next_power_of_2(
             vllm_config.model_config.max_model_len) // 16
         if page_size <= 16:


### PR DESCRIPTION
This pr temporarily fixes vmem oom before a permanent fix to reduce VREG spill.  When max-model-len is very long (for example, Llama70b, 32k tokens), we sometimes experience VMEM OOM because VREG spill take too much memory. 
