### PR TITLE
[Benchmark] Parameterization of streaming loading of multimodal datasets

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -701,6 +701,7 @@ class HuggingFaceDataset(BenchmarkDataset):
         self,
         dataset_path: str,
         dataset_split: str,
+        load_stream: bool = False,
         dataset_subset: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -708,6 +709,7 @@ class HuggingFaceDataset(BenchmarkDataset):
 
         self.dataset_split = dataset_split
         self.dataset_subset = dataset_subset
+        self.load_stream = load_stream
         self.load_data()
 
     def load_data(self) -> None:
@@ -716,7 +718,7 @@ class HuggingFaceDataset(BenchmarkDataset):
             self.dataset_path,
             name=self.dataset_subset,
             split=self.dataset_split,
-            streaming=True,
+            streaming=self.load_stream,
         )
         self.data = self.data.shuffle(seed=self.random_seed)
 

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -701,7 +701,7 @@ class HuggingFaceDataset(BenchmarkDataset):
         self,
         dataset_path: str,
         dataset_split: str,
-        load_stream: bool = False,
+        no_stream: bool = False,
         dataset_subset: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -709,7 +709,7 @@ class HuggingFaceDataset(BenchmarkDataset):
 
         self.dataset_split = dataset_split
         self.dataset_subset = dataset_subset
-        self.load_stream = load_stream
+        self.load_stream = not no_stream
         self.load_data()
 
     def load_data(self) -> None:

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -825,6 +825,7 @@ def main(args: argparse.Namespace):
             dataset_subset=args.hf_subset,
             dataset_split=args.hf_split,
             random_seed=args.seed,
+            load_stream=args.load_stream,
         ).sample(
             num_requests=args.num_prompts,
             tokenizer=tokenizer,
@@ -1032,6 +1033,11 @@ def create_argument_parser():
         default=None,
         help="Path to the sharegpt/sonnet dataset. "
         "Or the huggingface dataset ID if using HF dataset.",
+    )
+    parser.add_argument(
+        "--load-stream",
+        action="store_true",
+        help="Load the dataset in streaming mode.",
     )
     parser.add_argument(
         "--max-concurrency",

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -825,7 +825,7 @@ def main(args: argparse.Namespace):
             dataset_subset=args.hf_subset,
             dataset_split=args.hf_split,
             random_seed=args.seed,
-            load_stream=args.load_stream,
+            no_stream=args.no_stream,
         ).sample(
             num_requests=args.num_prompts,
             tokenizer=tokenizer,
@@ -1035,9 +1035,9 @@ def create_argument_parser():
         "Or the huggingface dataset ID if using HF dataset.",
     )
     parser.add_argument(
-        "--load-stream",
+        "--no-stream",
         action="store_true",
-        help="Load the dataset in streaming mode.",
+        help="Do not load the dataset in streaming mode.",
     )
     parser.add_argument(
         "--max-concurrency",

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -356,6 +356,7 @@ def get_requests(args, tokenizer):
     elif args.dataset_name == "burstgpt":
         dataset_cls = BurstGPTDataset
     elif args.dataset_name == "hf":
+        common_kwargs["load_stream"] = args.load_stream
         if args.dataset_path in VisionArenaDataset.SUPPORTED_DATASET_PATHS:
             dataset_cls = VisionArenaDataset
             common_kwargs["dataset_subset"] = None
@@ -609,6 +610,11 @@ def create_argument_parser():
         choices=["sharegpt", "random", "sonnet", "burstgpt", "hf"],
         help="Name of the dataset to benchmark on.",
         default="sharegpt",
+    )
+    parser.add_argument(
+        "--load-stream",
+        action="store_true",
+        help="Load the dataset in streaming mode.",
     )
     parser.add_argument(
         "--dataset",

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -356,7 +356,7 @@ def get_requests(args, tokenizer):
     elif args.dataset_name == "burstgpt":
         dataset_cls = BurstGPTDataset
     elif args.dataset_name == "hf":
-        common_kwargs["load_stream"] = args.load_stream
+        common_kwargs["no_stream"] = args.no_stream
         if args.dataset_path in VisionArenaDataset.SUPPORTED_DATASET_PATHS:
             dataset_cls = VisionArenaDataset
             common_kwargs["dataset_subset"] = None
@@ -612,7 +612,7 @@ def create_argument_parser():
         default="sharegpt",
     )
     parser.add_argument(
-        "--load-stream",
+        "--no-stream",
         action="store_true",
         help="Load the dataset in streaming mode.",
     )

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -614,7 +614,7 @@ def create_argument_parser():
     parser.add_argument(
         "--no-stream",
         action="store_true",
-        help="Load the dataset in streaming mode.",
+        help="Do not load the dataset in streaming mode.",
     )
     parser.add_argument(
         "--dataset",

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -482,6 +482,11 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument(
+        "--load-stream",
+        action="store_true",
+        help="Load the dataset in streaming mode.",
+    )
+    parser.add_argument(
         "--dataset-path",
         type=str,
         default=None,
@@ -674,6 +679,7 @@ def get_samples(args, tokenizer) -> list[SampleRequest]:
             dataset_subset=args.hf_subset,
             dataset_split=args.hf_split,
             random_seed=args.seed,
+            load_stream=args.load_stream,
         ).sample(
             num_requests=args.num_prompts,
             tokenizer=tokenizer,
@@ -971,6 +977,7 @@ class HuggingFaceDataset(BenchmarkDataset):
         self,
         dataset_path: str,
         dataset_split: str,
+        load_stream: bool = False,
         dataset_subset: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -978,6 +985,7 @@ class HuggingFaceDataset(BenchmarkDataset):
 
         self.dataset_split = dataset_split
         self.dataset_subset = dataset_subset
+        self.load_stream = load_stream
         self.load_data()
 
     def load_data(self) -> None:
@@ -986,7 +994,7 @@ class HuggingFaceDataset(BenchmarkDataset):
             self.dataset_path,
             name=self.dataset_subset,
             split=self.dataset_split,
-            streaming=True,
+            streaming=self.load_stream,
         )
         self.data = self.data.shuffle(seed=self.random_seed)
 

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -484,7 +484,7 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
     parser.add_argument(
         "--no-stream",
         action="store_true",
-        help="Load the dataset in streaming mode.",
+        help="Do not load the dataset in streaming mode.",
     )
     parser.add_argument(
         "--dataset-path",

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -482,7 +482,7 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument(
-        "--load-stream",
+        "--no-stream",
         action="store_true",
         help="Load the dataset in streaming mode.",
     )
@@ -679,7 +679,7 @@ def get_samples(args, tokenizer) -> list[SampleRequest]:
             dataset_subset=args.hf_subset,
             dataset_split=args.hf_split,
             random_seed=args.seed,
-            load_stream=args.load_stream,
+            no_stream=args.no_stream,
         ).sample(
             num_requests=args.num_prompts,
             tokenizer=tokenizer,
@@ -977,7 +977,7 @@ class HuggingFaceDataset(BenchmarkDataset):
         self,
         dataset_path: str,
         dataset_split: str,
-        load_stream: bool = False,
+        no_stream: bool = False,
         dataset_subset: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -985,7 +985,7 @@ class HuggingFaceDataset(BenchmarkDataset):
 
         self.dataset_split = dataset_split
         self.dataset_subset = dataset_subset
-        self.load_stream = load_stream
+        self.load_stream = not no_stream
         self.load_data()
 
     def load_data(self) -> None:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Currently, our multimodal datasets for benchmarks are loaded by default with [streaming](https://github.com/vllm-project/vllm/blob/e202dd2736bc575b11250b15311512d19d3225d5/benchmarks/benchmark_dataset.py#L719) enabled, but in some offline or poor network conditions,  we may need to cache a pre-cached dataset locally, The purpose of this PR is to add this parameter to control whether to stream load the dataset
## Test Plan
Notice that I added this parameter to both the test script and the cli script. so I have the following tests:

Cli

not stream

```shell
vllm bench serve --model Qwen/Qwen2.5-VL-3B-Instruct --endpoint_type openai-chat --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/vision-arena-bench-v0.1 --hf-split train --num-prompts 50
```
args namespace
```shell
Namespace(subparser='bench', bench_type='serve', dispatch_function=<function BenchmarkServingSubcommand.cmd at 0xfffdb1828790>, seed=0, num_prompts=50, dataset_name='hf', load_stream=False, dataset_path='lmarena-ai/vision-arena-bench-v0.1', custom_output_len=256, custom_skip_chat_template=False, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, random_input_len=1024, random_output_len=128, random_range_ratio=0.0, random_prefix_len=0, hf_subset=None, hf_split='train', hf_output_len=None, endpoint_type='openai-chat', label=None, backend='vllm', base_url=None, host='127.0.0.1', port=8000, endpoint='/v1/chat/completions', max_concurrency=None, model='Qwen/Qwen2.5-VL-3B-Instruct', tokenizer=None, use_beam_search=False, logprobs=None, request_rate=1.0, burstiness=1.0, trust_remote_code=False, disable_tqdm=False, profile=False, save_result=False, save_detailed=False, append_result=False, metadata=None, result_dir=None, result_filename=None, ignore_eos=False, percentile_metrics='ttft,tpot,itl', metric_percentiles='99', goodput=None, top_p=None, top_k=None, min_p=None, temperature=None, tokenizer_mode='auto', served_model_name=None, lora_modules=None, ramp_up_strategy=None, ramp_up_start_rps=None, ramp_up_end_rps=None)
```
stream mode

```shell
vllm bench serve --model Qwen/Qwen2.5-VL-3B-Instruct --endpoint_type openai-chat --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/vision-arena-bench-v0.1 --hf-split train --num-prompts 50 --load-stream
```
args namespace
```shell
Namespace(subparser='bench', bench_type='serve', dispatch_function=<function BenchmarkServingSubcommand.cmd at 0xfffd9317c820>, seed=0, num_prompts=50, dataset_name='hf', load_stream=True, dataset_path='lmarena-ai/vision-arena-bench-v0.1', custom_output_len=256, custom_skip_chat_template=False, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, random_input_len=1024, random_output_len=128, random_range_ratio=0.0, random_prefix_len=0, hf_subset=None, hf_split='train', hf_output_len=None, endpoint_type='openai-chat', label=None, backend='vllm', base_url=None, host='127.0.0.1', port=8000, endpoint='/v1/chat/completions', max_concurrency=None, model='Qwen/Qwen2.5-VL-3B-Instruct', tokenizer=None, use_beam_search=False, logprobs=None, request_rate=inf, burstiness=1.0, trust_remote_code=False, disable_tqdm=False, profile=False, save_result=False, save_detailed=False, append_result=False, metadata=None, result_dir=None, result_filename=None, ignore_eos=False, percentile_metrics='ttft,tpot,itl', metric_percentiles='99', goodput=None, top_p=None, top_k=None, min_p=None, temperature=None, tokenizer_mode='auto', served_model_name=None, lora_modules=None, ramp_up_strategy=None, ramp_up_start_rps=None, ramp_up_end_rps=None)
```

benchmark script

Not stream

```shell
python3 benchmarks/benchmark_serving.py --model Qwen/Qwen2.5-VL-3B-Instruct --backend openai-chat --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/vision-arena-bench-v0.1 --hf-split train --num-prompts 50
```

```shell
Namespace(backend='openai-chat', base_url=None, host='127.0.0.1', port=8000, endpoint='/v1/chat/completions', dataset_name='hf', dataset_path='lmarena-ai/vision-arena-bench-v0.1', load_stream=False, max_concurrency=None, model='Qwen/Qwen2.5-VL-3B-Instruct', tokenizer=None, use_beam_search=False, num_prompts=50, logprobs=None, request_rate=inf, burstiness=1.0, seed=0, trust_remote_code=False, disable_tqdm=False, profile=False, save_result=False, save_detailed=False, append_result=False, metadata=None, result_dir=None, result_filename=None, ignore_eos=False, percentile_metrics='ttft,tpot,itl', metric_percentiles='99', goodput=None, custom_output_len=256, custom_skip_chat_template=False, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, random_input_len=1024, random_output_len=128, random_range_ratio=0.0, random_prefix_len=0, hf_subset=None, hf_split='train', hf_output_len=None, top_p=None, top_k=None, min_p=None, temperature=None, tokenizer_mode='auto', served_model_name=None, lora_modules=None, ramp_up_strategy=None, ramp_up_start_rps=None, ramp_up_end_rps=None)
```

stream mode

```shell
Namespace(backend='openai-chat', base_url=None, host='127.0.0.1', port=8000, endpoint='/v1/chat/completions', dataset_name='hf', dataset_path='lmarena-ai/vision-arena-bench-v0.1', load_stream=True, max_concurrency=None, model='Qwen/Qwen2.5-VL-3B-Instruct', tokenizer=None, use_beam_search=False, num_prompts=50, logprobs=None, request_rate=inf, burstiness=1.0, seed=0, trust_remote_code=False, disable_tqdm=False, profile=False, save_result=False, save_detailed=False, append_result=False, metadata=None, result_dir=None, result_filename=None, ignore_eos=False, percentile_metrics='ttft,tpot,itl', metric_percentiles='99', goodput=None, custom_output_len=256, custom_skip_chat_template=False, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, random_input_len=1024, random_output_len=128, random_range_ratio=0.0, random_prefix_len=0, hf_subset=None, hf_split='train', hf_output_len=None, top_p=None, top_k=None, min_p=None, temperature=None, tokenizer_mode='auto', served_model_name=None, lora_modules=None, ramp_up_strategy=None, ramp_up_start_rps=None, ramp_up_end_rps=None)
```
and both results looks good:
```bash
============ Serving Benchmark Result ============
Successful requests:                     50        
Benchmark duration (s):                  12.84     
Total input tokens:                      11231     
Total generated tokens:                  5273      
Request throughput (req/s):              3.89      
Output token throughput (tok/s):         410.69    
Total Token throughput (tok/s):          1285.42   
---------------Time to First Token----------------
Mean TTFT (ms):                          1805.32   
Median TTFT (ms):                        1952.28   
P99 TTFT (ms):                           2534.29   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          102.19    
Median TPOT (ms):                        84.92     
P99 TPOT (ms):                           434.96    
---------------Inter-token Latency----------------
Mean ITL (ms):                           86.86     
Median ITL (ms):                         79.12     
P99 ITL (ms):                            560.93    
==================================================
```
