### PR TITLE
[Test] Remove docker build from test.

### DIFF
--- a/.buildkite/scripts/tpu/docker_run_bm.sh
+++ b/.buildkite/scripts/tpu/docker_run_bm.sh
@@ -22,16 +22,6 @@ trap remove_docker_container EXIT
 # Remove the container that might not be cleaned up in the previous run.
 remove_docker_container
 
-# Build docker image.
-# TODO: build the image outside the script and share the image with other
-# tpu test if building time is too long.
-DOCKER_BUILDKIT=1 docker build \
-  --build-arg max_jobs=16 \
-  --build-arg USE_SCCACHE=1 \
-  --build-arg GIT_REPO_CHECK=0 \
-  --tag vllm/vllm-tpu-bm \
-  --progress plain -f docker/Dockerfile.tpu .
-
 LOG_ROOT=$(mktemp -d)
 # If mktemp fails, set -e will cause the script to exit.
 echo "Results will be stored in: $LOG_ROOT"


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

## Purpose
Remove unnecessary steps from test. 
Both removed operations are done outside of the tests. 

## Test Plan
Test by CI pipeline.

## Test Result
from [the run](https://buildkite.com/vllm/ci/builds/23359#0197e5eb-8e26-4e00-9580-6f3f66f963d4), the "TPU V1 Benchmark Test" has only one "naming to docker.io/vllm/vllm-tpu-bm done" in log now(used to be 3) and the test passes. it mean the removing docker image build inside docker_run is safe. 

The warning in log `Post "https://agent.buildkite.com/v3/jobs/0197e5eb-8e26-4e00-9580-6f3f66f963d4/artifacts": context deadline exceeded (Attempt 1/10 Retrying in 500ms)` indicates the running machine has network issue but it is not what this PR is intent to fix and actually all the logs were successfully uploaded

