### PR TITLE
Remove Qwen Omni workaround that's no longer necessary

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -735,13 +735,6 @@ def get_hf_text_config(config: PretrainedConfig):
     """Get the "sub" config relevant to llm for multi modal models.
     No op for pure text models.
     """
-    # This block should be unnecessary after https://github.com/huggingface/transformers/pull/37517
-    if hasattr(config, "thinker_config"):
-        # TODO(suyang.fy): Refactor code.
-        #  For Qwen2.5-Omni, change hf_text_config to
-        #  thinker_config.text_config.
-        return config.thinker_config.text_config
-
     text_config = config.get_text_config()
 
     if text_config is not config:


### PR DESCRIPTION
This PR removes a workaround for Qwen Omni models which is no longer necessary on newer Transformers versions.

There have been several Transformers releases since https://github.com/huggingface/transformers/pull/37517 (the condition for removing this workaround) was merged and vLLM is currently on the latest version of Transformers.

