### PR TITLE
[V1][Metrics][Frontend] Add support for custom stat loggers via CLI --stat-loggers

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -326,6 +326,7 @@ class EngineArgs:
     max_num_seqs: Optional[int] = SchedulerConfig.max_num_seqs
     max_logprobs: int = ModelConfig.max_logprobs
     disable_log_stats: bool = False
+    stat_loggers: Optional[str] = None
     revision: Optional[str] = ModelConfig.revision
     code_revision: Optional[str] = ModelConfig.code_revision
     rope_scaling: dict[str, Any] = get_field(ModelConfig, "rope_scaling")
@@ -872,6 +873,14 @@ class EngineArgs:
         parser.add_argument('--disable-log-stats',
                             action='store_true',
                             help='Disable logging statistics.')
+        parser.add_argument(
+            "--stat-loggers",
+            type=str,
+            default=None,
+            help=("Comma-separated list of custom logger classes "
+                  "(subclasses of StatLoggerBase), "
+                  "e.g. mypkg.MyLogger1,mypkg.MyLogger2"),
+        )
 
         return parser
 


### PR DESCRIPTION
**✨ Add Support for Custom Stat Logger Classes via CLI Argument**
This PR adds support for dynamically loading custom `StatLoggerBase` classes via a new command-line argument: `--stat-loggers`.
The purpose is to allow injection of user-defined metric loggers into the vLLM runtime without modifying internal code.

**🔧 What’s New**
Added a new CLI argument:
`--stat-loggers`: comma-separated list of fully-qualified class paths
(e.g., `mylogger.PrometheusLogger,mylogger.JsonLogger`)

These classes are dynamically imported using `importlib`, and passed to `AsyncLLM.from_vllm_config`.

**📍 Example Usage**

```
python -m vllm.entrypoints.openai.api_server \
  --stat-loggers "mylogger.PrometheusLogger,mylogger.JsonLogger"
```
**💬 Context & Motivation**
This PR builds on the work in [#14661](https://github.com/vllm-project/vllm/pull/14661), which enabled `AsyncLLM` to accept custom `StatLoggerBase` instances directly.

It takes the next step by introducing a CLI-level hook for dynamically loading loggers.

This enables plug-and-play observability setups, supports multiple concurrent loggers, and follows a clean, extensible pattern that avoids hardcoding.