### PR TITLE
Remove torch_xla.tpu.version() from pallas.py.

### DIFF
--- a/vllm/v1/attention/backends/pallas.py
+++ b/vllm/v1/attention/backends/pallas.py
@@ -167,10 +167,6 @@ class PallasAttentionBackendImpl(AttentionImpl):
                                       "are not implemented for "
                                       "PallasAttentionBackendImpl")
 
-        tpu_version = torch_xla.tpu.version()
-        if tpu_version < 4:
-            raise NotImplementedError("TPU version must be 4 or higher.")
-
     def forward(
         self,
         layer: AttentionLayer,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Because of this [issue](https://github.com/pytorch/xla/issues/9449), some TPU test randomly fails. 
We used to use the tpu_version() to decide some setting but now it is just a safety check.  There is better place to put it.  Since there is no one actually using version < 4 on vLLM today and we focuses on v6e TPU, it is safe to remove it.  

## Test Plan
Run the test on CI and see result. 

## Test Result
TBD.

