### PR TITLE
[Benchmarks] Add memory tracking to serving benchmark

### DIFF
--- a/.buildkite/nightly-benchmarks/performance-benchmarks-descriptions.md
+++ b/.buildkite/nightly-benchmarks/performance-benchmarks-descriptions.md
@@ -30,7 +30,7 @@
 - GPU Models: llama-3.1 8B, llama-3 70B, mixtral 8x7B.
 - We also added a speculative decoding test for llama-3 70B on GPU, under QPS 2
 - CPU Models: llama-3.1 8B.
-- Evaluation metrics: throughput, TTFT (time to the first token, with mean, median and p99), ITL (inter-token latency, with mean, median and p99), peak memory usage, memory per request.
+- Evaluation metrics: throughput, TTFT (time to the first token, with mean, median and p99), ITL (inter-token latency, with mean, median and p99), peak memory usage (GiB), memory per request (MiB).
 - For CPU, we added random dataset tests to benchmark fixed input/output length with 100 prompts.
 
 {serving_tests_markdown_table}

--- a/.buildkite/nightly-benchmarks/performance-benchmarks-descriptions.md
+++ b/.buildkite/nightly-benchmarks/performance-benchmarks-descriptions.md
@@ -30,7 +30,7 @@
 - GPU Models: llama-3.1 8B, llama-3 70B, mixtral 8x7B.
 - We also added a speculative decoding test for llama-3 70B on GPU, under QPS 2
 - CPU Models: llama-3.1 8B.
-- Evaluation metrics: throughput, TTFT (time to the first token, with mean, median and p99), ITL (inter-token latency, with mean, median and p99).
+- Evaluation metrics: throughput, TTFT (time to the first token, with mean, median and p99), ITL (inter-token latency, with mean, median and p99), peak memory usage, memory per request.
 - For CPU, we added random dataset tests to benchmark fixed input/output length with 100 prompts.
 
 {serving_tests_markdown_table}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -118,6 +118,8 @@ Total generated tokens:                  2212
 Request throughput (req/s):              1.73      
 Output token throughput (tok/s):         382.89    
 Total Token throughput (tok/s):          619.85    
+Peak memory usage (GiB):                 1.59      
+Memory per request (MiB):                162.41 
 ---------------Time to First Token----------------
 Mean TTFT (ms):                          71.54     
 Median TTFT (ms):                        73.88     

--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import math
 import os
+import resource
 from typing import Any
 
 
@@ -72,3 +73,18 @@ def write_to_json(filename: str, records: list) -> None:
             cls=InfEncoder,
             default=lambda o: f"<{type(o).__name__} object is not JSON serializable>",
         )
+
+
+def get_memory_usage() -> float:
+    """Get peak memory usage in GiB using resource.getrusage()."""
+    # Note: ru_maxrss is in kilobytes on Linux, bytes on macOS
+    import platform
+
+    # macOS: ru_maxrss in bytes, Linux: ru_maxrss in kilobytes
+    divisor = 1 << 30 if platform.system() == "Darwin" else 1 << 20
+
+    max_self_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / divisor
+    max_children_usage = (
+        resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss / divisor
+    )
+    return max_self_usage + max_children_usage


### PR DESCRIPTION
## Purpose
Partially fix #16353 
Add memory usage tracking to benchmark_serving.py via two new metrics: peak_memory_gb and memory_per_request_mb.
These memory metrics will automatically be appended to the JSON output in the included in existing CI (for text model).

## Test Plan
Run benchmark_serving.py with command:
```
  vllm serve microsoft/Phi-3.5-mini-instruct \
    --host 0.0.0.0 \
    --port 8000 \
    --trust-remote-code \
    --max-model-len 4096 \
    --gpu-memory-utilization 0.8

  python benchmarks/benchmark_serving.py \
    --backend vllm \
    --base-url http://localhost:8000 \
    --model microsoft/Phi-3.5-mini-instruct \
    --dataset-name random \
    --num-prompts 10 \
    --save-result \
    --result-filename test_memory_fix.json
```

## Test Output
```
============ Serving Benchmark Result ============
Successful requests:                     10
Benchmark duration (s):                  1.95
Total input tokens:                      10240
Total generated tokens:                  1280
Request throughput (req/s):              5.12
Output token throughput (tok/s):         655.08
Total Token throughput (tok/s):          5895.72
Peak memory usage (GiB):                 1.59
Memory per request (MiB):                162.35
---------------Time to First Token----------------
Mean TTFT (ms):                          235.98
Median TTFT (ms):                        249.65
P99 TTFT (ms):                           365.82
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.34
Median TPOT (ms):                        13.24
P99 TPOT (ms):                           14.67
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.34
Median ITL (ms):                         12.53
P99 ITL (ms):                            52.02
==================================================
```

## Remaining work (Future PRs)
  1. Extend to other benchmarks: Add memory tracking to benchmark_throughput.py and benchmark_latency.py
  2. Multimodal CI tests: Add actual multimodal models to CI test configs
  3. Memory regression detection: Once we obtain a great threshold

