### PR TITLE
[Core] Introduce popleft_n and append_n in FreeKVCacheBlockQueue to further optimize block_pool

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import itertools
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import Callable, Optional
@@ -280,12 +279,12 @@ class BlockPool:
             ordered_blocks: A list of blocks to free ordered by their eviction
                 priority.
         """
-        # Create 2 iterators to allow iterateing over ordered_blocks twice.
-        blocks_iter1, blocks_iter2 = itertools.tee(ordered_blocks)
-        for block in blocks_iter1:
+        # Materialize the iterable to allow multiple passes.
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
             block.ref_cnt -= 1
         self.free_block_queue.append_n([
-            block for block in blocks_iter2
+            block for block in blocks_list
             if block.ref_cnt == 0 and not block.is_null
         ])
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -216,14 +216,16 @@ class BlockPool:
 
         ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
 
+        # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:
             for block in ret:
                 self._maybe_evict_cached_block(block)
-
-        for block in ret:
-            assert block.ref_cnt == 0
-            block.ref_cnt += 1
-
+                assert block.ref_cnt == 0
+                block.ref_cnt += 1
+        else:
+            for block in ret:
+                assert block.ref_cnt == 0
+                block.ref_cnt += 1
         return ret
 
     def _maybe_evict_cached_block(self, block: KVCacheBlock) -> bool:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -154,7 +154,7 @@ class KVCacheBlock:
     # Whether the block is a null block that should never be cached.
     is_null: bool = False
 
-    # TODO(Jialin): For performance, let callers to handle ref_cnt bumps to
+    # TODO(Jialin): For performance, let callers handle ref_cnt bumps to
     # avoid function calls.
     def incr_ref(self):
         self.ref_cnt += 1
@@ -284,9 +284,9 @@ class FreeKVCacheBlockQueue:
         Returns:
             A list of n free blocks.
         """
-        assert self.num_free_blocks >= n
         if n == 0:
             return []
+        assert self.num_free_blocks >= n
         self.num_free_blocks -= n
 
         curr_block = self.fake_free_list_head.next_free_block

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -361,14 +361,15 @@ class FreeKVCacheBlockQueue:
         last_block = self.fake_free_list_tail.prev_free_block
         assert last_block is not None, (
             "prev_free_block of fake_free_list_tail should always exist")
-        # Connect the last block of <blocks> to the fake tail
-        blocks[-1].next_free_block = self.fake_free_list_tail
-        self.fake_free_list_tail.prev_free_block = blocks[-1]
         # Add inter-connections between consecutive blocks
         for block in blocks:
             block.prev_free_block = last_block
             last_block.next_free_block = block
             last_block = block
+
+        # Connect the last block of <blocks> to the fake tail
+        last_block.next_free_block = self.fake_free_list_tail
+        self.fake_free_list_tail.prev_free_block = last_block
 
     def get_all_free_blocks(self) -> list[KVCacheBlock]:
         """Get all free blocks in the free list. Mainly used for testing.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -154,6 +154,8 @@ class KVCacheBlock:
     # Whether the block is a null block that should never be cached.
     is_null: bool = False
 
+    # TODO(Jialin): For performance, let callers to handle ref_cnt bumps to
+    # avoid function calls.
     def incr_ref(self):
         self.ref_cnt += 1
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Most of the block_pool operators are on critical path
- forward path is hard blocked by kv block allocation
- decode cycle end is hard blocked by kv block free

In this PR, we're focusing on further optimization these 2 operators.

### Bulk popleft instead of popleft n times
Originally, in block_pool.get_new_blocks, we popped blocks one at a time, which would triggered the second block to fake head connections (which are unnecessary operations as the second block might be popped right after this).

As we knew total number of blocks to pop ahead, we could simply introduce popleft_n for buck popleft. Overall, the number link list operations to linked list of popleft_n would only be half of n popleft.

### Bulk append instead of append n times
Similar, in block_pool.free_blocks, we invoke append one at a time. Introducing bulk append would also cut link list operations by half.

## Test Plan
- Evaluate with benchmark scripts
- Evaluate with benchmark_blockpoll
- New Unit Test for append_n and popleft_n are added

## Test Result

### benchmark scripts
- Get new blocks improved from 0.15ms to 0.008ms
- Free new blocks improved from 33us to 9us

After
<img width="840" height="168" alt="Screenshot 2025-07-19 at 2 33 42 AM" src="https://github.com/user-attachments/assets/a22991d1-0f3a-4576-ba7e-a9e0cb9aebe4" />
<img width="603" height="173" alt="Screenshot 2025-07-19 at 2 34 21 AM" src="https://github.com/user-attachments/assets/8d986488-c278-4331-9186-d84aebcdb92d" />

Before
<img width="838" height="276" alt="Screenshot 2025-07-19 at 2 31 59 AM" src="https://github.com/user-attachments/assets/86bb6de6-e42b-4b38-b3c6-97d9d773e762" />
<img width="859" height="311" alt="Screenshot 2025-07-19 at 2 32 55 AM" src="https://github.com/user-attachments/assets/f7cefd94-b0c3-4f8d-b374-87951c864211" />

### benchmark_blockpool
As expected, get_blocks and free_blocks times are cut in half.

After
<img width="800" height="230" alt="Screenshot 2025-07-19 at 2 22 07 AM" src="https://github.com/user-attachments/assets/85ab0be7-90f0-4da8-97f4-b2079ac06433" />
Before
<img width="805" height="233" alt="Screenshot 2025-07-19 at 2 23 21 AM" src="https://github.com/user-attachments/assets/32a8ad40-33af-4585-877c-e8e4d9bd7749" />


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
