### PR TITLE
[Bugfix] Add checks to prevent blocks from being invalidly occupied.

### DIFF
--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -93,6 +93,8 @@ class NaiveBlockAllocator(BlockAllocator):
             device: Optional[Device] = None) -> List[Block]:
         assert device is None
         num_blocks = len(block_token_ids)
+        if num_blocks > self.get_num_free_blocks:
+            raise BlockAllocator.NoFreeBlocksError()
 
         block_ids = []
         for i in range(num_blocks):

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -93,7 +93,7 @@ class NaiveBlockAllocator(BlockAllocator):
             device: Optional[Device] = None) -> List[Block]:
         assert device is None
         num_blocks = len(block_token_ids)
-        if num_blocks > self.get_num_free_blocks:
+        if num_blocks > self.get_num_free_blocks():
             raise BlockAllocator.NoFreeBlocksError()
 
         block_ids = []


### PR DESCRIPTION
Add a pre-judgment to prevent the successfully allocated blocks from being occupied when part of the allocation succeeds but the overall allocation fails.
