### PR TITLE
[Kernel] Add tune-able block sizes to unified 2d triton kernel

### DIFF
--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -82,16 +82,26 @@ def kernel_unified_attention_2d(
         stride_v_cache_2: tl.int64,  # int
         stride_v_cache_3: tl.constexpr,  # int
         query_start_len_ptr,  # [num_seqs+1]
-        BLOCK_Q: tl.constexpr,  # int
         num_seqs: tl.int32,
         BLOCK_M: tl.constexpr,  # int
+        BLOCK_N: tl.constexpr, # int
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
 
-    seq_idx = find_seq_idx(query_start_len_ptr, q_block_global_idx, num_seqs,
-                           BLOCK_Q, True)
+    BLOCK_Q: tl.constexpr = BLOCK_M // num_queries_per_kv
 
+    left: tl.int32 = 0
+    right = num_seqs
+    while left < right:
+        mid = (left + right) // 2
+        mid_val = tl.load(query_start_len_ptr + mid) // BLOCK_Q + mid
+        if mid_val <= q_block_global_idx:
+            left = mid + 1
+        else:
+            right = mid
+
+    seq_idx = left - 1
     q_block_start_idx = tl.load(query_start_len_ptr +
                                 seq_idx) // BLOCK_Q + seq_idx
 
@@ -106,13 +116,15 @@ def kernel_unified_attention_2d(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
-    offs_m = tl.arange(0, BLOCK_M)
+    offs_m = tl.arange(0, BLOCK_Q * num_queries_per_kv)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+
     query_pos = q_block_local_idx * BLOCK_Q + offs_m // num_queries_per_kv
 
     query_offset_0 = cur_batch_in_all_start_index + query_pos
     query_offset_1 = kv_head_idx * num_queries_per_kv + \
         offs_m % num_queries_per_kv
+    
     query_offset = (query_offset_0[:, None] * query_stride_0 +
                     query_offset_1[:, None] * query_stride_1 + offs_d[None, :])
 
@@ -120,7 +132,7 @@ def kernel_unified_attention_2d(
     query_mask_0 = tl.where(query_pos < cur_batch_query_len, 1, 0).to(tl.int1)
     query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
 
-    # Q : (BLOCK_M, HEAD_SIZE_PADDED)
+    # Q : (BLOCK_Q * num_queries_per_kv, HEAD_SIZE,)
     Q = tl.load(
         query_ptr + query_offset,
         mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
@@ -129,9 +141,12 @@ def kernel_unified_attention_2d(
 
     block_table_offset = seq_idx * block_table_stride
 
-    M = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
-    L = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
-    acc = tl.zeros([BLOCK_M, HEAD_SIZE_PADDED], dtype=tl.float32)
+    M = tl.full([BLOCK_Q * num_queries_per_kv],
+                float("-inf"),
+                dtype=tl.float32)
+    L = tl.full([BLOCK_Q * num_queries_per_kv], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_Q * num_queries_per_kv, HEAD_SIZE_PADDED],
+                   dtype=tl.float32)
 
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
@@ -154,27 +169,29 @@ def kernel_unified_attention_2d(
     # actual sequence length
     max_seq_prefix_len = tl.minimum(max_seq_prefix_len, seq_len)
 
-    # calculate the number of tiles (blocks) that need to be processed to
-    # cover the longest sequence prefix (due to causal masking, blocks beyond
-    # this prefix can be skipped)
-    num_blocks = cdiv_fn(max_seq_prefix_len, BLOCK_SIZE)
+    offs_n = tl.arange(0, BLOCK_N)
 
-    # iterate through tiles
-    for j in range(0, num_blocks):
+    # iterate through tiles (below the mask)
+    for start_n in range(0,
+                         max_seq_prefix_len,
+                         BLOCK_N):
 
-        physical_block_idx = tl.load(block_tables_ptr + block_table_offset + j)
+        start_n = tl.multiple_of(start_n, BLOCK_N)
 
-        offs_n = tl.arange(0, BLOCK_SIZE)
+        physical_block_idx = tl.load(block_tables_ptr + block_table_offset +
+                                     (start_n + offs_n) // BLOCK_SIZE,
+                                     mask=(start_n + offs_n) < seq_len,
+                                     other=0)
 
-        v_offset = (physical_block_idx * stride_v_cache_0 +
+        v_offset = (physical_block_idx[:, None] * stride_v_cache_0 +
                     kv_head_idx * stride_v_cache_2 +
                     offs_d[None, :] * stride_v_cache_3 +
-                    offs_n[:, None] * stride_v_cache_1)
+                    (offs_n[:, None] % BLOCK_SIZE) * stride_v_cache_1)
 
-        k_offset = (physical_block_idx * stride_k_cache_0 +
+        k_offset = (physical_block_idx[None, :] * stride_k_cache_0 +
                     kv_head_idx * stride_k_cache_2 +
                     offs_d[:, None] * stride_k_cache_3 +
-                    offs_n[None, :] * stride_k_cache_1)
+                    (offs_n[None, :] % BLOCK_SIZE) * stride_k_cache_1)
 
         # K : (HEAD_SIZE, BLOCK_SIZE)
         K_load = tl.load(key_cache_ptr + k_offset,
@@ -202,12 +219,13 @@ def kernel_unified_attention_2d(
         else:
             V = V_load
 
-        seq_offset = j * BLOCK_SIZE + offs_n
+        seq_offset = start_n + tl.arange(0, BLOCK_N)
 
         seq_mask = seq_offset[None, :] < context_len + query_pos[:, None] + 1
 
-        # S : (BLOCK_M, BLOCK_SIZE)
-        S = tl.zeros(shape=(BLOCK_M, BLOCK_SIZE), dtype=tl.float32)
+        # S : (BLOCK_Q * num_queries_per_kv, BLOCK_N,)
+        S = tl.zeros(shape=(BLOCK_Q * num_queries_per_kv, BLOCK_N),
+                     dtype=tl.float32)
 
         S += scale * tl.dot(Q, K)
 
@@ -225,29 +243,29 @@ def kernel_unified_attention_2d(
             S += alibi_slope[:, None] * (seq_offset - context_len)
 
         # compute running maximum
-        # m_j : (BLOCK_M,)
+        # m_j : (BLOCK_Q * num_queries_per_kv,)
         m_j = tl.maximum(M, tl.max(S, axis=1))
         # For sliding window there's a chance the max is -inf due to masking of
         # the entire row. In this case we need to set m_j 0 to avoid NaN
         m_j = tl.where(m_j > float("-inf"), m_j, 0.0)
 
-        # P : (BLOCK_M, BLOCK_SIZE)
+        # P : (BLOCK_Q * num_queries_per_kv, BLOCK_N,)
         P = tl.exp(S - m_j[:, None])
 
-        # l_j : (BLOCK_M,)
+        # l_j : (BLOCK_Q * num_queries_per_kv,)
         l_j = tl.sum(P, axis=1)
 
-        # alpha : (BLOCK_M, )
+        # alpha : (BLOCK_Q * num_queries_per_kv, )
         alpha = tl.exp(M - m_j)
 
-        # acc : (BLOCK_M, HEAD_SIZE_PADDED)
+        # acc : (BLOCK_Q * num_queries_per_kv, BLOCK_N,)
         acc = acc * alpha[:, None]
 
         # update constants
         L = L * alpha + l_j
         M = m_j
 
-        # acc : (BLOCK_M, HEAD_SIZE_PADDED)
+        # acc : (BLOCK_Q * num_queries_per_kv, BLOCK_N,)
         acc += tl.dot(P.to(V.dtype), V)
 
     # epilogue
@@ -604,8 +622,8 @@ def unified_attention(
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
 
-    BLOCK_M = 16
-    BLOCK_Q = BLOCK_M // num_queries_per_kv
+    BLOCK_M = 64 if triton.next_power_of_2(int(max_seqlen_q)) > 1 else 16
+    BLOCK_Q = BLOCK_M // num_queries_per_kv  # for 3d
 
     # Ideally we would launch with kernel with:
     # \sum_i[ceil(query_len[i] / BLOCK_Q)] blocks.
@@ -620,10 +638,14 @@ def unified_attention(
 
     # if batch contains a prefill
     if max_seqlen_q > 1 or total_num_q_blocks * num_kv_heads > 128:
-        kernel_unified_attention_2d[(
-            total_num_q_blocks,
-            num_kv_heads,
-        )](
+        
+        BLOCK_N = 16 if triton.next_power_of_2(int(max_seqlen_k)) < 128 else 64
+
+        grid = lambda META : (q.shape[0] // (META['BLOCK_M'] // num_queries_per_kv)
+                                + num_seqs, num_kv_heads)
+
+
+        kernel_unified_attention_2d[grid](
             output_ptr=out,
             query_ptr=q,
             key_cache_ptr=k,
@@ -657,9 +679,9 @@ def unified_attention(
             stride_v_cache_2=v.stride(2),
             stride_v_cache_3=v.stride(3),
             query_start_len_ptr=cu_seqlens_q,
-            BLOCK_Q=BLOCK_Q,
             num_seqs=num_seqs,
             BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
         )
     else:
         # for initial version, NUM_SEGMENTS = 16 is chosen as a default

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -620,7 +620,7 @@ def unified_attention(
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
 
-    BLOCK_M = 64 if triton.next_power_of_2(int(max_seqlen_q)) > 1 else 16
+    BLOCK_M = 64 if max_seqlen_q > 1 else 16
     BLOCK_Q = BLOCK_M // num_queries_per_kv  # for 3d
 
     # Ideally we would launch with kernel with:
@@ -637,7 +637,7 @@ def unified_attention(
     # if batch contains a prefill
     if max_seqlen_q > 1 or total_num_q_blocks * num_kv_heads > 128:
 
-        BLOCK_N = 16 if triton.next_power_of_2(int(max_seqlen_k)) < 128 else 64
+        BLOCK_N = 16 if max_seqlen_k <= 64 else 64
 
         grid = lambda META: (q.shape[0] // (META[
             'BLOCK_M'] // num_queries_per_kv) + num_seqs, num_kv_heads)

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -256,14 +256,14 @@ def kernel_unified_attention_2d(
         # alpha : (BLOCK_Q * num_queries_per_kv, )
         alpha = tl.exp(M - m_j)
 
-        # acc : (BLOCK_Q * num_queries_per_kv, BLOCK_N,)
+        # acc : (BLOCK_Q * num_queries_per_kv, HEAD_SIZE_PADDED,)
         acc = acc * alpha[:, None]
 
         # update constants
         L = L * alpha + l_j
         M = m_j
 
-        # acc : (BLOCK_Q * num_queries_per_kv, BLOCK_N,)
+        # acc : (BLOCK_Q * num_queries_per_kv, HEAD_SIZE_PADDED,)
         acc += tl.dot(P.to(V.dtype), V)
 
     # epilogue


### PR DESCRIPTION
This PR introduces tune-able block sizes to the unified attention kernel that enhances prefill attention performance. For now, we use simple heuristics to determine the right block sizes, but we intend to tune them more for targeted platforms in the very near future. 

## Performance

### `benchmark_latency.py`

On H100, _with_ this PR:
```
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1 python benchmarks/benchmark_latency.py \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --input-len 10000 --output-len 4 \
    --batch-size 1
...
Avg latency: 0.3723039971664548 seconds
10% percentile latency: 0.3671667315065861 seconds
25% percentile latency: 0.368670291849412 seconds
50% percentile latency: 0.37277518305927515 seconds
75% percentile latency: 0.3755023997509852 seconds
90% percentile latency: 0.3784640687983483 seconds
99% percentile latency: 0.3798159270081669 seconds
```

on H100, current upstream using the `triton_attn` backend:
```
Avg latency: 0.6647519522656997 seconds
10% percentile latency: 0.6590904780197888 seconds
25% percentile latency: 0.6594004178186879 seconds
50% percentile latency: 0.660066019045189 seconds
75% percentile latency: 0.6703241039067507 seconds
90% percentile latency: 0.6784501124173403 seconds
99% percentile latency: 0.6801793645089492 seconds
```

So, this PR decreases the latency of prefill by 78%.

### `benchmark_serving.py`

On H100, _with_ this PR:
```
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1 vllm serve meta-llama/Llama-3.1-8B-Instruct --disable-log-requests --no-enable-prefix-caching

python benchmarks/benchmark_serving.py --model /models/hf/meta-llama/Llama-3.1-8B-Instruct/main/ --dataset-name sharegpt --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json
...
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  20.32     
Total input tokens:                      215196    
Total generated tokens:                  197261    
Request throughput (req/s):              49.22     
Output token throughput (tok/s):         9708.59   
Total Token throughput (tok/s):          20299.89  
---------------Time to First Token----------------
Mean TTFT (ms):                          3460.93   
Median TTFT (ms):                        3277.94   
P99 TTFT (ms):                           6428.40   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          81.76     
Median TPOT (ms):                        45.50     
P99 TPOT (ms):                           214.88    
---------------Inter-token Latency----------------
Mean ITL (ms):                           36.51     
Median ITL (ms):                         25.51     
P99 ITL (ms):                            217.66    
==================================================
```

before, on H100 with current upstream using the `triton_attn` backend:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  21.20     
Total input tokens:                      215196    
Total generated tokens:                  198133    
Request throughput (req/s):              47.16     
Output token throughput (tok/s):         9344.13   
Total Token throughput (tok/s):          19492.97  
---------------Time to First Token----------------
Mean TTFT (ms):                          3613.11   
Median TTFT (ms):                        3433.86   
P99 TTFT (ms):                           6816.68   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          86.69     
Median TPOT (ms):                        48.43     
P99 TPOT (ms):                           228.71    
---------------Inter-token Latency----------------
Mean ITL (ms):                           38.26     
Median ITL (ms):                         25.77     
P99 ITL (ms):                            233.85    
==================================================
```

So, also here, this PR improves throughput, TTFT, and ITL about 4%. 


## Correctness

_With_ this PR on an H100:
```
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1 lm_eval --model vllm --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct --tasks gsm8k --num_fewshot 5 --batch_size auto --limit 500

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.798|±  |0.0180|
|     |       |strict-match    |     5|exact_match|↑  |0.780|±  |0.0185|
```

## More Context

The optimization allows the unified attention kernel to adapt the distribution of the work across compute units / streaming multiprocessors depending on the length of the requests in a batch. 
While, depending on the use-case, the performance increases are only modest (4%), this PR enables more fine-grained tuning of the unified attention kernel in the future. E.g. already with the vary basic heuristic, the performance increase is 78% for prefill-heavy latency use cases. 


CC @jvlunteren @tdoublep @SageMoore 
