### PR TITLE
[Misc] MoE ModularKernel : Introduce TopKWeightAndReduce 

### DIFF
--- a/tests/kernels/moe/test_pplx_moe.py
+++ b/tests/kernels/moe/test_pplx_moe.py
@@ -32,6 +32,8 @@ from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
 from vllm.model_executor.layers.fused_moe.fused_moe import get_default_config
 from vllm.model_executor.layers.fused_moe.modular_kernel import (
     FusedMoEModularKernel)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate)
 from vllm.platforms import current_platform
 from vllm.utils import round_up
 
@@ -371,7 +373,7 @@ def pplx_prepare_finalize(
         chunk_topk_weight,
         chunk_topk_ids,
         False,
-        weight_and_reduce_impl=None,
+        weight_and_reduce_impl=TopKWeightAndReduceDelegate(),
     )
 
     torch.cuda.synchronize()

--- a/tests/kernels/moe/test_pplx_moe.py
+++ b/tests/kernels/moe/test_pplx_moe.py
@@ -371,6 +371,7 @@ def pplx_prepare_finalize(
         chunk_topk_weight,
         chunk_topk_ids,
         False,
+        weight_and_reduce_impl=None,
     )
 
     torch.cuda.synchronize()

--- a/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
@@ -217,6 +217,10 @@ class BatchedDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return False
 
+    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+        # Let PrepareAndFinalize::finalize() decide the impl.
+        return None
+
     def workspace_shapes(
         self,
         a: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
@@ -7,6 +7,8 @@ import torch
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate)
 from vllm.model_executor.layers.fused_moe.utils import _resize_cache
 from vllm.triton_utils import tl, triton
 
@@ -217,9 +219,9 @@ class BatchedDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return False
 
-    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         # Let PrepareAndFinalize::finalize() decide the impl.
-        return None
+        return TopKWeightAndReduceDelegate()
 
     def workspace_shapes(
         self,

--- a/vllm/model_executor/layers/fused_moe/batched_triton_or_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batched_triton_or_deep_gemm_moe.py
@@ -101,10 +101,10 @@ class BatchedTritonOrDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
                 "Both implementations should agree on WeightAndReduce impls. "
                 f"Got bdge_war: {bdge_war}, and bte_war: {bte_war}")
 
-        if is_bdge_war:
+        if bdge_war is not None:
             return bdge_war
 
-        assert is_bte_war
+        assert bte_war is not None
         return bte_war
 
     def workspace_shapes(

--- a/vllm/model_executor/layers/fused_moe/batched_triton_or_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batched_triton_or_deep_gemm_moe.py
@@ -88,6 +88,10 @@ class BatchedTritonOrDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         return ((bdge is None or bdge.supports_expert_map())
                 and (bte is None or bte.supports_expert_map()))
 
+    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+        # Let PrepareAndFinalize::finalize() decide the impl.
+        return None
+
     def workspace_shapes(
         self,
         a: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cutlass_moe.py
@@ -255,6 +255,10 @@ class CutlassExpertsFp8(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return not self.use_batched_format
 
+    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+        # Let PrepareAndFinalize::finalize() decide the impl.
+        return None
+
     def workspace_shapes(
         self,
         a: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cutlass_moe.py
@@ -11,6 +11,8 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.layers.fused_moe.prepare_finalize import (
     MoEPrepareAndFinalizeNoEP)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate)
 from vllm.model_executor.layers.fused_moe.utils import (_fp8_perm,
                                                         _fp8_quantize,
                                                         _resize_cache)
@@ -255,9 +257,9 @@ class CutlassExpertsFp8(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return not self.use_batched_format
 
-    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         # Let PrepareAndFinalize::finalize() decide the impl.
-        return None
+        return TopKWeightAndReduceDelegate()
 
     def workspace_shapes(
         self,

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -85,6 +85,10 @@ class DeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return True
 
+    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+        # Let PrepareAndFinalize::finalize() decide the impl.
+        return None
+
     def workspace_shapes(
         self, a: torch.Tensor, aq: torch.Tensor, M: int, N: int, K: int,
         topk: int, global_num_experts: int, local_num_experts: int

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -12,6 +12,8 @@ from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
     _moe_permute)
 from vllm.model_executor.layers.fused_moe.prepare_finalize import (
     MoEPrepareAndFinalizeNoEP)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate)
 from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache, per_token_group_quant_fp8)
 from vllm.utils import has_deep_gemm, round_up
@@ -85,9 +87,9 @@ class DeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return True
 
-    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         # Let PrepareAndFinalize::finalize() decide the impl.
-        return None
+        return TopKWeightAndReduceDelegate()
 
     def workspace_shapes(
         self, a: torch.Tensor, aq: torch.Tensor, M: int, N: int, K: int,

--- a/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
@@ -6,10 +6,11 @@ import deep_ep
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from vllm import _custom_ops as ops
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input)
+from vllm.model_executor.layers.fused_moe.weight_and_reduce import (
+    ContiguousWeightAndReduce)
 
 
 class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
@@ -187,45 +188,25 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         return (expert_x, expert_x_scale, expert_tokens_meta, expert_topk_ids,
                 expert_topk_weights)
 
-    def _apply_weights_and_reduce(self, num_tokens: int,
-                                  fused_expert_output: torch.Tensor,
-                                  topk_weights: torch.Tensor,
-                                  apply_router_weight_on_input: bool,
-                                  output_dtype: torch.dtype):
-
-        hidden_dim = fused_expert_output.size(-1)
-        if fused_expert_output.ndim == 2:
-            fused_expert_output = fused_expert_output.view(
-                num_tokens, -1, hidden_dim)
-
-        if not apply_router_weight_on_input:
-            # The DeepEP combine kernels don't do the topk weight
-            # multiplication. We multiply the weights locally.
-            m_x_topk = fused_expert_output.size(0)
-            fused_expert_output.mul_(topk_weights.view(m_x_topk, -1, 1))
-
-        out = torch.empty((num_tokens, hidden_dim),
-                          device=fused_expert_output.device,
-                          dtype=output_dtype)
-        ops.moe_sum(fused_expert_output, out)
-
-        return out
-
     def finalize(self, output: torch.Tensor, fused_expert_output: torch.Tensor,
                  topk_weights: torch.Tensor, topk_ids: torch.Tensor,
-                 apply_router_weight_on_input: bool) -> None:
+                 apply_router_weight_on_input: bool,
+                 weight_and_reduce_impl: Optional[mk.WeightAndReduce]) -> None:
 
         assert self.handle is not None
 
         # fused_expert_output can have 0 tokens - This happens when none of the
         # tokens from the all2all reach this EP rank.
         if fused_expert_output.numel() != 0:
-            fused_expert_output = self._apply_weights_and_reduce(
-                num_tokens=topk_ids.size(0),
+            if weight_and_reduce_impl is None:
+                weight_and_reduce_impl = ContiguousWeightAndReduce()
+            fused_expert_output = weight_and_reduce_impl.apply(
+                output=None,
                 fused_expert_output=fused_expert_output,
                 topk_weights=topk_weights,
+                topk_ids=topk_ids,
                 apply_router_weight_on_input=apply_router_weight_on_input,
-                output_dtype=output.dtype)
+            )
 
         combined_x, _, event = self.buffer.combine(
             x=fused_expert_output,

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -166,8 +166,10 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
 
     def finalize(self, output: torch.Tensor, fused_expert_output: torch.Tensor,
                  topk_weights: torch.Tensor, topk_ids: torch.Tensor,
-                 apply_router_weight_on_input: bool) -> None:
-
+                 apply_router_weight_on_input: bool,
+                 weight_and_reduce_impl: Optional[mk.WeightAndReduce]) -> None:
+        # The weight application and reduction happens in the combine kernel.
+        assert weight_and_reduce_impl is None
         assert self.handle is not None
 
         combine_topk_weights = topk_weights

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -7,6 +7,8 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate)
 from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input, normalize_batched_scales_shape)
 
@@ -167,9 +169,10 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
     def finalize(self, output: torch.Tensor, fused_expert_output: torch.Tensor,
                  topk_weights: torch.Tensor, topk_ids: torch.Tensor,
                  apply_router_weight_on_input: bool,
-                 weight_and_reduce_impl: Optional[mk.WeightAndReduce]) -> None:
-        # The weight application and reduction happens in the combine kernel.
-        assert weight_and_reduce_impl is None
+                 weight_and_reduce_impl: mk.TopKWeightAndReduce) -> None:
+        assert isinstance(
+            weight_and_reduce_impl, TopKWeightAndReduceDelegate
+        ), ("Weight application and reduction happens in the combine kernel.")
         assert self.handle is not None
 
         combine_topk_weights = topk_weights

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -25,6 +25,8 @@ from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
     moe_align_block_size)
 from vllm.model_executor.layers.fused_moe.prepare_finalize import (
     MoEPrepareAndFinalizeNoEP)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate)
 from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache, moe_kernel_quantize_input)
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
@@ -1596,9 +1598,9 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return True
 
-    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         # Let PrepareAndFinalize::finalize() decide the impl.
-        return None
+        return TopKWeightAndReduceDelegate()
 
     def workspace_shapes(
         self,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1596,6 +1596,10 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
     def supports_expert_map(self) -> bool:
         return True
 
+    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+        # Let PrepareAndFinalize::finalize() decide the impl.
+        return None
+
     def workspace_shapes(
         self,
         a: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -7,6 +7,8 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate)
 from vllm.model_executor.layers.fused_moe.utils import (
     _validate_scale_shape, moe_kernel_quantize_input)
 from vllm.utils import cdiv, round_up
@@ -213,10 +215,11 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        weight_and_reduce_impl: Optional[mk.WeightAndReduce],
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
     ) -> None:
-        # The weight application and reduction happens in the combine kernel.
-        assert weight_and_reduce_impl is None
+        assert isinstance(
+            weight_and_reduce_impl, TopKWeightAndReduceDelegate
+        ), ("Weight application and reduction happens in the combine kernel.")
 
         # This argument is optional
         # There's not much point setting this unless it is != topk_ids.size(0)

--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -213,7 +213,11 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
+        weight_and_reduce_impl: Optional[mk.WeightAndReduce],
     ) -> None:
+        # The weight application and reduction happens in the combine kernel.
+        assert weight_and_reduce_impl is None
+
         # This argument is optional
         # There's not much point setting this unless it is != topk_ids.size(0)
         bound_m: Optional[torch.Tensor] = None

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize.py
@@ -6,10 +6,10 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceContiguous, TopKWeightAndReduceDelegate)
 from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input)
-from vllm.model_executor.layers.fused_moe.weight_and_reduce import (
-    ContiguousWeightAndReduce)
 
 
 class MoEPrepareAndFinalizeNoEP(mk.FusedMoEPrepareAndFinalize):
@@ -62,10 +62,10 @@ class MoEPrepareAndFinalizeNoEP(mk.FusedMoEPrepareAndFinalize):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        weight_and_reduce_impl: Optional[mk.WeightAndReduce],
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
     ) -> None:
-        if weight_and_reduce_impl is None:
-            weight_and_reduce_impl = ContiguousWeightAndReduce()
+        if isinstance(weight_and_reduce_impl, TopKWeightAndReduceDelegate):
+            weight_and_reduce_impl = TopKWeightAndReduceContiguous()
         weight_and_reduce_impl.apply(
             output=output,
             fused_expert_output=fused_expert_output,

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -24,6 +24,9 @@ class TopKWeightAndReduceDelegate(mk.TopKWeightAndReduce):
     weight + reduce.
     """
 
+    def __eq__(self, other):
+        return isinstance(other, TopKWeightAndReduceDelegate)
+
     def apply(self, output: Optional[torch.Tensor],
               fused_expert_output: torch.Tensor, topk_weights: torch.Tensor,
               topk_ids: torch.Tensor,
@@ -37,6 +40,9 @@ class TopKWeightAndReduceNoOP(mk.TopKWeightAndReduce):
     The fused_experts outputs have already been weight applied and reduced.
     This implementation is a no-op.
     """
+
+    def __eq__(self, other):
+        return isinstance(other, TopKWeightAndReduceNoOP)
 
     def apply(self, output: Optional[torch.Tensor],
               fused_expert_output: torch.Tensor, topk_weights: torch.Tensor,
@@ -54,6 +60,9 @@ class TopKWeightAndReduceContiguous(mk.TopKWeightAndReduce):
     TopKWeightAndReduce implementation for a fused_experts output
     of shape (m, topk, K)
     """
+
+    def __eq__(self, other):
+        return isinstance(other, TopKWeightAndReduceContiguous)
 
     def apply(self, output: Optional[torch.Tensor],
               fused_expert_output: torch.Tensor, topk_weights: torch.Tensor,
@@ -91,6 +100,10 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
 
     def __init__(self, rank: int):
         self.rank = rank
+
+    def __eq__(self, other):
+        return (isinstance(other, TopKWeightAndReduceContiguous)
+                and (other.rank == self.rank))
 
     def apply(self, output: Optional[torch.Tensor],
               fused_expert_output: torch.Tensor, topk_weights: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -102,7 +102,7 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
         self.rank = rank
 
     def __eq__(self, other):
-        return (isinstance(other, TopKWeightAndReduceContiguous)
+        return (isinstance(other, TopKWeightAndReduceNaiveBatched)
                 and (other.rank == self.rank))
 
     def apply(self, output: Optional[torch.Tensor],

--- a/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
@@ -82,10 +82,10 @@ class TritonOrDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
                 "Both implementations should agree on WeightAndReduce impls. "
                 f"Got dge_war: {dge_war}, and te_war: {te_war}")
 
-        if is_dge_war:
+        if dge_war is not None:
             return dge_war
 
-        assert is_te_war
+        assert te_war is not None
         return te_war
 
     def workspace_shapes(

--- a/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
@@ -69,6 +69,10 @@ class TritonOrDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         return ((dge is None or dge.supports_expert_map())
                 and (te is None or te.supports_expert_map()))
 
+    def weight_and_reduce_impl(self) -> Optional[mk.WeightAndReduce]:
+        # Let PrepareAndFinalize::finalize() decide the impl.
+        return None
+
     def workspace_shapes(
         self,
         a: torch.Tensor,


### PR DESCRIPTION
## Purpose
Introduce TopKWeightAndReduce class that could be used to bridge `FusedMoEPermuteExpertsUnpermute` object and the `PrepareAndFinalize::finalize()` method.
It is sometimes important that the fused_experts implementations also do the weight-application and reduction. To facilitate such implementations, we could use the `TopKWeightAndReduce` to let the fused_experts implementations communicate what the finalize() method should do (i.e. skip the weight-application and reduction in this case). 

This PR also standardizes all the weight-application and reduction implementations by having them in one place.

This is useful, for example in #20228 

## Test Plan
pytests: 
 `pytest -s tests/kernels/moe/test_modular_kernel_combinations.py` from https://github.com/vllm-project/vllm/pull/20449 
 `pytest -s tests/kernels/moe/test_pplx_moe.py`
 `pytest -s tests/kernels/moe/test_deepep_moe.py`
 `pytest -s tests/kernels/moe/test_deepep_deepgemm_moe.py`
 `pytest -s tests/kernels/moe/test_batched_moe.py `

## Test Result
  Tests pass locally

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
