### PR TITLE
raise 400 Bad Request with detailed error message for `aiohttp.ClientError`

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from http import HTTPStatus
 from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 
+import aiohttp
 import numpy as np
 from fastapi import Request
 from openai.types.responses import (
@@ -1210,7 +1211,10 @@ class OpenAIServing:
                 **_chat_template_kwargs,
             )
 
-        mm_data = await mm_data_future
+        try:
+            mm_data = await mm_data_future
+        except aiohttp.ClientError as e:
+            raise ValueError(f"{e.__class__.__name__} - {e}") from None
 
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

Fix #21254.

In more details, this tiny little PR improves UX of openai-compatible server users by adding proper network exception handling that may occur in multimodal asset downloading. Without this PR, the user receives 500 internal server error without further details, now the user receives 400 bad request with proper error message in the response (which is in the same vein with other frontend UX improvement PRs like #22803 and #22957.

### Commit Details

As far as I know, all multimodal inputs are processed by `OpenAIServing._preprocess_chat` for online serving mode, so this fix handles all network-related errors that can happen with respect to multimodal input preprocessing.

`aiohttp` raises a wide variety of client-side exceptions, so I think it would be helpful to return the exception class with the exception body.

## Test Plan

Check that a openai-compatible server returns a 400 Bad Request with a proper error message in the response body when the input image url is unreachable:

```bash
# On server side
vllm serve google/gemma-3-27b-it
```

```python
# On client side
from openai import OpenAI

client = OpenAI(base_url="http://localhost:8080/v1", api_key="DUMMY")
messages = [
  {"role": "user", "content": [
    {"type": "text", "text": "Describe the following picture."},
    {"type": "image_url", "image_url": {"url": "http://example.com/nonexisting_image.jpg"}},
  ]}
]
client.chat.completions.create(model="google/gemma-3-27b-it", messages=messages)
```

## Test Result

```python
Traceback (most recent call last):
File "<string>", line 14, in <module>
File "/app/.venv/lib/python3.10/site-packages/openai/_utils/_utils.py", line 279, in wrapper
  return func(*args, **kwargs)
File "/app/.venv/lib/python3.10/site-packages/openai/resources/chat/completions/completions.py", line 879, in create
  return self._post(
File "/app/.venv/lib/python3.10/site-packages/openai/_base_client.py", line 1290, in post
  return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
File "/app/.venv/lib/python3.10/site-packages/openai/_base_client.py", line 967, in request
  return self._request(
File "/app/.venv/lib/python3.10/site-packages/openai/_base_client.py", line 1071, in _request
  raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'object': 'error', 'message': "ClientResponseError - 404, message='Not Found', url='http://example.com/nonexisting_image.jpg' None", 'type': 'BadRequestError', 'param': None, 'code': 400}
```
