### PR TITLE
[XPU] Conditionally import CUDA-specific passes to avoid import errors on xpu platform

### DIFF
--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -7,7 +7,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
-if current_platform.is_cuda():
+if current_platform.is_cuda_alike():
     from .fusion import FusionPass
     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
     from .fusion_attn import AttnFusionPass

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -5,12 +5,15 @@ from torch import fx as fx
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+if current_platform.is_cuda():
+    from .fusion import FusionPass
+    from .collective_fusion import AllReduceFusionPass, AsyncTPPass
+    from .fusion_attn import AttnFusionPass
 
 from .activation_quant_fusion import ActivationQuantFusionPass
-from .collective_fusion import AllReduceFusionPass, AsyncTPPass
 from .fix_functionalization import FixFunctionalizationPass
-from .fusion import FusionPass
-from .fusion_attn import AttnFusionPass
 from .inductor_pass import CustomGraphPass, InductorPass, get_pass_context
 from .noop_elimination import NoOpEliminationPass
 from .sequence_parallelism import SequenceParallelismPass


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
When running draft models on XPUs, fusion and collective fusion passes are imported, but currently only CUDA operators are adapted. so when running on XPU devices, import errors occur due to these CUDA operators.

rootcause is here :  https://github.com/vllm-project/vllm/blob/9fb52e523abf7bdaf7e60cf2971edb5a1b13dc08/vllm/v1/spec_decode/eagle.py#L326

we need to avoid cuda operator import code to impact xpu platform
## Test Plan
pytest -v tests/v1/e2e/test_spec_decode.py 
## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
