### PR TITLE
Removing redundant python version check

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -23,11 +23,6 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import TypedDict
 
-if sys.version_info >= (3, 12):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
 import vllm.envs as envs
 from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient


### PR DESCRIPTION
## Purpose
Cleaning up redundant version check code

<!--- pyml disable-next-line no-emphasis-as-heading -->
