### PR TITLE
Temporarily suspend google/gemma-3-1b-it.

### DIFF
--- a/tests/entrypoints/llm/test_accuracy.py
+++ b/tests/entrypoints/llm/test_accuracy.py
@@ -69,6 +69,12 @@ def test_lm_eval_accuracy_v1_engine(model, monkeypatch: pytest.MonkeyPatch):
         more_args = None
         if current_platform.is_tpu():
             # Limit compilation time for TPU V1
+
+            if model == "google/gemma-3-1b-it":
+                pytest.skip(
+                    "Temporarily disabled due to test failures"
+                    "(timeout or accuracy mismatch). Re-enable once fixed.")
+
             more_args = "max_model_len=2048,max_num_seqs=64"
 
             # Add TP test (if provided)


### PR DESCRIPTION
## Purpose
Temporally remove the google/gemma-3-1b-it to unblock testing. 

Because

1. buildkite shows time out sometimes.
2. local run always gives me error: `AssertionError: Expected: 0.25 |  Measured: 0.13191811978771797`
3. This [PR](https://github.com/vllm-project/vllm/pull/15732) added the test but it seems the test actually didn't pass in the [buildkite run]( https://buildkite.com/vllm/ci/builds/16894#0195fd8a-65cb-4c52-85e7-373169bfd727). 

## Test Plan
Test and see result on fast check. 

## Test Result
The test passes in fastcheck
![image](https://github.com/user-attachments/assets/2d03b150-8489-41fc-a4a1-1403f4e355d5)

