### PR TITLE
[1/N] Refactor platform API to reduce `torch.cuda` call

### DIFF
--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -40,6 +40,7 @@ from vllm.distributed.parallel_state import (get_ep_group, get_node_count,
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MixtureOfExperts
+from vllm.platforms import current_platform
 
 from .rebalance_algo import rebalance_experts
 from .rebalance_execute import rearrange_expert_weights_inplace
@@ -425,7 +426,7 @@ class EplbState:
         time_start = None
         is_main_rank = ep_rank == 0
         if is_main_rank:
-            torch.cuda.synchronize()
+            current_platform.synchronize()
             time_start = time.perf_counter()
             logger.info("Rearranging experts %s...",
                         "(profile)" if is_profile else "")
@@ -541,7 +542,7 @@ class EplbState:
 
         if is_main_rank:
             assert time_start is not None
-            torch.cuda.synchronize()
+            current_platform.synchronize()
             time_end = time.perf_counter()
             logger.info(
                 "Rearranged experts%sin %.2f seconds.",

--- a/vllm/distributed/eplb/rebalance_execute.py
+++ b/vllm/distributed/eplb/rebalance_execute.py
@@ -14,6 +14,8 @@ import torch
 from torch.distributed import (P2POp, ProcessGroup, all_gather,
                                batch_isend_irecv, get_global_rank)
 
+from vllm.platforms import current_platform
+
 
 def idx_local_to_global(
     local_idx: int,
@@ -323,7 +325,7 @@ def rearrange_expert_weights_inplace(
     for layer in range(num_moe_layers):
         # NOTE(bowen): We need this synchronize to run, but I don't know why.
         # If you figure out the reason, please let me know -- thank you!
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         shuffle_layer(
             num_local_physical_experts,
             ep_rank,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -330,7 +330,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 and (weight.stride(-2) * weight.element_size()) % 512 == 0):
             num_pad = 256 // weight.element_size()
             weight = F.pad(weight, (0, num_pad), "constant", 0)[..., :-num_pad]
-            torch.cuda.empty_cache()
+            current_platform.empty_cache()
         return weight
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -343,7 +343,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 and (weight.stride(-2) * weight.element_size()) % 512 == 0):
             num_pad = 256 // weight.element_size()
             weight = F.pad(weight, (0, num_pad), "constant", 0)[..., :-num_pad]
-            torch.cuda.empty_cache()
+            current_platform.empty_cache()
         return weight
 
     def process_weights_after_loading(self, layer: Module) -> None:

--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -765,7 +765,7 @@ class BitsAndBytesModelLoader(BaseModelLoader):
             **stacked_quant_state_dict
         }
         self._bind_quant_states_to_params(model, stacked_quant_state_dict)
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config.model, model_config.revision)

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -335,3 +335,30 @@ class CpuPlatform(Platform):
         return (cls.supports_v1(model_config)
                 and arch in (CpuArchEnum.X86, CpuArchEnum.POWERPC,
                              CpuArchEnum.ARM, CpuArchEnum.S390X))
+
+    @classmethod
+    def empty_cache(cls):
+        pass
+
+    @classmethod
+    def reset_peak_memory_stats(cls):
+        pass
+
+    @classmethod
+    def mem_get_info(cls):
+        # FIXME: impl
+        return None
+
+    @classmethod
+    def memory_stats(cls):
+        # FIXME: impl
+        return None
+
+    @classmethod
+    def memory_reserved(cls):
+        # FIXME: impl
+        return None
+
+    @classmethod
+    def synchronize(cls):
+        torch.cpu.synchronize()

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -361,4 +361,4 @@ class CpuPlatform(Platform):
 
     @classmethod
     def synchronize(cls):
-        torch.cpu.synchronize()
+        pass

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -347,17 +347,20 @@ class CpuPlatform(Platform):
     @classmethod
     def mem_get_info(cls):
         # FIXME: impl
-        return None
+        # Returning (0, 0) as a placeholder for (free, total) memory.
+        return (0, 0)
 
     @classmethod
     def memory_stats(cls):
         # FIXME: impl
-        return None
+        # Returning an empty dict as a placeholder for memory stats.
+        return {}
 
     @classmethod
     def memory_reserved(cls):
         # FIXME: impl
-        return None
+        # Returning 0 as a placeholder for reserved memory.
+        return 0
 
     @classmethod
     def synchronize(cls):

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -519,6 +519,26 @@ class CudaPlatformBase(Platform):
         return supported
 
     @classmethod
+    def reset_peak_memory_stats(cls):
+        torch.cuda.reset_peak_memory_stats()
+
+    @classmethod
+    def mem_get_info(cls):
+        return torch.cuda.mem_get_info()
+
+    @classmethod
+    def memory_stats(cls):
+        return torch.cuda.memory_stats()
+
+    @classmethod
+    def memory_reserved(cls):
+        return torch.cuda.memory_reserved()
+
+    @classmethod
+    def empty_cache(cls):
+        torch.cuda.empty_cache()
+
+    @classmethod
     def get_num_sms(cls, device: torch.device):
         device_properties = torch.cuda.get_device_properties(device)
         num_sms = device_properties.multi_processor_count

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -518,6 +518,30 @@ class CudaPlatformBase(Platform):
                     supported = True
         return supported
 
+    @classmethod
+    def empty_cache(cls, ):
+        torch.cuda.empty_cache()
+
+    @classmethod
+    def reset_peak_memory_stats(cls):
+        torch.cuda.reset_peak_memory_stats()
+
+    @classmethod
+    def mem_get_info(cls):
+        return torch.cuda.mem_get_info()
+
+    @classmethod
+    def memory_stats(cls):
+        return torch.cuda.memory_stats()
+
+    @classmethod
+    def memory_reserved(cls):
+        return torch.cuda.memory_reserved()
+
+    @classmethod
+    def synchronize(cls):
+        return torch.cuda.synchronize()
+
 
 # NVML utils
 # Note that NVML is not affected by `CUDA_VISIBLE_DEVICES`,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -538,6 +538,10 @@ class CudaPlatformBase(Platform):
     def memory_reserved(cls):
         return torch.cuda.memory_reserved()
 
+    @classmethod
+    def empty_cache(cls):
+        torch.cuda.empty_cache()
+
 
 # NVML utils
 # Note that NVML is not affected by `CUDA_VISIBLE_DEVICES`,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -538,10 +538,6 @@ class CudaPlatformBase(Platform):
     def memory_reserved(cls):
         return torch.cuda.memory_reserved()
 
-    @classmethod
-    def synchronize(cls):
-        torch.cuda.synchronize()
-
 
 # NVML utils
 # Note that NVML is not affected by `CUDA_VISIBLE_DEVICES`,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -519,26 +519,6 @@ class CudaPlatformBase(Platform):
         return supported
 
     @classmethod
-    def reset_peak_memory_stats(cls):
-        torch.cuda.reset_peak_memory_stats()
-
-    @classmethod
-    def mem_get_info(cls):
-        return torch.cuda.mem_get_info()
-
-    @classmethod
-    def memory_stats(cls):
-        return torch.cuda.memory_stats()
-
-    @classmethod
-    def memory_reserved(cls):
-        return torch.cuda.memory_reserved()
-
-    @classmethod
-    def empty_cache(cls):
-        torch.cuda.empty_cache()
-
-    @classmethod
     def get_num_sms(cls, device: torch.device):
         device_properties = torch.cuda.get_device_properties(device)
         num_sms = device_properties.multi_processor_count

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -519,7 +519,7 @@ class CudaPlatformBase(Platform):
         return supported
 
     @classmethod
-    def empty_cache(cls, ):
+    def empty_cache(cls):
         torch.cuda.empty_cache()
 
     @classmethod
@@ -540,7 +540,7 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def synchronize(cls):
-        return torch.cuda.synchronize()
+        torch.cuda.synchronize()
 
 
 # NVML utils

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -538,6 +538,12 @@ class CudaPlatformBase(Platform):
     def empty_cache(cls):
         torch.cuda.empty_cache()
 
+    @classmethod
+    def get_num_sms(cls, device: torch.device):
+        device_properties = torch.cuda.get_device_properties(device)
+        num_sms = device_properties.multi_processor_count
+        return num_sms
+
 
 # NVML utils
 # Note that NVML is not affected by `CUDA_VISIBLE_DEVICES`,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -519,10 +519,6 @@ class CudaPlatformBase(Platform):
         return supported
 
     @classmethod
-    def empty_cache(cls):
-        torch.cuda.empty_cache()
-
-    @classmethod
     def reset_peak_memory_stats(cls):
         torch.cuda.reset_peak_memory_stats()
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -574,7 +574,7 @@ class Platform:
 
     @classmethod
     def empty_cache(cls):
-        raise NotImplementedError
+        torch.accelerator.empty_cache()
 
     @classmethod
     def reset_peak_memory_stats(cls):

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -572,6 +572,30 @@ class Platform:
         """
         return False
 
+    @classmethod
+    def empty_cache(cls, ):
+        raise NotImplementedError
+
+    @classmethod
+    def reset_peak_memory_stats(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def mem_get_info(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def memory_stats(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def memory_reserved(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def synchronize(cls):
+        torch.accelerator.synchronize()
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -573,7 +573,7 @@ class Platform:
         return False
 
     @classmethod
-    def empty_cache(cls, ):
+    def empty_cache(cls):
         raise NotImplementedError
 
     @classmethod

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -7,7 +7,7 @@ import random
 import sys
 from datetime import timedelta
 from platform import uname
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, NamedTuple, Optional, Union
 
 import numpy as np
 import torch
@@ -310,8 +310,7 @@ class Platform:
         """
         Set the device for the current platform.
         """
-        set_device_method = cls.get_platform_method("set_device")
-        set_device_method(device)
+        raise NotImplementedError
 
     @classmethod
     def pre_register_and_update(cls,
@@ -574,50 +573,28 @@ class Platform:
         return False
 
     @classmethod
-    def get_platform_method(cls, method_name: str):
-        """
-        Returns the platform-specific method for the given method name.
-        """
-        if not hasattr(cls, "device_type") or not cls.device_type:
-            raise NotImplementedError
-        try:
-            device_module = getattr(torch, cls.device_type)
-            method = getattr(device_module, method_name)
-        except AttributeError:
-            raise NotImplementedError(
-                f"{method_name} not implemented for platform with "
-                f"device_type '{cls.device_type}'") from None
-        return method
-
-    @classmethod
-    def empty_cache(cls) -> None:
+    def empty_cache(cls):
         # torch.accelerator.empty_cache() only works after torch 2.8
-        empty_cache_method = cls.get_platform_method("empty_cache")
-        empty_cache_method()
+        raise NotImplementedError
 
     @classmethod
-    def reset_peak_memory_stats(cls) -> None:
-        reset_peak_memory_stats_method = cls.get_platform_method(
-            "reset_peak_memory_stats")
-        reset_peak_memory_stats_method()
+    def reset_peak_memory_stats(cls):
+        raise NotImplementedError
 
     @classmethod
-    def mem_get_info(cls) -> tuple[int, int]:
-        mem_get_info_method = cls.get_platform_method("mem_get_info")
-        return mem_get_info_method()
+    def mem_get_info(cls):
+        raise NotImplementedError
 
     @classmethod
-    def memory_stats(cls) -> dict[str, Any]:
-        memory_stats_method = cls.get_platform_method("memory_stats")
-        return memory_stats_method()
+    def memory_stats(cls):
+        raise NotImplementedError
 
     @classmethod
-    def memory_reserved(cls) -> int:
-        memory_reserved_method = cls.get_platform_method("memory_reserved")
-        return memory_reserved_method()
+    def memory_reserved(cls):
+        raise NotImplementedError
 
     @classmethod
-    def synchronize(cls) -> None:
+    def synchronize(cls):
         torch.accelerator.synchronize()
 
     @classmethod

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -7,7 +7,7 @@ import random
 import sys
 from datetime import timedelta
 from platform import uname
-from typing import TYPE_CHECKING, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import numpy as np
 import torch

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -597,6 +597,14 @@ class Platform:
     def synchronize(cls):
         torch.accelerator.synchronize()
 
+    @classmethod
+    def get_num_sms(cls, device: torch.device) -> int:
+        """
+        Returns the number of streaming multiprocessors (SMS) on a single GPU.
+        By default we return zero
+        """
+        return 0
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -574,7 +574,8 @@ class Platform:
 
     @classmethod
     def empty_cache(cls):
-        torch.accelerator.empty_cache()
+        # torch.accelerator.empty_cache() only works after torch 2.8
+        raise NotImplementedError
 
     @classmethod
     def reset_peak_memory_stats(cls):

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -485,4 +485,11 @@ class RocmPlatform(Platform):
 
     @classmethod
     def synchronize(cls):
+        # leave this in case torch.acceleartor.synchronize() not work.
         torch.cuda.synchronize()
+
+    @classmethod
+    def get_num_sms(cls, device: torch.device):
+        device_properties = torch.cuda.get_device_properties(device)
+        num_sms = device_properties.multi_processor_count
+        return num_sms

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -464,26 +464,6 @@ class RocmPlatform(Platform):
         return True
 
     @classmethod
-    def empty_cache(cls):
-        torch.cuda.empty_cache()
-
-    @classmethod
-    def reset_peak_memory_stats(cls):
-        torch.cuda.reset_peak_memory_stats()
-
-    @classmethod
-    def mem_get_info(cls):
-        return torch.cuda.mem_get_info()
-
-    @classmethod
-    def memory_stats(cls):
-        return torch.cuda.memory_stats()
-
-    @classmethod
-    def memory_reserved(cls):
-        return torch.cuda.memory_reserved()
-
-    @classmethod
     def synchronize(cls):
         # leave this in case torch.acceleartor.synchronize() not work.
         torch.cuda.synchronize()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -464,6 +464,26 @@ class RocmPlatform(Platform):
         return True
 
     @classmethod
+    def empty_cache(cls):
+        torch.cuda.empty_cache()
+
+    @classmethod
+    def reset_peak_memory_stats(cls):
+        torch.cuda.reset_peak_memory_stats()
+
+    @classmethod
+    def mem_get_info(cls):
+        return torch.cuda.mem_get_info()
+
+    @classmethod
+    def memory_stats(cls):
+        return torch.cuda.memory_stats()
+
+    @classmethod
+    def memory_reserved(cls):
+        return torch.cuda.memory_reserved()
+
+    @classmethod
     def synchronize(cls):
         # leave this in case torch.acceleartor.synchronize() not work.
         torch.cuda.synchronize()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -462,3 +462,27 @@ class RocmPlatform(Platform):
     def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str,
                                     model_config: "ModelConfig") -> bool:
         return True
+
+    @classmethod
+    def empty_cache(cls):
+        torch.cuda.empty_cache()
+
+    @classmethod
+    def reset_peak_memory_stats(cls):
+        torch.cuda.reset_peak_memory_stats()
+
+    @classmethod
+    def mem_get_info(cls):
+        return torch.cuda.mem_get_info()
+
+    @classmethod
+    def memory_stats(cls):
+        return torch.cuda.memory_stats()
+
+    @classmethod
+    def memory_reserved(cls):
+        return torch.cuda.memory_reserved()
+
+    @classmethod
+    def synchronize(cls):
+        torch.cuda.synchronize()

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -226,3 +226,7 @@ class XPUPlatform(Platform):
     @classmethod
     def memory_reserved(cls):
         return torch.xpu.memory_reserved()
+
+    @classmethod
+    def empty_cache(cls):
+        torch.cuda.empty_cache()

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -199,11 +199,7 @@ class XPUPlatform(Platform):
         return torch.xpu.device_count()
 
     @classmethod
-    def reset_peak_memory_stats(cls):
-        torch.xpu.reset_peak_memory_stats()
-
-    @classmethod
-    def mem_get_info(cls):
+    def mem_get_info(cls) -> tuple[int, int]:
         if cls.is_data_center_gpu():
             return torch.xpu.mem_get_info()
         else:
@@ -218,15 +214,3 @@ class XPUPlatform(Platform):
             free_gpu_memory = total_gpu_memory - (used_memory +
                                                   NON_TORCH_ALLOCATIONS_BYTES)
             return free_gpu_memory, total_gpu_memory
-
-    @classmethod
-    def memory_stats(cls):
-        return torch.xpu.memory_stats()
-
-    @classmethod
-    def memory_reserved(cls):
-        return torch.xpu.memory_reserved()
-
-    @classmethod
-    def empty_cache(cls):
-        torch.cuda.empty_cache()

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -199,7 +199,11 @@ class XPUPlatform(Platform):
         return torch.xpu.device_count()
 
     @classmethod
-    def mem_get_info(cls) -> tuple[int, int]:
+    def reset_peak_memory_stats(cls):
+        torch.xpu.reset_peak_memory_stats()
+
+    @classmethod
+    def mem_get_info(cls):
         if cls.is_data_center_gpu():
             return torch.xpu.mem_get_info()
         else:
@@ -214,3 +218,15 @@ class XPUPlatform(Platform):
             free_gpu_memory = total_gpu_memory - (used_memory +
                                                   NON_TORCH_ALLOCATIONS_BYTES)
             return free_gpu_memory, total_gpu_memory
+
+    @classmethod
+    def memory_stats(cls):
+        return torch.xpu.memory_stats()
+
+    @classmethod
+    def memory_reserved(cls):
+        return torch.xpu.memory_reserved()
+
+    @classmethod
+    def empty_cache(cls):
+        torch.cuda.empty_cache()

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -197,3 +197,40 @@ class XPUPlatform(Platform):
     @classmethod
     def device_count(cls) -> int:
         return torch.xpu.device_count()
+
+    @classmethod
+    def empty_cache(cls, ):
+        torch.xpu.empty_cache()
+
+    @classmethod
+    def reset_peak_memory_stats(cls):
+        torch.xpu.reset_peak_memory_stats()
+
+    @classmethod
+    def mem_get_info(cls):
+        if cls.is_data_center_gpu():
+            return torch.xpu.mem_get_info()
+        else:
+            # we provide this function due to `torch.xpu.mem_get_info()` doesn't
+            # return correct free_gpu_memory on intel client GPU. We need to
+            # calculate/estiamte it.
+            _, total_gpu_memory = torch.xpu.mem_get_info()
+            # FIXME: memory_allocated() doesn't count non-torch allocations,
+            # and we don't have any API to get it. so we mark it as 128MB.
+            used_memory = torch.xpu.memory_allocated()
+            non_torch_allocations = 128 * 1024 * 1024
+            free_gpu_memory = total_gpu_memory - (used_memory +
+                                                  non_torch_allocations)
+            return free_gpu_memory, total_gpu_memory
+
+    @classmethod
+    def memory_stats(cls):
+        return torch.xpu.memory_stats()
+
+    @classmethod
+    def memory_reserved(cls):
+        return torch.xpu.memory_reserved()
+
+    @classmethod
+    def synchronize(cls):
+        return torch.xpu.synchronize()

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -199,10 +199,6 @@ class XPUPlatform(Platform):
         return torch.xpu.device_count()
 
     @classmethod
-    def empty_cache(cls):
-        torch.xpu.empty_cache()
-
-    @classmethod
     def reset_peak_memory_stats(cls):
         torch.xpu.reset_peak_memory_stats()
 
@@ -230,7 +226,3 @@ class XPUPlatform(Platform):
     @classmethod
     def memory_reserved(cls):
         return torch.xpu.memory_reserved()
-
-    @classmethod
-    def synchronize(cls):
-        torch.xpu.synchronize()

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -214,9 +214,9 @@ class XPUPlatform(Platform):
             # FIXME: memory_allocated() doesn't count non-torch allocations,
             # and we don't have any API to get it. so we mark it as 128MB.
             used_memory = torch.xpu.memory_allocated()
-            non_torch_allocations = 128 * 1024 * 1024
+            NON_TORCH_ALLOCATIONS_BYTES = 128 * 1024 * 1024
             free_gpu_memory = total_gpu_memory - (used_memory +
-                                                  non_torch_allocations)
+                                                  NON_TORCH_ALLOCATIONS_BYTES)
             return free_gpu_memory, total_gpu_memory
 
     @classmethod

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -199,7 +199,7 @@ class XPUPlatform(Platform):
         return torch.xpu.device_count()
 
     @classmethod
-    def empty_cache(cls, ):
+    def empty_cache(cls):
         torch.xpu.empty_cache()
 
     @classmethod
@@ -233,4 +233,4 @@ class XPUPlatform(Platform):
 
     @classmethod
     def synchronize(cls):
-        return torch.xpu.synchronize()
+        torch.xpu.synchronize()

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -2639,7 +2639,7 @@ class MemorySnapshot:
         # rather than `torch.cuda.memory_reserved()` .
         # After `torch.cuda.reset_peak_memory_stats()`,
         # `torch.cuda.memory_reserved()` will keep growing, and only shrink
-        # when we call `torch.cuda.empty_cache()` or OOM happens.
+        # when we call `current_platform.empty_cache()` or OOM happens.
         from vllm.platforms import current_platform
 
         self.torch_peak = current_platform.memory_stats().get(

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -2636,10 +2636,10 @@ class MemorySnapshot:
 
     def measure(self):
         # we measure the torch peak memory usage via allocated_bytes,
-        # rather than `torch.cuda.memory_reserved()` .
-        # After `torch.cuda.reset_peak_memory_stats()`,
-        # `torch.cuda.memory_reserved()` will keep growing, and only shrink
-        # when we call `current_platform.empty_cache()` or OOM happens.
+        # rather than `current_platform.memory_reserved()` .
+        # After `current_platform.reset_peak_memory_stats()`,
+        # `current_platform.memory_reserved()` will keep growing, and only
+        # shrink when we call `current_platform.empty_cache()` or OOM happens.
         from vllm.platforms import current_platform
 
         self.torch_peak = current_platform.memory_stats().get(
@@ -2648,7 +2648,7 @@ class MemorySnapshot:
         self.free_memory, self.total_memory = current_platform.mem_get_info()
         self.cuda_memory = self.total_memory - self.free_memory
 
-        # torch.cuda.memory_reserved() is how many bytes
+        # current_platform.memory_reserved() is how many bytes
         # PyTorch gets from cuda (by calling cudaMalloc, etc.)
         # this is used to measure the non-torch memory usage
         self.torch_memory = current_platform.memory_reserved()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -415,14 +415,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     # Note: used for model runner override.
     def _init_device_properties(self) -> None:
-        """Initialize attributes from torch.cuda.get_device_properties
+        """Initialize num_sms from current_platform
         """
-        if current_platform.is_cuda():
-            self.device_properties = torch.cuda.get_device_properties(
-                self.device)
-            self.num_sms = self.device_properties.multi_processor_count
-        else:
-            self.num_sms = None
+        self.num_sms = current_platform.get_num_sms(self.device)
 
     # Note: used for model runner override.
     def _sync_device(self) -> None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2664,21 +2664,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 if should_freeze:
                     gc.unfreeze()
 
-        @contextmanager
-        def freeze_gc():
-            # Optimize garbage collection during CUDA graph capture.
-            # Clean up, then freeze all remaining objects from being included
-            # in future collections.
-            gc.collect()
-            should_freeze = not envs.VLLM_ENABLE_CUDAGRAPH_GC
-            if should_freeze:
-                gc.freeze()
-            try:
-                yield
-            finally:
-                if should_freeze:
-                    gc.unfreeze()
-
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes
         # can reuse the memory pool allocated for the large shapes.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -319,7 +319,7 @@ class Worker(WorkerBase):
         # sampling related tensors of max possible shape to avoid memory
         # fragmentation issue.
         # NOTE: This is called after `capture_model` on purpose to prevent
-        # memory buffers from being cleared by `torch.cuda.empty_cache`.
+        # memory buffers from being cleared by `current_platform.empty_cache`.
         if get_pp_group().is_last_rank:
             max_num_reqs = min(self.scheduler_config.max_num_seqs,
                                self.scheduler_config.max_num_batched_tokens)

--- a/vllm/v1/worker/xpu_model_runner.py
+++ b/vllm/v1/worker/xpu_model_runner.py
@@ -25,9 +25,3 @@ class XPUModelRunner(GPUModelRunner):
         super().__init__(vllm_config, device)
         # FIXME: To be verified.
         self.cascade_attn_enabled = False
-
-    def _init_device_properties(self) -> None:
-        self.num_sms = None
-
-    def _sync_device(self) -> None:
-        torch.xpu.synchronize()

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -11,6 +11,7 @@ from vllm.distributed import get_world_group
 from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
+from vllm.utils import MemorySnapshot
 from vllm.v1.worker.gpu_worker import (Worker,
                                        init_worker_distributed_environment)
 from vllm.v1.worker.xpu_model_runner import XPUModelRunner
@@ -63,91 +64,17 @@ class XPUWorker(Worker):
         else:
             self.profiler = None
 
-    # we provide this function due to `torch.xpu.mem_get_info()` doesn't
-    # return correct free_gpu_memory on intel client GPU. We need to
-    # calculate/estiamte it.
-    def xpu_get_mem_info(self):
-        if current_platform.is_data_center_gpu():
-            return torch.xpu.mem_get_info()
-        else:
-            _, total_gpu_memory = torch.xpu.mem_get_info()
-            # FIXME: memory_allocated() doesn't count non-torch allocations,
-            # and we don't have any API to get it. so we mark it as 128MB.
-            used_memory = torch.xpu.memory_allocated()
-            non_torch_allocations = 128 * 1024 * 1024
-            free_gpu_memory = total_gpu_memory - (used_memory +
-                                                  non_torch_allocations)
-            return free_gpu_memory, total_gpu_memory
-
-    @torch.inference_mode()
-    def determine_available_memory(self) -> int:
-        """Profiles the peak memory usage of the model to determine how many
-        KV blocks may be allocated without OOMs.
-        The engine will first conduct a profiling of the existing memory usage.
-        Then, it calculate the maximum possible number of GPU and CPU blocks
-        that can be allocated with the remaining free memory.
-        .. tip::
-            You may limit the usage of GPU memory
-            by adjusting the `gpu_memory_utilization` parameter.
-        """
-        # Profile the memory usage of the model and get the maximum number of
-        # cache blocks that can be allocated with the remaining free memory.
-        torch.xpu.empty_cache()
-        torch.xpu.reset_peak_memory_stats()
-
-        free_gpu_memory, total_gpu_memory = torch.xpu.mem_get_info()
-        current_allocated_bytes = torch.xpu.memory_allocated()
-        msg = ("Before memory profiling run, "
-               f"total GPU memory: {total_gpu_memory / 1024**2:.2f} MB, "
-               f"model load takes {current_allocated_bytes / 1024**2:.2f} MB, "
-               f"free gpu memory is {free_gpu_memory / 1024**2:.2f} MB.")
-        logger.info(msg)
-        # Execute a forward pass with dummy inputs to profile the memory usage
-        # of the model.
-        self.model_runner.profile_run()
-
-        free_gpu_memory, _ = self.xpu_get_mem_info()
-        # NOTE(woosuk): Here we assume that the other processes using the same
-        # GPU did not change their memory usage during the profiling.
-        assert self.init_gpu_memory > free_gpu_memory, (
-            "Error in memory profiling. "
-            f"Initial free memory {self.init_gpu_memory}, current free memory"
-            f" {free_gpu_memory}. This happens when the GPU memory was "
-            "not properly cleaned up before initializing the vLLM instance.")
-
-        # Get the peak memory allocation recorded by torch
-        peak_memory = torch.xpu.memory_stats()["allocated_bytes.all.peak"]
-
-        torch.xpu.empty_cache()
-        torch_allocated_bytes = torch.xpu.memory_stats(
-        )["allocated_bytes.all.current"]
-        total_allocated_bytes = self.xpu_get_mem_info(
-        )[1] - self.xpu_get_mem_info()[0]
-
-        non_torch_allocations = total_allocated_bytes - torch_allocated_bytes
-        if non_torch_allocations > 0:
-            peak_memory += non_torch_allocations
-        available_kv_cache_memory = (
-            total_gpu_memory * self.cache_config.gpu_memory_utilization -
-            peak_memory)
-
-        msg = ("After memory profiling run, "
-               f"peak memory usage is {peak_memory / 1024**2:.2f} MB,"
-               f"torch mem is {torch_allocated_bytes / 1024**2:.2f} MB, "
-               f"non-torch mem is {non_torch_allocations / 1024**2:.2f} MB, "
-               f"free gpu memory is {free_gpu_memory / 1024**2:.2f} MB.")
-        logger.info(msg)
-
-        return int(available_kv_cache_memory)
-
     def init_device(self):
         if self.device_config.device.type == "xpu" and current_platform.is_xpu(
         ):
             self.device = torch.device(f"xpu:{self.local_rank}")
             current_platform.set_device(self.device)
-            torch.xpu.empty_cache()
-            self.init_gpu_memory = torch.xpu.get_device_properties(
-                self.local_rank).total_memory
+            current_platform.empty_cache()
+            self.init_gpu_memory = current_platform.get_device_total_memory(
+                self.local_rank)
+            self.init_snapshot = MemorySnapshot()
+            self.requested_memory = (self.init_snapshot.total_memory *
+                                     self.cache_config.gpu_memory_utilization)
         else:
             raise RuntimeError(
                 f"Not support device type: {self.device_config.device}")


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
[1/N] of RFC #20708. 
this PR add several API in `Platform` class , such as `empty_cache`, `reset_peak_memory_stats`, `mem_get_info`, `memory_stats`, `memory_reserved`, `synchronize`, which is directly called via `torch.cuda.xxx`.   Meanwhile,  I add these API for cpu/cuda/rocm/xpu platform. I can also add to other platform if necessary.

Note: I didn't change V0 code path since it may be removed. And I didn't change calls in tests/benchmarks/examples folder yet. 

## Test Plan
for current functionality and performance, it should not have any regression. functionality can be covered by vLLM CI.

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
