### PR TITLE
[Misc] Fix flashinfer import 

### DIFF
--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -20,10 +20,14 @@ from vllm.utils import direct_register_custom_op
 from .vllm_inductor_pass import VllmInductorPass
 
 if find_spec("flashinfer"):
-    import flashinfer.comm as flashinfer_comm
+    try:
+        # flashinfer.comm requires at least version 0.2.7.
+        import flashinfer.comm as flashinfer_comm
 
-    flashinfer_comm = (flashinfer_comm if hasattr(
-        flashinfer_comm, "trtllm_allreduce_fusion") else None)
+        flashinfer_comm = (flashinfer_comm if hasattr(
+            flashinfer_comm, "trtllm_allreduce_fusion") else None)
+    except ModuleNotFoundError:
+        flashinfer_comm = None
 else:
     flashinfer_comm = None
 from vllm.platforms import current_platform


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
It seems we don't have a mandatory minimum version require for flashinfer, so when I use flashinfer version 0.2.5 locally, it reports the following error:
```text
(VllmWorker rank=0 pid=722951) ERROR 07-14 07:16:26 [multiproc_executor.py:583]     import flashinfer.comm as flashinfer_comm
(VllmWorker rank=0 pid=722951) ERROR 07-14 07:16:26 [multiproc_executor.py:583] ModuleNotFoundError: No module named 'flashinfer.comm'


```
## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
