### PR TITLE
[V1] [ROCm] [AITER] Upgrade AITER to commit `916bf3c` and bugfix APIs

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -12,7 +12,7 @@ ARG PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
 ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
 ARG FA_BRANCH="1a7f4dfa"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="6487649"
+ARG AITER_BRANCH="916bf3c"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
 FROM ${BASE_IMAGE} AS base

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
@@ -8,9 +8,53 @@ import torch
 import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
+from vllm.utils import direct_register_custom_op
 
 from .cutlass import CutlassScaledMMLinearKernel
 from .ScaledMMLinearKernel import ScaledMMLinearLayerConfig
+
+
+def rocm_aiter_gemm_w8a8_impl(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    As: torch.Tensor,
+    Bs: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    output_dtype: torch.dtype = torch.float16,
+) -> torch.Tensor:
+
+    from aiter import gemm_a8w8_CK
+
+    # gemm_a8w8_CK(a, b, scale_a, scale_b, bias) expects
+    # a to be [M, K]
+    # b to be [N, K]
+    # CutlassScaledMMLinearKernel prepare weight `w_q` in [K, N] format
+    return gemm_a8w8_CK(A, B, As, Bs, bias, output_dtype)
+
+
+def rocm_aiter_gemm_w8a8_fake(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    As: torch.Tensor,
+    Bs: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    output_dtype: torch.dtype = torch.float16,
+) -> torch.Tensor:
+
+    m = A.shape[0]
+    n = B.shape[0]
+    Y = torch.empty(m, n, dtype=output_dtype, device=A.device)
+    return Y
+
+
+if current_platform.is_rocm():
+    direct_register_custom_op(
+        op_name="rocm_aiter_gemm_w8a8",
+        op_func=rocm_aiter_gemm_w8a8_impl,
+        mutates_args=[],
+        fake_impl=rocm_aiter_gemm_w8a8_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
 
 
 class AiterScaledMMLinearKernel(CutlassScaledMMLinearKernel):
@@ -111,10 +155,9 @@ class AiterScaledMMLinearKernel(CutlassScaledMMLinearKernel):
                     " w8a8 scaled gemm. `AiterScaledMMLinearKernel` " +
                     "does not support AITER block scaled GEMM.")
 
-        from aiter import gemm_a8w8_CK
-
         # gemm_a8w8_CK(a, b, scale_a, scale_b, bias) expects
         # a to be [M, K]
         # b to be [N, K]
         # CutlassScaledMMLinearKernel prepare weight `w_q` in [K, N] format
-        return gemm_a8w8_CK(x_q, w_q.t(), x_s, w_s, bias).to(out_dtype)
+        return torch.ops.vllm.rocm_aiter_gemm_w8a8(x_q, w_q.t(), x_s, w_s,
+                                                   bias, out_dtype)

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -55,7 +55,7 @@ def rocm_aiter_gemm_w8a8_blockscale_impl(
 ) -> torch.Tensor:
     import aiter as rocm_aiter
 
-    return rocm_aiter.gemm_a8w8_blockscale_CK(A, B, As, Bs, dtype=output_dtype)
+    return rocm_aiter.gemm_a8w8_blockscale(A, B, As, Bs, dtype=output_dtype)
 
 
 def rocm_aiter_gemm_w8a8_blockscale_fake(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Upgrading AITER commits to newer version `916bf3c` (Jul 12, 2025).

## Test Plan
Perform lm-eval on all of the representative models that are using AITER kernels (all lm-evals are evaluated on V1 Engine).

* `from aiter import gemm_a8w8_CK` (RedHat/Meta-Llama-3.1-405B-Instruct-quantized.w8a8)
* `aiter.flash_attn_varlen_func` (mistral, mistral-fp8, Llama-3, Llama-4 Bf16)
* `aiter.paged_attention_v1` (mistral, mistral-fp8, Llama-3, Llama-4 Bf16)
* `from aiter import topk_softmax` (mistral, mistral-fp8, Llama-4 Bf16)
* `from aiter.fused_moe_bf16_asm import asm_moe_tkw1` (Llama-4 FP8)
* `from aiter import biased_grouped_topk` (DeepSeek-R1)
* `from aiter import grouped_topk` (mistral, mistral-fp8, Llama-4 Bf16)
* `from aiter.fused_moe import fused_moe` (DeepSeek-R1, mistral, mistral-fp8, Llama-4 Bf16)
* `from aiter.ops.shuffle import shuffle_weight` (DeepSeek-R1, mistral, Llama-4)
* `aiter.gemm_a8w8_blockscale` (DeepSeek-R1)
* `from aiter.mla import mla_decode_fwd` (DeepSeek-R1)

## Test Result

### Test AITER Flash Attention Kernel:
LongBench Dataset
RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
Test Local and Global Attention Mechanism

vllm (pretrained=RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic,tensor_parallel_size=4,max_model_len=131072,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|            Tasks             |Version|Filter|n-shot|    Metric     |   |Value |   |Stderr|
|------------------------------|------:|------|-----:|---------------|---|-----:|---|-----:|
|longbench_passage_retrieval_en|      3|none  |     5|retrieval_score|↑  |0.8667|±  |0.0233|


### Other Affected Models
Evaluate on GSM8K on Affected Models:

#### deepseek-ai/DeepSeek-R1

V1

vllm (pretrained=deepseek-ai/DeepSeek-V3,tensor_parallel_size=8,max_model_len=32768,block_size=1,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9469|±  |0.0062|
|     |       |strict-match    |     5|exact_match|↑  |0.9469|±  |0.0062|


V0

vllm (pretrained=deepseek-ai/DeepSeek-V3,tensor_parallel_size=8,max_model_len=32768,block_size=1,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9265|±  |0.0072|
|     |       |strict-match    |     5|exact_match|↑  |0.9257|±  |0.0072|

#### mistralai/Mixtral-8x7B-Instruct-v0.1

vllm (pretrained=mistralai/Mixtral-8x7B-Instruct-v0.1,tensor_parallel_size=2,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6414|±  |0.0132|
|     |       |strict-match    |     5|exact_match|↑  |0.6376|±  |0.0132|


#### mistralai/Mixtral-8x7B-Instruct-v0.1 fp8 per tensor dynamic quantization

vllm (pretrained=mistralai/Mixtral-8x7B-Instruct-v0.1,tensor_parallel_size=2,quantization=fp8,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6027|±  |0.0135|
|     |       |strict-match    |     5|exact_match|↑  |0.5989|±  |0.0135|

#### meta-llama/Llama-3.3-70B-Instruct

vllm (pretrained=meta-llama/Llama-3.3-70B-Instruct,tensor_parallel_size=2,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9393|±  |0.0066|
|     |       |strict-match    |     5|exact_match|↑  |0.9136|±  |0.0077|




#### meta-llama/Llama-3.3-70B-Instruct fp8 per tensor dynamic quantization

vllm (pretrained=meta-llama/Llama-3.3-70B-Instruct,tensor_parallel_size=2,quantization=fp8,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9340|±  |0.0068|
|     |       |strict-match    |     5|exact_match|↑  |0.8992|±  |0.0083|

#### RedHat/Meta-Llama-3.1-405B-Instruct-quantized.w8a8 (V1 PTPC INT8 a8w8)

vllm (pretrained=RedHat/Meta-Llama-3.1-405B-Instruct-quantized.w8a8,tensor_parallel_size=4,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9212|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9151|±  |0.0077|

#### RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic

vllm (pretrained=RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic,tensor_parallel_size=8,max_model_len=100000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9158|±  |0.0076|
|     |       |strict-match    |     5|exact_match|↑  |0.9037|±  |0.0081|

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
