### PR TITLE
[CI Bugfix] Specify same TORCH_CUDA_ARCH_LIST for flashinfer aot and install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -408,7 +408,8 @@ RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
 
           # Needed to build AOT kernels
           pushd flashinfer
-            python3 -m flashinfer.aot
+            TORCH_CUDA_ARCH_LIST="${FI_TORCH_CUDA_ARCH_LIST}" \
+              python3 -m flashinfer.aot
             TORCH_CUDA_ARCH_LIST="${FI_TORCH_CUDA_ARCH_LIST}" \
               uv pip install --system --no-build-isolation .
           popd


### PR DESCRIPTION
Fix a small issue where TORCH_CUDA_ARCH_LIST was being overriden for the flashinfer install but not the aot compile. This would give issues on CUDA <12.8