### PR TITLE
Fix kv_cache_dtype handling for out-of-tree HPU plugin

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1352,24 +1352,8 @@ class EngineArgs:
 
         # No Fp8 KV cache so far.
         if self.kv_cache_dtype != "auto":
-            fp8_attention = self.kv_cache_dtype.startswith("fp8")
-            will_use_fa = (
-                current_platform.is_cuda()
-                and not envs.is_set("VLLM_ATTENTION_BACKEND")
-            ) or envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
-            supported = False
-            is_hpu_with_fp8_inc = (current_platform.is_out_of_tree()
-                                   and current_platform.device_name == 'hpu'
-                                   and self.kv_cache_dtype == "fp8_inc")
-            if (current_platform.is_rocm()
-                    or (current_platform.is_cuda()
-                        and current_platform.is_device_capability(100))
-                    or current_platform.is_tpu() or is_hpu_with_fp8_inc):
-                supported = True
-            elif fp8_attention and will_use_fa:
-                from vllm.attention.utils.fa_utils import (
-                    flash_attn_supports_fp8)
-                supported = flash_attn_supports_fp8()
+            supported = current_platform.is_kv_cache_dtype_supported(
+                self.kv_cache_dtype)
             if not supported:
                 _raise_or_fallback(feature_name="--kv-cache-dtype",
                                    recommend_to_remove=False)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1367,7 +1367,11 @@ class EngineArgs:
                 from vllm.attention.utils.fa_utils import (
                     flash_attn_supports_fp8)
                 supported = flash_attn_supports_fp8()
-
+            if (current_platform.is_out_of_tree() and 
+                current_platform.device_name == 'hpu' and 
+                self.kv_cache_dtype == "fp8_inc"):
+                supported = True
+                
             if not supported:
                 _raise_or_fallback(feature_name="--kv-cache-dtype",
                                    recommend_to_remove=False)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1358,20 +1358,18 @@ class EngineArgs:
                 and not envs.is_set("VLLM_ATTENTION_BACKEND")
             ) or envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
             supported = False
+            is_hpu_with_fp8_inc = (current_platform.is_out_of_tree()
+                                   and current_platform.device_name == 'hpu'
+                                   and self.kv_cache_dtype == "fp8_inc")
             if (current_platform.is_rocm()
                     or (current_platform.is_cuda()
                         and current_platform.is_device_capability(100))
-                    or current_platform.is_tpu()):
+                    or current_platform.is_tpu() or is_hpu_with_fp8_inc):
                 supported = True
             elif fp8_attention and will_use_fa:
                 from vllm.attention.utils.fa_utils import (
                     flash_attn_supports_fp8)
                 supported = flash_attn_supports_fp8()
-            if (current_platform.is_out_of_tree() and 
-                current_platform.device_name == 'hpu' and 
-                self.kv_cache_dtype == "fp8_inc"):
-                supported = True
-                
             if not supported:
                 _raise_or_fallback(feature_name="--kv-cache-dtype",
                                    recommend_to_remove=False)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -593,10 +593,8 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
         fp8_attention = kv_cache_dtype.startswith("fp8")
         will_use_fa = (not envs.is_set("VLLM_ATTENTION_BACKEND")
                        ) or envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
-        supported = False
-        if cls.is_device_capability(100):
-            supported = True
-        elif fp8_attention and will_use_fa:
+        supported = cls.is_device_capability(100)
+        if fp8_attention and will_use_fa:
             from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
             supported = flash_attn_supports_fp8()
         return supported

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -586,6 +586,21 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
             " not found. Assuming no NVLink available.")
         return False
 
+    @classmethod
+    def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str) -> bool:
+        if kv_cache_dtype == "auto":
+            return True
+        fp8_attention = kv_cache_dtype.startswith("fp8")
+        will_use_fa = (not envs.is_set("VLLM_ATTENTION_BACKEND")
+                       ) or envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
+        supported = False
+        if cls.is_device_capability(100):
+            supported = True
+        elif fp8_attention and will_use_fa:
+            from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
+            supported = flash_attn_supports_fp8()
+        return supported
+
 
 # Autodetect either NVML-enabled or non-NVML platform
 # based on whether NVML is available.

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -588,8 +588,6 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str) -> bool:
-        if kv_cache_dtype == "auto":
-            return True
         fp8_attention = kv_cache_dtype.startswith("fp8")
         will_use_fa = (not envs.is_set("VLLM_ATTENTION_BACKEND")
                        ) or envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -591,8 +591,10 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
         fp8_attention = kv_cache_dtype.startswith("fp8")
         will_use_fa = (not envs.is_set("VLLM_ATTENTION_BACKEND")
                        ) or envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
-        supported = cls.is_device_capability(100)
-        if fp8_attention and will_use_fa:
+        supported = False
+        if cls.is_device_capability(100):
+            supported = True
+        elif fp8_attention and will_use_fa:
             from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
             supported = flash_attn_supports_fp8()
         return supported

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -548,7 +548,13 @@ class Platform:
         """
         Returns if the kv_cache_dtype is supported by the current platform.
         """
-        return kv_cache_dtype == "auto"
+        import vllm.envs as envs
+        fp8_attention = kv_cache_dtype.startswith("fp8")
+        will_use_fa = envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
+        if fp8_attention and will_use_fa:
+            from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
+            return flash_attn_supports_fp8()
+        return False
 
 
 class UnspecifiedPlatform(Platform):

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -543,6 +543,13 @@ class Platform:
         """
         raise RuntimeError(f"Unsupported torch distributed backend: {backend}")
 
+    @classmethod
+    def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str) -> bool:
+        """
+        Returns if the kv_cache_dtype is supported by the current platform.
+        """
+        return kv_cache_dtype == "auto"
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -548,12 +548,6 @@ class Platform:
         """
         Returns if the kv_cache_dtype is supported by the current platform.
         """
-        import vllm.envs as envs
-        fp8_attention = kv_cache_dtype.startswith("fp8")
-        will_use_fa = envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
-        if fp8_attention and will_use_fa:
-            from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
-            return flash_attn_supports_fp8()
         return False
 
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -454,3 +454,15 @@ class RocmPlatform(Platform):
     @classmethod
     def device_count(cls) -> int:
         return cuda_device_count_stateless()
+
+    @classmethod
+    def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str) -> bool:
+        if kv_cache_dtype == "auto":
+            return True
+        fp8_attention = kv_cache_dtype.startswith("fp8")
+        will_use_fa = envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
+        supported = True
+        if fp8_attention and will_use_fa:
+            from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
+            supported = flash_attn_supports_fp8()
+        return supported

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -457,12 +457,4 @@ class RocmPlatform(Platform):
 
     @classmethod
     def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str) -> bool:
-        if kv_cache_dtype == "auto":
-            return True
-        fp8_attention = kv_cache_dtype.startswith("fp8")
-        will_use_fa = envs.VLLM_ATTENTION_BACKEND == "FLASH_ATTN_VLLM_V1"
-        supported = True
-        if fp8_attention and will_use_fa:
-            from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
-            supported = flash_attn_supports_fp8()
-        return supported
+        return True

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -190,6 +190,10 @@ class TpuPlatform(Platform):
                 and params.sampling_type == SamplingType.RANDOM_SEED):
             raise ValueError("Torch XLA does not support per-request seed.")
 
+    @classmethod
+    def is_kv_cache_dtype_supported(cls, kv_cache_dtype: str) -> bool:
+        return True
+
 
 try:
     from tpu_commons.platforms import TpuPlatform as TpuCommonsPlatform


### PR DESCRIPTION
PR https://github.com/vllm-project/vllm/pull/21131 removed HPU checks for `--kv-cache-dtype` flag, and now HPU out-of-tree plugin (https://github.com/vllm-project/vllm-gaudi) is unable to use KV cache quantization with INC due to `NotImplementedError: VLLM_USE_V1=1 is not supported with --kv-cache-dtype.`. This PR adds a check for out-of-tree HPU plugin and allows it to use fp8_inc KV cache quantization.