### PR TITLE
Fix docker/AppArmor crash caused by cpuinfo __cpuid jit path

### DIFF
--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -200,7 +200,7 @@ class UsageMessage:
         # don't call real cpu info to prevent sub-process from being spawned,
         # which would loose our monkey patch
         info = _ci._get_cpu_info_internal()
-        
+
         self.num_cpu = info.get("count", None)
         self.cpu_type = info.get("brand_raw", "")
         self.cpu_family_model_stepping = ",".join([

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -13,7 +13,8 @@ from threading import Thread
 from typing import Any, Optional, Union
 from uuid import uuid4
 
-import cpuinfo
+import cpuinfo.cpuinfo as _ci
+
 import psutil
 import requests
 import torch
@@ -192,7 +193,13 @@ class UsageMessage:
         self.platform = platform.platform()
         self.total_memory = psutil.virtual_memory().total
 
-        info = cpuinfo.get_cpu_info()
+        # avoids memprotect executable issues cpuid jit path (e.g. in docker, seccomp/AppArmor...)
+        _ci.CAN_CALL_CPUID_IN_SUBPROCESS = False
+        _ci.DataSource.can_cpuid = False
+
+        # don't call real cpu info to prevent sub-process from being spawned, which would loose our monkey patch
+        info = _ci._get_cpu_info_internal()
+        
         self.num_cpu = info.get("count", None)
         self.cpu_type = info.get("brand_raw", "")
         self.cpu_family_model_stepping = ",".join([

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -13,8 +13,7 @@ from threading import Thread
 from typing import Any, Optional, Union
 from uuid import uuid4
 
-import cpuinfo.cpuinfo as _ci.cpuinfo as _ci
-
+import cpuinfo.cpuinfo as _ci
 import psutil
 import requests
 import torch

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -13,8 +13,7 @@ from threading import Thread
 from typing import Any, Optional, Union
 from uuid import uuid4
 
-import cpuinfo.cpuinfo as _ci
-.cpuinfo as _ci
+import cpuinfo.cpuinfo as _ci.cpuinfo as _ci
 
 import psutil
 import requests


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
Fix crash induced by the `__cpuid` jit path of the `py-cpuinfo` library.

By default `vllm serve` will result in a `core.{pid}` file being generated as a result of cpuid helper subprocess being terminated when running on docker-based cloud instances, such as e.g. Prime Compute.

Many distros (especially Alpine or those built with PaX/grsecurity) and Docker's default seccomp/AppArmor profiles will refuse an `mmap(..., PROT_EXEC)` or a `mprotect(..., PROT_EXEC)`. If the syscall is blocked or the mapping succeeds without exec permission, trying to run code there will fault and dump core.

Please comment on whether this fix is in spirit or whether changes to `py-cpuinfo` are desired instead.

## Test Plan

- Run `vllm serve` pre change
- Run `vllm serve` post change
- Inspect cpu info dict with temporary debug print statement

## Test Result

- Run without change -> Core dump.
- Run with change -> no core dump.
- cpu info dict debug print contains plausible values

## Documentation Update
Not required.
