### PR TITLE
[Bugfix] Correct per_act_token in CompressedTensorsW8A8Fp8MoECutlassM…

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -929,10 +929,8 @@ class CompressedTensorsW8A8Fp8MoECutlassMethod(CompressedTensorsMoEMethod):
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias)
 
-        a1_scale = layer.w13_input_scale
-        a2_scale = layer.w2_input_scale
-        per_act_token = a1_scale.numel() != 1 if a1_scale is not None else (
-            a2_scale.numel() != 1 if a2_scale is not None else False)
+        per_act_token = (
+            self.input_quant.strategy == QuantizationStrategy.TOKEN)
 
         if self.fused_experts is None:
             # If no modular kernel is provided, use cutlass_moe_fp8
@@ -950,8 +948,8 @@ class CompressedTensorsW8A8Fp8MoECutlassMethod(CompressedTensorsMoEMethod):
                 expert_map=None if self.disable_expert_map else expert_map,
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
-                a1_scale=a1_scale,
-                a2_scale=a2_scale,
+                a1_scale=layer.w13_input_scale,
+                a2_scale=layer.w2_input_scale,
             )
         else:
             return self.fused_experts(


### PR DESCRIPTION
## Purpose

Both scout and maverick set activation quantization to be dynamic per token. But before this PR, `per_act_token` is set to dynamic per tensor.

This PR corrects the `per_act_token` setting, to be the same as set in `CompressedTensorsW8A8Fp8MoECutlassM::set_gemm_impl`.

## Test Plan

performance is slightly better after the change, verified with maverick:

```
vllm serve meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --max_model_len 8192 --kv_cache_dtype fp8 --enable-expert-parallel --tensor-parallel-size 8 --trust-remote-code --gpu-memory-utilization 0.8 --disable-log-requests 2>&1

python benchmarks/benchmark_serving.py  --model meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --port 8000  --dataset-name random  --ignore-eos  --num-prompts 513  --request-rate inf  --random-input-len 4096  --random-output-len 128 --max-concurrency 64
```

lm-eval

## Test Result

### performance

```
============ Serving Benchmark Result ============
Successful requests:                     513
Benchmark duration (s):                  65.13
Total input tokens:                      2099540
Total generated tokens:                  65664
Request throughput (req/s):              7.88
Output token throughput (tok/s):         1008.24
Total Token throughput (tok/s):          33245.63
---------------Time to First Token----------------
Mean TTFT (ms):                          823.27
Median TTFT (ms):                        542.43
P99 TTFT (ms):                           5784.35
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          56.21
Median TPOT (ms):                        58.26
P99 TPOT (ms):                           60.96
---------------Inter-token Latency----------------
Mean ITL (ms):                           56.21
Median ITL (ms):                         20.45
P99 ITL (ms):                            183.15
==================================================
```

vs. before this PR

```
============ Serving Benchmark Result ============
Successful requests:                     513
Benchmark duration (s):                  66.99
Total input tokens:                      2099540
Total generated tokens:                  65664
Request throughput (req/s):              7.66
Output token throughput (tok/s):         980.26
Total Token throughput (tok/s):          32323.22
---------------Time to First Token----------------
Mean TTFT (ms):                          837.14
Median TTFT (ms):                        557.77
P99 TTFT (ms):                           6027.90
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          57.90
Median TPOT (ms):                        59.76
P99 TPOT (ms):                           63.34
---------------Inter-token Latency----------------
Mean ITL (ms):                           57.90
Median ITL (ms):                         20.88
P99 ITL (ms):                            188.92
==================================================
```

### evaluation
```
lm_eval --model local-chat-completions --model_args model=meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=32 --tasks gsm8k --num_fewshot 5 --limit 200 --fewshot_as_multiturn --apply_chat_template
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.950|±  |0.0154|
|     |       |strict-match    |     5|exact_match|↑  |0.935|±  |0.0175|

vs. before this PR:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.925|±  |0.0187|
|     |       |strict-match    |     5|exact_match|↑  |0.910|±  |0.0203|

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
