### PR TITLE
[Misc] Respect `no_use_tqdm_on_load` flag while capturing CUDA graph

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2269,7 +2269,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             full_cg = self.full_cuda_graph
             # Only rank 0 should print progress bar during capture
             compilation_cases = reversed(self.cudagraph_batch_sizes)
-            if is_global_first_rank() and self.load_config.use_tqdm_on_load:
+            if (self.load_config.use_tqdm_on_load and is_global_first_rank()):
                 compilation_cases = tqdm(list(compilation_cases),
                                          desc="Capturing CUDA graph shapes")
             for num_tokens in compilation_cases:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2269,9 +2269,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             full_cg = self.full_cuda_graph
             # Only rank 0 should print progress bar during capture
             compilation_cases = reversed(self.cudagraph_batch_sizes)
-            if (self.load_config.use_tqdm_on_load and is_global_first_rank()):
-                compilation_cases = tqdm(list(compilation_cases),
-                                         desc="Capturing CUDA graph shapes")
+            if is_global_first_rank():
+                compilation_cases = tqdm(
+                    list(compilation_cases),
+                    disable=not self.load_config.use_tqdm_on_load,
+                    desc="Capturing CUDA graph shapes")
             for num_tokens in compilation_cases:
                 # We skip EPLB here since we don't want to record dummy metrics
                 for _ in range(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2269,7 +2269,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             full_cg = self.full_cuda_graph
             # Only rank 0 should print progress bar during capture
             compilation_cases = reversed(self.cudagraph_batch_sizes)
-            if is_global_first_rank():
+            if is_global_first_rank() and self.load_config.use_tqdm_on_load:
                 compilation_cases = tqdm(list(compilation_cases),
                                          desc="Capturing CUDA graph shapes")
             for num_tokens in compilation_cases:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1584,10 +1584,10 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                     cudagraph_inputs_embeds,
                 )
                 # Only rank 0 should print progress bar during capture
-                if (self.load_config.use_tqdm_on_load
-                        and get_tensor_model_parallel_rank() == 0):
+                if get_tensor_model_parallel_rank() == 0:
                     compilation_cases = tqdm(
                         list(compilation_cases),
+                        disable=not self.load_config.use_tqdm_on_load,
                         desc="Capturing CUDA graph shapes")
                 for batch_size, use_inputs_embeds in compilation_cases:
                     attn_metadata = (

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1584,7 +1584,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                     cudagraph_inputs_embeds,
                 )
                 # Only rank 0 should print progress bar during capture
-                if get_tensor_model_parallel_rank() == 0:
+                if (self.load_config.use_tqdm_on_load
+                        and get_tensor_model_parallel_rank() == 0):
                     compilation_cases = tqdm(
                         list(compilation_cases),
                         desc="Capturing CUDA graph shapes")


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Respect cli flag `--no-use-tqdm-on-load`

Currently tqdm progress is there regardless whether the flag is enabled/disabled
```
INFO 07-11 10:38:36 [kv_cache_utils.py:716] GPU KV cache size: 455,184 tokens
INFO 07-11 10:38:36 [kv_cache_utils.py:720] Maximum concurrency for 16,385 tokens per request: 27.76x
Capturing CUDA graph shapes:  27%|██▋       | 18/67 [00:05<00:15,  3.07it/s]
```

## Test Plan

In terminal
```bash
vllm serve Qwen/Qwen2.5-7B \
  --no-use-tqdm-on-load
```

## Test Result

tqdm no more there
```
INFO 07-11 10:45:39 [kv_cache_utils.py:716] GPU KV cache size: 455,184 tokens
INFO 07-11 10:45:39 [kv_cache_utils.py:720] Maximum concurrency for 16,385 tokens per request: 27.76x
INFO 07-11 10:46:01 [gpu_model_runner.py:2326] Graph capturing finished in 22 secs, took 0.51 GiB
INFO 07-11 10:46:01 [core.py:172] init engine (profile, create kv cache, warmup model) took 34.53 seconds
INFO 07-11 10:46:02 [loggers.py:137] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 28449
```


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
