### PR TITLE
[Core] Minimize number of dict lookup in _maybe_evict_cached_block

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -244,7 +244,7 @@ class BlockPool:
         """
         block_hash = block.block_hash
         if block_hash is None:
-            # The block doesn't have hash, # eviction is not needed
+            # The block doesn't have hash, eviction is not needed
             return False
         blocks_by_id = self.cached_block_hash_to_block.get(block_hash)
         if blocks_by_id is None:

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -253,8 +253,8 @@ class BlockPool:
             return False
         block.reset_hash()
         blocks_by_id.pop(block.block_id, None)
-        if len(blocks_by_id) == 0:
-            self.cached_block_hash_to_block.pop(block_hash)
+        if blocks_by_id:
+            del self.cached_block_hash_to_block[block_hash]
 
         if self.enable_kv_cache_events:
             # FIXME (Chen): Not sure whether we should return `hash_value`

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -243,22 +243,27 @@ class BlockPool:
             True if the block is evicted, False otherwise.
         """
         block_hash = block.block_hash
-        if block_hash and block_hash in self.cached_block_hash_to_block:
-            block.reset_hash()
-            del self.cached_block_hash_to_block[block_hash][block.block_id]
+        if block_hash is None:
+            # The block doesn't have hash, # eviction is not needed
+            return False
+        blocks_by_id = self.cached_block_hash_to_block.get(block_hash)
+        if blocks_by_id is None:
+            # block_hash not found in cached_block_hash_to_block,
+            # eviction is not needed
+            return False
+        block.reset_hash()
+        blocks_by_id.pop(block.block_id, None)
+        if len(blocks_by_id) == 0:
+            self.cached_block_hash_to_block.pop(block_hash)
 
-            if len(self.cached_block_hash_to_block[block_hash]) == 0:
-                del self.cached_block_hash_to_block[block_hash]
-
-            if self.enable_kv_cache_events:
-                # FIXME (Chen): Not sure whether we should return `hash_value`
-                # or `(hash_value, group_id)` here. But it's fine now because
-                # we disable hybrid kv cache manager when kv cache event is
-                # enabled, so there is only one group.
-                self.kv_event_queue.append(
-                    BlockRemoved(block_hashes=[block_hash.get_hash_value()]))
-            return True
-        return False
+        if self.enable_kv_cache_events:
+            # FIXME (Chen): Not sure whether we should return `hash_value`
+            # or `(hash_value, group_id)` here. But it's fine now because
+            # we disable hybrid kv cache manager when kv cache event is
+            # enabled, so there is only one group.
+            self.kv_event_queue.append(
+                BlockRemoved(block_hashes=[block_hash.get_hash_value()]))
+        return True
 
     def touch(self, blocks: tuple[list[KVCacheBlock], ...]) -> None:
         """Touch a block increases its reference count by 1, and may remove


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
With https://github.com/vllm-project/vllm/pull/21222, we noticed that _maybe_evict_cached_block became the new bottleneck for allocate_new_block.
<img width="1070" height="518" alt="Screenshot 2025-07-20 at 9 47 09 PM" src="https://github.com/user-attachments/assets/91a468de-ab31-4f11-9e68-2db2cd10a39f" />

And we notice that, we do duplicated key lookup against the same dict 4 times, and we could easily cut it down into 2.

## Test Plan
Compare trace with and without the change on top of https://github.com/vllm-project/vllm/pull/21222

## Test Result
Quite significant improvements 0.13ms -> 0.03ms

After
<img width="930" height="545" alt="Screenshot 2025-07-20 at 9 46 23 PM" src="https://github.com/user-attachments/assets/822b55c8-cd18-4719-9802-f9b1310e145c" />

Before
<img width="1070" height="518" alt="Screenshot 2025-07-20 at 9 47 09 PM" src="https://github.com/user-attachments/assets/da000717-3099-488b-9757-b12953131edc" />

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
