### PR TITLE
[BugFix] fix 3 issues: (1) using metadata for causal-conv1d, (2) indexing overflow in v1 vLLM, and (3) init_states in v0

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -583,8 +583,8 @@ class MambaMixer2(MambaBase, CustomOp):
             x = hidden_states_B_C_p.transpose(
                 0, 1)  # this is the form that causal-conv see
             if mamba2_metadata.cu_seqlen is None:
-                mamba2_metadata = update_metadata(
-                    x, attn_metadata.query_start_loc, mamba2_metadata)
+                mamba2_metadata = update_metadata(x, query_start_loc_p,
+                                                  mamba2_metadata)
             hidden_states_B_C_p = causal_conv1d_fn(
                 x,
                 conv_weights,
@@ -593,6 +593,7 @@ class MambaMixer2(MambaBase, CustomOp):
                 conv_states=conv_state,
                 has_initial_state=has_initial_states_p,
                 cache_indices=state_indices_tensor_p,
+                metadata=mamba2_metadata,
                 query_start_loc=query_start_loc_p).transpose(
                     0, 1)[:num_prefill_tokens]
 
@@ -603,9 +604,14 @@ class MambaMixer2(MambaBase, CustomOp):
             initial_states = None
             if (has_initial_states_p is not None and prep_initial_states):
                 # making a copy of the states
-                initial_states = torch.where(
-                    has_initial_states_p[:, None, None, None],
-                    ssm_state[state_indices_tensor_p], 0)
+                if envs.VLLM_USE_V1:
+                    initial_states = torch.where(
+                        has_initial_states_p[:, None, None, None],
+                        ssm_state[state_indices_tensor_p], 0)
+                else:
+                    initial_states = torch.where(
+                        has_initial_states_p[:num_prefills, None, None, None],
+                        ssm_state[state_indices_tensor_p], 0)
 
             scan_output, varlen_state = mamba_chunk_scan_combined(
                 hidden_states_p.view(1, num_prefill_tokens,

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -663,7 +663,8 @@ def _causal_conv1d_update_kernel(
 
     if IS_CONTINUOUS_BATCHING:
         # mask = idx_seq < batch
-        conv_state_batch_coord = tl.load(conv_state_indices_ptr + idx_seq)
+        conv_state_batch_coord = tl.load(conv_state_indices_ptr + idx_seq).to(
+            tl.int64)
     else:
         conv_state_batch_coord = idx_seq
     if USE_PAD_SLOT:  # noqa

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -55,7 +55,6 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     USE_PAD_SLOT: tl.constexpr,
     NP2_STATELEN: tl.constexpr,
-    DECODE_SEQLEN: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
@@ -415,7 +414,7 @@ def causal_conv1d_fn(
         activation = "silu"
 
     args = None
-    out = torch.zeros_like(x)
+    out = torch.empty_like(x)
     if metadata is not None:
         cu_seqlen = metadata.cu_seqlen
         nums_dict = metadata.nums_dict
@@ -606,7 +605,6 @@ def causal_conv1d_fn(
         IS_CONTINUOUS_BATCHING=cache_indices is not None,
         USE_PAD_SLOT=pad_slot_id is not None,
         NP2_STATELEN=np2_statelen,
-        DECODE_SEQLEN=1,
         #launch_cooperative_grid=True
         BLOCK_M=8,
         BLOCK_N=256,


### PR DESCRIPTION
## Purpose
This PR fixes 
* the causal-conv1d kernel now makes use of metadata to accelerate computation (it was missed out) from the previous PR #18218 
* fix the code in constructing `initial_states` for v0 vLLM (detected when running lm_eval with Bamba model) from previous PR #19327 
* Added indexing fix to the second kernel, similar to what proposed in the recent PR https://github.com/vllm-project/vllm/pull/20938, when the kernel is used in v1 VLLM which can have a much larger cache size and indexing can be overflow in 32-bit.

## Test Plan

In the main, running this is ok
```
export MODEL_NAME=mistralai/Mamba-Codestral-7B-v0.1
lm_eval --model vllm     --model_args pretrained=${MODEL_NAME},tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.95 --batch_size auto --trust_remote_code  --tasks gsm8k --limit=100 --device cuda:0 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.47|±  |0.0502|
|     |       |strict-match    |     5|exact_match|↑  | 0.47|±  |0.0502|
```

In the main, running this would trigger below error
```
export MODEL_NAME=ibm-ai-platform/Bamba-9B-v2
lm_eval --model vllm     --model_args pretrained=${MODEL_NAME},tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.95 --batch_size auto --trust_remote_code  --tasks gsm8k --limit=100 --device cuda:0 

[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/vllm_tuan/vllm_tuan/vllm/vllm/model_executor/models/bamba.py", line 502, in forward
[rank0]:     hidden_states = self.model(input_ids, positions, mamba_cache_params,
[rank0]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/vllm_tuan/vllm_tuan/vllm/vllm/model_executor/models/bamba.py", line 352, in forward
[rank0]:     hidden_states, residual = layer(
[rank0]:                               ^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/vllm_tuan/vllm_tuan/vllm/vllm/model_executor/models/bamba.py", line 126, in forward
[rank0]:     hidden_states = self.mamba(hidden_states, mamba_cache_params,
[rank0]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/vllm_tuan/vllm_tuan/vllm/vllm/model_executor/custom_op.py", line 44, in forward
[rank0]:     return self._forward_method(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/net/storage149/mnt/md0/tmhoangt/vllm_tuan/vllm_tuan/vllm/vllm/model_executor/layers/mamba/mamba_mixer2.py", line 650, in forward_cuda
[rank0]:     initial_states = torch.where(
[rank0]:                      ^^^^^^^^^^^^
[rank0]: RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
```

The reason is that in the codepath for v0 vLLM of mamba-mixer2, `has_initial_states_p` is not actually the prefill-only data; but it is the data of mixed prefill-decode batch. Therefore, we need to apply `has_initial_states_p[:num_prefills,...]`

With the PR, running this is ok now:
```
export MODEL_NAME=ibm-ai-platform/Bamba-9B-v2
lm_eval --model vllm     --model_args pretrained=${MODEL_NAME},tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.95 --batch_size auto --trust_remote_code  --tasks gsm8k --limit=100 --device cuda:0 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.37|±  |0.0485|
|     |       |strict-match    |     5|exact_match|↑  | 0.36|±  |0.0482|
```

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
