### PR TITLE
[Frontend] improve vllm bench <bench_type> --help display

### DIFF
--- a/vllm/entrypoints/cli/benchmark/main.py
+++ b/vllm/entrypoints/cli/benchmark/main.py
@@ -48,7 +48,7 @@ class BenchmarkSubcommand(CLISubcommand):
             cmd_subparser.set_defaults(dispatch_function=cmd_cls.cmd)
             cmd_cls.add_cli_args(cmd_subparser)
             show_filtered_argument_or_group_from_help(cmd_subparser,
-                                                      f"bench {cmd_cls.name}")
+                                                      ["bench", cmd_cls.name])
             cmd_subparser.epilog = VLLM_SUBCMD_PARSER_EPILOG
         return bench_parser
 

--- a/vllm/entrypoints/cli/benchmark/main.py
+++ b/vllm/entrypoints/cli/benchmark/main.py
@@ -8,6 +8,8 @@ import typing
 
 from vllm.entrypoints.cli.benchmark.base import BenchmarkSubcommandBase
 from vllm.entrypoints.cli.types import CLISubcommand
+from vllm.entrypoints.utils import (VLLM_SUBCMD_PARSER_EPILOG,
+                                    show_filtered_argument_or_group_from_help)
 
 if typing.TYPE_CHECKING:
     from vllm.utils import FlexibleArgumentParser
@@ -45,6 +47,9 @@ class BenchmarkSubcommand(CLISubcommand):
             )
             cmd_subparser.set_defaults(dispatch_function=cmd_cls.cmd)
             cmd_cls.add_cli_args(cmd_subparser)
+            show_filtered_argument_or_group_from_help(cmd_subparser,
+                                                      f"bench {cmd_cls.name}")
+            cmd_subparser.epilog = VLLM_SUBCMD_PARSER_EPILOG
         return bench_parser
 
 

--- a/vllm/entrypoints/cli/run_batch.py
+++ b/vllm/entrypoints/cli/run_batch.py
@@ -60,7 +60,7 @@ class RunBatchSubcommand(CLISubcommand):
         )
         run_batch_parser = make_arg_parser(run_batch_parser)
         show_filtered_argument_or_group_from_help(run_batch_parser,
-                                                  "run-batch")
+                                                  ["run-batch"])
         run_batch_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG
         return run_batch_parser
 

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -97,7 +97,7 @@ class ServeSubcommand(CLISubcommand):
             "https://docs.vllm.ai/en/latest/configuration/serve_args.html")
 
         serve_parser = make_arg_parser(serve_parser)
-        show_filtered_argument_or_group_from_help(serve_parser, "serve")
+        show_filtered_argument_or_group_from_help(serve_parser, ["serve"])
         serve_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG
         return serve_parser
 

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -15,8 +15,8 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 VLLM_SUBCMD_PARSER_EPILOG = (
-    "Tip: Use `vllm [serve|run-batch] --help=<keyword>` "
-    "to explore arguments from help.\n"
+    "Tip: Use `vllm [serve|run-batch|bench <bench_type>] "
+    "--help=<keyword>` to explore arguments from help.\n"
     "   - To view a argument group:     --help=ModelConfig\n"
     "   - To view a single argument:    --help=max-num-seqs\n"
     "   - To search by keyword:         --help=max\n"
@@ -184,7 +184,12 @@ def show_filtered_argument_or_group_from_help(parser, subcommand_name):
     # Only handle --help=<keyword> for the current subcommand.
     # Since subparser_init() runs for all subcommands during CLI setup,
     # we skip processing if the subcommand name is not in sys.argv.
-    if subcommand_name not in sys.argv:
+    parts = subcommand_name.split()
+    # sys.argv[0] is the program name. The subcommand follows.
+    # e.g., for `vllm bench latency`,
+    # sys.argv is `['vllm', 'bench', 'latency', ...]`
+    # and subcommand_name is "bench latency".
+    if len(sys.argv) <= len(parts) or sys.argv[1:1 + len(parts)] != parts:
         return
 
     for arg in sys.argv:

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import argparse
 import asyncio
 import functools
 import os
@@ -178,18 +179,19 @@ def _validate_truncation_size(
     return truncate_prompt_tokens
 
 
-def show_filtered_argument_or_group_from_help(parser, subcommand_name):
+def show_filtered_argument_or_group_from_help(parser: argparse.ArgumentParser,
+                                              subcommand_name: list[str]):
     import sys
 
     # Only handle --help=<keyword> for the current subcommand.
     # Since subparser_init() runs for all subcommands during CLI setup,
     # we skip processing if the subcommand name is not in sys.argv.
-    parts = subcommand_name.split()
     # sys.argv[0] is the program name. The subcommand follows.
     # e.g., for `vllm bench latency`,
     # sys.argv is `['vllm', 'bench', 'latency', ...]`
     # and subcommand_name is "bench latency".
-    if len(sys.argv) <= len(parts) or sys.argv[1:1 + len(parts)] != parts:
+    if len(sys.argv) <= len(subcommand_name) or sys.argv[
+            1:1 + len(subcommand_name)] != subcommand_name:
         return
 
     for arg in sys.argv:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

- Also too many args for `bench <bench_type>`, so add --help= to search:
```
Tip: Use `vllm [serve|run-batch|bench <bench_type>] --help=<keyword>` to explore arguments from help.
   - To view a argument group:     --help=ModelConfig
   - To view a single argument:    --help=max-num-seqs
   - To search by keyword:         --help=max
   - To list all groups:           --help=listgroup
  
$ vllm bench latency --help=options
INFO 07-03 17:42:07 [__init__.py:244] Automatically detected platform cpu.
options:
  --batch-size BATCH_SIZE
  --disable-detokenize  Do not detokenize responses (i.e. do not include detokenization time in the
                        latency measurement) (default: False)
  --disable-log-stats   Disable logging statistics. (default: False)
  --input-len INPUT_LEN
  --n N                 Number of generated sequences per prompt. (default: 1)
  --num-iters NUM_ITERS
                        Number of iterations to run. (default: 30)
  --num-iters-warmup NUM_ITERS_WARMUP
                        Number of iterations to run for warmup. (default: 10)
  --output-json OUTPUT_JSON
                        Path to save the latency results in JSON format. (default: None)
  --output-len OUTPUT_LEN
  --profile             profile the generation process of a single batch (default: False)
  --use-beam-search
  --use-v2-block-manager
                        [DEPRECATED] block manager v1 has been removed and SelfAttnBlockSpaceManager
                        (i.e. block manager v2) is now the default. Setting this flag to True or False
                        has no effect on vLLM behavior. (default: True)
  -h, --help            show this help message and exit
```

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
