### PR TITLE
[Bugfix] Fix the max_seq_len limit of 16384 for DeepSeek models

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -412,6 +412,8 @@ def test_load_config_pt_load_map_location(pt_load_map_location):
         ("BAAI/bge-reranker-base", None, 512, False),
         ("BAAI/bge-reranker-base", 256, 256, False),
         ("BAAI/bge-reranker-base", 513, 512, True),
+        ("deepseek-ai/DeepSeek-R1-Distill-Qwen-7B", None, 131072, False),
+        ("deepseek-ai/DeepSeek-R1-Distill-Qwen-7B", 131073, 131072, True),
     ])
 def test_get_and_verify_max_len(model_id, max_model_len, expected_max_len,
                                 should_raise):

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1434,6 +1434,10 @@ class ModelConfig:
         return getattr(self.hf_config, "matryoshka_dimensions", None)
 
     def get_and_verify_max_len(self, max_model_len: int):
+        # For pooling models, the tokenizer's `model_max_length` is often a
+        # reliable source for the maximum sequence length. However, for generative
+        # models, this can be incorrect and unduly limit the context window (e.g.,
+        # DeepSeek). Therefore, we only consider tokenizer_config for pooling models.
         tokenizer_config = None
         if self.runner_type == "pooling":
             tokenizer_config = try_get_tokenizer_config(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1434,10 +1434,12 @@ class ModelConfig:
         return getattr(self.hf_config, "matryoshka_dimensions", None)
 
     def get_and_verify_max_len(self, max_model_len: int):
-        tokenizer_config = try_get_tokenizer_config(
-            self.tokenizer,
-            trust_remote_code=self.trust_remote_code,
-            revision=self.tokenizer_revision)
+        tokenizer_config = None
+        if self.runner_type == "pooling":
+            tokenizer_config = try_get_tokenizer_config(
+                self.tokenizer,
+                trust_remote_code=self.trust_remote_code,
+                revision=self.tokenizer_revision)
         max_model_len = _get_and_verify_max_len(
             hf_config=self.hf_text_config,
             tokenizer_config=tokenizer_config,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1435,9 +1435,10 @@ class ModelConfig:
 
     def get_and_verify_max_len(self, max_model_len: int):
         # For pooling models, the tokenizer's `model_max_length` is often a
-        # reliable source for the maximum sequence length. However, for generative
-        # models, this can be incorrect and unduly limit the context window (e.g.,
-        # DeepSeek). Therefore, we only consider tokenizer_config for pooling models.
+        # reliable source for the maximum sequence length. However, for
+        # generative models, this can be incorrect and unduly limit the
+        # context window (e.g., DeepSeek-R1). Therefore, we only consider
+        # tokenizer_config for pooling models.
         tokenizer_config = None
         if self.runner_type == "pooling":
             tokenizer_config = try_get_tokenizer_config(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Checking of tokenizer 'model_max_length' should not be applied for generative models.

This issue was mentioned in #20304, which could be described as "the max-seq-len is limited to 16384, however it could be set a value up to 32768 when running the DeepSeek-R1-Distill-Qwen-32B model on 2 H100 GPUs in a version before."

This issue was introduced by #19201, which intents to fix the issue for embedding model of bert. However, it introduces the bug for generative models such as the DeepSeep-R1, DeepSeek-R1-Distill-Qwen-7B ,DeepSeek-R1-Distill-Qwen-32B, ... 


## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
