### PR TITLE
[Attention] Make local attention backend agnostic

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -495,10 +495,6 @@ class FlashInferImpl(AttentionImpl):
         kv_sharing_target_layer_name: Optional[int] = None,
         use_irope: bool = False,
     ) -> None:
-        if use_irope:
-            logger.warning_once(
-                "Using irope in FlashInfer is not supported yet, it will fall"
-                " back to global attention for long context.")
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
@@ -513,6 +509,7 @@ class FlashInferImpl(AttentionImpl):
         self.kv_cache_dtype = kv_cache_dtype
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+        self.use_irope = use_irope
 
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
 

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -385,13 +385,13 @@ def make_local_attention_virtual_batches(
         .view(virtual_batches, -1)
 
     query_start_loc_cpu = torch.from_numpy(cu_seqlens_q_local)
-    seq_lens_cpu = torch.from_numpy(seq_lens_np)
+    seq_lens_cpu = torch.from_numpy(seqlens_k_local)
 
     return CommonAttentionMetadata(
         query_start_loc_cpu=query_start_loc_cpu,
         query_start_loc=query_start_loc_cpu.to(device=device,
                                                non_blocking=True),
-        seq_lens_cpu=torch.from_numpy(seq_lens_np),
+        seq_lens_cpu=seq_lens_cpu,
         seq_lens=seq_lens_cpu.to(device=device, non_blocking=True),
         num_computed_tokens_cpu=torch.from_numpy(num_computed_tokens_local),
         num_reqs=len(seq_lens_cpu),

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -272,11 +272,14 @@ def infer_global_hyperparameters(
 #   block_table_local  : shape[local_virtual_batches, pages_per_local_batch]
 def make_local_attention_virtual_batches(
     attn_chunk_size: int,
-    query_start_loc_np: np.ndarray,
-    seq_lens_np: np.ndarray,
-    block_table: torch.Tensor,
+    common_attn_metadata: CommonAttentionMetadata,
     block_size: int = 0,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, torch.Tensor]:
+) -> CommonAttentionMetadata:
+    query_start_loc_np = common_attn_metadata.query_start_loc_cpu.numpy()
+    seq_lens_np = common_attn_metadata.seq_lens_cpu.numpy()
+    block_table = common_attn_metadata.block_table_tensor
+    device = common_attn_metadata.query_start_loc.device
+
     q_seqlens = query_start_loc_np[1:] - query_start_loc_np[:-1]
     actual_batch_size = seq_lens_np.shape[0]
 
@@ -339,6 +342,7 @@ def make_local_attention_virtual_batches(
                               attn_chunk_size,
                               dtype=np.int32)
     seqlens_k_local[cu_num_blocks - 1] = tokens_in_last_block
+    num_computed_tokens_local = seqlens_k_local - seqlens_q_local
 
     k_seqstarts_absolute = np.repeat(seq_lens_np, local_blocks) - \
         (rarange * attn_chunk_size + \
@@ -380,8 +384,22 @@ def make_local_attention_virtual_batches(
     block_table_local = block_table[batch_indices, block_indices]\
         .view(virtual_batches, -1)
 
-    return seqlens_q_local, cu_seqlens_q_local, seqlens_k_local, \
-        block_table_local
+    query_start_loc_cpu = torch.from_numpy(cu_seqlens_q_local)
+    seq_lens_cpu = torch.from_numpy(seq_lens_np)
+
+    return CommonAttentionMetadata(
+        query_start_loc_cpu=query_start_loc_cpu,
+        query_start_loc=query_start_loc_cpu.to(device=device,
+                                               non_blocking=True),
+        seq_lens_cpu=torch.from_numpy(seq_lens_np),
+        seq_lens=seq_lens_cpu.to(device=device, non_blocking=True),
+        num_computed_tokens_cpu=torch.from_numpy(num_computed_tokens_local),
+        num_reqs=len(seq_lens_cpu),
+        num_actual_tokens=common_attn_metadata.num_actual_tokens,
+        max_query_len=seqlens_q_local.max(),
+        block_table_tensor=block_table_local,
+        slot_mapping=common_attn_metadata.slot_mapping,
+    )
 
 
 def split_decodes_and_prefills(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -126,6 +126,21 @@ class FullAttentionSpec(AttentionSpec):
 
 
 @dataclass
+class ChunkedLocalAttentionSpec(AttentionSpec):
+    attention_chunk_size: int
+
+    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        max_model_len = vllm_config.model_config.max_model_len
+        return cdiv(max_model_len, self.block_size) * self.page_size_bytes
+
+    @property
+    def type_id(self) -> str:
+        return (
+            f"local_attention_{self.attention_chunk_size}_{self.block_size}_{self.page_size_bytes}"
+        )  # noqa
+
+
+@dataclass
 class SlidingWindowSpec(AttentionSpec):
     sliding_window: int
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -44,11 +44,14 @@ from vllm.utils import (STR_DTYPE_TO_TORCH_DTYPE, DeviceMemoryProfiler,
                         GiB_bytes, LazyLoader, check_use_alibi, get_dtype_size,
                         is_pin_memory_available, round_up)
 from vllm.v1.attention.backends.mamba_attn import Mamba2AttentionBackend
-from vllm.v1.attention.backends.utils import (AttentionMetadataBuilder,
-                                              CommonAttentionMetadata)
+from vllm.v1.attention.backends.utils import (
+    AttentionMetadataBuilder, CommonAttentionMetadata,
+    make_local_attention_virtual_batches)
 from vllm.v1.core.encoder_cache_manager import compute_encoder_budget
-from vllm.v1.kv_cache_interface import (AttentionSpec, FullAttentionSpec,
-                                        KVCacheConfig, KVCacheSpec, MambaSpec,
+from vllm.v1.kv_cache_interface import (AttentionSpec,
+                                        ChunkedLocalAttentionSpec,
+                                        FullAttentionSpec, KVCacheConfig,
+                                        KVCacheSpec, MambaSpec,
                                         SlidingWindowSpec)
 from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, LogprobsTensors,
                              ModelRunnerOutput)
@@ -704,6 +707,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if self.speculative_config and \
                 spec_decode_common_attn_metadata is None:
                 spec_decode_common_attn_metadata = common_attn_metadata
+
+            if isinstance(kv_cache_group_spec.kv_cache_spec,
+                          ChunkedLocalAttentionSpec):
+                common_attn_metadata = make_local_attention_virtual_batches(
+                    kv_cache_group_spec.kv_cache_spec.attention_chunk_size,
+                    common_attn_metadata, self.cache_config.block_size)
 
             # Prepare for cascade attention if enabled & beneficial.
             common_prefix_len = 0
@@ -2589,6 +2598,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
             # TODO: Support other attention modules, e.g., cross-attention
             if attn_module.attn_type == AttentionType.DECODER:
+                use_local_attention = (self.attention_chunk_size is not None
+                                       and attn_module.impl.use_irope)
                 if attn_module.sliding_window is not None:
                     kv_cache_spec[layer_name] = SlidingWindowSpec(
                         block_size=block_size,
@@ -2597,6 +2608,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         dtype=self.kv_cache_dtype,
                         sliding_window=attn_module.sliding_window,
                         use_mla=use_mla)
+                elif use_local_attention:
+                    kv_cache_spec[layer_name] = (ChunkedLocalAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=attn_module.num_kv_heads,
+                        head_size=attn_module.head_size,
+                        dtype=self.kv_cache_dtype,
+                        attention_chunk_size=self.attention_chunk_size,
+                        use_mla=use_mla))
                 else:
                     kv_cache_spec[layer_name] = FullAttentionSpec(
                         block_size=block_size,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Make local attention backend agnostic now that https://github.com/vllm-project/vllm/pull/20466 has landed so we can turn on llama4 iRoPE for FlashInfer on Blackwell

## Test Plan

Ruler eval

## Test Result

### This PR

```
VLLM_ATTENTION_BACKEND=FLASHINFER python -m lm_eval --model vllm --model_args pretrained=/home/lwilkinson/local_models/meta-llama--Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=2,gpu_memory_utilization=0.8,trust_remote_code=True,max_model_len=16384 --tasks ruler --limit 1 --batch_size auto --output_path ./test_fixed_flashinfer.json
...
|Groups|Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------|------:|------|------|-----:|---|-----:|---|------|
|ruler |      1|none  |      |  4096|↑  |0.9231|±  |   N/A|
```

```
VLLM_ATTENTION_BACKEND=FLASH_ATTN python -m lm_eval --model vllm --model_args pretrained=/home/lwilkinson/local_models/meta-llama--Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=2,gpu_memory_utilization=0.8,trust_remote_code=True,max_model_len=16384 --tasks ruler --limit 100 --batch_size auto --outp
ut_path ./test_fixed_flashinfer.json
...
|Groups|Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------|------:|------|------|-----:|---|-----:|---|------|
|ruler |      1|none  |      |  4096|↑  |0.9527|±  |   N/A|
```

### Main

```
VLLM_ATTENTION_BACKEND=FLASHINFER python -m lm_eval --model vllm --model_args pretrained=/home/lwilkinson/local_models/meta-llama--Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=2,gpu_memory_utilization=0.8,trust_remote_code=True,max_model_len=16384 --tasks ruler --limit 100 --batch_size auto --output_path ./test_fixed_flashinfer.json
...
|Groups|Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------|------:|------|------|-----:|---|-----:|---|------|
|ruler |      1|none  |      |  4096|↑  |0.6024|±  |   N/A|
```
```
VLLM_ATTENTION_BACKEND=FLASH_ATTN python -m lm_eval --model vllm --model_args pretrained=/home/lwilkinson/local_models/meta-llama--Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=2,gpu_memory_utilization=0.8,trust_remote_code=True,max_model_len=16384 --tasks ruler --limit 100 --batch_size auto --output_path ./test_fixed_flashinfer.json
...
|Groups|Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------|------:|------|------|-----:|---|-----:|---|------|
|ruler |      1|none  |      |  4096|↑  |0.9527|±  |   N/A|
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
