### PR TITLE
Integrate TensorSchema with shape validation for Phi3VImagePixelInputs

### DIFF
--- a/tests/standalone_tests/test_tensor_schema.py
+++ b/tests/standalone_tests/test_tensor_schema.py
@@ -94,3 +94,33 @@ def test_tensor_schema_validation_disabled_skips_shape_check():
         image_sizes=torch.randint(0, 256, (16, 2)),
         validate=False,
     )
+
+
+def test_tensor_schema_with_valid_resolve_binding_dims():
+    data = torch.randn(16, 64, 3, 336, 336)  # h=336, w=336
+    image_sizes = torch.randint(0, 256, (16, 2))
+
+    Phi3VImagePixelInputs(
+        data=data,
+        image_sizes=image_sizes,
+        resolve_bindings={
+            "h": 336,
+            "w": 336
+        },
+    )
+
+
+def test_tensor_schema_with_invalid_resolve_binding_dims():
+    data = torch.randn(16, 64, 3, 36, 36)  # h=36, w=36
+    image_sizes = torch.randint(0, 256, (16, 2))
+
+    # Should raise because 'h' and 'w' don't match resolve bindings
+    with pytest.raises(ValueError, match="dim\\[3\\] expected 336, got 36"):
+        Phi3VImagePixelInputs(
+            data=data,
+            image_sizes=image_sizes,
+            resolve_bindings={
+                "h": 336,
+                "w": 336
+            },
+        )

--- a/tests/standalone_tests/test_tensor_schema.py
+++ b/tests/standalone_tests/test_tensor_schema.py
@@ -12,6 +12,15 @@ def test_tensor_schema_valid_tensor():
         image_sizes=torch.randint(0, 256, (16, 2)),
     )
 
+def test_tensor_schema_optional_fields():
+    Phi3VImagePixelInputs(
+        data=torch.randn(16, 64, 3, 32, 32),
+        image_sizes=None,
+    )
+    
+    Phi3VImagePixelInputs(
+        data=torch.randn(16, 64, 3, 32, 32),
+    )
 
 def test_tensor_schema_constant_dim_failure():
     with pytest.raises(ValueError, match="dim\\[2\\] expected 3, got 4"):

--- a/tests/standalone_tests/test_tensor_schema.py
+++ b/tests/standalone_tests/test_tensor_schema.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from vllm.model_executor.models.phi3v import Phi3VImagePixelInputs
+
+
+def test_tensor_schema_valid_tensor():
+    Phi3VImagePixelInputs(
+        data=torch.randn(16, 64, 3, 32, 32),
+        image_sizes=torch.randint(0, 256, (16, 2)),
+    )
+
+
+def test_tensor_schema_constant_dim_failure():
+    with pytest.raises(ValueError, match="dim\\[2\\] expected 3, got 4"):
+        Phi3VImagePixelInputs(
+            data=torch.randn(16, 64, 4, 32, 32),  # dim[2] = 4
+            image_sizes=torch.randint(0, 256, (16, 2)),
+        )
+
+
+def test_tensor_schema_symbolic_dim_mismatch():
+    with pytest.raises(ValueError, match="expected 'bn'=12, got 16"):
+        Phi3VImagePixelInputs(
+            data=torch.randn(12, 64, 3, 32, 32),
+            image_sizes=torch.randint(0, 256, (16, 2)),
+        )
+
+
+def test_tensor_schema_list_tensor_valid():
+    Phi3VImagePixelInputs(
+        data=[torch.randn(64, 3, 32, 32) for _ in range(16)],
+        image_sizes=torch.randint(0, 256, (16, 2)),
+    )
+
+
+def test_tensor_schema_tuple_tensor_valid():
+    Phi3VImagePixelInputs(
+        data=tuple(torch.randn(64, 3, 32, 32) for _ in range(16)),
+        image_sizes=torch.randint(0, 256, (16, 2)),
+    )
+
+
+def test_tensor_schema_inconsistent_shapes_in_list():
+    with pytest.raises(ValueError, match="contains inconsistent shapes"):
+        Phi3VImagePixelInputs(
+            data=[torch.randn(64, 3, 32, 32), torch.randn(64, 3, 16, 16)] +
+                 [torch.randn(64, 3, 32, 32) for _ in range(14)],
+            image_sizes=torch.randint(0, 256, (16, 2)),
+        )
+
+
+def test_tensor_schema_empty_list():
+    with pytest.raises(ValueError, match="is an empty list"):
+        Phi3VImagePixelInputs(
+            data=[],
+            image_sizes=torch.randint(0, 256, (0, 2)),
+        )
+
+def test_tensor_schema_validation_disabled_skips_shape_check():
+    # This should NOT raise, because validation is turned off
+    # This would normally fail (dim[2] should be 3, not 4)
+    Phi3VImagePixelInputs(
+        data=torch.randn(16, 64, 4, 32, 32),
+        image_sizes=torch.randint(0, 256, (16, 2)),
+        validate=False
+    )

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -105,7 +105,7 @@ class Phi3VImagePixelInputs(TensorSchema):
         - w: Width of each patch
     """
 
-    type: Literal["pixel_values"] = "pixel_values"
+    type: Literal["pixel_values", "image_embeds"] = "pixel_values"
 
     # Supports either a stacked tensor or a list of (p, 3, h, w) tensors
     data: Annotated[

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any, Literal, Optional, TypedDict, Union
+from typing import Annotated, Any, Literal, Optional, TypedDict, Union
 
 import regex as re
 import torch
@@ -45,6 +45,7 @@ from vllm.multimodal.processing import (BaseMultiModalProcessor,
 from vllm.multimodal.profiling import BaseDummyInputsBuilder
 from vllm.sequence import IntermediateTensors
 from vllm.utils import is_list_of
+from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .clip import CLIPVisionModel
 from .interfaces import (MultiModalEmbeddings, SupportsMultiModal, SupportsPP,
@@ -52,36 +53,37 @@ from .interfaces import (MultiModalEmbeddings, SupportsMultiModal, SupportsPP,
 from .utils import (AutoWeightsLoader, WeightsMapper, flatten_bn,
                     init_vllm_registered_model, maybe_prefix,
                     merge_multimodal_embeddings)
-from vllm.utils.tensor_schema import TensorSchema, TensorShape
-from typing import TypedDict, Literal, Union, Annotated, Optional, List
 
 logger = init_logger(__name__)
 
 # Cannot find the following 2 numbers from hf config.
 _IMAGE_TOKEN_ID = 32044
 
-CLIP_VIT_LARGE_PATCH14_336_CONFIG = CLIPVisionConfig(dropout=0.0,
-                                                     hidden_act="quick_gelu",
-                                                     hidden_size=1024,
-                                                     image_size=336,
-                                                     intermediate_size=4096,
-                                                     num_attention_heads=16,
-                                                     num_channels=3,
-                                                     num_hidden_layers=24,
-                                                     patch_size=14,
-                                                     projection_dim=768)
+CLIP_VIT_LARGE_PATCH14_336_CONFIG = CLIPVisionConfig(
+    dropout=0.0,
+    hidden_act="quick_gelu",
+    hidden_size=1024,
+    image_size=336,
+    intermediate_size=4096,
+    num_attention_heads=16,
+    num_channels=3,
+    num_hidden_layers=24,
+    patch_size=14,
+    projection_dim=768,
+)
 
 
-def _init_img_processor(hf_config: PretrainedConfig,
-                        quant_config: Optional[QuantizationConfig],
-                        prefix: str = "") -> CLIPVisionModel:
+def _init_img_processor(
+    hf_config: PretrainedConfig,
+    quant_config: Optional[QuantizationConfig],
+    prefix: str = "",
+) -> CLIPVisionModel:
     clip_config = CLIP_VIT_LARGE_PATCH14_336_CONFIG
-    layer_idx = hf_config.img_processor.get('layer_idx', -2)
+    layer_idx = hf_config.img_processor.get("layer_idx", -2)
 
     # Initialize the CLIP only up to the required feature layer
     if layer_idx < 0:
-        num_hidden_layers = clip_config.num_hidden_layers + \
-            layer_idx + 1
+        num_hidden_layers = clip_config.num_hidden_layers + layer_idx + 1
     else:
         num_hidden_layers = layer_idx + 1
 
@@ -110,14 +112,12 @@ class Phi3VImagePixelInputs(TensorSchema):
     # Supports either a stacked tensor or a list of (p, 3, h, w) tensors
     data: Annotated[
         Union[torch.Tensor, list[torch.Tensor]],
-        TensorShape("bn", "p", 3, "h", "w")
+        TensorShape("bn", "p", 3, "h", "w", dynamic_dims={"p"}
+                    ),  # 'p' may vary across items
     ]
 
     # Stacked tensor with height and width for each image
-    image_sizes: Annotated[
-        Union[torch.Tensor, None],
-        TensorShape("bn", 2)
-    ]
+    image_sizes: Annotated[Union[torch.Tensor, None], TensorShape("bn", 2)]
 
 
 class Phi3VImageEmbeddingInputs(TypedDict):
@@ -162,31 +162,33 @@ class Phi3ImageEmbeddingBase(nn.Module):
 class Phi3HDImageEmbedding(Phi3ImageEmbeddingBase):
     """Phi3 Image embedding with HD transform."""
 
-    def __init__(self,
-                 config: PretrainedConfig,
-                 quant_config: Optional[QuantizationConfig],
-                 prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig],
+        prefix: str = "",
+    ) -> None:
         super().__init__()
 
         # n_embed or hidden_size
-        hidden_size = config.n_embd if hasattr(
-            config, 'n_embd') else config.hidden_size
+        hidden_size = (config.n_embd
+                       if hasattr(config, "n_embd") else config.hidden_size)
 
         self.img_processor = _init_img_processor(
             config, quant_config, prefix=f"{prefix}.img_processor")
 
-        image_dim_out = config.img_processor['image_dim_out']
-        self.num_img_tokens = config.img_processor['num_img_tokens']
+        image_dim_out = config.img_processor["image_dim_out"]
+        self.num_img_tokens = config.img_processor["num_img_tokens"]
 
         self.image_dim_out = image_dim_out
 
         # global_gn and sub_gn for hd transform, serves as line separator
-        self.use_hd_transform = config.embd_layer.get('use_hd_transform',
+        self.use_hd_transform = config.embd_layer.get("use_hd_transform",
                                                       False)
         self.with_learnable_separator = config.embd_layer.get(
-            'with_learnable_separator', False)
+            "with_learnable_separator", False)
         self.hd_transform_order = config.embd_layer.get(
-            'hd_transform_order', 'glb_sub')
+            "hd_transform_order", "glb_sub")
         # with_hd_transform and with_learnable_separator should have same value
         assert self.use_hd_transform and self.with_learnable_separator
 
@@ -204,7 +206,7 @@ class Phi3HDImageEmbedding(Phi3ImageEmbeddingBase):
                  nn.Linear(dim_projection, dim_projection)])
         self.img_projection = nn.Sequential(*layers)
 
-        self.type_feature = config.img_processor.get('type_feature', 'patch')
+        self.type_feature = config.img_processor.get("type_feature", "patch")
 
     def forward(self, pixel_values: torch.FloatTensor,
                 image_sizes: torch.Tensor) -> torch.FloatTensor:
@@ -227,9 +229,8 @@ class Phi3HDImageEmbedding(Phi3ImageEmbeddingBase):
         """
         image_features: (num_images, num_crops+1, 24*24, 1024)
         """
-        assert (
-            self.hd_transform_order == 'sub_glb'
-        ), f'hd_transform_order `{self.hd_transform_order}` not implemented'
+        assert self.hd_transform_order == "sub_glb", (
+            f"hd_transform_order `{self.hd_transform_order}` not implemented")
         if isinstance(self.img_projection, nn.Sequential):
             target_device = self.img_projection[0].bias.device
             target_dtype = self.img_projection[0].bias.dtype
@@ -366,8 +367,8 @@ class Phi3VDummyInputsBuilder(BaseDummyInputsBuilder[Phi3VProcessingInfo]):
     ) -> MultiModalDataDict:
         num_images = mm_counts.get("image", 0)
 
-        target_width, target_height = \
-            self.info.get_image_size_with_most_features()
+        target_width, target_height = (
+            self.info.get_image_size_with_most_features())
 
         return {
             "image":
@@ -515,9 +516,11 @@ class Phi3VMultiModalProcessor(BaseMultiModalProcessor[Phi3VProcessingInfo]):
         return token_ids, text, placeholders
 
 
-@MULTIMODAL_REGISTRY.register_processor(Phi3VMultiModalProcessor,
-                                        info=Phi3VProcessingInfo,
-                                        dummy_inputs=Phi3VDummyInputsBuilder)
+@MULTIMODAL_REGISTRY.register_processor(
+    Phi3VMultiModalProcessor,
+    info=Phi3VProcessingInfo,
+    dummy_inputs=Phi3VDummyInputsBuilder,
+)
 class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
                        SupportsQuant):
     hf_to_vllm_mapper = WeightsMapper(
@@ -555,7 +558,8 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
         self.vision_embed_tokens = Phi3HDImageEmbedding(
             config,
             self.quant_config,
-            prefix=maybe_prefix(prefix, "model.vision_embed_tokens"))
+            prefix=maybe_prefix(prefix, "model.vision_embed_tokens"),
+        )
 
         self.language_model = init_vllm_registered_model(
             vllm_config=vllm_config,
@@ -584,7 +588,8 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
             return Phi3VImagePixelInputs(
                 type="pixel_values",
                 data=flatten_bn(pixel_values),
-                image_sizes=flatten_bn(image_sizes, concat=True))
+                image_sizes=flatten_bn(image_sizes, concat=True),
+            )
 
         if image_embeds is not None:
             return Phi3VImageEmbeddingInputs(
@@ -598,7 +603,6 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
         self,
         image_input: Phi3VImageInputs,
     ) -> torch.Tensor:
-
         if image_input["type"] == "image_embeds":
             image_data = image_input["data"]
             if is_list_of(image_data, torch.Tensor):
@@ -635,20 +639,24 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
         multimodal_embeddings: Optional[MultiModalEmbeddings] = None,
     ) -> torch.Tensor:
         inputs_embeds = self.embed_tokens(input_ids)
-        if multimodal_embeddings is not None \
-            and len(multimodal_embeddings) != 0:
+        if (multimodal_embeddings is not None
+                and len(multimodal_embeddings) != 0):
             inputs_embeds = merge_multimodal_embeddings(
-                input_ids, inputs_embeds, multimodal_embeddings,
-                self.image_token_id)
+                input_ids,
+                inputs_embeds,
+                multimodal_embeddings,
+                self.image_token_id,
+            )
         return inputs_embeds
 
-    def forward(self,
-                input_ids: torch.Tensor,
-                positions: torch.Tensor,
-                intermediate_tensors: Optional[IntermediateTensors] = None,
-                inputs_embeds: Optional[torch.Tensor] = None,
-                **kwargs: object):
-
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs: object,
+    ):
         if intermediate_tensors is not None:
             inputs_embeds = None
 
@@ -660,10 +668,12 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
                                                       vision_embeddings)
             input_ids = None
 
-        hidden_states = self.language_model.model(input_ids,
-                                                  positions,
-                                                  intermediate_tensors,
-                                                  inputs_embeds=inputs_embeds)
+        hidden_states = self.language_model.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
 
         return hidden_states
 
@@ -677,7 +687,6 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
-
         loader = AutoWeightsLoader(self)
         autoloaded_weights = loader.load_weights(weights,
                                                  mapper=self.hf_to_vllm_mapper)

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -26,6 +26,7 @@ from transformers import (BatchFeature, CLIPVisionConfig, PretrainedConfig,
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
@@ -114,7 +115,7 @@ class Phi3VImagePixelInputs(TensorSchema):
     ]
 
     # Stacked tensor with height and width for each image
-    image_sizes: Annotated[Union[torch.Tensor, None], TensorShape("bn", 2)]
+    image_sizes: Annotated[Optional[torch.Tensor], TensorShape("bn", 2)]
 
 
 class Phi3VImageEmbeddingInputs(TypedDict):

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -26,7 +26,6 @@ from transformers import (BatchFeature, CLIPVisionConfig, PretrainedConfig,
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -589,7 +589,10 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
                 type="pixel_values",
                 data=flatten_bn(pixel_values),
                 image_sizes=flatten_bn(image_sizes, concat=True),
-            )
+                resolve_bindings={
+                    "h": CLIP_VIT_LARGE_PATCH14_336_CONFIG.image_size,
+                    "w": CLIP_VIT_LARGE_PATCH14_336_CONFIG.image_size
+                })
 
         if image_embeds is not None:
             return Phi3VImageEmbeddingInputs(

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -59,31 +59,28 @@ logger = init_logger(__name__)
 # Cannot find the following 2 numbers from hf config.
 _IMAGE_TOKEN_ID = 32044
 
-CLIP_VIT_LARGE_PATCH14_336_CONFIG = CLIPVisionConfig(
-    dropout=0.0,
-    hidden_act="quick_gelu",
-    hidden_size=1024,
-    image_size=336,
-    intermediate_size=4096,
-    num_attention_heads=16,
-    num_channels=3,
-    num_hidden_layers=24,
-    patch_size=14,
-    projection_dim=768,
-)
+CLIP_VIT_LARGE_PATCH14_336_CONFIG = CLIPVisionConfig(dropout=0.0,
+                                                     hidden_act="quick_gelu",
+                                                     hidden_size=1024,
+                                                     image_size=336,
+                                                     intermediate_size=4096,
+                                                     num_attention_heads=16,
+                                                     num_channels=3,
+                                                     num_hidden_layers=24,
+                                                     patch_size=14,
+                                                     projection_dim=768)
 
 
-def _init_img_processor(
-    hf_config: PretrainedConfig,
-    quant_config: Optional[QuantizationConfig],
-    prefix: str = "",
-) -> CLIPVisionModel:
+def _init_img_processor(hf_config: PretrainedConfig,
+                        quant_config: Optional[QuantizationConfig],
+                        prefix: str = "") -> CLIPVisionModel:
     clip_config = CLIP_VIT_LARGE_PATCH14_336_CONFIG
-    layer_idx = hf_config.img_processor.get("layer_idx", -2)
+    layer_idx = hf_config.img_processor.get('layer_idx', -2)
 
     # Initialize the CLIP only up to the required feature layer
     if layer_idx < 0:
-        num_hidden_layers = clip_config.num_hidden_layers + layer_idx + 1
+        num_hidden_layers = clip_config.num_hidden_layers + \
+            layer_idx + 1
     else:
         num_hidden_layers = layer_idx + 1
 
@@ -162,33 +159,31 @@ class Phi3ImageEmbeddingBase(nn.Module):
 class Phi3HDImageEmbedding(Phi3ImageEmbeddingBase):
     """Phi3 Image embedding with HD transform."""
 
-    def __init__(
-        self,
-        config: PretrainedConfig,
-        quant_config: Optional[QuantizationConfig],
-        prefix: str = "",
-    ) -> None:
+    def __init__(self,
+                 config: PretrainedConfig,
+                 quant_config: Optional[QuantizationConfig],
+                 prefix: str = "") -> None:
         super().__init__()
 
         # n_embed or hidden_size
-        hidden_size = (config.n_embd
-                       if hasattr(config, "n_embd") else config.hidden_size)
+        hidden_size = config.n_embd if hasattr(
+            config, 'n_embd') else config.hidden_size
 
         self.img_processor = _init_img_processor(
             config, quant_config, prefix=f"{prefix}.img_processor")
 
-        image_dim_out = config.img_processor["image_dim_out"]
-        self.num_img_tokens = config.img_processor["num_img_tokens"]
+        image_dim_out = config.img_processor['image_dim_out']
+        self.num_img_tokens = config.img_processor['num_img_tokens']
 
         self.image_dim_out = image_dim_out
 
         # global_gn and sub_gn for hd transform, serves as line separator
-        self.use_hd_transform = config.embd_layer.get("use_hd_transform",
+        self.use_hd_transform = config.embd_layer.get('use_hd_transform',
                                                       False)
         self.with_learnable_separator = config.embd_layer.get(
-            "with_learnable_separator", False)
+            'with_learnable_separator', False)
         self.hd_transform_order = config.embd_layer.get(
-            "hd_transform_order", "glb_sub")
+            'hd_transform_order', 'glb_sub')
         # with_hd_transform and with_learnable_separator should have same value
         assert self.use_hd_transform and self.with_learnable_separator
 
@@ -206,7 +201,7 @@ class Phi3HDImageEmbedding(Phi3ImageEmbeddingBase):
                  nn.Linear(dim_projection, dim_projection)])
         self.img_projection = nn.Sequential(*layers)
 
-        self.type_feature = config.img_processor.get("type_feature", "patch")
+        self.type_feature = config.img_processor.get('type_feature', 'patch')
 
     def forward(self, pixel_values: torch.FloatTensor,
                 image_sizes: torch.Tensor) -> torch.FloatTensor:
@@ -229,8 +224,9 @@ class Phi3HDImageEmbedding(Phi3ImageEmbeddingBase):
         """
         image_features: (num_images, num_crops+1, 24*24, 1024)
         """
-        assert self.hd_transform_order == "sub_glb", (
-            f"hd_transform_order `{self.hd_transform_order}` not implemented")
+        assert (
+            self.hd_transform_order == 'sub_glb'
+        ), f'hd_transform_order `{self.hd_transform_order}` not implemented'
         if isinstance(self.img_projection, nn.Sequential):
             target_device = self.img_projection[0].bias.device
             target_dtype = self.img_projection[0].bias.dtype
@@ -367,8 +363,8 @@ class Phi3VDummyInputsBuilder(BaseDummyInputsBuilder[Phi3VProcessingInfo]):
     ) -> MultiModalDataDict:
         num_images = mm_counts.get("image", 0)
 
-        target_width, target_height = (
-            self.info.get_image_size_with_most_features())
+        target_width, target_height = \
+            self.info.get_image_size_with_most_features()
 
         return {
             "image":
@@ -516,11 +512,9 @@ class Phi3VMultiModalProcessor(BaseMultiModalProcessor[Phi3VProcessingInfo]):
         return token_ids, text, placeholders
 
 
-@MULTIMODAL_REGISTRY.register_processor(
-    Phi3VMultiModalProcessor,
-    info=Phi3VProcessingInfo,
-    dummy_inputs=Phi3VDummyInputsBuilder,
-)
+@MULTIMODAL_REGISTRY.register_processor(Phi3VMultiModalProcessor,
+                                        info=Phi3VProcessingInfo,
+                                        dummy_inputs=Phi3VDummyInputsBuilder)
 class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
                        SupportsQuant):
     hf_to_vllm_mapper = WeightsMapper(
@@ -558,8 +552,7 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
         self.vision_embed_tokens = Phi3HDImageEmbedding(
             config,
             self.quant_config,
-            prefix=maybe_prefix(prefix, "model.vision_embed_tokens"),
-        )
+            prefix=maybe_prefix(prefix, "model.vision_embed_tokens"))
 
         self.language_model = init_vllm_registered_model(
             vllm_config=vllm_config,
@@ -606,6 +599,7 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
         self,
         image_input: Phi3VImageInputs,
     ) -> torch.Tensor:
+
         if image_input["type"] == "image_embeds":
             image_data = image_input["data"]
             if is_list_of(image_data, torch.Tensor):
@@ -642,24 +636,20 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
         multimodal_embeddings: Optional[MultiModalEmbeddings] = None,
     ) -> torch.Tensor:
         inputs_embeds = self.embed_tokens(input_ids)
-        if (multimodal_embeddings is not None
-                and len(multimodal_embeddings) != 0):
+        if multimodal_embeddings is not None \
+            and len(multimodal_embeddings) != 0:
             inputs_embeds = merge_multimodal_embeddings(
-                input_ids,
-                inputs_embeds,
-                multimodal_embeddings,
-                self.image_token_id,
-            )
+                input_ids, inputs_embeds, multimodal_embeddings,
+                self.image_token_id)
         return inputs_embeds
 
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        intermediate_tensors: Optional[IntermediateTensors] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
-        **kwargs: object,
-    ):
+    def forward(self,
+                input_ids: torch.Tensor,
+                positions: torch.Tensor,
+                intermediate_tensors: Optional[IntermediateTensors] = None,
+                inputs_embeds: Optional[torch.Tensor] = None,
+                **kwargs: object):
+
         if intermediate_tensors is not None:
             inputs_embeds = None
 
@@ -671,12 +661,10 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
                                                       vision_embeddings)
             input_ids = None
 
-        hidden_states = self.language_model.model(
-            input_ids,
-            positions,
-            intermediate_tensors,
-            inputs_embeds=inputs_embeds,
-        )
+        hidden_states = self.language_model.model(input_ids,
+                                                  positions,
+                                                  intermediate_tensors,
+                                                  inputs_embeds=inputs_embeds)
 
         return hidden_states
 
@@ -690,6 +678,7 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
+
         loader = AutoWeightsLoader(self)
         autoloaded_weights = loader.load_weights(weights,
                                                  mapper=self.hf_to_vllm_mapper)

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -115,7 +115,7 @@ class Phi3VImagePixelInputs(TensorSchema):
 
     # Stacked tensor with height and width for each image
     image_sizes: Annotated[
-        torch.Tensor,
+        Union[torch.Tensor, None],
         TensorShape("bn", 2)
     ]
 

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Annotated, Any, Literal, Optional, TypedDict, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 import regex as re
 import torch
@@ -117,13 +117,19 @@ class Phi3VImagePixelInputs(TensorSchema):
     image_sizes: Annotated[Optional[torch.Tensor], TensorShape("bn", 2)]
 
 
-class Phi3VImageEmbeddingInputs(TypedDict):
-    type: Literal["image_embeds"]
-    data: Union[torch.Tensor, list[torch.Tensor]]
-    """Shape: `(batch_size * num_images, image_feature_size, hidden_size)`
-
-    `hidden_size` must match the hidden size of language model backbone.
+class Phi3VImageEmbeddingInputs(TensorSchema):
     """
+    Dimensions:
+        - b: Batch size
+        - n: Number of images
+        - f: Image feature size (e.g., number of tokens per image)
+        - h: Hidden size (must match language model backbone)
+    """
+    type: Literal["image_embeds"] = "image_embeds"
+    data: Annotated[
+        Union[torch.Tensor, list[torch.Tensor]],
+        TensorShape("bn", "f", "h"),
+    ]
 
 
 Phi3VImageInputs = Union[Phi3VImagePixelInputs, Phi3VImageEmbeddingInputs]

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -9,12 +9,12 @@ import torch
 class TensorShape:
 
     def __init__(self,
-                 *dims: tuple[Union[int, str]],
-                 dynamic_dims: set[str] = None) -> None:
+                 *dims: Union[int, str],
+                 dynamic_dims: set[str, ...] = None) -> None:
         self.dims = dims
         self.dynamic_dims = dynamic_dims if dynamic_dims else set()
 
-    def resolve(self, **bindings: dict[str, int]) -> tuple[str, int]:
+    def resolve(self, **bindings: dict[str, int]) -> tuple[Union[int, str], ...]:
         resolved = []
         for dim in self.dims:
             if isinstance(dim, str) and dim in bindings:
@@ -39,10 +39,10 @@ class TensorSchema:
         if validate:
             self.validate()
 
-    def _match_shape_with_dynamic(self, actual: tuple[int, str],
-                                  reference: tuple[int, str],
-                                  expected_shape: tuple[Union[int, str]],
-                                  dynamic_dims: set[str]) -> bool:
+    def _match_shape_with_dynamic(self, actual: tuple[int, ...],
+                                  reference: tuple[int, ...],
+                                  expected_shape: tuple[Union[int, str], ...],
+                                  dynamic_dims: set[str, ...]) -> bool:
         if len(actual) != len(reference) or len(actual) > len(expected_shape):
             return False
 
@@ -59,11 +59,11 @@ class TensorSchema:
                 return False
         return True
 
-    def _validate_nested_tensors(self, value: Union[list[torch.Tensor],
-                                                    tuple[torch.Tensor]],
+    def _validate_nested_tensors(self, value: Union[list[torch.Tensor, ...],
+                                                    tuple[torch.Tensor, ...]],
                                  field_name: str,
-                                 expected_shape: tuple[Union[int, str]],
-                                 dynamic_dims: set[str]) -> tuple[int, str]:
+                                 expected_shape: tuple[Union[int, str], ...],
+                                 dynamic_dims: set[str, ...]) -> tuple[int, ...]:
         """Validate a list/tuple of tensors and return the actual shape."""
         if not value:
             raise ValueError(f"{field_name} is an empty list")
@@ -89,11 +89,11 @@ class TensorSchema:
         # shape = (len(list), *tensor.shape)
         return (len(value), ) + first.shape
 
-    def _validate_tensor_shape_expected(self, actual_shape: tuple[int, str],
-                                        expected_shape: tuple[Union[int, str]],
+    def _validate_tensor_shape_expected(self, actual_shape: tuple[int, ...],
+                                        expected_shape: tuple[Union[int, str], ...],
                                         field_name: str, shape_env: dict[str,
                                                                          int],
-                                        dynamic_dims: set[str]) -> None:
+                                        dynamic_dims: set[str, ...]) -> None:
         """Validate that the actual tensor shape matches the expected shape."""
         if len(actual_shape) != len(expected_shape):
             raise ValueError(f"{field_name} has rank {len(actual_shape)} "

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -48,7 +48,7 @@ class TensorSchema:
                 for arg in args:
                     if isinstance(arg, TensorShape):
                         expected_shape = arg.dims
-                        if isinstance(value, list) or isinstance(value, tuple):
+                        if isinstance(value, (list, tuple)):
                             if not value:
                                 raise ValueError(f"{field_name} is an empty list")
 
@@ -59,8 +59,9 @@ class TensorSchema:
                                     raise ValueError(f"{field_name}[{i}] is not a torch.Tensor")
                                 if v.shape != first.shape:
                                     raise ValueError(
-                                        f"{field_name} contains inconsistent shapes: "
-                                        f"{first.shape} vs {v.shape} at index {i}"
+                                        f"{field_name} contains inconsistent "
+                                        f"shapes: {first.shape} vs {v.shape} "
+                                        f"at index {i}"
                                     )
 
                             # Treat the list as a stacked tensor: shape = (len(list), *tensor.shape)
@@ -79,13 +80,16 @@ class TensorSchema:
                             if isinstance(dim, int):
                                 if actual_shape[i] != dim:
                                     raise ValueError(
-                                        f"{field_name} dim[{i}] expected {dim}, got {actual_shape[i]}"
+                                        f"{field_name} dim[{i}] expected "
+                                        f"{dim}, got {actual_shape[i]}"
                                     )
                             elif isinstance(dim, str):
                                 if dim in shape_env:
                                     if actual_shape[i] != shape_env[dim]:
                                         raise ValueError(
-                                            f"{field_name} dim[{i}] expected '{dim}'={shape_env[dim]}, got {actual_shape[i]}"
+                                            f"{field_name} dim[{i}] expected "
+                                            f"'{dim}'={shape_env[dim]}, got "
+                                            f"{actual_shape[i]}"
                                         )
                                 else:
                                     shape_env[dim] = actual_shape[i]

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -17,6 +17,9 @@ class TensorShape:
         self.dims = dims
         self.dynamic_dims = dynamic_dims if dynamic_dims else set()
 
+    def __class_getitem__(cls, item):
+        return cls
+
     def resolve(self, **bindings: dict[str,
                                        int]) -> tuple[Union[int, str], ...]:
         resolved = []

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -17,9 +17,6 @@ class TensorShape:
         self.dims = dims
         self.dynamic_dims = dynamic_dims if dynamic_dims else set()
 
-    def __class_getitem__(cls, item):
-        return cls
-
     def resolve(self, **bindings: dict[str,
                                        int]) -> tuple[Union[int, str], ...]:
         resolved = []
@@ -59,6 +56,9 @@ class TensorSchema:
 
         if validate:
             self.validate()
+
+    def __getitem__(self, item) -> Any:
+        return getattr(self, item)
 
     def _match_shape_with_dynamic(self, actual: tuple[int, ...],
                                   reference: tuple[int, ...],

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -14,7 +14,8 @@ class TensorShape:
         self.dims = dims
         self.dynamic_dims = dynamic_dims if dynamic_dims else set()
 
-    def resolve(self, **bindings: dict[str, int]) -> tuple[Union[int, str], ...]:
+    def resolve(self, **bindings: dict[str,
+                                       int]) -> tuple[Union[int, str], ...]:
         resolved = []
         for dim in self.dims:
             if isinstance(dim, str) and dim in bindings:
@@ -59,11 +60,11 @@ class TensorSchema:
                 return False
         return True
 
-    def _validate_nested_tensors(self, value: Union[list[torch.Tensor, ...],
-                                                    tuple[torch.Tensor, ...]],
-                                 field_name: str,
-                                 expected_shape: tuple[Union[int, str], ...],
-                                 dynamic_dims: set[str, ...]) -> tuple[int, ...]:
+    def _validate_nested_tensors(
+            self, value: Union[list[torch.Tensor, ...],
+                               tuple[torch.Tensor, ...]], field_name: str,
+            expected_shape: tuple[Union[int, str], ...],
+            dynamic_dims: set[str, ...]) -> tuple[int, ...]:
         """Validate a list/tuple of tensors and return the actual shape."""
         if not value:
             raise ValueError(f"{field_name} is an empty list")
@@ -90,7 +91,8 @@ class TensorSchema:
         return (len(value), ) + first.shape
 
     def _validate_tensor_shape_expected(self, actual_shape: tuple[int, ...],
-                                        expected_shape: tuple[Union[int, str], ...],
+                                        expected_shape: tuple[Union[int, str],
+                                                              ...],
                                         field_name: str, shape_env: dict[str,
                                                                          int],
                                         dynamic_dims: set[str, ...]) -> None:

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import inspect
+import torch
+from typing import get_type_hints, get_args, get_origin, Optional, Union
+
+
+class TensorShape:
+    def __init__(self, *dims):
+        self.dims = dims
+    
+    def __repr__(self):
+        return f"TensorShape{self.dims}"
+
+
+class TensorSchema:
+    def __init__(self, validate: bool = True, **kwargs):
+        """Initialize the schema with keyword arguments."""
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+        if validate:
+            self.validate()
+
+    
+    def validate(self):
+        type_hints = get_type_hints(self.__class__, include_extras=True)
+        shape_env = {}  # optional, used later for symbolic matching
+
+        for field_name, field_type in type_hints.items():
+            # Check if the field was provided
+            if not hasattr(self, field_name):
+                # Field is missing - check if it's optional
+                if get_origin(field_type) is Union:
+                    args = get_args(field_type)
+                    if type(None) in args:  # Optional field
+                        continue  # Skip validation for missing optional fields
+                # If not optional, raise error
+                raise ValueError(f"Required field '{field_name}' is missing")
+            
+            # Field exists, proceed with validation
+            value = getattr(self, field_name)
+
+            if get_origin(field_type) is not None:
+                args = get_args(field_type)
+
+                for arg in args:
+                    if isinstance(arg, TensorShape):
+                        expected_shape = arg.dims
+                        if isinstance(value, list) or isinstance(value, tuple):
+                            if not value:
+                                raise ValueError(f"{field_name} is an empty list")
+
+                            # Ensure all tensors in the list have the same shape
+                            first = value[0]
+                            for i, v in enumerate(value):
+                                if not isinstance(v, torch.Tensor):
+                                    raise ValueError(f"{field_name}[{i}] is not a torch.Tensor")
+                                if v.shape != first.shape:
+                                    raise ValueError(
+                                        f"{field_name} contains inconsistent shapes: "
+                                        f"{first.shape} vs {v.shape} at index {i}"
+                                    )
+
+                            # Treat the list as a stacked tensor: shape = (len(list), *tensor.shape)
+                            actual_shape = (len(value),) + first.shape
+
+                        elif isinstance(value, torch.Tensor):
+                            actual_shape = value.shape
+
+                        else:
+                            raise ValueError(f"{field_name} is neither a Tensor, List[Tensor] or Tuple[Tensor]")
+                            
+                        if len(actual_shape) != len(expected_shape):
+                            raise ValueError(f"{field_name} has rank {len(actual_shape)} but expected {len(expected_shape)}")
+
+                        for i, dim in enumerate(expected_shape):
+                            if isinstance(dim, int):
+                                if actual_shape[i] != dim:
+                                    raise ValueError(
+                                        f"{field_name} dim[{i}] expected {dim}, got {actual_shape[i]}"
+                                    )
+                            elif isinstance(dim, str):
+                                if dim in shape_env:
+                                    if actual_shape[i] != shape_env[dim]:
+                                        raise ValueError(
+                                            f"{field_name} dim[{i}] expected '{dim}'={shape_env[dim]}, got {actual_shape[i]}"
+                                        )
+                                else:
+                                    shape_env[dim] = actual_shape[i]
+                            else:
+                                raise TypeError(f"{field_name} dim[{i}] has unsupported type: {type(dim)}")
+
+    
+    def print_shapes(self):
+        """Print TensorShape annotations for debugging."""
+        print(f"Shapes in {self.__class__.__name__}:")
+        type_hints = get_type_hints(self.__class__, include_extras=True)
+        
+        for field_name, field_type in type_hints.items():
+            if get_origin(field_type) is not None:
+                args = get_args(field_type)
+                for arg in args:
+                    if isinstance(arg, TensorShape):
+                        print(f"  {field_name}: {arg}")

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -1,22 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import inspect
+from typing import Annotated, Union, get_args, get_origin, get_type_hints
+
 import torch
-from typing import (get_type_hints, get_args, get_origin, Optional, Union,
-                    Annotated)
 
 
 class TensorShape:
-    def __init__(self, *dims):
+
+    def __init__(self,
+                 *dims: Union[int, str],
+                 dynamic_dims: set[str] = None) -> None:
+        if dynamic_dims is None:
+            dynamic_dims = set()
         self.dims = dims
-    
+        self.dynamic_dims = dynamic_dims
+
     def __repr__(self):
         return f"TensorShape{self.dims}"
 
 
 class TensorSchema:
-    def __init__(self, validate: bool = True, **kwargs):
+
+    def __init__(self, validate: bool = True, **kwargs) -> None:
         """Initialize the schema with keyword arguments."""
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -24,22 +30,35 @@ class TensorSchema:
         if validate:
             self.validate()
 
-    
-    def validate(self):
+    def _match_shape_with_dynamic(self, actual, reference, expected_shape,
+                                  dynamic_dims):
+        if len(actual) != len(reference) or len(actual) > len(expected_shape):
+            return False
+
+        for i, (a, r) in enumerate(zip(actual, reference)):
+            dim = expected_shape[-len(actual) + i]
+            # Skip this dimension if it's marked dynamic
+            if dim in dynamic_dims:
+                continue
+            if a != r:
+                return False
+        return True
+
+    def validate(self) -> None:
         type_hints = get_type_hints(self.__class__, include_extras=True)
-        shape_env = {}  # optional, used later for symbolic matching
+        shape_env = {}
 
         for field_name, field_type in type_hints.items():
             # Check if the field was provided
-            if (not hasattr(self, field_name) or 
-                getattr(self, field_name) is None):
+            if (not hasattr(self, field_name)
+                    or getattr(self, field_name) is None):
                 # Field is missing - check if it's optional
                 # Handle Annotated types by extracting the actual type
                 actual_type = field_type
                 if get_origin(field_type) is Annotated:
                     args = get_args(field_type)
                     actual_type = args[0]  # First argument is the actual type
-                
+
                 # Check if the actual type is Optional (Union with None)
                 if get_origin(actual_type) is Union:
                     args = get_args(actual_type)
@@ -47,7 +66,7 @@ class TensorSchema:
                         continue  # Skip validation for missing optional fields
                 # If not optional, raise error
                 raise ValueError(f"Required field '{field_name}' is missing")
-            
+
             # Field exists, proceed with validation
             value = getattr(self, field_name)
 
@@ -62,22 +81,28 @@ class TensorSchema:
                                 raise ValueError(
                                     f"{field_name} is an empty list")
 
-                            # Ensure all tensors in the list have the same shape
+                            # Ensure all tensors in the list have the same
+                            # shape, besides dynamic dimensions
                             first = value[0]
                             for i, v in enumerate(value):
                                 if not isinstance(v, torch.Tensor):
                                     raise ValueError(
                                         f"{field_name}[{i}] is not a "
                                         f"torch.Tensor")
-                                if v.shape != first.shape:
+                                if not self._match_shape_with_dynamic(
+                                        v.shape,
+                                        first.shape,
+                                        expected_shape,
+                                        arg.dynamic_dims,
+                                ):
                                     raise ValueError(
                                         f"{field_name} contains inconsistent "
                                         f"shapes: {first.shape} vs {v.shape} "
                                         f"at index {i}")
 
-                            # Treat the list as a stacked tensor: 
+                            # Treat the list as a stacked tensor:
                             # shape = (len(list), *tensor.shape)
-                            actual_shape = (len(value),) + first.shape
+                            actual_shape = (len(value), ) + first.shape
 
                         elif isinstance(value, torch.Tensor):
                             actual_shape = value.shape
@@ -85,23 +110,25 @@ class TensorSchema:
                         else:
                             type_names = []
                             for arg in args:
-                                if hasattr(arg, '__name__'):
+                                if hasattr(arg, "__name__"):
                                     type_names.append(str(arg.__name__))
                                 else:
                                     type_names.append(str(arg))
-                                    
+
                             expected_types = ", ".join(type_names)
                             raise ValueError(
                                 f"{field_name} is not one of the expected "
                                 f"types: {expected_types}")
-                            
+
                         if len(actual_shape) != len(expected_shape):
                             raise ValueError(
                                 f"{field_name} has rank {len(actual_shape)} "
                                 f"but expected {len(expected_shape)}")
 
                         for i, dim in enumerate(expected_shape):
-                            if isinstance(dim, int):
+                            if dim in arg.dynamic_dims:
+                                continue
+                            elif isinstance(dim, int):
                                 if actual_shape[i] != dim:
                                     raise ValueError(
                                         f"{field_name} dim[{i}] expected "
@@ -120,12 +147,11 @@ class TensorSchema:
                                     f"{field_name} dim[{i}] has unsupported "
                                     f"type: {type(dim)}")
 
-    
-    def print_shapes(self):
+    def print_shapes(self) -> None:
         """Print TensorShape annotations for debugging."""
         print(f"Shapes in {self.__class__.__name__}:")
         type_hints = get_type_hints(self.__class__, include_extras=True)
-        
+
         for field_name, field_type in type_hints.items():
             if get_origin(field_type) is not None:
                 args = get_args(field_type)

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -3,7 +3,8 @@
 
 import inspect
 import torch
-from typing import get_type_hints, get_args, get_origin, Optional, Union, Annotated
+from typing import (get_type_hints, get_args, get_origin, Optional, Union,
+                    Annotated)
 
 
 class TensorShape:
@@ -30,7 +31,8 @@ class TensorSchema:
 
         for field_name, field_type in type_hints.items():
             # Check if the field was provided
-            if not hasattr(self, field_name) or getattr(self, field_name) is None:
+            if (not hasattr(self, field_name) or 
+                getattr(self, field_name) is None):
                 # Field is missing - check if it's optional
                 # Handle Annotated types by extracting the actual type
                 actual_type = field_type
@@ -57,21 +59,24 @@ class TensorSchema:
                         expected_shape = arg.dims
                         if isinstance(value, (list, tuple)):
                             if not value:
-                                raise ValueError(f"{field_name} is an empty list")
+                                raise ValueError(
+                                    f"{field_name} is an empty list")
 
                             # Ensure all tensors in the list have the same shape
                             first = value[0]
                             for i, v in enumerate(value):
                                 if not isinstance(v, torch.Tensor):
-                                    raise ValueError(f"{field_name}[{i}] is not a torch.Tensor")
+                                    raise ValueError(
+                                        f"{field_name}[{i}] is not a "
+                                        f"torch.Tensor")
                                 if v.shape != first.shape:
                                     raise ValueError(
                                         f"{field_name} contains inconsistent "
                                         f"shapes: {first.shape} vs {v.shape} "
-                                        f"at index {i}"
-                                    )
+                                        f"at index {i}")
 
-                            # Treat the list as a stacked tensor: shape = (len(list), *tensor.shape)
+                            # Treat the list as a stacked tensor: 
+                            # shape = (len(list), *tensor.shape)
                             actual_shape = (len(value),) + first.shape
 
                         elif isinstance(value, torch.Tensor):
@@ -86,30 +91,34 @@ class TensorSchema:
                                     type_names.append(str(arg))
                                     
                             expected_types = ", ".join(type_names)
-                            raise ValueError(f"{field_name} is not one of the expected types: {expected_types}")
+                            raise ValueError(
+                                f"{field_name} is not one of the expected "
+                                f"types: {expected_types}")
                             
                         if len(actual_shape) != len(expected_shape):
-                            raise ValueError(f"{field_name} has rank {len(actual_shape)} but expected {len(expected_shape)}")
+                            raise ValueError(
+                                f"{field_name} has rank {len(actual_shape)} "
+                                f"but expected {len(expected_shape)}")
 
                         for i, dim in enumerate(expected_shape):
                             if isinstance(dim, int):
                                 if actual_shape[i] != dim:
                                     raise ValueError(
                                         f"{field_name} dim[{i}] expected "
-                                        f"{dim}, got {actual_shape[i]}"
-                                    )
+                                        f"{dim}, got {actual_shape[i]}")
                             elif isinstance(dim, str):
                                 if dim in shape_env:
                                     if actual_shape[i] != shape_env[dim]:
                                         raise ValueError(
                                             f"{field_name} dim[{i}] expected "
                                             f"'{dim}'={shape_env[dim]}, got "
-                                            f"{actual_shape[i]}"
-                                        )
+                                            f"{actual_shape[i]}")
                                 else:
                                     shape_env[dim] = actual_shape[i]
                             else:
-                                raise TypeError(f"{field_name} dim[{i}] has unsupported type: {type(dim)}")
+                                raise TypeError(
+                                    f"{field_name} dim[{i}] has unsupported "
+                                    f"type: {type(dim)}")
 
     
     def print_shapes(self):


### PR DESCRIPTION
## Purpose
This PR integrates TensorSchema, a lightweight shape validation system proposed in RFC #14764, into the Phi3VImagePixelInputs schema. https://github.com/vllm-project/vllm/issues/14764

It adds automatic validation for tensor input shapes using Annotated[..., TensorShape(...)], enabling detection of constant dimension mismatches (e.g. == 3), symbolic dimension reuse (e.g. 'bn' shared across fields), and shape inconsistencies across Tensor, List[Tensor], and Tuple[Tensor] inputs.

This only affects internal model input validation. Future models can adopt TensorSchema by extending the base class and using Annotated with TensorShape.

For a walkthrough and example usage, see the following README:
https://github.com/bbeckca/tensor-schema/blob/main/README.md

FIX #14764

## Test Plan

```
python3 -m pytest tests/standalone_tests/test_tensor_schema.py
```

Includes tests for:
- Valid tensor, list, and tuple inputs
- Constant and symbolic dimension mismatches
- Variable-length dimensions via dynamic_dims (e.g. differing p values per image)
- Empty list handling
- Inconsistent shapes within a batch
- Optional fields: supports both None and omission (e.g. Union[torch.Tensor, None])
- Runtime shape substitution via resolve_bindings={"h": ..., "w": ...}
- Optional validation toggle with validate=False

## Test Result
```
benjibeck@Benjis-MBP vllm % python3 -m pytest tests/standalone_tests/test_tensor_schema.py
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.9.6, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/benjibeck/Projects/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 8 items                                                                                                                                                                                    

tests/standalone_tests/test_tensor_schema.py ........                                                                                                                                          [100%]

========================================================================================== warnings summary ==========================================================================================
../../Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35
  /Users/benjibeck/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================== 8 passed, 1 warning in 1.13s ====================================================================================
```
All test cases pass, including expected failures for invalid shapes and symbolic mismatches.