### PR TITLE
[Misc] Fix spec decode example

### DIFF
--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -79,7 +79,6 @@ def main():
         trust_remote_code=True,
         tensor_parallel_size=args.tp,
         enable_chunked_prefill=args.enable_chunked_prefill,
-        max_num_batched_tokens=args.max_num_batched_tokens,
         enforce_eager=args.enforce_eager,
         max_num_seqs=args.max_num_seqs,
         gpu_memory_utilization=0.8,

--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -80,7 +80,6 @@ def main():
         tensor_parallel_size=args.tp,
         enable_chunked_prefill=args.enable_chunked_prefill,
         enforce_eager=args.enforce_eager,
-        max_num_seqs=args.max_num_seqs,
         gpu_memory_utilization=0.8,
         speculative_config=speculative_config,
         disable_log_stats=False,


### PR DESCRIPTION
Fixes the bug introduced in #20240; `max_num_seqs` and `max_num_batched_tokens` are used while they are removed from the arg parser.