### PR TITLE
[Docs] Make TPU ref prettier in google_tpu.md

### DIFF
--- a/docs/getting_started/installation/google_tpu.md
+++ b/docs/getting_started/installation/google_tpu.md
@@ -58,9 +58,9 @@ assigned to your Google Cloud project for your immediate exclusive use.
 
 For more information about using TPUs with GKE, see:
 
-- <https://cloud.google.com/kubernetes-engine/docs/how-to/tpus>
-- <https://cloud.google.com/kubernetes-engine/docs/concepts/tpus>
-- <https://cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus>
+- [About TPUs in GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/tpus)
+- [Deploy TPU workloads in GKE Standard](https://cloud.google.com/kubernetes-engine/docs/how-to/tpus)
+- [Plan for TPUs in GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus)
 
 ## Configure a new environment
 


### PR DESCRIPTION
- The [current three links](https://docs.vllm.ai/en/stable/getting_started/installation/ai_accelerator.html#provision-cloud-tpus-with-gke) look awkward, so format them using standard Markdown syntax.
- Sort the short list in an alphabetical order.
