### PR TITLE
[Kernel] Basic tuned configs for NVFP4 CUTLASS dense GEMM

### DIFF
--- a/csrc/quantization/fp4/nvfp4_scaled_mm_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_scaled_mm_kernels.cu
@@ -134,7 +134,7 @@ typename Config::Gemm::Arguments args_from_options(
   using ElementB = typename Config::Gemm::ElementB;
   using ElementSFA = cutlass::float_ue4m3_t;
   using ElementSFB = cutlass::float_ue4m3_t;
-  using ElementD = typename Config::ElementD;
+  using ElementD = typename Config::Gemm::ElementD;
   using ElementCompute = float;
   using StrideA = typename Config::StrideA;
   using StrideB = typename Config::StrideB;

--- a/csrc/quantization/fp4/nvfp4_scaled_mm_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_scaled_mm_kernels.cu
@@ -20,46 +20,48 @@
 #include <c10/cuda/CUDAGuard.h>
 
 #include "cutlass_extensions/common.hpp"
-
 #include "cutlass/cutlass.h"
-
 #include "cutlass/gemm/collective/collective_builder.hpp"
 #include "cutlass/epilogue/collective/collective_builder.hpp"
 #include "cutlass/gemm/device/gemm_universal_adapter.h"
 #include "cutlass/gemm/kernel/gemm_universal.hpp"
-
 #include "cutlass/util/packed_stride.hpp"
+
+#include "core/math.hpp"
 
 using namespace cute;
 
 #if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
-// Kernel Perf config
-template <typename T>
-struct KernelTraits;
 
-template <>
-struct KernelTraits<float> {
-  using MmaTileShape = Shape<_128, _128, _256>;
+// Configuration for M in (256, inf)
+struct sm100_fp4_config_default {
+  using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileShape = Shape<_256, _256, _256>;
+  using ClusterShape = Shape<_2, _1, _1>;
+  using PerSmTileShape_MNK = Shape<_128, _256, _256>;
+};
+
+// Configuration for M in (16, 256]
+struct sm100_fp4_config_M256 {
+  using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileShape = Shape<_256, _128, _256>;
+  using ClusterShape = Shape<_2, _1, _1>;
+  using PerSmTileShape_MNK = Shape<_128, _128, _256>;
+};
+
+// Configuration for M in [1, 16]
+struct sm100_fp4_config_M16 {
+  using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileShape = Shape<_128, _128, _256>;
   using ClusterShape = Shape<_1, _1, _1>;
   using PerSmTileShape_MNK = Shape<_128, _128, _256>;
 };
 
-template <>
-struct KernelTraits<cutlass::half_t> {
-  using MmaTileShape = Shape<_256, _256, _256>;
-  using ClusterShape = Shape<_4, _4, _1>;
-  using PerSmTileShape_MNK = Shape<_128, _256, _256>;
-};
-
-template <>
-struct KernelTraits<cutlass::bfloat16_t> {
-  using MmaTileShape = Shape<_256, _256, _256>;
-  using ClusterShape = Shape<_4, _4, _1>;
-  using PerSmTileShape_MNK = Shape<_128, _256, _256>;
-};
-
-template <typename T>
-struct Fp4GemmSm100 {
+template <typename Config, typename OutType>
+struct Fp4GemmSm100Specialized {
   // A matrix configuration
   using ElementA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
   using LayoutATag = cutlass::layout::RowMajor;
@@ -71,21 +73,22 @@ struct Fp4GemmSm100 {
   static constexpr int AlignmentB = 32;
 
   // C/D matrix configuration
-  using ElementD = T;
-  using ElementC = T;
+  using ElementD = OutType;
+  using ElementC = OutType;
   using LayoutCTag = cutlass::layout::RowMajor;
   using LayoutDTag = cutlass::layout::RowMajor;
   static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
   static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
   // Kernel functional config
   using ElementAccumulator = float;
   using ArchTag = cutlass::arch::Sm100;
   using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
 
-  // Kernel Perf config
-  using MmaTileShape = typename KernelTraits<T>::MmaTileShape;
-  using ClusterShape = typename KernelTraits<T>::ClusterShape;
-  using PerSmTileShape_MNK = typename KernelTraits<T>::PerSmTileShape_MNK;
+  // Use config's tile shapes
+  using MmaTileShape = typename Config::TileShape;
+  using ClusterShape = typename Config::ClusterShape;
+  using PerSmTileShape_MNK = typename Config::PerSmTileShape_MNK;
 
   using CollectiveEpilogue =
       typename cutlass::epilogue::collective::CollectiveBuilder<
@@ -108,33 +111,25 @@ struct Fp4GemmSm100 {
       Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
   using StrideA = typename Gemm::GemmKernel::StrideA;
-  using LayoutA = decltype(cute::make_layout(make_shape(0, 0, 0), StrideA{}));
-  using LayoutSFA = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFA;
   using StrideB = typename Gemm::GemmKernel::StrideB;
-  using LayoutB = decltype(cute::make_layout(make_shape(0, 0, 0), StrideB{}));
-  using LayoutSFB = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFB;
-  using StrideC = typename Gemm::GemmKernel::StrideC;
-  using LayoutC = decltype(cute::make_layout(make_shape(0, 0, 0), StrideC{}));
   using StrideD = typename Gemm::GemmKernel::StrideD;
-  using LayoutD = decltype(cute::make_layout(make_shape(0, 0, 0), StrideD{}));
 };
 
-template <typename T>
-typename T::Gemm::Arguments args_from_options(
+template <typename Config>
+typename Config::Gemm::Arguments args_from_options(
     at::Tensor& D, at::Tensor const& A, at::Tensor const& B,
     at::Tensor const& A_sf, at::Tensor const& B_sf, at::Tensor const& alpha,
     int64_t M, int64_t N, int64_t K) {
-  using ElementA = typename T::Gemm::ElementA;
-  using ElementB = typename T::Gemm::ElementB;
+  using ElementUnpacked = cutlass::float_e2m1_t;
   using ElementSFA = cutlass::float_ue4m3_t;
   using ElementSFB = cutlass::float_ue4m3_t;
-  using ElementD = typename T::Gemm::ElementD;
+  using ElementD = typename Config::ElementD;
   using ElementCompute = float;
-  using StrideA = typename T::StrideA;
-  using StrideB = typename T::StrideB;
-  using StrideD = typename T::StrideD;
-  using Sm100BlkScaledConfig =
-      typename T::Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  using StrideA = typename Config::StrideA;
+  using StrideB = typename Config::StrideB;
+  using StrideD = typename Config::StrideD;
+  using Sm100BlkScaledConfig = typename Config::Gemm::GemmKernel::
+      CollectiveMainloop::Sm1xxBlkScaledConfig;
 
   int m = static_cast<int>(M);
   int n = static_cast<int>(N);
@@ -148,12 +143,12 @@ typename T::Gemm::Arguments args_from_options(
   auto layout_SFB = Sm100BlkScaledConfig::tile_atom_to_shape_SFB(
       cute::make_shape(m, n, k, 1));
 
-  typename T::Gemm::Arguments arguments{
+  typename Config::Gemm::Arguments arguments{
       cutlass::gemm::GemmUniversalMode::kGemm,
       {m, n, k, 1},
       {// Mainloop arguments
-       static_cast<ElementA const*>(A.data_ptr()), stride_A,
-       static_cast<ElementB const*>(B.data_ptr()), stride_B,
+       static_cast<ElementUnpacked const*>(A.data_ptr()), stride_A,
+       static_cast<ElementUnpacked const*>(B.data_ptr()), stride_B,
        static_cast<ElementSFA const*>(A_sf.data_ptr()), layout_SFA,
        static_cast<ElementSFB const*>(B_sf.data_ptr()), layout_SFB},
       {     // Epilogue arguments
@@ -167,17 +162,17 @@ typename T::Gemm::Arguments args_from_options(
   return arguments;
 }
 
-template <typename T>
+template <typename Config>
 void runGemm(at::Tensor& D, at::Tensor const& A, at::Tensor const& B,
              at::Tensor const& A_sf, at::Tensor const& B_sf,
              at::Tensor const& alpha, int64_t m, int64_t n, int64_t k,
              cudaStream_t stream) {
-  typename Fp4GemmSm100<T>::Gemm gemm;
+  typename Config::Gemm gemm;
 
   auto arguments =
-      args_from_options<Fp4GemmSm100<T>>(D, A, B, A_sf, B_sf, alpha, m, n, k);
+      args_from_options<Config>(D, A, B, A_sf, B_sf, alpha, m, n, k);
 
-  size_t workspace_size = Fp4GemmSm100<T>::Gemm::get_workspace_size(arguments);
+  size_t workspace_size = Config::Gemm::get_workspace_size(arguments);
   auto const workspace_options =
       torch::TensorOptions().dtype(torch::kUInt8).device(A.device());
   auto workspace = torch::empty(workspace_size, workspace_options);
@@ -188,12 +183,40 @@ void runGemm(at::Tensor& D, at::Tensor const& A, at::Tensor const& B,
 
   CUTLASS_CHECK(gemm.run(arguments, workspace.data_ptr(), stream));
 }
+
+// Dispatch function to select appropriate config based on M
+template <typename OutType>
+void cutlass_fp4_gemm_dispatch(torch::Tensor& D, torch::Tensor const& A,
+                               torch::Tensor const& B,
+                               torch::Tensor const& A_sf,
+                               torch::Tensor const& B_sf,
+                               torch::Tensor const& alpha, int64_t m, int64_t n,
+                               int64_t k, cudaStream_t stream) {
+  uint32_t const mp2 = std::max(static_cast<uint32_t>(16), next_pow_2(m));
+
+  if (mp2 <= 16) {
+    // m in [1, 16]
+    runGemm<Fp4GemmSm100Specialized<sm100_fp4_config_M16, OutType>>(
+        D, A, B, A_sf, B_sf, alpha, m, n, k, stream);
+  } else if (mp2 <= 256) {
+    // m in (16, 256]
+    runGemm<Fp4GemmSm100Specialized<sm100_fp4_config_M256, OutType>>(
+        D, A, B, A_sf, B_sf, alpha, m, n, k, stream);
+  } else {
+    // m in (256, inf)
+    runGemm<Fp4GemmSm100Specialized<sm100_fp4_config_default, OutType>>(
+        D, A, B, A_sf, B_sf, alpha, m, n, k, stream);
+  }
+}
+
 #else
-template <typename T>
-void runGemm(at::Tensor& D, at::Tensor const& A, at::Tensor const& B,
-             at::Tensor const& A_sf, at::Tensor const& B_sf,
-             at::Tensor const& alpha, int64_t m, int64_t n, int64_t k,
-             cudaStream_t stream) {
+template <typename OutType>
+void cutlass_fp4_gemm_dispatch(torch::Tensor& D, torch::Tensor const& A,
+                               torch::Tensor const& B,
+                               torch::Tensor const& A_sf,
+                               torch::Tensor const& B_sf,
+                               torch::Tensor const& alpha, int64_t m, int64_t n,
+                               int64_t k, cudaStream_t stream) {
   TORCH_CHECK(false,
               "Unsupported CUTLASS version. Set VLLM_CUTLASS_SRC_DIR to "
               "a CUTLASS 3.8 source directory to enable support.");
@@ -271,12 +294,13 @@ void cutlass_scaled_fp4_mm_sm100a(torch::Tensor& D, torch::Tensor const& A,
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream(A.get_device());
 
   if (out_dtype == at::ScalarType::Half) {
-    runGemm<cutlass::half_t>(D, A, B, A_sf, B_sf, alpha, m, n, k, stream);
+    cutlass_fp4_gemm_dispatch<cutlass::half_t>(D, A, B, A_sf, B_sf, alpha, m, n,
+                                               k, stream);
   } else if (out_dtype == at::ScalarType::BFloat16) {
-    runGemm<cutlass::bfloat16_t>(D, A, B, A_sf, B_sf, alpha, m, n, k, stream);
-  } else if (out_dtype == at::ScalarType::Float) {
-    runGemm<float>(D, A, B, A_sf, B_sf, alpha, m, n, k, stream);
+    cutlass_fp4_gemm_dispatch<cutlass::bfloat16_t>(D, A, B, A_sf, B_sf, alpha,
+                                                   m, n, k, stream);
   } else {
-    TORCH_CHECK(false, "Unsupported output data type of nvfp4 mm");
+    TORCH_CHECK(false, "Unsupported output data type of nvfp4 mm (", out_dtype,
+                ")");
   }
 }


### PR DESCRIPTION
## Purpose

Refactor the NVFP4 CUTLASS kernel to make it easy to specify new configs and use a few made by running the cutlass profiler. We can certainly do better than this, but it is a starting point.

## Test Plan

Use GEMM bench script from https://github.com/vllm-project/vllm/pull/20578 and manual lm-eval tests

## Test Result

Before:
```
python benchmarks/kernels/bench_nvfp4_gemm.py
meta-llama/Llama-3.1-8B-Instruct, N=6144 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.924172     3.737964       4.439497
1         16.0    94.808087    59.959389      71.160187
2         64.0   402.453176   235.645587     281.971021
3        128.0   729.098503   454.178740     549.526976
4        256.0  1127.022999   879.792065    1102.033286
5        512.0  1284.375329  1569.117801    2187.995534
6       1024.0  1325.576211  2221.422141    2894.987191
7       2048.0  1354.907564  2613.101820    3411.463557
8       4096.0  1365.255495  2947.881593    3645.594842
9       8192.0  1420.966950  3025.497089    3778.760919
10     16384.0  1360.143047  3038.844961    3904.329097
meta-llama/Llama-3.1-8B-Instruct, N=4096 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     2.743044     2.512813       2.959913
1         16.0    72.909522    39.923088      47.733914
2         64.0   286.504330   157.558962     189.042770
3        128.0   562.777427   307.651199     367.819965
4        256.0   892.743015   592.931511     736.484223
5        512.0  1334.196921  1096.955020    1464.945055
6       1024.0  1420.353132  1526.342525    1963.895274
7       2048.0  1542.245939  2127.586923    2869.959550
8       4096.0  1373.660366  2504.805111    3670.619383
9       8192.0  1353.645355  2637.876367    3414.764879
10     16384.0  1598.785266  2850.085214    3652.222036
meta-llama/Llama-3.1-8B-Instruct, N=28672 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.864423     7.462163       7.962781
1         16.0    81.321610   116.918922     127.857740
2         64.0   318.960754   452.769441     490.264990
3        128.0   605.964083   796.389757     873.748743
4        256.0  1064.514375  1507.182985    1649.608901
5        512.0  1190.217186  2357.907653    2885.773900
6       1024.0  1266.214628  2461.815161    3081.115981
7       2048.0  1344.744438  3102.554901    3466.322910
8       4096.0  1390.143842  3480.580696    3732.582197
9       8192.0  1477.990993  3359.169667    3901.655578
10     16384.0  1663.784607  2841.498490    3204.516143
meta-llama/Llama-3.1-8B-Instruct, N=4096 K=14336, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.028785     4.269722       5.000212
1         16.0    80.878370    68.211048      80.028498
2         64.0   308.309481   270.964799     319.184640
3        128.0   606.275177   520.047790     626.527530
4        256.0   854.833097  1022.346942    1250.919778
5        512.0  1259.046220  1759.090683    2483.819182
6       1024.0  1342.229769  1650.521253    2828.362268
7       2048.0  1421.170808  2455.604891    3159.432997
8       4096.0  1421.740507  2773.698866    3615.426328
9       8192.0  1441.527708  2877.289540    3906.919234
10     16384.0  1577.775723  3106.105504    4106.835007
```

After:
```
python benchmarks/kernels/bench_nvfp4_gemm.py
meta-llama/Llama-3.1-8B-Instruct, N=6144 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.748360     5.027197       6.528209
1         16.0    95.012563    82.093740     103.950550
2         64.0   405.476837   313.940114     394.495364
3        128.0   725.522532   609.624753     790.975948
4        256.0  1119.393636  1278.005360    1878.052339
5        512.0  1345.727547  1582.652561    2325.331164
6       1024.0  1449.987926  2256.670087    3026.897978
7       2048.0  1359.908835  3112.207708    4180.794032
8       4096.0  1420.388069  3094.562625    4169.369241
9       8192.0  1537.354317  3389.684127    4432.463118
10     16384.0  1470.448752  3593.449967    4527.330836
meta-llama/Llama-3.1-8B-Instruct, N=4096 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     2.746644     3.646941       4.877805
1         16.0    72.825095    58.960489      78.171651
2         64.0   285.867680   230.976059     298.494218
3        128.0   561.490591   450.930899     561.805098
4        256.0   894.274237   907.055723    1274.027790
5        512.0  1302.695719  1082.689765    1584.968614
6       1024.0  1402.349671  1932.508890    2940.174528
7       2048.0  1396.025866  2734.199087    3895.695589
8       4096.0  1516.304181  2925.244593    4468.271121
9       8192.0  1441.924220  3272.332653    4373.671078
10     16384.0  1631.857716  3278.056990    4333.859563
meta-llama/Llama-3.1-8B-Instruct, N=28672 K=4096, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     5.923978    10.110010      11.973119
1         16.0    83.906953   170.627308     182.576647
2         64.0   327.453656   685.383461     727.220699
3        128.0   632.567264  1292.102879    1447.365122
4        256.0  1053.531518  2769.925426    3507.711728
5        512.0  1231.650947  2595.528479    3037.678734
6       1024.0  1260.856134  3161.388123    3628.262923
7       2048.0  1390.243162  3900.859796    4021.098343
8       4096.0  1413.468482  4350.456110    4464.074427
9       8192.0  1579.034573  4377.088411    4504.379808
10     16384.0  1632.503522  3772.796678    4741.561451
meta-llama/Llama-3.1-8B-Instruct, N=4096 K=14336, BF16 vs NVFP4 GEMMs TFLOP/s:
    batch_size   torch-bf16        nvfp4  nvfp4-noquant
0          1.0     4.731264     6.866891       7.343916
1         16.0    79.915221   109.654692     128.470353
2         64.0   304.679766   414.799444     493.440075
3        128.0   601.144876   797.437874     886.860713
4        256.0   952.582390  1654.316938    2343.319056
5        512.0  1273.192346  1883.689973    2700.846772
6       1024.0  1431.294272  2842.313936    4905.733995
7       2048.0  1468.575193  3086.785025    4439.483105
8       4096.0  1436.096431  3222.535452    4494.492560
9       8192.0  1511.447333  3809.272605    5057.518249
10     16384.0  1532.640471  3792.924167    4903.159574
```