### PR TITLE
Enable multi-image support benchmarking for serving

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -375,6 +375,11 @@ async def async_request_openai_chat_completions(
             elif isinstance(mm_content, dict):
                 # Only single-image case. Append the one image.
                 content_list.append(mm_content)
+            else:
+                raise TypeError(
+                    "multi_modal_content must be a list or a dict, but got "
+                    f"{type(mm_content).__name__}"
+                )
 
             messages = [{"role": "user", "content": content_list}]
         else:

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -362,16 +362,30 @@ async def async_request_openai_chat_completions(
     async with aiohttp.ClientSession(
         trust_env=True, timeout=AIOHTTP_TIMEOUT
     ) as session:
-        content = [{"type": "text", "text": request_func_input.prompt}]
-        if request_func_input.multi_modal_content:
-            content.append(request_func_input.multi_modal_content)
+        prompt_text = request_func_input.prompt
+        mm_content = request_func_input.multi_modal_content
+
+        content_list = [{"type": "text", "text": prompt_text}]
+
+        # Check if image exist
+        if mm_content:
+            if isinstance(mm_content, list):
+                # Multi Images exist. Extend the list with all images.
+                content_list.extend(mm_content)
+            elif isinstance(mm_content, dict):
+                # Only single-image case. Append the one image.
+                content_list.append(mm_content)
+
+            messages = [{"role": "user", "content": content_list}]
+        else:
+            # text-only
+            messages = [{"role": "user", "content": prompt_text}]
+
         payload = {
             "model": request_func_input.model_name
             if request_func_input.model_name
             else request_func_input.model,
-            "messages": [
-                {"role": "user", "content": content},
-            ],
+            "messages": messages,
             "temperature": 0.0,
             "max_completion_tokens": request_func_input.output_len,
             "stream": True,

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -94,7 +94,7 @@ class BenchmarkDataset(ABC):
         """
         content = [{"text": prompt, "type": "text"}]
         if mm_content is not None:
-            content.append(mm_content)
+            content.extend(mm_content)
         return [{"role": "user", "content": content}]
 
     def load_data(self) -> None:

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -65,6 +65,7 @@ from benchmark_dataset import (
     HuggingFaceDataset,
     InstructCoderDataset,
     MTBenchDataset,
+    MuirBenchDataset,
     NextEditPredictionDataset,
     RandomDataset,
     SampleRequest,
@@ -357,7 +358,7 @@ async def benchmark(
         input_requests[0].multi_modal_data,
     )
 
-    assert test_mm_content is None or isinstance(test_mm_content, dict)
+    assert test_mm_content is None or isinstance(test_mm_content, (dict, list))
     test_input = RequestFuncInput(
         model=model_id,
         model_name=model_name,
@@ -795,6 +796,9 @@ def main(args: argparse.Namespace):
         elif args.dataset_path in ASRDataset.SUPPORTED_DATASET_PATHS:
             dataset_class = ASRDataset
             args.hf_split = "train"
+        elif args.dataset_path in MuirBenchDataset.SUPPORTED_DATASET_PATHS:
+            dataset_class = MuirBenchDataset
+            args.hf_split = "test"
         else:
             supported_datasets = set(
                 [


### PR DESCRIPTION
## Purpose

This PR updates the online benchmark script (`benchmarks/benchmark_serving.py`) to support multi-image prompts. This capability is necessary for accurately benchmarking multimodal models using dataset that support more than one image e.g. MUIRBENCH.

## Test Plan

To validate the changes, run the online benchmark script pointing to a multi-image dataset. The following command was used for testing with the MUIRBENCH dataset:

```sh
python3 benchmarks/benchmark_serving.py \
    --backend openai-chat \
    --endpoint /chat/completions \
    --base-url http://127.0.0.1:8688/v1 \
    --model gemma/gemma-3-27b-it \
    --request-rate "inf" \
    --percentile-metrics ttft,tpot,itl,e2el \
    --ignore-eos \
    --num-prompt 128 \
    --port 8688 \
    --dataset-path MUIRBENCH/MUIRBENCH \
    --dataset-name hf \
    --max-concurrency 128 \
    --save-result
```

## Test Result

The results from the test command are provided below:

```text
============ Serving Benchmark Result ============
Successful requests:                     128
Benchmark duration (s):                  116.25
Total input tokens:                      2808
Total generated tokens:                  16384
Request throughput (req/s):              1.10
Output token throughput (tok/s):         140.93
Total Token throughput (tok/s):          165.09
---------------Time to First Token----------------
Mean TTFT (ms):                          73745.15
Median TTFT (ms):                        71047.68
P99 TTFT (ms):                           111490.03
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          194.42
Median TPOT (ms):                        162.71
P99 TPOT (ms):                           425.83
---------------Inter-token Latency----------------
Mean ITL (ms):                           192.97
Median ITL (ms):                         40.98
P99 ITL (ms):                            1227.04
----------------End-to-end Latency----------------
Mean E2EL (ms):                          98436.22
Median E2EL (ms):                        88044.50
P99 E2EL (ms):                           116240.25
==================================================
```
