### PR TITLE
[feat] backup memory except model parameters when using level=2 in sleep mode

### DIFF
--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -247,9 +247,7 @@ def test_backup_memory_except_with_model():
     backup_x = x.clone()
 
     def assert_equal_without_parameters():
-        for b1, b2 in zip(backup_model.named_buffers(),
-                          model.named_buffers(),
-                          strict=True):
+        for b1, b2 in zip(backup_model.named_buffers(), model.named_buffers()):
             assert (b1[0] == b2[0])
             assert (b1[1] == b2[1]).all()
 
@@ -259,8 +257,7 @@ def test_backup_memory_except_with_model():
 
     # assert parameters are equal
     for b1, b2 in zip(backup_model.named_parameters(),
-                      model.named_parameters(),
-                      strict=True):
+                      model.named_parameters()):
         assert (b1[0] == b2[0])
         assert (b1[1] == b2[1]).all()
     assert_equal_without_parameters()

--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -177,3 +177,99 @@ def test_end_to_end(monkeypatch: pytest.MonkeyPatch, model: str, use_v1: bool):
 
         # cmp output
         assert output[0].outputs[0].text == output3[0].outputs[0].text
+
+
+@create_new_process_for_each_test()
+def test_backup_memory_except():
+    allocator = CuMemAllocator.get_instance()
+    named_tensors = []
+    tag = "discard"
+    with allocator.use_memory_pool(tag=tag):
+        x = torch.nn.Parameter(torch.randn(100, 100, device='cuda'))
+        y = torch.nn.Parameter(torch.randn(200, 100, device='cuda'))
+        z = torch.nn.Parameter(torch.randn(300, 100, device='cuda'))
+        named_tensors.append(("x", x))
+        named_tensors.append(("y", y))
+    backup_named_tensors = [t.clone() for _, t in named_tensors]
+    backup_z = z.clone()
+
+    allocator.backup_memory_except(named_tensors, tags=tag)
+    assert len(allocator.pointer_to_data) == 1
+    ptr, data = next(iter(allocator.pointer_to_data.items()))
+    assert ptr == x.data_ptr()
+    size = data.handle[1]
+    # torch's smallest segment size is 2MiB
+    assert size == 2 * 1024 * 1024
+    start = z.data_ptr() - x.data_ptr()
+    for _, t in named_tensors:
+        size -= t.nbytes
+        start -= t.nbytes
+    assert data.cpu_backup_tensor.nbytes == size
+    end = start + z.nbytes
+    assert (data.cpu_backup_tensor[start:end] == z.view(-1).view(
+        torch.uint8).cpu()).all()
+
+    allocator.sleep(offload_tags=tuple())
+    allocator.wake_up()
+
+    for t, (_, new_t) in zip(backup_named_tensors, named_tensors):
+        assert (t != new_t).any()
+
+    assert (backup_z == z).all()
+
+
+@create_new_process_for_each_test()
+def test_backup_memory_except_with_model():
+    allocator = CuMemAllocator.get_instance()
+    tag = "discard"
+
+    class ToyModel(torch.nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(12345, 100)
+            self.register_buffer("x", torch.randn(22345, 100))
+            self.y = torch.randn(12345, 5432)
+            self.register_buffer("z", torch.randn(23333, 100))
+            self.p = torch.nn.Parameter(torch.randn(31460, 100))
+
+        def forward(self, x):
+            return x
+
+    with allocator.use_memory_pool(tag=tag):
+        model = ToyModel()
+        model.to('cuda')
+        x = torch.randn(100, 100, device='cuda')
+
+    backup_model = ToyModel().to('cuda')
+    backup_model.load_state_dict(model.state_dict())
+    backup_model.y = model.y.clone()
+    backup_x = x.clone()
+
+    def assert_equal_without_parameters():
+        for b1, b2 in zip(backup_model.named_buffers(),
+                          model.named_buffers(),
+                          strict=True):
+            assert (b1[0] == b2[0])
+            assert (b1[1] == b2[1]).all()
+
+        assert (backup_model.y == model.y).all()
+
+        assert (backup_x == x).all()
+
+    # assert parameters are equal
+    for b1, b2 in zip(backup_model.named_parameters(),
+                      model.named_parameters(),
+                      strict=True):
+        assert (b1[0] == b2[0])
+        assert (b1[1] == b2[1]).all()
+    assert_equal_without_parameters()
+
+    allocator.backup_memory_except(list(model.named_parameters()), tags=tag)
+
+    allocator.sleep()
+    allocator.wake_up()
+
+    assert_equal_without_parameters()
+    for p in model.parameters():
+        assert (p == 0).all()

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -12,7 +12,7 @@ import dataclasses
 import gc
 import os
 from contextlib import contextmanager
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union, List, NamedTuple
 
 import torch
 
@@ -67,11 +67,18 @@ except ModuleNotFoundError:
 HandleType = tuple[int, int, int, int]
 
 
+class Interval(NamedTuple):
+    ptr: int
+    size: int
+    name: Optional[str] = None
+
+
 @dataclasses.dataclass
 class AllocationData:
     handle: HandleType
     tag: str
     cpu_backup_tensor: Optional[torch.Tensor] = None
+    backup_intervals: Optional[List[Interval]] = None
 
 
 def create_and_map(allocation_handle: HandleType) -> None:
@@ -101,6 +108,38 @@ def use_memory_pool_with_allocator(
     mem_pool = torch.cuda.memory.MemPool(new_alloc._allocator)
     with torch.cuda.memory.use_mem_pool(mem_pool):
         yield mem_pool, new_alloc
+
+
+def calc_interval_difference(
+        outer_intervals: List[Interval],
+        inner_intervals: List[Interval]) -> List[Tuple[int, List[Interval]]]:
+    """
+    :param outer_intervals: list of intervals, musted be sorted
+    :param inner_intervals: list of intervals, musted be sorted
+    :return: list of (ptr, intervals) that are in outer but not in inner.
+    """
+    outer_intervals = sorted(outer_intervals)
+    inner_intervals = sorted(inner_intervals)
+    i = 0
+    outer_diff_intervals: List[(int, List[Interval])] = []
+    for ptr, size, _ in outer_intervals:
+        backup_intervals: List[Interval] = []
+        last_offset = ptr
+        while i < len(inner_intervals) and inner_intervals[i].ptr < ptr + size:
+            _ptr, _size, _name = inner_intervals[i]
+            assert _ptr >= ptr and _ptr + _size <= ptr + size, \
+                f"tensor {_name} is not fully covered by allocator, " \
+                f"tensor addrs: ({_ptr}, {_size}), allocator addrs: ({ptr}, {size})"
+            diff = _ptr - last_offset
+            if diff > 0:
+                backup_intervals.append(Interval(last_offset, diff))
+            last_offset = _ptr + _size
+            i += 1
+        diff = ptr + size - last_offset
+        if diff > 0:
+            backup_intervals.append(Interval(last_offset, diff))
+        outer_diff_intervals.append((ptr, backup_intervals))
+    return outer_diff_intervals
 
 
 class CuMemAllocator:
@@ -171,6 +210,57 @@ class CuMemAllocator:
             data.cpu_backup_tensor = None
         return data.handle
 
+    def backup_memory_except(
+            self,
+            named_tensors: List[Tuple[str, torch.Tensor]],
+            tags: Optional[Union[Tuple[str, ...], str]] = None) -> None:
+        """
+        Found all mem addresses from self.pointer_to_data which matches tags,
+        and backup the difference mem addresses except the ones in named_tensors.
+        The mem addresses in named_tensors should be all involved in the memory from tags.
+        After backup, the memory of the named_tensors will be discarded when calling sleep level=2
+        buf the difference mem fragments will be backuped and restored when calling wake_up.
+        This is useful for the case when we do not want to backup all the memory from tags,
+        e.g. sleep level 2 will use this feature to only backup the difference mem fragments
+        and discard the model parameters since they will be updated in the next step.
+        """
+        if tags is None:
+            # by default, allocated tensors's fragments will be backup
+            tags = (CuMemAllocator.default_tag, )
+        elif isinstance(tags, str):
+            tags = (tags, )
+
+        assert isinstance(tags, tuple)
+
+        diff_intervals = calc_interval_difference(
+            [
+                Interval(ptr, item.handle[1])
+                for ptr, item in self.pointer_to_data.items()
+                if item.tag in tags
+            ],
+            [
+                Interval(t.data_ptr(), t.nbytes, name)
+                for name, t in named_tensors
+            ],
+        )
+
+        for addr, intervals in diff_intervals:
+            backup_size = sum(interval.size for interval in intervals)
+            if backup_size == 0:
+                continue
+            cpu_backup_tensor = torch.empty(
+                backup_size,
+                dtype=torch.uint8,
+                device='cpu',
+                pin_memory=is_pin_memory_available())
+            offset = 0
+            for ptr, size, _ in intervals:
+                cpu_ptr = cpu_backup_tensor[offset:offset + size].data_ptr()
+                libcudart.cudaMemcpy(cpu_ptr, ptr, size)
+                offset += size
+            self.pointer_to_data[addr].backup_intervals = intervals
+            self.pointer_to_data[addr].cpu_backup_tensor = cpu_backup_tensor
+
     def sleep(
             self,
             offload_tags: Optional[Union[tuple[str, ...],
@@ -204,6 +294,7 @@ class CuMemAllocator:
                 cpu_ptr = cpu_backup_tensor.data_ptr()
                 libcudart.cudaMemcpy(cpu_ptr, ptr, size_in_bytes)
                 data.cpu_backup_tensor = cpu_backup_tensor
+                data.backup_intervals = None
             unmap_and_release(handle)
 
         gc.collect()
@@ -223,7 +314,17 @@ class CuMemAllocator:
             if tags is None or data.tag in tags:
                 handle = data.handle
                 create_and_map(handle)
-                if data.cpu_backup_tensor is not None:
+                if data.backup_intervals is not None:
+                    assert data.cpu_backup_tensor is not None
+                    offset = 0
+                    for ptr, size, _ in data.backup_intervals:
+                        cpu_ptr = data.cpu_backup_tensor[offset:offset +
+                                                         size].data_ptr()
+                        libcudart.cudaMemcpy(ptr, cpu_ptr, size)
+                        offset += size
+                    data.backup_intervals = None
+                    data.cpu_backup_tensor = None
+                elif data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
                     if cpu_backup_tensor is not None:
                         size_in_bytes = cpu_backup_tensor.numel(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -58,9 +58,6 @@ class Worker(WorkerBase):
             from vllm.utils import init_cached_hf_modules
             init_cached_hf_modules()
 
-        # Buffers saved before sleep
-        self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
-
         # Torch profiler. Enabled and configured through env vars:
         # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
         if envs.VLLM_TORCH_PROFILER_DIR:
@@ -81,16 +78,16 @@ class Worker(WorkerBase):
     def sleep(self, level: int = 1) -> None:
         free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
 
-        # Save the buffers before level 2 sleep
+        default_tags = ("weights", )
+        allocator = CuMemAllocator.get_instance()
         if level == 2:
             model = self.model_runner.model
-            self._sleep_saved_buffers = {
-                name: buffer.cpu().clone()
-                for name, buffer in model.named_buffers()
-            }
+            allocator.backup_memory_except(
+                list(model.named_parameters()),
+                tags=default_tags,
+            )
 
-        allocator = CuMemAllocator.get_instance()
-        allocator.sleep(offload_tags=("weights", ) if level == 1 else tuple())
+        allocator.sleep(offload_tags=default_tags if level == 1 else tuple())
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep
@@ -103,14 +100,6 @@ class Worker(WorkerBase):
     def wake_up(self, tags: Optional[list[str]] = None) -> None:
         allocator = CuMemAllocator.get_instance()
         allocator.wake_up(tags)
-
-        # Restore the buffers after level 2 sleep
-        if len(self._sleep_saved_buffers):
-            model = self.model_runner.model
-            for name, buffer in model.named_buffers():
-                if name in self._sleep_saved_buffers:
-                    buffer.data.copy_(self._sleep_saved_buffers[name].data)
-            self._sleep_saved_buffers = {}
 
     def initialize_cache(self, num_gpu_blocks: int,
                          num_cpu_blocks: int) -> None:

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -100,9 +100,6 @@ class Worker(LocalOrDistributedWorkerBase):
         self.gpu_cache: Optional[List[List[torch.Tensor]]] = None
         self._seq_group_metadata_cache: Dict[str, SequenceGroupMetadata] = {}
 
-        # Buffers saved before sleep
-        self._sleep_saved_buffers: Dict[str, torch.Tensor] = {}
-
         # Torch profiler. Enabled and configured through env vars:
         # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
         if envs.VLLM_TORCH_PROFILER_DIR:
@@ -135,16 +132,16 @@ class Worker(LocalOrDistributedWorkerBase):
     def sleep(self, level: int = 1) -> None:
         free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
 
-        # Save the buffers before level 2 sleep
+        default_tags = ("weights", )
+        allocator = CuMemAllocator.get_instance()
         if level == 2:
             model = self.model_runner.model
-            self._sleep_saved_buffers = {
-                name: buffer.cpu().clone()
-                for name, buffer in model.named_buffers()
-            }
+            allocator.backup_memory_except(
+                list(model.named_parameters()),
+                tags=default_tags,
+            )
 
-        allocator = CuMemAllocator.get_instance()
-        allocator.sleep(offload_tags=("weights", ) if level == 1 else tuple())
+        allocator.sleep(offload_tags=default_tags if level == 1 else tuple())
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep
@@ -157,14 +154,6 @@ class Worker(LocalOrDistributedWorkerBase):
     def wake_up(self, tags: Optional[list[str]] = None) -> None:
         allocator = CuMemAllocator.get_instance()
         allocator.wake_up(tags=tags)
-
-        # Restore the buffers after level 2 sleep
-        if len(self._sleep_saved_buffers):
-            model = self.model_runner.model
-            for name, buffer in model.named_buffers():
-                if name in self._sleep_saved_buffers:
-                    buffer.data.copy_(self._sleep_saved_buffers[name].data)
-            self._sleep_saved_buffers = {}
 
     def init_device(self) -> None:
         if self.device_config.device.type == "cuda":


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR provides a more elegant way to resolve https://github.com/vllm-project/vllm/issues/15254. Though https://github.com/vllm-project/vllm/pull/16889 provides a method to backup the buffers when sleep in the model and restore them after wake up, if there's some other tensors allocated and saved in the model, e.g. save some tensors as attributes in the model, this GPU memory will be discard and make undefined behavior.

This PR add a method called `backup_memory_except` to backup GPU memory from `tags` except memory in `named_tensors`. By saving memory intervals in `backup_intervals` and backup memory to `cpu_backup_tensor`, we can restore these memory after wake_up.

![image](https://github.com/user-attachments/assets/917a2407-6493-4447-88b4-73a9c32c2c4e)

## Test Plan

I've already added `test_backup_memory_except` and `test_backup_memory_except_with_model` in `tests/basic_correctness/test_cumem.py`

## Test Result

All tests passed in `tests/basic_correctness/test_cumem.py`
![image](https://github.com/user-attachments/assets/9a176dc3-f1b0-46c8-8f5a-2ba1da09fced)


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
