### PR TITLE
[FIX] bump mistral common to support devstral 2507

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -33,7 +33,7 @@ pyzmq >= 25.0.0
 msgspec
 gguf >= 0.13.0
 importlib_metadata; python_version < '3.10'
-mistral_common[opencv] >= 1.6.2
+mistral_common[opencv] >= 1.7.0
 opencv-python-headless >= 4.11.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -23,7 +23,7 @@ jiwer # required for audio tests
 timm # required for internvl test
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
-mistral_common[opencv] >= 1.6.2 # required for pixtral test
+mistral_common[opencv] >= 1.7.0 # required for pixtral test
 num2words # required for smolvlm test
 opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -28,7 +28,7 @@ torchvision==0.22.0
 transformers_stream_generator # required for qwen-vl test
 mamba_ssm # required for plamo2 test
 matplotlib # required for qwen-vl test
-mistral_common[opencv] >= 1.6.2 # required for pixtral test
+mistral_common[opencv] >= 1.7.0 # required for pixtral test
 num2words # required for smolvlm test
 opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test


### PR DESCRIPTION
It resolves error:
ValueError: Unknown version: v13 in /app/cache/huggingface/hub/models--mistralai--Devstral-Small-2507. Make sure to use a valid version string: ['v1', 'v2', 'v3', 'v7', 'v11']

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

It resolves error:
ValueError: Unknown version: v13 in /app/cache/huggingface/hub/models--mistralai--Devstral-Small-2507. Make sure to use a valid version string: ['v1', 'v2', 'v3', 'v7', 'v11']

Recommended according to the documentation on https://huggingface.co/mistralai/Devstral-Small-2507#vllm-recommended.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
