### PR TITLE
[Bugfix] Fix the issue of missing engine_id in the multi connector

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3843,6 +3843,11 @@ class KVTransferConfig:
         if self.kv_connector is not None and self.kv_role is None:
             raise ValueError("Please specify kv_disagg_role when kv_connector "
                              f"is set, supported roles are {get_args(KVRole)}")
+        ktcs = self.kv_connector_extra_config.get("connectors")
+        if ktcs is not None:
+            for i, ktc in enumerate(ktcs):
+                temp_config = KVTransferConfig(**ktc)
+                ktcs[i] = asdict(temp_config)
 
     @property
     def is_kv_transfer_instance(self) -> bool:


### PR DESCRIPTION
to fix https://github.com/vllm-project/vllm/issues/20609

## Purpose
Fix the issue where the nixl connector's decode instance fails to locate the engine_id when both the nixl connector and lmcache connector are used simultaneously. 

## Test Plan
Below is my test command:
```
VLLM_LOGGING_LEVEL=DEBUG LMCACHE_CHUNK_SIZE=256 LMCACHE_LOCAL_CPU=True LMCACHE_MAX_LOCAL_CPU_SIZE=30.0 LMCACHE_LOG_LEVEL=INFO CUDA_VISIBLE_DEVICES=0,1 VLLM_NIXL_SIDE_CHANNEL_PORT=5559 vllm serve /models/Qwen3-1.7B --served-model-name "qwen3" --port 8100 --disable-log-requests --gpu-memory-utilization 0.9 --tensor-parallel-size 2 --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}]}}'

VLLM_LOGGING_LEVEL=DEBUG LMCACHE_CHUNK_SIZE=256 LMCACHE_LOCAL_CPU=True LMCACHE_MAX_LOCAL_CPU_SIZE=30.0 LMCACHE_LOG_LEVEL=INFO CUDA_VISIBLE_DEVICES=2,3 VLLM_NIXL_SIDE_CHANNEL_PORT=5659 vllm serve /weights/Qwen3-1.7B --served-model-name "qwen3" --port 8200 --disable-log-requests --gpu-memory-utilization 0.9 --tensor-parallel-size 2 --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}]}}'
```
