### PR TITLE
[Core] Add request preprocess counter in v1

### DIFF
--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -70,6 +70,9 @@ class EngineCoreRequest(
     current_wave: int = 0
     priority: int = 0
 
+    # Duration of input pre-processing in milliseconds
+    preproc_ms: float = 0.0
+
 
 class EngineCoreEventType(enum.IntEnum):
     """The type of engine core request event."""

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -93,6 +93,7 @@ class RequestState:
         arrival_time: float,
         queue: Optional[RequestOutputCollector],
         log_stats: bool,
+        preproc_ms: float,
     ):
         self.request_id = request_id
         self.parent_req = parent_req
@@ -107,6 +108,7 @@ class RequestState:
         self.max_tokens_param = max_tokens_param
         self.is_prefilling = True
         self.queue = queue
+        self.preproc_ms = preproc_ms
 
         self.stats = RequestStateStats(
             arrival_time=arrival_time) if log_stats else None
@@ -158,6 +160,7 @@ class RequestState:
             arrival_time=request.arrival_time,
             queue=queue,
             log_stats=log_stats,
+            preproc_ms=request.preproc_ms,
         )
 
     def make_request_output(
@@ -469,6 +472,7 @@ class OutputProcessor:
             finish_reason=finish_reason,
             num_prompt_tokens=len(req_state.prompt_token_ids),
             max_tokens_param=req_state.max_tokens_param,
+            preproc_ms=req_state.preproc_ms,
             req_stats=req_state.stats)
         self.lora_states.finish_request(req_state)
 

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -249,6 +249,7 @@ class Processor:
         if arrival_time is None:
             arrival_time = time.time()
 
+        preproc_start = time.monotonic_ns()
         # Process inputs, which includes:
         # 1. Tokenize text prompt, with LoRA request if one exists.
         # 2. For multimodal models with a merged preprocessor, preprocess
@@ -342,6 +343,8 @@ class Processor:
             else:
                 sorted_mm_inputs = orig_sorted_mm_inputs
 
+        preproc_ms = (time.monotonic_ns() - preproc_start) / 1e6
+
         return decoder_inputs.get("prompt"), EngineCoreRequest(
             request_id=request_id,
             prompt_token_ids=decoder_inputs["prompt_token_ids"],
@@ -356,6 +359,7 @@ class Processor:
             cache_salt=decoder_inputs.get("cache_salt"),
             priority=priority,
             data_parallel_rank=data_parallel_rank,
+            preproc_ms=preproc_ms,
         )
 
     def _validate_model_inputs(self,

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -78,6 +78,7 @@ class FinishedRequestStats:
     prefill_time: float = 0.0
     inference_time: float = 0.0
     decode_time: float = 0.0
+    preproc_ms: float = 0.0
 
 
 class IterationStats:
@@ -150,6 +151,7 @@ class IterationStats:
     def update_from_finished_request(self, finish_reason: "FinishReason",
                                      num_prompt_tokens: int,
                                      max_tokens_param: Optional[int],
+                                     preproc_ms: float,
                                      req_stats: RequestStateStats):
         e2e_latency = self._time_since(req_stats.arrival_time)
 
@@ -177,7 +179,8 @@ class IterationStats:
                                  queued_time=queued_time,
                                  prefill_time=prefill_time,
                                  inference_time=inference_time,
-                                 decode_time=decode_time)
+                                 decode_time=decode_time,
+                                 preproc_ms=preproc_ms)
         self.finished_requests.append(finished_req)
 
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.


## Purpose

Adding counter to check the preprocessing time of a request. Useful for benchmarking the compute done out of engine that could affect prefill and TTFT.

## Test Plan
Ran vLLM locally with internal frontend and added a debugging log (TO BE ADDED preproc time <>) in the frontend to display the preproc time.

## Test Result
Preproc time seems to be ~12-15 ms (almost always >12) running **with 96 batch size**
```
INFO 07-17 16:04:35 [loggers.py:111] TO BE ADDED preproc time = 14.33826
INFO 07-17 16:04:35 [loggers.py:111] TO BE ADDED preproc time = 12.948257
INFO 07-17 16:04:35 [loggers.py:111] TO BE ADDED preproc time = 12.431615
I0717 16:04:35.991000 800303 time_request_logger.py:198] Successfully completed request 21d4b3e160404ef6b9806a58065aad8d after 10.839 seconds
I0717 16:04:35.992000 800303 time_request_logger.py:198] Successfully completed request fc44d0c701364688a8cdaca840993309 after 10.865 seconds
I0717 16:04:35.992000 800303 time_request_logger.py:198] Successfully completed request fcfa9d366c3544788bd42cd909f0e7be after 10.785 seconds
```

with **batch size 12** preproc time is ~10-11 ms
```
INFO 07-17 16:07:55 [loggers.py:111] TO BE ADDED preproc time = 10.968963
INFO 07-17 16:07:55 [loggers.py:111] TO BE ADDED preproc time = 10.861009
INFO 07-17 16:07:55 [loggers.py:111] TO BE ADDED preproc time = 10.734798
I0717 16:07:55.421000 800303 time_request_logger.py:198] Successfully completed request f2a5e6f113bb4ffc80901bac28b001d6 after 1.608 seconds
I0717 16:07:55.421000 800303 time_request_logger.py:198] Successfully completed request ff94cbf765a54f1e8ede620aac284ca3 after 1.6 seconds
I0717 16:07:55.422000 800303 time_request_logger.py:198] Successfully completed request d89d021cdd1a4a3d87ab1b6a80fbdbd3 after 1.61 seconds
```

with **batch size 1** preproc time is also ~10-11 ms so that's the lowest cap
```

I0717 16:10:27.195000 800303 media_loader.py:147] Read ['...'] in 107.680845 ms
INFO 07-17 16:10:27 [async_llm.py:270] Added request cc80c7c6b67a4b47b1cfd86001a38f5f.
INFO 07-17 16:10:27 [loggers.py:111] TO BE ADDED preproc time = 10.888155
I0717 16:10:27.433000 800303 time_request_logger.py:198] Successfully completed request cc80c7c6b67a4b47b1cfd86001a38f5f after 0.344 seconds
I0717 16:10:27.436000 800303 time_request_logger.py:82] Received request with id: 800ad91d0c704cceb0eed9cd0b534a54 client: llm_loadgen Total concurrent requests = 1 (single requests = 1, full duplex sessions = 0)
I0717 16:10:27.550000 800303 media_loader.py:147] Read ['...'] in 114.027877 ms
INFO 07-17 16:10:27 [async_llm.py:270] Added request 800ad91d0c704cceb0eed9cd0b534a54.
INFO 07-17 16:10:27 [loggers.py:111] TO BE ADDED preproc time = 10.868295
I0717 16:10:27.789000 800303 time_request_logger.py:198] Successfully completed request 800ad91d0c704cceb0eed9cd0b534a54 after 0.351 seconds
I0717 16:10:27.793000 800303 time_request_logger.py:82] Received request with id: 549a5fc896db40d5befb856a5de3db29 client: llm_loadgen Total concurrent requests = 1 (single requests = 1, full duplex sessions = 0)
I0717 16:10:27.899000 800303 media_loader.py:147] Read ['...'] in 106.138304 ms
INFO 07-17 16:10:27 [async_llm.py:270] Added request 549a5fc896db40d5befb856a5de3db29.
INFO 07-17 16:10:28 [loggers.py:111] TO BE ADDED preproc time = 10.789917
I0717 16:10:28.135000 800303 time_request_logger.py:198] Successfully completed request 549a5fc896db40d5befb856a5de3db29 after 0.341 seconds
I0717 16:10:28.139000 800303 time_request_logger.py:82] Received request with id: 8d31c7acb3ff486cad09d39f0fa97447 client: llm_loadgen Total concurrent requests = 1 (single requests = 1, full duplex sessions = 0)
```

## (Optional) Documentation Update
