### PR TITLE
Allow serving Llama4ForCausalLM directly

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -83,6 +83,7 @@ _TEXT_GENERATION_MODELS = {
     "JAISLMHeadModel": ("jais", "JAISLMHeadModel"),
     "JambaForCausalLM": ("jamba", "JambaForCausalLM"),
     "LlamaForCausalLM": ("llama", "LlamaForCausalLM"),
+    "Llama4ForCausalLM": ("llama4", "Llama4ForCausalLM"),
     # For decapoda-research/llama-*
     "LLaMAForCausalLM": ("llama", "LlamaForCausalLM"),
     "MambaForCausalLM": ("mamba", "MambaForCausalLM"),


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Addresses #18022 and #20581. Some users want to serve text-only variants of Llama4 models.

## Test Plan
There is no official text-only model checkpoint at the moment, but I tested that serving still works with https://huggingface.co/trl-internal-testing/tiny-Llama4ForCausalLM

## Test Result

Below command works
```
vllm serve trl-internal-testing/tiny-Llama4ForCausalLM --gpu-memory-utilization 0.95 --max-model-len 512 --tensor_parallel_size 1
```

## (Optional) Documentation Update
Did not update `supported_models.md` yet as there is no example official HF model.

<!--- pyml disable-next-line no-emphasis-as-heading -->
