### PR TITLE
Fix docstring of PyNcclCommunicator device arg

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -30,8 +30,8 @@ class PyNcclCommunicator:
         Args:
             group: the process group to work on. If None, it will use the
                 default process group.
-            device: the device to bind the PyNcclCommunicator to. Can be
-                an integer, string or `torch.device` object.
+            device: the device to bind the PyNcclCommunicator to.
+                Must be an integer, string, or `torch.device` object.
             library_path: the path to the NCCL library. If None, it will
                 use the default library path.
         It is the caller's responsibility to make sure each communicator

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -30,8 +30,8 @@ class PyNcclCommunicator:
         Args:
             group: the process group to work on. If None, it will use the
                 default process group.
-            device: the device to bind the PyNcclCommunicator to. If None,
-                it will be bind to f"cuda:{local_rank}".
+            device: the device to bind the PyNcclCommunicator to. Can be
+                an integer, string or `torch.device` object.
             library_path: the path to the NCCL library. If None, it will
                 use the default library path.
         It is the caller's responsibility to make sure each communicator


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fixes the docstrings of `PyNcclCommunicator`, where it is said that `device` can be `None` - but this is not actually supported by `PyNcclCommunicator.__init__` and an `AssertionError` occurs when None is passed.

## Test Plan
No test needed - doc only.

<!--- pyml disable-next-line no-emphasis-as-heading -->
