### PR TITLE
[TPU] Optimize kv cache update kernel

### DIFF
--- a/vllm/attention/ops/pallas_kv_cache_update.py
+++ b/vllm/attention/ops/pallas_kv_cache_update.py
@@ -25,7 +25,7 @@ def _kv_cache_update_kernel(
     # head_dim]
     sem,
 ):
-    async_copies_in = []
+    async_copies = []
     block_idx = pl.program_id(0)
     num_slices_per_block = scratch.shape[0]
 
@@ -40,23 +40,25 @@ def _kv_cache_update_kernel(
             sem,
         )
         async_copy.start()
-        async_copies_in.append(async_copy)
+        async_copies.append(async_copy)
+
+    for async_copy in async_copies:
+        async_copy.wait()
 
     # Copy from scratch to kv_cache_hbm_ref
-    async_copies_out = []
+    async_copies.clear()
     for i in range(num_slices_per_block):
         offset_i = i + block_idx * num_slices_per_block
         kv_cache_start = slices_ref[0, offset_i]
         length = slices_ref[2, offset_i]
-        async_copies_in[i].wait()
         async_copy = pltpu.make_async_copy(
             scratch.at[i, pl.ds(0, length), ...],
             kv_cache_hbm_ref.at[pl.ds(kv_cache_start, length), ...],
             sem,
         )
         async_copy.start()
-        async_copies_out.append(async_copy)
-    for async_copy in async_copies_out:
+        async_copies.append(async_copy)
+    for async_copy in async_copies:
         async_copy.wait()
 
 

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -734,6 +734,13 @@ def next_power_of_2(n) -> int:
     return 1 << (n - 1).bit_length()
 
 
+def prev_power_of_2(n: int) -> int:
+    """The previous power of 2 (inclusive)"""
+    if n <= 0:
+        return 0
+    return 1 << (n.bit_length() - 1)
+
+
 def round_up(x: int, y: int) -> int:
     return ((x + y - 1) // y) * y
 

--- a/vllm/v1/attention/backends/pallas.py
+++ b/vllm/v1/attention/backends/pallas.py
@@ -318,3 +318,9 @@ def kv_cache_update_op_non_xla(kv: torch.Tensor, slot_mapping: torch.Tensor,
                                page_size: int,
                                num_slices_per_block: int) -> torch.Tensor:
     return kv_cache
+
+
+def get_page_size_bytes(block_size: int, num_kv_heads: int, head_size: int,
+                        kv_cache_dtype: torch.dtype) -> int:
+    """Returns the size in bytes of one page of the KV cache."""
+    return block_size * num_kv_heads * head_size * kv_cache_dtype.itemsize

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -30,7 +30,7 @@ from vllm.multimodal.inputs import (BatchedTensorInputs, MultiModalKwargs,
 from vllm.multimodal.utils import group_mm_inputs_by_modality
 from vllm.sequence import IntermediateTensors
 from vllm.utils import (STR_DTYPE_TO_TORCH_DTYPE, LayerBlockType, cdiv,
-                        is_pin_memory_available)
+                        is_pin_memory_available, next_power_of_2)
 from vllm.v1.attention.backends.pallas import (PallasAttentionBackend,
                                                PallasMetadata)
 from vllm.v1.core.encoder_cache_manager import compute_encoder_budget
@@ -56,8 +56,6 @@ logger = init_logger(__name__)
 INVALID_TOKEN_ID = -1
 # Smallest output size
 MIN_NUM_SEQS = 8
-# Block size used for kv cache updating kernel
-NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK = 8
 
 
 #########################################################
@@ -139,7 +137,11 @@ class TPUModelRunner(LoRAModelRunnerMixin):
         self.pin_memory = is_pin_memory_available()
         self.dtype = self.model_config.dtype
         if cache_config.cache_dtype == "auto":
-            self.kv_cache_dtype = self.dtype
+            model_dtype = self.dtype
+            if isinstance(model_dtype, str):
+                self.kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[model_dtype]
+            else:
+                self.kv_cache_dtype = model_dtype
         else:
             self.kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[
                 cache_config.cache_dtype]
@@ -191,6 +193,9 @@ class TPUModelRunner(LoRAModelRunnerMixin):
         )
         self.max_num_encoder_input_tokens = encoder_compute_budget
         self.encoder_cache_size = encoder_cache_size
+
+        self._num_slices_per_kv_cache_update_block = \
+            _get_num_slices_per_kv_cache_update_block(self._get_page_size_bytes())
 
         # Lazy initialization
         self.model: nn.Module  # Set after load_model
@@ -590,6 +595,10 @@ class TPUModelRunner(LoRAModelRunnerMixin):
             [kv_cache_start_indices, new_kv_start_indices, slice_lens], axis=1)
         return slot_mapping_metadata
 
+    def _get_page_size_bytes(self):
+        return self.block_size * self.num_kv_heads * self.head_size \
+            * self.kv_cache_dtype.itemsize
+
     def _prepare_inputs(self, scheduler_output: "SchedulerOutput",
                         start_index: int):
         assert scheduler_output.total_num_scheduled_tokens > 0
@@ -719,7 +728,7 @@ class TPUModelRunner(LoRAModelRunnerMixin):
         num_kv_update_slices = slot_mapping_metadata.shape[0]
         padded_num_slices = _get_padded_num_kv_cache_update_slices(
             padded_total_num_scheduled_tokens, self.max_num_reqs,
-            self.block_size)
+            self.block_size, self._num_slices_per_kv_cache_update_block)
         slot_mapping_metadata = np.pad(
             slot_mapping_metadata,
             [[0, padded_num_slices - len(slot_mapping_metadata)], [0, 0]],
@@ -750,8 +759,7 @@ class TPUModelRunner(LoRAModelRunnerMixin):
             num_kv_update_slices=torch.tensor([num_kv_update_slices],
                                               dtype=torch.int32,
                                               device=self.device),
-            num_slices_per_kv_cache_update_block=
-            NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK,
+            num_slices_per_kv_cache_update_block=self._num_slices_per_kv_cache_update_block,
         )
         # NOTE(woosuk): Due to chunked prefills, there can be at most 1 partial
         # request in the batch. While we should not sample any token from this
@@ -1178,7 +1186,8 @@ class TPUModelRunner(LoRAModelRunnerMixin):
         position_ids = torch.zeros(num_tokens,
                                    dtype=torch.int32).to(self.device)
         padded_num_slices = _get_padded_num_kv_cache_update_slices(
-            num_tokens, self.max_num_reqs, self.block_size)
+            num_tokens, self.max_num_reqs, self.block_size,
+            self._num_slices_per_kv_cache_update_block)
         num_kv_update_slices = torch.tensor([padded_num_slices],
                                             dtype=torch.int32).to(self.device)
         slot_mapping = torch.zeros((3, padded_num_slices),
@@ -1201,8 +1210,7 @@ class TPUModelRunner(LoRAModelRunnerMixin):
             query_start_loc=query_start_loc,
             num_seqs=num_seqs,
             num_kv_update_slices=num_kv_update_slices,
-            num_slices_per_kv_cache_update_block=
-            NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK,
+            num_slices_per_kv_cache_update_block=self._num_slices_per_kv_cache_update_block,
         )
 
         if self.is_multimodal_model:
@@ -1807,17 +1815,40 @@ def _get_padded_token_len(paddings: list[int], x: int) -> int:
     return paddings[index]
 
 
-def _get_padded_num_kv_cache_update_slices(num_tokens: int, max_num_reqs: int,
-                                           page_size: int) -> int:
+def _get_padded_num_kv_cache_update_slices(
+    num_tokens: int, max_num_reqs: int,
+    page_size: int, num_slices_per_kv_cache_update_block: int
+) -> int:
     """Calculates the padded number of KV cache update slices to avoid
     recompilation."""
     padded_num_slices = 2 * max_num_reqs + num_tokens // page_size
     padded_num_slices = min(padded_num_slices, num_tokens)
     padded_num_slices = (
-        padded_num_slices + NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK - 1
-    ) // NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK * \
-        NUM_SLICES_PER_KV_CACHE_UPDATE_BLOCK
+        padded_num_slices + num_slices_per_kv_cache_update_block - 1
+    ) // num_slices_per_kv_cache_update_block * \
+        num_slices_per_kv_cache_update_block
     return padded_num_slices
+
+
+def _get_num_slices_per_kv_cache_update_block(page_size_bytes: int) -> int:
+  """Find the optimum number of slices to copy per Pallas program instance.
+
+  Increasing the number of slices copied in one instance of the kernel program
+  will increase HBM bandwidth utilization via more in-flight DMAs.
+
+  However, it will also use more VMEM, and experimentally, we observed
+  performance regression at 128 slices on v6e, likely due to running
+  out of scalar registers. Thus this function will limit the number of
+  slices to 64.
+  """
+  # Conservative VMEM usage limit: 32 MiB
+  vmem_limit = 32 * 1024 * 1024
+  num_slices_per_block = vmem_limit // page_size_bytes
+  assert num_slices_per_block > 0, "Number of slices should be positive"
+  num_slices_per_block = next_power_of_2(num_slices_per_block)
+  if num_slices_per_block > 64:
+    num_slices_per_block = 64
+  return num_slices_per_block
 
 
 def replace_set_lora(model):


### PR DESCRIPTION
## Purpose

This PR improves the throughput of the kv cache update kernel from 28.15 GB/s to 91.65 GB/s on v6e.

This PR adds to optimizations on top of https://github.com/vllm-project/vllm/pull/19928. It picks the optimal number of slices to copy per kernel program instance based on results from microbenchmarks.

Reference data demonstrating improvements: https://github.com/tengyifei/playground/blob/master/pallas/better-index-copy.ipynb

An earlier commit in this PR also pipelined the DMAs into and out of VMEM, resulting in more in-flight DMAs. That improved throughput to 100 GB/s in microbenchmarks but actually _decreased_ the performance in `python3 ./benchmarks/benchmark_serving.py`. I'm not sure why this happens. In any case, I omitted that optimization in the latest commit because what matters is the end-to-end benchmark.

## Test plan

Kernel test: pytest -s -v tests/v1/tpu/test_kv_cache_update_kernel.py
Accuracy test: pytest -s -v tests/entrypoints/llm/test_accuracy.py::test_lm_eval_accuracy_v1_engine

## Test result

PASSED

## Llama 3.1 70B perf

```
vllm serve meta-llama/Llama-3.1-70B-Instruct --disable-log-requests --gpu-memory-utilization 0.98 --max-num-batched-tokens 2048 --max-num-seqs 128 --max-model-len 2048 --no-enable-prefix-caching --tensor_parallel_size=8

python3 ./benchmarks/benchmark_serving.py --model meta-llama/Llama-3.1-70B-Instruct --dataset-name sonnet --dataset-path benchmarks/sonnet_4x.txt --sonnet-input-len 1800 --sonnet-output-len 128 --ignore_eos
```

- Before: 6.73 reqs/s
- This PR: 6.77 reqs/s
