### PR TITLE
[Bugfix] Correct input_len/prefix_len for RandomDataset in benchmarking

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -312,7 +312,7 @@ class RandomDataset(BenchmarkDataset):
 
         vocab_size = tokenizer.vocab_size
         num_special_tokens = tokenizer.num_special_tokens_to_add()
-        real_input_len = input_len - num_special_tokens
+        real_input_len = input_len - num_special_tokens - prefix_len
 
         prefix_token_ids = (
             np.random.randint(0, vocab_size, size=prefix_len).tolist()


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x] The test plan, such as providing test command.
- [ x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
Resolve prefix_len related bug in benchmarking_dataset.py to enable auto_tune.sh script.

When executing benchmarking/auto_tune.sh script, benchmarking_server.py script was being launched as shown here:
```shell
    python benchmarks/benchmark_serving.py \
        --backend vllm \
        --model google/gemma-3-27b-it  \
        --dataset-name random \
        --random-input-len 1500 \
        --random-output-len 200 \
        --ignore-eos \
        --disable-tqdm \
        --request-rate inf \
        --percentile-metrics ttft,tpot,itl,e2el \
        --goodput e2el:10000 \
        --num-prompts 1000 \
        --random-prefix-len 750 \
        --port 8004 \
        --profile &> "$bm_log"
```

However, failure would occur with the following output:

```
ERROR 07-18 16:39:37 [serving_completion.py:139] ValueError: This model's maximum context length is 1700 tokens. However, you requested 2450 tokens (2250 in the messages, 200 in the completion). Please reduce the length of the messages or completion.
```
Discovered line 315 of benchmarking_dataset.py contained the following line:

```python
real_input_len = input_len - num_special_tokens
```

## Test Plan
Updated to:

```python
real_input_len = input_len - num_special_tokens - prefix_len
```

## Test Result
Next run was successful with expected prefix cache hit rate %:

```
INFO 07-18 18:09:24 [loggers.py:118] Engine 000: Avg prompt throughput: 1649.9 tokens/s, Avg generation throughput: 44.1 tokens/s, Running: 10 reqs, Waiting: 990 reqs, GPU KV cache usage: 6.2%, Prefix cache hit rate: 50.4%
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
