### PR TITLE
[Bugfix] fix  the block.prev_block reference - release problem

### DIFF
--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -161,7 +161,6 @@ class BlockTable:
             if end_block_idx > 0:
                 self._blocks[end_block_idx].prev_block = None
 
-
         # Ensure there are enough empty slots for the new tokens plus
         # lookahead slots
         self.ensure_num_empty_slots(num_empty_slots=len(token_ids) +

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -157,7 +157,7 @@ class BlockTable:
                 if b is not null_block:
                     self._allocator.free(b)
                     self._blocks[idx] = null_block
-            # RRelease references to blocks that are already recycled.
+            # Release references to blocks that are already recycled.
             if end_block_idx > 0:
                 self._blocks[end_block_idx].prev_block = None
 

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -157,6 +157,9 @@ class BlockTable:
                 if b is not null_block:
                     self._allocator.free(b)
                     self._blocks[idx] = null_block
+            if end_block_idx > 0:
+                self._blocks[end_block_idx].prev_block = None
+
 
         # Ensure there are enough empty slots for the new tokens plus
         # lookahead slots

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -157,6 +157,7 @@ class BlockTable:
                 if b is not null_block:
                     self._allocator.free(b)
                     self._blocks[idx] = null_block
+            # RRelease references to blocks that are already recycled.
             if end_block_idx > 0:
                 self._blocks[end_block_idx].prev_block = None
 

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -416,6 +416,10 @@ class NullBlock(Block):
     def prev_block(self):
         return self._proxy.prev_block
 
+    @prev_block.setter
+    def prev_block(self, value: Optional[Block]) -> None:
+        raise ValueError("null block should not be modified")
+
     @property
     def extra_hash(self):
         return None

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -53,6 +53,12 @@ class Block(ABC):
     def prev_block(self) -> Optional["Block"]:
         pass
 
+    @prev_block.setter
+    @abstractmethod
+    def prev_block(self, value: Optional["Block"]) -> None:
+        """NOTE: Do not use this API outside Block."""
+        self._prev_block = value
+
     @property
     @abstractmethod
     def extra_hash(self) -> Optional[int]:

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -456,6 +456,10 @@ class NaiveBlock(Block):
     @property
     def prev_block(self) -> Optional["Block"]:
         return self._prev_block
+    
+    @prev_block.setter
+    def prev_block(self, value: Optional["Block"]) -> None:
+        self._prev_block = value
 
     @property
     def extra_hash(self):

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -454,11 +454,11 @@ class NaiveBlock(Block):
         return self._block_size
 
     @property
-    def prev_block(self) -> Optional["Block"]:
+    def prev_block(self) -> Optional[Block]:
         return self._prev_block
     
     @prev_block.setter
-    def prev_block(self, value: Optional["Block"]) -> None:
+    def prev_block(self, value: Optional[Block]) -> None:
         self._prev_block = value
 
     @property

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -456,7 +456,7 @@ class NaiveBlock(Block):
     @property
     def prev_block(self) -> Optional[Block]:
         return self._prev_block
-    
+
     @prev_block.setter
     def prev_block(self, value: Optional[Block]) -> None:
         self._prev_block = value

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -885,6 +885,10 @@ class PrefixCachingBlock(Block):
     @property
     def prev_block(self) -> Optional[Block]:
         return self._prev_block
+    
+    @prev_block.setter
+    def prev_block(self, value: Optional[Block]) -> None:
+        self._prev_block = value
 
     @property
     def extra_hash(self) -> Optional[int]:

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -885,7 +885,7 @@ class PrefixCachingBlock(Block):
     @property
     def prev_block(self) -> Optional[Block]:
         return self._prev_block
-    
+
     @prev_block.setter
     def prev_block(self, value: Optional[Block]) -> None:
         self._prev_block = value


### PR DESCRIPTION
**Background:** Currently, the BlockTable supports the sliding - window attention mechanism. When the tokens stored in the BlockTable exceed the window limit, truncation will be performed, truncating the old ones and releasing the corresponding physical blocks.

**Problem:** At this time, only the physical blocks are released and the logical blocks are returned to the blockPool, but the remaining blocks still retain the references to the released blocks. This will lead to the following problems:

**1 Unable to continue forking:** When forking the currently truncated blockTable, since the condition for forking is whether the current prev_block is None or not, the previously released blocks will be collected again. As a result, the reference - count assertion will fail during forking.
release:
![image](https://github.com/user-attachments/assets/587b2e47-ae9a-4820-bfc3-df1cd3a92003)

fork:
![image](https://github.com/user-attachments/assets/50fdd9cf-913d-4f21-9fd9-358b511693f9)

**2 Block reference confusion:** A more serious problem is that if the corresponding memory allocator allocates blocks between the release and forking, it will directly reference the previously released physical and logical blocks. At this time, new content is stored in these blocks. Later, when forking the original blockTable, it will pass the existing assertion check and fork successfully. However, in fact, the internally referenced blocks have all been updated, resulting in reference confusion.

**Test Verification:**
 
def test_num_blocks_fork_when_free():
     num_gpu_blocks = 1024
    allocator = CpuGpuBlockAllocator.create(
        allocator_type='naive',
        num_gpu_blocks=num_gpu_blocks,
        num_cpu_blocks=0,
        block_size=16,
    ) 
    token_ids = list(range(65)) 
    block_table = BlockTable(
        block_size=16,
        block_allocator=allocator,
        max_block_sliding_window=2
    ) 
    block_table.allocate(token_ids=token_ids, device=Device.GPU)
    token_ids = list(range(6))
    # free two blocks
    block_table.append_token_ids(token_ids,0, 65)
    # Allocate twice, and the previously freed block will be referenced again. At this time, the assertion in fork will be passed （assert refcount != 1, "can't fork free'd block"）
    # allocator.allocate_mutable_block(None,device=Device.GPU)
    # allocator.allocate_mutable_block(None,device=Device.GPU)
    block_table.fork() 
   
 
**Proposal:** When releasing a block, the corresponding reference should be released simultaneously for the already - released block.

Specific Modifications: Open the prev_block property. When the previous reference is released, release the prev_block of the boundary block in a timely manner.
● Since the prev_block of the block returned to the pool will be re - initialized, only the prev_block of the left - most block in the sliding window needs to be released.