### PR TITLE
[CI/Build] Fix FlashInfer double build in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -400,7 +400,7 @@ RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
           echo "🏗️  Building FlashInfer for arches: ${FI_TORCH_CUDA_ARCH_LIST}"
 
           git clone --depth 1 --recursive --shallow-submodules \
-            --single-branch --branch ${FLASHINFER_GIT_REF} \
+            --branch ${FLASHINFER_GIT_REF} \
             ${FLASHINFER_GIT_REPO} flashinfer
 
           # Needed to build AOT kernels

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -390,14 +390,14 @@ RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
           # Exclude CUDA arches for older versions (11.x and 12.0-12.7)
           # TODO: Update this to allow setting TORCH_CUDA_ARCH_LIST as a build arg.
           if [[ "${CUDA_VERSION}" == 11.* ]]; then
-              TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9"
+              FI_TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9"
           elif [[ "${CUDA_VERSION}" == 12.[0-7]* ]]; then
-              TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a"
+              FI_TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a"
           else
               # CUDA 12.8+ supports 10.0a and 12.0
-              TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0a 12.0"
+              FI_TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0a 12.0"
           fi
-          echo "🏗️  Building FlashInfer for arches: ${TORCH_CUDA_ARCH_LIST}"
+          echo "🏗️  Building FlashInfer for arches: ${FI_TORCH_CUDA_ARCH_LIST}"
 
           git clone --depth 1 --recursive --shallow-submodules \
             --single-branch --branch ${FLASHINFER_GIT_REF} \
@@ -406,7 +406,7 @@ RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
           # Needed to build AOT kernels
           pushd flashinfer
             python3 -m flashinfer.aot
-            TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
+            TORCH_CUDA_ARCH_LIST="${FI_TORCH_CUDA_ARCH_LIST}" \
               uv pip install --system --no-build-isolation .
           popd
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -387,27 +387,23 @@ RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
       if [[ "$CUDA_VERSION" == 12.8* ]]; then
           uv pip install --system ${FLASHINFER_CUDA128_INDEX_URL}/${FLASHINFER_CUDA128_WHEEL}
       else
-          export TORCH_CUDA_ARCH_LIST='7.5 8.0 8.9 9.0a 10.0a 12.0'
-          git clone ${FLASHINFER_GIT_REPO} --single-branch --branch ${FLASHINFER_GIT_REF} --recursive
-          # Needed to build AOT kernels
-          (cd flashinfer && \
-              python3 -m flashinfer.aot && \
-              uv pip install --system --no-build-isolation . \
-          )
-          rm -rf flashinfer
-
-          # Default arches (skipping 10.0a and 12.0 since these need 12.8)
+          # Exclude CUDA arches for older versions (11.x and 12.0-12.7)
           # TODO: Update this to allow setting TORCH_CUDA_ARCH_LIST as a build arg.
-          TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a"
           if [[ "${CUDA_VERSION}" == 11.* ]]; then
               TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9"
+          elif [[ "${CUDA_VERSION}" == 12.[0-7]* ]]; then
+              TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a"
+          else
+              # CUDA 12.8+ supports 10.0a and 12.0
+              TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0a 12.0"
           fi
           echo "🏗️  Building FlashInfer for arches: ${TORCH_CUDA_ARCH_LIST}"
 
           git clone --depth 1 --recursive --shallow-submodules \
-            --branch v0.2.6.post1 \
-            https://github.com/flashinfer-ai/flashinfer.git flashinfer
+            --single-branch --branch ${FLASHINFER_GIT_REF} \
+            ${FLASHINFER_GIT_REPO} flashinfer
 
+          # Needed to build AOT kernels
           pushd flashinfer
             python3 -m flashinfer.aot
             TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \


### PR DESCRIPTION
## Purpose

It seems there was a bad merge between https://github.com/vllm-project/vllm/pull/18064 and https://github.com/vllm-project/vllm/pull/20136 that resulted in FlashInfer being built "both ways" with both sets of TORCH_CUDA_ARCH_LIST. I'm not sure how the CUDA 11.8 build was working with this in place, but this may have resulted in some of the JIT performance weirdness observed in the last release.

## Test Plan

## Test Result
