### PR TITLE
[Bugfix] Restrict Machete to only run on Hopper

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -32,6 +32,9 @@ class MacheteLinearKernel(MPLinearKernel):
         if not current_platform.is_cuda():
             return False, "Machete only supported on CUDA"
 
+        if not current_platform.is_device_capability(90):
+            return False, "Machete requires compute capability of 90 (Hopper)"
+
         if c.has_g_idx and\
             c.partition_weight_shape[0] != c.full_weight_shape[0]:
             return False, "Act reordering currently not supported by Machete, "\


### PR DESCRIPTION
## Purpose

Machete is only built for SM90a

https://github.com/vllm-project/vllm/blob/9907fc4494bd7b6ba5c02aa934c637374dfc5fb6/CMakeLists.txt#L650-L652

## Test Plan

## Test Result