### PR TITLE
[Bugfix] Fix Machete zero point issue for GPTQ models on SM90

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -119,6 +119,8 @@ class MacheteLinearKernel(MPLinearKernel):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         c = self.config
         w_q, w_s, w_zp, _ = self._get_weight_params(layer)
+        if not c.zero_points:
+            w_zp = None
 
         x_2d = x.reshape(-1, x.shape[-1])
         out_shape = x.shape[:-1] + (c.partition_weight_shape[1], )

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py
@@ -119,14 +119,17 @@ class MacheteLinearKernel(MPLinearKernel):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         c = self.config
         w_q, w_s, w_zp, _ = self._get_weight_params(layer)
-        if not c.zero_points:
-            w_zp = None
 
         x_2d = x.reshape(-1, x.shape[-1])
         out_shape = x.shape[:-1] + (c.partition_weight_shape[1], )
 
         if c.has_g_idx:
             x_2d = self.act_perm(x_2d)
+
+        if c.zero_points:
+            assert w_zp is not None
+        else:
+            w_zp = None
 
         output = ops.machete_mm(a=x_2d,
                                 b_q=w_q,


### PR DESCRIPTION
## Purpose

FIX https://github.com/vllm-project/vllm/issues/20974 https://github.com/vllm-project/vllm/issues/20986

The issue was that the GPTQ caller was setting `zero_points=False`, however since it always allocates its `qzeros` param that still gets loaded into the machete kernel. We just need to filter out that case to fix.

## Test Plan

Manual testing of the issue on H100

## Test Result

Before
```
lm_eval --model vllm --model_args pretrained=Qwen/Qwen3-30B-A3B-GPTQ-Int4 --tasks gsm8k --num_fewshot 5 --batch_size auto
...
from user code:
   File "/home/mgoin/code/vllm/vllm/model_executor/models/qwen3_moe.py", line 369, in forward
    hidden_states, residual = layer(positions, hidden_states, residual)
  File "/home/mgoin/code/vllm/vllm/model_executor/models/qwen3_moe.py", line 305, in forward
    hidden_states = self.self_attn(
  File "/home/mgoin/code/vllm/vllm/model_executor/models/qwen3_moe.py", line 223, in forward
    qkv, _ = self.qkv_proj(hidden_states)
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/linear.py", line 510, in forward
    output_parallel = self.quant_method.apply(self, input_, bias)
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/gptq_marlin.py", line 372, in apply
    return self.kernel.apply_weights(layer, x, bias)
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/kernels/mixed_precision/machete.py", line 129, in apply_weights
    output = ops.machete_mm(a=x_2d,
  File "/home/mgoin/code/vllm/vllm/_custom_ops.py", line 1099, in machete_mm
    return torch.ops._C.machete_mm(a, b_q, b_type.id, out_type, b_group_scales,

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```

After
```
lm_eval --model vllm --model_args pretrained=Qwen/Qwen3-30B-A3B-GPTQ-Int4 --tasks gsm8k --num_fewshot 5 --batch_size auto
...
vllm (pretrained=Qwen/Qwen3-30B-A3B-GPTQ-Int4), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7915|±  |0.0112|
|     |       |strict-match    |     5|exact_match|↑  |0.8901|±  |0.0086|
```
