### PR TITLE
[cold start] replace VLLM_COMPILE_DEPYF with debug_dump_dir

### DIFF
--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -93,27 +93,19 @@ class TorchCompileWrapperWithCustomDispatcher:
             return
 
         self.compiled_codes.append(new_code)
-        local_cache_dir = self.vllm_config.compilation_config.local_cache_dir
-        if isinstance(local_cache_dir, str):
-            decompiled_file_name = ("transformed_code.py"
-                                    if envs.VLLM_COMPILE_DEPYF else
-                                    "transformed_code_README.txt")
-
-            decompiled_file = os.path.join(local_cache_dir,
-                                           decompiled_file_name)
+        debug_dump_dir = self.vllm_config.compilation_config.debug_dump_path
+        if isinstance(debug_dump_dir, str) and debug_dump_dir != "":
+            decompiled_file = os.path.join(debug_dump_dir,
+                                           "transformed_code.py")
+            print(f"decompiled_file:{decompiled_file}")
             if not os.path.exists(decompiled_file):
                 try:
                     # usually the decompilation will succeed for most models,
                     # as we guarantee a full-graph compilation in Dynamo.
                     # but there's no 100% guarantee, since decompliation is
                     # not a reversible process.
-                    if envs.VLLM_COMPILE_DEPYF:
-                        import depyf
-                        src = depyf.decompile(new_code)
-                    else:
-                        src = (
-                            "To get a transformed_code.py file, re-run with "
-                            "VLLM_COMPILE_DEPYF=1")
+                    import depyf
+                    src = depyf.decompile(new_code)
 
                     with open(decompiled_file, "w") as f:
                         f.write(src)

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -97,7 +97,6 @@ class TorchCompileWrapperWithCustomDispatcher:
         if isinstance(debug_dump_dir, str) and debug_dump_dir != "":
             decompiled_file = os.path.join(debug_dump_dir,
                                            "transformed_code.py")
-            print(f"decompiled_file:{decompiled_file}")
             if not os.path.exists(decompiled_file):
                 try:
                     # usually the decompilation will succeed for most models,

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -95,7 +95,8 @@ class TorchCompileWrapperWithCustomDispatcher:
         self.compiled_codes.append(new_code)
         debug_dump_dir = self.vllm_config.compilation_config.debug_dump_path
         if isinstance(debug_dump_dir, str) and debug_dump_dir != "":
-            decompiled_file = os.path.join(debug_dump_dir,
+            rank = self.vllm_config.parallel_config.rank
+            decompiled_file = os.path.join(debug_dump_dir, f"rank_{rank}",
                                            "transformed_code.py")
             if not os.path.exists(decompiled_file):
                 try:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -97,7 +97,6 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
-    VLLM_COMPILE_DEPYF: bool = False
     Q_SCALE_CONSTANT: int = 200
     K_SCALE_CONSTANT: int = 200
     V_SCALE_CONSTANT: int = 100
@@ -741,11 +740,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
-
-    # If set, vllm will decompile the torch compiled code and dump to
-    # transformed_code.py. This is useful for debugging.
-    "VLLM_COMPILE_DEPYF":
-    lambda: bool(int(os.getenv("VLLM_COMPILE_DEPYF", "0"))),
 
     # If set, vllm will run in development mode, which will enable
     # some additional endpoints for developing and debugging,


### PR DESCRIPTION
Replace VLLM_COMPILE_DEPYF with debug_dump_dir to reduce # environment variables.

This PR also moves transformed_code.py from cache_dir to debug_dump_dir.

## Example
`vllm serve facebook/opt-125m` gives dir without `transformed_code.py`
<img width="183" height="65" alt="image" src="https://github.com/user-attachments/assets/7d04b922-250d-4d51-944a-28bbfdc7882b" />



`vllm serve facebook/opt-125m --compilation-config '{"debug_dump_path":"/home/boyuan/.cache/vllm/torch_compile_cache/debug_dump"}'` gives dir with `transformed_code.py`.

<img width="448" height="643" alt="image" src="https://github.com/user-attachments/assets/005d505a-75cb-4108-9548-99cc94257655" />



