### PR TITLE
feat(sleep): should empty_cache when sleep

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -80,6 +80,9 @@ class Worker(WorkerBase):
 
     def sleep(self, level: int = 1) -> None:
         free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
+        # should empty_cache before sleep since torch may allocate some other mem in cache segments
+        # after handling user completion requests
+        torch.cuda.empty_cache()
 
         # Save the buffers before level 2 sleep
         if level == 2:

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -134,6 +134,9 @@ class Worker(LocalOrDistributedWorkerBase):
 
     def sleep(self, level: int = 1) -> None:
         free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
+        # should empty_cache before sleep since torch may allocate some other mem in cache segments
+        # after handling user completion requests
+        torch.cuda.empty_cache()
 
         # Save the buffers before level 2 sleep
         if level == 2:


### PR DESCRIPTION
Should empty_cache before sleep since torch may allocate some other mem in cache segments after handling user completion requests