### PR TITLE
[XPU] dispatch xpu/cuda specific calls in the model runner

### DIFF
--- a/vllm/v1/worker/xpu_model_runner.py
+++ b/vllm/v1/worker/xpu_model_runner.py
@@ -25,9 +25,3 @@ class XPUModelRunner(GPUModelRunner):
         super().__init__(vllm_config, device)
         # FIXME: To be verified.
         self.cascade_attn_enabled = False
-
-    def _init_device_properties(self) -> None:
-        self.num_sms = None
-
-    def _sync_device(self) -> None:
-        torch.xpu.synchronize()


### PR DESCRIPTION
## Purpose

`XPUModelRunner` inherits from `GPUModelRunner` and customizes couple methods. In 2 cases customization is just dispatching logic for different torch backends (cuda vs. xpu). Furhter, as vLLM has generic tests for the v1 core not differentiating between cuda or xpu, it makes sense to have single `GPUModelRunner` covering both cuda and xpu as it's already covered by existing tests which just need to be enabled for XPU to get good coverage. This commit implements described approach.

## Test Result

After the commit these tests which previously were failing now pass:
* `tests/v1/worker/test_gpu_model_runner.py::test_init_kv_cache_without_kv_sharing`
* `tests/v1/worker/test_gpu_model_runner.py::test_init_kv_cache_with_kv_sharing_valid`

The change in `_sync_device()` is taking effect in this test:
* `tests/v1/engine/test_llm_engine.py::test_engine_metrics`

Overall, as of a3e4e85ece3c01cf58ffe049540b988e3751001c with this change applied all tests in `tests/v1/worker` and `tests/v1/engine` are now passing on XPU.

CC: @Liangliang-Ma