### PR TITLE
Fix DeepSeek-R1-0528 chat template

### DIFF
--- a/examples/tool_chat_template_deepseekr1.jinja
+++ b/examples/tool_chat_template_deepseekr1.jinja
@@ -11,7 +11,7 @@
             {% set ns.system_prompt = ns.system_prompt + '\n\n' + message['content'] %}
         {%- endif %}
     {%- endif %}
-{%- endfor %}
+{%- endfor -%}
 
 {#- Adapted from https://github.com/sgl-project/sglang/blob/main/examples/chat_template/tool_chat_template_deepseekr1.jinja #}
 {% if tools is defined and tools is not none %}
@@ -27,8 +27,8 @@
     {% set ns.system_prompt = ns.system_prompt + '\n\n' + tool_ns.text %}
 {% endif %}
 
-{{ bos_token }}
-{{ ns.system_prompt }}
+{{- bos_token }}
+{{- ns.system_prompt }}
 {%- for message in messages %}
     {% set content = message['content'] %}
     {%- if message['role'] == 'user' %}
@@ -70,7 +70,7 @@
             {{'<｜tool▁outputs▁end｜>' + content + '<｜end▁of▁sentence｜>'}}
             {%- set ns.is_tool = false -%}
         {%- else %}
-            {{content + '<｜end▁of▁sentence｜>'}}
+            {{- content + '<｜end▁of▁sentence｜>'}}
         {%- endif %}
     {%- endif %}
     {%- if message['role'] == 'tool' %}
@@ -88,5 +88,5 @@
     {{'<｜tool▁outputs▁end｜>'}}
 {% endif %}
 {% if add_generation_prompt and not ns.is_last_user and not ns.is_tool %}
-    {{'<｜Assistant｜>'}}
-{% endif %}
+    {{- '<｜Assistant｜>'}}
+{%- endif %}

--- a/examples/tool_chat_template_deepseekr1.jinja
+++ b/examples/tool_chat_template_deepseekr1.jinja
@@ -45,7 +45,7 @@
     {%- if message['role'] == 'assistant' and message['tool_calls'] is defined and message['tool_calls'] is not none %}
         {%- set ns.is_last_user = false -%}
         {%- if ns.is_tool %}
-            {{'<｜tool▁outputs▁end｜>'}}
+            {{- '<｜tool▁outputs▁end｜>'}}
         {%- endif %}
         {%- set ns.is_first = false %}
         {%- set ns.is_tool = false -%}
@@ -53,21 +53,21 @@
         {%- for tool in message['tool_calls'] %}
             {%- if not ns.is_first %}
                 {%- if content is none %}
-                    {{'<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments']|tojson + '\n' + '```' + '<｜tool▁call▁end｜>'}}
+                    {{- '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments']|tojson + '\n' + '```' + '<｜tool▁call▁end｜>'}}
                 {%- else %}
-                    {{content + '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments']|tojson + '\n' + '```' + '<｜tool▁call▁end｜>'}}
+                    {{- content + '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments']|tojson + '\n' + '```' + '<｜tool▁call▁end｜>'}}
                 {%- endif %}
                 {%- set ns.is_first = true -%}
             {%- else %}
-                {{'\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments']|tojson + '\n' + '```' + '<｜tool▁call▁end｜>'}}
+                {{- '\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments']|tojson + '\n' + '```' + '<｜tool▁call▁end｜>'}}
             {%- endif %}
         {%- endfor %}
-        {{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}
+        {{- '<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}
     {%- endif %}
     {%- if message['role'] == 'assistant' and (message['tool_calls'] is not defined or message['tool_calls'] is none)%}
         {%- set ns.is_last_user = false -%}
         {%- if ns.is_tool %}
-            {{'<｜tool▁outputs▁end｜>' + content + '<｜end▁of▁sentence｜>'}}
+            {{- '<｜tool▁outputs▁end｜>' + content + '<｜end▁of▁sentence｜>'}}
             {%- set ns.is_tool = false -%}
         {%- else %}
             {{- content + '<｜end▁of▁sentence｜>'}}
@@ -77,16 +77,16 @@
         {%- set ns.is_last_user = false -%}
         {%- set ns.is_tool = true -%}
         {%- if ns.is_output_first %}
-            {{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + content + '<｜tool▁output▁end｜>'}}
+            {{- '<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + content + '<｜tool▁output▁end｜>'}}
             {%- set ns.is_output_first = false %}
         {%- else %}
-            {{'\n<｜tool▁output▁begin｜>' + content + '<｜tool▁output▁end｜>'}}
+            {{- '\n<｜tool▁output▁begin｜>' + content + '<｜tool▁output▁end｜>'}}
         {%- endif %}
     {%- endif %}
 {%- endfor -%}
 {% if ns.is_tool %}
-    {{'<｜tool▁outputs▁end｜>'}}
-{% endif %}
+    {{- '<｜tool▁outputs▁end｜>'}}
+{%- endif %}
 {% if add_generation_prompt and not ns.is_last_user and not ns.is_tool %}
     {{- '<｜Assistant｜>'}}
 {%- endif %}


### PR DESCRIPTION
## Purpose / Overview

The chat template `examples/tool_chat_template_deepseekr1.jinja` for DeepSeek-R1-0528 produces prompts that differ from those rendered with the original chat template in the tokenizer_config.json, even for requests without tool use.

Our expectation is that for requests with no tools and no tool_calls in the messages history, the recommended vllm chat template should be equivalent to the original chat template in the tokenizer_config.json. 

The difference in the rendered prompts is purely in whitespaces: because of the multi-line formatting of the jinja template in `examples/tool_chat_template_deepseekr1.jinja` and no consequent use of whitespace-stripping jinja blocks like `{%-` or `{{-`, multiple spaces and newline characters appear in the rendered prompt and result in additional whitespace tokens.
While these additional whitespace tokens in the prompt do not cause harm for many use cases, we were surprised to find out that for certain requests the response behavior was different between a vllm deployment with and without `--chat-template examples/tool_chat_template_deepseekr1.jinja`.

Thus, we suggest to add whitespace-control to the vllm jinja template so that the rendered prompt for requests without tool use is identical to the one obtained with the original one.
In addition, we also suggest to clean up excessive whitespace for requests with tools. In our tests, this change yielded a small but significant improvement in BFCL benchmark scores. 

This PR improves on https://github.com/vllm-project/vllm/pull/18874. Interestingly, there had already been [a comment](https://github.com/vllm-project/vllm/pull/18874#issuecomment-2928548830) by @wukaixingxp about excessive whitespace, but it had not been addressed in detail.

## Tests

### Rendered prompt comparison

#### (1) for requests without tools
a) an example message rendered with the original R1-0528 chat template from its tokenizer_config.json (see https://nebula.packetcoders.io/j2-render/s_4c918b3d/):
```
<|begin_of_text|>You are a helpful assistant.<｜User｜>Who are you?<｜Assistant｜>I am an AI assistant<｜end▁of▁sentence｜><｜User｜>What is the weather in Munich?<｜Assistant｜>
```
b) an example message rendered with the current tool_chat_template_deepseekr1.jinja (see https://nebula.packetcoders.io/j2-render/s_8354d180/)
```

<|begin_of_text|>
You are a helpful assistant.<｜User｜>Who are you?<｜Assistant｜>            I am an AI assistant<｜end▁of▁sentence｜><｜User｜>What is the weather in Munich?<｜Assistant｜>
```
c) an example message rendered with the suggested corrected tool_chat_template_deepseekr1.jinja from this PR (see https://nebula.packetcoders.io/j2-render/s_2f2ff276/)
```
<|begin_of_text|>You are a helpful assistant.<｜User｜>Who are you?<｜Assistant｜>I am an AI assistant<｜end▁of▁sentence｜><｜User｜>What is the weather in Munich?<｜Assistant｜>
```

#### (2) for requests with tools
a) an example message rendered with the current tool_chat_template_deepseekr1.jinja (see https://nebula.packetcoders.io/j2-render/s_fe7b8fc8/)
```

<|begin_of_text|>
you are helpful assistant.

You are a helpful assistant with tool calling capabilities. When a tool call is needed, you MUST use the following format to issue the call:
<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>FUNCTION_NAME
```json
{"param1": "value1", "param2": "value2"}
``<｜tool▁call▁end｜><｜tool▁calls▁end｜>

Make sure the JSON is valid.## Tools

### Function

You have the following functions available:


```json
{"function": {"description": "Get the current weather", "name": "get_current_weather", "parameters": {"properties": {"format": {"enum": ["celsius", "fahrenheit"], "type": "string"}, "location": {"description": "The city and country, e.g. San Francisco, USA", "type": "string"}}, "required": ["location", "format"], "type": "object"}}, "type": "function"}
``
<｜User｜>Who are you?<｜Assistant｜>            I am AI assistant<｜end▁of▁sentence｜><｜User｜>What is the weather in SF and Seattle?<｜Assistant｜>                    <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
```json
"{\"city\": \"SF\", \"metric\": \"fahrenheit\"}"
``<｜tool▁call▁end｜>                
<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
```json
"{\"city\": \"Seattle\", \"metric\": \"fahrenheit\"}"
``<｜tool▁call▁end｜>        <｜tool▁calls▁end｜><｜end▁of▁sentence｜>            <｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>[{"response": "Sunny"},{"response": "Rainy"}]<｜tool▁output▁end｜>            <｜tool▁outputs▁end｜>SF is Sunny and Seattle is Rainy<｜end▁of▁sentence｜><｜User｜>what about NYC?<｜Assistant｜>
```

b) an example message rendered with the suggested corrected tool_chat_template_deepseekr1.jinja from this PR (see https://nebula.packetcoders.io/j2-render/s_59846767/)
```
<|begin_of_text|>you are helpful assistant.

You are a helpful assistant with tool calling capabilities. When a tool call is needed, you MUST use the following format to issue the call:
<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>FUNCTION_NAME
```json
{"param1": "value1", "param2": "value2"}
``<｜tool▁call▁end｜><｜tool▁calls▁end｜>

Make sure the JSON is valid.## Tools

### Function

You have the following functions available:


```json
{"function": {"description": "Get the current weather", "name": "get_current_weather", "parameters": {"properties": {"format": {"enum": ["celsius", "fahrenheit"], "type": "string"}, "location": {"description": "The city and country, e.g. San Francisco, USA", "type": "string"}}, "required": ["location", "format"], "type": "object"}}, "type": "function"}
``
<｜User｜>Who are you?<｜Assistant｜>I am AI assistant<｜end▁of▁sentence｜><｜User｜>What is the weather in SF and Seattle?<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
```json
"{\"city\": \"SF\", \"metric\": \"fahrenheit\"}"
``<｜tool▁call▁end｜>
<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
```json
"{\"city\": \"Seattle\", \"metric\": \"fahrenheit\"}"
``<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜><｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>[{"response": "Sunny"},{"response": "Rainy"}]<｜tool▁output▁end｜><｜tool▁outputs▁end｜>SF is Sunny and Seattle is Rainy<｜end▁of▁sentence｜><｜User｜>what about NYC?<｜Assistant｜>
```

### Benchmark results
With the benchmark from the [Berkeley Function Calling Leaderboard](https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard) we measured and evaluated the tool-calling capabilities with the old and the corrected tool_chat_template_deepseekr1.jinja, in 6 runs each, at a temperature of 0.6.

| chat template | BFCL "simple" | BFCL "multiple" | BFCL "parallel" | BFCL "parallel_multiple" |
|--------|--------|--------|--------|--------|
| old template with excess whitespace | 0.884(5) | 0.78(1) | 0.28(3) | 0.36(3) |
| new template with stripped whitespace | **0.93(1)** | **0.95(1)** | **0.37(2)** | **0.39(2)** |

That means, this PR could yield small but significant improvements in tool calling as measured in these benchmarks at T=0.6. 
