### PR TITLE
fix: Handle unsupported message fields in tool calling

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -158,8 +158,9 @@ def make_mistral_chat_completion_request(
     # [1]: https://github.com/mistralai/mistral-common/blob/f4a06998b75ed78bbf5aaf569590b772ea26c9f6/src/mistral_common/protocol/instruct/messages.py#L80
     for message in messages:
         # Remove reasoning_content as unsupported by Mistral
-        _ = message.pop("reasoning_content", None)  # type: ignore
-        _ = message.pop("name", None)  # type: ignore
+        # Remove fields unsupported by Mistral
+        for key in ("reasoning_content", "name"):
+            _ = message.pop(key, None)  # type: ignore
 
         # Convert list text content to string
         if message.get("role") in ("assistant", "tool"):

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -159,6 +159,7 @@ def make_mistral_chat_completion_request(
     for message in messages:
         # Remove reasoning_content as unsupported by Mistral
         _ = message.pop("reasoning_content", None)  # type: ignore
+        _ = message.pop("name", None)  # type: ignore
 
         # Convert list text content to string
         if message.get("role") in ("assistant", "tool"):


### PR DESCRIPTION
When using the --tokenizer-mode mistral option in vLLM, a ValidationError occurs if tool calling messages include unsupported fields such as name or reasoning_content. This is because, under mistral mode, vLLM ignores the Jinja-based chat_template and strictly adheres to Mistral’s native chat format.

This PR resolves the issue by explicitly removing the unsupported name and reasoning_content fields during message preprocessing in mistral.py.

🔍 Changes:
- Removed name key from each message before tokenization.
- Prevents 500 errors due to schema validation failures when using Tool Calling with Mistral.
- File: `vllm/transformers_utils/tokenizers/mistral.py`

This ensures tool calling is compatible with Mistral’s tokenizer mode.