### PR TITLE
test_attention compat with coming xformers change

### DIFF
--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -450,7 +450,8 @@ def test_multi_query_kv_attention(
             start += seq_len
         # xformers.AttentionBias to Tensor for use in reference impl.
         alibi_bias = [
-            b.materialize(b.shape, device=device).squeeze() for b in attn_bias
+            b.materialize((num_query_heads, i, i), device=device).squeeze()
+            for b, i in zip(attn_bias, seq_lens)
         ]
     else:
         attn_bias = BlockDiagonalCausalMask.from_seqlens(seq_lens)

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -450,7 +450,7 @@ def test_multi_query_kv_attention(
             start += seq_len
         # xformers.AttentionBias to Tensor for use in reference impl.
         alibi_bias = [
-            b.materialize((num_query_heads, i, i), device=device).squeeze()
+            b.materialize((1, num_query_heads, i, i), device=device).squeeze()
             for b, i in zip(attn_bias, seq_lens)
         ]
     else:


### PR DESCRIPTION
Summary:
Update a test in vllm to not depend on internal details of the LowerTriangularMaskWithTensorBias object in xformers. This makes it work both with and without an expected upcoming change to xformers.

Testing: this is a small change to a vllm test which leaves it passing.

Context: the xformers library is expecting to change bias types back to not inherit tensors - basically https://github.com/facebookresearch/xformers/commit/96fd4808a4e976b0f30bff6d2f413df7d9d9a2d1 will be reverted. That inheritance is no longer needed for torch.compile, and in fact makes life harder for torch.export.

Test Plan:
See CI on D75689669

Rollback Plan:

Differential Revision: D77789850


