### PR TITLE
[Misc] Restrict deep_gemm's log output

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -43,13 +43,13 @@ def _valid_deep_gemm(hidden_states: torch.Tensor, w1: torch.Tensor,
     aligned by `dg.get_m_alignment_for_contiguous_layout()`.
     """
     if not has_deep_gemm():
-        logger.debug("DeepGemm disabled: deep_gemm not available.")
+        logger.debug_once("DeepGemm disabled: deep_gemm not available.")
         return False
 
     M = hidden_states.size(0)
     _, K, N = w2.size()
     if not _valid_deep_gemm_shape(M, N, K):
-        logger.debug("DeepGemm disabled: unaligned problem size.")
+        logger.debug_once("DeepGemm disabled: unaligned problem size.")
         return False
 
     if (w1.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn):

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -49,7 +49,7 @@ def _valid_deep_gemm(hidden_states: torch.Tensor, w1: torch.Tensor,
     M = hidden_states.size(0)
     _, K, N = w2.size()
     if not _valid_deep_gemm_shape(M, N, K):
-        logger.debug_once("DeepGemm disabled: unaligned problem size.")
+        logger.debug("DeepGemm disabled: unaligned problem size.")
         return False
 
     if (w1.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn):


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Only need to print once, instead of repeatedly outputting like shown below
```text
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
DEBUG 07-11 16:11:47 [deep_gemm_moe.py:46] DeepGemm disabled: deep_gemm not available.
```
## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
