### PR TITLE
[Bugfix] Replace unavailable video url in multimodal test

### DIFF
--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -39,7 +39,7 @@ TEST_IMAGE_URLS = [
 
 TEST_VIDEO_URLS = [
     "https://www.bogotobogo.com/python/OpenCV_Python/images/mean_shift_tracking/slow_traffic_small.mp4",
-    "https://raw.githubusercontent.com/opencv/opencv/refs/heads/master/samples/data/vtest.avi",
+    "https://github.com/opencv/opencv/raw/refs/tags/4.12.0/samples/data/vtest.avi",
 ]
 
 

--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -39,7 +39,7 @@ TEST_IMAGE_URLS = [
 
 TEST_VIDEO_URLS = [
     "https://www.bogotobogo.com/python/OpenCV_Python/images/mean_shift_tracking/slow_traffic_small.mp4",
-    "https://filesamples.com/samples/video/avi/sample_640x360.avi",
+    "https://raw.githubusercontent.com/opencv/opencv/refs/heads/master/samples/data/vtest.avi",
 ]
 
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Seems that filesamples.com judged the CI machine IP as spawn bot by mistake, this PR swithced the .avi video url to the sample video in opencv repo.

## Test Plan
```
pytest -s -v tests/multimodal/test_utils.py -k test_fetch_video_http
```

## Test Result
Test should pass now

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
