### PR TITLE
[BUGFIX][NON_CUDA] Fix failing introduced by #20061 when import bitsandbytes.py

### DIFF
--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -5,7 +5,11 @@ from typing import Any, Callable, Optional, Union
 
 import torch
 
-from vllm.model_executor.layers.fused_moe import fused_experts
+from vllm.triton_utils import HAS_TRITON
+
+if HAS_TRITON:
+    from vllm.model_executor.layers.fused_moe import fused_experts
+
 from vllm.model_executor.layers.fused_moe.layer import (FusedMoE,
                                                         FusedMoEMethodBase)
 from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR is to fixed an exception introduce by #20061 
#20061 will do import in bitsandbytes.py
```
from vllm.model_executor.layers.fused_moe import fused_experts
```
However, in vllm/model_executor/layer.fused_moe/__init__.py
fused_moe is imported under condition
```
if HAS_TRITON:
    # import to register the custom ops
    import vllm.model_executor.layers.fused_moe.fused_marlin_moe  # noqa
    import vllm.model_executor.layers.fused_moe.fused_moe  # noqa
```

For any platform doesn't enable Triton, will hit error as below

For HW doesn't has_triton enabled, when import bitsandbytes, it will trigger error as below:
```
vllm-gaudi/tests/models/language/generation/test_common.py:52: in launch_lm_eval
    llm = VLLM(**model_args)
          ^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.12/dist-packages/lm_eval/models/vllm_causallms.py:177: in __init__
    self.model = LLM(**self.model_args)
                 ^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/entrypoints/llm.py:274: in __init__
    self.llm_engine = LLMEngine.from_engine_args(
/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/v1/engine/llm_engine.py:142: in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/engine/arg_utils.py:1104: in create_engine_config
    model_config = self.create_model_config()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/engine/arg_utils.py:976: in create_model_config
    return ModelConfig(
/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/config.py:631: in __post_init__
    self._verify_quantization()
/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/config.py:935: in _verify_quantization
    method = me_quant.get_quantization_config(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/model_executor/layers/quantization/__init__.py:94: in get_quantization_config
    from .bitsandbytes import BitsAndBytesConfig
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    # SPDX-License-Identifier: Apache-2.0
    # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
    
    from typing import Any, Callable, Optional, Union
    
    import torch
    
>   from vllm.model_executor.layers.fused_moe import fused_experts
E   ImportError: cannot import name 'fused_experts' from 'vllm.model_executor.layers.fused_moe' (/usr/local/lib/python3.12/dist-packages/vllm-0.9.2rc2.dev178+g5f0af36af.gaudi000-py3.12.egg/vllm/model_executor/layers/fused_moe/__init__.py)
```

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
