### PR TITLE
Configure Gemini

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,4 +1,4 @@
-# Enables fun features such as a poem in the initial pull request summary.
+# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
 have_fun: false
 code_review:
   comment_severity_threshold: HIGH

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,6 @@
+# Enables fun features such as a poem in the initial pull request summary.
+have_fun: false
+code_review:
+  comment_severity_threshold: HIGH
+  pull_request_opened:
+    summary: false

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
-have_fun: false
+have_fun: false  # Just review the code
 code_review:
-  comment_severity_threshold: HIGH
+  comment_severity_threshold: HIGH  # Reduce quantity of comments
   pull_request_opened:
-    summary: false
+    summary: false  # Don't summarize the PR in a separate comment


### PR DESCRIPTION
- Disables `have_fun` to stop unnecessary verbosity in comments.
- Increase comment threshold to `HIGH` to reduce the number of comments.
- Disable the PR summary so that developers/reviewers don't get 2 notifications from Gemini per PR (one from the summary, one from the review), the developer should already have explained what their PR does.