### PR TITLE
Fix tool_calls to fit with openai client

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1566,7 +1566,7 @@ class ChatMessage(OpenAIBaseModel):
     annotations: Optional[OpenAIAnnotation] = None
     audio: Optional[OpenAIChatCompletionAudio] = None
     function_call: Optional[FunctionCall] = None
-    tool_calls: list[ToolCall] = Field(default_factory=list)
+    tool_calls: Optional[list[ToolCall]] = None
 
     # vLLM-specific fields that are not in OpenAI spec
     reasoning_content: Optional[str] = None
@@ -1620,7 +1620,7 @@ class DeltaMessage(OpenAIBaseModel):
     role: Optional[str] = None
     content: Optional[str] = None
     reasoning_content: Optional[str] = None
-    tool_calls: list[DeltaToolCall] = Field(default_factory=list)
+    tool_calls: Optional[list[DeltaToolCall]] = None
 
 
 class ChatCompletionResponseStreamChoice(OpenAIBaseModel):


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

To align with the agent and edit mode in the vscode copilot chat extension, link: https://github.com/relic-yuexi/vscode-copilot-chat/tree/feat-ui and the official openai-python code, link: https://github.com/openai/openai-python/blob/1c0b4642054544af92c0c3a8cdf5ef3c3f62f1d7/src/openai/types/chat/chat_completion_message.py#L78, this modification has been made. Special thanks to @zhuangqh for pointing out this issue, which he identified in issue https://github.com/microsoft/vscode/issues/255934

## Test Plan

```
# pip install openai>=1.0.0
from openai import OpenAI

client = OpenAI(

    api_key="",
  
    base_url=""
)

try:
    resp = client.chat.completions.create(
        model="",   
        messages=[
            {"role": "user", "content": "你好，请用一句话介绍你自己"}
        ],
        max_tokens=100,
        tools=tools
    )
    print(resp.choices[0].message.content)
except Exception as e:
    print("调用失败：", e)

print(resp.choices[0].message.tool_calls) # Must be None

tools=[
  {
    "type": "function",
    "function": {
      "name": "get_current_temperature",
      "description": "Get current temperature at a location.",
      "parameters": {
        "type": "object",
        "properties": {
          "location": {
            "type": "string",
            "description": "The location to get the temperature for, in the format \"City, State, Country\"."
          },
          "unit": {
            "type": "string",
            "enum": [
              "celsius",
              "fahrenheit"
            ],
            "description": "The unit to return the temperature in. Defaults to \"celsius\"."
          }
        },
        "required": [
          "location"
        ]
      }
    }
  },
  {
    "type": "function",
    "function": {
      "name": "get_temperature_date",
      "description": "Get temperature at a location and date.",
      "parameters": {
        "type": "object",
        "properties": {
          "location": {
            "type": "string",
            "description": "The location to get the temperature for, in the format \"City, State, Country\"."
          },
          "date": {
            "type": "string",
            "description": "The date to get the temperature for, in the format \"Year-Month-Day\"."
          },
          "unit": {
            "type": "string",
            "enum": [
              "celsius",
              "fahrenheit"
            ],
            "description": "The unit to return the temperature in. Defaults to \"celsius\"."
          }
        },
        "required": [
          "location",
          "date"
        ]
      }
    }
  }
]

messages = [ 
    {"role": "user",  "content": "What's the temperature in San Francisco now? How about tomorrow? Current Date: 2024-09-30."}
]

response = client.chat.completions.create(
    model="",
    messages=messages,
    tools=tools,
    temperature=0.7,
    top_p=0.8,
    max_tokens=512,
    extra_body={
        "repetition_penalty": 1.05,
        "chat_template_kwargs": {"enable_thinking": False}  # default to True
    },
)

print(response.choices[0].message.tool_calls) # must be a list like normal

```

## Test Result

<img width="677" height="146" alt="image" src="https://github.com/user-attachments/assets/27989f95-ed8f-48db-86ef-153d58dc86e3" />

<img width="657" height="153" alt="image" src="https://github.com/user-attachments/assets/6b2242fd-9353-4de7-8f54-a37aec015127" />

<img width="432" height="235" alt="image" src="https://github.com/user-attachments/assets/8a0de7b7-dda0-4d98-a420-1f69bafbce28" />


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
