### PR TITLE
[Bugfix] Fix: add patch_rope_scaling after hf override

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -39,7 +39,7 @@ from vllm.transformers_utils.config import (
     get_hf_text_config, get_pooling_config,
     get_sentence_transformer_tokenizer_config, is_encoder_decoder,
     try_get_generation_config, try_get_safetensors_metadata,
-    try_get_tokenizer_config, uses_mrope)
+    try_get_tokenizer_config, uses_mrope, patch_rope_scaling)
 from vllm.transformers_utils.s3_utils import S3Model
 from vllm.transformers_utils.utils import is_s3, maybe_model_redirect
 # yapf conflicts with isort for this block
@@ -543,7 +543,7 @@ class ModelConfig:
         if hf_overrides_fn:
             logger.debug("Overriding HF config with %s", hf_overrides_fn)
             hf_config = hf_overrides_fn(hf_config)
-
+        patch_rope_scaling(hf_config)
         self.hf_config = hf_config
 
         self.hf_text_config = get_hf_text_config(self.hf_config)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -38,8 +38,8 @@ from vllm.transformers_utils.config import (
     ConfigFormat, get_config, get_hf_image_processor_config,
     get_hf_text_config, get_pooling_config,
     get_sentence_transformer_tokenizer_config, is_encoder_decoder,
-    try_get_generation_config, try_get_safetensors_metadata,
-    try_get_tokenizer_config, uses_mrope, patch_rope_scaling)
+    patch_rope_scaling, try_get_generation_config,
+    try_get_safetensors_metadata, try_get_tokenizer_config, uses_mrope)
 from vllm.transformers_utils.s3_utils import S3Model
 from vllm.transformers_utils.utils import is_s3, maybe_model_redirect
 # yapf conflicts with isort for this block

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -38,8 +38,8 @@ from vllm.transformers_utils.config import (
     ConfigFormat, get_config, get_hf_image_processor_config,
     get_hf_text_config, get_pooling_config,
     get_sentence_transformer_tokenizer_config, is_encoder_decoder,
-    patch_rope_scaling, try_get_generation_config,
-    try_get_safetensors_metadata, try_get_tokenizer_config, uses_mrope)
+    try_get_generation_config, try_get_safetensors_metadata,
+    try_get_tokenizer_config, uses_mrope)
 from vllm.transformers_utils.s3_utils import S3Model
 from vllm.transformers_utils.utils import is_s3, maybe_model_redirect
 # yapf conflicts with isort for this block
@@ -534,16 +534,12 @@ class ModelConfig:
             self.config_format = ConfigFormat(self.config_format)
 
         hf_config = get_config(self.hf_config_path or self.model,
-                               self.trust_remote_code, self.revision,
-                               self.code_revision, self.config_format)
-
-        if hf_overrides_kw:
-            logger.debug("Overriding HF config with %s", hf_overrides_kw)
-            hf_config.update(hf_overrides_kw)
-        if hf_overrides_fn:
-            logger.debug("Overriding HF config with %s", hf_overrides_fn)
-            hf_config = hf_overrides_fn(hf_config)
-        patch_rope_scaling(hf_config)
+                               self.trust_remote_code,
+                               self.revision,
+                               self.code_revision,
+                               self.config_format,
+                               hf_overrides_kw=hf_overrides_kw,
+                               hf_overrides_fn=hf_overrides_fn)
         self.hf_config = hf_config
 
         self.hf_text_config = get_hf_text_config(self.hf_config)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -305,6 +305,9 @@ def get_config(
     revision: Optional[str] = None,
     code_revision: Optional[str] = None,
     config_format: ConfigFormat = ConfigFormat.AUTO,
+    hf_overrides_kw: Optional[dict[str, Any]] = None,
+    hf_overrides_fn: Optional[Callable[[PretrainedConfig],
+                                       PretrainedConfig]] = None,
     **kwargs,
 ) -> PretrainedConfig:
     # Separate model folder from file path for GGUF models
@@ -422,6 +425,13 @@ def get_config(
                 f"Can't get gguf config for {config.model_type}.")
         model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
         config.update({"architectures": [model_type]})
+
+    if hf_overrides_kw:
+        logger.debug("Overriding HF config with %s", hf_overrides_kw)
+        config.update(hf_overrides_kw)
+    if hf_overrides_fn:
+        logger.debug("Overriding HF config with %s", hf_overrides_fn)
+        config = hf_overrides_fn(config)
 
     patch_rope_scaling(config)
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR addresses a compatibility issue when using legacy `rope_scaling` parameters via `--hf-overrides`.

When specifying `rope_scaling` directly in the model's `config.json`, legacy parameters like:

```json
"rope_scaling": {
  "type": "yarn",
  "factor": 4.0,
  "original_max_position_embeddings": 35268
}
```
are handled correctly by the `patch_rope_scaling` function, which maps "type" to "rope_type".

However, when passing the same configuration via --hf-overrides, a KeyError: 'rope_type' is raised:
```shell
rope_type = rope_scaling["rope_type"]
KeyError: 'rope_type'
```

This PR ensures that `patch_rope_scaling` is invoked after applying hf-overrides, so that legacy parameters are properly converted even when passed via command-line overrides.

This improves backward compatibility and prevents runtime errors when using the --hf-overrides mechanism with legacy rope_scaling configs.

## Test Plan

Use the following command to serve the Qwen2.5 model with `yarn` rope_scaling.

```shell
# File: test_legacy_yarn_override.sh
vllm serve Qwen/Qwen2.5-32B-Instruct \
    --tensor-parallel-size 8 \
    --max-model-len 141072 \
    --gpu-memory-utilization 0.5 \
    --hf-overrides '{"rope_scaling": {"factor": 4.0, "type":"yarn", "original_max_position_embeddings":35268}}'
```

## Test Result
Before fix:

```bash
$ bash test_legacy_yarn_override.sh
DEBUG 07-12 08:53:25 [__init__.py:31] No plugins for group vllm.platform_plugins found.
DEBUG 07-12 08:53:25 [__init__.py:35] Checking if TPU platform is available.
DEBUG 07-12 08:53:25 [__init__.py:45] TPU platform is not available because: No module named 'libtpu'
DEBUG 07-12 08:53:25 [__init__.py:52] Checking if CUDA platform is available.
DEBUG 07-12 08:53:25 [__init__.py:72] Confirmed CUDA platform is available.
DEBUG 07-12 08:53:25 [__init__.py:100] Checking if ROCm platform is available.
DEBUG 07-12 08:53:25 [__init__.py:114] ROCm platform is not available because: No module named 'amdsmi'
DEBUG 07-12 08:53:25 [__init__.py:121] Checking if HPU platform is available.
DEBUG 07-12 08:53:25 [__init__.py:128] HPU platform is not available because habana_frameworks is not found.
DEBUG 07-12 08:53:25 [__init__.py:138] Checking if XPU platform is available.
DEBUG 07-12 08:53:25 [__init__.py:157] XPU platform is not available because: No module named 'intel_extension_for_pytorch'
DEBUG 07-12 08:53:25 [__init__.py:164] Checking if CPU platform is available.
DEBUG 07-12 08:53:25 [__init__.py:186] Checking if Neuron platform is available.
DEBUG 07-12 08:53:25 [__init__.py:52] Checking if CUDA platform is available.
DEBUG 07-12 08:53:25 [__init__.py:72] Confirmed CUDA platform is available.
INFO 07-12 08:53:25 [__init__.py:253] Automatically detected platform cuda.
DEBUG 07-12 08:53:29 [utils.py:162] Setting VLLM_WORKER_MULTIPROC_METHOD to 'spawn'
DEBUG 07-12 08:53:29 [__init__.py:39] Available plugins for group vllm.general_plugins:
DEBUG 07-12 08:53:29 [__init__.py:41] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
DEBUG 07-12 08:53:29 [__init__.py:44] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 07-12 08:53:29 [api_server.py:1639] vLLM API server version 0.1.dev7658+gb639327
INFO 07-12 08:53:29 [cli_args.py:325] non-default args: {'model': '/mnt/longcontext/models/siyuan/llama3/Qwen2.5-32B-Instruct', 'max_model_len': 141072, 'hf_overrides': {'rope_scaling': {'factor': 4.0, 'type': 'yarn', 'original_max_position_embeddings': 35268}}, 'tensor_parallel_size': 8, 'gpu_memory_utilization': 0.5}
WARNING 07-12 08:53:29 [__init__.py:2703] Found ulimit of 4096 and failed to automatically increase with error current limit exceeds maximum limit. This can cause fd limit errors like `OSError: [Errno 24] Too many open files`. Consider increasing with ulimit -n
DEBUG 07-12 08:53:30 [config.py:541] Overriding HF config with {'rope_scaling': {'factor': 4.0, 'type': 'yarn', 'original_max_position_embeddings': 35268}}
INFO 07-12 08:53:37 [config.py:852] This model supports multiple tasks: {'classify', 'reward', 'embed', 'generate'}. Defaulting to 'generate'.
Traceback (most recent call last):
  File "/home/aiscuser/.conda/envs/vllm_test/bin/vllm", line 8, in <module>
    sys.exit(main())
  File "/home/aiscuser/vllm/vllm/entrypoints/cli/main.py", line 65, in main
    args.dispatch_function(args)
  File "/home/aiscuser/vllm/vllm/entrypoints/cli/serve.py", line 57, in cmd
    uvloop.run(run_server(args))
  File "/home/aiscuser/.conda/envs/vllm_test/lib/python3.10/site-packages/uvloop/__init__.py", line 82, in run
    return loop.run_until_complete(wrapper())
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/aiscuser/.conda/envs/vllm_test/lib/python3.10/site-packages/uvloop/__init__.py", line 61, in wrapper
    return await main
  File "/home/aiscuser/vllm/vllm/entrypoints/openai/api_server.py", line 1675, in run_server
    await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
  File "/home/aiscuser/vllm/vllm/entrypoints/openai/api_server.py", line 1695, in run_server_worker
    async with build_async_engine_client(args, client_config) as engine_client:
  File "/home/aiscuser/.conda/envs/vllm_test/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/home/aiscuser/vllm/vllm/entrypoints/openai/api_server.py", line 158, in build_async_engine_client
    async with build_async_engine_client_from_engine_args(
  File "/home/aiscuser/.conda/envs/vllm_test/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/home/aiscuser/vllm/vllm/entrypoints/openai/api_server.py", line 180, in build_async_engine_client_from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context=usage_context)
  File "/home/aiscuser/vllm/vllm/engine/arg_utils.py", line 1104, in create_engine_config
    model_config = self.create_model_config()
  File "/home/aiscuser/vllm/vllm/engine/arg_utils.py", line 976, in create_model_config
    return ModelConfig(
  File "/home/aiscuser/.conda/envs/vllm_test/lib/python3.10/site-packages/pydantic/_internal/_dataclasses.py", line 123, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  File "/home/aiscuser/vllm/vllm/config.py", line 617, in __post_init__
    self.max_model_len = self.get_and_verify_max_len(self.max_model_len)
  File "/home/aiscuser/vllm/vllm/config.py", line 1492, in get_and_verify_max_len
    max_model_len = _get_and_verify_max_len(
  File "/home/aiscuser/vllm/vllm/config.py", line 3512, in _get_and_verify_max_len
    rope_type = rope_scaling["rope_type"]
KeyError: 'rope_type'
```

After the fix:

```bash
$ bash test_legacy_yarn_override.sh
DEBUG 07-12 08:55:26 [__init__.py:31] No plugins for group vllm.platform_plugins found.
DEBUG 07-12 08:55:26 [__init__.py:35] Checking if TPU platform is available.
DEBUG 07-12 08:55:26 [__init__.py:45] TPU platform is not available because: No module named 'libtpu'
DEBUG 07-12 08:55:26 [__init__.py:52] Checking if CUDA platform is available.
DEBUG 07-12 08:55:26 [__init__.py:72] Confirmed CUDA platform is available.
DEBUG 07-12 08:55:26 [__init__.py:100] Checking if ROCm platform is available.
DEBUG 07-12 08:55:26 [__init__.py:114] ROCm platform is not available because: No module named 'amdsmi'
DEBUG 07-12 08:55:26 [__init__.py:121] Checking if HPU platform is available.
DEBUG 07-12 08:55:26 [__init__.py:128] HPU platform is not available because habana_frameworks is not found.
DEBUG 07-12 08:55:26 [__init__.py:138] Checking if XPU platform is available.
DEBUG 07-12 08:55:26 [__init__.py:157] XPU platform is not available because: No module named 'intel_extension_for_pytorch'
DEBUG 07-12 08:55:26 [__init__.py:164] Checking if CPU platform is available.
DEBUG 07-12 08:55:26 [__init__.py:186] Checking if Neuron platform is available.
DEBUG 07-12 08:55:26 [__init__.py:52] Checking if CUDA platform is available.
DEBUG 07-12 08:55:26 [__init__.py:72] Confirmed CUDA platform is available.
INFO 07-12 08:55:26 [__init__.py:253] Automatically detected platform cuda.
DEBUG 07-12 08:55:29 [utils.py:162] Setting VLLM_WORKER_MULTIPROC_METHOD to 'spawn'
DEBUG 07-12 08:55:29 [__init__.py:39] Available plugins for group vllm.general_plugins:
DEBUG 07-12 08:55:29 [__init__.py:41] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
DEBUG 07-12 08:55:29 [__init__.py:44] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 07-12 08:55:30 [api_server.py:1639] vLLM API server version 0.1.dev7658+gb639327
INFO 07-12 08:55:30 [cli_args.py:325] non-default args: {'model': '/mnt/longcontext/models/siyuan/llama3/Qwen2.5-32B-Instruct', 'max_model_len': 141072, 'hf_overrides': {'rope_scaling': {'factor': 4.0, 'type': 'yarn', 'original_max_position_embeddings': 35268}}, 'tensor_parallel_size': 8, 'gpu_memory_utilization': 0.5}
WARNING 07-12 08:55:30 [__init__.py:2703] Found ulimit of 4096 and failed to automatically increase with error current limit exceeds maximum limit. This can cause fd limit errors like `OSError: [Errno 24] Too many open files`. Consider increasing with ulimit -n
DEBUG 07-12 08:55:30 [config.py:541] Overriding HF config with {'rope_scaling': {'factor': 4.0, 'type': 'yarn', 'original_max_position_embeddings': 35268}}
INFO 07-12 08:55:30 [config.py:241] Replacing legacy 'type' key with 'rope_type'
```


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
