### PR TITLE
Update serial_utils.py

### DIFF
--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -77,8 +77,13 @@ class MsgpackEncoder:
             # top-level encoded buffer instead of copying their data into the
             # new buffer.
             return bufs
+        # Add serialization error handling to alert the user
+        except TypeError as e:
+            print(f"Fatal error {e} !!")
+            exit(-1)
         finally:
             self.aux_buffers = None
+
 
     def encode_into(self, obj: Any, buf: bytearray) -> Sequence[bytestr]:
         try:


### PR DESCRIPTION
Add serialization error handling to alert the user



## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

I had a stuck issue when training under H20 x 2 nvlink, without any error output,
I've added user alerts

## Test Plan

run train with out  "VLLM_ALLOW_INSECURE_SERIALIZATION=1" see alerts

## Test Result

Object of type XXX is not serializable Set VLLM_ALLOW_INSECURE_SERIALIZATION=1 to allow fallback to pickle-based serialization.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
