### PR TITLE
[cold start time] add envs.VLLM_COMPILE_DEPYF to guard decompile

### DIFF
--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -103,8 +103,13 @@ class TorchCompileWrapperWithCustomDispatcher:
                     # as we guarantee a full-graph compilation in Dynamo.
                     # but there's no 100% guarantee, since decompliation is
                     # not a reversible process.
-                    import depyf
-                    src = depyf.decompile(new_code)
+                    if envs.VLLM_COMPILE_DEPYF:
+                        import depyf
+                        src = depyf.decompile(new_code)
+                    else:
+                        src = ("Please set VLLM_COMPILE_DEPYF=1 to populate "
+                               "this file")
+
                     with open(decompiled_file, "w") as f:
                         f.write(src)
 

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -95,8 +95,12 @@ class TorchCompileWrapperWithCustomDispatcher:
         self.compiled_codes.append(new_code)
         local_cache_dir = self.vllm_config.compilation_config.local_cache_dir
         if isinstance(local_cache_dir, str):
+            decompiled_file_name = ("transformed_code.py"
+                                    if envs.VLLM_COMPILE_DEPYF else
+                                    "transformed_code_README.txt")
+
             decompiled_file = os.path.join(local_cache_dir,
-                                           "transformed_code.py")
+                                           decompiled_file_name)
             if not os.path.exists(decompiled_file):
                 try:
                     # usually the decompilation will succeed for most models,
@@ -107,8 +111,9 @@ class TorchCompileWrapperWithCustomDispatcher:
                         import depyf
                         src = depyf.decompile(new_code)
                     else:
-                        src = ("Please set VLLM_COMPILE_DEPYF=1 to populate "
-                               "this file")
+                        src = (
+                            "To get a transformed_code.py file, re-run with "
+                            "VLLM_COMPILE_DEPYF=1")
 
                     with open(decompiled_file, "w") as f:
                         f.write(src)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -97,6 +97,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
+    VLLM_COMPILE_DEPYF: bool = False
     Q_SCALE_CONSTANT: int = 200
     K_SCALE_CONSTANT: int = 200
     V_SCALE_CONSTANT: int = 100
@@ -740,6 +741,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
+
+    # If set, vllm will decompile the torch compiled code and dump to
+    # transformed_code.py. This is useful for debugging.
+    "VLLM_COMPILE_DEPYF":
+    lambda: bool(int(os.getenv("VLLM_COMPILE_DEPYF", "0"))),
 
     # If set, vllm will run in development mode, which will enable
     # some additional endpoints for developing and debugging,


### PR DESCRIPTION
Custom bytecode hook takes a long time (~20 seconds on llama-3.1-70b). It decompiles the compiled code and dumps to `transformed_code.py`, which may be used for debugging purpose. This PR adds an env variable `VLLM_COMPILE_DEPYF` to skip this decompile and reduce cold start time.

## Example
`vllm serve facebook/opt-125m` gives:
<img width="560" height="82" alt="image" src="https://github.com/user-attachments/assets/787fe2e5-2b74-432d-8b33-aa3ea33cd607" />

`VLLM_COMPILE_DEPYF=1 vllm serve facebook/opt-125m` gives:
<img width="637" height="256" alt="image" src="https://github.com/user-attachments/assets/f35e6fbe-29a1-47b9-ac88-34dbd7862bb1" />
