### PR TITLE
[Bugfix] Add missing field to TritonLanguagePlaceholder

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -92,3 +92,4 @@ class TritonLanguagePlaceholder(types.ModuleType):
         self.constexpr = None
         self.dtype = None
         self.int64 = None
+        self.int32 = None


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

```tl.int32``` is used but missing in ```TritonLanguagePlaceholder```.

https://github.com/vllm-project/vllm/blob/cbd14ed5613c6c20b3225e81f32a9bfe3a0d32ac/vllm/model_executor/layers/mamba/ops/causal_conv1d.py#L30

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
