### PR TITLE
[compile][startup] Disable C++ compilation of symbolic shapes

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -234,8 +234,15 @@ def _support_torch_compile(
                     code.co_filename)
                 return inline_call(parent, func, args, kwargs)
 
-            with patch.object(InliningInstructionTranslator, 'inline_call',
-                              patched_inline_call):
+            # Disable the C++ compilation of symbolic shape guards. C++-fication
+            # of symbolic shape guards can improve guard overhead. But, since
+            # vllm skip guards anyways, setting this flag to False can improve
+            # compile time.
+            with torch._dynamo.config.patch("enable_cpp_symbolic_shape_guards",
+                                            False), patch.object(
+                                                InliningInstructionTranslator,
+                                                'inline_call',
+                                                patched_inline_call):
                 output = self.compiled_callable(*args, **kwargs)
             return output
 


### PR DESCRIPTION
## Purpose
For nightly, pytorch compiles the symbolic guards into C++. This can increase compile time. Since vllm drops the guards anyways, skip the compilation of symbolic guards to C++.

## Test Plan
Existing tests

## Test Result
Reduces build_guards from ~5 seconds to 0.5 seconds.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
