### PR TITLE
[Kernel][Bugfix] Fixup some warnings in nvfp4_blockwise_moe when CUDA < 12.8

### DIFF
--- a/csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
+++ b/csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
@@ -335,8 +335,10 @@ void run_fp4_blockwise_scaled_group_mm(
   TORCH_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 
+#if defined ENABLE_NVFP4 && ENABLE_NVFP4
 constexpr auto FLOAT4_E2M1X2 = at::ScalarType::Byte;
 constexpr auto SF_DTYPE = at::ScalarType::Float8_e4m3fn;
+#endif
 
 #define CHECK_TYPE(x, st, m) \
   TORCH_CHECK(x.scalar_type() == st, ": Inconsistency of Tensor type:", m)


### PR DESCRIPTION
## Purpose

Clean up 10 warnings that look like:
```
#30 1224.0 /workspace/csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu(339): warning #177-D: variable "SF_DTYPE" was declared but never referenced
#30 1224.0   constexpr auto SF_DTYPE = at::ScalarType::Float8_e4m3fn;
#30 1224.0                  ^
#30 1224.0
#30 1224.0 /workspace/csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu(338): warning #177-D: variable "FLOAT4_E2M1X2" was declared but never referenced
#30 1224.0   constexpr auto FLOAT4_E2M1X2 = at::ScalarType::Byte;
```

These aren't used when `ENABLE_NVFP4` is not defined, so this PR also defines away the definition in that case.
