### PR TITLE
[Bugfix] Fix grafana's model_name list showing other values

### DIFF
--- a/examples/online_serving/prometheus_grafana/grafana.json
+++ b/examples/online_serving/prometheus_grafana/grafana.json
@@ -1495,7 +1495,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(model_name)",
+        "definition": "label_values({__name__=~\"vllm:.*\"},model_name)",
         "hide": 0,
         "includeAll": false,
         "label": "model_name",
@@ -1503,7 +1503,7 @@
         "name": "model_name",
         "options": [],
         "query": {
-          "query": "label_values(model_name)",
+          "query": "label_values({__name__=~\"vllm:.*\"},model_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

I found that when I used Grafana, model_name showed some strange values, like 'Intel XXX'.

![image](https://github.com/user-attachments/assets/4a108b88-44b7-44bf-92c5-af55c3d04194)

## Purpose

Limit model_name to only display vllm-related model names.

## Test Plan

Import the modified json into Grafana and view it again.

## Test Result

![image](https://github.com/user-attachments/assets/cae91a4c-629b-44e6-8e26-c90e735fae6e)


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
