### PR TITLE
[Bugfix][Benchmark] Make sure the output length > 0 when testing prefill workload.

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -324,6 +324,10 @@ class RandomDataset(BenchmarkDataset):
         input_low = int(real_input_len * (1 - range_ratio))
         input_high = int(real_input_len * (1 + range_ratio))
         output_low = int(output_len * (1 - range_ratio))
+        # Prevent output_low from being 0, which would cause sampling 0 tokens
+        # and fail the request. 
+        # This happens when range_ratio > 0 and output_len = 1.
+        output_low = max(output_low, 1)
         output_high = int(output_len * (1 + range_ratio))
 
         # Add logging for debugging

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -324,9 +324,8 @@ class RandomDataset(BenchmarkDataset):
         input_low = int(real_input_len * (1 - range_ratio))
         input_high = int(real_input_len * (1 + range_ratio))
         output_low = int(output_len * (1 - range_ratio))
-        # Prevent output_low from being 0, which would cause sampling 0 tokens
-        # and fail the request. 
-        # This happens when range_ratio > 0 and output_len = 1.
+        # Ensure the lower bound for output length is at least 1 to prevent
+        # sampling 0 tokens, which can cause request failures.
         output_low = max(output_low, 1)
         output_high = int(output_len * (1 + range_ratio))
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

When testing on `random` dataset using prefill workload (i.e. output_len == 1) with `random_range_ratio > 0`, the `output_low` will be 0, result in request execution failure. This PR fixes this.

Example benchmarking command that will trigger request execution failure:
```
python benchmark_serving.py --model meta-llama/Llama-3.1-8B-Instruct --dataset-name random --random-input-len 10000 --random-output-len 1 --random-range-ratio 0.9 --request-rate inf --num-prompts 100
```

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
