### PR TITLE
[Core] Optimize update checks in LogitsProcessor

### DIFF
--- a/vllm/v1/sample/logits_processor.py
+++ b/vllm/v1/sample/logits_processor.py
@@ -419,7 +419,6 @@ class MinTokensLogitsProcessor(LogitsProcessor):
 
         if batch_update:
             # Process added requests.
-            needs_update |= bool(batch_update.added)
             for index, params, output_tok_ids in batch_update.added:
                 if (isinstance(params, SamplingParams)
                         and (min_tokens := params.min_tokens)
@@ -427,9 +426,10 @@ class MinTokensLogitsProcessor(LogitsProcessor):
                     # Replace request metadata at batch index
                     self.min_toks[index] = (min_tokens, output_tok_ids,
                                             params.all_stop_token_ids)
-                else:
+                    needs_update = True
+                elif self.min_toks.pop(index, None) is not None:
                     # Drop request metadata at batch index
-                    self.min_toks.pop(index, None)
+                    needs_update = True
 
             if self.min_toks:
                 # Process removed requests.

--- a/vllm/v1/sample/logits_processor.py
+++ b/vllm/v1/sample/logits_processor.py
@@ -335,14 +335,19 @@ class LogitBiasLogitsProcessor(LogitsProcessor):
         if not batch_update:
             return
 
+        needs_update: bool = False
         # Process added requests.
-        needs_update = bool(batch_update.added)
         for index, params, _ in batch_update.added:
             if isinstance(params, SamplingParams) and (lb :=
                                                        params.logit_bias):
                 self.biases[index] = lb
+                needs_update = True
             else:
-                self.biases.pop(index, None)
+                # Drop biases metadata at batch index
+                if self.biases.pop(index, None) is not None:
+                    # If a new request replaces an old request which
+                    # specified biases, we should update processor tensors
+                    needs_update = True
 
         if self.biases:
             # Process removed requests.
@@ -427,9 +432,12 @@ class MinTokensLogitsProcessor(LogitsProcessor):
                     self.min_toks[index] = (min_tokens, output_tok_ids,
                                             params.all_stop_token_ids)
                     needs_update = True
-                elif self.min_toks.pop(index, None) is not None:
-                    # Drop request metadata at batch index
-                    needs_update = True
+                else:
+                    # Drop min_toks metadata at batch index
+                    if self.min_toks.pop(index, None) is not None:
+                        # If a new request replaces an old request which
+                        # specified min_toks, we should update processor tensors
+                        needs_update = True
 
             if self.min_toks:
                 # Process removed requests.


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fix update checks in MinTokensLogitsProcessor and LogitBiasLogitsProcessor. For a benchmark run without override min length or logit bias, we still see noticeable cost coming from MinTokensLogitsProcessor and LogitBiasLogitsProcessor.

<img width="1540" height="538" alt="Screenshot 2025-07-19 at 11 05 47 PM" src="https://github.com/user-attachments/assets/05d01ac2-2480-4a96-a8a0-02df2a5b4603" />

We found that it's due to inefficient needs_update tagging which would be tagged to True whenever there're new requests added to the batch. In this diff, we would tag needs_update to True, if
- new added request had customized min_token config
- a request with min_token config got popped

## Test Plan
Rerun the benchmark.
```
# vLLM Serving
export VLLM_USE_MODELSCOPE=False;
export VLLM_TORCH_PROFILER_DIR=~/vllm_profile; # for profiling
vllm serve facebook/opt-125m \
    --swap-space 16 \
    --disable-log-requests \
    --host :: \
    --dtype float16

# Capture traces
vllm bench serve \
    --dataset-name random \
    --model facebook/opt-125m \
    --served-model-name facebook/opt-125m \
    --random-input-len 700 \
    --random-output-len 1 \
    --endpoint /v1/completions \
    --ignore-eos \
    --host localhost \
    --port 8000 \
    --request-rate 200 \
    --num-prompts 100
```

## Test Result
Confirmed the cost from MinTokensLogitsProcessor and LogitBiasLogitsProcessor is mostly gone.

After
<img width="936" height="174" alt="Screenshot 2025-07-20 at 2 56 38 AM" src="https://github.com/user-attachments/assets/f17bbe46-9211-4251-9a2e-af37f7ceb8b9" />
Before
<img width="1145" height="210" alt="Screenshot 2025-07-20 at 2 58 38 AM" src="https://github.com/user-attachments/assets/a29509bb-b3ec-4889-9518-f9da48585f88" />

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
