### PR TITLE
[Compilation fix] add stubs to allow compilation without sm100

### DIFF
--- a/csrc/attention/mla/cutlass_mla_entry.cu
+++ b/csrc/attention/mla/cutlass_mla_entry.cu
@@ -29,16 +29,14 @@ void sm100_cutlass_mla_decode(
     torch::Tensor const& out, torch::Tensor const& q_nope,
     torch::Tensor const& q_pe, torch::Tensor const& kv_c_and_k_pe_cache,
     torch::Tensor const& seq_lens, torch::Tensor const& page_table,
-    torch::Tensor const& workspace, double sm_scale,
-    int64_t num_kv_splits =
-        1 /* Set to 1 to avoid cuda_graph issue by default. */) {
+    torch::Tensor const& workspace, double sm_scale, int64_t num_kv_splits) {
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled cutlass MLA");
 }
 
-int64_t sm100_cutlass_mla_get_workspace_size(
-    int64_t max_seq_len, int64_t num_batches, int64_t sm_count = 0,
-    int64_t num_kv_splits =
-        1 /* Set to 1 to avoid cuda_graph issue by default. */) {
+int64_t sm100_cutlass_mla_get_workspace_size(int64_t max_seq_len,
+                                             int64_t num_batches,
+                                             int64_t sm_count = 0,
+                                             int64_t num_kv_splits) {
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled cutlass MLA");
 }
 #endif

--- a/csrc/attention/mla/cutlass_mla_entry.cu
+++ b/csrc/attention/mla/cutlass_mla_entry.cu
@@ -35,7 +35,7 @@ void sm100_cutlass_mla_decode(
 
 int64_t sm100_cutlass_mla_get_workspace_size(int64_t max_seq_len,
                                              int64_t num_batches,
-                                             int64_t sm_count = 0,
+                                             int64_t sm_count,
                                              int64_t num_kv_splits) {
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled cutlass MLA");
 }

--- a/csrc/attention/mla/cutlass_mla_entry.cu
+++ b/csrc/attention/mla/cutlass_mla_entry.cu
@@ -23,6 +23,23 @@ void cutlass_mla_decode_sm100a(torch::Tensor const& out,
                                torch::Tensor const& kv_c_and_k_pe_cache,
                                torch::Tensor const& seq_lens,
                                torch::Tensor const& page_table, double scale);
+#else
+// define fallback stubs
+void cutlass_mla_decode_sm100a(torch::Tensor const& out,
+                               torch::Tensor const& q_nope,
+                               torch::Tensor const& q_pe,
+                               torch::Tensor const& kv_c_and_k_pe_cache,
+                               torch::Tensor const& seq_lens,
+                               torch::Tensor const& page_table, double scale) {
+  TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled cutlass MLA");
+}
+
+int64_t sm100_cutlass_mla_get_workspace_size(int64_t max_seq_len,
+                                             int64_t num_batches,
+                                             int64_t sm_count,
+                                             int64_t num_kv_splits) {
+  TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled cutlass MLA");
+}
 #endif
 
 void cutlass_mla_decode(torch::Tensor const& out, torch::Tensor const& q_nope,

--- a/csrc/attention/mla/cutlass_mla_entry.cu
+++ b/csrc/attention/mla/cutlass_mla_entry.cu
@@ -24,20 +24,21 @@ void cutlass_mla_decode_sm100a(torch::Tensor const& out,
                                torch::Tensor const& seq_lens,
                                torch::Tensor const& page_table, double scale);
 #else
-// define fallback stubs
-void cutlass_mla_decode_sm100a(torch::Tensor const& out,
-                               torch::Tensor const& q_nope,
-                               torch::Tensor const& q_pe,
-                               torch::Tensor const& kv_c_and_k_pe_cache,
-                               torch::Tensor const& seq_lens,
-                               torch::Tensor const& page_table, double scale) {
+// fallback stubs
+void sm100_cutlass_mla_decode(
+    torch::Tensor const& out, torch::Tensor const& q_nope,
+    torch::Tensor const& q_pe, torch::Tensor const& kv_c_and_k_pe_cache,
+    torch::Tensor const& seq_lens, torch::Tensor const& page_table,
+    torch::Tensor const& workspace, double sm_scale,
+    int64_t num_kv_splits =
+        1 /* Set to 1 to avoid cuda_graph issue by default. */) {
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled cutlass MLA");
 }
 
-int64_t sm100_cutlass_mla_get_workspace_size(int64_t max_seq_len,
-                                             int64_t num_batches,
-                                             int64_t sm_count,
-                                             int64_t num_kv_splits) {
+int64_t sm100_cutlass_mla_get_workspace_size(
+    int64_t max_seq_len, int64_t num_batches, int64_t sm_count = 0,
+    int64_t num_kv_splits =
+        1 /* Set to 1 to avoid cuda_graph issue by default. */) {
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled cutlass MLA");
 }
 #endif


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Previously, when setting `TORCH_CUDA_ARCH_LIST="9.0"` for example, vllm would complain because some symbols were missing.

`sm100_cutlass_mla_get_workspace_size` is indeed referenced in `csrc/torch_bindings.cpp`

Add stubs to fix this situation.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
