### PR TITLE
[bugfix] Remove the attribute 'version' from docker compose

### DIFF
--- a/examples/online_serving/prometheus_grafana/docker-compose.yaml
+++ b/examples/online_serving/prometheus_grafana/docker-compose.yaml
@@ -1,5 +1,4 @@
 # docker-compose.yaml
-version: "3"
 
 services:
   prometheus:


### PR DESCRIPTION
## Purpose
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion