### PR TITLE
[Bugfix] Remove assertion of expert_map being None

### DIFF
--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -100,10 +100,13 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         hidden_dim = a1.size(-1)  # K
 
         assert topk_ids.size(0) == num_tokens
-        # force clear expert_map because with expert map, -1 id is used for
+        # expert_map should be None because with expert map, -1 id is used for
         # non-local token; this causes error when casting ids to the
         # topk_indices_dtype() uint32
-        expert_map = None
+        #
+        # commented otherwise pre-commit check on unused var fails
+        #
+        # expert_map = None
 
         # Is this always going to be a1.device?
         device = a1.device

--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -100,9 +100,10 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         hidden_dim = a1.size(-1)  # K
 
         assert topk_ids.size(0) == num_tokens
-        assert expert_map is None, """with expert map, -1 id is used for
-            non-local token; this causes error when casting ids to the
-            topk_indices_dtype() uint32"""
+        # force clear expert_map because with expert map, -1 id is used for
+        # non-local token; this causes error when casting ids to the
+        # topk_indices_dtype() uint32
+        expert_map = None
 
         # Is this always going to be a1.device?
         device = a1.device


### PR DESCRIPTION
## Purpose

to address comment in https://github.com/vllm-project/vllm/pull/20166/files/ec668c3190d74c8a0b5415ea85784a1cdb0703fd#r2196073272 for passing pplx tests

## Test Plan

n/a. this only removes assertion.

## Test Result

n/a

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
