### PR TITLE
Renable google/gemma-3-1b-it accuracy test.

### DIFF
--- a/tests/entrypoints/llm/test_accuracy.py
+++ b/tests/entrypoints/llm/test_accuracy.py
@@ -71,9 +71,8 @@ def test_lm_eval_accuracy_v1_engine(model, monkeypatch: pytest.MonkeyPatch):
             # Limit compilation time for TPU V1
 
             if model == "google/gemma-3-1b-it":
-                pytest.skip(
-                    "Temporarily disabled due to test failures"
-                    "(timeout or accuracy mismatch). Re-enable once fixed.")
+                # TPU + google/gemma-3-1b-it + xet doesn't work well.
+                m.setenv("HF_HUB_DISABLE_XET", "1")
 
             more_args = "max_model_len=2048,max_num_seqs=64"
 


### PR DESCRIPTION
## Purpose
Re-enable accuracy test for google/gemma-3-1b-it accuracy on TPU by disabling huggingface xet. 

## Description
Load the test loads `google/gemma-3-1b-it` it hangs. huggingface verbose logs: 

```
Request d4ac3eb5-9582-4c8a-bda8-050633b0e516: GET https://huggingface.co/api/models/google/gemma-3-1b-it/revision/main (authenticated: True)
DEBUG:huggingface_hub.utils._http:Request d4ac3eb5-9582-4c8a-bda8-050633b0e516: GET https://huggingface.co/api/models/google/gemma-3-1b-it/revision/main (authenticated: True)
Request c6d97010-4bdc-45f3-b6d5-3aea6365915c: HEAD https://huggingface.co/google/gemma-3-1b-it/resolve/dcc83ea841ab6100d6b47a070329e1ba4cf78752/model.safetensors (authenticated: True)
DEBUG:huggingface_hub.utils._http:Request c6d97010-4bdc-45f3-b6d5-3aea6365915c: HEAD https://huggingface.co/google/gemma-3-1b-it/resolve/dcc83ea841ab6100d6b47a070329e1ba4cf78752/model.safetensors (authenticated: True)
Downloading 'model.safetensors' to '/root/.cache/huggingface/hub/models--google--gemma-3-1b-it/blobs/3d4ef8d71c14db7e448a09ebe891cfb6bf32c57a9b44499ae0d1c098e48516b6.incomplete'
INFO:huggingface_hub.file_download:Downloading 'model.safetensors' to '/root/.cache/huggingface/hub/models--google--gemma-3-1b-it/blobs/3d4ef8d71c14db7e448a09ebe891cfb6bf32c57a9b44499ae0d1c098e48516b6.incomplete'
Xet Storage is enabled for this repo. Downloading file from Xet Storage..
DEBUG:huggingface_hub.file_download:Xet Storage is enabled for this repo. Downloading file from Xet Storage..
Request 29520666-b0fc-4512-aede-9591ac3e0aa4: GET https://huggingface.co/api/models/google/gemma-3-1b-it/xet-read-token/dcc83ea841ab6100d6b47a070329e1ba4cf78752 (authenticated: True)
DEBUG:huggingface_hub.utils._http:Request 29520666-b0fc-4512-aede-9591ac3e0aa4: GET https://huggingface.co/api/models/google/gemma-3-1b-it/xet-read-token/dcc83ea841ab6100d6b47a070329e1ba4cf78752 (authenticated: True)

```

I tried other ways like explicitly installing `python3 -m pip install huggingface_hub[hf_xet]` but i didn't work well: after doing it, it has more chances not hang to timeout but quickly and consistently gives `Fatal Python error: Segmentation fault ` 

## Test Plan
Test on CI fast check.

## Test Result
<img width="1668" height="711" alt="image" src="https://github.com/user-attachments/assets/b97ae25f-f814-4fb5-ab16-38252a2a391e" />