### PR TITLE
FIX: Add libnuma-dev to Dockerfile for dev stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,7 +83,7 @@ ARG GET_PIP_URL
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
     && apt-get update -y \
-    && apt-get install -y ccache software-properties-common git curl sudo libnuma-dev \
+    && apt-get install -y ccache software-properties-common git curl sudo \
     && if [ ! -z ${DEADSNAKES_MIRROR_URL} ] ; then \
         if [ ! -z "${DEADSNAKES_GPGKEY_URL}" ] ; then \
             mkdir -p -m 0755 /etc/apt/keyrings ; \
@@ -261,6 +261,8 @@ ENV UV_INDEX_STRATEGY="unsafe-best-match"
 # Use copy mode to avoid hardlink failures with Docker cache mounts
 ENV UV_LINK_MODE=copy
 
+# Install libnuma-dev, required by fastsafetensors (fixes #20384)
+RUN apt-get update && apt-get install -y libnuma-dev && rm -rf /var/lib/apt/lists/*
 COPY requirements/lint.txt requirements/lint.txt
 COPY requirements/test.txt requirements/test.txt
 COPY requirements/dev.txt requirements/dev.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,7 +83,7 @@ ARG GET_PIP_URL
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
     && apt-get update -y \
-    && apt-get install -y ccache software-properties-common git curl sudo \
+    && apt-get install -y ccache software-properties-common git curl sudo libnuma-dev \
     && if [ ! -z ${DEADSNAKES_MIRROR_URL} ] ; then \
         if [ ! -z "${DEADSNAKES_GPGKEY_URL}" ] ; then \
             mkdir -p -m 0755 /etc/apt/keyrings ; \


### PR DESCRIPTION
## Purpose
This PR fixes a Docker build failure that occurs in the `dev` stage. The build fails because the `fastsafetensors` Python package requires the `libnuma-dev` system dependency, which is missing from the base Docker image. The error log shows `fatal error: numa.h: No such file or directory` during the installation of development requirements.

This PR resolves the issue by adding `libnuma-dev` to the `apt-get install` command in the `base` stage of the `docker/Dockerfile`.

Fixes #20384

## Test Plan
To verify the fix, run a Docker build targeting the `dev` stage from the root of the repository. The build, which previously failed, should now complete successfully.

**Command:**
```bash
docker build . --target dev

## Test Result
After applying the changes to the docker/Dockerfile, a local Docker build using the command above was executed and it completed successfully. The RUN uv pip install -r requirements/dev.txt step passed without any compilation errors related to fastsafetensors.