### PR TITLE
[Misc] Removed undefined cmake variables MOE_PERMUTE_ARCHS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,6 +768,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   list(APPEND VLLM_MOE_EXT_SRC "csrc/moe/moe_wna16.cu")
 endif()
 
+if(VLLM_GPU_LANG STREQUAL "CUDA")
+  set(MOE_PERMUTE_SRC
+      "csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu"
+      "csrc/moe/moe_permute_unpermute_op.cu")
+
+  list(APPEND VLLM_MOE_EXT_SRC "${MOE_PERMUTE_SRC}")
+endif()
+
 set_gencode_flags_for_srcs(
   SRCS "${VLLM_MOE_EXT_SRC}"
   CUDA_ARCHS "${CUDA_ARCHS}")
@@ -836,17 +844,6 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   endif()
 endif()
 
-if(VLLM_GPU_LANG STREQUAL "CUDA")
-  set(MOE_PERMUTE_SRC
-      "csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu"
-      "csrc/moe/moe_permute_unpermute_op.cu")
-
-  set_gencode_flags_for_srcs(
-    SRCS "${MOE_PERMUTE_SRC}"
-    CUDA_ARCHS "${CUDA_ARCHS}")
-
-  list(APPEND VLLM_MOE_EXT_SRC "${MOE_PERMUTE_SRC}")
-endif()
 message(STATUS "Enabling moe extension.")
 define_gpu_extension_target(
   _moe_C


### PR DESCRIPTION
Looks like this was missed from https://github.com/vllm-project/vllm/pull/14568

It caused issues when we build vllm with TORCH_CUDA_ARCH_LIST being specified such as TORCH_CUDA_ARCH_LIST="9.0a". Because we didn't pass CUDA_ARCHS correctly to compile moe_permute_unpermute_op, we ended up with the following failure:

Without the fix:
```
$ pytest tests/kernels/moe/test_cutlass_moe.py -k test_run_cutlass_moe_fp8[8-True-False-128-1-8192-5120-31]
...
RuntimeError: CUDA error: the provided PTX was compiled with an unsupported toolchain
```

With the fix:
```
$ pytest tests/kernels/moe/test_cutlass_moe.py -k test_run_cutlass_moe_fp8[8-True-False-128-1-8192-5120-31]
...
1 passed, 461 deselected, 2 warnings in 5.00s
```

Tags:

## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
