### PR TITLE
[Bugfix] Capture ray import error as string to avoid persistent references

### DIFF
--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -145,7 +145,9 @@ try:
 
 except ImportError as e:
     ray = None  # type: ignore
-    ray_import_err = e
+    # only capture string to avoid variable references in the traceback that can
+    # prevent garbage collection in some cases
+    ray_import_err = str(e)
     RayWorkerWrapper = None  # type: ignore
 
 
@@ -157,8 +159,8 @@ def ray_is_available() -> bool:
 def assert_ray_available():
     """Raise an exception if Ray is not available."""
     if ray is None:
-        raise ValueError("Failed to import Ray, please install Ray with "
-                         "`pip install ray`.") from ray_import_err
+        raise ValueError(f"Failed to import Ray: {ray_import_err}."
+                         "Please install Ray with `pip install ray`.")
 
 
 def _verify_bundles(placement_group: "PlacementGroup",


### PR DESCRIPTION
## Purpose

Fix a bug that prevents an `LLM()` instance from being garbage collected after deletion. This could result in unexpected memory usage or an `EADDRINUSE` error when attempting to create a second `LLM()` in the same process.

## Test Plan

This is a simple script to reproduce the problem:
```
import gc
import weakref

from vllm import LLM

llm = LLM(model="ibm-granite/granite-3.3-2b-instruct", max_model_len=32000, max_num_seqs=2, tensor_parallel_size=2, enforce_eager=True)

# a weakref does not prevent garbage collection
weakllm = weakref.ref(llm)

print("BEFORE refcount", len(gc.get_referrers(weakllm())))
del llm
gc.collect()

if weakllm() is not None:
  print("AFTER refcount", len(gc.get_referrers(weakllm())))
  print("NOT GARBAGE COLLECTED!")
  print(gc.get_referrers[0])
```

If Ray is installed, then I get `BEFORE refcount 1` and the `weakllm` loses its referent. If Ray is not installed, I instead get:
```
BEFORE refcount 2
NOT GARBAGE COLLECTED!
AFTER refcount 1
[<frame at 0x7fb6861f0040, file '/tmp/home/my-vllm/lib64/python3.12/site-packages/vllm/entrypoints/llm.py', line 276, code __init__>]
```

## Test Result

After applying the fix from this PR, the refcount is only 1 even with `ray` uninstalled, so the `llm` resources get garbage collected as desired.