### PR TITLE
[Bugfix] Fix Tensor Parallelism Padding Consistency in Granite Models

### DIFF
--- a/vllm/model_executor/models/granite.py
+++ b/vllm/model_executor/models/granite.py
@@ -273,6 +273,10 @@ class GraniteModel(nn.Module):
                 self.vocab_size,
                 config.hidden_size,
                 org_num_embeddings=config.vocab_size,
+                padding_size=DEFAULT_VOCAB_PADDING_SIZE
+                # We need bigger padding if using lora for kernel
+                # compatibility
+                if not lora_config else lora_config.lora_vocab_padding_size,
                 quant_config=quant_config,
             )
         else:


### PR DESCRIPTION
## Purpose
There appears to be an edge case in the way that padding is handled when tensor parallelism > 1 is used with LoRA. The core of the issue appears to be a mismatch in the padding between the `ParallelLMHead` and the `VocabParallelEmbedding`.

To reproduce it, try to initialize a granite 3.3 model with tensor parallelism and LoRA enabled; it'll crash in the profiling run:
```python
from vllm import LLM
model_id = "ibm-granite/granite-3.3-8b-instruct"

model = LLM(
    model=model_id,
    enable_lora=True,
    tensor_parallel_size=2,
    enforce_eager=True,
    max_model_len=2048,
    max_num_seqs=2,
)
```

If you run the above with `CUDA_LAUNCH_BLOCKING=1`, you'll see it crashes indexing into the logits with the shard mapping [here](https://github.com/vllm-project/vllm/blob/main/vllm/lora/layers.py#L1135), because there are out of bounds indices.

After investigating, this appears to be caused by a mismatch in the padding. The warmup / sizes for this model are as follows:

- dummy LoRA vocab size is `256`
- model vocab (unpadded) is `49159`

When we initialize the `VocabParallelEmbedding`, we do not pass padding explicitly, so we take the default of `64`. This leads to:

- No padding needed for the LoRA since it's already divisible by `64`
- Padding the vocab from `49159` -> `49216` to be divisible by `64`
- Total padded vocab size of `49216 ` + `256` = `49472`

When we initialize the `ParallelLMHead` though, we pass a larger size for the LoRA (256). When it calls through the superclass, the result is

- No padding needed for the LoRA since it's already divisible by `256`
- Padding the vocab from `49159` -> `49408` to be divisible by `256`.
- Total padded vocab size of `49408 ` + `256` = `49664`

In the part where it's crashing you can see that the `logits.shape` is `[tp_size, 49472]`, and the `torch.max(self.sharded_to_full_mapping_gpu)` is `49663`; so the mapping numbers from the padding with 256 are being used to map into indices from the 64 padding, which breaks if the nearest multiple of 64 & 256 for the vocab size are not the same.

I think the right fix here is to use consistent padding in the `VocabParallelEmbedding`. This also probably affects other models - I imagine we probably should be doing this in every model that changes the padding size for lora?

## Test Plan
You can test this a bit more completely using a granite 8b model and a lora from https://huggingface.co/ibm-granite/granite-3.3-8b-rag-agent-lib, e.g, the hallucination detection lora. Adapting the example code:

```bash
from transformers import AutoTokenizer
from nltk import tokenize
from vllm import LLM, SamplingParams
from vllm.lora.request import LoRARequest

from vllm import LLM
model_id = "ibm-granite/granite-3.3-8b-instruct"

device = "cuda"

tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side='left', trust_remote_code=True)

hallucination_sys_prompt = "Split the last assistant response into individual sentences. For each sentence in the last assistant response, identify the faithfulness by comparing with the provided documents and generate the faithfulness reasoning and faithfulness decision. Ensure that your output includes all response sentence IDs, and for each response sentence ID, provide the corresponding faithfulness reasoning and faithfulness decision. The output must be a json structure."

def format_conversation(conversation):
    response_sents = tokenize.sent_tokenize(conversation[-1]["content"])
    response_sents_with_ids = []
    for ind, sent in enumerate(response_sents):
        response_sents_with_ids.append(f"<i{ind}> {sent}")
    conversation[-1]["content"] = ' '.join(response_sents_with_ids)
    conversation.append({
        "role": "system",
        "content": hallucination_sys_prompt
    })
    return conversation


conversation = [
    {
        "role": "user",
        "content": "What happened to Dennis Wilson of the Beach Boys in 1983?"
    },
    {
        "role": "assistant",
        "content": "Dennis Wilson of the Beach Boys drowned in Marina del Rey on December 28, 1983, while diving from a friend's boat trying to recover items that he had previously thrown overboard in fits of rage. Forensic pathologists believed that Dennis experienced shallow-water blackout just before his death"
    }
]
input_conversation = format_conversation(conversation=conversation)

documents = [
    {
        "doc_id": 1,
        "text": "The Beach Boys are an American rock band formed in Hawthorne, California, in 1961. The group's original lineup consisted of brothers Brian, Dennis, and Carl Wilson; their cousin Mike Love; and their friend Al Jardine. Distinguished by their vocal harmonies and early surf songs, they are one of the most influential acts of the rock era. The band drew on the music of jazz-based vocal groups, 1950s rock and roll, and black R&B to create their unique sound, and with Brian as composer, arranger, producer, and de facto leader, often incorporated classical or jazz elements and unconventional recording techniques in innovative ways. In 1983, tensions between Dennis and Love escalated so high that each obtained a restraining order against each other. With the rest of the band fearing that he would end up like Brian, Dennis was given an ultimatum after his last performance in November 1983 to check into rehab for his alcohol problems or be banned from performing live with them. Dennis checked into rehab for his chance to get sober, but on December 28, 1983, he fatally drowned in Marina del Rey while diving from a friend's boat trying to recover items that he had previously thrown overboard in fits of rage."
    },
    {
        "doc_id": 2,
        "text": "A cigarette smoker since the age of 13, Carl was diagnosed with lung cancer after becoming ill at his vacation home in Hawaii, in early 1997. Despite his illness, Carl continued to perform while undergoing chemotherapy. He played and sang throughout the Beach Boys' entire summer tour which ended in the fall of 1997. During the performances, he sat on a stool, but he stood while singing \"God Only Knows\".  Carl died of lung cancer in Los Angeles, surrounded by his family, on February 6, 1998, just two months after the death of his mother, Audree Wilson. He was interred at Westwood Village Memorial Park Cemetery in Los Angeles."
    },
    {
        "doc_id": 3,
        "text": "Carl Dean Wilson (December 21, 1946 - February 6, 1998) was an American musician, singer, and songwriter who co-founded the Beach Boys. He is best remembered as their lead guitarist, as the youngest brother of bandmates Brian and Dennis Wilson, and as the group's de facto leader in the early 1970s. He was also the band's musical director on stage from 1965 until his death. Influenced by the guitar playing of Chuck Berry and the Ventures, Carl's initial role in the group was that of lead guitarist and backing vocals, but he performed lead vocals on several of their later hits, including \"God Only Knows\" (1966), \"Good Vibrations\" (1966), and \"Kokomo\" (1988). By the early 1980s the Beach Boys were in disarray; the band had split into several camps. Frustrated with the band's sluggishness to record new material and reluctance to rehearse, Wilson took a leave of absence in 1981.  He quickly recorded and released a solo album, Carl Wilson, composed largely of rock n' roll songs co-written with Myrna Smith-Schilling, a former backing vocalist for Elvis Presley and Aretha Franklin, and wife of Wilson's then-manager Jerry Schilling. The album briefly charted, and its second single, \"Heaven\", reached the top 20 on Billboard's Adult Contemporary chart."
    }
]

# Generate answer
input_text = tokenizer.apply_chat_template(conversation=input_conversation, documents=documents, tokenize=False)

model = LLM(
    model=model_id,
    enable_lora=True,
    tensor_parallel_size=2,
    enforce_eager=True,
    max_model_len=2048,
    max_num_seqs=2,
)

outputs = model.generate(
    input_text,
    lora_request = LoRARequest(
        lora_name="hallucination_detection",
        lora_path="hallucination_detection_lora",
        lora_int_id=1,
    ),
    sampling_params=SamplingParams(
        temperature=0,
        max_tokens=500,
    )
)

# Print the outputs.
print("\nGenerated Outputs:\n" + "-" * 60)
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Output:    {generated_text!r}")
    print("-" * 60)
```


## Test Result
Running the above successfully initializes the model by fixing the padding misalignment, and the output with `tp=2` matches the output with no tensor parallelism.

```
Output:    '[{"i": 0, "r": "This sentence makes a factual claim about Dennis Wilson\'s death. The document states \'on December 28, 1983, he fatally drowned in Marina del Rey while diving from a friend\'s boat trying to recover items that he had previously thrown overboard in fits of rage.\' This matches exactly with the claim in the sentence.", "f": "faithful"}, {"i": 1, "r": "This sentence makes a factual claim about the cause of Dennis Wilson\'s death. However, the provided context does not mention anything about forensic pathologists or shallow-water blackout. Therefore, this claim cannot be verified from the provided context.", "f": "unfaithful"}]'
```

FYI @DarkLight1337 