### PR TITLE
[Feature][EPLB] Add eplb support for Qwen3

### DIFF
--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -22,7 +22,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only Qwen3MoE model compatible with HuggingFace weights."""
-from collections.abc import Iterable
+import typing
+from collections.abc import Callable, Iterable
 from typing import Any, Optional, Union
 
 import torch
@@ -31,8 +32,9 @@ from transformers import PretrainedConfig
 
 from vllm.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
-from vllm.config import CacheConfig, VllmConfig
-from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import (get_ep_group, get_pp_group,
+                              get_tensor_model_parallel_world_size)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe import FusedMoE
@@ -50,8 +52,8 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsLoRA, SupportsPP
-from .utils import (AutoWeightsLoader, extract_layer_index,
+from .interfaces import MixtureOfExperts, SupportsLoRA, SupportsPP
+from .utils import (AutoWeightsLoader, PPMissingLayer, extract_layer_index,
                     is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
                     maybe_prefix)
@@ -101,23 +103,47 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        enable_eplb: bool = False,
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
+
+        self.ep_group = get_ep_group().device_group
+        self.ep_rank = self.ep_group.rank()
+        self.ep_size = self.ep_group.size()
+        self.n_routed_experts = config.num_experts
 
         if self.tp_size > config.num_experts:
             raise ValueError(
                 f"Tensor parallel size {self.tp_size} is greater than "
                 f"the number of experts {config.num_experts}.")
 
-        self.experts = FusedMoE(num_experts=config.num_experts,
+        # Load balancing settings.
+        vllm_config = get_current_vllm_config()
+        parallel_config = vllm_config.parallel_config
+        self.enable_eplb = enable_eplb
+
+        self.n_logical_experts = self.n_routed_experts
+        self.n_redundant_experts = parallel_config.num_redundant_experts
+        self.n_physical_experts = (self.n_logical_experts +
+                                   self.n_redundant_experts)
+        self.n_local_physical_experts = self.n_physical_experts // self.ep_size
+
+        self.physical_expert_start = (self.ep_rank *
+                                      self.n_local_physical_experts)
+        self.physical_expert_end = (self.physical_expert_start +
+                                    self.n_local_physical_experts)
+
+        self.experts = FusedMoE(num_experts=self.n_routed_experts,
                                 top_k=config.num_experts_per_tok,
                                 hidden_size=config.hidden_size,
                                 intermediate_size=config.moe_intermediate_size,
                                 reduce_results=False,
                                 renormalize=config.norm_topk_prob,
                                 quant_config=quant_config,
-                                prefix=f"{prefix}.experts")
+                                prefix=f"{prefix}.experts",
+                                enable_eplb=self.enable_eplb,
+                                num_redundant_experts=self.n_redundant_experts)
 
         self.gate = ReplicatedLinear(config.hidden_size,
                                      config.num_experts,
@@ -246,6 +272,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
         cache_config: Optional[CacheConfig] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        enable_eplb: bool = False,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -277,7 +304,8 @@ class Qwen3MoeDecoderLayer(nn.Module):
             (layer_idx + 1) % config.decoder_sparse_step == 0):
             self.mlp = Qwen3MoeSparseMoeBlock(config=config,
                                               quant_config=quant_config,
-                                              prefix=f"{prefix}.mlp")
+                                              prefix=f"{prefix}.mlp",
+                                              enable_eplb=enable_eplb)
         else:
             self.mlp = Qwen3MoeMLP(hidden_size=config.hidden_size,
                                    intermediate_size=config.intermediate_size,
@@ -323,6 +351,9 @@ class Qwen3MoeModel(nn.Module):
         config = vllm_config.model_config.hf_config
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
+        parallel_config = vllm_config.parallel_config
+        enable_eplb = parallel_config.enable_eplb
+        self.num_redundant_experts = parallel_config.num_redundant_experts
 
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
@@ -336,7 +367,8 @@ class Qwen3MoeModel(nn.Module):
             lambda prefix: Qwen3MoeDecoderLayer(config=config,
                                                 cache_config=cache_config,
                                                 quant_config=quant_config,
-                                                prefix=prefix),
+                                                prefix=prefix,
+                                                enable_eplb=enable_eplb),
             prefix=f"{prefix}.layers",
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -400,6 +432,15 @@ class Qwen3MoeModel(nn.Module):
                            ".v_scale", "_v_scale", ".weight_scale",
                            "_weight_scale", ".input_scale", "_input_scale")
 
+        # Params for weights, fp8 weight scales, fp8 activation scales
+        # (param_name, weight_name, expert_id, shard_id)
+        expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.num_experts,
+            num_redundant_experts=self.num_redundant_experts)
+
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
@@ -433,27 +474,50 @@ class Qwen3MoeModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
+                is_expert_weight = False
                 for mapping in expert_params_mapping:
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
                         continue
-                    name = name.replace(weight_name, param_name)
-                    # Skip layers on other devices.
-                    if is_pp_missing_parameter(name, self):
+
+                    # Anyway, this is an expert weight and should not be
+                    # attempted to load as other weights later
+                    is_expert_weight = True
+
+                    # Do not modify `name` since the loop may continue here
+                    # Instead, create a new variable
+                    name_mapped = name.replace(weight_name, param_name)
+
+                    if is_pp_missing_parameter(name_mapped, self):
                         continue
+
                     # Skip loading extra parameters for GPTQ/modelopt models.
-                    if name.endswith(
+                    if name_mapped.endswith(
                             ignore_suffixes) and name not in params_dict:
                         continue
-                    param = params_dict[name]
-                    weight_loader = param.weight_loader
-                    weight_loader(param,
-                                  loaded_weight,
-                                  name,
-                                  shard_id=shard_id,
-                                  expert_id=expert_id)
-                    break
+
+                    param = params_dict[name_mapped]
+                    # We should ask the weight loader to return success or not
+                    # here since otherwise we may skip experts with other
+                    # available replicas.
+                    weight_loader = typing.cast(Callable[..., bool],
+                                                param.weight_loader)
+                    success = weight_loader(param,
+                                            loaded_weight,
+                                            name_mapped,
+                                            shard_id=shard_id,
+                                            expert_id=expert_id,
+                                            return_success=True)
+                    if success:
+                        name = name_mapped
+                        break
                 else:
+                    if is_expert_weight:
+                        # We've checked that this is an expert weight
+                        # However it's not mapped locally to this rank
+                        # So we simply skip it
+                        continue
+
                     # Skip loading extra parameters for GPTQ/modelopt models.
                     if name.endswith(
                             ignore_suffixes) and name not in params_dict:
@@ -482,7 +546,8 @@ class Qwen3MoeModel(nn.Module):
         return loaded_params
 
 
-class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
+class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA,
+                          MixtureOfExperts):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -513,6 +578,48 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)
+
+        # Set MoE hyperparameters
+        self.expert_weights = []
+
+        self.moe_layers: list[FusedMoE] = []
+        example_layer = None
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+
+            assert isinstance(layer, Qwen3MoeDecoderLayer)
+            if isinstance(layer.mlp, Qwen3MoeSparseMoeBlock):
+                example_layer = layer.mlp
+                self.moe_layers.append(layer.mlp.experts)
+
+        if example_layer is None:
+            raise RuntimeError("No Qwen3MoE layer found in the model.layers.")
+
+        self.num_moe_layers = len(self.moe_layers)
+        self.num_expert_groups = 1
+        self.num_shared_experts = 0
+        self.num_logical_experts = example_layer.n_logical_experts
+        self.num_physical_experts = example_layer.n_physical_experts
+        self.num_local_physical_experts = example_layer.n_local_physical_experts
+        self.num_routed_experts = example_layer.n_routed_experts
+        self.num_redundant_experts = example_layer.n_redundant_experts
+
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+    ) -> None:
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+            )
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
In response to https://github.com/vllm-project/vllm/issues/20468, add EPLB support for Qwen3-fp8 model.

## Test Plan
Running ```CUDA_VISIBLE_DEVICES=0,1,2,3 python path_to_this_script.py```
```
# SPDX-License-Identifier: Apache-2.0  
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project  
  
from vllm import LLM, SamplingParams  
  
# Sample prompts.  
prompts = [  
    "Hello, my name is",  
    "The president of the United States is",  
    "The capital of France is",  
    "The future of AI is",  
]  
# Create a sampling params object.  
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)  
  
  
def main():  
    # Create an LLM with EPLB parameters.  
    llm = LLM(  
        model="Qwen/Qwen3-235B-A22B-FP8",
        tensor_parallel_size=4,
        enable_expert_parallel=True,  
        enable_eplb=True,  
        num_redundant_experts=32,  
        eplb_window_size=1000,  
        eplb_step_interval=3000,
        trust_remote_code=True,
        enforce_eager=True,
    )  
    # Generate texts from the prompts.  
    # The output is a list of RequestOutput objects  
    # that contain the prompt, generated text, and other information.  
    outputs = llm.generate(prompts, sampling_params)  
    # Print the outputs.  
    print("\nGenerated Outputs:\n" + "-" * 60)  
    for output in outputs:  
        prompt = output.prompt  
        generated_text = output.outputs[0].text  
        print(f"Prompt:    {prompt!r}")  
        print(f"Output:    {generated_text!r}")  
        print("-" * 60)  
  
  
if __name__ == "__main__":  
    main()
```

## Test Result
```
...

^[[1;36m(VllmWorker rank=0 pid=91414)^[[0;0m INFO 07-11 11:56:57 [eplb_state.py:353] Rearranging experts (profile)...
^[[1;36m(VllmWorker rank=0 pid=91414)^[[0;0m INFO 07-11 11:57:03 [eplb_state.py:428] Rearranged experts (profile) in 5.19 seconds.
^[[1;36m(VllmWorker rank=0 pid=91414)^[[0;0m INFO 07-11 11:57:07 [gpu_worker.py:241] Available KV cache memory: 7.62 GiB
^[[1;36m(VllmWorker rank=2 pid=91416)^[[0;0m INFO 07-11 11:57:07 [gpu_worker.py:241] Available KV cache memory: 7.44 GiB
^[[1;36m(VllmWorker rank=3 pid=91417)^[[0;0m INFO 07-11 11:57:07 [gpu_worker.py:241] Available KV cache memory: 8.37 GiB
^[[1;36m(VllmWorker rank=1 pid=91415)^[[0;0m INFO 07-11 11:57:07 [gpu_worker.py:241] Available KV cache memory: 7.44 GiB
INFO 07-11 11:57:08 [kv_cache_utils.py:716] GPU KV cache size: 170,064 tokens
INFO 07-11 11:57:08 [kv_cache_utils.py:720] Maximum concurrency for 40,960 tokens per request: 4.15x
INFO 07-11 11:57:08 [kv_cache_utils.py:716] GPU KV cache size: 165,872 tokens
INFO 07-11 11:57:08 [kv_cache_utils.py:720] Maximum concurrency for 40,960 tokens per request: 4.05x
INFO 07-11 11:57:08 [kv_cache_utils.py:716] GPU KV cache size: 165,872 tokens
INFO 07-11 11:57:08 [kv_cache_utils.py:720] Maximum concurrency for 40,960 tokens per request: 4.05x
INFO 07-11 11:57:08 [kv_cache_utils.py:716] GPU KV cache size: 186,784 tokens
INFO 07-11 11:57:08 [kv_cache_utils.py:720] Maximum concurrency for 40,960 tokens per request: 4.56x
INFO 07-11 11:57:10 [core.py:172] init engine (profile, create kv cache, warmup model) took 19.07 seconds

Generated Outputs:
------------------------------------------------------------
Prompt:    'Hello, my name is'
Output:    " Alex. I'm 13 years old. I'm from Canada. I"
------------------------------------------------------------
Prompt:    'The president of the United States is'
Output:    ' the head of state and head of government of the United States, indirectly elected to'
------------------------------------------------------------
Prompt:    'The capital of France is'
Output:    ' Paris. The capital of Poland is Warsaw. The capital of Germany is Berlin.'
------------------------------------------------------------
Prompt:    'The future of AI is'
Output:    ' collaborative\n\nThe future of AI is collaborative\n\nWhile artificial intelligence (AI) has'
------------------------------------------------------------

```
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
