### PR TITLE
[Bugfix] Fix the issue where `reasoning_content` is `None` when Thinkng is enabled and `tool_choice` is set to `'required'`.

### DIFF
--- a/tests/entrypoints/openai/test_completion_with_function_calling.py
+++ b/tests/entrypoints/openai/test_completion_with_function_calling.py
@@ -145,7 +145,11 @@ async def test_function_tool_use(client: openai.AsyncOpenAI, model_name: str,
                     "enable_thinking": enable_thinking
                 }
             })
-
+        if enable_thinking:
+            assert chat_completion.choices[0].message.\
+                reasoning_content is not None
+            assert chat_completion.choices[0].message.\
+                reasoning_content != ""
         assert chat_completion.choices[0].message.tool_calls is not None
         assert len(chat_completion.choices[0].message.tool_calls) > 0
     else:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1049,6 +1049,7 @@ class OpenAIServingChat(OpenAIServing):
                 message = ChatMessage(
                     role=role,
                     content="",
+                    reasoning_content=reasoning_content,
                     tool_calls=[
                         tool_call_class(function=FunctionCall(
                             name=tool_call.name,


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/20663
## Test Result

Before:
```
ChatCompletion(id='chatcmpl-4e05fee0c73c4811ba8c7f21939c06c8', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='chatcmpl-tool-f227417118b24070b61554cc4416aba9', function=Function(arguments='{"city": "Beijing", "country": "China", "unit": "celsius"}', name='get_current_weather'), type='function')], reasoning_content=None), stop_reason=None)], created=1752032478, model='Qwen/Qwen3-8B', object='chat.completion', service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=228, prompt_tokens=247, total_tokens=475, completion_tokens_details=None, prompt_tokens_details=None), prompt_logprobs=None, kv_transfer_params=None)
```

After
```
ChatCompletion(id='chatcmpl-ccd1ac636c004d76821ed0e81c55014f', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='chatcmpl-tool-027f368f49084786a3728df40263bc9e', function=Function(arguments='{"city": "Beijing", "country": "China", "unit": "celsius"}', name='get_current_weather'), type='function')], reasoning_content="\nOkay, the user is asking about the weather in Beijing. Let me check the tools provided. There's a function called get_current_weather. The parameters required are country and unit, with city as optional but defaulting to Vienna. Since the user mentioned Beijing, I should specify the city as Beijing. The country parameter is required, so I need to set that to China. The unit isn't specified, so maybe I should default to celsius as it's commonly used. Let me make sure the function call includes all required parameters. Country is China, unit is celsius, and city is Beijing. That should work.\n"), stop_reason=None)], created=1752032282, model='Qwen/Qwen3-8B', object='chat.completion', service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=173, prompt_tokens=247, total_tokens=420, completion_tokens_details=None, prompt_tokens_details=None), prompt_logprobs=None, kv_transfer_params=None)
```