### PR TITLE
Enable group size 64 for Machete

### DIFF
--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -14,6 +14,8 @@ import torch
 
 from tests.kernels.utils import opcheck
 from vllm import _custom_ops as ops
+from vllm.model_executor.layers.quantization.utils.machete_utils import (
+    query_machete_supported_group_sizes)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     pack_rows, quantize_weights)
 from vllm.platforms import current_platform
@@ -45,8 +47,6 @@ MNK_SHAPES = [
     (1024, 4096, 8192),
     (1024, 8192, 4096),
 ]
-
-GROUP_SIZES_TO_TEST: list[Optional[int]] = [128, -1]
 
 
 @dataclass
@@ -270,7 +270,7 @@ def test_machete_all_schedules(shape, types: TypeConfig):
     if types.group_scale_type is None:
         group_sizes = [None]
     else:
-        group_sizes = GROUP_SIZES_TO_TEST
+        group_sizes = query_machete_supported_group_sizes(types.act_type)
 
     for group_size in group_sizes:
         if not group_size_valid(shape, group_size):
@@ -299,7 +299,7 @@ def test_machete_heuristic(shape, types: TypeConfig):
     if types.group_scale_type is None:
         group_sizes = [None]
     else:
-        group_sizes = GROUP_SIZES_TO_TEST
+        group_sizes = query_machete_supported_group_sizes(types.act_type)
 
     for group_size in group_sizes:
         if not group_size_valid(shape, group_size):

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -27,7 +27,7 @@ class MacheteLinearKernel(MPLinearKernel):
     @classmethod
     def can_implement(cls,
                       c: MPLinearLayerConfig) -> tuple[bool, Optional[str]]:
-        return False, "temp disable machete"
+
         if c.has_g_idx and\
             c.partition_weight_shape[0] != c.full_weight_shape[0]:
             return False, "Act reordering currently not supported by Machete, "\

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -8,8 +8,8 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.machete_utils import (
-    check_machete_supports_shape, query_machete_supported_quant_types,
-    query_machete_supported_group_sizes)
+    check_machete_supports_shape, query_machete_supported_group_sizes,
+    query_machete_supported_quant_types)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     pack_quantized_values_into_int32, unpack_quantized_values_into_int32)
 from vllm.model_executor.parameter import (BasevLLMParameter,

--- a/vllm/model_executor/layers/quantization/utils/machete_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/machete_utils.py
@@ -7,7 +7,6 @@ import torch
 
 from vllm.scalar_type import ScalarType, scalar_types
 
-MACHETE_SUPPORTED_GROUP_SIZES = [-1, 128]
 MACHETE_PREPACKED_BLOCK_SHAPE = [64, 128]
 
 
@@ -20,6 +19,13 @@ def query_machete_supported_quant_types(zero_points: bool) -> list[ScalarType]:
 
 def query_machete_supported_act_types(zero_points: bool) -> list[ScalarType]:
     return [torch.float16, torch.bfloat16]
+
+
+def query_machete_supported_group_sizes(act_type: torch.dtype) -> list[int]:
+    if act_type in [torch.float16, torch.bfloat16]:
+        return [-1, 64, 128]
+    else:
+        return [-1, 128]
 
 
 def check_machete_supports_shape(in_features: int, out_featrues: int) \

--- a/vllm/model_executor/layers/quantization/utils/machete_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/machete_utils.py
@@ -22,6 +22,16 @@ def query_machete_supported_act_types(zero_points: bool) -> list[ScalarType]:
 
 
 def query_machete_supported_group_sizes(act_type: torch.dtype) -> list[int]:
+    """Queries the supported group sizes for Machete quantization based on the activation type.
+
+    Args:
+        act_type: The activation data type (e.g., torch.float16, torch.bfloat16).
+
+    Returns:
+        A list of integers representing the supported group sizes. The group size must
+        be divisible by `TileShapeK = 128 * 8 // num_bits(act_type)`.
+        -1 indicates per-channel quantization.
+    """
     if act_type in [torch.float16, torch.bfloat16]:
         return [-1, 64, 128]
     else:

--- a/vllm/model_executor/layers/quantization/utils/machete_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/machete_utils.py
@@ -22,13 +22,14 @@ def query_machete_supported_act_types(zero_points: bool) -> list[ScalarType]:
 
 
 def query_machete_supported_group_sizes(act_type: torch.dtype) -> list[int]:
-    """Queries the supported group sizes for Machete quantization based on the activation type.
+    """
+    Queries the supported group sizes for Machete based on the activation type.
 
     Args:
-        act_type: The activation data type (e.g., torch.float16, torch.bfloat16).
+        act_type: The activation data type (torch.float16, torch.bfloat16).
 
     Returns:
-        A list of integers representing the supported group sizes. The group size must
+        A list of supported group sizes. The group size must
         be divisible by `TileShapeK = 128 * 8 // num_bits(act_type)`.
         -1 indicates per-channel quantization.
     """


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Allow group size 64 for Machete when using fp16/bf16 activations. It seems the current restriction is that the group size must be divisible `TileShapeK` (defined [here](https://github.com/vllm-project/vllm/blob/main/csrc/quantization/machete/machete_mm_kernel.cuh#L108)). For fp16/bf16 activations then `TileShapeK = 128 * 8 / 16 = 64`, so it should work with group size 64 (confirmed by tests). From our internal tests, gs=64 could help close the gap between unquantized and gs=128.

## Test Plan

1. Add group size 64 to bf16/fp16 configs in `test_machete_mm.py` for correctness test.
2. run benchmark machete script to compare gs64 and gs128 latency diff
3. run `mmlu_pro` benchmark and compare machete impl with marlin. For this we tested on internal w4a16 gs=64 checkpoint based on `CohereLabs/c4ai-command-a-03-2025`

## Test Result

`test_machete_mm.py` - pass

latency benchmark comparing gs=128 and gs=64 for llama 2 70b at different batch sizes
![Screenshot 2025-06-30 at 8 04 00 PM](https://github.com/user-attachments/assets/db324e9b-f3f3-460f-8c89-d48dbdd72d0c)
no significant different in the latency

lm-eval mmlu_pro
```
machete (44m31.226s)
mmlu_pro: {'exact_match,custom-extract': np.float64(0.6887466755319149), 'exact_match_stderr,custom-extract': np.float64(0.004137972156240047), 'alias': 'mmlu_pro'}

marlin (60m58.985s)
mmlu_pro: {'exact_match,custom-extract': np.float64(0.6859208776595744), 'exact_match_stderr,custom-extract': np.float64(0.004144509045124367), 'alias': 'mmlu_pro'}
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
