### PR TITLE
[Installation] Fix python only installation wheel packaging missing libs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -403,6 +403,11 @@ class repackage_wheel(build_ext):
                     package_data[package_name] = []
 
                 wheel.extract(file)
+                # copy extracted files to self.build_lib directory
+                # so that they can be included in the packed wheel
+                dst_file = os.path.join(self.build_lib, file.filename)
+                os.makedirs(os.path.dirname(dst_file), exist_ok=True)
+                self.copy_file(file.filename, dst_file)
                 if file_name.endswith(".py"):
                     # python files shouldn't be added to package_data
                     continue


### PR DESCRIPTION
## Purpose

When re-packaging wheel from pre-built wheel (without editable mode) as described in https://docs.vllm.ai/en/stable/getting_started/installation/gpu.html#set-up-using-python-only-build-without-compilation, pre-built libs are not copied to the build_lib dir. Output wheel will not contain the libs.

## Test Result

test command:

```bash
env VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_LOCATION=https://github.com/vllm-project/vllm/releases/download/v0.8.5.post1/vllm-0.8.5.post1-cp38-abi3-manylinux1_x86_64.whl pip wheel -v --no-deps -w dist .
```

The output wheel contains the libs correctly.