### PR TITLE
fix crash when empty sequence is sent to cuda penalty kernel

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -311,7 +311,7 @@ def apply_repetition_penalties(logits: torch.Tensor, prompt_mask: torch.Tensor,
         output_mask: A boolean tensor indicating which tokens appear in the output.
         repetition_penalties: The repetition penalties of shape (num_seqs, ).
     """
-    if current_platform.is_cuda() and logits.is_contiguous():
+    if current_platform.is_cuda() and logits.is_contiguous() and logits.size(0) > 0:
         apply_repetition_penalties_cuda(logits, prompt_mask, output_mask,
                                         repetition_penalties)
     else:


### PR DESCRIPTION
Fixes #20484


Debug code that allowed me to find the issue : 

```python
 print('before apply_repetition_penalties')
    # Apply repetition penalties as a custom op
    from vllm._custom_ops import apply_repetition_penalties
    try:
        print('logits.shape', logits.shape)
        print('prompt_mask.shape', prompt_mask.shape)
        print('output_mask.shape', output_mask.shape)
        print('repetition_penalties.shape', repetition_penalties.shape)
        
        
        print('logits', logits)
        print('prompt_mask', prompt_mask)
        print('output_mask', output_mask)
        print('repetition_penalties', repetition_penalties)
        
        
        apply_repetition_penalties(logits, prompt_mask, output_mask,
                               repetition_penalties)
    except Exception as e:
        print(f"Error applying repetition penalties: {e}")
        raise
    print('after apply_repetition_penalties')
    
    
```
    It crashed right after : 
    
```text
before apply_repetition_penalties
logits.shape torch.Size([0, 152064])
prompt_mask.shape torch.Size([0, 152064])
output_mask.shape torch.Size([0, 152064])
repetition_penalties.shape torch.Size([0])
logits tensor([], device='cuda:0', size=(0, 152064), dtype=torch.bfloat16)
prompt_mask tensor([], device='cuda:0', size=(0, 152064), dtype=torch.bool)
output_mask tensor([], device='cuda:0', size=(0, 152064), dtype=torch.bool)
repetition_penalties tensor([], device='cuda:0', dtype=torch.bfloat16)
ERROR 07-04 12:26:45 [client.py:307] RuntimeError('Engine process (pid 3667499) died.')
ERROR 07-04 12:26:45 [client.py:307] NoneType: None
```


Cause : `int tile_num = std::min(vocab_size, std::max(1, (sms + num_seqs - 1) / num_seqs));` has division by zero


    