### PR TITLE
[Hardware][RISC-V] Add RISC-V architecture  cpu inference support

### DIFF
--- a/csrc/cpu/attention.cpp
+++ b/csrc/cpu/attention.cpp
@@ -66,6 +66,10 @@ struct KernelVecType<c10::BFloat16> {
 };
     #endif
   #else
+    #ifdef __riscv
+      #ifndef RISCV_BF16_SUPPORT
+      // pass
+      #else
 template <>
 struct KernelVecType<c10::BFloat16> {
   using q_load_vec_type = vec_op::BF16Vec8;
@@ -75,6 +79,18 @@ struct KernelVecType<c10::BFloat16> {
   using qk_acc_vec_type = vec_op::FP32Vec16;
   using v_load_vec_type = vec_op::BF16Vec16;
 };
+      #endif
+    #else
+template <>
+struct KernelVecType<c10::BFloat16> {
+  using q_load_vec_type = vec_op::BF16Vec8;
+  using q_vec_type = vec_op::FP32Vec16;
+  using k_load_vec_type = vec_op::BF16Vec16;
+  using k_vec_type = vec_op::FP32Vec16;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::BF16Vec16;
+};
+    #endif
   #endif
 #endif
 

--- a/csrc/cpu/cpu_types.hpp
+++ b/csrc/cpu/cpu_types.hpp
@@ -13,6 +13,9 @@
 #elif defined(__aarch64__)
   // arm implementation
   #include "cpu_types_arm.hpp"
+#elif defined(__riscv)
+  // riscv implementation
+  #include "cpu_types_riscv.hpp"
 #else
   #warning "unsupported vLLM cpu implementation, vLLM will compile with scalar"
   #include "cpu_types_scalar.hpp"

--- a/csrc/cpu/cpu_types_riscv.hpp
+++ b/csrc/cpu/cpu_types_riscv.hpp
@@ -1,0 +1,447 @@
+#include <riscv_vector.h>
+#include <torch/all.h>
+#include <cmath>
+
+typedef vfloat16m1_t fixed_vfloat16m1_t
+    __attribute__((riscv_rvv_vector_bits(128)));
+typedef vfloat16m2_t fixed_vfloat16m2_t
+    __attribute__((riscv_rvv_vector_bits(256)));
+typedef vfloat32m1_t fixed_vfloat32m1_t
+    __attribute__((riscv_rvv_vector_bits(128)));
+typedef vfloat32m2_t fixed_vfloat32m2_t
+    __attribute__((riscv_rvv_vector_bits(256)));
+typedef vfloat32m4_t fixed_vfloat32m4_t
+    __attribute__((riscv_rvv_vector_bits(512)));
+
+namespace vec_op {
+
+#ifdef RISCV_BF16_SUPPORT
+  #define VLLM_DISPATCH_CASE_FLOATING_TYPES(...)         \
+    AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+    AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
+    AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
+#else
+  #define VLLM_DISPATCH_CASE_FLOATING_TYPES(...)         \
+    AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+    AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)
+#endif
+
+#define VLLM_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME, VLLM_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__))
+
+#ifndef CPU_OP_GUARD
+  #define CPU_KERNEL_GUARD_IN(NAME)
+  #define CPU_KERNEL_GUARD_OUT(NAME)
+#else
+  #define CPU_KERNEL_GUARD_IN(NAME) \
+    std::cout << #NAME << " invoked." << std::endl;
+  #define CPU_KERNEL_GUARD_OUT(NAME) \
+    std::cout << #NAME << " exit." << std::endl;
+#endif
+
+#define FORCE_INLINE __attribute__((always_inline)) inline
+
+namespace {
+template <typename T, T... indexes, typename F>
+constexpr void unroll_loop_item(std::integer_sequence<T, indexes...>, F&& f) {
+  (f(std::integral_constant<T, indexes>{}), ...);
+};
+};  // namespace
+
+template <typename T, T count, typename F,
+          typename = std::enable_if_t<std::is_invocable_v<F, T>>>
+constexpr void unroll_loop(F&& f) {
+  unroll_loop_item(std::make_integer_sequence<T, count>{}, std::forward<F>(f));
+}
+
+template <typename T>
+struct Vec {
+  constexpr static int get_elem_num() { return T::VEC_ELEM_NUM; };
+};
+
+struct FP32Vec8;
+struct FP32Vec16;
+
+struct FP16Vec8 : public Vec<FP16Vec8> {
+  constexpr static int VEC_ELEM_NUM = 8;
+
+  fixed_vfloat16m1_t reg;
+
+  explicit FP16Vec8(const void* ptr)
+      : reg(__riscv_vle16_v_f16m1(static_cast<const _Float16*>(ptr),
+                                  VEC_ELEM_NUM)) {};
+
+  explicit FP16Vec8(const FP32Vec8&);
+
+  void save(void* ptr) const {
+    __riscv_vse16_v_f16m1(static_cast<_Float16*>(ptr), reg, VEC_ELEM_NUM);
+  }
+};
+
+struct FP16Vec16 : public Vec<FP16Vec16> {
+  constexpr static int VEC_ELEM_NUM = 16;
+
+  fixed_vfloat16m2_t reg;
+
+  explicit FP16Vec16(const void* ptr)
+      : reg(__riscv_vle16_v_f16m2(reinterpret_cast<const _Float16*>(ptr),
+                                  VEC_ELEM_NUM)) {};
+
+  explicit FP16Vec16(const FP32Vec16& vec);
+
+  void save(void* ptr) const {
+    __riscv_vse16_v_f16m2(reinterpret_cast<_Float16*>(ptr), reg, VEC_ELEM_NUM);
+  }
+
+  void save(void* ptr, const int elem_num) const {
+    vuint16m2_t index = __riscv_vid_v_u16m2(elem_num);
+    vbool8_t mask = __riscv_vmsltu_vx_u16m2_b8(index, elem_num, VEC_ELEM_NUM);
+    __riscv_vse16_v_f16m2_m(mask, reinterpret_cast<_Float16*>(ptr), reg,
+                            VEC_ELEM_NUM);
+  }
+};
+
+#ifdef RISCV_BF16_SUPPORT
+typedef vbfloat16m1_t fixed_vbfloat16m1_t
+    __attribute__((riscv_rvv_vector_bits(128)));
+
+struct BF16Vec8 : public Vec<BF16Vec8> {
+  constexpr static int VEC_ELEM_NUM = 8;
+
+  fixed_vbfloat16m1_t reg;
+
+  explicit BF16Vec8(const void* ptr)
+      : reg(*reinterpret_cast<const fixed_vbfloat16m1_t*>(ptr)) {};
+
+  explicit BF16Vec8(fixed_vbfloat16m1_t data) : reg(data) {};
+
+  explicit BF16Vec8(const FP32Vec8&);
+
+  explicit BF16Vec8(fixed_vfloat32m2_t v)
+      : reg(__riscv_vfncvtbf16_f_f_w_bf16m1(v, VEC_ELEM_NUM)) {};
+
+  void save(void* ptr) const {
+    *reinterpret_cast<fixed_vbfloat16m1_t*>(ptr) = reg;
+  }
+};
+
+typedef vbfloat16m2_t fixed_vbfloat16m2_t
+    __attribute__((riscv_rvv_vector_bits(256)));
+
+struct BF16Vec16 : public Vec<BF16Vec16> {
+  constexpr static int VEC_ELEM_NUM = 16;
+
+  fixed_vbfloat16m2_t reg;
+
+  explicit BF16Vec16(const void* ptr)
+      : reg(*reinterpret_cast<const fixed_vbfloat16m2_t*>(ptr)) {};
+
+  explicit BF16Vec16(fixed_vbfloat16m2_t data) : reg(data) {};
+
+  explicit BF16Vec16(const FP32Vec16&);
+
+  explicit BF16Vec16(fixed_vfloat32m4_t v)
+      : reg(__riscv_vfncvtbf16_f_f_w_bf16m2(v, VEC_ELEM_NUM)) {};
+
+  void save(void* ptr) const {
+    *reinterpret_cast<fixed_vbfloat16m2_t*>(ptr) = reg;
+  };
+};
+
+typedef vbfloat16m4_t fixed_vbfloat16m4_t
+    __attribute__((riscv_rvv_vector_bits(512)));
+
+struct BF16Vec32 : public Vec<BF16Vec32> {
+  constexpr static int VEC_ELEM_NUM = 32;
+
+  fixed_vbfloat16m4_t reg;
+
+  explicit BF16Vec32(const void* ptr)
+      : reg(*reinterpret_cast<const fixed_vbfloat16m4_t*>(ptr)) {};
+
+  explicit BF16Vec32(fixed_vbfloat16m4_t data) : reg(data) {};
+
+  explicit BF16Vec32(const BF16Vec8& vec8_data)
+      : reg(__riscv_vcreate_v_bf16m1_bf16m4(vec8_data.reg, vec8_data.reg,
+                                            vec8_data.reg, vec8_data.reg)) {};
+
+  void save(void* ptr) const {
+    *reinterpret_cast<fixed_vbfloat16m4_t*>(ptr) = reg;
+  };
+};
+#endif
+
+struct FP32Vec4 : public Vec<FP32Vec4> {
+  constexpr static int VEC_ELEM_NUM = 4;
+
+  union AliasReg {
+    fixed_vfloat32m1_t reg;
+    float values[VEC_ELEM_NUM];
+  };
+
+  fixed_vfloat32m1_t reg;
+
+  explicit FP32Vec4(float v) : reg(__riscv_vfmv_v_f_f32m1(v, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec4() : reg(__riscv_vfmv_v_f_f32m1(0.0f, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec4(const float* ptr)
+      : reg(__riscv_vle32_v_f32m1(ptr, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec4(fixed_vfloat32m1_t data) : reg(data) {};
+
+  explicit FP32Vec4(const FP32Vec4& data) : reg(data.reg) {};
+};
+
+struct FP32Vec8 : public Vec<FP32Vec8> {
+  constexpr static int VEC_ELEM_NUM = 8;
+
+  union AliasReg {
+    fixed_vfloat32m2_t reg;
+    float values[VEC_ELEM_NUM];
+  };
+
+  fixed_vfloat32m2_t reg;
+
+  explicit FP32Vec8(float v) : reg(__riscv_vfmv_v_f_f32m2(v, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec8() : reg(__riscv_vfmv_v_f_f32m2(0.0f, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec8(const float* ptr)
+      : reg(__riscv_vle32_v_f32m2(ptr, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec8(fixed_vfloat32m2_t data) : reg(data) {};
+
+  explicit FP32Vec8(const FP32Vec8& data) : reg(data.reg) {};
+
+  explicit FP32Vec8(const FP16Vec8& v)
+      : reg(__riscv_vfwcvt_f_f_v_f32m2(v.reg, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec8(fixed_vfloat16m1_t v)
+      : reg(__riscv_vfwcvt_f_f_v_f32m2(v, VEC_ELEM_NUM)) {};
+
+#ifdef RISCV_BF16_SUPPORT
+  explicit FP32Vec8(fixed_vbfloat16m1_t v)
+      : reg(__riscv_vfwcvtbf16_f_f_v_f32m2(v, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec8(const BF16Vec8& v)
+      : reg(__riscv_vfwcvtbf16_f_f_v_f32m2(v.reg, VEC_ELEM_NUM)) {};
+#endif
+
+  float reduce_sum() const {
+    AliasReg ar;
+    ar.reg = reg;
+    float answer = 0;
+    unroll_loop<int, VEC_ELEM_NUM>(
+        [&answer, &ar](int i) { answer += ar.values[i]; });
+
+    return answer;
+  }
+
+  FP32Vec8 exp() const {
+    AliasReg ar;
+    ar.reg = reg;
+
+    float exp_vals[VEC_ELEM_NUM];
+    unroll_loop<int, VEC_ELEM_NUM>(
+        [&exp_vals, &ar](int i) { exp_vals[i] = expf(ar.values[i]); });
+    fixed_vfloat32m2_t result = __riscv_vle32_v_f32m2(exp_vals, VEC_ELEM_NUM);
+
+    return FP32Vec8(result);
+  }
+
+  FP32Vec8 tanh() const {
+    AliasReg ar;
+    ar.reg = reg;
+
+    float tanh_vals[VEC_ELEM_NUM];
+    unroll_loop<int, VEC_ELEM_NUM>(
+        [&tanh_vals, &ar](int i) { tanh_vals[i] = tanhf(ar.values[i]); });
+    fixed_vfloat32m2_t result = __riscv_vle32_v_f32m2(tanh_vals, VEC_ELEM_NUM);
+
+    return FP32Vec8(result);
+  }
+
+  FP32Vec8 er() const {
+    AliasReg ar;
+    ar.reg = reg;
+
+    float er_vals[VEC_ELEM_NUM];
+    unroll_loop<int, VEC_ELEM_NUM>(
+        [&er_vals, &ar](int i) { er_vals[i] = erf(ar.values[i]); });
+    fixed_vfloat32m2_t result = __riscv_vle32_v_f32m2(er_vals, VEC_ELEM_NUM);
+
+    return FP32Vec8(result);
+  }
+
+  FP32Vec8 operator*(const FP32Vec8& b) const {
+    return FP32Vec8(__riscv_vfmul_vv_f32m2(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  FP32Vec8 operator+(const FP32Vec8& b) const {
+    return FP32Vec8(__riscv_vfadd_vv_f32m2(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  FP32Vec8 operator-(const FP32Vec8& b) const {
+    return FP32Vec8(__riscv_vfsub_vv_f32m2(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  FP32Vec8 operator/(const FP32Vec8& b) const {
+    return FP32Vec8(__riscv_vfdiv_vv_f32m2(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  void save(float* ptr) const { __riscv_vse32_v_f32m2(ptr, reg, VEC_ELEM_NUM); }
+};
+
+struct FP32Vec16 : public Vec<FP32Vec16> {
+  constexpr static int VEC_ELEM_NUM = 16;
+
+  union AliasReg {
+    fixed_vfloat32m4_t reg;
+    float values[VEC_ELEM_NUM];
+  };
+
+  fixed_vfloat32m4_t reg;
+
+  explicit FP32Vec16(float v) : reg(__riscv_vfmv_v_f_f32m4(v, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec16() : reg(__riscv_vfmv_v_f_f32m4(0.0f, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec16(const float* ptr)
+      : reg(__riscv_vle32_v_f32m4(ptr, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec16(fixed_vfloat32m4_t data) : reg(data) {};
+
+  explicit FP32Vec16(const FP32Vec8& data)
+      : reg(__riscv_vcreate_v_f32m2_f32m4(data.reg, data.reg)) {};
+
+  explicit FP32Vec16(const FP32Vec16& data) : reg(data.reg) {};
+
+  explicit FP32Vec16(const FP16Vec8& v) : FP32Vec16(FP32Vec8(v.reg)) {};
+
+#ifdef RISCV_BF16_SUPPORT
+  explicit FP32Vec16(fixed_vbfloat16m2_t v)
+      : reg(__riscv_vfwcvtbf16_f_f_v_f32m4(v, VEC_ELEM_NUM)) {};
+#endif
+
+  explicit FP32Vec16(const FP32Vec4& data)
+      : reg(__riscv_vcreate_v_f32m1_f32m4(data.reg, data.reg, data.reg,
+                                          data.reg)) {};
+
+#ifdef RISCV_BF16_SUPPORT
+  explicit FP32Vec16(const BF16Vec16& v)
+      : reg(__riscv_vfwcvtbf16_f_f_v_f32m4(v.reg, VEC_ELEM_NUM)) {};
+
+  explicit FP32Vec16(const BF16Vec8& v) : FP32Vec16(FP32Vec8(v)) {};
+#endif
+
+  explicit FP32Vec16(const FP16Vec16& v)
+      : reg(reg = __riscv_vfwcvt_f_f_v_f32m4(v.reg, VEC_ELEM_NUM)) {};
+
+  FP32Vec16 operator+(const FP32Vec16& b) const {
+    return FP32Vec16(__riscv_vfadd_vv_f32m4(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  FP32Vec16 operator-(const FP32Vec16& b) const {
+    return FP32Vec16(__riscv_vfsub_vv_f32m4(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  FP32Vec16 operator*(const FP32Vec16& b) const {
+    return FP32Vec16(__riscv_vfmul_vv_f32m4(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  FP32Vec16 operator/(const FP32Vec16& b) const {
+    return FP32Vec16(__riscv_vfdiv_vv_f32m4(reg, b.reg, VEC_ELEM_NUM));
+  }
+
+  float reduce_sum() const {
+    AliasReg ar;
+    ar.reg = reg;
+    float answer = 0;
+    unroll_loop<int, VEC_ELEM_NUM>(
+        [&answer, &ar](int i) { answer += ar.values[i]; });
+
+    return answer;
+  }
+
+  template <int group_size>
+  float reduce_sub_sum(int idx) {
+    static_assert(VEC_ELEM_NUM % group_size == 0);
+
+    AliasReg ar;
+    ar.reg = reg;
+    float answer = 0;
+    const int start = idx * group_size;
+    unroll_loop<int, group_size>(
+        [&answer, &start, ar](int i) { answer += ar.values[start + i]; });
+
+    return answer;
+  };
+
+  void save(float* ptr) const { __riscv_vse32_v_f32m4(ptr, reg, VEC_ELEM_NUM); }
+};
+
+template <typename T>
+struct VecType {
+  using vec_type = void;
+};
+
+template <typename T>
+using vec_t = typename VecType<T>::vec_type;
+
+template <>
+struct VecType<float> {
+  using vec_type = FP32Vec8;
+};
+
+template <>
+struct VecType<c10::Half> {
+  using vec_type = FP16Vec8;
+};
+
+#ifdef RISCV_BF16_SUPPORT
+template <>
+struct VecType<c10::BFloat16> {
+  using vec_type = BF16Vec8;
+};
+#endif
+
+template <typename T>
+void storeFP32(float v, T* ptr) {
+  *ptr = v;
+}
+
+template <>
+inline void storeFP32<c10::Half>(float v, c10::Half* ptr) {
+  *reinterpret_cast<_Float16*>(ptr) = v;
+}
+
+inline FP16Vec16::FP16Vec16(const FP32Vec16& v) {
+  reg = __riscv_vfncvt_f_f_w_f16m2(v.reg, VEC_ELEM_NUM);
+};
+
+inline FP16Vec8 ::FP16Vec8(const FP32Vec8& v) {
+  reg = __riscv_vfncvt_f_f_w_f16m1(v.reg, VEC_ELEM_NUM);
+};
+
+inline void fma(FP32Vec16& acc, FP32Vec16& a, FP32Vec16& b) {
+  acc.reg = __riscv_vfmacc_vv_f32m4(acc.reg, a.reg, b.reg, 16);
+};
+
+#ifdef RISCV_BF16_SUPPORT
+inline BF16Vec8::BF16Vec8(const FP32Vec8& v)
+    : reg(__riscv_vfncvtbf16_f_f_w_bf16m1(v.reg, VEC_ELEM_NUM)) {};
+
+inline BF16Vec16::BF16Vec16(const FP32Vec16& v)
+    : reg(__riscv_vfncvtbf16_f_f_w_bf16m2(v.reg, VEC_ELEM_NUM)) {};
+#endif
+
+inline void prefetch(const void* addr) { __builtin_prefetch(addr, 0, 1); }
+
+#ifdef RISCV_BF16_SUPPORT
+template <>
+inline void storeFP32<c10::BFloat16>(float v, c10::BFloat16* ptr) {
+  *ptr = static_cast<__bf16>(v);
+};
+#endif
+}  // namespace vec_op

--- a/csrc/cpu/mla_decode.cpp
+++ b/csrc/cpu/mla_decode.cpp
@@ -40,6 +40,8 @@ struct KernelVecType<c10::BFloat16> {
 };
 #elif defined(__aarch64__) && !defined(ARM_BF16_SUPPORT)
 // pass
+#elif defined(__riscv) && !defined(RISCV_BF16_SUPPORT)
+// pass
 #else
 template <>
 struct KernelVecType<c10::BFloat16> {

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -10,14 +10,14 @@ setuptools>=77.0.3,<80.0.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.8.0+cpu; platform_machine == "x86_64"
 torch==2.8.0; platform_system == "Darwin"
-torch==2.8.0; platform_machine == "ppc64le" or platform_machine == "aarch64"
+torch==2.8.0; platform_machine == "ppc64le" or platform_machine == "aarch64" or platform_machine == "riscv64"
 
 # required for the image processor of minicpm-o-2_6, this must be updated alongside torch
-torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"
+torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x" and platform_machine != "riscv64"
 torchaudio==2.8.0; platform_machine == "ppc64le"
 
 # required for the image processor of phi3v, this must be updated alongside torch
-torchvision; platform_machine != "ppc64le" and platform_machine != "s390x"
+torchvision; platform_machine != "ppc64le" and platform_machine != "s390x" and platform_machine != "riscv64"
 torchvision==0.23.0; platform_machine == "ppc64le"
 datasets # for benchmark scripts
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1160,11 +1160,13 @@ class EngineArgs:
 
         # Set default arguments for V1 Engine.
         self._set_default_args(usage_context, model_config)
-        # Disable chunked prefill for POWER (ppc64le)/ARM/s390x CPUs in V1
+        # Disable chunked prefill for POWER (ppc64le)/ARM/s390x/RISC-V
+        # CPUs in V1
         if current_platform.is_cpu() and current_platform.get_cpu_architecture(
-        ) in (CpuArchEnum.POWERPC, CpuArchEnum.S390X, CpuArchEnum.ARM):
+        ) in (CpuArchEnum.POWERPC, CpuArchEnum.S390X, CpuArchEnum.ARM,
+              CpuArchEnum.RISCV):
             logger.info("Chunked prefill is not supported for ARM and POWER "
-                        "and S390X CPUs; "
+                        "and S390X and RISC-V CPUs;  "
                         "disabling it for V1 backend.")
             self.enable_chunked_prefill = False
         assert self.enable_chunked_prefill is not None


### PR DESCRIPTION
## Purpose
This PR adds comprehensive RISC-V 64-bit architecture support to vLLM, specifically targeting platforms with RVV 1.0 vector extension. This enables vLLM to run efficiently on RISC-V CPUs, related to #19611 and #8996.

## Changes
- Add csrc/cpu/cpu_types_riscv.hpp, which implement fp16/bf16/fp32
- Add kernel for RISC-V in csrc/cpu/attention.cpp
- Add RISC-V CPU detection in cmake/cpu_extension.cmake 

## Test 
cpu: QEMU RISC-V virt with RVV 1.0
os: openeuler 23.09
gcc: gcc version 15.0.0
model : Qwen/Qwen1.5-0.5B

We run Qwen/Qwen1.5-0.5B model no QEMU RISC-V openeuler by the below python script run_qwen_riscv.py.
<details>
  <summary> run_qwen_riscv.py </summary>
  
```python
from vllm import LLM, SamplingParams

# Sample prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

# Create an LLM.
llm = LLM(model="Qwen/Qwen1.5-0.5B")
# Generate texts from the prompts. The output is a list of RequestOutput objects
# that contain the prompt, generated text, and other information.
outputs = llm.generate(prompts, sampling_params)
# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

</details>

command:
```bash
(vllm-github) [root@openeuler-riscv64 test]# export VLLM_USE_V1=0
(vllm-github) [root@openeuler-riscv64 test]# python run_qwen_riscv.py
INFO 07-01 09:33:52 [importing.py:17] Triton not installed or not compatible; certain GPU-related functions will not be available.
WARNING 07-01 09:33:52 [importing.py:29] Triton is not installed. Using dummy decorators. Install it via `pip install triton` to enable kernel compilation.
INFO 07-01 09:34:33 [__init__.py:244] Automatically detected platform cpu.
INFO 07-01 09:38:51 [config.py:822] This model supports multiple tasks: {'classify', 'reward', 'embed', 'generate', 'score'}. Defaulting to 'generate'.
INFO 07-01 09:38:51 [config.py:1967] Disabled the custom all-reduce kernel because it is not supported on current platform.
INFO 07-01 09:38:51 [llm_engine.py:231] Initializing a V0 LLM engine (v0.1.dev6936+gb124e10.d20250627) with config: model='Qwen/Qwen1.5-0.5B', speculative_config=None, tokenizer='Qwen/Qwen1.5-0.5B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cpu, decoding_config=DecodingConfig(backend='xgrammar', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=None, served_model_name=Qwen/Qwen1.5-0.5B, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=False, pooler_config=None, compilation_config={"level":0,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":[],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":false,"cudagraph_num_of_warmups":0,"cudagraph_capture_sizes":[],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":256,"local_cache_dir":null}, use_cached_outputs=False,
INFO 07-01 09:39:33 [cpu.py:59] Using Torch SDPA backend.
INFO 07-01 09:39:34 [parallel_state.py:1065] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
INFO 07-01 09:39:36 [weight_utils.py:292] Using model weights format ['*.safetensors']
INFO 07-01 09:39:37 [weight_utils.py:345] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:10<00:00, 10.25s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:10<00:00, 10.27s/it]

INFO 07-01 09:39:48 [default_loader.py:272] Loading weights took 10.69 seconds
INFO 07-01 09:39:48 [executor_base.py:113] # cpu blocks: 5461, # CPU blocks: 0
INFO 07-01 09:39:48 [executor_base.py:118] Maximum concurrency for 32768 tokens per request: 2.67x
INFO 07-01 09:40:08 [llm_engine.py:429] init engine (profile, create kv cache, warmup model) took 20.41 seconds
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 27.98it/s]
Processed prompts:   0%|                                                                                                            | 0/4 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]WARNING 07-01 09:41:03 [cpu.py:230] Pin memory is not supported on CPU.
Processed prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [05:13<00:00, 78.35s/it, est. speed input: 0.07 toks/s, output: 0.20 toks/s]
Prompt: 'Hello, my name is', Generated text: ' Emily, and I have been a part of the Music Academy for the past year'
Prompt: 'The president of the United States is', Generated text: ' the head of state of the United States of America. In the USA, the'
Prompt: 'The capital of France is', Generated text: ' the city ________ the Louvre Museum. A．next to B．at'
Prompt: 'The future of AI is', Generated text: ' here\nAccording to latest research, the AI industry is growing at a 1'
```
And GSM8k eval with Qwen1.5-0.5B on QEMU:
```bash
[root@openeuler-riscv64 test]# lm_eval --model vllm --model_args pretrained=Qwen/Qwen1.5-0.5B --tasks gsm8k --num_fewshot 5 --batch_size auto
......
vllm (pretrained=Qwen/Qwen1.5-0.5B), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.1751|±  |0.0105|
|     |       |strict-match    |     5|exact_match|↑  |0.1729|±  |0.0104|
```
## Notes
- Currently there is no prebuilt package for riscv64 on pypi, so some whl packages such as pyarrow need to be compiled manually.
- To support RISC-V bf16,  must use gcc 15.0.0+