### PR TITLE
[Docs] Update Tensorizer usage documentation

### DIFF
--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -1,7 +1,4 @@
----
-title: Loading models with CoreWeave's Tensorizer
----
-[](){ #tensorizer }
+# Loading models with CoreWeave's Tensorizer
 
 vLLM supports loading models with [CoreWeave's Tensorizer](https://docs.coreweave.com/coreweave-machine-learning-and-ai/inference/tensorizer).
 vLLM model tensors that have been serialized to disk, an HTTP/HTTPS endpoint, or S3 endpoint can be deserialized

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -14,7 +14,7 @@ To install `tensorizer`, run `pip install vllm[tensorizer]`.
 ## The basics
 
 To load a model using Tensorizer, the model first needs to be serialized by
-Tensorizer. [The example script](https://docs.vllm.ai/en/latest/examples/others/tensorize_vllm_model.html) takes care of this process.
+Tensorizer. [The example script](../../examples/others/tensorize_vllm_model.md) takes care of this process.
 
 Let's walk through a basic example by serializing `facebook/opt-125m` using the script, and then loading it for inference.
 

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -8,25 +8,24 @@ vLLM model tensors that have been serialized to disk, an HTTP/HTTPS endpoint, or
 at runtime extremely quickly directly to the GPU, resulting in significantly
 shorter Pod startup times and CPU memory usage. Tensor encryption is also supported.
 
-vLLM fully integrates Tensorizer in to its model loading machinery. The 
-following will give a brief overview on how to get started with using 
-Tensorizer on vLLM.
+vLLM fully integrates Tensorizer in to its model loading machinery. The following will give a brief overview on how to get started with using Tensorizer on vLLM.
+
+## Installing Tensorizer
+
+To install `tensorizer`, run `pip install vllm[tensorizer]`.
 
 ## The basics
-To load a model using Tensorizer, it first needs to be serialized by Tensorizer.
-The example script in [examples/others/tensorize_vllm_model.py] takes care of 
-this process.
-(https://docs.vllm.ai/en/latest/examples/others/tensorize_vllm_model.html)
 
-Let's walk through a basic example by serializing `facebook/opt-125m` using the
-script, and then loading it for inference.
+To load a model using Tensorizer, the model first needs to be serialized by 
+Tensorizer. [The example script](https://docs.vllm.ai/en/latest/examples/others/tensorize_vllm_model.html) takes care of this process.
 
-## Saving a vLLM model with Tensorizer
-To save a model with Tensorizer, call the example script with the necessary
+Let's walk through a basic example by serializing `facebook/opt-125m` using the script, and then loading it for inference.
+
+## Serializing a vLLM model with Tensorizer
+
+To serialize a model with Tensorizer, call the example script with the necessary
 CLI arguments. The docstring for the script itself explains the CLI args
-and how to use it properly in great detail, and we'll use one of the 
-examples from the docstring directly, assuming we want to save our model at 
-our S3 bucket example `s3://my-bucket`:
+and how to use it properly in great detail, and we'll use one of the examples from the docstring directly, assuming we want to serialize and save our model at our S3 bucket example `s3://my-bucket`:
 
 ```bash
 python examples/others/tensorize_vllm_model.py \
@@ -36,10 +35,7 @@ python examples/others/tensorize_vllm_model.py \
    --suffix v1
 ```
 
-This saves the model tensors at `s3://my-bucket/vllm/facebook/opt-125m/v1`. If 
-you intend on applying a LoRA adapter to your tensorized model, you can pass 
-the HF id of the LoRA adapter in the above command, and the artifacts will be 
-saved there too:
+This saves the model tensors at `s3://my-bucket/vllm/facebook/opt-125m/v1`. If you intend on applying a LoRA adapter to your tensorized model, you can pass the HF id of the LoRA adapter in the above command, and the artifacts will be saved there too:
 
 ```bash
 python examples/others/tensorize_vllm_model.py \
@@ -51,11 +47,8 @@ python examples/others/tensorize_vllm_model.py \
 ```
 
 ## Serving the model using Tensorizer
-Once the model is serialized where you want it, you can load the model using 
-`vllm serve` or the `LLM` entrypoint. The directory where the 
-model artifacts were saved can be passed to the `model` argument for 
-`LLM()` and `vllm serve`. For example, to serve the tensorized model 
-saved previously with the LoRA adapter, you'd do:
+
+Once the model is serialized where you want it, you can load the model using `vllm serve` or the `LLM` entrypoint. You can pass the directory where you saved the model to the `model` argument for `LLM()` and `vllm serve`. For example, to serve the tensorized model saved previously with the LoRA adapter, you'd do:
 
 ```bash
 vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
@@ -74,20 +67,9 @@ llm = LLM(
 )
 ```
 
-`tensorizer`'s core objects that serialize and deserialize models are 
-`TensorSerializer` and `TensorDeserializer` respectively. In order to 
-pass arbitrary kwargs to these, which will configure the serialization 
-and deserialization processes, you can provide them as keys to 
-`model_loader_extra_config` with `serialization_kwargs` and 
-`deserialization_kwargs` respectively. Full docstrings detailing all 
-parameters for the aforementioned objects can be found in `tensorizer`'s
-[serialization.py](https://github.
-com/coreweave/tensorizer/blob/main/tensorizer/serialization.py) file.
+`tensorizer`'s core objects that serialize and deserialize models are `TensorSerializer` and `TensorDeserializer` respectively. In order to pass arbitrary kwargs to these, which will configure the serialization and deserialization processes, you can provide them as keys to `model_loader_extra_config` with `serialization_kwargs` and `deserialization_kwargs` respectively. Full docstrings detailing all parameters for the aforementioned objects can be found in `tensorizer`'s [serialization.py](https://github.com/coreweave/tensorizer/blob/main/tensorizer/serialization.py) file.
 
-As an example, CPU concurrency can be limited when serializing with 
-`tensorizer` via the `limit_cpu_concurrency` parameter in the 
-initializer for `TensorSerializer`. To set `limit_cpu_concurrency` to 
-some arbitrary value, you would do so like this when serializing:
+As an example, CPU concurrency can be limited when serializing with `tensorizer` via the `limit_cpu_concurrency` parameter in the initializer for `TensorSerializer`. To set `limit_cpu_concurrency` to some arbitrary value, you would do so like this when serializing:
 
 ```bash
 python examples/others/tensorize_vllm_model.py \
@@ -99,10 +81,7 @@ python examples/others/tensorize_vllm_model.py \
    --suffix v1
 ```
 
-As an example when customizing the loading process via `TensorDeserializer`, 
-one could limit the number of concurrency readers during 
-deserialization with the `num_readers` parameter in the initializer 
-via `model_loader_extra_config` like so:
+As an example when customizing the loading process via `TensorDeserializer`, you could limit the number of concurrency readers during deserialization with the `num_readers` parameter in the initializer via `model_loader_extra_config` like so:
 
 ```bash
 vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
@@ -122,8 +101,3 @@ llm = LLM(
     model_loader_extra_config={"deserialization_kwargs": {"num_readers": 2}}
 )
 ```
-
-
-
-!!! note
-    Note that to use this feature you will need to install `tensorizer` by running `pip install vllm[tensorizer]`.

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -67,6 +67,8 @@ llm = LLM(
 )
 ```
 
+## Options for configuring Tensorizer
+
 `tensorizer`'s core objects that serialize and deserialize models are `TensorSerializer` and `TensorDeserializer` respectively. In order to pass arbitrary kwargs to these, which will configure the serialization and deserialization processes, you can provide them as keys to `model_loader_extra_config` with `serialization_kwargs` and `deserialization_kwargs` respectively. Full docstrings detailing all parameters for the aforementioned objects can be found in `tensorizer`'s [serialization.py](https://github.com/coreweave/tensorizer/blob/main/tensorizer/serialization.py) file.
 
 As an example, CPU concurrency can be limited when serializing with `tensorizer` via the `limit_cpu_concurrency` parameter in the initializer for `TensorSerializer`. To set `limit_cpu_concurrency` to some arbitrary value, you would do so like this when serializing:

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -1,13 +1,129 @@
-# Loading models with CoreWeave's Tensorizer
+---
+title: Loading models with CoreWeave's Tensorizer
+---
+[](){ #tensorizer }
 
 vLLM supports loading models with [CoreWeave's Tensorizer](https://docs.coreweave.com/coreweave-machine-learning-and-ai/inference/tensorizer).
 vLLM model tensors that have been serialized to disk, an HTTP/HTTPS endpoint, or S3 endpoint can be deserialized
 at runtime extremely quickly directly to the GPU, resulting in significantly
 shorter Pod startup times and CPU memory usage. Tensor encryption is also supported.
 
-For more information on CoreWeave's Tensorizer, please refer to
-[CoreWeave's Tensorizer documentation](https://github.com/coreweave/tensorizer). For more information on serializing a vLLM model, as well a general usage guide to using Tensorizer with vLLM, see
-the [vLLM example script](../../examples/others/tensorize_vllm_model.md).
+vLLM fully integrates Tensorizer in to its model loading machinery. The 
+following will give a brief overview on how to get started with using 
+Tensorizer on vLLM.
+
+## The basics
+To load a model using Tensorizer, it first needs to be serialized by Tensorizer.
+The example script in [examples/others/tensorize_vllm_model.py] takes care of 
+this process.
+(https://docs.vllm.ai/en/latest/examples/others/tensorize_vllm_model.html)
+
+Let's walk through a basic example by serializing `facebook/opt-125m` using the
+script, and then loading it for inference.
+
+## Saving a vLLM model with Tensorizer
+To save a model with Tensorizer, call the example script with the necessary
+CLI arguments. The docstring for the script itself explains the CLI args
+and how to use it properly in great detail, and we'll use one of the 
+examples from the docstring directly, assuming we want to save our model at 
+our S3 bucket example `s3://my-bucket`:
+
+```bash
+python examples/others/tensorize_vllm_model.py \
+   --model facebook/opt-125m \
+   serialize \
+   --serialized-directory s3://my-bucket \
+   --suffix v1
+```
+
+This saves the model tensors at `s3://my-bucket/vllm/facebook/opt-125m/v1`. If 
+you intend on applying a LoRA adapter to your tensorized model, you can pass 
+the HF id of the LoRA adapter in the above command, and the artifacts will be 
+saved there too:
+
+```bash
+python examples/others/tensorize_vllm_model.py \
+   --model facebook/opt-125m \
+   --lora-path <lora_id> \
+   serialize \
+   --serialized-directory s3://my-bucket \
+   --suffix v1
+```
+
+## Serving the model using Tensorizer
+Once the model is serialized where you want it, you can load the model using 
+`vllm serve` or the `LLM` entrypoint. The directory where the 
+model artifacts were saved can be passed to the `model` argument for 
+`LLM()` and `vllm serve`. For example, to serve the tensorized model 
+saved previously with the LoRA adapter, you'd do:
+
+```bash
+vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
+    --load-format tensorizer \
+    --enable-lora 
+```
+
+Or, with `LLM()`:
+
+```python
+from vllm import LLM
+llm = LLM(
+    "s3://my-bucket/vllm/facebook/opt-125m/v1", 
+    load_format="tensorizer",
+    enable_lora=True
+)
+```
+
+`tensorizer`'s core objects that serialize and deserialize models are 
+`TensorSerializer` and `TensorDeserializer` respectively. In order to 
+pass arbitrary kwargs to these, which will configure the serialization 
+and deserialization processes, you can provide them as keys to 
+`model_loader_extra_config` with `serialization_kwargs` and 
+`deserialization_kwargs` respectively. Full docstrings detailing all 
+parameters for the aforementioned objects can be found in `tensorizer`'s
+[serialization.py](https://github.
+com/coreweave/tensorizer/blob/main/tensorizer/serialization.py) file.
+
+As an example, CPU concurrency can be limited when serializing with 
+`tensorizer` via the `limit_cpu_concurrency` parameter in the 
+initializer for `TensorSerializer`. To set `limit_cpu_concurrency` to 
+some arbitrary value, you would do so like this when serializing:
+
+```bash
+python examples/others/tensorize_vllm_model.py \
+   --model facebook/opt-125m \
+   --lora-path <lora_id> \
+   serialize \
+   --serialized-directory s3://my-bucket \
+   --serialization-kwargs '{"limit_cpu_concurrency": 2}' \
+   --suffix v1
+```
+
+As an example when customizing the loading process via `TensorDeserializer`, 
+one could limit the number of concurrency readers during 
+deserialization with the `num_readers` parameter in the initializer 
+via `model_loader_extra_config` like so:
+
+```bash
+vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
+    --load-format tensorizer \
+    --enable-lora \
+    --model-loader-extra-config '{"deserialization_kwargs": {"num_readers": 2}}'
+```
+
+Or with `LLM()`:
+
+```python
+from vllm import LLM
+llm = LLM(
+    "s3://my-bucket/vllm/facebook/opt-125m/v1", 
+    load_format="tensorizer",
+    enable_lora=True,
+    model_loader_extra_config={"deserialization_kwargs": {"num_readers": 2}}
+)
+```
+
+
 
 !!! note
     Note that to use this feature you will need to install `tensorizer` by running `pip install vllm[tensorizer]`.

--- a/docs/models/extensions/tensorizer.md
+++ b/docs/models/extensions/tensorizer.md
@@ -13,7 +13,7 @@ To install `tensorizer`, run `pip install vllm[tensorizer]`.
 
 ## The basics
 
-To load a model using Tensorizer, the model first needs to be serialized by 
+To load a model using Tensorizer, the model first needs to be serialized by
 Tensorizer. [The example script](https://docs.vllm.ai/en/latest/examples/others/tensorize_vllm_model.html) takes care of this process.
 
 Let's walk through a basic example by serializing `facebook/opt-125m` using the script, and then loading it for inference.

--- a/examples/others/tensorize_vllm_model.py
+++ b/examples/others/tensorize_vllm_model.py
@@ -84,18 +84,24 @@ Or for deserializing:
 Once a model is serialized, tensorizer can be invoked with the `LLM` class 
 directly to load models:
 
-    llm = LLM(model="facebook/opt-125m",
-              load_format="tensorizer",
-              model_loader_extra_config=TensorizerConfig(
-                    tensorizer_uri = path_to_tensors,
-                    num_readers=3,
-                    )
-              )
+```python
+from vllm import LLM
+llm = LLM(
+    "s3://my-bucket/vllm/facebook/opt-125m/v1", 
+    load_format="tensorizer",
+    enable_lora=True
+)
+```
+
             
 A serialized model can be used during model loading for the vLLM OpenAI
-inference server. `model_loader_extra_config` is exposed as the CLI arg
-`--model-loader-extra-config`, and accepts a JSON string literal of the
-TensorizerConfig arguments desired.
+inference server:
+
+```
+vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
+    --load-format tensorizer \
+    --enable-lora 
+```
 
 In order to see all of the available arguments usable to configure 
 loading with tensorizer that are given to `TensorizerConfig`, run:
@@ -116,10 +122,9 @@ the LoRA artifacts are in your model artifacts directory and specifying
 `--enable-lora`. For instance:
 
 ```
-vllm serve <model_path> \
+vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
     --load-format tensorizer \
-    --model-loader-extra-config '{"tensorizer_uri": "<model_path>.tensors"}' \
-    --enable-lora
+    --enable-lora 
 ```
 """
 

--- a/examples/others/tensorize_vllm_model.py
+++ b/examples/others/tensorize_vllm_model.py
@@ -88,8 +88,7 @@ directly to load models:
 from vllm import LLM
 llm = LLM(
     "s3://my-bucket/vllm/facebook/opt-125m/v1", 
-    load_format="tensorizer",
-    enable_lora=True
+    load_format="tensorizer"
 )
 ```
 
@@ -99,8 +98,7 @@ inference server:
 
 ```
 vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
-    --load-format tensorizer \
-    --enable-lora 
+    --load-format tensorizer
 ```
 
 In order to see all of the available arguments usable to configure 


### PR DESCRIPTION
# Updated `tensorizer` usage patterns documentation

This PR updates the two `tensorizer` usage information sources on vLLM: the example script, and its dedicated documentation page. It reflects the new usage patterns made by recent `tensorizer` feature updates, and provides a more detailed guide on using `tensorizer` with vLLM.