### PR TITLE
[UT] V1 Fix InputBatch.min_p assignment for unset min_p values

### DIFF
--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -177,6 +177,11 @@ def _create_sampling_params():
     return SamplingParams(
         top_k=np.random.randint(1, 10),
         top_p=np.random.uniform(0.0, 1.0),
+        # During the InputBatch.add_request process,
+        # if the SamplingParam.min_p attribute is not set,
+        # the InputBatch.min_p_reqs will not be processed correctly,
+        # consequently leading to the InputBatch.min_p not being assigned the correct value.
+        min_p=np.random.uniform(0.0, 1.0),
         presence_penalty=np.random.uniform(-2.0, 2.0),
         repetition_penalty=np.random.uniform(0.0, 2.0),
         frequency_penalty=np.random.uniform(-2.0, 2.0),


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
During the InputBatch.add_request process, if the SamplingParam.min_p attribute is not set, the InputBatch.min_p_reqs will not be processed correctly, consequently leading to the InputBatch.min_p not being assigned the correct value.


## Test Plan
pytest -v tests/v1/worker/test_gpu_input_batch.py
## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
