### PR TITLE
[BugFix] Fix: ImportError when building on hopper systems

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 /vllm/lora @jeejeelee
 /vllm/reasoning @aarnphm
 /vllm/entrypoints @aarnphm
-CMakeLists.txt @tlrmchlsmth
+CMakeLists.txt @tlrmchlsmth @LucasWilkinson
 
 # Any change to the VllmConfig changes can have a large user-facing impact,
 # so spam a lot of people

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -239,11 +239,6 @@ void cutlass_moe_mm(
     torch::Tensor const& b_strides, torch::Tensor const& c_strides,
     bool per_act_token, bool per_out_ch);
 
-void cutlass_blockwise_scaled_grouped_mm(
-    torch::Tensor& output, const torch::Tensor& a, const torch::Tensor& b,
-    const torch::Tensor& scales_a, const torch::Tensor& scales_b,
-    const torch::Tensor& problem_sizes, const torch::Tensor& expert_offsets);
-
 void cutlass_fp4_group_mm(
     torch::Tensor& output, const torch::Tensor& a, const torch::Tensor& b,
     const torch::Tensor& a_blockscale, const torch::Tensor& b_blockscales,

--- a/csrc/quantization/cutlass_w8a8/moe/blockwise_scaled_group_mm_sm100.cu
+++ b/csrc/quantization/cutlass_w8a8/moe/blockwise_scaled_group_mm_sm100.cu
@@ -1,3 +1,5 @@
+#include "core/registration.h"
+
 #include <torch/all.h>
 #include <cutlass/arch/arch.h>
 
@@ -367,7 +369,6 @@ void cutlass_blockwise_scaled_grouped_mm(
 }
 
 TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
-    m.impl("cutlass_blockwise_scaled_grouped_mm", 
-           &cutlass_blockwise_scaled_grouped_mm);
+  m.impl("cutlass_blockwise_scaled_grouped_mm",
+         &cutlass_blockwise_scaled_grouped_mm);
 }
-  

--- a/csrc/quantization/cutlass_w8a8/moe/blockwise_scaled_group_mm_sm100.cu
+++ b/csrc/quantization/cutlass_w8a8/moe/blockwise_scaled_group_mm_sm100.cu
@@ -365,3 +365,9 @@ void cutlass_blockwise_scaled_grouped_mm(
   }
 #endif
 }
+
+TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
+    m.impl("cutlass_blockwise_scaled_grouped_mm", 
+           &cutlass_blockwise_scaled_grouped_mm);
+}
+  

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -399,8 +399,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor scales_a, Tensor scales_b, "
       "Tensor problem_sizes, Tensor expert_offsets) -> ()",
       {stride_tag});
-  ops.impl("cutlass_blockwise_scaled_grouped_mm", torch::kCUDA,
-           &cutlass_blockwise_scaled_grouped_mm);
+  // conditionally compiled so impl registration is in source file
 
   // cutlass nvfp4 block scaled group GEMM
   ops.def(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

Fix:
```
[ImportError: /home/lwilkinson/code/vllm2/vllm/_C.abi3.so: undefined symbol: _Z35cutlass_blockwise_scaled_grouped_mmRN2at6TensorERKS0_S3_S3_S3_S3_S3_]
```

when building from source on hopper systems.

Caused by https://github.com/vllm-project/vllm/pull/19757 conditionally compiling `csrc/quantization/cutlass_w8a8/moe/blockwise_scaled_group_mm_sm100.cu` but did not make the linkage conditional.

Also adding my self as a CMakeList code owner to get more eyes and hopefully catch these things early (please let me know if you'd prefer the to be a separate PR .

## Test Plan

- For hopper systems test that vLLM starts up after a local build
- For Blackwell systems test that `python -m pytest tests/kernels/moe/test_cutlass_grouped_gemm.py ` still passes

## Test Result

- For hopper systems vLLM now starts up after a local build
- For Blackwell systems confirmed `python -m pytest tests/kernels/moe/test_cutlass_grouped_gemm.py` passes

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
