### PR TITLE
[LMCache][Example] Align the PYTHONHASHSEED for prefillers and decoders for KV chunks hashing

### DIFF
--- a/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_vllm_launcher.sh
+++ b/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_vllm_launcher.sh
@@ -15,6 +15,14 @@ else
     MODEL=$2
 fi
 
+# The prefillers and decoders in LMCache use the same hash seed for all chunk keys.
+# This seed must be aligned so that decoders can identify and retrieve KV cache
+# entries stored by prefillers.
+#
+# WARNING: Using a fixed hash seed is insecure and makes the application vulnerable to
+# denial-of-service attacks. In a production environment, this should be set to a
+# secure random value. This is set to a fixed value for demonstration purposes only.
+export PYTHONHASHSEED=${VLLM_PYTHON_HASH_SEED:-123}
 
 if [[ $1 == "prefiller" ]]; then
     # Prefiller listens on port 8100


### PR DESCRIPTION
Add and align the **PYTHONHASHSEED** for prefillers and decoders for hashing the chunks.
For now the LMCache uses the hash seed from the vllm, so it is needed to align the hash seed for all prefillers and decoders, so that the decoders can identify and retrieve the kv cache chunks saved by the prefillers.
https://github.com/LMCache/LMCache/blob/dev/lmcache/v1/token_database.py#L106-L107