### PR TITLE
[PP][V1]: Integrate Token Throttling into vLLM

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2176,13 +2176,17 @@ class SchedulerConfig:
     for all attention layers even if there are multiple type of attention layers
     like full attention and sliding window attention.
     """
-    
+
     num_iterp: int = 8
     """Number of iterations to process waiting prefill tokens (Token Throttling)
     """
-    
+
     kv_thresh: float = 0.1
     """KV cache threshold for prefill operations (Token Throttling)
+    """
+
+    minp: int = 32
+    """Minimum prefill token count per batch (Token Throttling)
     """
 
     def compute_hash(self) -> str:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2176,6 +2176,14 @@ class SchedulerConfig:
     for all attention layers even if there are multiple type of attention layers
     like full attention and sliding window attention.
     """
+    
+    num_iterp: int = 8
+    """Number of iterations to process waiting prefill tokens (Token Throttling)
+    """
+    
+    kv_thresh: float = 0.1
+    """KV cache threshold for prefill operations (Token Throttling)
+    """
 
     def compute_hash(self) -> str:
         """

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -464,6 +464,9 @@ class EngineArgs:
 
     enable_multimodal_encoder_data_parallel: bool = \
         ParallelConfig.enable_multimodal_encoder_data_parallel
+        
+    num_iterp: int = SchedulerConfig.num_iterp
+    kv_thresh: float = SchedulerConfig.kv_thresh
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
@@ -889,6 +892,17 @@ class EngineArgs:
         scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"])
+        
+        scheduler_group.add_argument(
+            "--num-iterp",
+            **scheduler_kwargs["num_iterp"]
+        )
+        
+        scheduler_group.add_argument(
+            "--kv-thresh",
+            **scheduler_kwargs["kv_thresh"]
+        )
+        
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -464,9 +464,10 @@ class EngineArgs:
 
     enable_multimodal_encoder_data_parallel: bool = \
         ParallelConfig.enable_multimodal_encoder_data_parallel
-        
+
     num_iterp: int = SchedulerConfig.num_iterp
     kv_thresh: float = SchedulerConfig.kv_thresh
+    minp: int = SchedulerConfig.minp
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
@@ -892,17 +893,14 @@ class EngineArgs:
         scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"])
-        
-        scheduler_group.add_argument(
-            "--num-iterp",
-            **scheduler_kwargs["num_iterp"]
-        )
-        
-        scheduler_group.add_argument(
-            "--kv-thresh",
-            **scheduler_kwargs["kv_thresh"]
-        )
-        
+
+        scheduler_group.add_argument("--num-iterp",
+                                     **scheduler_kwargs["num_iterp"])
+
+        scheduler_group.add_argument("--kv-thresh",
+                                     **scheduler_kwargs["kv_thresh"])
+
+        scheduler_group.add_argument("--minp", **scheduler_kwargs["minp"])
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -72,6 +72,7 @@ class TokenBudget:
                                      req.num_computed_tokens
                                      for req in self.scheduler.waiting)
             num_decode_tokens = 0
+            # running requests include both prefill and decode requests
             for request in self.scheduler.running:
                 if request.computed_prompt:
                     num_decode_tokens += 1

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -40,6 +40,9 @@ logger = init_logger(__name__)
 
 
 class TokenBudget:
+    """ Unified management of the token budget in the chunked prefill 
+    and the prefill and decode budget of Token Throttling
+    """
 
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
@@ -75,6 +78,7 @@ class TokenBudget:
             kv_free = 1 - self.scheduler.kv_cache_manager.usage
 
             # prefill token budget
+            assert self.kv_thresh != 1
             prefill_ratio = max(0, (kv_free - self.kv_thresh) /
                                 (1 - self.kv_thresh))
             prefill_token_budget = max(num_prefill_tokens // self.num_iterp,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -42,6 +42,11 @@ logger = init_logger(__name__)
 class TokenBudget:
     """ Unified management of the token budget in the chunked prefill 
     and the prefill and decode budget of Token Throttling
+    
+    NOTE(guoty) Token Throttling: Dynamically adjust prefill and 
+    decode token budget according to system states
+    Reference: https://arxiv.org/abs/2504.14775
+    Code: https://github.com/gty111/gLLM
     """
 
     def __init__(self, scheduler: Scheduler):
@@ -57,13 +62,11 @@ class TokenBudget:
         self.minp = scheduler.scheduler_config.minp
 
     def update(self):
+        # fixed token budget
         if not self.scheduler.use_pp:
             self.token_budget = self.max_num_scheduled_tokens
+        # Token Throttling
         else:
-            # NOTE(guoty) Token Throttling
-            # Reference: https://arxiv.org/abs/2504.14775
-            # Code: https://github.com/gty111/gLLM
-
             # system states
             num_prefill_tokens = sum(req.num_prompt_tokens -
                                      req.num_computed_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -170,9 +170,8 @@ class Scheduler(SchedulerInterface):
         # Code: https://github.com/gty111/gLLM
         
         # hyperparameters
-        # TODO: make them pass in config
-        iterp = 8
-        kv_thresh = 0.1
+        num_iterp = self.scheduler_config.num_iterp
+        kv_thresh = self.scheduler_config.kv_thresh
         
         # system states
         num_prefill_tokens = reduce(lambda num_acc, req: num_acc + req.num_prompt_tokens - req.num_computed_tokens, self.waiting, 0)
@@ -182,7 +181,7 @@ class Scheduler(SchedulerInterface):
         
         # prefill token budget
         prefill_ratio = max(0, (kv_free - kv_thresh) / (1 - kv_thresh))
-        prefill_token_budget = min(self.max_num_scheduled_tokens * prefill_ratio, num_prefill_tokens // iterp)
+        prefill_token_budget = min(self.max_num_scheduled_tokens * prefill_ratio, num_prefill_tokens // num_iterp)
         prefill_token_budget = int(prefill_token_budget)
         
         # decode token budget

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -39,6 +39,89 @@ from vllm.v1.structured_output import StructuredOutputManager
 
 logger = init_logger(__name__)
 
+class TokenBudget():
+    def __init__(self, scheduler: Scheduler):
+        self.scheduler = scheduler
+        
+        self.use_pp = scheduler.use_pp
+        self.pp_size = scheduler.parallel_config.pipeline_parallel_size
+
+        self.max_num_scheduled_tokens = scheduler.max_num_scheduled_tokens
+        
+        self.num_iterp = scheduler.scheduler_config.num_iterp
+        self.kv_thresh = scheduler.scheduler_config.kv_thresh
+        
+    def update(self) -> Tuple:
+        if not self.scheduler.use_pp:
+            self.token_budget = self.max_num_scheduled_tokens
+        else:
+            # NOTE(guoty) Token Throttling
+            # Reference: https://arxiv.org/abs/2504.14775 
+            # Code: https://github.com/gty111/gLLM
+            
+            # system states
+            num_prefill_tokens = reduce(lambda num_acc, req: num_acc + req.num_prompt_tokens - req.num_computed_tokens, self.scheduler.waiting, 0)
+            num_decode_tokens = 0
+            for request in self.scheduler.running:
+                if request.computed_prompt:
+                    num_decode_tokens += 1
+                else:
+                    num_prefill_tokens += request.num_prompt_tokens - request.num_computed_tokens
+            kv_free = 1 - self.scheduler.kv_cache_manager.usage
+            
+            
+            # prefill token budget
+            prefill_ratio = max(0, (kv_free - self.kv_thresh) / (1 - self.kv_thresh))
+            prefill_token_budget = max(num_prefill_tokens // self.num_iterp, 32)
+            prefill_token_budget = min(self.max_num_scheduled_tokens * prefill_ratio, prefill_token_budget)
+            
+            # decode token budget
+            if num_decode_tokens < self.pp_size:
+                decode_token_budget = 1
+            else:
+                decode_token_budget = (num_decode_tokens + random.randint(0, self.pp_size-1)) // self.pp_size
+            
+            # print(f'P:{prefill_token_budget} D:{decode_token_budget} WP:{num_prefill_tokens} RD:{num_decode_tokens} KV:{kv_free}')
+            self.prefill_token_budget = int(prefill_token_budget)
+            self.decode_token_budget = int(decode_token_budget)
+    
+    def has_running(self):
+        if not self.use_pp:
+            return self.token_budget > 0
+        else:
+            return self.prefill_token_budget > 0 or self.decode_token_budget > 0
+    
+    def has_waiting(self):
+        if not self.use_pp:
+            return self.token_budget > 0
+        else:
+            return self.prefill_token_budget > 0
+        
+    def get(self, computed_prompt: bool):
+        if not self.use_pp:
+            return self.token_budget
+        else:
+            if computed_prompt:
+                return self.decode_token_budget
+            else:
+                return self.prefill_token_budget
+    
+    def consume(self, num_new_tokens: int, computed_prompt: bool):
+        if not self.use_pp:
+            self.token_budget -= num_new_tokens
+        else:
+            if computed_prompt:
+                self.decode_token_budget -= num_new_tokens
+            else:
+                self.prefill_token_budget -= num_new_tokens
+                
+    def verify(self):
+        if not self.use_pp:
+            assert self.token_budget >= 0
+        else:
+            assert self.prefill_token_budget >= 0 and self.decode_token_budget >= 0
+        
+
 
 class Scheduler(SchedulerInterface):
 
@@ -164,35 +247,7 @@ class Scheduler(SchedulerInterface):
         )
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         
-    def get_throttling_token_budget(self) -> Tuple:
-        # NOTE(guoty) Token Throttling
-        # Reference: https://arxiv.org/abs/2504.14775 
-        # Code: https://github.com/gty111/gLLM
-        
-        # hyperparameters
-        num_iterp = self.scheduler_config.num_iterp
-        kv_thresh = self.scheduler_config.kv_thresh
-        
-        # system states
-        num_prefill_tokens = reduce(lambda num_acc, req: num_acc + req.num_prompt_tokens - req.num_computed_tokens, self.waiting, 0)
-        kv_free = 1 - self.kv_cache_manager.usage
-        num_decode_tokens = len(self.running)
-        pp_size = self.parallel_config.pipeline_parallel_size
-        
-        # prefill token budget
-        prefill_ratio = max(0, (kv_free - kv_thresh) / (1 - kv_thresh))
-        prefill_token_budget = min(self.max_num_scheduled_tokens * prefill_ratio, num_prefill_tokens // num_iterp)
-        prefill_token_budget = int(prefill_token_budget)
-        
-        # decode token budget
-        if num_decode_tokens < pp_size:
-            decode_token_budget = 1
-        else:
-            decode_token_budget = (num_decode_tokens + random.randint(0, pp_size-1)) // pp_size
-        decode_token_budget = int(decode_token_budget)
-        
-        # print(f'P:{prefill_token_budget} D:{decode_token_budget} WP:{num_prefill_tokens} RD:{num_decode_tokens} KV:{kv_free}')
-        return prefill_token_budget, decode_token_budget
+        self.token_budget = TokenBudget(self)
 
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:
@@ -221,7 +276,6 @@ class Scheduler(SchedulerInterface):
 
         req_to_new_block_ids: dict[str, tuple[list[int], ...]] = {}
         num_scheduled_tokens: dict[str, int] = {}
-        token_budget = self.max_num_scheduled_tokens
         # Encoder-related.
         scheduled_encoder_inputs: dict[str, list[int]] = {}
         encoder_budget = self.max_num_encoder_input_tokens
@@ -231,14 +285,12 @@ class Scheduler(SchedulerInterface):
         # For logging.
         scheduled_timestamp = time.monotonic()
 
-        # Token Throttling 
-        if self.use_pp:
-            prefill_token_budget, decode_token_budget = self.get_throttling_token_budget()
-
+        token_budget = self.token_budget
+        token_budget.update()
+        
         # First, schedule the RUNNING requests.
         req_index = 0
-        token_budget = decode_token_budget if self.use_pp else token_budget
-        while req_index < len(self.running) and token_budget > 0:
+        while req_index < len(self.running) and token_budget.has_running():
             request = self.running[req_index]
 
             num_new_tokens = (request.num_tokens_with_spec -
@@ -247,7 +299,7 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens):
                 num_new_tokens = (
                     self.scheduler_config.long_prefill_token_threshold)
-            num_new_tokens = min(num_new_tokens, token_budget)
+            num_new_tokens = min(num_new_tokens, token_budget.get(request.computed_prompt))
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -332,7 +384,7 @@ class Scheduler(SchedulerInterface):
             req_to_new_block_ids[request.request_id] = (
                 new_blocks.get_block_ids())
             num_scheduled_tokens[request.request_id] = num_new_tokens
-            token_budget -= num_new_tokens
+            token_budget.consume(num_new_tokens, request.computed_prompt)
             req_index += 1
 
             # Speculative decode related.
@@ -368,9 +420,8 @@ class Scheduler(SchedulerInterface):
         skipped_waiting_requests = create_request_queue(self.policy)
 
         # Next, schedule the WAITING requests.
-        token_budget = prefill_token_budget if self.use_pp else token_budget
         if not preempted_reqs:
-            while self.waiting and token_budget > 0:
+            while self.waiting and token_budget.has_waiting():
                 if len(self.running) == self.max_num_running_reqs:
                     break
 
@@ -458,12 +509,12 @@ class Scheduler(SchedulerInterface):
                     # chunked prefill has to be enabled explicitly to allow
                     # pooling requests to be chunked
                     if not self.scheduler_config.chunked_prefill_enabled and \
-                        num_new_tokens > token_budget:
+                        num_new_tokens > token_budget.get(False):
                         self.waiting.pop_request()
                         skipped_waiting_requests.prepend_request(request)
                         continue
 
-                    num_new_tokens = min(num_new_tokens, token_budget)
+                    num_new_tokens = min(num_new_tokens, token_budget.get(False))
                     assert num_new_tokens > 0
 
                     # Schedule encoder inputs.
@@ -531,7 +582,7 @@ class Scheduler(SchedulerInterface):
                 req_to_new_block_ids[request.request_id] = (
                     self.kv_cache_manager.get_block_ids(request.request_id))
                 num_scheduled_tokens[request.request_id] = num_new_tokens
-                token_budget -= num_new_tokens
+                token_budget.consume(num_new_tokens, False)
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 # Count the number of prefix cached tokens.
@@ -553,7 +604,7 @@ class Scheduler(SchedulerInterface):
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
-        assert token_budget >= 0
+        token_budget.verify()
         assert len(self.running) <= self.max_num_running_reqs
         # Since some requests in the RUNNING queue may not be scheduled in
         # this step, the total number of scheduled requests can be smaller than

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -188,6 +188,10 @@ class Request:
             return None
         events, self.events = self.events, []
         return events
+    
+    @property
+    def computed_prompt(self) -> bool:
+        return self.num_computed_tokens >= self.num_prompt_tokens
 
 
 class RequestStatus(enum.IntEnum):

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -188,7 +188,7 @@ class Request:
             return None
         events, self.events = self.events, []
         return events
-    
+
     @property
     def computed_prompt(self) -> bool:
         return self.num_computed_tokens >= self.num_prompt_tokens


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

related issue #20298 

Token Throttling can provide great acceleration !!!
- :arrow_down: TTFT  ~90% 
- :arrow_down: TPOT  ~80%
- :arrow_down:   E2EL ~80%
- :arrow_up: Throughput ~30%

## Results

### PP 4 x A100 Qwen2.5-32B-Instruct  2048 reqs 16reqs/s

Before this PR
```
============ Serving Benchmark Result ============
Successful requests:                     2048      
Benchmark duration (s):                  230.58    
Total input tokens:                      461482    
Total generated tokens:                  321537    
Request throughput (req/s):              8.88      
Output token throughput (tok/s):         1394.46   
Total Token throughput (tok/s):          3395.84   
---------------Time to First Token----------------
Mean TTFT (ms):                          5352.71   
Median TTFT (ms):                        1120.93   
P99 TTFT (ms):                           45253.78  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          519.36    
Median TPOT (ms):                        525.18    
P99 TPOT (ms):                           815.52    
---------------Inter-token Latency----------------
Mean ITL (ms):                           465.41    
Median ITL (ms):                         346.97    
P99 ITL (ms):                            1134.22   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          73049.72  
Median E2EL (ms):                        66975.69  
P99 E2EL (ms):                           194345.25 
==================================================
```
After this PR

```
============ Serving Benchmark Result ============
Successful requests:                     2048      
Benchmark duration (s):                  166.96    
Total input tokens:                      461482    
Total generated tokens:                  321661    
Request throughput (req/s):              12.27     
Output token throughput (tok/s):         1926.62   
Total Token throughput (tok/s):          4690.70   
---------------Time to First Token----------------
Mean TTFT (ms):                          430.14    
Median TTFT (ms):                        427.23    
P99 TTFT (ms):                           776.04    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          124.69    
Median TPOT (ms):                        130.74    
P99 TPOT (ms):                           172.69    
---------------Inter-token Latency----------------
Mean ITL (ms):                           123.01    
Median ITL (ms):                         123.12    
P99 ITL (ms):                            241.26    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          19308.33  
Median E2EL (ms):                        13640.60  
P99 E2EL (ms):                           63897.94  
==================================================
```

### PP 4 x 4090 Qwen2.5-14B 2048 reqs 16 reqs/s

Before this PR
```
============ Serving Benchmark Result ============
Successful requests:                     2048      
Benchmark duration (s):                  192.02    
Total input tokens:                      461482    
Total generated tokens:                  324320    
Request throughput (req/s):              10.67     
Output token throughput (tok/s):         1689.01   
Total Token throughput (tok/s):          4092.35   
---------------Time to First Token----------------
Mean TTFT (ms):                          2763.79   
Median TTFT (ms):                        714.80    
P99 TTFT (ms):                           19896.00  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          317.25    
Median TPOT (ms):                        336.91    
P99 TPOT (ms):                           479.97    
---------------Inter-token Latency----------------
Mean ITL (ms):                           306.85    
Median ITL (ms):                         239.34    
P99 ITL (ms):                            644.64    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          48134.31  
Median E2EL (ms):                        39115.40  
P99 E2EL (ms):                           144711.79 
==================================================
```

After this PR
```
============ Serving Benchmark Result ============
Successful requests:                     2048      
Benchmark duration (s):                  153.52    
Total input tokens:                      461482    
Total generated tokens:                  325002    
Request throughput (req/s):              13.34     
Output token throughput (tok/s):         2117.06   
Total Token throughput (tok/s):          5123.14   
---------------Time to First Token----------------
Mean TTFT (ms):                          202.44    
Median TTFT (ms):                        202.30    
P99 TTFT (ms):                           368.38    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          57.84     
Median TPOT (ms):                        58.02     
P99 TPOT (ms):                           69.62     
---------------Inter-token Latency----------------
Mean ITL (ms):                           58.15     
Median ITL (ms):                         57.26     
P99 ITL (ms):                            92.94     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          9129.29   
Median E2EL (ms):                        6551.08   
P99 E2EL (ms):                           28441.91  
==================================================
```

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
