### PR TITLE
[Nvidia] Integrate cudnn prefill paged attention kernel for head_dim == 128 models, like Llama family

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -8,12 +8,13 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-import vllm.envs as envs
 from flashinfer import (BatchDecodeWithPagedKVCacheWrapper,
                         BatchPrefillWithPagedKVCacheWrapper,
                         MultiLevelCascadeAttentionWrapper)
 from flashinfer.decode import trtllm_batch_decode_with_kv_cache
 from flashinfer.prefill import cudnn_batch_prefill_with_kv_cache
+
+import vllm.envs as envs
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionType)
 from vllm.config import VllmConfig
@@ -466,8 +467,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self._get_workspace_buffer()
             assert self._workspace_buffer is not None, \
                 "workspace_buffer is not set"
-        query_start_loc = common_attn_metadata.query_start_loc_cpu.to(
-            self.device)
+        query_start_loc = common_attn_metadata.query_start_loc_cpu.to(self.device)
         attn_metadata = FlashInferMetadata(
             num_actual_tokens=num_actual_tokens,
             qo_indptr_cpu=common_attn_metadata.query_start_loc_cpu,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -8,12 +8,13 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-import vllm.envs as envs
 from flashinfer import (BatchDecodeWithPagedKVCacheWrapper,
                         BatchPrefillWithPagedKVCacheWrapper,
                         MultiLevelCascadeAttentionWrapper)
 from flashinfer.decode import trtllm_batch_decode_with_kv_cache
 from flashinfer.prefill import cudnn_batch_prefill_with_kv_cache
+
+import vllm.envs as envs
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionType)
 from vllm.config import VllmConfig

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -467,7 +467,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self._get_workspace_buffer()
             assert self._workspace_buffer is not None, \
                 "workspace_buffer is not set"
-        query_start_loc = common_attn_metadata.query_start_loc_cpu.to(self.device)
+        query_start_loc = common_attn_metadata.query_start_loc_cpu.to( \
+            self.device)
         attn_metadata = FlashInferMetadata(
             num_actual_tokens=num_actual_tokens,
             qo_indptr_cpu=common_attn_metadata.query_start_loc_cpu,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import torch
-
 from flashinfer import (BatchDecodeWithPagedKVCacheWrapper,
                         BatchPrefillWithPagedKVCacheWrapper,
                         MultiLevelCascadeAttentionWrapper)

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -653,7 +653,6 @@ class FlashInferImpl(AttentionImpl):
             assert prefill_wrapper._logits_soft_cap == (self.logits_soft_cap
                                                         or 0.0)
             assert prefill_wrapper._sm_scale == self.scale
-
             prefill_wrapper.run(
                 prefill_query,
                 kv_cache_permute,
@@ -663,7 +662,6 @@ class FlashInferImpl(AttentionImpl):
             )
         elif num_prefill_tokens > 0 and is_cudnn_supported(
                 attn_metadata.head_dim):
-
             output[num_decode_tokens:], _ = cudnn_batch_prefill_with_kv_cache(
                 q=query[num_decode_tokens:],
                 k_cache=kv_cache_permute[:, 0],


### PR DESCRIPTION
## Purpose

Integrate cudnnn pagedKVcache API for blackwell. observed  throughput 2x improvement using below command:
`python3 benchmarks/benchmark_throughput.py --model=meta-llama/Llama-3.1-8B  --quantization=fp8  --trust-remote-code  --enable-chunked-prefill  --input-len 8000  --output-len 1000 --num-prompts 300`

Before:
Throughput: 0.32 requests/s, 2846.05 total tokens/s, 316.23 output tokens/s

After:
Throughput: 0.35 requests/s, 3143.47 total tokens/s, 349.27 output tokens/s


## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
