### PR TITLE
[BugFix] Fix DP headless mode arg validation

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -119,15 +119,15 @@ def run_headless(args: argparse.Namespace):
     if not envs.VLLM_USE_V1:
         raise ValueError("Headless mode is only supported for V1")
 
+    if engine_args.data_parallel_rank is not None:
+        raise ValueError("data_parallel_rank is not applicable in "
+                         "headless mode")
+
     parallel_config = vllm_config.parallel_config
     local_engine_count = parallel_config.data_parallel_size_local
 
     if local_engine_count <= 0:
         raise ValueError("data_parallel_size_local must be > 0 in "
-                         "headless mode")
-
-    if parallel_config.data_parallel_rank is not None:
-        raise ValueError("data_parallel_rank is not applicable in "
                          "headless mode")
 
     host = parallel_config.data_parallel_master_ip


### PR DESCRIPTION
Last-minute bug introduced in https://github.com/vllm-project/vllm/pull/19790.

Had intended to check `engine_args.data_parallel_rank` rather than `parallel_config.data_parallel_rank`, the latter will never be None.

Will make sure we have proper CI coverage of headless mode in a follow-on PR.

Fixes #20399