### PR TITLE
[TPU][Bugfix] fix the MoE OOM issue

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1564,8 +1564,13 @@ class FusedMoE(torch.nn.Module):
 
     def forward(self, hidden_states: torch.Tensor,
                 router_logits: torch.Tensor):
-        return torch.ops.vllm.moe_forward(hidden_states, router_logits,
-                                          self.layer_name)
+        # TODO: Once the OOM issue for the TPU backend is resolved, we will
+        # switch to using the moe_forward custom op.
+        if current_platform.is_tpu():
+            return self.forward_impl(hidden_states, router_logits)
+        else:
+            return torch.ops.vllm.moe_forward(hidden_states, router_logits,
+                                              self.layer_name)
 
     def forward_impl_chunked(self, full_hidden_states: torch.Tensor,
                              full_router_logits: torch.Tensor):


### PR DESCRIPTION
## Purpose

The XLA backend for TPUs handles its own functionalization, so we don't need to wrap it as a custom operation to benefit from torch.compile's auto-functionalization. Additionally, using a custom operation would cause HBM OOM errors on TPU.

## Test Plan

```
vllm serve mistralai/Mixtral-8x7B-Instruct-v0.1 --seed 42 --disable-log-requests --gpu-memory-utilization 0.95  --max-num-batched-tokens 4096 --max-num-seqs 256 --tensor-parallel-size 8 --max-model-len 2048 --no-enable-prefix-caching 
```

## Test Result

Passed. (There's HBM OOM without the fix)
