### PR TITLE
Add Dockerfile argument for VLLM_USE_PRECOMPILED environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -207,6 +207,19 @@ ARG SCCACHE_ENDPOINT
 ARG SCCACHE_BUCKET_NAME=vllm-build-sccache
 ARG SCCACHE_REGION_NAME=us-west-2
 ARG SCCACHE_S3_NO_CREDENTIALS=0
+
+# Flag to control whether to use pre-built vLLM wheels
+ARG VLLM_USE_PRECOMPILED
+# TODO: in setup.py VLLM_USE_PRECOMPILED is sensitive to truthiness, it will take =0 as "true", this should be fixed
+ENV VLLM_USE_PRECOMPILED=""
+RUN if [ "${VLLM_USE_PRECOMPILED}" = "1" ]; then \
+        export VLLM_USE_PRECOMPILED=1 && \
+        echo "Using precompiled wheels"; \
+    else \
+        unset VLLM_USE_PRECOMPILED && \
+        echo "Leaving VLLM_USE_PRECOMPILED unset to build wheels from source"; \
+    fi
+
 # if USE_SCCACHE is set, use sccache to speed up compilation
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=.git,target=.git \


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [v] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [v] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [n/a] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This adds a build argument so that we can determine if we want to set VLLM_USE_PRECOMPILED in order to conditionally build the wheel during CI testing. Which could potentially save time during runs when the wheel doesn't need to be built.

## Test Plan

Should have no impact without implementation and uses a current default. Can be manually tested with:

```
docker build --build-arg VLLM_USE_PRECOMPILED=1 -t test .
```

## Test Result

(exit 0)

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
