### PR TITLE
[Misc] allow pulling vllm in Ray runtime environment

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -57,6 +57,7 @@ from vllm.utils import (DEFAULT_MAX_NUM_BATCHED_TOKENS,
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
     from ray.util.placement_group import PlacementGroup
+    from ray.runtime_env import RuntimeEnv
     from transformers.configuration_utils import PretrainedConfig
 
     import vllm.model_executor.layers.quantization as me_quant
@@ -73,6 +74,7 @@ if TYPE_CHECKING:
 else:
     DataclassInstance = Any
     PlacementGroup = Any
+    RuntimeEnv = Any
     PretrainedConfig = Any
     ExecutorBase = Any
     QuantizationConfig = Any
@@ -1901,6 +1903,9 @@ class ParallelConfig:
 
     placement_group: Optional["PlacementGroup"] = None
     """ray distributed model workers placement group."""
+
+    runtime_env: Optional["RuntimeEnv"] = None
+    """ray runtime environment for distributed workers"""
 
     distributed_executor_backend: Optional[Union[DistributedExecutorBackend,
                                                  type["ExecutorBase"]]] = None

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -56,8 +56,8 @@ from vllm.utils import (DEFAULT_MAX_NUM_BATCHED_TOKENS,
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
-    from ray.util.placement_group import PlacementGroup
     from ray.runtime_env import RuntimeEnv
+    from ray.util.placement_group import PlacementGroup
     from transformers.configuration_utils import PretrainedConfig
 
     import vllm.model_executor.layers.quantization as me_quant

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1088,12 +1088,14 @@ class EngineArgs:
         # we are in a Ray actor. If so, then the placement group will be
         # passed to spawned processes.
         placement_group = None
+        runtime_env = None
         if is_in_ray_actor():
             import ray
 
             # This call initializes Ray automatically if it is not initialized,
             # but we should not do this here.
             placement_group = ray.util.get_current_placement_group()
+            runtime_env = ray.get_runtime_context().runtime_env
 
         data_parallel_external_lb = self.data_parallel_rank is not None
         if data_parallel_external_lb:
@@ -1170,6 +1172,7 @@ class EngineArgs:
             disable_custom_all_reduce=self.disable_custom_all_reduce,
             ray_workers_use_nsight=self.ray_workers_use_nsight,
             placement_group=placement_group,
+            runtime_env=runtime_env,
             distributed_executor_backend=self.distributed_executor_backend,
             worker_cls=self.worker_cls,
             worker_extension_cls=self.worker_extension_cls,

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -288,14 +288,14 @@ def initialize_ray_cluster(
     elif current_platform.is_rocm() or current_platform.is_xpu():
         # Try to connect existing ray instance and create a new one if not found
         try:
-            ray.init("auto")
+            ray.init("auto", runtime_env=parallel_config.runtime_env)
         except ConnectionError:
             logger.warning(
                 "No existing RAY instance detected. "
                 "A new instance will be launched with current node resources.")
-            ray.init(address=ray_address, num_gpus=parallel_config.world_size)
+            ray.init(address=ray_address, num_gpus=parallel_config.world_size, runtime_env=parallel_config.runtime_env)
     else:
-        ray.init(address=ray_address)
+        ray.init(address=ray_address, runtime_env=parallel_config.runtime_env)
 
     device_str = current_platform.ray_device_key
     if not device_str:

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -293,7 +293,9 @@ def initialize_ray_cluster(
             logger.warning(
                 "No existing RAY instance detected. "
                 "A new instance will be launched with current node resources.")
-            ray.init(address=ray_address, num_gpus=parallel_config.world_size, runtime_env=parallel_config.runtime_env)
+            ray.init(address=ray_address,
+                    num_gpus=parallel_config.world_size,
+                    runtime_env=parallel_config.runtime_env)
     else:
         ray.init(address=ray_address, runtime_env=parallel_config.runtime_env)
 

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -294,8 +294,8 @@ def initialize_ray_cluster(
                 "No existing RAY instance detected. "
                 "A new instance will be launched with current node resources.")
             ray.init(address=ray_address,
-                    num_gpus=parallel_config.world_size,
-                    runtime_env=parallel_config.runtime_env)
+                     num_gpus=parallel_config.world_size,
+                     runtime_env=parallel_config.runtime_env)
     else:
         ray.init(address=ray_address, runtime_env=parallel_config.runtime_env)
 


### PR DESCRIPTION
## Purpose
The engine is run in a spawned subprocess, which Ray interprets as a new job with its own runtime environment. This means that vllm can't be pulled through the Ray runtime environment, as we don't pass the original job's runtime env through to the subprocess.

This issue was reported here.

## Test Plan
Ran a Ray job with the following code
```
vision_processor_config = vLLMEngineProcessorConfig(
        model="Qwen/Qwen2.5-VL-32B-Instruct",
        engine_kwargs=dict(
            tensor_parallel_size=1,  
            pipeline_parallel_size=NUMBER_OF_GPUS,
            max_model_len=4096,
            enable_chunked_prefill=True,
            max_num_batched_tokens=2048,
            distributed_executor_backend="ray",
            device="cuda",
        ),
        # Override Ray's runtime env to include the Hugging Face token. Ray Data uses Ray under the hood to orchestrate the inference pipeline.
        runtime_env=dict(
            env_vars=dict(
                HF_TOKEN="<token>",
                VLLM_USE_V1="1",
            ),
        ),
        batch_size=1,
        concurrency=1,
        has_image=False
    )
    
    #build the processor
    processor = build_llm_processor(
        vision_processor_config,
        preprocess=lambda row: dict(
            messages=[
                {"role": "system", "content": "You are a bot that responds with haikus."},
                {"role": "user", "content": row["item"]}
            ],
            sampling_params=dict(
                temperature=0.3,
                max_tokens=250,
            )
        ),
        postprocess=lambda row: dict(
            answer=row["generated_text"],
            **row  # This will return all the original columns in the dataset.
        ),
    )

    #create the dataset
    ds = ray.data.from_items(["Start of the haiku is: Complete this for me..."])
    ds = processor(ds)
    ds.show(limit=1)
```

## Test Result
I checked in the Ray dashboard that the launched job has the runtime env provided in the `engine_kwargs`.