### PR TITLE
[BugFix] make utils.current_stream thread-safety (#21252)

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1383,12 +1383,11 @@ def find_nccl_library() -> str:
 
 prev_set_stream = torch.cuda.set_stream
 
-_current_stream = None
+_current_stream_tls = threading.local()
 
 
 def _patched_set_stream(stream: torch.cuda.Stream) -> None:
-    global _current_stream
-    _current_stream = stream
+    _current_stream_tls.value = stream
     prev_set_stream(stream)
 
 
@@ -1407,16 +1406,16 @@ def current_stream() -> torch.cuda.Stream:
     from C/C++ code.
     """
     from vllm.platforms import current_platform
-    global _current_stream
-    if _current_stream is None:
+    if not hasattr(_current_stream_tls,
+                   "value") or _current_stream_tls.value is None:
         # when this function is called before any stream is set,
         # we return the default stream.
         # On ROCm using the default 0 stream in combination with RCCL
         # is hurting performance. Therefore creating a dedicated stream
         # per process
-        _current_stream = torch.cuda.Stream() if current_platform.is_rocm(
-        ) else torch.cuda.current_stream()
-    return _current_stream
+        _current_stream_tls.value = torch.cuda.Stream(
+        ) if current_platform.is_rocm() else torch.cuda.current_stream()
+    return _current_stream_tls.value
 
 
 def enable_trace_function_call_for_thread(vllm_config: VllmConfig) -> None:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fix #21252 , make `current_stream` to be thread-safety

## Test Plan

run `python -m pytest tests/test_utils.py::test_current_stream_multithread`

## Test Result

PASS

```
(vllm) simpx@galaxy:~/workspace/vllm (main)$ python -m pytest tests/test_utils.py::test_current_stream_multithread -v
 -s
INFO 07-20 23:02:35 [__init__.py:235] Automatically detected platform cuda.
================================================ test session starts ================================================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0 -- /home/simpx/workspace/vllm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/simpx/workspace/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 1 item                                                                                                    

tests/test_utils.py::test_current_stream_multithread PASSED
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
