### PR TITLE
[Bugfix] Fix missing placeholder in logger debug

### DIFF
--- a/vllm/transformers_utils/configs/mistral.py
+++ b/vllm/transformers_utils/configs/mistral.py
@@ -42,7 +42,7 @@ def adapt_config_dict(config_dict: dict[str, Any],
 
     config = PretrainedConfig.from_dict(config_dict)
 
-    logger.debug("Initialized config", config)
+    logger.debug("Initialized config %s", config)
 
     return config
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fix the error log shown in model tests:

```
[2025-07-21T05:11:22Z] Traceback (most recent call last):
[2025-07-21T05:11:22Z]   File "/usr/lib/python3.12/logging/__init__.py", line 1160, in emit
[2025-07-21T05:11:22Z]     msg = self.format(record)
[2025-07-21T05:11:22Z]           ^^^^^^^^^^^^^^^^^^^
[2025-07-21T05:11:22Z]   File "/usr/lib/python3.12/logging/__init__.py", line 999, in format
[2025-07-21T05:11:22Z]     return fmt.format(record)
[2025-07-21T05:11:22Z]            ^^^^^^^^^^^^^^^^^^
[2025-07-21T05:11:22Z]   File "/usr/local/lib/python3.12/dist-packages/vllm/logging_utils/formatter.py", line 14, in format
[2025-07-21T05:11:22Z]     msg = logging.Formatter.format(self, record)
[2025-07-21T05:11:22Z]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2025-07-21T05:11:22Z]   File "/usr/lib/python3.12/logging/__init__.py", line 703, in format
[2025-07-21T05:11:22Z]     record.message = record.getMessage()
[2025-07-21T05:11:22Z]                      ^^^^^^^^^^^^^^^^^^^
[2025-07-21T05:11:22Z]   File "/usr/lib/python3.12/logging/__init__.py", line 392, in getMessage
[2025-07-21T05:11:22Z]     msg = msg % self.args
[2025-07-21T05:11:22Z]           ~~~~^~~~~~~~~~~
[2025-07-21T05:11:22Z] TypeError: not all arguments converted during string formatting
```

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
