### PR TITLE
[Third Party] Add a hook to the GPU Model Runner in Worker KV Connector start_load_kv()

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1365,7 +1365,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 num_tokens_across_dp=num_tokens_across_dp,
                 skip_cuda_graphs=skip_cuda_graphs,
         ):
-            self.maybe_setup_kv_connector(scheduler_output, gpu_model_runner=self)
+            self.maybe_setup_kv_connector(scheduler_output,
+                                          gpu_model_runner=self)
 
             model_output = self.model(
                 input_ids=input_ids,
@@ -1686,7 +1687,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self, scheduler_output: "SchedulerOutput") -> ModelRunnerOutput:
         # KV send/recv even if no work to do.
         with set_forward_context(None, self.vllm_config):
-            self.maybe_setup_kv_connector(scheduler_output, gpu_model_runner=self)
+            self.maybe_setup_kv_connector(scheduler_output,
+                                          gpu_model_runner=self)
             finished_sending, finished_recving = (
                 self.get_finished_kv_transfers(scheduler_output))
 
@@ -1699,7 +1701,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return output
 
     @staticmethod
-    def maybe_setup_kv_connector(scheduler_output: "SchedulerOutput", **kwargs):
+    def maybe_setup_kv_connector(scheduler_output: "SchedulerOutput",
+                                 **kwargs):
         # Update KVConnector with the KVConnector metadata forward().
         if has_kv_transfer_group():
             kv_connector = get_kv_transfer_group()


### PR DESCRIPTION
Provide a hook for a worker kv connector to fetch cached token ids directly from the gpu model runner since https://github.com/vllm-project/vllm/pull/20291/files#diff-cafd89ce8a698a56acb24ada62831cbc7a980782f78a52d1742ba238031f296c removed the new_token_ids from the scheduler output. 

Takes advantage of the fact that the `KVConnectorBase_V1` already has kwargs for `start_load_kv` to try not to modify any interfaces. 