### PR TITLE
Add test case for compiling multiple graphs

### DIFF
--- a/tests/compile/piecewise/test_multiple_graphs.py
+++ b/tests/compile/piecewise/test_multiple_graphs.py
@@ -10,7 +10,8 @@ from torch.library import Library
 
 from vllm.compilation.backends import set_model_tag
 from vllm.compilation.counter import compilation_counter
-from vllm.compilation.decorators import ignore_torch_compile, support_torch_compile
+from vllm.compilation.decorators import (ignore_torch_compile,
+                                         support_torch_compile)
 from vllm.config import (CompilationConfig, CompilationLevel, VllmConfig,
                          set_current_vllm_config)
 from vllm.envs import VLLM_USE_V1
@@ -46,33 +47,37 @@ direct_register_custom_op(
     target_lib=silly_lib,
 )
 
+
 @support_torch_compile
 class ParentModel(nn.Module):
+
     def __init__(self,
                  *,
                  vllm_config: VllmConfig,
                  prefix: str = '',
                  **kwargs) -> None:
         super().__init__()
-    
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x
 
 
 class Attention(nn.Module):
+
     def __init__(self, mlp_size: int, hidden_size: int) -> None:
         super().__init__()
         self.pre_attn = nn.Linear(mlp_size, hidden_size, bias=False)
         self.post_attn = nn.Linear(hidden_size, mlp_size, bias=False)
 
-        nn.init.xavier_normal_(self.pre_attn.weight.data,
-                            generator=torch.Generator().manual_seed(
-                                RANDOM_SEED),
-                            gain=0.001)
-        nn.init.xavier_normal_(self.post_attn.weight.data,
-                            generator=torch.Generator().manual_seed(
-                                RANDOM_SEED),
-                            gain=0.001)
+        # Initialize to same weights for testing
+        nn.init.xavier_normal_(
+            self.pre_attn.weight.data,
+            generator=torch.Generator().manual_seed(RANDOM_SEED),
+            gain=0.001)
+        nn.init.xavier_normal_(
+            self.post_attn.weight.data,
+            generator=torch.Generator().manual_seed(RANDOM_SEED),
+            gain=0.001)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.pre_attn(x)
@@ -82,35 +87,41 @@ class Attention(nn.Module):
         x = self.post_attn(x)
         return x
 
+
 @support_torch_compile
 class CompiledAttention(nn.Module):
+
     def __init__(self,
-                *,
-                mlp_size: int,
-                hidden_size: int,
-                vllm_config: VllmConfig,
-                prefix: str = '',
-                **kwargs) -> None:
+                 *,
+                 mlp_size: int,
+                 hidden_size: int,
+                 vllm_config: VllmConfig,
+                 prefix: str = '',
+                 **kwargs) -> None:
         super().__init__()
         self.attn = Attention(mlp_size, hidden_size)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.attn(x)
 
+
 @support_torch_compile
 class CompiledAttentionTwo(CompiledAttention):
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.attn(x) + x
 
+
 @ignore_torch_compile
 class SimpleModel(ParentModel):
+
     def __init__(self,
-                *,
-                mlp_size: int,
-                hidden_size: int,
-                vllm_config: VllmConfig,
-                prefix: str = '',
-                **kwargs) -> None:
+                 *,
+                 mlp_size: int,
+                 hidden_size: int,
+                 vllm_config: VllmConfig,
+                 prefix: str = '',
+                 **kwargs) -> None:
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         self.attn_one = Attention(mlp_size, hidden_size)
         self.attn_two = Attention(mlp_size, hidden_size)
@@ -120,19 +131,21 @@ class SimpleModel(ParentModel):
         x = self.attn_two(x) + x
         return x
 
+
 @ignore_torch_compile
 class SimpleModelWithTwoGraphs(ParentModel):
+
     def __init__(self,
-                *,
-                mlp_size: int,
-                hidden_size: int,
-                vllm_config: VllmConfig,
-                prefix: str = '',
-                **kwargs) -> None:
+                 *,
+                 mlp_size: int,
+                 hidden_size: int,
+                 vllm_config: VllmConfig,
+                 prefix: str = '',
+                 **kwargs) -> None:
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         # Test will fail without `set_model_tag`` here with error:
         # "ValueError: too many values to unpack (expected 3)"
-        # This is because CompiledAttention and CompiledAttentionTwo 
+        # This is because CompiledAttention and CompiledAttentionTwo
         # have different implmentations but the same torch.compile
         # cache dir will be used by default
         with set_model_tag("attn_one"):
@@ -149,9 +162,9 @@ class SimpleModelWithTwoGraphs(ParentModel):
                 vllm_config=vllm_config,
                 prefix=f"{prefix}.attn_two",
             )
-        
+
         self.hidden_states = torch.zeros((BATCH_SIZE, MLP_SIZE)).cuda()
-    
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         bsz = x.shape[0]
         # CUDAGraph expects same tensor addresses for each run
@@ -166,29 +179,25 @@ def test_ignore_torch_compile_decorator():
     assert VLLM_USE_V1
 
     # piecewise
-    vllm_config = VllmConfig(
-        compilation_config=CompilationConfig(
-            level=CompilationLevel.PIECEWISE,
-            use_cudagraph=True,
-            splitting_ops=["silly.attention"],
-            cudagraph_capture_sizes=[1, 2],
-        )
-    )
+    vllm_config = VllmConfig(compilation_config=CompilationConfig(
+        level=CompilationLevel.PIECEWISE,
+        use_cudagraph=True,
+        splitting_ops=["silly.attention"],
+        cudagraph_capture_sizes=[1, 2],
+    ))
 
     with set_current_vllm_config(vllm_config):
-        model = SimpleModel(
-            mlp_size=MLP_SIZE,
-            hidden_size=HIDDEN_SIZE,
-            vllm_config=vllm_config, 
-            prefix=''
-        ).eval().cuda()
+        model = SimpleModel(mlp_size=MLP_SIZE,
+                            hidden_size=HIDDEN_SIZE,
+                            vllm_config=vllm_config,
+                            prefix='').eval().cuda()
 
     with compilation_counter.expect(
-        num_graphs_seen=0,
-        num_piecewise_graphs_seen=0,
-        num_piecewise_capturable_graphs_seen=0,
-        num_backend_compilations=0,
-        num_cudagraph_captured=0,
+            num_graphs_seen=0,
+            num_piecewise_graphs_seen=0,
+            num_piecewise_capturable_graphs_seen=0,
+            num_backend_compilations=0,
+            num_cudagraph_captured=0,
     ), set_forward_context({}, vllm_config=vllm_config):
         # first run is for compile
         model(torch.randn(BATCH_SIZE, MLP_SIZE).cuda())
@@ -196,7 +205,7 @@ def test_ignore_torch_compile_decorator():
         # run cudagraph captured sizes
         model(torch.randn(2, MLP_SIZE).cuda())
         model(torch.randn(1, MLP_SIZE).cuda())
-    
+
 
 @torch.inference_mode
 def run_model(vllm_config, model: nn.Module):
@@ -218,65 +227,57 @@ def run_model(vllm_config, model: nn.Module):
         output = output.cpu()
         return output.cpu()
 
+
 def test_multi_graph_piecewise_compile(monkeypatch):
     assert VLLM_USE_V1
 
     monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-    
+
     outputs = []
 
     # piecewise compile
-    vllm_config = VllmConfig(
-        compilation_config=CompilationConfig(
-            level=CompilationLevel.PIECEWISE,
-            use_cudagraph=True,
-            splitting_ops=["silly.attention"],
-            cudagraph_capture_sizes=[1, 2],
-        )
-    )
+    vllm_config = VllmConfig(compilation_config=CompilationConfig(
+        level=CompilationLevel.PIECEWISE,
+        use_cudagraph=True,
+        splitting_ops=["silly.attention"],
+        cudagraph_capture_sizes=[1, 2],
+    ))
 
     with set_current_vllm_config(vllm_config):
-        model = SimpleModelWithTwoGraphs(
-            mlp_size=MLP_SIZE,
-            hidden_size=HIDDEN_SIZE,
-            vllm_config=vllm_config, 
-            prefix=''
-        ).eval().cuda()
+        model = SimpleModelWithTwoGraphs(mlp_size=MLP_SIZE,
+                                         hidden_size=HIDDEN_SIZE,
+                                         vllm_config=vllm_config,
+                                         prefix='').eval().cuda()
 
     with compilation_counter.expect(
-        num_graphs_seen=2,  # two graphs for the model
-        num_piecewise_graphs_seen=6,
-        # attn_one, attn_two each has 3 piecewise graphs 
-        # (pre_attn, post_attn, silly_attention) each
-        num_piecewise_capturable_graphs_seen=4, 
-        # attn_one, attn_two has pre_attn and post_attn each, total=4
-        num_backend_compilations=4, # num_piecewise_capturable_graphs_seen
-        num_cudagraph_captured=8, 
-        # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
+            num_graphs_seen=2,  # two graphs for the model
+            num_piecewise_graphs_seen=6,
+            # attn_one, attn_two each has 3 piecewise graphs
+            # (pre_attn, post_attn, silly_attention) each
+            num_piecewise_capturable_graphs_seen=4,
+            # attn_one, attn_two has pre_attn and post_attn each, total=4
+            num_backend_compilations=4,  # num_piecewise_capturable_graphs_seen
+            num_cudagraph_captured=8,
+            # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
     ):
         outputs.append(run_model(vllm_config, model))
 
     # no compile or cudagraph
-    vllm_config = VllmConfig(
-        compilation_config=CompilationConfig(
-            level=CompilationLevel.NO_COMPILATION,
-        )
-    )
+    vllm_config = VllmConfig(compilation_config=CompilationConfig(
+        level=CompilationLevel.NO_COMPILATION, ))
 
     with set_current_vllm_config(vllm_config):
-        model = SimpleModelWithTwoGraphs(
-            mlp_size=MLP_SIZE,
-            hidden_size=HIDDEN_SIZE,
-            vllm_config=vllm_config, 
-            prefix=''
-        ).eval().cuda()
+        model = SimpleModelWithTwoGraphs(mlp_size=MLP_SIZE,
+                                         hidden_size=HIDDEN_SIZE,
+                                         vllm_config=vllm_config,
+                                         prefix='').eval().cuda()
 
     with compilation_counter.expect(
-        num_graphs_seen=0,
-        num_piecewise_graphs_seen=0,
-        num_piecewise_capturable_graphs_seen=0,
-        num_backend_compilations=0,
-        num_cudagraph_captured=0,
+            num_graphs_seen=0,
+            num_piecewise_graphs_seen=0,
+            num_piecewise_capturable_graphs_seen=0,
+            num_backend_compilations=0,
+            num_cudagraph_captured=0,
     ):
         outputs.append(run_model(vllm_config, model))
 

--- a/tests/compile/piecewise/test_multiple_graphs.py
+++ b/tests/compile/piecewise/test_multiple_graphs.py
@@ -123,11 +123,11 @@ class SimpleModelWithTwoGraphs(ParentModel):
                  prefix: str = '',
                  **kwargs) -> None:
         super().__init__(vllm_config=vllm_config, prefix=prefix)
-        # Test will fail without `set_model_tag`` here with error:
+        # Test will fail without set_model_tag here with error:
         # "ValueError: too many values to unpack (expected 3)"
         # This is because CompiledAttention and CompiledAttentionTwo
         # have different implmentations but the same torch.compile
-        # cache dir will be used by default
+        # cache dir will be used as default prefix is 'model_tag'
         with set_model_tag("attn_one"):
             self.attn_one = CompiledAttention(
                 mlp_size=mlp_size,

--- a/tests/compile/piecewise/test_multiple_graphs.py
+++ b/tests/compile/piecewise/test_multiple_graphs.py
@@ -155,10 +155,8 @@ class SimpleModelWithTwoGraphs(ParentModel):
         return x
 
 
-def test_ignore_torch_compile_decorator(monkeypatch):
+def test_ignore_torch_compile_decorator():
     assert VLLM_USE_V1
-
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
 
     # piecewise
     vllm_config = VllmConfig(compilation_config=CompilationConfig(
@@ -260,10 +258,8 @@ def run_model(vllm_config, model: nn.Module, inputs: torch.Tensor):
         return output.cpu()
 
 
-def test_multi_graph_piecewise_compile(monkeypatch):
+def test_multi_graph_piecewise_compile():
     assert VLLM_USE_V1
-
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
 
     outputs = []
 

--- a/tests/compile/piecewise/test_multiple_graphs.py
+++ b/tests/compile/piecewise/test_multiple_graphs.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Test (piecewise) compilation with a simple model where multiple submodules
+are compiled and graph captured separately.
+"""
+import torch
+from torch import nn
+from torch.library import Library
+
+from vllm.compilation.backends import set_model_tag
+from vllm.compilation.counter import compilation_counter
+from vllm.compilation.decorators import ignore_torch_compile, support_torch_compile
+from vllm.config import (CompilationConfig, CompilationLevel, VllmConfig,
+                         set_current_vllm_config)
+from vllm.envs import VLLM_USE_V1
+from vllm.forward_context import set_forward_context
+from vllm.utils import direct_register_custom_op
+
+# create a library to hold the custom op
+silly_lib = Library("silly", "FRAGMENT")  # noqa
+
+BATCH_SIZE = 32
+MLP_SIZE = 128
+HIDDEN_SIZE = 1024
+RANDOM_SEED = 0
+
+
+def silly_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                    out: torch.Tensor) -> None:
+    out.copy_(q)
+    out += k
+    out += v
+
+
+def silly_attention_fake(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                         out: torch.Tensor) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="attention",
+    op_func=silly_attention,
+    mutates_args=["out"],
+    fake_impl=silly_attention_fake,
+    target_lib=silly_lib,
+)
+
+@support_torch_compile
+class ParentModel(nn.Module):
+    def __init__(self,
+                 *,
+                 vllm_config: VllmConfig,
+                 prefix: str = '',
+                 **kwargs) -> None:
+        super().__init__()
+    
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+class Attention(nn.Module):
+    def __init__(self, mlp_size: int, hidden_size: int) -> None:
+        super().__init__()
+        self.pre_attn = nn.Linear(mlp_size, hidden_size, bias=False)
+        self.post_attn = nn.Linear(hidden_size, mlp_size, bias=False)
+
+        nn.init.xavier_normal_(self.pre_attn.weight.data,
+                            generator=torch.Generator().manual_seed(
+                                RANDOM_SEED),
+                            gain=0.001)
+        nn.init.xavier_normal_(self.post_attn.weight.data,
+                            generator=torch.Generator().manual_seed(
+                                RANDOM_SEED),
+                            gain=0.001)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pre_attn(x)
+        attn_output = torch.empty_like(x)
+        torch.ops.silly.attention(x, x, x, attn_output)
+        x = attn_output
+        x = self.post_attn(x)
+        return x
+
+@support_torch_compile
+class CompiledAttention(nn.Module):
+    def __init__(self,
+                *,
+                mlp_size: int,
+                hidden_size: int,
+                vllm_config: VllmConfig,
+                prefix: str = '',
+                **kwargs) -> None:
+        super().__init__()
+        self.attn = Attention(mlp_size, hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.attn(x)
+
+@support_torch_compile
+class CompiledAttentionTwo(CompiledAttention):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.attn(x) + x
+
+@ignore_torch_compile
+class SimpleModel(ParentModel):
+    def __init__(self,
+                *,
+                mlp_size: int,
+                hidden_size: int,
+                vllm_config: VllmConfig,
+                prefix: str = '',
+                **kwargs) -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        self.attn_one = Attention(mlp_size, hidden_size)
+        self.attn_two = Attention(mlp_size, hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.attn_one(x)
+        x = self.attn_two(x) + x
+        return x
+
+@ignore_torch_compile
+class SimpleModelWithTwoGraphs(ParentModel):
+    def __init__(self,
+                *,
+                mlp_size: int,
+                hidden_size: int,
+                vllm_config: VllmConfig,
+                prefix: str = '',
+                **kwargs) -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        # Test will fail without `set_model_tag`` here with error:
+        # "ValueError: too many values to unpack (expected 3)"
+        # This is because CompiledAttention and CompiledAttentionTwo 
+        # have different implmentations but the same torch.compile
+        # cache dir will be used by default
+        with set_model_tag("attn_one"):
+            self.attn_one = CompiledAttention(
+                mlp_size=mlp_size,
+                hidden_size=hidden_size,
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.attn_one",
+            )
+        with set_model_tag("attn_two"):
+            self.attn_two = CompiledAttentionTwo(
+                mlp_size=mlp_size,
+                hidden_size=hidden_size,
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.attn_two",
+            )
+        
+        self.hidden_states = torch.zeros((BATCH_SIZE, MLP_SIZE)).cuda()
+    
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        bsz = x.shape[0]
+        # CUDAGraph expects same tensor addresses for each run
+        self.hidden_states[:bsz].copy_(x)
+        x = self.attn_one(self.hidden_states[:bsz])
+        self.hidden_states[:bsz].copy_(x)
+        x = self.attn_two(self.hidden_states[:bsz])
+        return x
+
+
+def test_ignore_torch_compile_decorator():
+    assert VLLM_USE_V1
+
+    # piecewise
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            level=CompilationLevel.PIECEWISE,
+            use_cudagraph=True,
+            splitting_ops=["silly.attention"],
+            cudagraph_capture_sizes=[1, 2],
+        )
+    )
+
+    with set_current_vllm_config(vllm_config):
+        model = SimpleModel(
+            mlp_size=MLP_SIZE,
+            hidden_size=HIDDEN_SIZE,
+            vllm_config=vllm_config, 
+            prefix=''
+        ).eval().cuda()
+
+    with compilation_counter.expect(
+        num_graphs_seen=0,
+        num_piecewise_graphs_seen=0,
+        num_piecewise_capturable_graphs_seen=0,
+        num_backend_compilations=0,
+        num_cudagraph_captured=0,
+    ), set_forward_context({}, vllm_config=vllm_config):
+        # first run is for compile
+        model(torch.randn(BATCH_SIZE, MLP_SIZE).cuda())
+
+        # run cudagraph captured sizes
+        model(torch.randn(2, MLP_SIZE).cuda())
+        model(torch.randn(1, MLP_SIZE).cuda())
+    
+
+@torch.inference_mode
+def run_model(vllm_config, model: nn.Module):
+    with set_forward_context({}, vllm_config=vllm_config):
+        # Pre-allocate memory for CUDAGraph which expects
+        # static tensor addresses
+        inputs = torch.randn(BATCH_SIZE, MLP_SIZE).cuda()
+
+        # First run is for compile
+        model(inputs)
+
+        # Run CUDAGraph captured sizes
+        model(inputs[:2])
+        model(inputs[:1])
+
+        inputs[:2].fill_(1.0)
+        output = model(inputs[:2])
+
+        output = output.cpu()
+        return output.cpu()
+
+def test_multi_graph_piecewise_compile(monkeypatch):
+    assert VLLM_USE_V1
+
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    
+    outputs = []
+
+    # piecewise compile
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            level=CompilationLevel.PIECEWISE,
+            use_cudagraph=True,
+            splitting_ops=["silly.attention"],
+            cudagraph_capture_sizes=[1, 2],
+        )
+    )
+
+    with set_current_vllm_config(vllm_config):
+        model = SimpleModelWithTwoGraphs(
+            mlp_size=MLP_SIZE,
+            hidden_size=HIDDEN_SIZE,
+            vllm_config=vllm_config, 
+            prefix=''
+        ).eval().cuda()
+
+    with compilation_counter.expect(
+        num_graphs_seen=2,  # two graphs for the model
+        num_piecewise_graphs_seen=6,
+        # attn_one, attn_two each has 3 piecewise graphs 
+        # (pre_attn, post_attn, silly_attention) each
+        num_piecewise_capturable_graphs_seen=4, 
+        # attn_one, attn_two has pre_attn and post_attn each, total=4
+        num_backend_compilations=4, # num_piecewise_capturable_graphs_seen
+        num_cudagraph_captured=8, 
+        # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
+    ):
+        outputs.append(run_model(vllm_config, model))
+
+    # no compile or cudagraph
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            level=CompilationLevel.NO_COMPILATION,
+        )
+    )
+
+    with set_current_vllm_config(vllm_config):
+        model = SimpleModelWithTwoGraphs(
+            mlp_size=MLP_SIZE,
+            hidden_size=HIDDEN_SIZE,
+            vllm_config=vllm_config, 
+            prefix=''
+        ).eval().cuda()
+
+    with compilation_counter.expect(
+        num_graphs_seen=0,
+        num_piecewise_graphs_seen=0,
+        num_piecewise_capturable_graphs_seen=0,
+        num_backend_compilations=0,
+        num_cudagraph_captured=0,
+    ):
+        outputs.append(run_model(vllm_config, model))
+
+    assert torch.allclose(outputs[0], outputs[1])

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -423,6 +423,12 @@ class InductorAdaptor(CompilerInterface):
             if is_torch_equal_or_newer("2.6"):
                 stack.enter_context(
                     torch._inductor.config.patch(fx_graph_remote_cache=False))
+                # InductorAdaptor (unfortunately) requires AOTAutogradCache
+                # to be turned off to run. It will fail to acquire the hash_str
+                # and error if not.
+                # StandaloneInductorAdaptor (PyTorch 2.8+) fixes this problem.
+                stack.enter_context(
+                    torch._functorch.config.patch(enable_autograd_cache=False))
                 stack.enter_context(
                     torch._functorch.config.patch(
                         enable_remote_autograd_cache=False))

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -173,8 +173,8 @@ def _support_torch_compile(
         self.do_not_compile = \
             vllm_config.compilation_config.level in [
             CompilationLevel.NO_COMPILATION, CompilationLevel.DYNAMO_AS_IS
-        ] or not supports_dynamo() or getattr(
-            self, IGNORE_COMPILE_KEY, False)
+        ] or not supports_dynamo() or (
+            IGNORE_COMPILE_KEY in self.__class__.__dict__)
         if self.do_not_compile:
             return
         compilation_counter.num_models_seen += 1


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
In some cases, we might want to compile multiple subgraphs, e.g. if some submodules in the model are not traceable with torch dynamo. See #14913 and #19719 for motivating scenarios.

This PR adds a test case showcasing how this can be supported in vLLM for piecewise compilation. This requires several components:

- Each subgraph in the model being compiled needs to be initialized with `set_model_tag(tag)` to ensure compile cache is not shared between these subgraphs (initially added in #19064 to support compiling multiple models)
- Pre-allocate static buffers to be used as arg inputs to each compiled subgraph as CUDA Graph expects static tensor addresses between runs
- Added `ignore_torch_compile` helper decorator in scenarios where a class inherits a parent module that has `support_torch_compile` decorator applied but this class does not want to compile its forward(). Added `test_ignore_torch_compile_decorator` that tests this.

Also disables AOTAutogradCache in `StandaloneInductor` adaptor which is needed for compilation caching to work. `StandaloneInductorAdaptor` in PyTorch 2.8+ will fix this problem (thanks @zou3519)

## Test Plan
```
pytest tests/compile/piecewise/test_multiple_graphs.py
```

## Test Result
Both newly added unit tests (`test_ignore_torch_compile_decorator` and `test_multi_graph_piecewise_compile`) pass

