### PR TITLE
[Meta] Unshift eagle prefill and support draft kv sharing from base

### DIFF
--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -15,6 +15,13 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
                  std::vector<torch::Tensor> const& value_caches,
                  const torch::Tensor& block_mapping);
 
+void copy_blocks_between_layers(
+    std::vector<torch::Tensor> const& src_key_caches,
+    std::vector<torch::Tensor> const& src_value_caches,
+    std::vector<torch::Tensor> const& dst_key_caches,
+    std::vector<torch::Tensor> const& dst_value_caches,
+    const torch::Tensor& block_mapping);
+
 void copy_blocks_mla(std::vector<torch::Tensor> const& kv_caches,
                      const torch::Tensor& block_mapping);
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -650,6 +650,15 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
       "copy_blocks_mla(Tensor(a!)[] kv_caches, Tensor block_mapping) -> ()");
   cache_ops.impl("copy_blocks_mla", torch::kCUDA, &copy_blocks_mla);
 
+  // Copy blocks between different caches
+  cache_ops.def(
+      "copy_blocks_between_layers(Tensor(a!)[] src_key_caches, Tensor(b!)[] "
+      "src_value_caches, "
+      "Tensor(c!)[] dst_key_caches, Tensor(d!)[] dst_value_caches, "
+      "Tensor block_mapping) -> ()");
+  cache_ops.impl("copy_blocks_between_layers", torch::kCUDA,
+                 &copy_blocks_between_layers);
+
   // Reshape the key and value tensors and cache them.
   cache_ops.def(
       "reshape_and_cache(Tensor key, Tensor value,"

--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -68,6 +68,12 @@ def parse_args():
     parser.add_argument("--model-dir", type=str, default=None)
     parser.add_argument("--eagle-dir", type=str, default=None)
     parser.add_argument("--custom-mm-prompts", action="store_true")
+    parser.add_argument(
+        "--no-prefill-token-shift",
+        dest="prefill_token_shift",
+        action="store_false",
+        help="Disable prefill token shift (default: enabled)",
+    )
     return parser.parse_args()
 
 
@@ -109,6 +115,7 @@ def main():
             "method": args.method,
             "model": eagle_dir,
             "num_speculative_tokens": args.num_spec_tokens,
+            "prefill_token_shift": args.prefill_token_shift,
         }
     elif args.method == "ngram":
         speculative_config = {

--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -74,9 +74,9 @@ def parse_args():
         action="store_false",
         help="Disable prefill token shift (default: enabled)",
     )
-    parser.add_argument("--target_kv_layer_copy_from", type=int, default=-1)
+    parser.add_argument("--target-kv-layer-copy-from", type=int, default=-1)
     parser.add_argument(
-        "--draft_kv_layer_copy_to",
+        "--draft-kv-layer-copy-to",
         type=str,
         default="",
         help="comma separated list of layer indices to copy to",

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -128,8 +128,10 @@ def test_ngram_correctness(
 @pytest.mark.parametrize(
     "model_setup, mm_enabled, prefill_shift",
     [
-        # TODO: Re-enable this once tests/models/test_initialization.py is fixed, see PR #22333 #22611
-        # (("eagle3", "Qwen/Qwen3-8B", "AngelSlim/Qwen3-8B_eagle3", 1), False, True),
+        # TODO: Re-enable this once tests/models/test_initialization.py is
+        # fixed, see PR #22333 #22611
+        # (("eagle3", "Qwen/Qwen3-8B", "AngelSlim/Qwen3-8B_eagle3", 1),
+        #  False, True),
         (
             ("eagle", "meta-llama/Llama-3.1-8B-Instruct",
              "yuhuili/EAGLE-LLaMA3.1-Instruct-8B", 1),
@@ -172,7 +174,8 @@ def test_ngram_correctness(
         ),
     ],
     ids=[
-        # TODO: Re-enable this once tests/models/test_initialization.py is fixed, see PR #22333 #22611
+        # TODO: Re-enable this once tests/models/test_initialization.py is
+        # fixed, see PR #22333 #22611
         # "qwen3_eagle3",
         "llama3_eagle",
         "llama3_eagle3",

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1632,6 +1632,28 @@ def copy_blocks_mla(kv_caches: list[torch.Tensor],
     torch.ops._C_cache_ops.copy_blocks_mla(kv_caches, block_mapping)
 
 
+def copy_blocks_between_layers(src_key_caches: list[torch.Tensor],
+                               src_value_caches: list[torch.Tensor],
+                               dst_key_caches: list[torch.Tensor],
+                               dst_value_caches: list[torch.Tensor],
+                               block_mapping: torch.Tensor) -> None:
+    """Copy blocks between different key-value caches across model layers.
+    
+    Args:
+        src_key_caches: List of source key cache tensors.
+        src_value_caches: List of source value cache tensors.
+        dst_key_caches: List of destination key cache tensors.
+        dst_value_caches: List of destination value cache tensors.
+        block_mapping: Tensor of shape (num_blocks, 2) containing pairs of
+            (src_block_idx, dst_block_idx) to copy.
+    """
+    torch.ops._C_cache_ops.copy_blocks_between_layers(src_key_caches,
+                                                      src_value_caches,
+                                                      dst_key_caches,
+                                                      dst_value_caches,
+                                                      block_mapping)
+
+
 def swap_blocks(src: torch.Tensor, dst: torch.Tensor,
                 block_mapping: torch.Tensor) -> None:
     torch.ops._C_cache_ops.swap_blocks(src, dst, block_mapping)

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1980,6 +1980,14 @@ class SpeculativeConfig:
         ParallelConfig] = None  # type: ignore
     """The parallel configuration for the draft model initialized internal."""
 
+    # Shift prefill tokens for draft, only used in eagle
+    prefill_token_shift: bool = True
+    """Shift tokens during draft prefill or not"""
+
+    # Config for kv sharing, map from base model layer to draft layer
+    kv_sharing_mapping: SkipValidation[dict[str, str]] = None
+    """KV copy mapping for prefill stage from base to draft"""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -2362,6 +2370,11 @@ class SpeculativeConfig:
 
     def use_eagle(self) -> bool:
         return self.method in ("eagle", "eagle3", "deepseek_mtp")
+
+    def eagle_shift_prefill_token(self) -> bool:
+        if self.use_eagle():
+            return self.prefill_token_shift
+        return False
 
     def __repr__(self) -> str:
         method = self.method

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1985,6 +1985,7 @@ class SpeculativeConfig:
     """Shift tokens during draft prefill or not"""
 
     # Config for kv sharing, map from base model layer to draft layer
+    # Key is draft layer, value is base layer
     kv_sharing_mapping: SkipValidation[dict[str, str]] = None
     """KV copy mapping for prefill stage from base to draft"""
 

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1986,7 +1986,7 @@ class SpeculativeConfig:
 
     # Config for kv sharing, map from base model layer to draft layer
     # Key is draft layer, value is base layer
-    kv_sharing_mapping: SkipValidation[dict[str, str]] = None
+    kv_sharing_mapping: SkipValidation[dict[str, str]] = None  # type: ignore
     """KV copy mapping for prefill stage from base to draft"""
 
     def compute_hash(self) -> str:

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -185,11 +185,6 @@ class Llama4Attention(nn.Module):
         is_gguf = quant_config and quant_config.get_name() == "gguf"
         if is_gguf and config.model_type == "llama":
             is_neox_style = False
-        elif config.model_type == "eagle":
-            # EAGLE draft model does not use neox style RoPE
-            is_neox_style = False
-        else:
-            is_neox_style = True
 
         self.rotary_emb = get_rope(
             self.head_dim,

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -185,6 +185,11 @@ class Llama4Attention(nn.Module):
         is_gguf = quant_config and quant_config.get_name() == "gguf"
         if is_gguf and config.model_type == "llama":
             is_neox_style = False
+        elif config.model_type == "eagle":
+            # EAGLE draft model does not use neox style RoPE
+            is_neox_style = False
+        else:
+            is_neox_style = True
 
         self.rotary_emb = get_rope(
             self.head_dim,
@@ -262,7 +267,6 @@ class Llama4DecoderLayer(nn.Module):
         super().__init__()
 
         self.layer_idx = extract_layer_index(prefix)
-        self.global_layer = config.no_rope_layers[self.layer_idx] == 0
         self.hidden_size = config.hidden_size
         rope_theta = config.rope_theta
         rope_scaling = config.rope_scaling

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -46,6 +46,10 @@ class CachedRequestState:
 
     lora_request: Optional[LoRARequest] = None
 
+    # Bootstrap eagle and MTP related hidden states
+    # support caching last hidden states for partial prefill
+    prefill_hidden_states: Optional[torch.Tensor] = None
+
     def __post_init__(self):
         self.num_prompt_tokens = len(self.prompt_token_ids)
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
+from vllm._custom_ops import copy_blocks_between_layers
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.config import ModelConfig, SchedulerConfig
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings


### PR DESCRIPTION
## Purpose
- Allow eagle prefill to execute without token shifting
- -  This solves issue of eagle MM with partial prefill and match the token prefix on base and draft
- -  On par acceptance is expected, with a dummy last token hidden state to bootstrap
- -  Some small latency increase occurred when prefill request is in the batch
- Support draft kv sharing from base for upcoming/or other models requiring that to boost acceptance
- Add kv copy kernel for between layers and unified with current one
## Test Plan
locally run MT_Bench with and w/o non-prefill-shift
Prefill shift
```
CUDA_VISIBLE_DEVICES=4,5,6,7 VLLM_USE_V1=1 python examples/offline_inference/spec_decode.py  --num_spec_tokens 7 --num_prompts 80 --method eagle  --model_dir /home/zhiweiz/local/models/scout_base_HF_20250605_201140 --eagle_dir /home/zhiweiz/local/models/scout_draft_HF_20250605_202942 --tp 4 --dataset-name hf --dataset-path philschmid/mt-bench
```

Non Shifting
```
CUDA_VISIBLE_DEVICES=4,5,6,7 VLLM_USE_V1=1 python examples/offline_inference/spec_decode.py  --num_spec_tokens 7 --num_prompts 80 --method eagle  --model_dir /home/zhiweiz/local/models/scout_base_HF_20250605_201140 --eagle_dir /home/zhiweiz/local/models/scout_draft_HF_20250605_202942 --tp 4 --dataset-name hf --dataset-path philschmid/mt-bench --no-prefill-token-shift
```

lm_eval on chartqa with and w/o non-prefill-shift

Prefill shift
```
CUDA_VISIBLE_DEVICES=4,5,6,7 lm_eval --model vllm-vlm --model_args '{"pretrained":"/home/zhiweiz/local/models/scout_base_HF_20250605_201140","max_model_len":32768,"gpu_memory_utilization":0.9,"speculative_config":{"method":"eagle","model":"/home/zhiweiz/local/models/scout_draft_HF_20250605_202942","num_speculative_tokens":3,"draft_tensor_parallel_size":4,"max_model_len":32768,"prefill_token_shift":true},"num_lookahead_slots":3,"max_num_batched_tokens":16384,"tensor_parallel_size":4}' --tasks chartqa --batch_size 32 --apply_chat_template
```
non-prefill-shift
```
CUDA_VISIBLE_DEVICES=4,5,6,7 lm_eval --model vllm-vlm --model_args '{"pretrained":"/home/zhiweiz/local/models/scout_base_HF_20250605_201140","max_model_len":32768,"gpu_memory_utilization":0.9,"speculative_config":{"method":"eagle","model":"/home/zhiweiz/local/models/scout_draft_HF_20250605_202942","num_speculative_tokens":3,"draft_tensor_parallel_size":4,"max_model_len":32768,"prefill_token_shift":false},"num_lookahead_slots":3,"max_num_batched_tokens":16384,"tensor_parallel_size":4}' --tasks chartqa --batch_size 32 --apply_chat_template
```

Showcasing:
Run MT_Bench with kv sharing, flags might subject to change based on review: 
```
VLLM_DECODE_ONLY_ATTN=1 CUDA_VISIBLE_DEVICES=4,5,6,7 VLLM_USE_V1=1 python examples/offline_inference/spec_decode.py  --num_spec_tokens 3 --num_prompts 80 --method eagle  --model_dir /home/zhiweiz/local/models/scout_base_HF_20250605_201140 --eagle_dir /home/zhiweiz/local/models/scout_draft_HF_20250605_202942 --tp 4 --dataset-name hf --dataset-path philschmid/mt-bench  --target_kv_layer_copy_from 47 --draft_kv_layer_copy_to 48,49,50 --no-prefill-token-shift
```

Benchmark Serving
server script, toggle with prefill_token_shift
```
#!/bin/bash
# Configuration of environment variables
export VLLM_USE_MODELSCOPE=False
export VLLM_TORCH_PROFILER_DIR=~/vllm_profile
export CUDA_VISIBLE_DEVICES=4,5,6,7
export VLLM_USE_V1=1
export SAFETENSORS_FAST_GPU=1
# Command to run the vllm server
spec_dec_config='{"method": "eagle", "model": "/home/zhiweiz/local/models/scout_draft_HF_20250605_202942", "prefill_token_shift": false, "num_speculative_tokens": 3, "draft_tensor_parallel_size": 4, "max_model_len": 32768}'
vllm serve /home/zhiweiz/local/models/scout_base_HF_20250605_201140 --disable-log-requests \
    -tp 4 \
    --max-num-seqs 128 \
    --max_num_batched_tokens=80000 \
    --max-model-len=32768 \
    --no-enable-prefix-caching \
    --trust-remote-code \
    --speculative-config="$spec_dec_config" \
    --num-lookahead-slots=3 \
    2>&1 | tee /data/users/$USER/logs/server/vllm_17b16e_vllm_serving$(date +%Y%m%d_%H%M%S).log
```

Benchmark script
```
python benchmarks/benchmark_serving.py --backend vllm --model /home/zhiweiz/local/models/scout_base_HF_20250605_201140 --dataset-name hf --dataset-path philschmid/mt-bench --seed 0 --max-concurrency 16 2>&1 | tee /data/users/$USER/tmp/vllm_17b16e_vllm_loadgen$(date +%Y%m%d_%H%M%S).log\n
```


## Test Result
MM chartqa with partial prefill and prefill shifting
```
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]   File "/home/zhiweiz/vllm-public/vllm/v1/worker/gpu_model_runner.py", line 1760, in execute_model
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]     spec_token_ids = self.propose_draft_token_ids(
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]   File "/home/zhiweiz/vllm-public/vllm/v1/worker/gpu_model_runner.py", line 1867, in propose_draft_token_ids
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]     draft_mm_embeds = self._gather_mm_embeddings(
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]   File "/home/zhiweiz/vllm-public/vllm/v1/worker/gpu_model_runner.py", line 1251, in _gather_mm_embeddings
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]     assert req_id in self.encoder_cache
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=0 pid=2466009) ERROR 07-31 14:47:17 [multiproc_executor.py:594] AssertionError
```

MM chartqa with partial prefill and non-prefill-shifting
Passed with the following
```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value |   |Stderr|
|-------|------:|------|-----:|-----------------|---|-----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  |0.8848|±  |0.0064|
|       |       |none  |     0|exact_match      |↑  |0.6576|±  |0.0095|
|       |       |none  |     0|relaxed_accuracy |↑  |0.8932|±  |0.0062|
```

MT_Bench non-prefill-shift

```
--------------------------------------------------
total_num_output_tokens: 17631
num_drafts: 5116
num_draft_tokens: 35812
num_accepted_tokens: 12545
mean acceptance length: 3.45
--------------------------------------------------
acceptance at token 0: 0.77
acceptance at token 1: 0.55
acceptance at token 2: 0.39
acceptance at token 3: 0.27
acceptance at token 4: 0.20
acceptance at token 5: 0.15
acceptance at token 6: 0.11
```

MT_Bench prefill-shift
```
total_num_output_tokens: 17759
num_drafts: 5221
num_draft_tokens: 36547
num_accepted_tokens: 12577
mean acceptance length: 3.41
--------------------------------------------------
acceptance at token 0: 0.77
acceptance at token 1: 0.55
acceptance at token 2: 0.38
acceptance at token 3: 0.27
acceptance at token 4: 0.20
acceptance at token 5: 0.14
acceptance at token 6: 0.11
```

Baseline benchmarking (prefill shifting)
```
============ Serving Benchmark Result ============
Successful requests:                     1000
Maximum request concurrency:             16
Benchmark duration (s):                  200.36
Total input tokens:                      77841
Total generated tokens:                  219778
Request throughput (req/s):              4.99
Output token throughput (tok/s):         1096.93
Total Token throughput (tok/s):          1485.44
---------------Time to First Token----------------
Mean TTFT (ms):                          90.44
Median TTFT (ms):                        85.27
P99 TTFT (ms):                           206.29
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.07
Median TPOT (ms):                        14.06
P99 TPOT (ms):                           19.59
---------------Inter-token Latency----------------
Mean ITL (ms):                           39.08
Median ITL (ms):                         37.52
P99 ITL (ms):                            62.61
```


Non-shifting prefill
```
============ Serving Benchmark Result ============
Successful requests:                     1000
Maximum request concurrency:             16
Benchmark duration (s):                  203.83
Total input tokens:                      77841
Total generated tokens:                  219334
Request throughput (req/s):              4.91
Output token throughput (tok/s):         1076.04
Total Token throughput (tok/s):          1457.92
---------------Time to First Token----------------
Mean TTFT (ms):                          93.55
Median TTFT (ms):                        85.97
P99 TTFT (ms):                           393.62
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.36
Median TPOT (ms):                        14.26
P99 TPOT (ms):                           20.59
---------------Inter-token Latency----------------
Mean ITL (ms):                           39.83
Median ITL (ms):                         37.83
P99 ITL (ms):                            63.15
```

KV copy show casing
```
total_num_output_tokens: 17699
num_drafts: 7494
num_draft_tokens: 22482
num_accepted_tokens: 10207
mean acceptance length: 2.36
--------------------------------------------------
acceptance at token 0: 0.69
acceptance at token 1: 0.42
acceptance at token 2: 0.25
```
Note this is for special model designs, training free would have very small AL drop