### PR TITLE
Map Mistral-HF models back onto Mistral format on-the-fly

### DIFF
--- a/vllm/model_executor/models/mistral3.py
+++ b/vllm/model_executor/models/mistral3.py
@@ -120,13 +120,13 @@ class Mistral3MultiModalProjector(nn.Module):
         self.linear_1 = ColumnParallelLinear(vision_hidden_size,
                                              text_hidden_size,
                                              bias=multimodal_projector_bias,
-                                             quant_config=quant_config,
+                                             quant_config=None,
                                              prefix=f"{prefix}.linear_1")
         self.act = get_act_fn(projector_hidden_act)
         self.linear_2 = RowParallelLinear(text_hidden_size,
                                           text_hidden_size,
                                           bias=multimodal_projector_bias,
-                                          quant_config=quant_config,
+                                          quant_config=None,
                                           prefix=f"{prefix}.linear_2")
 
     def forward(self, image_features: torch.Tensor,

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -56,7 +56,7 @@ from .vision import VisionEncoderInfo, resolve_visual_encoder_outputs
 import logging
 import os
 logger = logging.getLogger(__name__)
-logger.setLevel(os.environ["VLLM_LOGGING_LEVEL"])
+logger.setLevel(os.getenv("VLLM_LOGGING_LEVEL", "INFO"))
 
 try:
     from xformers import ops as xops

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -518,7 +518,7 @@ class PixtralForConditionalGeneration(nn.Module, SupportsMultiModal,
         r"^language_model\.model\.layers\.(\d+)\.(.+)\.(g_idx|zp|scales|zeros|qweight|qzeros)$": r"layers.\1.\2.\3"
     }
 
-    def maybe_remap_mistral3(self, name: str, tensor: torch.Tensor) -> Tuple[str, torch.Tensor]:
+    def maybe_remap_mistral3(self, name: str, tensor: torch.Tensor) -> tuple[str, torch.Tensor]:
         """Remap HF-style weight names back to original Pixtral format."""
         self.logger.debug(f"Considering {name}")
 

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -711,9 +711,10 @@ class FeedForward(nn.Module):
         self.w3 = nn.Linear(args.hidden_size,
                             args.intermediate_size,
                             bias=False)
+        self.act_fn = nn.GELU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+        return self.w2(self.act_fn(self.w1(x)) * self.w3(x))
 
 
 class Attention(nn.Module):

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -53,7 +53,9 @@ from .utils import (flatten_bn, init_vllm_registered_model, maybe_prefix,
                     merge_multimodal_embeddings)
 from .vision import VisionEncoderInfo, resolve_visual_encoder_outputs
 
-import logging
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
 import os
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VLLM_LOGGING_LEVEL", "INFO"))

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -697,10 +697,9 @@ class FeedForward(nn.Module):
         self.w3 = nn.Linear(args.hidden_size,
                             args.intermediate_size,
                             bias=False)
-        self.act_fn = nn.GELU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w2(self.act_fn(self.w1(x)) * self.w3(x))
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
 
 
 class Attention(nn.Module):

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -633,7 +633,7 @@ class VisionEncoderArgs:
     image_token_id: int
     adapter_bias: bool = True
     spatial_merge_size: int = 1
-    add_pre_mm_projector_layer_norm: bool = False
+    add_pre_mm_projector_layer_norm: bool = True
     mm_projector_id: str = ""
 
 

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -339,13 +339,14 @@ class PixtralForConditionalGeneration(nn.Module, SupportsMultiModal,
         raise ValueError("Only image modality is supported")
 
     packed_modules_mapping = {}
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config
         multimodal_config = vllm_config.model_config.multimodal_config
         self.config = config
         self.multimodal_config = multimodal_config
-        
+
         dataclass_fields = {field.name for field in fields(VisionEncoderArgs)}
         vision_args = {
             key: value
@@ -487,42 +488,66 @@ class PixtralForConditionalGeneration(nn.Module, SupportsMultiModal,
 
     # Reverse mapping from HF to original Pixtral format
     MISTRAL3_REVERSE_MAPPING = {
-        r"^language_model\.lm_head\.weight": r"output.weight",
-        r"^language_model\.model\.norm\.weight": r"norm.weight",
-        r"^language_model\.model\.embed_tokens\.weight": r"tok_embeddings.weight",
-        r"^language_model\.model\.layers\.(\d+)\.input_layernorm\.weight": r"layers.\1.attention_norm.weight",
-        r"^language_model\.model\.layers\.(\d+)\.post_attention_layernorm\.weight": r"layers.\1.ffn_norm.weight",
-        r"^language_model\.model\.layers\.(\d+)\.self_attn\.(q|k|v|o)_proj\.weight": r"layers.\1.attention.w\2.weight",
-        r"^language_model\.model\.layers\.(\d+)\.mlp\.gate_proj\.weight": r"layers.\1.feed_forward.w1.weight",
-        r"^language_model\.model\.layers\.(\d+)\.mlp\.down_proj\.weight": r"layers.\1.feed_forward.w2.weight",
-        r"^language_model\.model\.layers\.(\d+)\.mlp\.up_proj\.weight": r"layers.\1.feed_forward.w3.weight",
-        r"^vision_tower\.transformer\.layers\.(\d+)\.attention_norm\.weight": r"vision_encoder.transformer.layers.\1.attention_norm.weight",
-        r"^vision_tower\.transformer\.layers\.(\d+)\.ffn_norm\.weight": r"vision_encoder.transformer.layers.\1.ffn_norm.weight",
-        r"^vision_tower\.transformer\.layers\.(\d+)\.attention\.(q|k|v|o)_proj\.weight": r"vision_encoder.transformer.layers.\1.attention.w\2.weight",
-        r"^vision_tower\.transformer\.layers\.(\d+)\.feed_forward\.gate_proj\.weight": r"vision_encoder.transformer.layers.\1.feed_forward.w1.weight",
-        r"^vision_tower\.transformer\.layers\.(\d+)\.feed_forward\.down_proj\.weight": r"vision_encoder.transformer.layers.\1.feed_forward.w2.weight",
-        r"^vision_tower\.transformer\.layers\.(\d+)\.feed_forward\.up_proj\.weight": r"vision_encoder.transformer.layers.\1.feed_forward.w3.weight",
-        r"^multi_modal_projector\.linear_1": r"vision_language_adapter.w_in",
-        r"^multi_modal_projector\.linear_2": r"vision_language_adapter.w_out",
-        r"^vision_tower\.ln_pre\.weight": r"vision_encoder.ln_pre.weight",
-        r"^vision_tower\.patch_conv\.weight": r"vision_encoder.patch_conv.weight",
-        r"^multi_modal_projector\.patch_merger\.merging_layer\.weight": r"patch_merger.merging_layer.weight",
-        r"^multi_modal_projector\.norm\.weight": r"pre_mm_projector_norm.weight",
-        r"^language_model\.model\.layers\.(\d+)\.(.+)\.(g_idx|zp|scales|zeros|qweight|qzeros)$": r"layers.\1.\2.\3"
+        r"^language_model\.lm_head\.weight":
+        r"output.weight",
+        r"^language_model\.model\.norm\.weight":
+        r"norm.weight",
+        r"^language_model\.model\.embed_tokens\.weight":
+        r"tok_embeddings.weight",
+        r"^language_model\.model\.layers\.(\d+)\.input_layernorm\.weight":
+        r"layers.\1.attention_norm.weight",
+        r"^language_model\.model\.layers\.(\d+)\.post_attention_layernorm\.weight":
+        r"layers.\1.ffn_norm.weight",
+        r"^language_model\.model\.layers\.(\d+)\.self_attn\.(q|k|v|o)_proj\.weight":
+        r"layers.\1.attention.w\2.weight",
+        r"^language_model\.model\.layers\.(\d+)\.mlp\.gate_proj\.weight":
+        r"layers.\1.feed_forward.w1.weight",
+        r"^language_model\.model\.layers\.(\d+)\.mlp\.down_proj\.weight":
+        r"layers.\1.feed_forward.w2.weight",
+        r"^language_model\.model\.layers\.(\d+)\.mlp\.up_proj\.weight":
+        r"layers.\1.feed_forward.w3.weight",
+        r"^vision_tower\.transformer\.layers\.(\d+)\.attention_norm\.weight":
+        r"vision_encoder.transformer.layers.\1.attention_norm.weight",
+        r"^vision_tower\.transformer\.layers\.(\d+)\.ffn_norm\.weight":
+        r"vision_encoder.transformer.layers.\1.ffn_norm.weight",
+        r"^vision_tower\.transformer\.layers\.(\d+)\.attention\.(q|k|v|o)_proj\.weight":
+        r"vision_encoder.transformer.layers.\1.attention.w\2.weight",
+        r"^vision_tower\.transformer\.layers\.(\d+)\.feed_forward\.gate_proj\.weight":
+        r"vision_encoder.transformer.layers.\1.feed_forward.w1.weight",
+        r"^vision_tower\.transformer\.layers\.(\d+)\.feed_forward\.down_proj\.weight":
+        r"vision_encoder.transformer.layers.\1.feed_forward.w2.weight",
+        r"^vision_tower\.transformer\.layers\.(\d+)\.feed_forward\.up_proj\.weight":
+        r"vision_encoder.transformer.layers.\1.feed_forward.w3.weight",
+        r"^multi_modal_projector\.linear_1":
+        r"vision_language_adapter.w_in",
+        r"^multi_modal_projector\.linear_2":
+        r"vision_language_adapter.w_out",
+        r"^vision_tower\.ln_pre\.weight":
+        r"vision_encoder.ln_pre.weight",
+        r"^vision_tower\.patch_conv\.weight":
+        r"vision_encoder.patch_conv.weight",
+        r"^multi_modal_projector\.patch_merger\.merging_layer\.weight":
+        r"patch_merger.merging_layer.weight",
+        r"^multi_modal_projector\.norm\.weight":
+        r"pre_mm_projector_norm.weight",
+        r"^language_model\.model\.layers\.(\d+)\.(.+)\.(g_idx|zp|scales|zeros|qweight|qzeros)$":
+        r"layers.\1.\2.\3"
     }
 
-    def maybe_remap_mistral3(self, name: str, tensor: torch.Tensor) -> tuple[str, torch.Tensor]:
+    def maybe_remap_mistral3(self, name: str,
+                             tensor: torch.Tensor) -> tuple[str, torch.Tensor]:
         """Remap HF-style weight names back to original Pixtral format."""
 
         for pattern, replacement in self.MISTRAL3_REVERSE_MAPPING.items():
             new_name, n_replace = re.subn(pattern, replacement, name)
             if n_replace > 0:
-                logger.debug(f"remapped %s to %s for Pixtral compat", name, new_name)
+                logger.debug("remapped %s to %s for Pixtral compat", name,
+                             new_name)
                 return new_name, tensor
         return name, tensor  # Return unchanged if no match
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-    
+
         def is_vision_encoder_weights(weight: tuple[str, torch.Tensor]):
             return weight[0].startswith("vision_encoder")
 
@@ -554,7 +579,8 @@ class PixtralForConditionalGeneration(nn.Module, SupportsMultiModal,
 
         def llm_weights_generator():
             # Single pass over weights
-            remapped_weights = (self.maybe_remap_mistral3(name, w) for name, w in weights)
+            remapped_weights = (self.maybe_remap_mistral3(name, w)
+                                for name, w in weights)
             for name, w in remapped_weights:
                 if is_vision_encoder_weights((name, w)):
                     # Load vision encoder weights directly
@@ -565,9 +591,7 @@ class PixtralForConditionalGeneration(nn.Module, SupportsMultiModal,
                         dim1 = param.shape[0]  # num_heads * head_dim
                         dim2 = param.shape[1]  # hidden_size
                         w = inverse_permute_for_rope(w, n_heads, dim1, dim2)
-                        logger.debug(
-                            "reversed permute_for_rope for %s", name
-                        )
+                        logger.debug("reversed permute_for_rope for %s", name)
                     with torch.no_grad():
                         default_weight_loader(param, w)
                 elif is_patch_merger((name, w)):

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -216,6 +216,7 @@ _MULTIMODAL_MODELS = {
     "PaliGemmaForConditionalGeneration": ("paligemma", "PaliGemmaForConditionalGeneration"),  # noqa: E501
     "Phi3VForCausalLM": ("phi3v", "Phi3VForCausalLM"),
     "PixtralForConditionalGeneration": ("pixtral", "PixtralForConditionalGeneration"),  # noqa: E501
+    "Mistral3ForConditionalGeneration": ("pixtral", "PixtralForConditionalGeneration"),  # noqa: E501
     "QwenVLForConditionalGeneration": ("qwen_vl", "QwenVLForConditionalGeneration"),  # noqa: E501
     "Qwen2VLForConditionalGeneration": ("qwen2_vl", "Qwen2VLForConditionalGeneration"),  # noqa: E501
     "Qwen2_5_VLForConditionalGeneration": ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),  # noqa: E501

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -216,7 +216,7 @@ _MULTIMODAL_MODELS = {
     "PaliGemmaForConditionalGeneration": ("paligemma", "PaliGemmaForConditionalGeneration"),  # noqa: E501
     "Phi3VForCausalLM": ("phi3v", "Phi3VForCausalLM"),
     "PixtralForConditionalGeneration": ("pixtral", "PixtralForConditionalGeneration"),  # noqa: E501
-    "Mistral3ForConditionalGeneration": ("pixtral", "PixtralForConditionalGeneration"),  # noqa: E501
+    "Mistral3ForConditionalGeneration":  ("pixtral", "PixtralForConditionalGeneration"),  # noqa: E501
     "QwenVLForConditionalGeneration": ("qwen_vl", "QwenVLForConditionalGeneration"),  # noqa: E501
     "Qwen2VLForConditionalGeneration": ("qwen2_vl", "Qwen2VLForConditionalGeneration"),  # noqa: E501
     "Qwen2_5_VLForConditionalGeneration": ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),  # noqa: E501


### PR DESCRIPTION
## Purpose

This is a WIP PR to begin the process of integrating the changes from my Mistral-3.1-rebase branch onto main. I've used this with success to utilize quantized checkpoints of Mistral-Small-3.1 and Mistral-Small-3.2 along with the Mistral tokenizer, enabling tool calling. We just take the transformers Mistral conversion script and invert its operations on checkpoint load, which means remapping the weight names and reversing their RoPE modifications.

It also requires some minor massaging of the `config.json` to successfully load, which you can see here: https://huggingface.co/jeffcookio/Mistral-Small-3.2-24B-Instruct-2506-awq-sym/commit/00a485337ebdba586119eacbcd6e54c3dff75c11

This allows one to use quantized Mistral-HF checkpoints with `--tokenizer-mode mistral` (*not* `--load-format mistral` or `--config-format mistral`) on startup. Both image and text modalities work great in my experience and are at least as good as running the HF checkpoints on main (but I haven't run any evals).

Things to improve to exit WIP status:

* [ ] Quantized weights are not loaded intelligently/dynamically really, we just have a regex that remaps common quantized weight names at the end of `MISTRAL3_REVERSE_MAPPING`.
* [ ] `add_pre_mm_projector_layer_norm` default is swapped to `True` to work around failure to read this value out of `config.json`. This breaks earlier Pixtrals.
* [ ] `QuantConfig` explicitly set to `None` on `multi_modal_projector` instead of dynamically detecting whether its quantized in that particular checkpoint or not.
* [ ] I'm not clear if we should use `F.silu` or `nn.GELU` for the activation on the forward pass (you can see commits going back and forth on this as I was testing). This is another change `transformers` makes in its implementation
* [ ] No tests or documentation updates.
* [ ] No sign-offs 
* [x] No `yapf` formatting.
* [ ] `Mistral3ForConditionalGeneration` is overridden in the model registry with a repeated registry key. We may need to introduce a special architecture name or an additional flag read out of `config.json` to allow users to specify whether we should try to load the checkpoint as Mistral-HF or Pixtral.

Note: requires https://github.com/vllm-project/vllm/pull/20503 for successful tool calling with Mistral-Small-3.2.

Creating this as WIP instead of just an ongoing branch on my fork because @mgoin expressed interest in it at https://vllm-dev.slack.com/archives/C07QP347J4D/p1751465349646219?thread_ts=1751399869.254259&cid=C07QP347J4D.

Please feel free to hack away on this, make suggestions, etc. I'd love to see it upstreamed so I don't have to keep maintaining it separately.

## Test Plan

Write some tests to validate behavior.

## Test Result

N/A yet.

## (Optional) Documentation Update

Should document the ability to run Mistral-HF quantized checkpoints with `--tokenizer-mode mistral`, and additionally, should document that failure to do so prohibits tool calling.