### PR TITLE
[Bugfix] improve regex for hermes tool detection

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
@@ -105,11 +105,11 @@ class Hermes2ProToolParser(ToolParser):
                 ]
                 tool_call_start = model_output.find(self.tool_call_start_token)
                 content = (model_output[:tool_call_start]
-                           if tool_call_start >= 0 else None)
+                           if tool_call_start > 0 else None)
                 return ExtractedToolCallInformation(
                     tools_called=True,
                     tool_calls=tool_calls,
-                    content=content if content else None)
+                    content=content)
 
             except Exception:
                 logger.exception(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

Improve the hermes parser to be less strict. Some model like qwen can sometimes output double xml tag for tool_call.

Generated output:
```
\n<tool_call>\n<tool_call>\n[...REDACTED...]\n</tool_call>
```

Stack
```
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111] Error in extracting tool call from response.
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111] Traceback (most recent call last):
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py", line 89, in extract_tool_ca
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]     json.loads(match[0] if match[0] else match[1])
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]   File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]     return _default_decoder.decode(s)
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]   File "/usr/lib/python3.12/json/decoder.py", line 338, in decode
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]   File "/usr/lib/python3.12/json/decoder.py", line 356, in raw_decode
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111]     raise JSONDecodeError("Expecting value", s, err.value) from None
api ERROR 07-04 00:00:23 [hermes_tool_parser.py:111] json.decoder.JSONDecodeError: Expecting value: line 2 column 1 (char 1)
```


## Test Plan

Difficult to give you a buggy prompt as our contains sensitive information. 

## Test Result

Result completion with buggy prompt:

Before
```json
{
  "id": "chatcmpl-vgunWp",
  "object": "chat.completion",
  "created": 1751612418,
  "model": "Qwen/Qwen2.5-72B-Instruct",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "reasoning_content": null,
        "content": "The repository contains the following files:\n\n- `.gitattributes`\n- `.py`\n- `README.md`\n- `app.py`\n- `requirements.txt`\n\nNext, I will review the contents of these files. Let's start with the `app.py` file, which is likely the main application script.\n<tool_call>\n<tool_call>\n{\"name\": \"tool-1_hf_get_file_content\", \"arguments\": {\"file_path\": \"app.py\", \"repo_type\": \"spaces\", \"repository\": \"xcid/test\"}}\n</tool_call>",
        "tool_calls": []
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": null
    }
  ],
  "usage": {
    "prompt_tokens": 3052,
    "total_tokens": 3173,
    "completion_tokens": 121,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "kv_transfer_params": null
}
```

After
```json
{
  "id": "chatcmpl-BGqu6p",
  "object": "chat.completion",
  "created": 1751612343,
  "model": "Qwen/Qwen2.5-72B-Instruct",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "reasoning_content": null,
        "content": "The repository contains the following files:\n\n- `.gitattributes`\n- `.py`\n- `README.md`\n- `app.py`\n- `requirments.txt`\n\nNext, I will review the contents of these files. Let's start with the `app.py` file, which is likely the main application script.\n",
        "tool_calls": [
          {
            "id": "chatcmpl-tool-6b38a134cc2d4f3b84526f2936155583",
            "type": "function",
            "function": {
              "name": "tool-1_hf_get_file_content",
              "arguments": "{\"repo_type\": \"spaces\", \"repository\": \"xcid/test\", \"file_path\": \"app.py\"}"
            }
          }
        ]
      },
      "logprobs": null,
      "finish_reason": "tool_calls",
      "stop_reason": null
    }
  ],
  "usage": {
    "prompt_tokens": 3052,
    "total_tokens": 3173,
    "completion_tokens": 121,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "kv_transfer_params": null
}
```

Co-authored-by: @oOraph
