### PR TITLE
[fix][xpu] return dummy values instead of all-zero tensors during profile run

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -475,7 +475,7 @@ class FlashAttentionImpl(AttentionImpl):
 
         if attn_metadata is None:
             # Profiling run.
-            return output
+            return output.random_(0, 10)
 
         # IMPORTANT!
         # NOTE(woosuk): With piece-wise CUDA graphs, this method is executed in


### PR DESCRIPTION
return dummy data instead of all-zero tensor as in some cases it's not properly handled by ipex kernels.