### PR TITLE
[Bugfix] Add checks to prevent blocks from being invalidly occupied.

### DIFF
--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -157,6 +157,9 @@ class BlockTable:
                 if b is not null_block:
                     self._allocator.free(b)
                     self._blocks[idx] = null_block
+            if end_block_idx > 0:
+                self._blocks[end_block_idx].prev_block = None
+
 
         # Ensure there are enough empty slots for the new tokens plus
         # lookahead slots

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -53,6 +53,12 @@ class Block(ABC):
     def prev_block(self) -> Optional["Block"]:
         pass
 
+    @prev_block.setter
+    @abstractmethod
+    def prev_block(self, value: Optional["Block"]) -> None:
+        """NOTE: Do not use this API outside Block."""
+        self._prev_block = value
+
     @property
     @abstractmethod
     def extra_hash(self) -> Optional[int]:

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -93,6 +93,8 @@ class NaiveBlockAllocator(BlockAllocator):
             device: Optional[Device] = None) -> List[Block]:
         assert device is None
         num_blocks = len(block_token_ids)
+        if num_blocks > self.get_num_free_blocks:
+            raise BlockAllocator.NoFreeBlocksError()
 
         block_ids = []
         for i in range(num_blocks):

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -456,6 +456,10 @@ class NaiveBlock(Block):
     @property
     def prev_block(self) -> Optional["Block"]:
         return self._prev_block
+    
+    @prev_block.setter
+    def prev_block(self, value: Optional["Block"]) -> None:
+        self._prev_block = value
 
     @property
     def extra_hash(self):


### PR DESCRIPTION
Add a pre-judgment to prevent the successfully allocated blocks from being occupied when part of the allocation succeeds but the overall allocation fails.
