### PR TITLE
[Bugfix] Fix ndarray video color from VideoAsset

### DIFF
--- a/tests/multimodal/utils.py
+++ b/tests/multimodal/utils.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import cv2
 import numpy as np
+import numpy.typing as npt
 from PIL import Image
 
 
@@ -31,3 +33,38 @@ def random_audio(
 ):
     audio_len = rng.randint(min_len, max_len)
     return rng.rand(audio_len), sr
+
+
+def create_video_from_image(
+    image_path: str,
+    video_path: str,
+    num_frames: int = 10,
+    fps: float = 1.0,
+):
+    image = cv2.imread(image_path)
+    height, width, _ = image.shape
+    video_writer = cv2.VideoWriter(
+        video_path,
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        fps,
+        (width, height),
+    )
+
+    for _ in range(num_frames):
+        video_writer.write(image)
+
+    video_writer.release()
+    return video_path
+
+
+def cosine_similarity(A: npt.NDArray,
+                      B: npt.NDArray,
+                      axis: int = -1) -> npt.NDArray:
+    """Compute cosine similarity between two vectors."""
+    return (np.sum(A * B, axis=axis) /
+            (np.linalg.norm(A, axis=axis) * np.linalg.norm(B, axis=axis)))
+
+
+def normalize_image(image: npt.NDArray) -> npt.NDArray:
+    """Normalize image to [0, 1] range."""
+    return image.astype(np.float32) / 255.0

--- a/tests/multimodal/utils.py
+++ b/tests/multimodal/utils.py
@@ -40,14 +40,23 @@ def create_video_from_image(
     video_path: str,
     num_frames: int = 10,
     fps: float = 1.0,
+    is_color: bool = True,
+    fourcc: str = "mp4v",
 ):
     image = cv2.imread(image_path)
-    height, width, _ = image.shape
+    if not is_color:
+        # Convert to grayscale if is_color is False
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        height, width = image.shape
+    else:
+        height, width, _ = image.shape
+
     video_writer = cv2.VideoWriter(
         video_path,
-        cv2.VideoWriter_fourcc(*"mp4v"),
+        cv2.VideoWriter_fourcc(*fourcc),
         fps,
         (width, height),
+        isColor=is_color,
     )
 
     for _ in range(num_frames):

--- a/vllm/assets/video.py
+++ b/vllm/assets/video.py
@@ -59,7 +59,7 @@ def video_to_ndarrays(path: str, num_frames: int = -1) -> npt.NDArray:
         if idx in frame_indices:  # only decompress needed
             ret, frame = cap.retrieve()
             if ret:
-                frames.append(frame)
+                frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
 
     frames = np.stack(frames)
     if len(frames) < num_frames:

--- a/vllm/assets/video.py
+++ b/vllm/assets/video.py
@@ -59,6 +59,8 @@ def video_to_ndarrays(path: str, num_frames: int = -1) -> npt.NDArray:
         if idx in frame_indices:  # only decompress needed
             ret, frame = cap.retrieve()
             if ret:
+                # OpenCV uses BGR format, we need to convert it to RGB
+                # for PIL and transformers compatibility
                 frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
 
     frames = np.stack(frames)
@@ -71,10 +73,7 @@ def video_to_ndarrays(path: str, num_frames: int = -1) -> npt.NDArray:
 def video_to_pil_images_list(path: str,
                              num_frames: int = -1) -> list[Image.Image]:
     frames = video_to_ndarrays(path, num_frames)
-    return [
-        Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-        for frame in frames
-    ]
+    return [Image.fromarray(frame) for frame in frames]
 
 
 def video_get_metadata(path: str) -> dict[str, Any]:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- FIX #21053 
- Add missing opencv color conversion for VideoAsset ndarray sampling.

## Test Plan
```
python examples/offline_inference/vision_language.py -m llava-onevision --modality video
```

## Test Result
```
Question: "What's color of the shirt wron by baby?"

Outputs before:
--------------------------------------------------
The shirt worn by the baby is yellow.
--------------------------------------------------

Outputs after:
--------------------------------------------------
The shirt worn by the baby is light blue.
--------------------------------------------------
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
