### PR TITLE
[Frontend] fix duplicate output for bench subcmd

### DIFF
--- a/vllm/entrypoints/cli/benchmark/main.py
+++ b/vllm/entrypoints/cli/benchmark/main.py
@@ -44,6 +44,7 @@ class BenchmarkSubcommand(CLISubcommand):
                 cmd_cls.name,
                 help=cmd_cls.help,
                 description=cmd_cls.help,
+                usage=f"vllm bench {cmd_cls.name} [options]",
             )
             cmd_subparser.set_defaults(dispatch_function=cmd_cls.cmd)
             cmd_cls.add_cli_args(cmd_subparser)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose


Currently, bench `serve/throughput/latency` display two times for options. 
- Cause long text output
- Duplicate output
- Should same as the other format like `serve`
```
$ vllm bench latency --help
INFO 07-03 22:50:48 [__init__.py:244] Automatically detected platform cpu.
usage: vllm bench <bench_type> [options] latency [-h] [--input-len INPUT_LEN] [--output-len OUTPUT_LEN]
                                                 [--batch-size BATCH_SIZE] [--n N] [--use-beam-search]
                                                 [--num-iters-warmup NUM_ITERS_WARMUP]
                                                 [--num-iters NUM_ITERS] [--profile]
                                                 [--output-json OUTPUT_JSON] [--disable-detokenize]
                                                 [--model MODEL]
                                                 [--task {auto,classify,draft,embed,embedding,generate,reward,score,transcription}]
                                                 [--tokenizer TOKENIZER]
                                                 [--tokenizer-mode {auto,custom,mistral,slow}]
                                                 [--trust-remote-code | --no-trust-remote-code]
                                                 [--dtype {auto,bfloat16,float,float16,float32,half}]
                                                 [--seed SEED] [--hf-config-path HF_CONFIG_PATH]
                                                 [--allowed-local-media-path ALLOWED_LOCAL_MEDIA_PATH]
                                                 [--revision REVISION] [--code-revision CODE_REVISION]
                                                 [--rope-scaling ROPE_SCALING] [--rope-theta ROPE_THETA]
                                                 [--tokenizer-revision TOKENIZER_REVISION]
                                                 [--max-model-len MAX_MODEL_LEN]
                                                 [--quantization QUANTIZATION]
                                                 [--enforce-eager | --no-enforce-eager]
                                                 [--max-seq-len-to-capture MAX_SEQ_LEN_TO_CAPTURE]
                                                 [--max-logprobs MAX_LOGPROBS]
                                                 [--disable-sliding-window | --no-disable-sliding-window]
                                                 [--disable-cascade-attn | --no-disable-cascade-attn]
                                                 [--skip-tokenizer-init | --no-skip-tokenizer-init]
                                                 [--enable-prompt-embeds | --no-enable-prompt-embeds]
                                                 [--served-model-name SERVED_MODEL_NAME [SERVED_MODEL_NAME
                                                 ....
                                                
Benchmark the latency of a single batch of requests.

options:
  --batch-size BATCH_SIZE
  --disable-detokenize  Do not detokenize responses (i.e. do not include detokenization time in the
                        latency measurement) (default: False)
  --disable-log-stats   Disable logging statistics. (default: False)
  --input-len INPUT_LEN
  --n N                 Number of generated sequences per prompt. (default: 1)
  --num-iters NUM_ITERS
                        Number of iterations to run. (default: 30)
  --num-iters-warmup NUM_ITERS_WARMUP
                        Number of iterations to run for warmup. (default: 10)
```

To:
```
$ vllm bench latency --help
INFO 07-03 22:52:10 [__init__.py:244] Automatically detected platform cpu.
usage: vllm bench latency [options]

Benchmark the latency of a single batch of requests.

options:
  --batch-size BATCH_SIZE
  --disable-detokenize  Do not detokenize responses (i.e. do not include detokenization time in the
                        latency measurement) (default: False)
  --disable-log-stats   Disable logging statistics. (default: False)
  --input-len INPUT_LEN
  --n N                 Number of generated sequences per prompt. (default: 1)
```

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
