### PR TITLE
[Misc] Small: Fix video loader return type annotations.

### DIFF
--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -172,9 +172,10 @@ async def test_fetch_video_http(video_url: str, num_frames: int):
             "num_frames": num_frames,
         }})
 
-    video_sync = connector.fetch_video(video_url)
-    video_async = await connector.fetch_video_async(video_url)
-    assert np.array_equal(video_sync[0], video_async[0])
+    video_sync, metadata_sync = connector.fetch_video(video_url)
+    video_async, metadata_async = await connector.fetch_video_async(video_url)
+    assert np.array_equal(video_sync, video_async)
+    assert metadata_sync == metadata_async
 
 
 # Used for the next two tests related to `merge_and_sort_multimodal_metadata`.

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -228,7 +228,7 @@ class MediaConnector:
         video_url: str,
         *,
         image_mode: str = "RGB",
-    ) -> npt.NDArray:
+    ) -> tuple[npt.NDArray, dict[str, Any]]:
         """
         Load video from a HTTP or base64 data URL.
         """
@@ -248,7 +248,7 @@ class MediaConnector:
         video_url: str,
         *,
         image_mode: str = "RGB",
-    ) -> npt.NDArray:
+    ) -> tuple[npt.NDArray, dict[str, Any]]:
         """
         Asynchronously load video from a HTTP or base64 data URL.
 


### PR DESCRIPTION
A recent PR (#19331) changed video loader to return metadata within a tuple. We need to fix the video processing pipeline's return type to correctly reflect that. 