### PR TITLE
[PD] Log KVTransfer metrics 

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVTransferAggregatedStats
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -78,6 +79,12 @@ class KVConnectorBase_V1(ABC):
     @property
     def role(self) -> KVConnectorRole:
         return self._role
+
+    def get_transfer_stats(self) -> Optional[KVTransferAggregatedStats]:
+        """
+        Get the transfer stats.
+        """
+        return None
 
     # ==============================
     # Worker-side methods
@@ -187,7 +194,7 @@ class KVConnectorBase_V1(ABC):
 
     def get_finished(
         self, finished_req_ids: set[str]
-    ) -> tuple[Optional[set[str]], Optional[set[str]]]:
+    ) -> tuple[Optional[set[str]], Optional[set[str]], Optional[KVTransferAggregatedStats]]:
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
@@ -199,7 +206,7 @@ class KVConnectorBase_V1(ABC):
             The finished saves/sends req ids must belong to a set provided in a
             call to this method (this call or a prior one).
         """
-        return None, None
+        return None, None, None
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -8,6 +8,7 @@ from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVTransferAggregatedStats
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -89,7 +90,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
 
     def get_finished(
         self, finished_req_ids: set[str]
-    ) -> tuple[Optional[set[str]], Optional[set[str]]]:
+    ) -> tuple[Optional[set[str]], Optional[set[str]], Optional[KVTransferAggregatedStats]]:
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
@@ -101,7 +102,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             The finished saves/sends req ids must belong to a set provided in a
             call to this method (this call or a prior one).
         """
-        return self._lmcache_engine.get_finished(finished_req_ids)
+        return self._lmcache_engine.get_finished(finished_req_ids), None
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass
-import time
+from dataclasses import dataclass, field
 
 from vllm.logger import init_logger
 
@@ -26,10 +25,9 @@ class KVTransferAggregatedStats:
 @dataclass 
 class KVTransferStats:
     """Container for transfer performance metrics"""
-    transfer_durations: list[float]  # Transfer durations in seconds
-    bytes_transferred: list[int]     # Bytes transferred per transfer
-    num_blocks_transferred: list[int] # Number of blocks per transfer
-    last_log_time: float             # Last time we logged metrics
+    transfer_durations: list[float]=field(default_factory=list)  # Transfer durations in seconds
+    bytes_transferred: list[int]=field(default_factory=list)     # Bytes transferred per transfer
+    num_blocks_transferred: list[int]=field(default_factory=list) # Number of blocks per transfer
     num_transfers: int = 0
     
     def reset(self):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass
+import time
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+@dataclass 
+class KVTransferAggregatedStats:
+    """Container for aggregating performance metrics across engines"""
+    avg_transfer_durations: float = 0.0
+    avg_bytes_transferred: float = 0.0
+    num_blocks_transferred: int = 0
+    num_successful_transfers: int = 0
+
+    def aggregate(self, other: "KVTransferAggregatedStats"):
+        if other.is_empty():
+            return
+        
+        # Reduce stats
+        self.num_successful_transfers += other.num_successful_transfers
+    
+    def is_empty(self) -> bool:
+        return self.num_successful_transfers == 0
+    
+@dataclass 
+class KVTransferStats:
+    """Container for transfer performance metrics"""
+    transfer_durations: list[float]  # Transfer durations in seconds
+    bytes_transferred: list[int]     # Bytes transferred per transfer
+    num_blocks_transferred: list[int] # Number of blocks per transfer
+    last_log_time: float             # Last time we logged metrics
+    num_transfers: int = 0
+    
+    def reset(self):
+        self.transfer_durations = []
+        self.bytes_transferred = []
+        self.num_blocks_transferred = []
+
+    def observe(self):
+        # TODO finish this
+        self.num_transfers += 1
+    
+    def reduce_and_reset(self) -> KVTransferAggregatedStats:
+        # NOTE (NickLucche): to have statistical significance, we assume the 
+        # size of the measurements groups to be the same. This allows to bound
+        # the size of the messages.
+        # TODO finish this
+        stats = KVTransferAggregatedStats(
+            avg_transfer_durations=11.0,
+            avg_bytes_transferred=0.0,
+            num_blocks_transferred=0,
+            num_successful_transfers=self.num_transfers)
+        self.num_transfers = 0
+        return stats
+    
+    def record_transfer(self, duration: float, bytes_count: int, num_blocks: int):
+        self.transfer_durations.append(duration)
+        self.bytes_transferred.append(bytes_count)
+        self.num_blocks_transferred.append(num_blocks)
+    
+    def get_throughput_stats(self, now: float) -> tuple[float, float, float]:
+        """Get transfer throughput statistics"""
+        pass
+    
+    def get_latency_stats(self) -> tuple[float, float, float]:
+        """Get transfer latency statistics"""
+        # TODO possible use 
+        import numpy as np
+        durations = np.array(self.transfer_durations)
+        avg_latency = float(np.mean(durations))
+        p50_latency = float(np.percentile(durations, 50))
+        p95_latency = float(np.percentile(durations, 95))
+        
+        return avg_latency, p50_latency, p95_latency
+
+class KVTransferLogging:
+    def __init__(self):
+        self.reset()
+        self.transfer_stats = None
+    
+    def reset(self):
+        self.transfer_durations = []
+        self.bytes_transferred = []
+        self.num_blocks_transferred: int = 0
+
+    def observe(self, transfer_stats: KVTransferAggregatedStats):
+        self.transfer_stats = transfer_stats
+        # self.transfer_durations.append(transfer_stats.transfer_durations)
+        # self.bytes_transferred.append(transfer_stats.bytes_transferred)
+        # self.num_blocks_transferred += transfer_stats.num_blocks_transferred
+    
+    def log(self, log_fn=logger.info):
+        """Log transfer metrics periodically, similar to throughput logging"""
+        # Only log if we have transfer data
+        if self.transfer_stats is not None:
+            log_fn("KV Transfer metrics: %s", self.transfer_stats)
+            # bytes_per_sec, blocks_per_sec, transfers_per_sec = \
+            #     self.transfer_metrics.get_throughput_stats(now)
+                
+            # # Get latency stats
+            # avg_latency, p50_latency, p95_latency = \
+            #     self.transfer_metrics.get_latency_stats()
+            
+            # # Format throughput for readability
+            # if bytes_per_sec >= 1024**3:  # GB/s
+            #     bytes_throughput_str = f"{bytes_per_sec / (1024**3):.2f} GB/s"
+            # elif bytes_per_sec >= 1024**2:  # MB/s
+            #     bytes_throughput_str = f"{bytes_per_sec / (1024**2):.1f} MB/s"
+            # elif bytes_per_sec >= 1024:  # KB/s
+            #     bytes_throughput_str = f"{bytes_per_sec / 1024:.1f} KB/s"
+            # else:  # B/s
+            #     bytes_throughput_str = f"{bytes_per_sec:.1f} B/s"
+            
+            # # Log the metrics in a format similar to the existing throughput logs
+            # logger.info(
+            #     "Engine %s: KV Transfer metrics: "
+            #     "Avg transfer throughput: %s, "
+            #     "Blocks/s: %.1f, Transfers/s: %.1f, "
+            #     "Avg latency: %.3fs, P50: %.3fs, P95: %.3fs, "
+            #     "Total transfers: %d",
+            #     self.engine_id,
+            #     bytes_throughput_str,
+            #     blocks_per_sec,
+            #     transfers_per_sec,
+            #     avg_latency,
+            #     p50_latency,
+            #     p95_latency,
+            #     len(self.transfer_metrics.transfer_durations)
+            # )
+        
+        # # Reset metrics for next interval
+        # self.transfer_metrics.reset(now)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -9,6 +9,7 @@ import torch
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVTransferAggregatedStats
 from vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_engine import (
     P2pNcclEngine)
 from vllm.distributed.parallel_state import get_world_group
@@ -271,7 +272,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
 
     def get_finished(
             self, finished_req_ids: set[str],
-            **kwargs) -> tuple[Optional[set[str]], Optional[set[str]]]:
+            **kwargs) -> tuple[Optional[set[str]], Optional[set[str]], Optional[KVTransferAggregatedStats]]:
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -16,6 +16,7 @@ import zmq
 from vllm.config import KVTransferConfig
 from vllm.distributed.device_communicators.pynccl_wrapper import (
     NCCLLibrary, buffer_type, cudaStream_t, ncclComm_t, ncclDataTypeEnum)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVTransferAggregatedStats
 from vllm.distributed.kv_transfer.kv_connector.v1.p2p.tensor_memory_pool import (  # noqa: E501
     TensorMemoryPool)
 from vllm.utils import current_stream, get_ip
@@ -448,7 +449,7 @@ class P2pNcclEngine:
 
     def get_finished(
         self, finished_req_ids: set[str], forward_context: "ForwardContext"
-    ) -> tuple[Optional[set[str]], Optional[set[str]]]:
+    ) -> tuple[Optional[set[str]], Optional[set[str]], Optional[KVTransferAggregatedStats]]:
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
@@ -481,8 +482,8 @@ class P2pNcclEngine:
 
         # TODO:Retrieve requests that have already received the KV cache.
         finished_recving: set[str] = set()
-
-        return finished_sending or None, finished_recving or None
+        # TODO: Stats not supported yet.
+        return finished_sending or None, finished_recving or None, None
 
     def _ping(self):
         sock = self.context.socket(zmq.DEALER)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -861,6 +861,7 @@ class Scheduler(SchedulerInterface):
                         events=request.take_events(),
                         kv_transfer_params=kv_transfer_params,
                         num_cached_tokens=request.num_cached_tokens,
+                        kv_transfer_stats=model_runner_output.kv_transfer_stats,
                     ))
 
             else:

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Union
 import msgspec
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVTransferAggregatedStats
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MultiModalKwargs
 from vllm.multimodal.inputs import PlaceholderRange
@@ -114,6 +115,7 @@ class EngineCoreOutput(
     stop_reason: Union[int, str, None] = None
     events: Optional[list[EngineCoreEvent]] = None
     kv_transfer_params: Optional[dict[str, Any]] = None
+    kv_transfer_stats: Optional[KVTransferAggregatedStats] = None
 
     # The number of tokens with prefix cache hits.
     num_cached_tokens: int = 0

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -379,6 +379,7 @@ class OutputProcessor:
                 continue
 
             # 1) Compute stats for this iteration.
+            # TODO: add kv transfer stats
             self._update_stats_from_output(req_state, engine_core_output,
                                            engine_core_timestamp,
                                            iteration_stats)
@@ -455,7 +456,8 @@ class OutputProcessor:
                                            engine_core_timestamp,
                                            req_state.is_prefilling,
                                            req_state.prompt_len,
-                                           req_state.stats, lora_stats)
+                                           req_state.stats, lora_stats,
+                                           engine_core_output.kv_transfer_stats)
 
     def _update_stats_from_finished(self, req_state: RequestState,
                                     finish_reason: Optional[FinishReason],

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -6,6 +6,8 @@ from typing import NamedTuple, Optional
 
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVTransferAggregatedStats
+
 
 class LogprobsLists(NamedTuple):
 
@@ -110,6 +112,8 @@ class ModelRunnerOutput:
 
     # req_id -> num_nans_in_logits
     num_nans_in_logits: Optional[dict[str, int]] = None
+
+    kv_transfer_stats: Optional[KVTransferAggregatedStats] = None
 
 
 EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[],


### PR DESCRIPTION
First attempt at addressing observability for KVCache transfers, starting from outputting to std.out.

The main concern here is the fact that these metrics have to be gathered at the worker level -and in the worker process-while having to go all the way to the scheduler process.
This results in a couple perhaps-not-so-pleasant interface changes that I'd like to discuss in this thread.

How does it look:
```
INFO:     127.0.0.1:42880 - "POST /v1/completions HTTP/1.1" 200 OK
INFO 07-03 13:32:10 [loggers.py:123] Engine 000: Avg prompt throughput: 53.2 tokens/s, Avg generation throughput: 0.1 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.3%, Prefix cache hit rate: 0.0%
INFO 07-03 13:32:10 [metrics.py:109] KV Transfer metrics: KVTransferAggregatedStats(avg_transfer_durations=0.0, avg_bytes_transferred=0.0, num_blocks_transferred=0, num_successful_transfers=0)

INFO 07-03 13:32:20 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.3%, Prefix cache hit rate: 0.0%
INFO 07-03 13:32:20 [metrics.py:109] KV Transfer metrics: KVTransferAggregatedStats(avg_transfer_durations=0.0, avg_bytes_transferred=0.0, num_blocks_transferred=0, num_successful_transfers=0)
DEBUG 07-03 13:32:30 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.3%, Prefix cache hit rate: 0.0%
DEBUG 07-03 13:32:30 [metrics.py:109] KV Transfer metrics: KVTransferAggregatedStats(avg_transfer_durations=0.0, avg_bytes_transferred=0.0, num_blocks_transferred=0, num_successful_transfers=0)
```