### PR TITLE
[Bugfix] Bump up mistral_common to support v13 tokenizer

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -28,7 +28,7 @@ torchvision==0.22.0
 transformers_stream_generator # required for qwen-vl test
 mamba_ssm # required for plamo2 test
 matplotlib # required for qwen-vl test
-mistral_common[opencv] >= 1.6.4 # required for pixtral test
+mistral_common[opencv] >= 1.7.0 # required for pixtral test
 num2words # required for smolvlm test
 opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -28,7 +28,7 @@ torchvision==0.22.0
 transformers_stream_generator # required for qwen-vl test
 mamba_ssm # required for plamo2 test
 matplotlib # required for qwen-vl test
-mistral_common[opencv] >= 1.6.2 # required for pixtral test
+mistral_common[opencv] >= 1.6.4 # required for pixtral test
 num2words # required for smolvlm test
 opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -305,7 +305,7 @@ mbstrdecoder==1.1.3
     #   typepy
 mdurl==0.1.2
     # via markdown-it-py
-mistral-common==1.6.2
+mistral-common==1.7.0
     # via -r requirements/test.in
 more-itertools==10.5.0
     # via lm-eval


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fix #20902
v13 tokenizer exists in >=v1.6.4
https://github.com/mistralai/mistral-common/blob/v1.6.4/src/mistral_common/tokens/tokenizers/base.py#L106

## Test Plan
```
vllm serve mistralai/Devstral-Small-2507 --served-model-name mistralai/Devstral-Small-2507 --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice --tensor-parallel-size 1
```

## Test Result
Model serving ok

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
