### PR TITLE
[Misc] HF Hub LoRA Resolver

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1204,7 +1204,7 @@ steps:
   - pytest -v -s distributed/test_distributed_oot.py
   - pytest -v -s entrypoints/openai/test_oot_registration.py # it needs a clean process
   - pytest -v -s models/test_oot_registration.py # it needs a clean process
-  - pytest -v -s plugins/lora_resolvers # unit tests for in-tree lora resolver plugins
+  - pytest -v -s plugins/lora_resolvers # unit tests for lora resolver plugins
 
 - label: Pipeline + Context Parallelism Test # 45min
   timeout_in_minutes: 60

--- a/docs/design/lora_resolver_plugins.md
+++ b/docs/design/lora_resolver_plugins.md
@@ -10,7 +10,7 @@ receives a request for a LoRA adapter that hasn't been loaded yet, the resolver 
 to locate and load the adapter from their configured storage locations. This enables:
 
 - **Dynamic LoRA Loading**: Load adapters on-demand without server restarts
-- **Multiple Storage Backends**: Support for filesystem, S3, and custom backends. The built-in `lora_filesystem_resolver` requires a local storage path, but custom resolvers can be implemented to fetch from any source.
+- **Multiple Storage Backends**: Support for filesystem, S3, and custom backends. The built-in `lora_filesystem_resolver` requires a local storage path, while the built-in `hf_hub_resolver` will pull LoRA adapters from Huggingface Hub and proceed in an identical manner. In general, custom resolvers can be implemented to fetch from any source.
 - **Automatic Discovery**: Seamless integration with existing LoRA workflows
 - **Scalable Deployment**: Centralized adapter management across multiple vLLM instances
 

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -162,10 +162,12 @@ Alternatively, you can use the LoRAResolver plugin to dynamically load LoRA adap
 
 You can set up multiple LoRAResolver plugins if you want to load LoRA adapters from different sources. For example, you might have one resolver for local files and another for S3 storage. vLLM will load the first LoRA adapter that it finds.
 
-You can either install existing plugins or implement your own. By default, vLLM comes with a [resolver plugin to load LoRA adapters from a local directory.](https://github.com/vllm-project/vllm/tree/main/vllm/plugins/lora_resolvers)
-To enable this resolver, set `VLLM_ALLOW_RUNTIME_LORA_UPDATING` to True, set `VLLM_PLUGINS` to include `lora_filesystem_resolver`, and then set `VLLM_LORA_RESOLVER_CACHE_DIR` to a local directory. When vLLM receives a request using a LoRA adapter `foobar`,
+You can either install existing plugins or implement your own. By default, vLLM comes with a [resolver plugin to load LoRA adapters from a local directory, as well as a resolver plugin to load LoRA adapters from a repo on Hugging Face Hub](https://github.com/vllm-project/vllm/tree/main/vllm/plugins/lora_resolvers)
+To enable either of these resolvers, you must `set VLLM_ALLOW_RUNTIME_LORA_UPDATING` to True.
+- To leverage a local directory, set `VLLM_PLUGINS` to include `lora_filesystem_resolver` and set `VLLM_LORA_RESOLVER_CACHE_DIR` to a local directory. When vLLM receives a request using a LoRA adapter `foobar`,
 it will first look in the local directory for a directory `foobar`, and attempt to load the contents of that directory as a LoRA adapter. If successful, the request will complete as normal and
 that adapter will then be available for normal use on the server.
+- To leverage a repository on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO` to a repository ID on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `foobar`, it will download the adapter, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`.
 
 Alternatively, follow these example steps to implement your own plugin:
 

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -164,9 +164,9 @@ You can set up multiple LoRAResolver plugins if you want to load LoRA adapters f
 
 You can either install existing plugins or implement your own. By default, vLLM comes with a [resolver plugin to load LoRA adapters from a local directory, as well as a resolver plugin to load LoRA adapters from a repo on Hugging Face Hub](https://github.com/vllm-project/vllm/tree/main/vllm/plugins/lora_resolvers)
 To enable either of these resolvers, you must `set VLLM_ALLOW_RUNTIME_LORA_UPDATING` to True.
+
 - To leverage a local directory, set `VLLM_PLUGINS` to include `lora_filesystem_resolver` and set `VLLM_LORA_RESOLVER_CACHE_DIR` to a local directory. When vLLM receives a request using a LoRA adapter `foobar`,
-it will first look in the local directory for a directory `foobar`, and attempt to load the contents of that directory as a LoRA adapter. If successful, the request will complete as normal and
-that adapter will then be available for normal use on the server.
+it will first look in the local directory for a directory `foobar`, and attempt to load the contents of that directory as a LoRA adapter. If successful, the request will complete as normal and that adapter will then be available for normal use on the server.
 - To leverage repositories on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO_LIST` to a comma separated list of repository IDs on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `my/repo/subpath`, it will download the adapter at the `subpath` of `my/repo` if it exists, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`.
 
 Alternatively, follow these example steps to implement your own plugin:

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -162,12 +162,12 @@ Alternatively, you can use the LoRAResolver plugin to dynamically load LoRA adap
 
 You can set up multiple LoRAResolver plugins if you want to load LoRA adapters from different sources. For example, you might have one resolver for local files and another for S3 storage. vLLM will load the first LoRA adapter that it finds.
 
-You can either install existing plugins or implement your own. By default, vLLM comes with a [resolver plugin to load LoRA adapters from a local directory, as well as a resolver plugin to load LoRA adapters from a repo on Hugging Face Hub](https://github.com/vllm-project/vllm/tree/main/vllm/plugins/lora_resolvers)
+You can either install existing plugins or implement your own. By default, vLLM comes with a [resolver plugin to load LoRA adapters from a local directory, as well as a resolver plugin to load LoRA adapters from repositories on Hugging Face Hub](https://github.com/vllm-project/vllm/tree/main/vllm/plugins/lora_resolvers)
 To enable either of these resolvers, you must `set VLLM_ALLOW_RUNTIME_LORA_UPDATING` to True.
 
 - To leverage a local directory, set `VLLM_PLUGINS` to include `lora_filesystem_resolver` and set `VLLM_LORA_RESOLVER_CACHE_DIR` to a local directory. When vLLM receives a request using a LoRA adapter `foobar`,
 it will first look in the local directory for a directory `foobar`, and attempt to load the contents of that directory as a LoRA adapter. If successful, the request will complete as normal and that adapter will then be available for normal use on the server.
-- To leverage repositories on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO_LIST` to a comma separated list of repository IDs on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `my/repo/subpath`, it will download the adapter at the `subpath` of `my/repo` if it exists, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`.
+- To leverage repositories on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO_LIST` to a comma separated list of repository IDs on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `my/repo/subpath`, it will download the adapter at the `subpath` of `my/repo` if it exists and contains an `adapter_config.json`, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`.
 
 Alternatively, follow these example steps to implement your own plugin:
 

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -167,7 +167,7 @@ To enable either of these resolvers, you must `set VLLM_ALLOW_RUNTIME_LORA_UPDAT
 - To leverage a local directory, set `VLLM_PLUGINS` to include `lora_filesystem_resolver` and set `VLLM_LORA_RESOLVER_CACHE_DIR` to a local directory. When vLLM receives a request using a LoRA adapter `foobar`,
 it will first look in the local directory for a directory `foobar`, and attempt to load the contents of that directory as a LoRA adapter. If successful, the request will complete as normal and
 that adapter will then be available for normal use on the server.
-- To leverage a repository on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO` to a repository ID on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `foobar`, it will download the adapter, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`.
+- To leverage repositories on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO_LIST` to a comma separated list of repository IDs on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `my/repo/subpath`, it will download the adapter at the `subpath` of `my/repo` if it exists, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`.
 
 Alternatively, follow these example steps to implement your own plugin:
 

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -167,7 +167,7 @@ To enable either of these resolvers, you must `set VLLM_ALLOW_RUNTIME_LORA_UPDAT
 
 - To leverage a local directory, set `VLLM_PLUGINS` to include `lora_filesystem_resolver` and set `VLLM_LORA_RESOLVER_CACHE_DIR` to a local directory. When vLLM receives a request using a LoRA adapter `foobar`,
 it will first look in the local directory for a directory `foobar`, and attempt to load the contents of that directory as a LoRA adapter. If successful, the request will complete as normal and that adapter will then be available for normal use on the server.
-- To leverage repositories on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO_LIST` to a comma separated list of repository IDs on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `my/repo/subpath`, it will download the adapter at the `subpath` of `my/repo` if it exists and contains an `adapter_config.json`, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`.
+- To leverage repositories on Hugging Face Hub, set `VLLM_PLUGINS` to include `lora_hf_hub_resolver` and set `VLLM_LORA_RESOLVER_HF_REPO_LIST` to a comma separated list of repository IDs on Hugging Face Hub. When vLLM receives a request for the LoRA adapter `my/repo/subpath`, it will download the adapter at the `subpath` of `my/repo` if it exists and contains an `adapter_config.json`, then build a request to the cached dir for the adapter, similar to the `lora_filesystem_resolver`. Please note that enabling remote downloads is insecure and not intended for use in production environments.
 
 Alternatively, follow these example steps to implement your own plugin:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ vllm = "vllm.entrypoints.cli.main:main"
 
 [project.entry-points."vllm.general_plugins"]
 lora_filesystem_resolver = "vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver"
+lora_hf_hub_resolver = "vllm.plugins.lora_resolvers.hf_hub_resolver:register_hf_hub_resolver"
 
 [tool.setuptools_scm]
 # no extra settings needed, presence enables setuptools-scm

--- a/tests/plugins/lora_resolvers/test_hf_hub_resolver.py
+++ b/tests/plugins/lora_resolvers/test_hf_hub_resolver.py
@@ -15,6 +15,7 @@ NON_LORA_SUBPATH = "ibm-granite/granite-3.3-8b-rag-agent-lib/README.md"
 LIB_DOWNLOAD_DIR = os.path.join(
     HF_HUB_CACHE, "models--ibm-granite--granite-3.3-8b-rag-agent-lib"
 )
+INVALID_REPO_NAME = "thisrepodoesnotexist"
 
 # Repo with only one LoRA in the root dir
 LORA_REPO_MODEL_NAME = "meta-llama/Llama-2-7b-hf"
@@ -61,7 +62,7 @@ async def test_hf_resolver_with_multiple_repos():
 
 @pytest.mark.asyncio
 async def test_missing_adapter():
-    hf_resolver = HfHubResolver(LORA_LIB)
+    hf_resolver = HfHubResolver([LORA_LIB])
     assert hf_resolver is not None
 
     missing_lora_request = await hf_resolver.resolve_lora(LORA_LIB_MODEL_NAME, "foobar")
@@ -70,10 +71,22 @@ async def test_missing_adapter():
 
 @pytest.mark.asyncio
 async def test_nonlora_adapter():
-    hf_resolver = HfHubResolver(LORA_LIB)
+    hf_resolver = HfHubResolver([LORA_LIB])
     assert hf_resolver is not None
 
     readme_request = await hf_resolver.resolve_lora(
         LORA_LIB_MODEL_NAME, NON_LORA_SUBPATH
     )
     assert readme_request is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_repo():
+    hf_resolver = HfHubResolver([LORA_LIB])
+    assert hf_resolver is not None
+
+    invalid_repo_req = await hf_resolver.resolve_lora(
+        INVALID_REPO_NAME,
+        f"{INVALID_REPO_NAME}/foo",
+    )
+    assert invalid_repo_req is None

--- a/tests/plugins/lora_resolvers/test_hf_hub_resolver.py
+++ b/tests/plugins/lora_resolvers/test_hf_hub_resolver.py
@@ -90,3 +90,18 @@ async def test_invalid_repo():
         f"{INVALID_REPO_NAME}/foo",
     )
     assert invalid_repo_req is None
+
+
+@pytest.mark.asyncio
+async def test_trailing_slash():
+    hf_resolver = HfHubResolver([LORA_LIB])
+    assert hf_resolver is not None
+
+    lora_request = await hf_resolver.resolve_lora(
+        LORA_LIB_MODEL_NAME,
+        f"{LORA_NAME}/",
+    )
+    assert lora_request is not None
+    assert lora_request.lora_name == f"{LORA_NAME}/"
+    assert LIB_DOWNLOAD_DIR in lora_request.lora_path
+    assert "adapter_config.json" in os.listdir(lora_request.lora_path)

--- a/tests/plugins/lora_resolvers/test_hf_resolver.py
+++ b/tests/plugins/lora_resolvers/test_hf_resolver.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+
+import pytest
+from huggingface_hub.constants import HF_HUB_CACHE
+
+from vllm.plugins.lora_resolvers.hf_hub_resolver import HfHubResolver
+
+MODEL_NAME = "ibm-granite/granite-3.3-8b-instruct"
+LORA_LIB = "ibm-granite/granite-3.3-8b-rag-agent-lib"
+LORA_NAME = "answerability_prediction_lora"
+LIB_DOWNLOAD_DIR = os.path.join(
+    HF_HUB_CACHE, "models--ibm-granite--granite-3.3-8b-rag-agent-lib")
+
+
+@pytest.mark.asyncio
+async def test_hf_resolver():
+    hf_resolver = HfHubResolver(LORA_LIB)
+    assert hf_resolver is not None
+
+    lora_request = await hf_resolver.resolve_lora(MODEL_NAME, LORA_NAME)
+    assert lora_request is not None
+    assert lora_request.lora_name == LORA_NAME
+    assert LIB_DOWNLOAD_DIR in lora_request.lora_path
+    assert "adapter_config.json" in os.listdir(lora_request.lora_path)
+
+
+@pytest.mark.asyncio
+async def test_missing_adapter():
+    hf_resolver = HfHubResolver(LORA_LIB)
+    assert hf_resolver is not None
+
+    missing_lora_request = await hf_resolver.resolve_lora(MODEL_NAME, "foobar")
+    assert missing_lora_request is None
+
+
+@pytest.mark.asyncio
+async def test_nonlora_adapter():
+    hf_resolver = HfHubResolver(LORA_LIB)
+    assert hf_resolver is not None
+
+    readme_request = await hf_resolver.resolve_lora(MODEL_NAME, "README.md")
+    assert readme_request is None

--- a/tests/plugins/lora_resolvers/test_hf_resolver.py
+++ b/tests/plugins/lora_resolvers/test_hf_resolver.py
@@ -7,19 +7,52 @@ from huggingface_hub.constants import HF_HUB_CACHE
 
 from vllm.plugins.lora_resolvers.hf_hub_resolver import HfHubResolver
 
-MODEL_NAME = "ibm-granite/granite-3.3-8b-instruct"
+LORA_LIB_MODEL_NAME = "ibm-granite/granite-3.3-8b-instruct"
+# Repo with multiple LoRAs contained in it
 LORA_LIB = "ibm-granite/granite-3.3-8b-rag-agent-lib"
-LORA_NAME = "answerability_prediction_lora"
+LORA_NAME = "ibm-granite/granite-3.3-8b-rag-agent-lib/answerability_prediction_lora"  # noqa: E501
+NON_LORA_SUBPATH = "ibm-granite/granite-3.3-8b-rag-agent-lib/README.md"
 LIB_DOWNLOAD_DIR = os.path.join(
-    HF_HUB_CACHE, "models--ibm-granite--granite-3.3-8b-rag-agent-lib")
+    HF_HUB_CACHE, "models--ibm-granite--granite-3.3-8b-rag-agent-lib"
+)
+
+# Repo with only one LoRA in the root dir
+LORA_REPO_MODEL_NAME = "meta-llama/Llama-2-7b-hf"
+LORA_REPO = "yard1/llama-2-7b-sql-lora-test"
+REPO_DOWNLOAD_DIR = os.path.join(
+    HF_HUB_CACHE, "models--yard1--llama-2-7b-sql-lora-test"
+)
 
 
 @pytest.mark.asyncio
-async def test_hf_resolver():
-    hf_resolver = HfHubResolver(LORA_LIB)
+async def test_hf_resolver_with_direct_path():
+    hf_resolver = HfHubResolver([LORA_REPO])
     assert hf_resolver is not None
 
-    lora_request = await hf_resolver.resolve_lora(MODEL_NAME, LORA_NAME)
+    lora_request = await hf_resolver.resolve_lora(LORA_REPO_MODEL_NAME, LORA_REPO)
+    assert lora_request.lora_name == LORA_REPO
+    assert REPO_DOWNLOAD_DIR in lora_request.lora_path
+    assert "adapter_config.json" in os.listdir(lora_request.lora_path)
+
+
+@pytest.mark.asyncio
+async def test_hf_resolver_with_nested_paths():
+    hf_resolver = HfHubResolver([LORA_LIB])
+    assert hf_resolver is not None
+
+    lora_request = await hf_resolver.resolve_lora(LORA_LIB_MODEL_NAME, LORA_NAME)
+    assert lora_request is not None
+    assert lora_request.lora_name == LORA_NAME
+    assert LIB_DOWNLOAD_DIR in lora_request.lora_path
+    assert "adapter_config.json" in os.listdir(lora_request.lora_path)
+
+
+@pytest.mark.asyncio
+async def test_hf_resolver_with_multiple_repos():
+    hf_resolver = HfHubResolver([LORA_LIB, LORA_REPO])
+    assert hf_resolver is not None
+
+    lora_request = await hf_resolver.resolve_lora(LORA_LIB_MODEL_NAME, LORA_NAME)
     assert lora_request is not None
     assert lora_request.lora_name == LORA_NAME
     assert LIB_DOWNLOAD_DIR in lora_request.lora_path
@@ -31,7 +64,7 @@ async def test_missing_adapter():
     hf_resolver = HfHubResolver(LORA_LIB)
     assert hf_resolver is not None
 
-    missing_lora_request = await hf_resolver.resolve_lora(MODEL_NAME, "foobar")
+    missing_lora_request = await hf_resolver.resolve_lora(LORA_LIB_MODEL_NAME, "foobar")
     assert missing_lora_request is None
 
 
@@ -40,5 +73,7 @@ async def test_nonlora_adapter():
     hf_resolver = HfHubResolver(LORA_LIB)
     assert hf_resolver is not None
 
-    readme_request = await hf_resolver.resolve_lora(MODEL_NAME, "README.md")
+    readme_request = await hf_resolver.resolve_lora(
+        LORA_LIB_MODEL_NAME, NON_LORA_SUBPATH
+    )
     assert readme_request is None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -864,16 +864,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_LORA_RESOLVER_CACHE_DIR": lambda: os.getenv(
         "VLLM_LORA_RESOLVER_CACHE_DIR", None
     ),
-    # Enables torch CUDA profiling if set to 1.
-    # Deprecated, see profiler_config.
-    "VLLM_TORCH_CUDA_PROFILE": lambda: os.getenv("VLLM_TORCH_CUDA_PROFILE"),
-    # A remote HF repo containing one or more LoRA adapters, which
+    # A remote HF repo(s) containing one or more LoRA adapters, which
     # may be downloaded and leveraged as needed. Only works if plugins
     # are enabled and VLLM_ALLOW_RUNTIME_LORA_UPDATING is enabled.
     # Values should be comma separated.
     "VLLM_LORA_RESOLVER_HF_REPO_LIST": lambda: os.getenv(
         "VLLM_LORA_RESOLVER_HF_REPO_LIST", None
     ),
+    # Enables torch CUDA profiling if set to 1.
+    # Deprecated, see profiler_config.
+    "VLLM_TORCH_CUDA_PROFILE": lambda: os.getenv("VLLM_TORCH_CUDA_PROFILE"),
     # Enables torch profiler if set.
     # Deprecated, see profiler_config.
     "VLLM_TORCH_PROFILER_DIR": lambda: os.getenv("VLLM_TORCH_PROFILER_DIR"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
     # See also vllm/config/profiler.py and `--profiler-config` argument
     VLLM_TORCH_CUDA_PROFILE: str | None = None
     VLLM_LORA_RESOLVER_HF_REPO: str | None = None
+    VLLM_LORA_RESOLVER_HF_REPO_LIST: str | None = None
     VLLM_TORCH_PROFILER_DIR: str | None = None
     VLLM_TORCH_PROFILER_RECORD_SHAPES: str | None = None
     VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY: str | None = None
@@ -870,7 +871,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # A remote HF repo containing one or more LoRA adapters, which
     # may be downloaded and leveraged as needed. Only works if plugins
     # are enabled and VLLM_ALLOW_RUNTIME_LORA_UPDATING is enabled.
-    "VLLM_LORA_RESOLVER_HF_REPO": lambda: os.getenv("VLLM_LORA_RESOLVER_HF_REPO", None),
+    # Values should be comma separated.
+    "VLLM_LORA_RESOLVER_HF_REPO_LIST": lambda: os.getenv(
+        "VLLM_LORA_RESOLVER_HF_REPO_LIST", None
+    ),
     # Enables torch profiler if set.
     # Deprecated, see profiler_config.
     "VLLM_TORCH_PROFILER_DIR": lambda: os.getenv("VLLM_TORCH_PROFILER_DIR"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
     # Deprecated env variables for profiling, kept for backward compatibility
     # See also vllm/config/profiler.py and `--profiler-config` argument
     VLLM_TORCH_CUDA_PROFILE: str | None = None
+    VLLM_LORA_RESOLVER_HF_REPO: str | None = None
     VLLM_TORCH_PROFILER_DIR: str | None = None
     VLLM_TORCH_PROFILER_RECORD_SHAPES: str | None = None
     VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY: str | None = None
@@ -866,6 +867,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enables torch CUDA profiling if set to 1.
     # Deprecated, see profiler_config.
     "VLLM_TORCH_CUDA_PROFILE": lambda: os.getenv("VLLM_TORCH_CUDA_PROFILE"),
+    # A remote HF repo containing one or more LoRA adapters, which
+    # may be downloaded and leveraged as needed. Only works if plugins
+    # are enabled and VLLM_ALLOW_RUNTIME_LORA_UPDATING is enabled.
+    "VLLM_LORA_RESOLVER_HF_REPO": lambda: os.getenv("VLLM_LORA_RESOLVER_HF_REPO", None),
     # Enables torch profiler if set.
     # Deprecated, see profiler_config.
     "VLLM_TORCH_PROFILER_DIR": lambda: os.getenv("VLLM_TORCH_PROFILER_DIR"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -92,7 +92,6 @@ if TYPE_CHECKING:
     # Deprecated env variables for profiling, kept for backward compatibility
     # See also vllm/config/profiler.py and `--profiler-config` argument
     VLLM_TORCH_CUDA_PROFILE: str | None = None
-    VLLM_LORA_RESOLVER_HF_REPO: str | None = None
     VLLM_LORA_RESOLVER_HF_REPO_LIST: str | None = None
     VLLM_TORCH_PROFILER_DIR: str | None = None
     VLLM_TORCH_PROFILER_RECORD_SHAPES: str | None = None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -89,10 +89,10 @@ if TYPE_CHECKING:
     VLLM_HTTP_TIMEOUT_KEEP_ALIVE: int = 5  # seconds
     VLLM_PLUGINS: list[str] | None = None
     VLLM_LORA_RESOLVER_CACHE_DIR: str | None = None
+    VLLM_LORA_RESOLVER_HF_REPO_LIST: str | None = None
     # Deprecated env variables for profiling, kept for backward compatibility
     # See also vllm/config/profiler.py and `--profiler-config` argument
     VLLM_TORCH_CUDA_PROFILE: str | None = None
-    VLLM_LORA_RESOLVER_HF_REPO_LIST: str | None = None
     VLLM_TORCH_PROFILER_DIR: str | None = None
     VLLM_TORCH_PROFILER_RECORD_SHAPES: str | None = None
     VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY: str | None = None

--- a/vllm/plugins/lora_resolvers/filesystem_resolver.py
+++ b/vllm/plugins/lora_resolvers/filesystem_resolver.py
@@ -16,6 +16,17 @@ class FilesystemResolver(LoRAResolver):
         self, base_model_name: str, lora_name: str
     ) -> LoRARequest | None:
         lora_path = os.path.join(self.lora_cache_dir, lora_name)
+        maybe_lora_request = await self._get_lora_req_from_path(
+            lora_name, lora_path, base_model_name
+        )
+        return maybe_lora_request
+
+    async def _get_lora_req_from_path(
+        self, lora_name: str, lora_path: str, base_model_name: str
+    ) -> LoRARequest | None:
+        """Builds a LoraRequest pointing to the lora path if it's a valid
+        LoRA adapter and has a matching base_model_name.
+        """
         if os.path.exists(lora_path):
             adapter_config_path = os.path.join(
                 self.lora_cache_dir, lora_name, "adapter_config.json"

--- a/vllm/plugins/lora_resolvers/filesystem_resolver.py
+++ b/vllm/plugins/lora_resolvers/filesystem_resolver.py
@@ -28,9 +28,8 @@ class FilesystemResolver(LoRAResolver):
         LoRA adapter and has a matching base_model_name.
         """
         if os.path.exists(lora_path):
-            adapter_config_path = os.path.join(
-                self.lora_cache_dir, lora_name, "adapter_config.json"
-            )
+            adapter_config_path = os.path.join(lora_path, "adapter_config.json")
+
             if os.path.exists(adapter_config_path):
                 with open(adapter_config_path) as file:
                     adapter_config = json.load(file)

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -12,8 +12,8 @@ from vllm.plugins.lora_resolvers.filesystem_resolver import FilesystemResolver
 
 
 class HfHubResolver(FilesystemResolver):
-    def __init__(self, repo_list: str):
-        self.repo_list = repo_list
+    def __init__(self, repo_list: list[str]):
+        self.repo_list: list[str] = repo_list
         self.adapter_dirs: dict[str, set[str]] = {}
 
     async def resolve_lora(
@@ -27,14 +27,15 @@ class HfHubResolver(FilesystemResolver):
         """
         # If a LoRA name begins with the repository name, it's disambiguated
         maybe_repo = await self._resolve_repo(lora_name)
+
+        # If we haven't inspected this repo before, save available adapter dirs
+        if maybe_repo is not None and maybe_repo not in self.adapter_dirs:
+            self.adapter_dirs[maybe_repo] = await self._get_adapter_dirs(maybe_repo)
+
         maybe_subpath = await self._resolve_repo_subpath(lora_name, maybe_repo)
 
         if maybe_repo is None or maybe_subpath is None:
             return None
-
-        # Get the potential valid adapter subpaths in the HF repo if we haven't
-        if maybe_repo is not None and maybe_repo not in self.adapter_dirs:
-            self.adapter_dirs[maybe_repo] = await self._get_adapter_dirs(maybe_repo)
 
         repo_path = await asyncio.to_thread(
             snapshot_download,
@@ -49,6 +50,14 @@ class HfHubResolver(FilesystemResolver):
         return maybe_lora_request
 
     async def _resolve_repo(self, lora_name: str) -> str | None:
+        """Given a fully qualified path to a LoRA with respect to its HF Hub
+        repo, match the right repo to potentially download from if one exists.
+
+        Args:
+            lora_name: Path to LoRA in HF Hub, e.g., <org>/<repo>/<subpath>,
+                match on <org>/<repo> (if it contains an adapter directly) or
+                <org>/<repo>/ if it may have one in subdirs.
+        """
         for potential_repo in self.repo_list:
             if lora_name.startswith(potential_repo) and (
                 len(lora_name) == len(potential_repo)
@@ -60,20 +69,35 @@ class HfHubResolver(FilesystemResolver):
     async def _resolve_repo_subpath(
         self, lora_name: str, maybe_repo: str | None
     ) -> str | None:
+        """Given the fully qualified path of the LoRA with respect to the HF
+        Repo, get the subpath to download from assuming it's actually got an
+        adapter in it.
+
+        Args:
+            lora_name: Path to LoRA in HF Hub, e.g., <org>/<repo>/<subpath>
+            maybe_repo: Path to the repo to match against if one exists.
+        """
         if maybe_repo is None:
             return None
         repo_len = len(maybe_repo)
-        if (
-            lora_name == maybe_repo
-            or len(lora_name) == repo_len + 1
-            and lora_name[-1] == "/"
+        if lora_name == maybe_repo or (
+            len(lora_name) == repo_len + 1 and lora_name[-1] == "/"
         ):
             # Resolves to the root of the directory
-            return "."
-        return lora_name[repo_len + 1 :]
+            adapter_dir = "."
+        else:
+            adapter_dir = lora_name[repo_len + 1 :]
+
+        # Only download if the directory actually contains an adapter
+        is_adapter = adapter_dir in self.adapter_dirs[maybe_repo]
+        return adapter_dir if is_adapter else None
 
     async def _get_adapter_dirs(self, repo_name: str) -> set[str]:
-        """Gets the subpaths within a HF repo containing an adapter config."""
+        """Gets the subpaths within a HF repo that contain an adapter config.
+
+        Args:
+            repo_name: Name of the HF hub repo to inspect.
+        """
         repo_files = await asyncio.to_thread(HfApi().list_repo_files, repo_id=repo_name)
         adapter_dirs = {
             os.path.dirname(name)

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
 import os
 
 from huggingface_hub import HfApi, snapshot_download
@@ -13,29 +14,24 @@ from vllm.plugins.lora_resolvers.filesystem_resolver import FilesystemResolver
 class HfHubResolver(FilesystemResolver):
     def __init__(self, repo_name: str):
         self.repo_name = repo_name
-        # At initialization time, get all directories
-        # in the repo containing an adapter_config.json;
-        # these are the dirs we will allows downloads for
-        # for potential LoRA requests.
-        repo_files = HfApi().list_repo_files(repo_id=repo_name)
-        self.adapter_dirs = {
-            os.path.dirname(name)
-            for name in repo_files
-            if name.endswith("adapter_config.json")
-        }
+        self.adapter_dirs: None | set[str] = None
 
     async def resolve_lora(
         self, base_model_name: str, lora_name: str
     ) -> LoRARequest | None:
         """Resolves potential LoRA requests in a remote repo on HF Hub.
         This is effectively the same behavior as the filesystem resolver, but
-        with an extra guard + snapshot_download on dirs containing an adapter
-        config prior to inspecting the cached dir to build a potential LoRA
+        with a snapshot_download on dirs containing an adapter config prior
+        to inspecting the cached dir to build a potential LoRA
         request.
         """
+        if self.adapter_dirs is None:
+            self.adapter_dirs = await self._get_adapter_dirs()
         if lora_name in self.adapter_dirs:
-            repo_path = snapshot_download(
-                repo_id=self.repo_name, allow_patterns=f"{lora_name}/*"
+            repo_path = await asyncio.to_thread(
+                snapshot_download,
+                repo_id=self.repo_name,
+                allow_patterns=f"{lora_name}/*",
             )
             lora_path = os.path.join(repo_path, lora_name)
             maybe_lora_request = await self._get_lora_req_from_path(
@@ -43,6 +39,17 @@ class HfHubResolver(FilesystemResolver):
             )
             return maybe_lora_request
         return None
+
+    async def _get_adapter_dirs(self) -> set[str]:
+        """Gets the subpaths within a HF repo containing an adapter config."""
+        repo_files = await asyncio.to_thread(
+            HfApi().list_repo_files, repo_id=self.repo_name
+        )
+        return {
+            os.path.dirname(name)
+            for name in repo_files
+            if name.endswith("adapter_config.json")
+        }
 
 
 def register_hf_hub_resolver():

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -27,7 +27,8 @@ class HfHubResolver(FilesystemResolver):
         """
         if self.adapter_dirs is None:
             self.adapter_dirs = await self._get_adapter_dirs()
-        if lora_name in self.adapter_dirs:
+
+        if self.adapter_dirs and lora_name in self.adapter_dirs:
             repo_path = await asyncio.to_thread(
                 snapshot_download,
                 repo_id=self.repo_name,

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import os
+from typing import Optional
+
+from huggingface_hub import HfApi, snapshot_download
+
+from vllm.lora.request import LoRARequest
+from vllm.plugins.lora_resolvers.filesystem_resolver import FilesystemResolver
+
+
+class HfHubResolver(FilesystemResolver):
+    """Similar in usage to the filesystem_resolver, but allows for the use
+    of HF hub. This plugin assumes the contents of the HF repo are static."""
+
+    def __init__(self, repo_name: str):
+        self.repo_name = repo_name
+        repo_files = HfApi().list_repo_files(repo_id=repo_name)
+        # valid potential adapters are file path to directories
+        # containing the adapter configs
+        self.adapter_dirs = [
+            name.split("/")[0] for name in repo_files
+            if name.endswith("adapter_config.json")
+        ]
+
+    async def resolve_lora(self, base_model_name: str,
+                           lora_name: str) -> Optional[LoRARequest]:
+        if lora_name in self.adapter_dirs:
+            repo_path = snapshot_download(repo_id=self.repo_name,
+                                          allow_patterns=f"{lora_name}/*")
+            lora_path = os.path.join(repo_path, lora_name)
+
+            if os.path.exists(lora_path):
+                adapter_config_path = os.path.join(lora_path,
+                                                   "adapter_config.json")
+                if os.path.exists(adapter_config_path):
+                    with open(adapter_config_path) as file:
+                        adapter_config = json.load(file)
+
+                    if adapter_config["peft_type"] == "LORA" and adapter_config[
+                            "base_model_name_or_path"] == base_model_name:
+                        lora_request = LoRARequest(lora_name=lora_name,
+                                                   lora_int_id=abs(
+                                                       hash(lora_name)),
+                                                   lora_path=lora_path)
+                        return lora_request
+        return None

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -18,11 +18,11 @@ class HfHubResolver(FilesystemResolver):
         # these are the dirs we will allows downloads for
         # for potential LoRA requests.
         repo_files = HfApi().list_repo_files(repo_id=repo_name)
-        self.adapter_dirs = [
-            name.split("/")[0]
+        self.adapter_dirs = {
+            os.path.dirname(name)
             for name in repo_files
             if name.endswith("adapter_config.json")
-        ]
+        }
 
     async def resolve_lora(
         self, base_model_name: str, lora_name: str

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -12,9 +12,9 @@ from vllm.plugins.lora_resolvers.filesystem_resolver import FilesystemResolver
 
 
 class HfHubResolver(FilesystemResolver):
-    def __init__(self, repo_name: str):
-        self.repo_name = repo_name
-        self.adapter_dirs: None | set[str] = None
+    def __init__(self, repo_list: str):
+        self.repo_list = repo_list
+        self.adapter_dirs: dict[str, set[str]] = {}
 
     async def resolve_lora(
         self, base_model_name: str, lora_name: str
@@ -25,40 +25,72 @@ class HfHubResolver(FilesystemResolver):
         to inspecting the cached dir to build a potential LoRA
         request.
         """
-        if self.adapter_dirs is None:
-            self.adapter_dirs = await self._get_adapter_dirs()
+        # If a LoRA name begins with the repository name, it's disambiguated
+        maybe_repo = await self._resolve_repo(lora_name)
+        maybe_subpath = await self._resolve_repo_subpath(lora_name, maybe_repo)
 
-        if self.adapter_dirs and lora_name in self.adapter_dirs:
-            repo_path = await asyncio.to_thread(
-                snapshot_download,
-                repo_id=self.repo_name,
-                allow_patterns=f"{lora_name}/*",
-            )
-            lora_path = os.path.join(repo_path, lora_name)
-            maybe_lora_request = await self._get_lora_req_from_path(
-                lora_name, lora_path, base_model_name
-            )
-            return maybe_lora_request
+        if maybe_repo is None or maybe_subpath is None:
+            return None
+
+        # Get the potential valid adapter subpaths in the HF repo if we haven't
+        if maybe_repo is not None and maybe_repo not in self.adapter_dirs:
+            self.adapter_dirs[maybe_repo] = await self._get_adapter_dirs(maybe_repo)
+
+        repo_path = await asyncio.to_thread(
+            snapshot_download,
+            repo_id=maybe_repo,
+            allow_patterns=f"{maybe_subpath}/*" if maybe_subpath != "." else "*",
+        )
+
+        lora_path = os.path.join(repo_path, maybe_subpath)
+        maybe_lora_request = await self._get_lora_req_from_path(
+            lora_name, lora_path, base_model_name
+        )
+        return maybe_lora_request
+
+    async def _resolve_repo(self, lora_name: str) -> str | None:
+        for potential_repo in self.repo_list:
+            if lora_name.startswith(potential_repo) and (
+                len(lora_name) == len(potential_repo)
+                or lora_name[len(potential_repo)] == "/"
+            ):
+                return potential_repo
         return None
 
-    async def _get_adapter_dirs(self) -> set[str]:
+    async def _resolve_repo_subpath(
+        self, lora_name: str, maybe_repo: str | None
+    ) -> str | None:
+        if maybe_repo is None:
+            return None
+        repo_len = len(maybe_repo)
+        if (
+            lora_name == maybe_repo
+            or len(lora_name) == repo_len + 1
+            and lora_name[-1] == "/"
+        ):
+            # Resolves to the root of the directory
+            return "."
+        return lora_name[repo_len + 1 :]
+
+    async def _get_adapter_dirs(self, repo_name: str) -> set[str]:
         """Gets the subpaths within a HF repo containing an adapter config."""
-        repo_files = await asyncio.to_thread(
-            HfApi().list_repo_files, repo_id=self.repo_name
-        )
-        return {
+        repo_files = await asyncio.to_thread(HfApi().list_repo_files, repo_id=repo_name)
+        adapter_dirs = {
             os.path.dirname(name)
             for name in repo_files
             if name.endswith("adapter_config.json")
         }
+        if "adapter_config.json" in repo_files:
+            adapter_dirs.add(".")
+        return adapter_dirs
 
 
 def register_hf_hub_resolver():
     """Register the Hf hub LoRA Resolver with vLLM"""
 
-    hf_repo = envs.VLLM_LORA_RESOLVER_HF_REPO
-    if hf_repo:
-        hf_hub_resolver = HfHubResolver(hf_repo)
+    hf_repo_list = envs.VLLM_LORA_RESOLVER_HF_REPO_LIST
+    if hf_repo_list:
+        hf_hub_resolver = HfHubResolver(hf_repo_list.split(","))
         LoRAResolverRegistry.register_resolver("Hf Hub Resolver", hf_hub_resolver)
 
     return

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -1,48 +1,56 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import json
 import os
-from typing import Optional
 
 from huggingface_hub import HfApi, snapshot_download
 
+import vllm.envs as envs
 from vllm.lora.request import LoRARequest
+from vllm.lora.resolver import LoRAResolverRegistry
 from vllm.plugins.lora_resolvers.filesystem_resolver import FilesystemResolver
 
 
 class HfHubResolver(FilesystemResolver):
-    """Similar in usage to the filesystem_resolver, but allows for the use
-    of HF hub. This plugin assumes the contents of the HF repo are static."""
-
     def __init__(self, repo_name: str):
         self.repo_name = repo_name
+        # At initialization time, get all directories
+        # in the repo containing an adapter_config.json;
+        # these are the dirs we will allows downloads for
+        # for potential LoRA requests.
         repo_files = HfApi().list_repo_files(repo_id=repo_name)
-        # valid potential adapters are file path to directories
-        # containing the adapter configs
         self.adapter_dirs = [
-            name.split("/")[0] for name in repo_files
+            name.split("/")[0]
+            for name in repo_files
             if name.endswith("adapter_config.json")
         ]
 
-    async def resolve_lora(self, base_model_name: str,
-                           lora_name: str) -> Optional[LoRARequest]:
+    async def resolve_lora(
+        self, base_model_name: str, lora_name: str
+    ) -> LoRARequest | None:
+        """Resolves potential LoRA requests in a remote repo on HF Hub.
+        This is effectively the same behavior as the filesystem resolver, but
+        with an extra guard + snapshot_download on dirs containing an adapter
+        config prior to inspecting the cached dir to build a potential LoRA
+        request.
+        """
         if lora_name in self.adapter_dirs:
-            repo_path = snapshot_download(repo_id=self.repo_name,
-                                          allow_patterns=f"{lora_name}/*")
+            repo_path = snapshot_download(
+                repo_id=self.repo_name, allow_patterns=f"{lora_name}/*"
+            )
             lora_path = os.path.join(repo_path, lora_name)
-
-            if os.path.exists(lora_path):
-                adapter_config_path = os.path.join(lora_path,
-                                                   "adapter_config.json")
-                if os.path.exists(adapter_config_path):
-                    with open(adapter_config_path) as file:
-                        adapter_config = json.load(file)
-
-                    if adapter_config["peft_type"] == "LORA" and adapter_config[
-                            "base_model_name_or_path"] == base_model_name:
-                        lora_request = LoRARequest(lora_name=lora_name,
-                                                   lora_int_id=abs(
-                                                       hash(lora_name)),
-                                                   lora_path=lora_path)
-                        return lora_request
+            maybe_lora_request = await self._get_lora_req_from_path(
+                lora_name, lora_path, base_model_name
+            )
+            return maybe_lora_request
         return None
+
+
+def register_hf_hub_resolver():
+    """Register the Hf hub LoRA Resolver with vLLM"""
+
+    hf_repo = envs.VLLM_LORA_RESOLVER_HF_REPO
+    if hf_repo:
+        hf_hub_resolver = HfHubResolver(hf_repo)
+        LoRAResolverRegistry.register_resolver("Hf Hub Resolver", hf_hub_resolver)
+
+    return

--- a/vllm/plugins/lora_resolvers/hf_hub_resolver.py
+++ b/vllm/plugins/lora_resolvers/hf_hub_resolver.py
@@ -86,7 +86,8 @@ class HfHubResolver(FilesystemResolver):
             # Resolves to the root of the directory
             adapter_dir = "."
         else:
-            adapter_dir = lora_name[repo_len + 1 :]
+            # It's a subpath; removing trailing slashes if there are any
+            adapter_dir = lora_name[repo_len + 1 :].rstrip("/")
 
         # Only download if the directory actually contains an adapter
         is_adapter = adapter_dir in self.adapter_dirs[maybe_repo]


### PR DESCRIPTION
## Purpose
This PR adds a new LoRA Resolver to be installed with vLLM, which is pretty much the same as the file system resolver, but for one or more HF repos containing adapter(s). When a request comes in that is a subdir in the HF repo which contains an adapter config, it downloads it model, then does the same thing as the filesystem resolver. This is mostly for convenience when working with things like [granite rag library](https://huggingface.co/ibm-granite/granite-3.3-8b-rag-agent-lib), which has a bunch of lora's for granite3.3 models.


Note that the repo path/id is included in the lora ID to disambiguate between potential conflicts if multiple repos are used.

## Test Plan
Tests are added - you can also try it with the example here:


```bash
VLLM_ALLOW_RUNTIME_LORA_UPDATING=True VLLM_PLUGINS=lora_hf_hub_resolver VLLM_LORA_RESOLVER_HF_REPO_LIST=ibm-granite/granite-3.3-8b-rag-agent-lib vllm serve ibm-granite/granite-3.3-8b-instruct --enforce-eager --enable-lora
```

```python
from openai import OpenAI

# Modify OpenAI's API key and API base to use vLLM's API server.
openai_api_key = "EMPTY"
openai_api_base = "http://localhost:8000/v1"

client = OpenAI(
    # defaults to os.environ.get("OPENAI_API_KEY")
    api_key=openai_api_key,
    base_url=openai_api_base,
)

models = client.models.list()
model = models.data[0].id

chat_completion = client.chat.completions.create(
    messages=[
    {
        "role": "user",
        "content": "What is IBM Research?"
    },
    {
        "role": "assistant",
        "content": "IBM research is a part of IBM.<|start_of_role|>certainty<|end_of_role|>"
    },    
    ],
    model="ibm-granite/granite-3.3-8b-rag-agent-lib/hallucination_detection_lora",
    max_tokens=20,
)

print("Chat completion results:")
print(chat_completion)
```
will pull and use the `certainty_lora` from the granite rag lora library.

## Test Result
Tests are passing and the example above does work when you install the package with the new entry point.

## Documentation Update
Docs are updated (both in the readme doc for the lora resolver and the relevant vllm public docs section)

CC @joerunde 

---

> [!NOTE]
> Adds dynamic LoRA loading from Hugging Face Hub via a new resolver plugin and wires it into config, docs, and CI.
> 
> - New `HfHubResolver` plugin (`vllm/plugins/lora_resolvers/hf_hub_resolver.py`) that lists repo files and `snapshot_download`s adapter subpaths; registered as `lora_hf_hub_resolver`
> - New env var `VLLM_LORA_RESOLVER_HF_REPO_LIST` and loader in `vllm/envs.py` to configure allowed HF repos
> - Refactors `FilesystemResolver` to extract `_get_lora_req_from_path` and reuse validation logic
> - Adds tests `tests/plugins/lora_resolvers/test_hf_hub_resolver.py`; updates Buildkite to run `pytest -v -s plugins/lora_resolvers`
> - Documents HF Hub resolver usage in `docs/design/lora_resolver_plugins.md` and `docs/features/lora.md`
> - Exposes plugin via entry point in `pyproject.toml` (`vllm.general_plugins: lora_hf_hub_resolver`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 321b21f89d3e7e78ffdaaf04fe406f8d7e8a6ef7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds dynamic LoRA loading from Hugging Face Hub via a new resolver plugin and wires it into config, docs, and CI.
> 
> - New `HfHubResolver` in `vllm/plugins/lora_resolvers/hf_hub_resolver.py`; registered as `lora_hf_hub_resolver` via entry point in `pyproject.toml`
> - New env var `VLLM_LORA_RESOLVER_HF_REPO_LIST` plumbed in `vllm/envs.py` to configure allowed repos
> - Refactors `FilesystemResolver` to share `_get_lora_req_from_path` for adapter validation
> - Adds tests `tests/plugins/lora_resolvers/test_hf_hub_resolver.py` and enables `pytest -v -s plugins/lora_resolvers` in Buildkite
> - Updates docs in `docs/design/lora_resolver_plugins.md` and `docs/features/lora.md` to cover HF Hub usage and setup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad1463258c0c01d738add122c480ed1f38f7a392. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
