### PR TITLE
[Frontend] change default log request behavior

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -253,7 +253,7 @@ export https_proxy=http://your.proxy.server:port
 https_proxy=http://your.proxy.server:port huggingface-cli download <model_name>
 
 # or use vllm cmd directly
-https_proxy=http://your.proxy.server:port  vllm serve <model_name> --disable-log-requests
+https_proxy=http://your.proxy.server:port  vllm serve <model_name>
 ```
 
 - Set the proxy in Python interpreter:

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -290,6 +290,22 @@ def test_prefix_cache_default():
     assert not engine_args.enable_prefix_caching
 
 
+def test_log_request_default_and_legacy_flag(caplog_vllm):
+    parser = AsyncEngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    args = parser.parse_args([])
+    caplog_vllm.clear()
+    engine_args = AsyncEngineArgs.from_cli_args(args=args)
+    assert engine_args.disable_log_requests
+    assert "--disable-log-requests" in caplog_vllm.text
+
+    caplog_vllm.clear()
+    args = parser.parse_args(["--enable-legacy-log-requests"])
+    engine_args = AsyncEngineArgs.from_cli_args(args=args)
+    assert not engine_args.disable_log_requests
+    assert caplog_vllm.text == ""
+
+
 # yapf: disable
 @pytest.mark.parametrize(("arg", "expected", "option"), [
     (None, None, "mm-processor-kwargs"),

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -326,7 +326,7 @@ async def main(args):
         for name in served_model_names
     ]
 
-    if args.disable_log_requests:
+    if engine_args.disable_log_requests:
         request_logger = None
     else:
         request_logger = RequestLogger(max_log_len=args.max_log_len)


### PR DESCRIPTION
## Summary
- disable request logging by default
- add `--enable-legacy-log-requests` flag
- warn when no log request flag is provided
- update example doc snippet
- test new CLI flag behaviour

## Testing
- `pytest tests/engine/test_arg_utils.py::test_log_request_default_and_legacy_flag -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files vllm/engine/arg_utils.py vllm/entrypoints/openai/api_server.py vllm/entrypoints/openai/run_batch.py tests/engine/test_arg_utils.py docs/models/supported_models.md` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68781d09f15c83299730ec3d4ca30646