### PR TITLE
Integration SM100 FlashInfer fused allreduce RMSNorm

### DIFF
--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from importlib.util import find_spec
-from pathlib import Path
 
 import pytest
 import torch
@@ -75,9 +74,9 @@ class TestAllReduceFusedAddRMSNormModel(torch.nn.Module):
                     reason="Only test on CUDA")
 @pytest.mark.skipif(not find_spec("flashinfer"),
                     reason="flashinfer is not installed")
-def test_all_reduce_fusion_pass_replace(test_model: str, batch_size: int,
-                                        seq_len: int, hidden_size: int,
-                                        dtype: torch.dtype):
+def test_all_reduce_fusion_pass_replace(test_model: torch.nn.Module,
+                                        batch_size: int, seq_len: int,
+                                        hidden_size: int, dtype: torch.dtype):
     num_processes = 2
 
     def run_torch_spawn(fn, nprocs):
@@ -117,11 +116,7 @@ def all_reduce_fusion_pass_on_test_model(local_rank: int, world_size: int,
                                              custom_ops=["+rms_norm"],
                                              compile_sizes=[2, 4, 8]))
     vllm_config.compilation_config.pass_config = PassConfig(
-        enable_flashinfer_allreduce_fusion=True,
-        dump_graph_dir=Path("dump_graph"),
-        dump_graph_stages=[
-            "before_all_reduce_fusion_pass", "after_all_reduce_fusion_pass"
-        ])
+        enable_flashinfer_allreduce_fusion=True)
     vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
 
     # this is a fake model name to construct the model config

--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from importlib.util import find_spec
+from pathlib import Path
+
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.collective_fusion import AllReduceFusionPass
+from vllm.config import (CompilationConfig, CompilationLevel, DeviceConfig,
+                         ModelConfig, PassConfig, VllmConfig)
+from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.distributed.parallel_state import (init_distributed_environment,
+                                             initialize_model_parallel)
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.platforms import current_platform
+from vllm.utils import update_environment_variables
+
+from ..utils import multi_gpu_test
+from .backend import TestBackend
+
+
+class TestAllReduceRMSNormModel(torch.nn.Module):
+
+    def __init__(self, hidden_size=16, eps=1e-6):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.norm = RMSNorm(hidden_size, eps)
+
+    def forward(self, hidden_states, residual):
+        view = hidden_states.reshape(-1, self.hidden_size)
+        all_reduce = tensor_model_parallel_all_reduce(view)
+        norm = self.norm(all_reduce)
+        return norm
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_reduce.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.flashinfer_trtllm_allreduce_fusion.default]
+
+
+class TestAllReduceFusedAddRMSNormModel(torch.nn.Module):
+
+    def __init__(self, hidden_size=16, eps=1e-6):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.norm = RMSNorm(hidden_size, eps)
+
+    def forward(self, hidden_states, residual):
+        view = hidden_states.reshape(-1, self.hidden_size)
+        all_reduce = tensor_model_parallel_all_reduce(view)
+        norm, _ = self.norm(all_reduce, residual)
+        return norm
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_reduce.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.flashinfer_trtllm_allreduce_fusion.default]
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model",
+    [TestAllReduceRMSNormModel, TestAllReduceFusedAddRMSNormModel])
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [8])
+@pytest.mark.parametrize("hidden_size", [4096])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"],
+                    reason="Only test on CUDA")
+@pytest.mark.skipif(not find_spec("flashinfer"),
+                    reason="flashinfer is not installed")
+def test_all_reduce_fusion_pass_replace(test_model: str, batch_size: int,
+                                        seq_len: int, hidden_size: int,
+                                        dtype: torch.dtype):
+    num_processes = 2
+
+    def run_torch_spawn(fn, nprocs):
+        torch.multiprocessing.spawn(fn,
+                                    args=(num_processes, test_model,
+                                          batch_size, seq_len, hidden_size,
+                                          dtype),
+                                    nprocs=nprocs)
+
+    run_torch_spawn(all_reduce_fusion_pass_on_test_model, num_processes)
+
+
+def all_reduce_fusion_pass_on_test_model(local_rank: int, world_size: int,
+                                         test_model_cls: torch.nn.Module,
+                                         batch_size: int, seq_len: int,
+                                         hidden_size: int, dtype: torch.dtype):
+    current_platform.seed_everything(0)
+
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    torch.set_default_device(device)
+    torch.set_default_dtype(dtype)
+
+    update_environment_variables({
+        'RANK': str(local_rank),
+        'LOCAL_RANK': str(local_rank),
+        'WORLD_SIZE': str(world_size),
+        'MASTER_ADDR': 'localhost',
+        'MASTER_PORT': '12345',
+    })
+
+    init_distributed_environment()
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(level=CompilationLevel.PIECEWISE,
+                                             custom_ops=["+rms_norm"],
+                                             compile_sizes=[2, 4, 8]))
+    vllm_config.compilation_config.pass_config = PassConfig(
+        enable_flashinfer_allreduce_fusion=True,
+        dump_graph_dir=Path("dump_graph"),
+        dump_graph_stages=[
+            "before_all_reduce_fusion_pass", "after_all_reduce_fusion_pass"
+        ])
+    vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
+
+    # this is a fake model name to construct the model config
+    # in the vllm_config, it's not really used.
+    model_name = "nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e"
+    vllm_config.model_config = ModelConfig(model=model_name,
+                                           task="auto",
+                                           tokenizer=model_name,
+                                           tokenizer_mode="auto",
+                                           trust_remote_code=True,
+                                           dtype=dtype,
+                                           seed=42)
+
+    all_reduce_fusion_pass = AllReduceFusionPass(vllm_config)
+    backend = TestBackend(all_reduce_fusion_pass)
+
+    model = test_model_cls(hidden_size)
+
+    hidden_states = torch.randn((batch_size * seq_len, hidden_size),
+                                dtype=dtype,
+                                requires_grad=False)
+    residual = torch.randn((batch_size * seq_len, hidden_size),
+                           dtype=dtype,
+                           requires_grad=False)
+
+    compiled_model = torch.compile(model, backend=backend)
+    compiled_model(hidden_states, residual)
+
+    backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
+    backend.check_after_ops(model.ops_in_model_after())

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -400,8 +400,9 @@ class AllReduceFusionPass(VllmInductorPass):
 
         self.patterns: PatternMatcherPass = PatternMatcherPass(
             pass_name="all_reduce_fusion_pass")
-        self.hidden_dim = (config.model_config.get_hidden_size()
-                           if config.model_config else 4096)
+        if config.model_config is None:
+            return
+        self.hidden_dim = config.model_config.get_hidden_size()
         self.group = get_tp_group().device_group
         rank = get_tensor_model_parallel_rank()
         use_fp32_lamport = self.model_dtype == torch.float32

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -291,7 +291,7 @@ class AllReduceRMSNORMPattern(BasePattern):
         epsilon: float,
         dtype: torch.dtype,
         device: str,
-        allreduce_params: Optional[FlashInferFusedAllReduceParams],
+        allreduce_params: FlashInferFusedAllReduceParams,
     ):
         super().__init__(dtype, device)
         self.epsilon = epsilon
@@ -323,8 +323,6 @@ class AllReduceRMSNORMPattern(BasePattern):
         def replacement(input: torch.Tensor, rms_result: torch.Tensor,
                         weight: torch.Tensor):
             residual = torch.zeros_like(input)
-            assert (self.allreduce_params
-                    is not None), "No allreduce params for flashinfer provided"
             allreduce = auto_functionalized(
                 torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default,
                 allreduce_in=input,
@@ -348,7 +346,7 @@ class AllReduceFusedAddRMSNormPattern(BasePattern):
         epsilon: float,
         dtype: torch.dtype,
         device: str,
-        allreduce_params: Optional[FlashInferFusedAllReduceParams] = None,
+        allreduce_params: FlashInferFusedAllReduceParams,
     ):
         super().__init__(dtype, device)
         self.epsilon = epsilon
@@ -380,8 +378,6 @@ class AllReduceFusedAddRMSNormPattern(BasePattern):
 
         def replacement(residual: torch.Tensor, input: torch.Tensor,
                         weight: torch.Tensor):
-            assert (self.allreduce_params
-                    is not None), "No allreduce params for flashinfer provided"
             allreduce = auto_functionalized(
                 torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default,
                 allreduce_in=input,

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -7,7 +7,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
 from .activation_quant_fusion import ActivationQuantFusionPass
-from .collective_fusion import AsyncTPPass
+from .collective_fusion import AllReduceFusionPass, AsyncTPPass
 from .fix_functionalization import FixFunctionalizationPass
 from .fusion import FusionPass
 from .fusion_attn import AttnFusionPass
@@ -62,7 +62,8 @@ class PostGradPassManager(CustomGraphPass):
 
         if self.pass_config.enable_attn_fusion:
             self.passes += [AttnFusionPass(config)]
-
+        if self.pass_config.enable_flashinfer_allreduce_fusion:
+            self.passes += [AllReduceFusionPass(config)]
         self.fix_functionalization = FixFunctionalizationPass(config)
 
     def add(self, pass_: InductorPass):

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -62,8 +62,11 @@ class PostGradPassManager(CustomGraphPass):
 
         if self.pass_config.enable_attn_fusion:
             self.passes += [AttnFusionPass(config)]
-        if self.pass_config.enable_flashinfer_allreduce_fusion:
-            self.passes += [AllReduceFusionPass(config)]
+        if self.pass_config.enable_fi_allreduce_fusion:
+            self.passes += [
+                AllReduceFusionPass(
+                    config, self.pass_config.fi_allreduce_fusion_max_token_num)
+            ]
         self.fix_functionalization = FixFunctionalizationPass(config)
 
     def add(self, pass_: InductorPass):

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3962,6 +3962,8 @@ class PassConfig:
     """Whether to enable sequence parallelism."""
     enable_async_tp: bool = False
     """Whether to enable async TP."""
+    enable_flashinfer_allreduce_fusion: bool = False
+    """Whether to enable flashinfer allreduce fusion."""
 
     # TODO(luka) better pass enabling system.
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3962,8 +3962,10 @@ class PassConfig:
     """Whether to enable sequence parallelism."""
     enable_async_tp: bool = False
     """Whether to enable async TP."""
-    enable_flashinfer_allreduce_fusion: bool = False
+    enable_fi_allreduce_fusion: bool = False
     """Whether to enable flashinfer allreduce fusion."""
+    fi_allreduce_fusion_max_token_num: int = 1024
+    """Max number of tokens to used in flashinfer allreduce fusion."""
 
     # TODO(luka) better pass enabling system.
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -139,6 +139,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16: bool = True
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: Optional[int] = None
     VLLM_NIXL_ABORT_REQUEST_TIMEOUT: int = 120
+    VLLM_USE_FLASHINFER_ALLREDUCE: bool = False
 
 
 def get_default_cache_root():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -139,7 +139,6 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16: bool = True
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: Optional[int] = None
     VLLM_NIXL_ABORT_REQUEST_TIMEOUT: int = 120
-    VLLM_USE_FLASHINFER_ALLREDUCE: bool = False
 
 
 def get_default_cache_root():


### PR DESCRIPTION
## Purpose

Integrates FlashInfer fused allreduce RMSNorm using fusion passes.
Can be enabled in compilation config: `--compilation-config='{"pass_config": {"enable_flashinfer_allreduce_fusion": true}, "custom_ops": ["+rms_norm"], "level":3}'`

Baseline, no custom ops:
![image](https://github.com/user-attachments/assets/656547ef-8205-47cc-bee1-c26e9abe5fe8)
After:
![image](https://github.com/user-attachments/assets/5a1c3820-5357-4554-a6a6-6db10b4ba09b)

## Benchmarking End-to-End
Llama-3.1-70B-Instruct TP=4 on B200 GPUs

### Client: 
       DURATION_SECONDS=60; \
       vllm bench serve \
        --model meta-llama/Llama-3.1-70B-Instruct \
        --dataset-name sonnet  \
        --dataset-path benchmarks/sonnet.txt \
        --request-rate "$qps" \
        --num-prompts $((DURATION_SECONDS * qps))`
### Server.

Baseline:
`vllm serve meta-llama/Llama-3.1-70B-Instruct  --disable-log-requests --no-enable-prefix-caching -tp 4`
PR: `vllm serve meta-llama/Llama-3.1-70B-Instruct  --disable-log-requests --no-enable-prefix-caching -tp 4 --compilation-config='{"pass_config": {"enable_flashinfer_allreduce_fusion": true}, "custom_ops": ["+rms_norm"], "level":3}'`

### Results:
Baseline
| QPS | Mean TTFT (ms) | Median TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) |
|---|---|---|---|---|
| 1 | 42.557 | 41.910 | 13.210 | 13.216 |
| 5 | 46.372 | 44.402 | 14.442 | 14.382 |
| 10 | 54.465 | 49.271 | 17.834 | 17.953 |  

PR:
| QPS | Mean TTFT (ms) | Median TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) |
|---|---|---|---|---|
| 1 | 43.9 | 42.54 | 11.875 | 11.864 |
| 5 | 48.234 | 46.041 | 13.261 | 13.185 |
| 10 | 52.725 | 46.457 | 15.352 | 14.292 |

TPOT gets around 10-15% speedup 

## Test Plan
Added `tests/compile/test_fusion_all_reduce.py`
