### PR TITLE
[CI] upgrade schemathesis to 4.1.0 from 3.39.15

### DIFF
--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -31,7 +31,7 @@ lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7
 mteb>=1.38.11, <2 # required for mteb test
 transformers==4.52.4
 tokenizers==0.21.1
-schemathesis>=3.39.15 # Required for openai schema test.
+schemathesis~=4.1.0 # Required for openai schema test.
 # quantization
 bitsandbytes>=0.46.1
 buildkite-test-collector==0.1.9

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -37,7 +37,7 @@ lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7
 mteb[bm25s]>=1.38.11, <2 # required for mteb test
 transformers==4.55.2
 tokenizers==0.21.1
-schemathesis>=3.39.15 # Required for openai schema test.
+schemathesis~=4.1.0 # Required for openai schema test.
 # quantization
 bitsandbytes==0.46.1
 buildkite-test-collector==0.1.9

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -273,7 +273,7 @@ h11==0.14.0
     #   uvicorn
 h5py==3.13.0
     # via terratorch
-harfile==0.3.0
+harfile==0.3.1
     # via schemathesis
 hf-xet==1.1.7
     # via huggingface-hub
@@ -902,6 +902,7 @@ rich==13.9.4
     #   genai-perf
     #   lightning
     #   mteb
+    #   schemathesis
     #   typer
 rioxarray==0.19.0
     # via terratorch
@@ -930,7 +931,7 @@ safetensors==0.4.5
     #   peft
     #   timm
     #   transformers
-schemathesis==3.39.15
+schemathesis==4.1.0
     # via -r requirements/test.in
 scikit-image==0.25.2
     # via albumentations
@@ -1015,7 +1016,6 @@ sqlparse==0.5.3
 starlette==0.46.2
     # via
     #   fastapi
-    #   schemathesis
     #   starlette-testclient
 starlette-testclient==0.4.1
     # via schemathesis
@@ -1063,8 +1063,6 @@ tokenizers==0.21.1
     #   -r requirements/test.in
     #   transformers
 tomli==2.2.1
-    # via schemathesis
-tomli-w==1.2.0
     # via schemathesis
 torch==2.7.1+cu128
     # via
@@ -1187,6 +1185,7 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pydantic-extra-types
     #   pytorch-lightning
+    #   schemathesis
     #   sqlalchemy
     #   torch
     #   torchgeo
@@ -1235,9 +1234,7 @@ xxhash==3.5.0
     #   datasets
     #   evaluate
 yarl==1.17.1
-    # via
-    #   aiohttp
-    #   schemathesis
+    # via aiohttp
 zipp==3.23.0
     # via importlib-metadata
 zstandard==0.23.0


### PR DESCRIPTION
It's better and faster.

https://github.com/schemathesis/schemathesis/releases/tag/v4.1.0
https://github.com/schemathesis/schemathesis/releases/tag/v4.0.0