### PR TITLE
[Misc] Fix `Unable to detect current VLLM config. Defaulting to NHD kv cache layout` warning

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -97,10 +97,10 @@ def get_kv_connector_cache_layout():
     # used for faster transfer.
     vllm_config = get_current_vllm_config()
     kv_config = vllm_config.kv_transfer_config
-    if vllm_config.model_config is None or kv_config is None:
+    if kv_config is not None and vllm_config.model_config is None:
         logger.warning_once("Unable to detect current VLLM config. " \
         "Defaulting to NHD kv cache layout.")
-    else:
+    elif kv_config is not None:
         use_mla = vllm_config.model_config.use_mla
         if not use_mla and kv_config.kv_connector == "NixlConnector":
             logger.info_once("NixlConnector detected. Setting KV cache " \

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -138,7 +138,7 @@ def get_kv_cache_layout():
     if cache_layout is None:
         cache_layout = get_kv_connector_cache_layout()
     else:
-        logger.info_once("`FLASHINFER_KV_CACHE_LAYOUT` environment variable " \
+        logger.info_once("`VLLM_KV_CACHE_LAYOUT` environment variable " \
         "detected. Setting KV cache layout to %s.", cache_layout)
 
     return cache_layout


### PR DESCRIPTION
This warning was popping up in scenarios where it wasn't meant to be shown, as the original purpose
was to notify of the KV layout change in disagg PD setups.

```
INFO 07-02 17:57:24 [default_loader.py:272] Loading weights took 0.31 seconds
INFO 07-02 17:57:25 [gpu_model_runner.py:1782] Model loading took 1.1201 GiB and 0.721210 seconds
INFO 07-02 17:57:30 [backends.py:508] Using cache directory: /home/mgoin/.cache/vllm/torch_compile_cache/a9f88f5fe5/rank_0_0/backbone for vLLM's torch.compile
INFO 07-02 17:57:30 [backends.py:519] Dynamo bytecode transform time: 4.93 s
INFO 07-02 17:57:34 [backends.py:155] Directly load the compiled graph(s) for shape None from the cache, took 3.627 s
INFO 07-02 17:57:34 [monitor.py:34] torch.compile takes 4.93 s in total
INFO 07-02 17:57:35 [gpu_worker.py:232] Available KV cache memory: 64.43 GiB
INFO 07-02 17:57:35 [kv_cache_utils.py:716] GPU KV cache size: 603,248 tokens
INFO 07-02 17:57:35 [kv_cache_utils.py:720] Maximum concurrency for 40,960 tokens per request: 14.73x
# Gone from non-PD deployments
=>WARNING 07-02 17:57:35 [utils.py:101] Unable to detect current VLLM config. Defaulting to NHD kv cache layout.
```
