### PR TITLE
[ROCm][Regression] Remove tensor creation that harms performance on ROCm

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -247,10 +247,6 @@ class RocmPlatform(Platform):
         Set the device for the current platform.
         """
         torch.cuda.set_device(device)
-        # With this trick we can force the device to be set eagerly
-        # see https://github.com/pytorch/pytorch/issues/155668
-        # for why and when it is needed
-        _ = torch.zeros(1, device=device)
 
     @classmethod
     @lru_cache(maxsize=8)


### PR DESCRIPTION

Revert adding empty tensor creation on ROCm that was added in https://github.com/vllm-project/vllm/pull/20262
This change is a performance hit on several configs, such as
```
VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 python benchmarks/benchmark_latency.py --model meta-llama/Llama-3.1-70B-Instruct --dtype float16 --batch-size 1 --input-len 1024 --output-len 1024 -tp 8 --max-model-len 65536 -O '{"pass_config":{"enable_attn_fusion":true,"enable_noop":true,"enable_fusion":true},"full_cuda_graph":true}' --num-iters-warmup 1 --num-iters 3
```
brings the performance down by 20%

So unless https://github.com/pytorch/pytorch/issues/155668 has a breaking effect on ROCm with torch 2.7, and there is not better way to resolve it, I suggest reverting this change
cc @jikunshang 