### PR TITLE
[Bugfix] Fix missing per_act_token parameter in compressed_tensors_moe

### DIFF
--- a/vllm/model_executor/layers/fused_moe/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cutlass_moe.py
@@ -322,7 +322,7 @@ def cutlass_moe_fp8(
     topk_ids: torch.Tensor,
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
-    per_act_token: bool,
+    per_act_token: Optional[bool] = None,
     activation: str = "silu",
     a1_scale: Optional[torch.Tensor] = None,
     a2_scale: Optional[torch.Tensor] = None,
@@ -366,6 +366,9 @@ def cutlass_moe_fp8(
     Returns:
     - torch.Tensor: The fp16 output tensor after applying the MoE layer.
     """
+    if per_act_token is None:
+        per_act_token = a1_scale.numel() != 1 if a1_scale is not None else (
+            a2_scale.numel() != 1 if a2_scale is not None else False)
     per_out_ch = w1_scale.numel() != w1_q.size(0)
 
     num_experts = global_num_experts if global_num_experts != -1 else w1_q.size(


### PR DESCRIPTION
## Purpose
Fix maverick serving broken issue from refactor PR #19636.

`per_act_token` was added in cutlass_moe_fp8 in PR #19636, but not passed in in some caller (e.g. CompressedTensorsW8A8Fp8MoECutlassMethod) and not given default value, causing failure,

e.g.
https://github.com/vllm-project/vllm/blob/7e908704919376cea9ff0f361596c1a0b14db1a3/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py#L934-L940

the per_act_token assignment was removed in PR #19636, so we add back the value if it is not passed (default None) to fix Maverick serving issue
## Test Plan

Serving:

```
export MODEL=/data/users/vllm/models/maverick_instruct_fp8_oss; VLLM_DISABLE_COMPILE_CACHE=1 lm_eval --model vllm --tasks gsm8k --model_args pretrained=$MODEL,max_model_len=131072,tensor_parallel_size=8 --batch_size auto
```

lm_eval:

```
VLLM_DISABLE_COMPILE_CACHE=1 lm_eval --model vllm --tasks gsm8k --model_args pretrained=$MODEL,max_model_len=131072,tensor_parallel_size=8 --batch_size auto
```

```
vllm (pretrained=/data/users/vllm/models/maverick_instruct_fp8_oss,max_model_len=131072,tensor_parallel_size=8), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9227|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9212|±  |0.0074|

```

