### PR TITLE
[Bugfix] Fix torch.compile x LoRA for PyTorch 2.8 

### DIFF
--- a/vllm/lora/layers.py
+++ b/vllm/lora/layers.py
@@ -240,17 +240,19 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         added_tokens_mask = torch.where(x > self.base_layer.org_vocab_size - 1,
                                         1, 0)
-        embeddings_indices = torch.narrow(
-            self.punica_wrapper._embeddings_indices, 1, 0, x.size(0))
 
-        indices = embeddings_indices[1]
+        # NB: Don't use torch.narrow here. torch.narrow triggers some
+        # Dynamic Shape specialization in torch.compile
+        num_tokens = x.shape[0]
+        indices_1 = self.punica_wrapper._embeddings_indices[1][:num_tokens]
+        indices_0 = self.punica_wrapper._embeddings_indices[0][:num_tokens]
+
         full_lora_a_embeddings = F.embedding(
-            x + indices,
+            x + indices_1,
             self.lora_a_stacked_2d,
         )
-        indices = embeddings_indices[0]
         full_output = self.base_layer.forward(x +
-                                              (indices * added_tokens_mask))
+                                              (indices_0 * added_tokens_mask))
 
         full_output_org = full_output
         if full_output.ndim == 3:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

In PyTorch 2.8, we fixed a bug around torch.compile dynamic shapes. This surfaced a latent bug in vLLM's LoRA implementation not being torch.compile-able. In PyTorch 2.7, the LoRA implementation is able to be torch.compile'd due to the bug in torch.compile.

- The problem is that a sequence of 3 operations in the LoRA implementation (torch.narrow followed by an add or mul) causes torch.compile to specialize on the batch size of the input, which causes torch.compile's dynamic shape compilation to fail (since it is unable to trace out a graph that works for dynamic batch size).
- The workaround is to just rewrite it a bit into a form that torch.compile is happy with. This has no perf implications, because taking an additional view on a tensor is free.

## Test Plan

Build vLLM with PyTorch 2.8rc.
Run pytest tests/lora/test_quant_model.py::test_quant_model_lora[model0].

I do not have suggestions for how to test this otherwise. We are unable to trigger a failure in PyTorch 2.7 and we do not run the lora tests against PyTorch 2.8 in CI.

## Test Result

Test passes.

## (Optional) Documentation Update

n/a
