### PR TITLE
[Docs] Make tables more space efficient in `supported_models.md`

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -314,6 +314,13 @@ See [this page](generative_models.md) for more information on how to use generat
 
 Specified using `--task generate`.
 
+<style>
+th {
+  white-space: nowrap;
+  min-width: 0 !important;
+}
+</style>
+
 | Architecture | Models | Example HF Models | [LoRA](../features/lora.md) | [PP](../serving/distributed_serving.md) | [V1](gh-issue:8779) |
 |--------------|--------|-------------------|----------------------|---------------------------|---------------------|
 | `AquilaForCausalLM` | Aquila, Aquila2 | `BAAI/Aquila-7B`, `BAAI/AquilaChat-7B`, etc. | ✅︎ | ✅︎ | ✅︎ |


### PR DESCRIPTION
Reduces the min width of table headers so that the columns that only contain green tick emojis take up less horizontal space.

This leaves more horizontal space for the other columns leading to less wrapping and less vertical space consumed by the table.