### PR TITLE
[Bugfix] Fix the issue of token count in BlockTable

### DIFF
--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -105,7 +105,7 @@ class BlockTable:
                                                      device=device,
                                                      extra_hash=extra_hash)
         self.update(blocks)
-        self._num_full_slots = len(token_ids)
+        self._num_full_slots += len(token_ids)
 
     def update(self, blocks: List[Block]) -> None:
         """Resets the table to the newly provided blocks 


### PR DESCRIPTION
 
## Purpose

path: BlockTable#allocate
When calling the allocate method to allocate a block, we should increment _num_full_slots.
 