### PR TITLE
[Frontend] Remove print left in FrontendArgs.add_cli_args

### DIFF
--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -192,7 +192,6 @@ schema. Example: `[{"type": "text", "text": "Hello world!"}]`"""
         # Special case: allowed_origins, allowed_methods, allowed_headers all
         # need json.loads type
         # Should also remove nargs
-        print(frontend_kwargs["allowed_origins"])
         frontend_kwargs["allowed_origins"]["type"] = json.loads
         frontend_kwargs["allowed_methods"]["type"] = json.loads
         frontend_kwargs["allowed_headers"]["type"] = json.loads


### PR DESCRIPTION
I suddenly started seeing these weird `{'default': ['*'], 'help': 'Allowed origins.', 'type': <class 'str'>, 'nargs': '+'}` logs on main.
```
vllm serve RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16 --load-format=dummy
INFO 07-15 12:45:46 [__init__.py:253] Automatically detected platform cuda.
{'default': ['*'], 'help': 'Allowed origins.', 'type': <class 'str'>, 'nargs': '+'}
INFO 07-15 12:45:48 [api_server.py:1637] vLLM API server version 0.9.2rc2.dev155+g5b6fe23d0
{'default': ['*'], 'help': 'Allowed origins.', 'type': <class 'str'>, 'nargs': '+'}
INFO 07-15 12:45:48 [cli_args.py:268] non-default args: {'model': 'RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16', 'load_format': 'dummy'}
...
```

It seems https://github.com/vllm-project/vllm/pull/20206 had left a `print` statement behind from debugging, so this PR removes it.

Now I see the expected:
```
vllm serve RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16 --load-format=dummy
INFO 07-15 13:38:10 [__init__.py:253] Automatically detected platform cuda.
INFO 07-15 13:38:12 [api_server.py:1637] vLLM API server version 0.9.2rc2.dev155+g5b6fe23d0
INFO 07-15 13:38:12 [cli_args.py:267] non-default args: {'model': 'RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16', 'load_format': 'dummy'}
```