### PR TITLE
[Bugfix] Fix a couple PPLX+CUTLASS MoE bugs

### DIFF
--- a/vllm/model_executor/layers/fused_moe/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cutlass_moe.py
@@ -320,6 +320,7 @@ class CutlassExpertsFp8(mk.FusedMoEPermuteExpertsUnpermute):
 
         activation_callable = lambda o, i: self.activation(activation, o, i)
 
+        topk_ids = topk_ids.view(dtype=torch.int32)
         in_dtype = hidden_states.dtype
         run_cutlass_moe_fp8(
             output, hidden_states, w1, w2, topk_ids, activation_callable,

--- a/vllm/model_executor/layers/fused_moe/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cutlass_moe.py
@@ -320,7 +320,6 @@ class CutlassExpertsFp8(mk.FusedMoEPermuteExpertsUnpermute):
 
         activation_callable = lambda o, i: self.activation(activation, o, i)
 
-        topk_ids = topk_ids.view(dtype=torch.int32)
         in_dtype = hidden_states.dtype
         run_cutlass_moe_fp8(
             output, hidden_states, w1, w2, topk_ids, activation_callable,

--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -204,7 +204,7 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             out_expert_x_scale=expert_x_scale,
             dp_x=a1q,
             dp_x_scale=a1q_scale,
-            indices=topk_ids,
+            indices=topk_ids.view(dtype=torch.uint32),
             bound_m=bound_m,
         )
 
@@ -249,7 +249,7 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             topk_weights = torch.ones_like(topk_weights)
 
         self.a2a.combine(out_tokens=output,
-                         indices=topk_ids,
+                         indices=topk_ids.view(dtype=torch.uint32),
                          weights=topk_weights,
                          expert_y=fused_expert_output,
                          bound_m=bound_m)


### PR DESCRIPTION
Fix two bugs that prevented CUTLASS MoE to run with PPLX:

1. PPLX's All To All dispatch and combine functions require `topk_ids` to have the type `uint32`. Since we never expect elements of `topk_ids` to be negative when running with PPLX, this can be resolved with reinterpret casting the current signed `int32` type to unsigned.
2. CUTLASS MoE can be run from `compressed_tensors.py` either with PPLX or without it. If we run with PPLX, we end up running `CutlassExpertsFp8`'s forward function which takes different arguments than a straightforward non-PPLX `cutlass_moe_fp8` call. On the current main, this results in errors when running with PPLX. Fixing this issue also makes it easier to bring back pre-computed strides in [PR20762](https://github.com/vllm-project/vllm/pull/20762).

#### Testing:

PPLX run:
```
export MASTER_ADDR=127.0.0.1
export MASTER_PORT=29500
export VLLM_ALL2ALL_BACKEND=pplx
python3 examples/offline_inference/data_parallel.py \
        --model="nm-testing/DeepSeek-Coder-V2-Lite-Instruct-FP8" \
        --dp-size=2 \
        --tp-size=1 \
        --trust-remote-code
```

Non-PPLX run: run inference with `LLM(model="nm-testing/DeepSeek-Coder-V2-Lite-Instruct-FP8")`