### PR TITLE
[Docs] Update EAGLE example

### DIFF
--- a/docs/features/spec_decode.md
+++ b/docs/features/spec_decode.md
@@ -201,6 +201,7 @@ an [EAGLE (Extrapolation Algorithm for Greater Language-model Efficiency)](https
         speculative_config={
             "model": "yuhuili/EAGLE-LLaMA3-Instruct-8B",
             "draft_tensor_parallel_size": 1,
+            "num_speculative_tokens": 2,
         },
     )
 


### PR DESCRIPTION
Copy pasting the example after changes to spec decoding conf yields:

```
  File "/home/nicolo/llmd/vllm/vllm/engine/arg_utils.py", line 1039, in create_speculative_config
    speculative_config = SpeculativeConfig.from_dict(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicolo/llmd/vllm/vllm/config.py", line 2543, in from_dict
    return cls(**dict_value)
           ^^^^^^^^^^^^^^^^^
  File "/home/nicolo/llmd/.venv/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 123, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
pydantic_core._pydantic_core.ValidationError: 1 validation error for SpeculativeConfig
  Value error, num_speculative_tokens must be provided with speculative model unless the draft model config contains an n_predict parameter. [type=value_error, input_value=ArgsKwargs((), {'model': ...sable_log_stats': True}), input_type=ArgsKwargs]

```
