### PR TITLE
[Bugfix] Prevent IndexError for cached requests when pipeline parallelism is disabled

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -635,6 +635,8 @@ class Scheduler(SchedulerInterface):
                 token_ids = req.all_token_ids[req.num_computed_tokens:req.
                                               num_computed_tokens + num_tokens]
                 new_token_ids.append(token_ids)
+            else:
+                new_token_ids.append([])
             new_block_ids.append(req_to_new_block_ids[req_id])
             num_computed_tokens.append(req.num_computed_tokens)
         # Because resumed_reqs is usually empty, it is more efficient to do


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
To fix #20485 

When pipeline parallelism (`use_pp`) is disabled, the `new_token_ids` list was not populated, while other lists in the same scope, such as `req_ids` and `new_block_ids`, were. This discrepancy in list lengths could lead to an `IndexError: list index out of range` in downstream code that consumes the `CachedRequestData` object.

The fix ensures that `new_token_ids` is always aligned with the other lists by appending an empty list (`[]`) for each request when `use_pp` is `False`. This guarantees consistent list lengths and prevents the runtime error, improving the scheduler's robustness.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
