### PR TITLE
[XPU] Enable external_launcher to serve as an executor via torchrun

### DIFF
--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -7,6 +7,7 @@ import torch.distributed
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
+from vllm.distributed import get_world_group
 from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
@@ -155,7 +156,8 @@ class XPUWorker(Worker):
                                             current_platform.dist_backend)
 
         # global all_reduce needed for overall oneccl warm up
-        torch.distributed.all_reduce(torch.zeros(1).xpu())
+        torch.distributed.all_reduce(torch.zeros(1).xpu(),
+                                     group=get_world_group().device_group)
 
         # Set random seed.
         set_random_seed(self.model_config.seed)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
torchrun pre-initializes the distributed environment, binding the default group to the Gloo backend, will cause the all_reduce with xpu tensor won't work. fix by specifying the group as the device group referred to by get_world_group
## Test Plan
export VLLM_WORKER_MULTIPROC_METHOD=spawn
cd tests/
torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
