### PR TITLE
[Misc] Improve logging for dynamic shape cache compilation

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -120,10 +120,15 @@ class CompilerManager:
         handle = self.cache[(runtime_shape, graph_index, self.compiler.name)]
         compiled_graph = self.compiler.load(handle, graph, example_inputs,
                                             graph_index, runtime_shape)
-        logger.debug(
-            "Directly load the %s-th graph for shape %s from %s via "
-            "handle %s", graph_index, str(runtime_shape), self.compiler.name,
-            handle)
+        if runtime_shape is None:
+            logger.debug(
+                "Directly load the %s-th graph for dynamic shape from %s via "
+                "handle %s", graph_index, self.compiler.name, handle)
+        else:
+            logger.debug(
+                "Directly load the %s-th graph for shape %s from %s via "
+                "handle %s", graph_index, str(runtime_shape),
+                self.compiler.name, handle)
         return compiled_graph
 
     def compile(self,
@@ -152,9 +157,15 @@ class CompilerManager:
                 # there can be multiple graphs due to piecewise compilation.
                 now = time.time()
                 elapsed = now - compilation_start_time
-                logger.info(
-                    "Directly load the compiled graph(s) for shape %s "
-                    "from the cache, took %.3f s", str(runtime_shape), elapsed)
+                if runtime_shape is None:
+                    logger.info(
+                        "Directly load the compiled graph(s) for dynamic shape "
+                        "from the cache, took %.3f s", elapsed)
+                else:
+                    logger.info(
+                        "Directly load the compiled graph(s) for shape %s "
+                        "from the cache, took %.3f s", str(runtime_shape),
+                        elapsed)
             return compiled_graph
 
         # no compiler cached the graph, or the cache is disabled,
@@ -184,9 +195,15 @@ class CompilerManager:
                 else:
                     logger.info("Cache the graph of shape %s for later use",
                                 str(runtime_shape))
-            logger.debug(
-                "store the %s-th graph for shape %s from %s via handle %s",
-                graph_index, str(runtime_shape), self.compiler.name, handle)
+            if runtime_shape is None:
+                logger.debug(
+                    "store the %s-th graph for dynamic shape from %s via "
+                    "handle %s", graph_index, self.compiler.name, handle)
+            else:
+                logger.debug(
+                    "store the %s-th graph for shape %s from %s via handle %s",
+                    graph_index, str(runtime_shape), self.compiler.name,
+                    handle)
 
         # after compiling the last graph, record the end time
         if graph_index == num_graphs - 1:
@@ -194,7 +211,7 @@ class CompilerManager:
             elapsed = now - compilation_start_time
             compilation_config.compilation_time += elapsed
             if runtime_shape is None:
-                logger.info("Compiling a graph for general shape takes %.2f s",
+                logger.info("Compiling a graph for dynamic shape takes %.2f s",
                             elapsed)
             else:
                 logger.info("Compiling a graph for shape %s takes %.2f s",
@@ -312,7 +329,7 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
                 i for i, x in enumerate(args) if isinstance(x, torch.SymInt)
             ]
             global compilation_start_time
-            compiled_graph_for_general_shape = self.vllm_backend.\
+            compiled_graph_for_dynamic_shape = self.vllm_backend.\
                 compiler_manager.compile(
                 submod,
                 args,
@@ -327,7 +344,7 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
             self.module.__dict__[target] = piecewise_backend(
                 submod, self.vllm_config, self.graph_pool, index,
                 len(self.compile_submod_names), sym_shape_indices,
-                compiled_graph_for_general_shape, self.vllm_backend)
+                compiled_graph_for_dynamic_shape, self.vllm_backend)
 
             compilation_counter.num_piecewise_capturable_graphs_seen += 1
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -197,11 +197,11 @@ class CompilerManager:
                                 str(runtime_shape))
             if runtime_shape is None:
                 logger.debug(
-                    "store the %s-th graph for dynamic shape from %s via "
+                    "Store the %s-th graph for dynamic shape from %s via "
                     "handle %s", graph_index, self.compiler.name, handle)
             else:
                 logger.debug(
-                    "store the %s-th graph for shape %s from %s via handle %s",
+                    "Store the %s-th graph for shape %s from %s via handle %s",
                     graph_index, str(runtime_shape), self.compiler.name,
                     handle)
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -179,10 +179,11 @@ class CompilerManager:
             if graph_index == 0:
                 # adds some info logging for the first graph
                 if runtime_shape is None:
-                    logger.info("Cache the graph for DYNAMIC shape for later use")
+                    logger.info(
+                        "Cache the graph for dynamic shape for later use")
                 else:
                     logger.info("Cache the graph of shape %s for later use",
-                            str(runtime_shape))
+                                str(runtime_shape))
             logger.debug(
                 "store the %s-th graph for shape %s from %s via handle %s",
                 graph_index, str(runtime_shape), self.compiler.name, handle)

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -178,7 +178,10 @@ class CompilerManager:
             self.is_cache_updated = True
             if graph_index == 0:
                 # adds some info logging for the first graph
-                logger.info("Cache the graph of shape %s for later use",
+                if runtime_shape is None:
+                    logger.info("Cache the graph for DYNAMIC shape for later use")
+                else:
+                    logger.info("Cache the graph of shape %s for later use",
                             str(runtime_shape))
             logger.debug(
                 "store the %s-th graph for shape %s from %s via handle %s",


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
<img width="308" alt="Screenshot 2025-07-07 at 9 32 51 AM" src="https://github.com/user-attachments/assets/9b216743-53a7-4b44-9f50-a0e16bdc83e0" />

When a graph is compiled for dynamic shapes, the previous log message ("Cache the graph of shape None for later use") is ambiguous. This update makes it clear that the cached graph supports dynamic inputs, improving clarity of the compilation process.

Slack Issue: https://vllm-dev.slack.com/archives/C08K1FAHFPH/p1751506800619009
## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
