### PR TITLE
Let GraniteMoeAttention use YaRN

### DIFF
--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -24,7 +24,7 @@
 # limitations under the License.
 """Inference-only GraniteMoe model."""
 from collections.abc import Iterable
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 from torch import nn
@@ -113,6 +113,7 @@ class GraniteMoeAttention(nn.Module):
         num_kv_heads: int,
         max_position: int = 4096 * 32,
         rope_theta: float = 10000,
+        rope_scaling: Optional[dict[str, Any]] = None,
         cache_config: Optional[CacheConfig] = None,
         quant_config: Optional[QuantizationConfig] = None,
         attention_multiplier: Optional[float] = None,
@@ -163,6 +164,7 @@ class GraniteMoeAttention(nn.Module):
             max_position=max_position,
             base=int(self.rope_theta),
             is_neox_style=True,
+            rope_scaling=rope_scaling,
         )
         self.attn = Attention(self.num_heads,
                               self.head_dim,
@@ -198,12 +200,14 @@ class GraniteMoeDecoderLayer(nn.Module):
         self.hidden_size = config.hidden_size
         # Requires transformers > 4.32.0
         rope_theta = getattr(config, "rope_theta", 10000)
+        rope_scaling = getattr(config, "rope_scaling", None)
         self.self_attn = GraniteMoeAttention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             max_position=config.max_position_embeddings,
             num_kv_heads=config.num_key_value_heads,
             rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
             cache_config=cache_config,
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",

--- a/vllm/model_executor/models/granitemoeshared.py
+++ b/vllm/model_executor/models/granitemoeshared.py
@@ -81,12 +81,14 @@ class GraniteMoeSharedDecoderLayer(nn.Module):
         self.hidden_size = config.hidden_size
         # Requires transformers > 4.32.0
         rope_theta = getattr(config, "rope_theta", 10000)
+        rope_scaling = getattr(config, "rope_scaling", None)
         self.self_attn = GraniteMoeAttention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             max_position=config.max_position_embeddings,
             num_kv_heads=config.num_key_value_heads,
             rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
             cache_config=cache_config,
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
We have some new GraniteMoE models that use YaRN that are currently producing garbage output after 4k context length. The models use YaRN but right now vLLM modeling code is not passing the `rope_scaling` info to `get_rope` so the YaRN isn't getting picked up. This is a simple fix for that.  

## Test Plan

I can reproduce the issue using long prompts from longbench as follows:
```python
from vllm import LLM, SamplingParams
from datasets import load_dataset
import os
model = LLM(
    "/models/new_granite",
    tensor_parallel_size=2,
    enforce_eager=True,
)
sampling_params = SamplingParams(max_tokens=100,
                                 temperature=0.0,
                                 ignore_eos=True)
data = load_dataset('THUDM/LongBench', "2wikimqa", split='test')
prompt = data[0]['context']
output = model.generate([prompt], sampling_params)
print("Prompt length:  ", len(output[0].prompt_token_ids))
print("Generated text: ", repr(output[0].outputs[0].text))
```
produces on main:
```
Prompt length:   8973
Generated text:  'ss.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n. of Hung Hung man.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.'
```

## Test Result
After the fix from this PR it produces:
```
Prompt length:   8973
Generated text:  '\n\nNotes\n\nReferences\n\nCategory:Ottoman princesses\nCategory:14th-century births\nCategory:14th-century deaths\nCategory:1390s deaths\nCategory:14th-century Ottoman people\nCategory:14th-century women rulers\nCategory:14th-century women rulers in Asia\nCategory:15th-century O'
```


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
