### PR TITLE
Fix bullets in incremental_build.md

### DIFF
--- a/docs/contributing/incremental_build.md
+++ b/docs/contributing/incremental_build.md
@@ -84,6 +84,7 @@ Below is an example of what the generated `CMakeUserPresets.json` might look lik
 ```
 
 **What do the various configurations mean?**
+
 - `CMAKE_CUDA_COMPILER`: Path to your `nvcc` binary. The script attempts to find this automatically.
 - `CMAKE_C_COMPILER_LAUNCHER`, `CMAKE_CXX_COMPILER_LAUNCHER`, `CMAKE_CUDA_COMPILER_LAUNCHER`: Setting these to `ccache` (or `sccache`) significantly speeds up rebuilds by caching compilation results. Ensure `ccache` is installed (e.g., `sudo apt install ccache` or `conda install ccache`). The script sets these by default.
 - `VLLM_PYTHON_EXECUTABLE`: Path to the Python executable in your vLLM development environment. The script will prompt for this, defaulting to the current Python environment if suitable.


### PR DESCRIPTION
Just a small fix to the broken bullet list on the incremental cmake docs
<img width="1341" alt="Screenshot 2025-07-08 at 3 27 43 PM" src="https://github.com/user-attachments/assets/0c8251ac-79c3-4434-8281-17e1f76d2e64" />
