### PR TITLE
[Docs] Move code block out of admonition now that it's short

### DIFF
--- a/docs/design/v1/p2p_nccl_connector.md
+++ b/docs/design/v1/p2p_nccl_connector.md
@@ -61,11 +61,9 @@ To address the above issues, I have designed and developed a local Tensor memory
 
 # Install vLLM
 
-??? console "Commands"
-
-    ```shell
-    pip install "vllm>=0.9.2"
-    ```
+```shell
+pip install "vllm>=0.9.2"
+```
 
 # Run xPyD
 


### PR DESCRIPTION
The code block now takes up the same amount of space as the admonition so now the admonition just makes it harder to see the information.