### PR TITLE
[CI] Increase the threshold of the MTEB RERANK tests

### DIFF
--- a/tests/models/language/pooling/mteb_utils.py
+++ b/tests/models/language/pooling/mteb_utils.py
@@ -23,7 +23,7 @@ MTEB_EMBED_TOL = 1e-4
 # See #19344
 MTEB_RERANK_TASKS = ["NFCorpus"]
 MTEB_RERANK_LANGS = ["en"]
-MTEB_RERANK_TOL = 1e-3
+MTEB_RERANK_TOL = 2e-3
 
 
 class VllmMtebEncoder(mteb.Encoder):

--- a/tests/models/language/pooling/test_baai.py
+++ b/tests/models/language/pooling/test_baai.py
@@ -68,7 +68,6 @@ RERANK_MODELS = [
                     enable_test=False),
     RerankModelInfo("BAAI/bge-reranker-v2-m3",
                     architecture="XLMRobertaForSequenceClassification",
-                    dtype="float32",
                     enable_test=False)
 ]
 

--- a/tests/models/language/pooling/test_jina.py
+++ b/tests/models/language/pooling/test_jina.py
@@ -18,11 +18,8 @@ EMBEDDING_MODELS = [
 ]
 
 RERANK_MODELS = [
-    RerankModelInfo(
-        "jinaai/jina-reranker-v2-base-multilingual",
-        architecture="XLMRobertaForSequenceClassification",
-        dtype="float32",
-    )
+    RerankModelInfo("jinaai/jina-reranker-v2-base-multilingual",
+                    architecture="XLMRobertaForSequenceClassification")
 ]
 
 

--- a/tests/models/language/pooling/test_qwen3_reranker.py
+++ b/tests/models/language/pooling/test_qwen3_reranker.py
@@ -12,11 +12,9 @@ from .mteb_utils import RerankModelInfo, mteb_test_rerank_models
 RERANK_MODELS = [
     RerankModelInfo("Qwen/Qwen3-Reranker-0.6B",
                     architecture="Qwen3ForSequenceClassification",
-                    dtype="float32",
                     enable_test=True),
     RerankModelInfo("Qwen/Qwen3-Reranker-4B",
                     architecture="Qwen3ForSequenceClassification",
-                    dtype="float32",
                     enable_test=False)
 ]
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
fix [Nightly build to run all tests](https://buildkite.com/vllm/ci/builds/23393) 

Just as I said in #19344.

> I don't know why, but the differences between the models on local and CI machines are greater than those between fp16 and fp32.

try MTEB_RERANK_TOL = 1e-3 -> MTEB_RERANK_TOL = 2e-3

- test_bge_reranker_v2_gemma
ci
[2025-07-08T06:18:58Z] FAILED models/language/pooling/test_bge_reranker_v2_gemma.py::test_rerank_models_mteb[model_info0] - AssertionError
[2025-07-08T05:22:14Z] VLLM: torch.float16 0.33624
[2025-07-08T05:22:14Z] SentenceTransformers: torch.float32 0.33757
[2025-07-08T05:22:14Z] Difference: 0.0013299999999999979


local
pytest -s -vvv tests/models/language/pooling/test_bge_reranker_v2_gemma.py
VLLM: torch.float16 0.33913
SentenceTransformers: torch.float32 0.33956
Difference: 0.00042999999999998595

- test_qwen3_reranker

ci
[2025-07-08T06:18:58Z] FAILED models/language/pooling/test_qwen3_reranker.py::test_rerank_models_mteb[model_info0] - AssertionError
[2025-07-08T06:12:54Z] VLLM: torch.float32 0.25841
[2025-07-08T06:12:54Z] SentenceTransformers: torch.float32 0.25736
[2025-07-08T06:12:54Z] Difference: -0.0010499999999999954


local
pytest -s -vvv tests/models/language/pooling/test_qwen3_reranker.py
VLLM: torch.bfloat16 0.26518
SentenceTransformers: torch.float32 0.26513
Difference: -5.0000000000050004e-05

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
