### PR TITLE
[Chore] Remove outdated transformers check

### DIFF
--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -22,8 +22,8 @@ from typing import Literal, Optional, TypedDict, Union
 
 import torch
 from torch import nn
-from transformers import (AddedToken, BatchFeature, Idefics3Config,
-                          Idefics3ImageProcessor, Idefics3Processor)
+from transformers import (BatchFeature, Idefics3Config, Idefics3ImageProcessor,
+                          Idefics3Processor)
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.linear import ReplicatedLinear
@@ -199,21 +199,14 @@ class Idefics3ProcessingInfo(BaseProcessingInfo):
 
         return grid_w * grid_h + 1
 
-    # TODO: Remove after requiring transformers>=4.52
-    def _get_content(self, token: Union[AddedToken, str]) -> str:
-        if isinstance(token, str):
-            return token
-
-        return token.content
-
     def _get_image_token(
             self,
             processor: Optional[Idefics3Processor]) -> tuple[str, str, str]:
         if processor is None:
             processor = self.get_hf_processor()
 
-        image_token = self._get_content(processor.image_token)
-        fake_image_token = self._get_content(processor.fake_image_token)
+        image_token = processor.image_token
+        fake_image_token = processor.fake_image_token
         global_image_token = processor.global_image_tag
         return image_token, fake_image_token, global_image_token
 


### PR DESCRIPTION
## Purpose

Since `requirements/common.txt` is at transformers >= 4.53.2, we don't need this version check. Also there was an unused import that pre-commit caught.

<!--- pyml disable-next-line no-emphasis-as-heading -->
