### PR TITLE
Revert invalid spellchecker fix on deepseek_vl2

### DIFF
--- a/vllm/model_executor/models/deepseek_vl2.py
+++ b/vllm/model_executor/models/deepseek_vl2.py
@@ -351,11 +351,11 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         embed_std = 1 / torch.sqrt(
             torch.tensor(self.projector_config.n_embed, dtype=torch.float32))
         if self.tile_tag == "2D":
-            # <|view_separator|>, <|\n|>
+            # <|view_seperator|>, <|\n|>
             self.image_newline = nn.Parameter(
                 torch.randn(self.projector_config.n_embed) * embed_std)
             # This is a typo in original implementation
-            self.view_separator = nn.Parameter(
+            self.view_seperator = nn.Parameter(
                 torch.randn(self.projector_config.n_embed) * embed_std)
         else:
             raise ValueError(
@@ -560,13 +560,13 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
             if self.global_view_pos == "head":
                 global_local_features = torch.cat([
                     global_features,
-                    self.view_separator[None, :],
+                    self.view_seperator[None, :],
                     local_features,
                 ])
             else:
                 global_local_features = torch.cat([
                     local_features,
-                    self.view_separator[None, :],
+                    self.view_seperator[None, :],
                     global_features,
                 ])
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [N/A] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose: Fix #20617

Due to a typo on the Deepseek side, we need to undo a fix found by a change to the spellchecker in the deepseek_vl2.py file introduced by commit 2f1c19b2456d4fb15f3475c9db5b077777feab76 .

## Test Plan: Load Deepseek VL2 model

Try loading a deepseek VL2 model before and after the changes.

## Test Result

Before: Fails with error:
```text
vllm_server  | ERROR 07-08 00:46:53 [core.py:586] ValueError: There is no module or parameter named 'view_seperator' in DeepseekVLV2ForCausalLM
```

After: Succeeds and loads without error.

## (Optional) Documentation Update

N/A.

<!--- pyml disable-next-line no-emphasis-as-heading -->
