### PR TITLE
[Bug Fix] get_distributed_init_method should get the ip from get_ip i…

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -140,6 +140,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16: bool = True
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: Optional[int] = None
     VLLM_NIXL_ABORT_REQUEST_TIMEOUT: int = 120
+    VLLM_LOOPBACK_IP: str = ""
 
 
 def get_default_cache_root():
@@ -970,6 +971,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, use the TRTLLM Decode Attention backend in flashinfer.
     "VLLM_USE_TRTLLM_DECODE_ATTENTION":
     lambda: os.getenv("VLLM_USE_TRTLLM_DECODE_ATTENTION", None),
+
+    # Used to force set up loopback IP
+    "VLLM_LOOPBACK_IP":
+    lambda: os.getenv("VLLM_LOOPBACK_IP", ""),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -812,6 +812,33 @@ def get_ip() -> str:
     return "0.0.0.0"
 
 
+def test_loopback_bind(address, family):
+    try:
+        s = socket.socket(family, socket.SOCK_DGRAM)
+        s.bind((address, 0))  # Port 0 = auto assign
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+def get_loopback_ip() -> str:
+    loopback_ip = envs.VLLM_LOOPBACK_IP
+    if loopback_ip:
+        return loopback_ip
+
+    # VLLM_LOOPBACK_IP is not set, try to get it based on network interface
+
+    if test_loopback_bind("127.0.0.1", socket.AF_INET):
+        return "127.0.0.1"
+    elif test_loopback_bind("::1", socket.AF_INET6):
+        return "::1"
+    else:
+        raise RuntimeError(
+            "Neither 127.0.0.1 nor ::1 are bound to a local interface. "
+            "Set the VLLM_LOOPBACK_IP environment variable explicitly.")
+
+
 def is_valid_ipv6_address(address: str) -> bool:
     try:
         ipaddress.IPv6Address(address)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -30,8 +30,8 @@ from vllm.distributed.device_communicators.shm_broadcast import (Handle,
 from vllm.executor.multiproc_worker_utils import (
     _add_prefix, set_multiprocessing_worker_envs)
 from vllm.logger import init_logger
-from vllm.utils import (get_distributed_init_method, get_mp_context,
-                        get_open_port)
+from vllm.utils import (get_distributed_init_method, get_loopback_ip,
+                        get_mp_context, get_open_port)
 from vllm.v1.executor.abstract import Executor, FailureCallback
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.worker.worker_base import WorkerWrapperBase
@@ -63,9 +63,9 @@ class MultiprocExecutor(Executor):
 
         # Multiprocessing-based executor does not support multi-node setting.
         # Since it only works for single node, we can use the loopback address
-        # 127.0.0.1 for communication.
+        # get_loopback_ip() for communication.
         distributed_init_method = get_distributed_init_method(
-            "127.0.0.1", get_open_port())
+            get_loopback_ip(), get_open_port())
 
         # Initialize worker and set up message queues for SchedulerOutputs
         # and ModelRunnerOutputs


### PR DESCRIPTION
…nstead of hardcoding

## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

To sum up, fix the manual hardcoding IPV4 address in get_distributed_init_method() process. 

After upgrading from V0 to V1, got the socket hanging issue for IPV6 machine, when trying to load VLLM with multi-GPU on a single node.

```
E0706 21:35:24.263926  6889 TCPStore.cpp:334] [c10d] TCP client failed to connect/validate to host 127.0.0.1:33605 - timed out (try=1, timeout=600000ms): The client socket has timed out after 600000ms while trying to connect to (127.0.0.1, 33605).
```

Even when manually set up "VLLM_HOST_IP": "::1", the issue still persist because `get_ip()` was never called. Check the detailed C10D log, and compare the following logs between V1 and V0.

## VLLM V0 (can figure out ipv6 address)
I0713 16:11:09.316910   955 socket.cpp:779] [c10d - debug] The client socket will attempt to connect to an IPv6 address of (::1, 47387).
I0713 16:11:09.316920   955 socket.cpp:850] [c10d - trace] The client socket is attempting to connect to [localhost]:47387.
I0713 16:11:09.317106   955 socket.cpp:946] [c10d] The client socket has connected to [localhost]:47387

## VLLM V1 (use ipv4 address)
I0713 15:56:27.161973  1058 socket.cpp:779] [c10d - debug] The client socket will attempt to connect to an IPv6 address of (127.0.0.1, 42603). I0713 15:56:27.161981  1058 socket.cpp:850] [c10d - trace] The client socket is attempting to connect to [localhost]:42603. I0713 15:56:27.162492  1058 socket.cpp:925] [c10d - trace] The server socket on [localhost]:42603 is not yet listening (errno: 111 - Connection refused), will retry.

The root cause of the issue is that the manual IP set up in distributed_init_method(), fix it by using get_ip() function instead of using "127.0.0.1"

## Root cause 

The multi-proc ip set up with forced set up as 127.0.0.1

## Test Plan

Test locally with this change.

## Test Result

Success compile.

## (Optional) Documentation Update

get_distributed_init_method() will use the IP from get_ip()

<!--- pyml disable-next-line no-emphasis-as-heading -->
