### PR TITLE
[Bugfix] : Fix typo - logger.warn_once -> logger.warning_once

### DIFF
--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -111,7 +111,7 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         # topk_indices_dtype() int32
         #
         if expert_map is not None:
-            logger.warn_once(
+            logger.warning_once(
                 "The PPLX backend does not support expert mapping. "
                 "The provided `expert_map` will be ignored.")
         expert_map = None  #noqa: F841


### PR DESCRIPTION
## Purpose
Fix typo in `pplx_prepare_finalize.py` . 
`pytest -s tests/kernels/moe/test_modular_kernel_combinations.py` triggers the issue. 

## Test Plan
`pytest -s tests/kernels/moe/test_modular_kernel_combinations.py`

## Test Result
verified that the test doesn't complain

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
