### PR TITLE
adding reasoning_content as an optional field

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -169,6 +169,12 @@ class ConversationMessage(TypedDict, total=False):
     content: Union[Optional[str], list[dict[str, str]]]
     """The contents of the message"""
 
+    reasoning_content: Optional[str]
+    """Optional field to retain the reasoning_content.
+    Some chat templates might need to use the reasoning content from previous
+    turns
+    """
+
     tool_call_id: Optional[str]
     """Tool call that this message is responding to."""
 


### PR DESCRIPTION
adding reasoning_content as an optional field to `CustomChatCompletionMessageParam`. This gives the flexibility of using reasoning_content of previous turns in chat template if needed

## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Adding the flexibility of using reasoning content in chat template

## Test Plan
Ran it locally

## Test Result
It is working

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
