### PR TITLE
[Prefix Cache] Add reproducible prefix-cache block hashing using SHA-256 + CBOR (64bit)

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -47,3 +47,4 @@ python-json-logger # Used by logging as per examples/others/logging_configuratio
 scipy # Required for phi-4-multimodal-instruct
 ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
+cbor2 # Required for cross-language serialization of hashable objects

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,6 +11,7 @@ ruff
 # Required for argparse hook only
 -f https://download.pytorch.org/whl/cpu
 cachetools
+cbor2
 cloudpickle
 fastapi
 msgspec

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -8,7 +8,7 @@ import torch
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
 from vllm.sampling_params import SamplingParams
-from vllm.utils import GiB_bytes, sha256, sha256_cbor
+from vllm.utils import GiB_bytes, sha256, sha256_cbor_64bit
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 # disable yapf here as it formats differently than isort such that both fail
 # yapf: disable
@@ -79,7 +79,7 @@ def new_sliding_window_spec(block_size=16,
                              sliding_window=sliding_window)
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor_64bit, hash])
 def test_none_hash(monkeypatch, hash_fn):
     import vllm.v1.core.kv_cache_utils
 
@@ -291,7 +291,7 @@ def test_generate_block_hash_extra_keys_cache_salt():
     assert next_mm_idx == 1
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor_64bit, hash])
 def test_hash_block_tokens(hash_fn):
     import vllm.v1.core.kv_cache_utils
     init_none_hash(hash_fn)
@@ -308,7 +308,7 @@ def test_hash_block_tokens(hash_fn):
     assert block_hash.extra_keys == extra_keys
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor_64bit, hash])
 def test_hash_request_tokens(hash_fn):
     import vllm.v1.core.kv_cache_utils
     init_none_hash(hash_fn)
@@ -338,7 +338,7 @@ def test_hash_request_tokens(hash_fn):
     assert block_hashes[1].extra_keys == ("hash2", )
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor_64bit, hash])
 def test_hash_tokens_different_mm_input(hash_fn):
     init_none_hash(hash_fn)
 
@@ -367,7 +367,7 @@ def test_hash_tokens_different_mm_input(hash_fn):
     assert block_hashes1[1] != block_hashes2[1]
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor_64bit, hash])
 def test_hash_request_tokens_no_mm_inputs(hash_fn):
     init_none_hash(hash_fn)
 

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -16,8 +16,8 @@ from vllm.v1.core.kv_cache_utils import (
     FreeKVCacheBlockQueue, KVCacheBlock, PrefixCachingMetrics,
     estimate_max_model_len, generate_block_hash_extra_keys,
     get_kv_cache_config, get_max_concurrency_for_kv_cache_config,
-    hash_block_tokens, hash_request_tokens, unify_kv_cache_configs,
-    init_none_hash)
+    hash_block_tokens, hash_request_tokens, init_none_hash,
+    unify_kv_cache_configs)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, KVCacheTensor,
                                         SlidingWindowSpec)
@@ -77,6 +77,7 @@ def new_sliding_window_spec(block_size=16,
                              dtype=dtype,
                              use_mla=use_mla,
                              sliding_window=sliding_window)
+
 
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_none_hash(monkeypatch, hash_fn):
@@ -339,7 +340,6 @@ def test_hash_request_tokens(hash_fn):
 
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_hash_tokens_different_mm_input(hash_fn):
-    import vllm.v1.core.kv_cache_utils
     init_none_hash(hash_fn)
 
     request1 = make_request(
@@ -369,7 +369,6 @@ def test_hash_tokens_different_mm_input(hash_fn):
 
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_hash_request_tokens_no_mm_inputs(hash_fn):
-    import vllm.v1.core.kv_cache_utils
     init_none_hash(hash_fn)
 
     request = make_request(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -8,7 +8,7 @@ import torch
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
 from vllm.sampling_params import SamplingParams
-from vllm.utils import GiB_bytes, sha256
+from vllm.utils import GiB_bytes, sha256, sha256_cbor
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 # disable yapf here as it formats differently than isort such that both fail
 # yapf: disable
@@ -16,7 +16,8 @@ from vllm.v1.core.kv_cache_utils import (
     FreeKVCacheBlockQueue, KVCacheBlock, PrefixCachingMetrics,
     estimate_max_model_len, generate_block_hash_extra_keys,
     get_kv_cache_config, get_max_concurrency_for_kv_cache_config,
-    hash_block_tokens, hash_request_tokens, unify_kv_cache_configs)
+    hash_block_tokens, hash_request_tokens, unify_kv_cache_configs,
+    init_none_hash)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, KVCacheTensor,
                                         SlidingWindowSpec)
@@ -77,25 +78,27 @@ def new_sliding_window_spec(block_size=16,
                              use_mla=use_mla,
                              sliding_window=sliding_window)
 
-
-def test_none_hash(monkeypatch):
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
+def test_none_hash(monkeypatch, hash_fn):
     import vllm.v1.core.kv_cache_utils
 
     # case 1: PYTHONHASHSEED is not set, use random
     with monkeypatch.context() as m:
         m.delenv('PYTHONHASHSEED', raising=False)
         reloaded_kv_cache_utils = importlib.reload(vllm.v1.core.kv_cache_utils)
+        reloaded_kv_cache_utils.init_none_hash(hash_fn)
         assert reloaded_kv_cache_utils.NONE_HASH is not None
         assert isinstance(reloaded_kv_cache_utils.NONE_HASH, int)
         assert reloaded_kv_cache_utils.NONE_HASH != 0
 
-    # case 2: PYTHONHASHSEED is set, use the seed
+    # case 2: PYTHONHASHSEED is set, use the seed and hash_fn
     with monkeypatch.context() as m:
         m.setenv('PYTHONHASHSEED', 'python hash seed')
         reloaded_kv_cache_utils = importlib.reload(vllm.v1.core.kv_cache_utils)
+        reloaded_kv_cache_utils.init_none_hash(hash_fn)
         assert reloaded_kv_cache_utils.NONE_HASH is not None
         assert isinstance(reloaded_kv_cache_utils.NONE_HASH, int)
-        assert sha256('python hash seed') == reloaded_kv_cache_utils.NONE_HASH
+        assert hash_fn('python hash seed') == reloaded_kv_cache_utils.NONE_HASH
 
 
 def test_kv_cache_block():
@@ -287,9 +290,10 @@ def test_generate_block_hash_extra_keys_cache_salt():
     assert next_mm_idx == 1
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_hash_block_tokens(hash_fn):
     import vllm.v1.core.kv_cache_utils
+    init_none_hash(hash_fn)
     parent_block_hash = 123
     curr_block_token_ids = (1, 2, 3)
     extra_keys = ("key1", "key2")
@@ -303,9 +307,10 @@ def test_hash_block_tokens(hash_fn):
     assert block_hash.extra_keys == extra_keys
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_hash_request_tokens(hash_fn):
     import vllm.v1.core.kv_cache_utils
+    init_none_hash(hash_fn)
     request = make_request(
         request_id=0,
         prompt_token_ids=[_ for _ in range(6)],
@@ -332,8 +337,11 @@ def test_hash_request_tokens(hash_fn):
     assert block_hashes[1].extra_keys == ("hash2", )
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_hash_tokens_different_mm_input(hash_fn):
+    import vllm.v1.core.kv_cache_utils
+    init_none_hash(hash_fn)
+
     request1 = make_request(
         request_id=0,
         prompt_token_ids=[_ for _ in range(6)],
@@ -359,8 +367,11 @@ def test_hash_tokens_different_mm_input(hash_fn):
     assert block_hashes1[1] != block_hashes2[1]
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_hash_request_tokens_no_mm_inputs(hash_fn):
+    import vllm.v1.core.kv_cache_utils
+    init_none_hash(hash_fn)
+
     request = make_request(
         request_id=0,
         prompt_token_ids=[_ for _ in range(6)],

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -15,7 +15,8 @@ from vllm.utils import sha256, sha256_cbor
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheManager, Request
 from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
-                                         KVCacheBlock, hash_block_tokens, init_none_hash)
+                                         KVCacheBlock, hash_block_tokens,
+                                         init_none_hash)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, SlidingWindowSpec)
 
@@ -101,9 +102,8 @@ def test_prefill(hash_algo):
     )
 
     # choose the hash function according to the parameter
-    hash_fn = (
-            sha256_cbor if hash_algo == "sha256_cbor" else
-            sha256 if hash_algo == "sha256" else hash)
+    hash_fn = (sha256_cbor if hash_algo == "sha256_cbor" else
+               sha256 if hash_algo == "sha256" else hash)
 
     # Complete 3 blocks (48 tokens)
     common_token_ids = [i for i in range(3) for _ in range(16)]

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -11,11 +11,11 @@ import torch
 from vllm.distributed.kv_events import AllBlocksCleared, BlockRemoved
 from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
 from vllm.sampling_params import SamplingParams
-from vllm.utils import sha256
+from vllm.utils import sha256, sha256_cbor
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheManager, Request
 from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
-                                         KVCacheBlock, hash_block_tokens)
+                                         KVCacheBlock, hash_block_tokens, init_none_hash)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, SlidingWindowSpec)
 
@@ -91,7 +91,7 @@ def make_kv_cache_config_hybrid_model(block_size: int,
     )
 
 
-@pytest.mark.parametrize("hash_algo", ["sha256", "hash"])
+@pytest.mark.parametrize("hash_algo", ["sha256", "sha256_cbor", "hash"])
 def test_prefill(hash_algo):
     manager = KVCacheManager(
         make_kv_cache_config(16, 11),
@@ -101,7 +101,9 @@ def test_prefill(hash_algo):
     )
 
     # choose the hash function according to the parameter
-    hash_fn = sha256 if hash_algo == "sha256" else hash
+    hash_fn = (
+            sha256_cbor if hash_algo == "sha256_cbor" else
+            sha256 if hash_algo == "sha256" else hash)
 
     # Complete 3 blocks (48 tokens)
     common_token_ids = [i for i in range(3) for _ in range(16)]
@@ -696,12 +698,14 @@ def test_basic_prefix_caching_disabled():
     assert not blocks
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
 def test_cache_blocks(hash_fn):
     """
     This is a unit test that tests the correctness of the _cache_full_blocks
     function of KVCacheManager.
     """
+    init_none_hash(hash_fn)
+
     block_size = 4
     block_pool = BlockPool(
         num_gpu_blocks=5,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -11,7 +11,7 @@ import torch
 from vllm.distributed.kv_events import AllBlocksCleared, BlockRemoved
 from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
 from vllm.sampling_params import SamplingParams
-from vllm.utils import sha256, sha256_cbor
+from vllm.utils import sha256, sha256_cbor_64bit
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheManager, Request
 from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
@@ -92,7 +92,7 @@ def make_kv_cache_config_hybrid_model(block_size: int,
     )
 
 
-@pytest.mark.parametrize("hash_algo", ["sha256", "sha256_cbor", "hash"])
+@pytest.mark.parametrize("hash_algo", ["sha256", "sha256_cbor_64bit", "hash"])
 def test_prefill(hash_algo):
     manager = KVCacheManager(
         make_kv_cache_config(16, 11),
@@ -102,7 +102,7 @@ def test_prefill(hash_algo):
     )
 
     # choose the hash function according to the parameter
-    hash_fn = (sha256_cbor if hash_algo == "sha256_cbor" else
+    hash_fn = (sha256_cbor_64bit if hash_algo == "sha256_cbor_64bit" else
                sha256 if hash_algo == "sha256" else hash)
 
     # Complete 3 blocks (48 tokens)
@@ -698,7 +698,7 @@ def test_basic_prefix_caching_disabled():
     assert not blocks
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor, hash])
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor_64bit, hash])
 def test_cache_blocks(hash_fn):
     """
     This is a unit test that tests the correctness of the _cache_full_blocks

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1503,7 +1503,7 @@ class ModelConfig:
 
 BlockSize = Literal[1, 8, 16, 32, 64, 128]
 CacheDType = Literal["auto", "fp8", "fp8_e4m3", "fp8_e5m2"]
-PrefixCachingHashAlgo = Literal["builtin", "sha256"]
+PrefixCachingHashAlgo = Literal["builtin", "sha256", "sha256_cbor"]
 
 
 @config
@@ -1548,7 +1548,12 @@ class CacheConfig:
     prefix_caching_hash_algo: PrefixCachingHashAlgo = "builtin"
     """Set the hash algorithm for prefix caching:\n
     - "builtin" is Python's built-in hash.\n
-    - "sha256" is collision resistant but with certain overheads."""
+    - "sha256" is collision resistant but with certain overheads.
+    This option uses Pickle for object serialization before hashing.\n
+    - "sha256_cbor" provides a reproducible, cross-language compatible hash. 
+    It serializes objects using canonical CBOR and hashes them with SHA-256. 
+    The resulting hash is truncated to 64 bits for compatibility with certain
+    vLLM components."""
     cpu_offload_gb: float = 0
     """The space in GiB to offload to CPU, per GPU. Default is 0, which means
     no offloading. Intuitively, this argument can be seen as a virtual way to

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1503,7 +1503,7 @@ class ModelConfig:
 
 BlockSize = Literal[1, 8, 16, 32, 64, 128]
 CacheDType = Literal["auto", "fp8", "fp8_e4m3", "fp8_e5m2"]
-PrefixCachingHashAlgo = Literal["builtin", "sha256", "sha256_cbor"]
+PrefixCachingHashAlgo = Literal["builtin", "sha256", "sha256_cbor_64bit"]
 
 
 @config
@@ -1550,10 +1550,10 @@ class CacheConfig:
     - "builtin" is Python's built-in hash.\n
     - "sha256" is collision resistant but with certain overheads.
     This option uses Pickle for object serialization before hashing.\n
-    - "sha256_cbor" provides a reproducible, cross-language compatible hash. 
-    It serializes objects using canonical CBOR and hashes them with SHA-256. 
-    The resulting hash is truncated to 64 bits for compatibility with certain
-    vLLM components."""
+    - "sha256_cbor_64bit" provides a reproducible, cross-language compatible 
+    hash. It serializes objects using canonical CBOR and hashes them with 
+    SHA-256. The resulting hash consists of the lower 64 bits of the SHA-256
+    digest."""
     cpu_offload_gb: float = 0
     """The space in GiB to offload to CPU, per GPU. Default is 0, which means
     no offloading. Intuitively, this argument can be seen as a virtual way to

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3177,6 +3177,7 @@ def sha256(input) -> int:
     return int.from_bytes(hashlib.sha256(input_bytes).digest(),
                           byteorder="big")
 
+
 def sha256_cbor(input) -> int:
     """
     Hash objects using CBOR serialization and SHA-256, then truncate to 64bits.

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3178,12 +3178,11 @@ def sha256(input) -> int:
                           byteorder="big")
 
 
-def sha256_cbor(input) -> int:
+def sha256_cbor_64bit(input) -> int:
     """
     Hash objects using CBOR serialization and SHA-256, then truncate to 64bits.
 
-    This option is useful for non-Python-dependent serialization and hashing,
-    while ensuring the result fits within a 64-bit unsigned integer.
+    This option is useful for non-Python-dependent serialization and hashing.
 
     Args:
         input: Object to be serialized and hashed. Supported types include
@@ -3193,13 +3192,12 @@ def sha256_cbor(input) -> int:
 
     Returns:
         An integer in the range [0, 2^64-1] representing the lower 64 bits
-        of the SHA-256 hash of the serialized input.
+        of the SHA-256 hash of the CBOR serialized input.
     """
     input_bytes = cbor2.dumps(input, canonical=True)
     full_hash = int.from_bytes(hashlib.sha256(input_bytes).digest(),
                                byteorder="big")
-    # Truncate to 64 bits for compatibility with 64-bit serializers (KVEvents)
-    # TODO: KVEvents hash type to support arbitrary length hashes
+
     return full_hash & ((1 << 64) - 1)
 
 

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -52,6 +52,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import cachetools
+import cbor2
 import cloudpickle
 import numpy as np
 import numpy.typing as npt
@@ -3175,6 +3176,30 @@ def sha256(input) -> int:
     input_bytes = pickle.dumps(input, protocol=pickle.HIGHEST_PROTOCOL)
     return int.from_bytes(hashlib.sha256(input_bytes).digest(),
                           byteorder="big")
+
+def sha256_cbor(input) -> int:
+    """
+    Hash objects using CBOR serialization and SHA-256, then truncate to 64bits.
+
+    This option is useful for non-Python-dependent serialization and hashing,
+    while ensuring the result fits within a 64-bit unsigned integer.
+
+    Args:
+        input: Object to be serialized and hashed. Supported types include
+            basic Python types and complex structures like lists, tuples, and
+            dictionaries.
+            Custom classes must implement CBOR serialization methods.
+
+    Returns:
+        An integer in the range [0, 2^64-1] representing the lower 64 bits
+        of the SHA-256 hash of the serialized input.
+    """
+    input_bytes = cbor2.dumps(input, canonical=True)
+    full_hash = int.from_bytes(hashlib.sha256(input_bytes).digest(),
+                               byteorder="big")
+    # Truncate to 64 bits for compatibility with 64-bit serializers (KVEvents)
+    # TODO: KVEvents hash type to support arbitrary length hashes
+    return full_hash & ((1 << 64) - 1)
 
 
 def is_torch_equal_or_newer(target: str) -> bool:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.logger import init_logger
-from vllm.utils import sha256, sha256_cbor
+from vllm.utils import sha256, sha256_cbor_64bit
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_utils import (BlockHash, KVCacheBlock,
                                          hash_request_tokens, init_none_hash)
@@ -80,7 +80,7 @@ class KVCacheManager:
 
         self.enable_caching = enable_caching
         self.caching_hash_fn = (
-            sha256_cbor if caching_hash_algo == "sha256_cbor" else
+            sha256_cbor_64bit if caching_hash_algo == "sha256_cbor_64bit" else
             sha256 if caching_hash_algo == "sha256" else hash)
         init_none_hash(self.caching_hash_fn)
         self.use_eagle = use_eagle

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -7,10 +7,10 @@ from typing import Optional
 
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.logger import init_logger
-from vllm.utils import sha256
+from vllm.utils import sha256, sha256_cbor
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_utils import (BlockHash, KVCacheBlock,
-                                         hash_request_tokens)
+                                         hash_request_tokens, init_none_hash)
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats
 from vllm.v1.request import Request, RequestStatus
@@ -79,7 +79,11 @@ class KVCacheManager:
         self.max_model_len = max_model_len
 
         self.enable_caching = enable_caching
-        self.caching_hash_fn = sha256 if caching_hash_algo == "sha256" else hash
+        self.caching_hash_fn = (
+            sha256_cbor if caching_hash_algo == "sha256_cbor" else
+            sha256 if caching_hash_algo == "sha256" else
+            hash)
+        init_none_hash(self.caching_hash_fn)
         self.use_eagle = use_eagle
         self.log_stats = log_stats
         # FIXME: make prefix cache stats conditional on log_stats

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -81,8 +81,7 @@ class KVCacheManager:
         self.enable_caching = enable_caching
         self.caching_hash_fn = (
             sha256_cbor if caching_hash_algo == "sha256_cbor" else
-            sha256 if caching_hash_algo == "sha256" else
-            hash)
+            sha256 if caching_hash_algo == "sha256" else hash)
         init_none_hash(self.caching_hash_fn)
         self.use_eagle = use_eagle
         self.log_stats = log_stats

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -58,13 +58,11 @@ NONE_HASH: int
 def init_none_hash(hash_fn: Callable):
     global NONE_HASH
 
-    seed = os.getenv("PYTHONHASHSEED")
-    if seed is None:
-        # Use random bytes as seed if not set
-        source = os.urandom(32)
-    else:
-        source = seed
-    NONE_HASH = hash_fn(source)
+    NONE_HASH = (
+        int.from_bytes(os.urandom(32), byteorder="big")
+        if os.getenv("PYTHONHASHSEED") is None
+        else hash_fn(os.getenv("PYTHONHASHSEED"))
+    )
 
 
 class PrefixCachingMetrics:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, NamedTuple, Optional
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.utils import GiB_bytes, cdiv, sha256, sha256_cbor
+from vllm.utils import GiB_bytes, cdiv
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, KVCacheSpec,
                                         KVCacheTensor, SlidingWindowSpec)
@@ -55,14 +55,14 @@ class BlockHashWithGroupId(NamedTuple):
 #
 # The function `init_none_hash` initializes this variable globally.
 NONE_HASH: int
+
+
 def init_none_hash(hash_fn: Callable):
     global NONE_HASH
 
-    NONE_HASH = (
-        int.from_bytes(os.urandom(32), byteorder="big")
-        if os.getenv("PYTHONHASHSEED") is None
-        else hash_fn(os.getenv("PYTHONHASHSEED"))
-    )
+    NONE_HASH = (int.from_bytes(os.urandom(32), byteorder="big")
+                 if os.getenv("PYTHONHASHSEED") is None else hash_fn(
+                     os.getenv("PYTHONHASHSEED")))
 
 
 class PrefixCachingMetrics:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -66,8 +66,7 @@ def init_none_hash(hash_fn: Callable):
             "PYTHONHASHSEED is not set. This will lead to non-reproducible "
             "block-hashes when using sha256_cbor_64bit as the hash function."
             "Consider setting PYTHONHASHSEED to a fixed value for "
-            "reproducibility."
-        )
+            "reproducibility.")
 
     NONE_HASH = (int.from_bytes(os.urandom(32), byteorder="big")
                  if hash_seed is None else hash_fn(hash_seed))


### PR DESCRIPTION
## Purpose

As part of [[RFC]: KV-Cache Management Standardization for Interop #20492](https://github.com/vllm-project/vllm/issues/20492) and to support the development of `llm-d`'s vLLM-native global KV-Cache indexer, prefix-cache block hashing must be reproducible. Given the same prefix-cache key input and configuration, the block hash should be reproducible - with no constraints over technical stack choices.

This PR introduces:
- A new block hashing function: `sha256_cbor`, which serializes input objects using canonical CBOR (via `cbor2`) and hashes them with SHA-256
  - The result is truncated to 64 bits to match the current KVEvents schema, which does not yet support full 256-bit hash keys
    - Regardless, 64 bits provide extremely low collision odds for practical KV-cache sizes (e.g., 1M tokens cache with 16-tokens chunking -> ~62k blocks -> ~1 in 10 billion collision rate using the birthday bound, while keeping KVEvent traffic bandwidth compact
- A change to the global `NONE_HASH` initialization logic to use the configured hash function

These changes make the prefix hashing logic reproducible, non-language-specific, and aligned with future cross-system KV-Cache interoperability goals outlined in the RFC.

## Test Plan

The relevant test files were updated, there is no need for new ones:
- `tests/v1/core/test_kv_cache_utils.py`
- `tests/v1/core/test_prefix_caching.py`

### Profiling

The total difference hashing a 50k tokens request (block size 16) is negligible.

```
=== System Information ===
Platform: macOS-15.5-arm64-arm-64bit-Mach-O
Processor: arm
Python version: 3.13.5
CPU count: 8
RAM: 32.0 GB
=========================

=== Hash Function Profiling Summary ===
AI workload equivalent per run: 50,000 tokens processed
Profiling config: 1000 runs, 3125 blocks/run, block_size=16
---------------------------------------
hash: mean=0.0012s, std=0.0020s
    Mean time per token: 0.00000002s
sha256: mean=0.0054s, std=0.0003s
    Mean time per token: 0.00000011s
sha256_cbor_64bit: mean=0.0171s, std=0.0044s
    Mean time per token: 0.00000034s
---------------------------------------
Comparison (relative slowdown, higher is slower):
    hash: 1.00x (baseline) mean diff: (0.0000s per 50,000 tokens, 0.00000000s per token)
    sha256: 4.62x  mean diff: (+0.0042s per 50,000 tokens, +0.00000008s per token)
    sha256_cbor_64bit: 14.73x  mean diff: (+0.0159s per 50,000 tokens, +0.00000032s per token)
=======================================
```

code: https://pastebin.com/7thahB9Y

## Test Results

All updated tests pass.