### PR TITLE
[Bugfix] Fix vLLM startup to avoid a hard dependency on Outlines

### DIFF
--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING
 import torch
 from regex import escape as regex_escape
 
-from vllm.model_executor.guided_decoding.outlines_logits_processors import (
-    OutlinesVocabulary, get_cache, get_vocabulary)
 from vllm.sampling_params import SamplingParams
 from vllm.utils import LazyLoader
 from vllm.v1.structured_output.backend_types import (StructuredOutputBackend,
@@ -24,6 +22,8 @@ from vllm.v1.structured_output.backend_types import (StructuredOutputBackend,
 if TYPE_CHECKING:
     import outlines_core as oc
     import outlines_core.json_schema as json_schema
+    from vllm.model_executor.guided_decoding.outlines_logits_processors import (
+        OutlinesVocabulary, get_cache, get_vocabulary)
 else:
     oc = LazyLoader("oc", globals(), "outlines_core")
     json_schema = LazyLoader("json_schema", globals(),


### PR DESCRIPTION
Follow up https://github.com/vllm-project/vllm/issues/15975

Before
```
# vllm serve Qwen/Qwen3-1.7B                                                                                       130 ↵
INFO 07-13 08:53:03 [__init__.py:253] Automatically detected platform cuda.
INFO 07-13 08:53:06 [api_server.py:1641] vLLM API server version 0.9.2rc2.dev77+gfdd52d530
INFO 07-13 08:53:06 [cli_args.py:325] non-default args: {'model': 'Qwen/Qwen3-1.7B'}
INFO 07-13 08:53:15 [config.py:1560] Using max model len 40960
INFO 07-13 08:53:15 [config.py:2374] Chunked prefill is enabled with max_num_batched_tokens=2048.
Traceback (most recent call last):
  File "/root/anaconda3/bin/vllm", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/root/vllm/vllm/entrypoints/cli/main.py", line 65, in main
    args.dispatch_function(args)
  File "/root/vllm/vllm/entrypoints/cli/serve.py", line 57, in cmd
    uvloop.run(run_server(args))
  File "/root/anaconda3/lib/python3.12/site-packages/uvloop/__init__.py", line 109, in run
    return __asyncio.run(
           ^^^^^^^^^^^^^^
  File "/root/anaconda3/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/root/anaconda3/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/root/anaconda3/lib/python3.12/site-packages/uvloop/__init__.py", line 61, in wrapper
    return await main
           ^^^^^^^^^^
  File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 1677, in run_server
    await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
  File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 1697, in run_server_worker
    async with build_async_engine_client(args, client_config) as engine_client:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 158, in build_async_engine_client
    async with build_async_engine_client_from_engine_args(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 189, in build_async_engine_client_from_engine_args
    from vllm.v1.engine.async_llm import AsyncLLM
  File "/root/vllm/vllm/v1/engine/async_llm.py", line 36, in <module>
    from vllm.v1.engine.processor import Processor
  File "/root/vllm/vllm/v1/engine/processor.py", line 26, in <module>
    from vllm.v1.structured_output.backend_outlines import (
  File "/root/vllm/vllm/v1/structured_output/backend_outlines.py", line 16, in <module>
    from vllm.model_executor.guided_decoding.outlines_logits_processors import (
  File "/root/vllm/vllm/model_executor/guided_decoding/outlines_logits_processors.py", line 17, in <module>
    from outlines_core import Guide, Index, Vocabulary
ImportError: cannot import name 'Guide' from 'outlines_core' (/root/anaconda3/lib/python3.12/site-packages/outlines_core/__init__.py)

```

After
```
# vllm serve Qwen/Qwen3-1.7B
...
...
INFO 07-13 08:55:52 [launcher.py:37] Route: /rerank, Methods: POST
INFO 07-13 08:55:52 [launcher.py:37] Route: /v1/rerank, Methods: POST
INFO 07-13 08:55:52 [launcher.py:37] Route: /v2/rerank, Methods: POST
INFO 07-13 08:55:52 [launcher.py:37] Route: /invocations, Methods: POST
INFO 07-13 08:55:52 [launcher.py:37] Route: /metrics, Methods: GET
INFO:     Started server process [226555]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```