### PR TITLE
[Bugfix] Voxtral on Blackwell GPUs (RTX 50 series)

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -26,13 +26,15 @@ from vllm.utils import direct_register_custom_op
 try:
     from xformers import ops as xops
 
-    if current_platform.is_cuda() and current_platform.has_device_capability(100):
+    if current_platform.is_cuda() and current_platform.has_device_capability(
+            100):
         # Xformers FA is not compatible with B200
         USE_XFORMERS_OPS = False
     else:
         USE_XFORMERS_OPS = True
 except ImportError:
     USE_XFORMERS_OPS = False
+
 
 class Attention(nn.Module):
     """Attention layer.

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -39,9 +39,9 @@ def check_xformers_availability():
         USE_XFORMERS_OPS = False
     else:
         try:
-            import importlib
+            from importlib.util import find_spec
 
-            importlib.util.find_spec("xformers.ops")
+            find_spec("xformers.ops")
             USE_XFORMERS_OPS = True
         except ImportError:
             USE_XFORMERS_OPS = False

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -39,7 +39,9 @@ def check_xformers_availability():
         USE_XFORMERS_OPS = False
     else:
         try:
-            import xformers.ops
+            import importlib
+            
+            importlib.util.find_spec("xformers.ops")
             USE_XFORMERS_OPS = True
         except ImportError:
             USE_XFORMERS_OPS = False

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -313,6 +313,9 @@ class MultiHeadAttention(nn.Module):
             self.attn_backend = backend if backend in {
                 _Backend.TORCH_SDPA, _Backend.XFORMERS, _Backend.PALLAS_VLLM_V1
             } else _Backend.TORCH_SDPA
+        if self.attn_backend == _Backend.XFORMERS and current_platform.is_cuda() and current_platform.has_device_capability(100):
+            # currently, xformers does not support blackwell architecture
+            self.attn_backend = _Backend.TORCH_SDPA
 
     def forward(
         self,

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -40,7 +40,7 @@ def check_xformers_availability():
     else:
         try:
             import importlib
-            
+
             importlib.util.find_spec("xformers.ops")
             USE_XFORMERS_OPS = True
         except ImportError:

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -313,7 +313,9 @@ class MultiHeadAttention(nn.Module):
             self.attn_backend = backend if backend in {
                 _Backend.TORCH_SDPA, _Backend.XFORMERS, _Backend.PALLAS_VLLM_V1
             } else _Backend.TORCH_SDPA
-        if self.attn_backend == _Backend.XFORMERS and current_platform.is_cuda() and current_platform.has_device_capability(100):
+
+        if self.attn_backend == _Backend.XFORMERS and current_platform.is_cuda(
+        ) and current_platform.has_device_capability(100):
             # currently, xformers does not support blackwell architecture
             # TODO: remove this once xformers supports blackwell
             self.attn_backend = _Backend.TORCH_SDPA

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -315,6 +315,7 @@ class MultiHeadAttention(nn.Module):
             } else _Backend.TORCH_SDPA
         if self.attn_backend == _Backend.XFORMERS and current_platform.is_cuda() and current_platform.has_device_capability(100):
             # currently, xformers does not support blackwell architecture
+            # TODO: remove this once xformers supports blackwell
             self.attn_backend = _Backend.TORCH_SDPA
 
     def forward(

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -343,8 +343,8 @@ class MultiHeadAttention(nn.Module):
                 _Backend.TORCH_SDPA, _Backend.XFORMERS, _Backend.PALLAS_VLLM_V1
             } else _Backend.TORCH_SDPA
 
-        if self.attn_backend == _Backend.XFORMERS and not check_xformers_availability(
-        ):
+        if (self.attn_backend == _Backend.XFORMERS
+                and not check_xformers_availability()):
             self.attn_backend = _Backend.TORCH_SDPA
 
     def forward(

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -16,13 +16,13 @@ from vllm.distributed.kv_transfer import (get_kv_transfer_group,
                                           has_kv_transfer_group,
                                           is_v1_kv_transfer_group)
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.platforms import _Backend, current_platform
 from vllm.utils import direct_register_custom_op
-from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 USE_XFORMERS_OPS = None
@@ -34,7 +34,7 @@ def check_xformers_availability():
         return USE_XFORMERS_OPS
 
     if current_platform.is_cuda() and current_platform.has_device_capability(
-        100):
+            100):
         # Xformers FA is not compatible with B200
         USE_XFORMERS_OPS = False
     else:
@@ -340,8 +340,9 @@ class MultiHeadAttention(nn.Module):
             self.attn_backend = backend if backend in {
                 _Backend.TORCH_SDPA, _Backend.XFORMERS, _Backend.PALLAS_VLLM_V1
             } else _Backend.TORCH_SDPA
-        
-        if self.attn_backend == _Backend.XFORMERS and not check_xformers_availability():
+
+        if self.attn_backend == _Backend.XFORMERS and not check_xformers_availability(
+        ):
             self.attn_backend = _Backend.TORCH_SDPA
 
     def forward(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
Voxtral uses `MultiHeadAttention` class, which uses xformers for acceleration   
But unfortunately, xformers does not support Blackwell GPUs   
This PR allows the code to fallback onto torch_sdpa backend for compatibility   

Similar PR: #20998 
Similar Issues: #20025, #20193

## Test Plan

Use the command from Mistral AI documentation to start a server
```bash
uv run vllm serve mistralai/Voxtral-Mini-3B-2507 --tokenizer_mode mistral --config_format mistral --load_format mistral
```

## Test Result

The command crashes before fix
```
CUDA error (/__w/xformers/xformers/third_party/flash-attention/hopper/flash_fwd_launch_template.h:175): no kernel image is available for execution on the device
Traceback (most recent call last):
  File "/home/masaki/dev/ml/voxtral/./bin/vllm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/entrypoints/cli/main.py", line 54, in main
    args.dispatch_function(args)
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/entrypoints/cli/serve.py", line 57, in cmd
    uvloop.run(run_server(args))
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/uvloop/__init__.py", line 105, in run
    return runner.run(wrapper())
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/masaki/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/uvloop/__init__.py", line 61, in wrapper
    return await main
           ^^^^^^^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 1687, in run_server
    await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 1707, in run_server_worker
    async with build_async_engine_client(args, client_config) as engine_client:
  File "/home/masaki/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 158, in build_async_engine_client
    async with build_async_engine_client_from_engine_args(
  File "/home/masaki/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 194, in build_async_engine_client_from_engine_args
    async_llm = AsyncLLM.from_vllm_config(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 162, in from_vllm_config
    return cls(
           ^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 124, in __init__
    self.engine_core = EngineCoreClient.make_async_mp_client(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 96, in make_async_mp_client
    return AsyncMPClient(*client_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 666, in __init__
    super().__init__(
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 403, in __init__
    with launch_core_engines(vllm_config, executor_class,
  File "/home/masaki/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/contextlib.py", line 144, in __exit__
    next(self.gen)
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/v1/engine/utils.py", line 444, in launch_core_engines
    wait_for_engine_startup(
  File "/home/masaki/dev/ml/voxtral/lib/python3.11/site-packages/vllm/v1/engine/utils.py", line 494, in wait_for_engine_startup
    raise RuntimeError("Engine core initialization failed. "
RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
/home/masaki/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```

The server is up and running after fix
```
> uv run vllm serve mistralai/Voxtral-Mini-3B-2507 --tokenizer_mode mistral --config_format mistral --load_format mistral
INFO 07-16 22:23:00 [__init__.py:253] Automatically detected platform cuda.
INFO 07-16 22:23:01 [api_server.py:1651] vLLM API server version 0.9.2rc2.dev296+ga931b4cdc
INFO 07-16 22:23:01 [cli_args.py:298] non-default args: {'model_tag': 'mistralai/Voxtral-Mini-3B-2507', 'model': 'mistralai/Voxtral-Mini-3B-2507', 'tokenizer_mode': 'mistral', 'config_format': 'mistral', 'load_format': 'mistral'}
ERROR 07-16 22:23:06 [config.py:129] Error retrieving safetensors: 'mistralai/Voxtral-Mini-3B-2507' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files., retrying 1 of 2
ERROR 07-16 22:23:08 [config.py:127] Error retrieving safetensors: 'mistralai/Voxtral-Mini-3B-2507' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files.
INFO 07-16 22:23:08 [config.py:3466] Downcasting torch.float32 to torch.bfloat16.
INFO 07-16 22:23:08 [config.py:1561] Using max model len 32768
INFO 07-16 22:23:08 [config.py:2357] Chunked prefill is enabled with max_num_batched_tokens=2048.
/home/masaki/dev/ml/voxtral/.venv/lib/python3.11/site-packages/mistral_common/tokens/tokenizers/tekken.py:337: FutureWarning: The attributed `special_token_policy` is deprecated and will be removed in 1.10.0. Please pass a special token policy explicitly to the relevant methods.
  warnings.warn(
INFO 07-16 22:23:11 [__init__.py:253] Automatically detected platform cuda.
INFO 07-16 22:23:12 [core.py:532] Waiting for init message from front-end.
INFO 07-16 22:23:12 [core.py:69] Initializing a V1 LLM engine (v0.9.2rc2.dev296+ga931b4cdc) with config: model='mistralai/Voxtral-Mini-3B-2507', speculative_config=None, tokenizer='mistralai/Voxtral-Mini-3B-2507', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=mistralai/Voxtral-Mini-3B-2507, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":3,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":1,"cudagraph_capture_sizes":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":512,"local_cache_dir":null}
INFO 07-16 22:23:13 [parallel_state.py:1090] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
/home/masaki/dev/ml/voxtral/.venv/lib/python3.11/site-packages/mistral_common/tokens/tokenizers/tekken.py:337: FutureWarning: The attributed `special_token_policy` is deprecated and will be removed in 1.10.0. Please pass a special token policy explicitly to the relevant methods.
  warnings.warn(
WARNING 07-16 22:23:13 [topk_topp_sampler.py:59] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
INFO 07-16 22:23:13 [gpu_model_runner.py:1742] Starting to load model mistralai/Voxtral-Mini-3B-2507...
INFO 07-16 22:23:14 [gpu_model_runner.py:1747] Loading model from scratch...
INFO 07-16 22:23:14 [cuda.py:297] Using Flash Attention backend on V1 engine.
INFO 07-16 22:23:14 [weight_utils.py:296] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 07-16 22:23:14 [weight_utils.py:349] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.13s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.13s/it]

INFO 07-16 22:23:16 [default_loader.py:272] Loading weights took 1.32 seconds
INFO 07-16 22:23:16 [gpu_model_runner.py:1773] Model loading took 8.7223 GiB and 2.008780 seconds
INFO 07-16 22:23:16 [gpu_model_runner.py:2213] Encoder cache will be initialized with a budget of 32768 tokens, and profiled with 1 audio items of the maximum feature size.
WARNING 07-16 22:23:17 [registry.py:184] VoxtralProcessorAdapter did not return `BatchFeature`. Make sure to match the behaviour of `ProcessorMixin` when implementing custom processors.
/home/masaki/dev/ml/voxtral/.venv/lib/python3.11/site-packages/mistral_common/tokens/tokenizers/tekken.py:461: FutureWarning: Using the tokenizer's special token policy (SpecialTokenPolicy.IGNORE) is deprecated. It will be removed in 1.10.0. Please pass a special token policy explicitly. Future default will be SpecialTokenPolicy.IGNORE.
  warnings.warn(
INFO 07-16 22:23:21 [backends.py:530] Using cache directory: /home/masaki/.cache/vllm/torch_compile_cache/8ba9ee621b/rank_0_0/backbone for vLLM's torch.compile
INFO 07-16 22:23:21 [backends.py:541] Dynamo bytecode transform time: 2.63 s
INFO 07-16 22:23:23 [backends.py:161] Directly load the compiled graph(s) for dynamic shape from the cache, took 2.075 s
INFO 07-16 22:23:23 [monitor.py:34] torch.compile takes 2.63 s in total
INFO 07-16 22:23:24 [gpu_worker.py:244] Available KV cache memory: 15.52 GiB
INFO 07-16 22:23:24 [kv_cache_utils.py:732] GPU KV cache size: 135,616 tokens
INFO 07-16 22:23:24 [kv_cache_utils.py:736] Maximum concurrency for 32,768 tokens per request: 4.14x
Capturing CUDA graph shapes: 100%|███████████████████████| 67/67 [00:20<00:00,  3.30it/s]
INFO 07-16 22:23:45 [gpu_model_runner.py:2303] Graph capturing finished in 20 secs, took 0.63 GiB
INFO 07-16 22:23:45 [core.py:178] init engine (profile, create kv cache, warmup model) took 28.61 seconds
/home/masaki/dev/ml/voxtral/.venv/lib/python3.11/site-packages/mistral_common/tokens/tokenizers/tekken.py:337: FutureWarning: The attributed `special_token_policy` is deprecated and will be removed in 1.10.0. Please pass a special token policy explicitly to the relevant methods.
  warnings.warn(
INFO 07-16 22:23:45 [loggers.py:137] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 8476
INFO 07-16 22:23:47 [api_server.py:1714] Starting vLLM API server 0 on http://0.0.0.0:8000
INFO 07-16 22:23:47 [launcher.py:29] Available routes are:
INFO 07-16 22:23:47 [launcher.py:37] Route: /openapi.json, Methods: GET, HEAD
INFO 07-16 22:23:47 [launcher.py:37] Route: /docs, Methods: GET, HEAD
INFO 07-16 22:23:47 [launcher.py:37] Route: /docs/oauth2-redirect, Methods: GET, HEAD
INFO 07-16 22:23:47 [launcher.py:37] Route: /redoc, Methods: GET, HEAD
INFO 07-16 22:23:47 [launcher.py:37] Route: /health, Methods: GET
INFO 07-16 22:23:47 [launcher.py:37] Route: /load, Methods: GET
INFO 07-16 22:23:47 [launcher.py:37] Route: /ping, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /ping, Methods: GET
INFO 07-16 22:23:47 [launcher.py:37] Route: /tokenize, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /detokenize, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/models, Methods: GET
INFO 07-16 22:23:47 [launcher.py:37] Route: /version, Methods: GET
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/responses, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/responses/{response_id}, Methods: GET
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/responses/{response_id}/cancel, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/chat/completions, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/completions, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/embeddings, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /pooling, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /classify, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /score, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/score, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/audio/transcriptions, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/audio/translations, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /rerank, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v1/rerank, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /v2/rerank, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /invocations, Methods: POST
INFO 07-16 22:23:47 [launcher.py:37] Route: /metrics, Methods: GET
INFO:     Started server process [1904560]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```
