### PR TITLE
[Hardware][PPC64LE] Enable V1 for ppc64le and ARM

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1089,7 +1089,7 @@ class EngineArgs:
             # Disable chunked prefill for POWER (ppc64le) CPUs in V1
             if current_platform.is_cpu(
             ) and current_platform.get_cpu_architecture(
-            ) == CpuArchEnum.POWERPC:
+            ) in (CpuArchEnum.POWERPC, CpuArchEnum.ARM):
                 logger.info("Chunked prefill is not supported for POWER CPUs; "
                             "disabling it for V1 backend.")
                 self.enable_chunked_prefill = False

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1086,12 +1086,13 @@ class EngineArgs:
         # Set default arguments for V0 or V1 Engine.
         if use_v1:
             self._set_default_args_v1(usage_context, model_config)
-            # Disable chunked prefill for POWER (ppc64le) CPUs in V1
+            # Disable chunked prefill for POWER (ppc64le)/ARM CPUs in V1
             if current_platform.is_cpu(
-            ) and current_platform.get_cpu_architecture(
-            ) in (CpuArchEnum.POWERPC, CpuArchEnum.ARM):
-                logger.info("Chunked prefill is not supported for POWER CPUs; "
-                            "disabling it for V1 backend.")
+            ) and current_platform.get_cpu_architecture() in (
+                    CpuArchEnum.POWERPC, CpuArchEnum.ARM):
+                logger.info(
+                    "Chunked prefill is not supported for ARM and POWER CPUs; "
+                    "disabling it for V1 backend.")
                 self.enable_chunked_prefill = False
         else:
             self._set_default_args_v0(model_config)

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -266,4 +266,4 @@ class CpuPlatform(Platform):
         """
         arch = cls.get_cpu_architecture()
         return (cls.supports_v1(model_config)
-                and arch in (CpuArchEnum.X86, CpuArchEnum.POWERPC))
+                and arch in (CpuArchEnum.X86, CpuArchEnum.POWERPC, CpuArchEnum.ARM))

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -265,5 +265,5 @@ class CpuPlatform(Platform):
         supplied model configuration.
         """
         arch = cls.get_cpu_architecture()
-        return (cls.supports_v1(model_config)
-                and arch in (CpuArchEnum.X86, CpuArchEnum.POWERPC, CpuArchEnum.ARM))
+        return (cls.supports_v1(model_config) and arch
+                in (CpuArchEnum.X86, CpuArchEnum.POWERPC, CpuArchEnum.ARM))

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -264,5 +264,6 @@ class CpuPlatform(Platform):
         """Returns whether the current platform can use v1 by default for the
         supplied model configuration.
         """
-        return cls.supports_v1(
-            model_config) and cls.get_cpu_architecture() == CpuArchEnum.X86
+        arch = cls.get_cpu_architecture()
+        return (cls.supports_v1(model_config)
+                and arch in (CpuArchEnum.X86, CpuArchEnum.POWERPC))

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -77,7 +77,6 @@ class TorchSDPAMetadataBuilderV1(AttentionMetadataBuilder[TorchSDPAMetadata]):
                  block_table: BlockTable) -> None:
         self.runner = runner
         self.block_table = block_table
-
         # For reorder
         self.reorder_prompt_req_index_list = np.empty(self.runner.max_num_reqs,
                                                       dtype=np.int64)
@@ -162,11 +161,12 @@ class TorchSDPAMetadataBuilderV1(AttentionMetadataBuilder[TorchSDPAMetadata]):
             num_prefill_tokens=num_prefill_tokens,
             num_decode_tokens=num_decode_tokens,
             slot_mapping=slot_mapping,
+            seq_lens=runner.seq_lens_cpu[:num_reqs].tolist(),  # ensure seq_lens is set
             seq_lens_tensor=runner.
             seq_lens_cpu[num_prompt_req:num_reqs],  # decode
             max_decode_seq_len=max_decode_seq_len,  # decode
             block_tables=block_table_tensor[num_prompt_req:num_reqs],  # decode
-            chunked_prefill=True,
+            chunked_prefill=self.runner.scheduler_config.chunked_prefill_enabled,
             max_query_len=max_query_len,
             max_kv_len=max_prefill_seq_len,
             prefill_query_start_loc=runner.

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -161,7 +161,8 @@ class TorchSDPAMetadataBuilderV1(AttentionMetadataBuilder[TorchSDPAMetadata]):
             num_prefill_tokens=num_prefill_tokens,
             num_decode_tokens=num_decode_tokens,
             slot_mapping=slot_mapping,
-            seq_lens=runner.seq_lens_cpu[:num_reqs].tolist(),  # ensure seq_lens is set
+            # to ensure inference when chunked_prefill is disabled
+            seq_lens=runner.seq_lens_cpu[:num_reqs].tolist(),  
             seq_lens_tensor=runner.
             seq_lens_cpu[num_prompt_req:num_reqs],  # decode
             max_decode_seq_len=max_decode_seq_len,  # decode

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -162,12 +162,13 @@ class TorchSDPAMetadataBuilderV1(AttentionMetadataBuilder[TorchSDPAMetadata]):
             num_decode_tokens=num_decode_tokens,
             slot_mapping=slot_mapping,
             # to ensure inference when chunked_prefill is disabled
-            seq_lens=runner.seq_lens_cpu[:num_reqs].tolist(),  
+            seq_lens=runner.seq_lens_cpu[:num_reqs].tolist(),
             seq_lens_tensor=runner.
             seq_lens_cpu[num_prompt_req:num_reqs],  # decode
             max_decode_seq_len=max_decode_seq_len,  # decode
             block_tables=block_table_tensor[num_prompt_req:num_reqs],  # decode
-            chunked_prefill=self.runner.scheduler_config.chunked_prefill_enabled,
+            chunked_prefill=self.runner.scheduler_config.
+            chunked_prefill_enabled,
             max_query_len=max_query_len,
             max_kv_len=max_prefill_seq_len,
             prefill_query_start_loc=runner.

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -3,7 +3,6 @@
 import os
 from importlib import util
 from typing import Optional
-import platform
 
 import torch
 
@@ -12,7 +11,7 @@ from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.logger import init_logger
 from vllm.model_executor.utils import set_random_seed
-from vllm.platforms import current_platform
+from vllm.platforms import CpuArchEnum, current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import ModelRunnerOutput
@@ -44,8 +43,7 @@ class CPUWorker(Worker):
         omp_cpuids = envs.VLLM_CPU_OMP_THREADS_BIND
         self.local_omp_cpuid = "all"
         if omp_cpuids == "auto":
-            arch = platform.machine()
-            if arch == "ppc64le":
+            if current_platform.get_cpu_architecture() == CpuArchEnum.POWERPC:
                 self.local_omp_cpuid = (
                     self.get_cpus_id_binding_based_on_numa_nodes_ppc64le())
             else:
@@ -159,7 +157,6 @@ class CPUWorker(Worker):
                 "fallback to no thread-binding. To get better performance,"
                 "please try to manually bind threads.")
         return rank_to_cpus
-
 
     def get_cpus_id_binding_based_on_numa_nodes_ppc64le(self) -> str:
         """

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -3,6 +3,7 @@
 import os
 from importlib import util
 from typing import Optional
+import platform
 
 import torch
 
@@ -43,8 +44,13 @@ class CPUWorker(Worker):
         omp_cpuids = envs.VLLM_CPU_OMP_THREADS_BIND
         self.local_omp_cpuid = "all"
         if omp_cpuids == "auto":
-            self.local_omp_cpuid = self.get_cpus_id_binding_based_on_numa_nodes(
-            )
+            arch = platform.machine()
+            if arch == "ppc64le":
+                self.local_omp_cpuid = (
+                    self.get_cpus_id_binding_based_on_numa_nodes_ppc64le())
+            else:
+                self.local_omp_cpuid = (
+                    self.get_cpus_id_binding_based_on_numa_nodes())
         else:
             self.local_omp_cpuid = omp_cpuids.split("|")[self.rank]
 
@@ -146,6 +152,61 @@ class CPUWorker(Worker):
                 rank_to_cpus_list = node_to_cpus[self.rank][:end]
                 rank_to_cpus = ','.join(str(x) for x in rank_to_cpus_list)
                 logger.info("auto thread-binding list: %s", rank_to_cpus)
+        else:
+            logger.warning(
+                "Auto thread-binding is not supported due to "
+                "the lack of package numa and psutil,"
+                "fallback to no thread-binding. To get better performance,"
+                "please try to manually bind threads.")
+        return rank_to_cpus
+
+
+    def get_cpus_id_binding_based_on_numa_nodes_ppc64le(self) -> str:
+        """
+        Power (ppc64le) specific: Selects a subset of threads per core for 
+        each NUMA node.This is robust to SMT mode (SMT-8, SMT-4, etc) 
+        because the OS only exposes available threads.This maximizes 
+        performance by avoiding oversubscription of logical CPUs on Power.
+        """
+
+        def select_threads_per_power_core(node_cpu_ids):
+            return [cpu for cpu in node_cpu_ids if cpu % 8 < 4]
+
+        rank_to_cpus = self.local_omp_cpuid
+        world_size = self.vllm_config.parallel_config.world_size
+        libnuma_found = util.find_spec("numa") is not None
+        psutil_found = util.find_spec("psutil") is not None
+        if libnuma_found and psutil_found:
+            import psutil
+            from numa import info
+            cpus_allow_list = psutil.Process().cpu_affinity()
+            numa_size = info.get_num_configured_nodes()
+
+            node_to_cpus = []
+            for i in range(numa_size):
+                node_intersect = set(
+                    info.node_to_cpus(i)).intersection(cpus_allow_list)
+                if bool(node_intersect):
+                    node_to_cpus.append(sorted(list(node_intersect)))
+
+            if world_size > len(node_to_cpus):
+                logger.error(
+                    "Auto thread-binding failed due to "
+                    "world size: %d is larger than "
+                    "allowed NUMA nodes number: %d."
+                    "Please try to bind threads manually.", world_size,
+                    len(node_to_cpus))
+            else:
+                node_cpus_this_rank = node_to_cpus[self.rank]
+                node_cpus_this_rank = select_threads_per_power_core(
+                    node_cpus_this_rank)
+                cpu_count_per_numa = len(node_cpus_this_rank)
+                num_of_reserved_cpu = min(envs.VLLM_CPU_NUM_OF_RESERVED_CPU,
+                                          cpu_count_per_numa // 2)
+                end = cpu_count_per_numa - num_of_reserved_cpu
+                rank_to_cpus_list = node_cpus_this_rank[:end]
+                rank_to_cpus = ','.join(str(x) for x in rank_to_cpus_list)
+                logger.info("ppc64le thread-binding list: %s", rank_to_cpus)
         else:
             logger.warning(
                 "Auto thread-binding is not supported due to "


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

FIX #20622

## Purpose
This PR enables V1 Engine for IBM POWER, as V0 Engine would be deprecated (https://github.com/vllm-project/vllm/pull/20437, https://github.com/vllm-project/vllm/pull/20412). 

As chunked prefill is not supported on ppc64le, this PR turns off chunked prefill in case of ppc64le. 

Also, the CPU binding logic is not optimized for POWER (The issue and its impact are described in detail in https://github.com/vllm-project/vllm/issues/20089. #20387  ), this PR adds that logic in case of V1 as well. 
## Test Plan
Local testing
## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
