### PR TITLE
[Bench] Add NVFP4 GEMM benchmark script

### DIFF
--- a/benchmarks/kernels/bench_nvfp4_gemm.py
+++ b/benchmarks/kernels/bench_nvfp4_gemm.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+import copy
+import itertools
+
+import torch
+from weight_shapes import WEIGHT_SHAPES
+
+from vllm import _custom_ops as ops
+from vllm.scalar_type import scalar_types
+from vllm.triton_utils import triton
+
+FLOAT4_E2M1_MAX = scalar_types.float4_e2m1f.max()
+FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+PROVIDER_CFGS = {
+    "torch-bf16": dict(enabled=True),
+    "nvfp4": dict(no_a_quant=False, enabled=True),
+    "nvfp4-noquant": dict(no_a_quant=True, enabled=True),
+}
+
+_enabled = [k for k, v in PROVIDER_CFGS.items() if v["enabled"]]
+
+
+def _quant_weight_nvfp4(b: torch.Tensor, device: str):
+    # Compute global scale for weight
+    b_global_scale = (
+        (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.amax(b.flatten(), dim=-1)
+    ).to(torch.float32)
+    b_fp4, scale_b_fp4 = ops.scaled_fp4_quant(b, b_global_scale)
+    return b_fp4.t(), scale_b_fp4, b_global_scale
+
+
+def build_nvfp4_runner(cfg, a, b, dtype, device):
+    b_fp4, scale_b_fp4, b_global_scale = _quant_weight_nvfp4(b, device)
+
+    # Compute global scale for activation
+    a_global_scale = (
+        (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.amax(a.flatten(), dim=-1)
+    ).to(torch.float32)
+
+    # Alpha for the GEMM operation
+    alpha = 1.0 / (a_global_scale * b_global_scale)
+
+    if cfg["no_a_quant"]:
+        # Pre-quantize activation
+        a_fp4, scale_a_fp4 = ops.scaled_fp4_quant(a, a_global_scale)
+
+        def run():
+            return ops.cutlass_scaled_fp4_mm(
+                a_fp4, b_fp4, scale_a_fp4, scale_b_fp4, alpha, dtype
+            )
+
+        return run
+
+    # Quantize activation on-the-fly
+    def run():
+        a_fp4, scale_a_fp4 = ops.scaled_fp4_quant(a, a_global_scale)
+        return ops.cutlass_scaled_fp4_mm(
+            a_fp4, b_fp4, scale_a_fp4, scale_b_fp4, alpha, dtype
+        )
+
+    return run
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size"],
+        x_vals=[1, 16, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384],
+        x_log=False,
+        line_arg="provider",
+        line_vals=_enabled,
+        line_names=_enabled,
+        ylabel="TFLOP/s (larger is better)",
+        plot_name="BF16 vs NVFP4 GEMMs",
+        args={},
+    )
+)
+def benchmark(batch_size, provider, N, K):
+    M = batch_size
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    a = torch.randn((M, K), device=device, dtype=dtype)
+    b = torch.randn((N, K), device=device, dtype=dtype)
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "torch-bf16":
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            lambda: torch.nn.functional.linear(a, b), quantiles=quantiles
+        )
+    else:
+        cfg = PROVIDER_CFGS[provider]
+        run_quant = build_nvfp4_runner(cfg, a, b, dtype, device)
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            lambda: run_quant(), quantiles=quantiles
+        )
+
+    to_tflops = lambda t_ms: (2 * M * N * K) * 1e-12 / (t_ms * 1e-3)
+    return to_tflops(ms), to_tflops(max_ms), to_tflops(min_ms)
+
+
+def prepare_shapes(args):
+    out = []
+    for model, tp_size in itertools.product(args.models, args.tp_sizes):
+        for KN, tp_dim in copy.deepcopy(WEIGHT_SHAPES[model]):
+            KN[tp_dim] //= tp_size
+            KN.append(model)
+            out.append(KN)
+    return out
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        type=str,
+        default=["meta-llama/Llama-3.1-8B-Instruct"],
+        choices=list(WEIGHT_SHAPES.keys()),
+    )
+    parser.add_argument("--tp-sizes", nargs="+", type=int, default=[1])
+    args = parser.parse_args()
+
+    for K, N, model in prepare_shapes(args):
+        print(f"{model}, N={N} K={K}, BF16 vs NVFP4 GEMMs TFLOP/s:")
+        benchmark.run(
+            print_data=True,
+            show_plots=True,
+            save_path=f"bench_nvfp4_res_n{N}_k{K}",
+            N=N,
+            K=K,
+        )
+
+    print("Benchmark finished!")

--- a/benchmarks/kernels/bench_nvfp4_gemm.py
+++ b/benchmarks/kernels/bench_nvfp4_gemm.py
@@ -29,7 +29,7 @@ def _quant_weight_nvfp4(b: torch.Tensor, device: str):
         (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.amax(b.flatten(), dim=-1)
     ).to(torch.float32)
     b_fp4, scale_b_fp4 = ops.scaled_fp4_quant(b, b_global_scale)
-    return b_fp4.t(), scale_b_fp4, b_global_scale
+    return b_fp4, scale_b_fp4, b_global_scale
 
 
 def build_nvfp4_runner(cfg, a, b, dtype, device):

--- a/benchmarks/kernels/bench_nvfp4_gemm.py
+++ b/benchmarks/kernels/bench_nvfp4_gemm.py
@@ -8,8 +8,13 @@ import torch
 from weight_shapes import WEIGHT_SHAPES
 
 from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.triton_utils import triton
+
+if not current_platform.has_device_capability(100):
+    raise RuntimeError("NVFP4 requires compute capability of 10.0 (Blackwell)")
+
 
 FLOAT4_E2M1_MAX = scalar_types.float4_e2m1f.max()
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max


### PR DESCRIPTION
## Purpose

Create a GEMM benchmarking scripts for NVFP4 vs Torch B16 to measure the speedup from just the GEMM vs Input Quant+GEMM.

This will make it obvious where we need tuned configs for the CUTLASS NVFP4 kernel

## Test Plan

## Test Result

```
python benchmarks/kernels/bench_nvfp4_gemm.py
INFO 07-07 10:59:52 [__init__.py:253] Automatically detected platform cuda.
meta-llama/Llama-3.1-8B-Instruct, N=6144 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
BF16 vs NVFP4 GEMMs:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.924172     3.737964       4.439497
1         16.0    94.808087    59.959389      71.160187
2         64.0   402.453176   235.645587     281.971021
3        128.0   729.098503   454.178740     549.526976
4        256.0  1127.022999   879.792065    1102.033286
5        512.0  1284.375329  1569.117801    2187.995534
6       1024.0  1325.576211  2221.422141    2894.987191
7       2048.0  1354.907564  2613.101820    3411.463557
8       4096.0  1365.255495  2947.881593    3645.594842
9       8192.0  1420.966950  3025.497089    3778.760919
10     16384.0  1360.143047  3038.844961    3904.329097
meta-llama/Llama-3.1-8B-Instruct, N=4096 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
BF16 vs NVFP4 GEMMs:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     2.743044     2.512813       2.959913
1         16.0    72.909522    39.923088      47.733914
2         64.0   286.504330   157.558962     189.042770
3        128.0   562.777427   307.651199     367.819965
4        256.0   892.743015   592.931511     736.484223
5        512.0  1334.196921  1096.955020    1464.945055
6       1024.0  1420.353132  1526.342525    1963.895274
7       2048.0  1542.245939  2127.586923    2869.959550
8       4096.0  1373.660366  2504.805111    3670.619383
9       8192.0  1353.645355  2637.876367    3414.764879
10     16384.0  1598.785266  2850.085214    3652.222036
meta-llama/Llama-3.1-8B-Instruct, N=28672 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
BF16 vs NVFP4 GEMMs:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.864423     7.462163       7.962781
1         16.0    81.321610   116.918922     127.857740
2         64.0   318.960754   452.769441     490.264990
3        128.0   605.964083   796.389757     873.748743
4        256.0  1064.514375  1507.182985    1649.608901
5        512.0  1190.217186  2357.907653    2885.773900
6       1024.0  1266.214628  2461.815161    3081.115981
7       2048.0  1344.744438  3102.554901    3466.322910
8       4096.0  1390.143842  3480.580696    3732.582197
9       8192.0  1477.990993  3359.169667    3901.655578
10     16384.0  1663.784607  2841.498490    3204.516143
meta-llama/Llama-3.1-8B-Instruct, N=4096 K=14336, BF16 vs NVFP4 GEMMs TFLOP/s:
BF16 vs NVFP4 GEMMs:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.028785     4.269722       5.000212
1         16.0    80.878370    68.211048      80.028498
2         64.0   308.309481   270.964799     319.184640
3        128.0   606.275177   520.047790     626.527530
4        256.0   854.833097  1022.346942    1250.919778
5        512.0  1259.046220  1759.090683    2483.819182
6       1024.0  1342.229769  1650.521253    2828.362268
7       2048.0  1421.170808  2455.604891    3159.432997
8       4096.0  1421.740507  2773.698866    3615.426328
9       8192.0  1441.527708  2877.289540    3906.919234
10     16384.0  1577.775723  3106.105504    4106.835007
Benchmark finished!
```