### PR TITLE
[BugFix][CPU] Fix `TorchSDPABackendImpl` doesn't have `use_irope` 

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2628,7 +2628,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # TODO: Support other attention modules, e.g., cross-attention
             if attn_module.attn_type == AttentionType.DECODER:
                 use_local_attention = (self.attention_chunk_size is not None
-                                       and attn_module.impl.use_irope)
+                                       and getattr(attn_module.impl,
+                                                   "use_irope", False))
                 if attn_module.sliding_window is not None:
                     kv_cache_spec[layer_name] = SlidingWindowSpec(
                         block_size=block_size,


### PR DESCRIPTION
Temp fix to avoid potential error with `TorchSDPABackendImpl` not saving iRoPE; preferred fix is: https://github.com/vllm-project/vllm/pull/21188 but putting this up this simple fix incase that doesnt make it in time for the cut