### PR TITLE
[Doc] Add outline for content tabs

### DIFF
--- a/docs/mkdocs/stylesheets/extra.css
+++ b/docs/mkdocs/stylesheets/extra.css
@@ -143,3 +143,13 @@ body[data-md-color-scheme="slate"] .md-nav__item--section > label.md-nav__link .
 [data-md-color-scheme="slate"] .logo-light {
   display: none;
 }
+
+/* Outline for content tabs */
+.md-typeset .tabbed-set {
+  border: 0.075rem solid var(--md-default-fg-color);
+  border-radius: 0.2rem;
+}
+
+.md-typeset .tabbed-content {
+  padding: 0 0.6em;
+}


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

Add outline to content tabs in docs to make it clearer where they start and stop. The numbers used in the CSS are the same as for admonitions.

Before: 
![image](https://github.com/user-attachments/assets/0b801e72-3803-457b-a5c9-5f41cc41f2e2)

After:
![image](https://github.com/user-attachments/assets/28a97dd3-54d9-4ce6-b6ec-9f4eeb2f0339)


As requested in https://vllm-dev.slack.com/archives/C07QH6WQC66/p1748017290470629?thread_ts=1747427213.020199&cid=C07QH6WQC66

cc @davidxia 

## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
