### PR TITLE
[benchmark] Sending request strictly follows the random intervals

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -138,7 +138,7 @@ async def get_request(
         input_requests = list(input_requests)
 
     total_requests = len(input_requests)
-    request_index = 0
+    assert total_requests > 0, "No requests provided."
 
     # Precompute delays among requests to minimize request send laggings
     request_rates = []
@@ -163,7 +163,7 @@ async def get_request(
     # Calculate the cumulative delay time from the first sent out requests.
     for i in range(1, len(delay_ts)):
         delay_ts[i] += delay_ts[i - 1]
-    if ramp_up_strategy is None:
+    if ramp_up_strategy is None and delay_ts[-1] != float("inf"):
         # When ramp_up_strategy is not set, we assume the request rate is fixed
         # and all requests should be sent in target_total_delay_s, the following
         # logic would re-scale delay time to ensure the final delay_ts
@@ -176,7 +176,7 @@ async def get_request(
         # from different random seeds. 
         target_total_delay_s = total_requests / request_rate
         normalize_factor = target_total_delay_s / delay_ts[-1]
-        delay_ts = [delay * normalize_factor for delay in delay_ts]    
+        delay_ts = [delay * normalize_factor for delay in delay_ts]
 
     start_ts = time.time()
     request_index = 0

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -140,29 +140,52 @@ async def get_request(
     total_requests = len(input_requests)
     request_index = 0
 
-    for request in input_requests:
+    # Precompute delays among requests to minimize request send laggings
+    request_rates = []
+    delay_ts = []
+    for request_index, request in enumerate(input_requests):
         current_request_rate = _get_current_request_rate(ramp_up_strategy,
                                                       ramp_up_start_rps,
                                                       ramp_up_end_rps,
-                                                      request_index,
+                                                      len(delay_ts),
                                                       total_requests,
                                                       request_rate)
-
-        yield request, current_request_rate
-        
-        request_index += 1
-
+        request_rates.append(current_request_rate)
         if current_request_rate == float("inf"):
-            # If the request rate is infinity, then we don't need to wait.
-            continue
+            delay_ts.append(0)
+        else:
+            theta = 1.0 / (current_request_rate * burstiness)
 
-        theta = 1.0 / (current_request_rate * burstiness)
+            # Sample the request interval from the gamma distribution.
+            # If burstiness is 1, it follows exponential distribution.
+            delay_ts.append(np.random.gamma(shape=burstiness, scale=theta))
+    
+    # Calculate the cumulative delay time from the first sent out requests.
+    for i in range(1, len(delay_ts)):
+        delay_ts[i] += delay_ts[i - 1]
+    if ramp_up_strategy is None:
+        # When ramp_up_strategy is not set, we assume the request rate is fixed
+        # and all requests should be sent in target_total_delay_s, the following
+        # logic would re-scale delay time to ensure the final delay_ts
+        # align with target_total_delay_s.
+        #
+        # NOTE: If we simply accumulate the random delta values 
+        # from the gamma distribution, their sum would have 1-2% gap 
+        # from target_total_delay_s. The purpose of the following logic is to
+        # close the gap for stablizing the throughput data 
+        # from different random seeds. 
+        target_total_delay_s = total_requests / request_rate
+        normalize_factor = target_total_delay_s / delay_ts[-1]
+        delay_ts = [delay * normalize_factor for delay in delay_ts]    
 
-        # Sample the request interval from the gamma distribution.
-        # If burstiness is 1, it follows exponential distribution.
-        interval = np.random.gamma(shape=burstiness, scale=theta)
-        # The next request will be sent after the interval.
-        await asyncio.sleep(interval)
+    start_ts = time.time()
+    request_index = 0
+    for request_index, request in enumerate(input_requests):
+        current_ts = time.time()
+        sleep_interval_s = start_ts + delay_ts[request_index] - current_ts
+        if sleep_interval_s > 0:
+            await asyncio.sleep(sleep_interval_s)
+        yield request, request_rates[request_index]
 
 
 def calculate_metrics(

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -163,7 +163,7 @@ async def get_request(
     # Calculate the cumulative delay time from the first sent out requests.
     for i in range(1, len(delay_ts)):
         delay_ts[i] += delay_ts[i - 1]
-    if ramp_up_strategy is None and delay_ts[-1] != float("inf"):
+    if ramp_up_strategy is None and delay_ts[-1] != 0:
         # When ramp_up_strategy is not set, we assume the request rate is fixed
         # and all requests should be sent in target_total_delay_s, the following
         # logic would re-scale delay time to ensure the final delay_ts

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -147,7 +147,7 @@ async def get_request(
         current_request_rate = _get_current_request_rate(ramp_up_strategy,
                                                       ramp_up_start_rps,
                                                       ramp_up_end_rps,
-                                                      len(delay_ts),
+                                                      request_index,
                                                       total_requests,
                                                       request_rate)
         request_rates.append(current_request_rate)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fix benchmark script not sending requests in time issue (https://github.com/vllm-project/vllm/issues/21104)

The main changes are
1) Precompute time gaps for each requests
2) When ramp_up_strategy is not set, re-scale time gaps to ensure we're strictly follow the preset request-rate
3) Only sleep for updated intervals to ensure the script is sending requests at the pre-computed pace.

## Test Plan
```
export VLLM_USE_MODELSCOPE=False;
vllm serve facebook/opt-125m \
    --swap-space 16 \
    --disable-log-requests \
    --host :: \
    --dtype float16

vllm bench serve \
    --dataset-name random \
    --model facebook/opt-125m \
    --served-model-name facebook/opt-125m \
    --random-input-len 700 \
    --random-output-len 1 \
    --endpoint /v1/completions \
    --ignore-eos \
    --host localhost \
    --port 8000 \
    --request-rate 200 \
    --num-prompts 10000
```

## Test Result
**Throughput**
Better reflect the server side throughput, when request-rate set to 200
- request throughput changed from 183 -> 199.89
- token throughput changed from 128K -> 140K

After
<img width="361" height="296" alt="Screenshot 2025-07-17 at 1 40 21 AM" src="https://github.com/user-attachments/assets/d30642b3-c823-436f-ae85-44e24f6b945b" /> |
Before
<img width="361" height="296" alt="Screenshot 2025-07-17 at 1 17 41 AM" src="https://github.com/user-attachments/assets/b31a513b-1fe6-41e5-9d18-cedda814dfe2" />

**Send Request Pace**
Request sent are almost 100% align with expected pace, while the original send rate is strictly lower than expectation.

After
<img width="948" height="641" alt="Screenshot 2025-07-17 at 1 40 08 AM" src="https://github.com/user-attachments/assets/883ebaf8-1823-4404-af2e-d83cbbbfc4b9" />
Before
<img width="945" height="637" alt="Screenshot 2025-07-17 at 12 56 14 AM" src="https://github.com/user-attachments/assets/18c4a2d7-3891-4fb1-880a-af34a7edcd99" />


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
