### PR TITLE
[Bugfix] Mistral crashes on tool with no description

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -168,7 +168,8 @@ def make_mistral_chat_completion_request(
                 message["content"] = content
 
     # The Mistral client, in comparison to the OpenAI client, requires the
-    # "parameters" dict to be present, even if it's empty.
+    # "parameters" dict and the "description" string to be present
+    # even if they are empty.
     if tools:
         for function in [
                 tool["function"] for tool in tools
@@ -176,6 +177,8 @@ def make_mistral_chat_completion_request(
         ]:
             if function.get("parameters") is None:
                 function["parameters"] = {}
+            if function.get("description") is None:
+                function["description"] = ""
 
     from mistral_common.protocol.instruct.request import ChatCompletionRequest
     return ChatCompletionRequest(messages=messages,


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/21165.

Adds a default empty description string to Mistral to avoid a crash if a description is not provided to a tool. The Mistral client, in comparison to the OpenAI client, requires the "description" string to be present, even if it's empty.
