### PR TITLE
[CI/Build] fix cpu_extension for apple silicon

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -102,6 +102,7 @@ else()
     find_isa(${CPUINFO} "S390" S390_FOUND)
 endif()
 
+
 if (AVX512_FOUND AND NOT AVX512_DISABLED)
     list(APPEND CXX_COMPILE_FLAGS
         "-mavx512f"

--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -60,7 +60,7 @@ endfunction()
 
 
 function(check_sysctl TARGET OUT)
-    execute_process(COMMAND sysctl -n ${TARGET}
+    execute_process(COMMAND sysctl -n "${TARGET}"
                     RESULT_VARIABLE SYSCTL_RET
                     OUTPUT_VARIABLE SYSCTL_INFO
                     ERROR_QUIET
@@ -87,7 +87,6 @@ is_avx512_disabled(AVX512_DISABLED)
 
 if (MACOSX_FOUND AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     message(STATUS "Apple Silicon Detected")
-    set(APPLE_SILICON_FOUND TRUE)
     set(ENABLE_NUMA OFF)
     check_sysctl(hw.optional.neon ASIMD_FOUND)
     check_sysctl(hw.optional.arm.FEAT_BF16 ARM_BF16_FOUND)
@@ -101,7 +100,6 @@ else()
     find_isa(${CPUINFO} "bf16" ARM_BF16_FOUND) # Check for ARM BF16 support
     find_isa(${CPUINFO} "S390" S390_FOUND)
 endif()
-
 
 if (AVX512_FOUND AND NOT AVX512_DISABLED)
     list(APPEND CXX_COMPILE_FLAGS

--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -58,6 +58,22 @@ function (find_isa CPUINFO TARGET OUT)
     endif()
 endfunction()
 
+
+function(check_sysctl TARGET OUT)
+    execute_process(COMMAND sysctl -n ${TARGET}
+                    RESULT_VARIABLE SYSCTL_RET
+                    OUTPUT_VARIABLE SYSCTL_INFO
+                    ERROR_QUIET
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(SYSCTL_RET EQUAL 0 AND
+      (SYSCTL_INFO STREQUAL "1" OR SYSCTL_INFO GREATER 0))
+        set(${OUT} ON PARENT_SCOPE)
+    else()
+        set(${OUT} OFF PARENT_SCOPE)
+    endif()
+endfunction()
+
+
 function (is_avx512_disabled OUT)
     set(DISABLE_AVX512 $ENV{VLLM_CPU_DISABLE_AVX512})
     if(DISABLE_AVX512 AND DISABLE_AVX512 STREQUAL "true")
@@ -70,7 +86,11 @@ endfunction()
 is_avx512_disabled(AVX512_DISABLED)
 
 if (MACOSX_FOUND AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    message(STATUS "Apple Silicon Detected")
     set(APPLE_SILICON_FOUND TRUE)
+    set(ENABLE_NUMA OFF)
+    check_sysctl(hw.optional.neon ASIMD_FOUND)
+    check_sysctl(hw.optional.arm.FEAT_BF16 ARM_BF16_FOUND)
 else()
     find_isa(${CPUINFO} "avx2" AVX2_FOUND)
     find_isa(${CPUINFO} "avx512f" AVX512_FOUND)
@@ -81,7 +101,6 @@ else()
     find_isa(${CPUINFO} "bf16" ARM_BF16_FOUND) # Check for ARM BF16 support
     find_isa(${CPUINFO} "S390" S390_FOUND)
 endif()
-
 
 if (AVX512_FOUND AND NOT AVX512_DISABLED)
     list(APPEND CXX_COMPILE_FLAGS
@@ -149,9 +168,6 @@ elseif (ASIMD_FOUND)
         set(MARCH_FLAGS "-march=armv8.2-a+dotprod+fp16")  
     endif()
     list(APPEND CXX_COMPILE_FLAGS ${MARCH_FLAGS})     
-elseif(APPLE_SILICON_FOUND)
-    message(STATUS "Apple Silicon Detected")
-    set(ENABLE_NUMA OFF)
 elseif (S390_FOUND)
     message(STATUS "S390 detected")
     # Check for S390 VXE support


### PR DESCRIPTION
## Purpose
The purpose for this pr is to fix the cpu installation from source for apple silicon CPUs. Recently, basic serving capabilities and examples stopped working in my local setup (M3 pro). I bisected my way to this pr #14129 which introduced int8 quantization for ARM CPU. The problem lied on the fact that although apple silicon shared some codepath with the rest of the arm cpu in `cpu_extension.cmake`, it also had some specific configurations that ended up breaking build after the int8 support was introduced; more specifically, apple silicon pathway was not enabling ASIMD_FOUND thus not including `quant.cpp` (`cpu_extension.cmake:284`) source.

After a fresh install from source 
```bash
git clone https://github.com/vllm-project/vllm.git
cd vllm
uv venv --python 3.12 --seed
source .venv/bin/activate
uv pip install -r requirements/cpu.txt
uv pip install -e .
```
Basic example failed with
```bash
python examples/offline_inference/basic/basic.py
> WARNING 07-18 12:13:35 [_custom_ops.py:20] Failed to import from vllm._C with ImportError("dlopen([...]/vllm/vllm/_C.abi3.so, 0x0002): symbol not found in flat namespace '__Z14int8_scaled_mmRN2at6TensorERKS0_S3_S3_S3_RKNSt3__18optionalIS0_EE'")
> [...]
> AttributeError: '_OpNamespace' '_C_cache_ops' object has no attribute 'reshape_and_cache'
```

In order to fix, this pr enabled ASIMD_FOUND for apple silicon as well. For safety, it checked for support with the following command: `sysctl -n hw.optional.neon`. As far as I know, all apple silicon, starting from M1 up to M4 generation support this feature, but still decided to gate ASIMD_FOUND on this check in the case the support is dropped for future generations.

After this fix, cpu installation from source started working again.

This pr also enables bf16 support for apple silicon. This feature is gated via the following check hw.optional.arm.FEAT_BF16. Based on this [LLVM's commit](https://github.com/llvm/llvm-project/commit/677da09d0259d7530d32e85cb561bee15f0066e2#diff-9c6b94ec4c0b662b700d94091204d00cea9ad766ef596ca67c0f5b84d957aff8), bf16 support was introduced for cpu in m2 generation.

## Test Plan
Unfortunately I'm not familiar enough with build runs in CI, I would appreciate some guidance for this point.