### PR TITLE
[benchmark] Port benchmark request sent optimization to benchmark_serving

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -30,7 +30,7 @@ import os
 import random
 import time
 import warnings
-from collections.abc import AsyncGenerator, Iterable
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, Optional
@@ -73,6 +73,7 @@ from benchmark_dataset import (
     VisionArenaDataset,
 )
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
+from vllm.benchmarks.serve import get_request
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
 
@@ -105,101 +106,6 @@ class BenchmarkMetrics:
     median_e2el_ms: float
     std_e2el_ms: float
     percentiles_e2el_ms: list[tuple[float, float]]
-
-
-def _get_current_request_rate(
-    ramp_up_strategy: Optional[Literal["linear", "exponential"]],
-    ramp_up_start_rps: Optional[int],
-    ramp_up_end_rps: Optional[int],
-    request_index: int,
-    total_requests: int,
-    request_rate: float,
-) -> float:
-    if (
-        ramp_up_strategy
-        and ramp_up_start_rps is not None
-        and ramp_up_end_rps is not None
-    ):
-        progress = request_index / max(total_requests - 1, 1)
-        if ramp_up_strategy == "linear":
-            increase = (ramp_up_end_rps - ramp_up_start_rps) * progress
-            return ramp_up_start_rps + increase
-        elif ramp_up_strategy == "exponential":
-            ratio = ramp_up_end_rps / ramp_up_start_rps
-            return ramp_up_start_rps * (ratio**progress)
-        else:
-            raise ValueError(f"Unknown ramp-up strategy: {ramp_up_strategy}")
-    return request_rate
-
-
-async def get_request(
-    input_requests: list[SampleRequest],
-    request_rate: float,
-    burstiness: float = 1.0,
-    ramp_up_strategy: Optional[Literal["linear", "exponential"]] = None,
-    ramp_up_start_rps: Optional[int] = None,
-    ramp_up_end_rps: Optional[int] = None,
-) -> AsyncGenerator[tuple[SampleRequest, float], None]:
-    """
-    Asynchronously generates requests at a specified rate
-    with OPTIONAL burstiness and OPTIONAL ramp-up strategy.
-
-    Args:
-        input_requests:
-            A list of input requests, each represented as a SampleRequest.
-        request_rate:
-            The rate at which requests are generated (requests/s).
-        burstiness (optional):
-            The burstiness factor of the request generation.
-            Only takes effect when request_rate is not inf.
-            Default value is 1, which follows a Poisson process.
-            Otherwise, the request intervals follow a gamma distribution.
-            A lower burstiness value (0 < burstiness < 1) results
-            in more bursty requests, while a higher burstiness value
-            (burstiness > 1) results in a more uniform arrival of requests.
-         ramp_up_strategy (optional):
-            The ramp-up strategy. Can be "linear" or "exponential".
-            If None, uses constant request rate (specified by request_rate).
-        ramp_up_start_rps (optional):
-            The starting request rate for ramp-up.
-        ramp_up_end_rps (optional):
-            The ending request rate for ramp-up.
-    """
-    assert burstiness > 0, (
-        f"A positive burstiness factor is expected, but given {burstiness}."
-    )
-    # Convert to list to get length for ramp-up calculations
-    if isinstance(input_requests, Iterable) and not isinstance(input_requests, list):
-        input_requests = list(input_requests)
-
-    total_requests = len(input_requests)
-    request_index = 0
-
-    for request in input_requests:
-        current_request_rate = _get_current_request_rate(
-            ramp_up_strategy,
-            ramp_up_start_rps,
-            ramp_up_end_rps,
-            request_index,
-            total_requests,
-            request_rate,
-        )
-
-        yield request, current_request_rate
-
-        request_index += 1
-
-        if current_request_rate == float("inf"):
-            # If the request rate is infinity, then we don't need to wait.
-            continue
-
-        theta = 1.0 / (current_request_rate * burstiness)
-
-        # Sample the request interval from the gamma distribution.
-        # If burstiness is 1, it follows exponential distribution.
-        interval = np.random.gamma(shape=burstiness, scale=theta)
-        # The next request will be sent after the interval.
-        await asyncio.sleep(interval)
 
 
 def calculate_metrics(

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -179,12 +179,12 @@ async def get_request(
         delay_ts = [delay * normalize_factor for delay in delay_ts]
 
     start_ts = time.time()
-    request_index = 0
     for request_index, request in enumerate(input_requests):
-        current_ts = time.time()
-        sleep_interval_s = start_ts + delay_ts[request_index] - current_ts
-        if sleep_interval_s > 0:
-            await asyncio.sleep(sleep_interval_s)
+        if delay_ts[request_index] > 0:
+            current_ts = time.time()
+            sleep_interval_s = start_ts + delay_ts[request_index] - current_ts
+            if sleep_interval_s > 0:
+                await asyncio.sleep(sleep_interval_s)
         yield request, request_rates[request_index]
 
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Port changes in https://github.com/vllm-project/vllm/pull/21108 to benchmark_serving script as well. However, instead of copypasta the code changes, we directly let benchmark_serving scripts depends on serve.py functions to avoid code duplication.

In a long run, we would completely get rid of benchmark_serving (https://github.com/vllm-project/vllm/issues/21206). However, that's out of the scope of this PR which is focusing on closing gaps among these 2 benchmark scripts.

## Test Plan
Check request throughput in the following scenarios:
- fix request rate
- unlimited request rate

## Test Result

### Fixed request rate benchmark run
- Request Rate 200: Throughput improved 184.01 -> 199.89
- Request Rate 1000: Throughput improved 687.95 -> 771.87 

Before (Request Rate 200)
<img width="359" height="292" alt="Screenshot 2025-07-18 at 3 19 40 PM" src="https://github.com/user-attachments/assets/5574a5a1-be92-496a-b48b-58c4e54344df" />
After (Request Rate 200)
<img width="359" height="295" alt="Screenshot 2025-07-18 at 3 20 18 PM" src="https://github.com/user-attachments/assets/43ef20ca-9dcb-49f5-8bcb-fca04407760c" />
Before (Request Rate 1000)
<img width="361" height="297" alt="Screenshot 2025-07-18 at 3 28 01 PM" src="https://github.com/user-attachments/assets/c4097933-d808-451f-b8af-b1b9a21c3b9c" />
After (Request Rate 1000)
<img width="370" height="298" alt="Screenshot 2025-07-18 at 3 29 17 PM" src="https://github.com/user-attachments/assets/c5af7208-453a-44e2-b9a7-52d544697c31" />

```
python benchmarks/benchmark_serving.py \
    --dataset-name random \
    --model facebook/opt-125m \
    --served-model-name facebook/opt-125m \
    --random-input-len 700 \
    --random-output-len 1 \
    --endpoint /v1/completions \
    --ignore-eos \
    --host localhost \
    --port 8000 \
    --request-rate 200 \
    --num-prompts 10000
```

### Unlimited request rate
Request Rate slight improvements: 418.24 -> 433.88

**Additional observations** It UNEXPECTED that the server request throughput of Unlimited request rate is worse  request rate 1000, which indicates there're weakness of the benchmark scripts or server for churn of requests. We're going to follow up for the investigation as a separate issue.

Before
<img width="360" height="297" alt="Screenshot 2025-07-18 at 3 25 10 PM" src="https://github.com/user-attachments/assets/9dfcdf27-11fe-4cd0-b076-c763ef215c00" />
After
<img width="360" height="297" alt="Screenshot 2025-07-18 at 3 22 47 PM" src="https://github.com/user-attachments/assets/095767a1-82df-4759-8e26-9267dd2fd834" />



## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
