### PR TITLE
[benchmark] add max-concurrency in result table

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -522,6 +522,8 @@ async def benchmark(
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
     if max_concurrency is not None:
         print("{:<40} {:<10}".format("Maximum request concurrency:", max_concurrency))
+    if request_rate != float("inf"):
+        print("{:<40} {:<10.2f}".format("Request rate configured (RPS):", request_rate))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
     print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -520,6 +520,8 @@ async def benchmark(
 
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
+    if max_concurrency is not None:
+        print("{:<40} {:<10}".format("Maximum request concurrency:", max_concurrency))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
     print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))

--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -569,6 +569,8 @@ async def benchmark(
 
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
+    if max_concurrency is not None:
+        print("{:<40} {:<10}".format("Maximum request concurrency:", max_concurrency))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
     print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))

--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -571,6 +571,8 @@ async def benchmark(
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
     if max_concurrency is not None:
         print("{:<40} {:<10}".format("Maximum request concurrency:", max_concurrency))
+    if request_rate != float("inf"):
+        print("{:<40} {:<10.2f}".format("Request rate configured (RPS):", request_rate))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
     print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -477,6 +477,12 @@ async def benchmark(
 
     print("{s:{c}^{n}}".format(s=' Serving Benchmark Result ', n=50, c='='))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
+    if max_concurrency is not None:
+        print("{:<40} {:<10}".format("Maximum request concurrency:",
+                                     max_concurrency))
+    if request_rate != float('inf'):
+        print("{:<40} {:<10.2f}".format("Request rate configured (RPS):",
+                                        request_rate ))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):",
                                     benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

to fix https://github.com/vllm-project/vllm/issues/21094

## Test Plan

test CLI
```
(venv) root@vllm-lmcache-dev-0:/peter# OPENAI_API_KEY=$API_KEY  python3 vllm/benchmarks/benchmark_serving.py --backend openai-chat    \
 --base-url  https://api.groq.com/openai      --endpoint "/v1/chat/completions"    \
 --dataset-name=sharegpt     --dataset-path=/mnt/models/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json     \
--model "moonshotai/Kimi-K2-Instruct"     --trust_remote_code      \
--served-model-name "moonshotai/kimi-k2-instruct"    \
--num-prompts 10    \
--max-concurrency 3    \
--save-result    --temperature 0.7    --save-detailed
```

## Test Result





```
Namespace(backend='openai-chat', base_url='https://api.groq.com/openai', host='127.0.0.1', port=8000, endpoint='/v1/chat/completions', dataset_name='sharegpt', dataset_path='/mnt/models/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json', max_concurrency=3, model='moonshotai/Kimi-K2-Instruct', tokenizer=None, use_beam_search=False, num_prompts=10, logprobs=None, request_rate=inf, burstiness=1.0, seed=0, trust_remote_code=True, disable_tqdm=False, profile=False, save_result=True, save_detailed=True, append_result=False, metadata=None, result_dir=None, result_filename=None, ignore_eos=False, percentile_metrics='ttft,tpot,itl', metric_percentiles='99', goodput=None, custom_output_len=256, custom_skip_chat_template=False, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, random_input_len=1024, random_output_len=128, random_range_ratio=0.0, random_prefix_len=0, hf_subset=None, hf_split=None, hf_output_len=None, top_p=None, top_k=None, min_p=None, temperature=0.7, tokenizer_mode='auto', served_model_name='moonshotai/kimi-k2-instruct', lora_modules=None, ramp_up_strategy=None, ramp_up_start_rps=None, ramp_up_end_rps=None)
WARNING 07-17 05:34:37 [tokenizer.py:262] Using a slow tokenizer. This might cause a significant slowdown. Consider using a fast tokenizer instead.
Starting initial single prompt test run...
Initial test run completed. Starting main benchmark run...
Traffic request rate: inf RPS.
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 3
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:08<00:00,  1.19it/s]
============ Serving Benchmark Result ============
Successful requests:                     10
Maximum request concurrency:             3         <--------------------  what's new
Benchmark duration (s):                  8.38
Total input tokens:                      1366
Total generated tokens:                  2667
Request throughput (req/s):              1.19
Output token throughput (tok/s):         318.37
Total Token throughput (tok/s):          481.44
---------------Time to First Token----------------
Mean TTFT (ms):                          698.56
Median TTFT (ms):                        645.54
P99 TTFT (ms):                           1008.26
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.21
Median TPOT (ms):                        4.53
P99 TPOT (ms):                           17.95
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.22
Median ITL (ms):                         0.09
P99 ITL (ms):                            31.18
==================================================

```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
