### PR TITLE
[Refactor] Fix Compile Warning #1444-D

### DIFF
--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -20,6 +20,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include "../cuda_compat.h"
+#include <cuda/std/functional>
 
 #ifndef USE_ROCM
     #include <cub/util_type.cuh>
@@ -62,7 +63,7 @@ __launch_bounds__(TPB) __global__
 
     const int thread_row_offset = blockIdx.x * num_cols;
 
-    cub::Sum sum;
+    cuda::std::plus<float> sum;  
     float threadData(-FLT_MAX);
 
     // Don't touch finished rows.

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -63,7 +63,7 @@ __launch_bounds__(TPB) __global__
 
     const int thread_row_offset = blockIdx.x * num_cols;
 
-    cuda::std::plus<float> sum;  
+    cuda::std::plus<float> sum;
     float threadData(-FLT_MAX);
 
     // Don't touch finished rows.


### PR DESCRIPTION
## Purpose

 Fix Compile Warning #1444-D: type "cub::CUB_200802_SM_1000::Sum" was declared deprecated ("use cuda::std::plus instead")
