### PR TITLE
[Misc] DeepEPHighThroughtput - Enable Inductor pass

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -182,9 +182,6 @@ class CudaPlatformBase(Platform):
             compilation_config.use_cudagraph = False
             if model_config is not None:
                 model_config.enforce_eager = True
-            # TODO (varun): Turning this ON gives incorrect results for the
-            # Deepseek-V2-lite model.
-            vllm_config.compilation_config.use_inductor = False
 
     @classmethod
     def get_current_memory_usage(cls,


### PR DESCRIPTION
## Purpose
DeepEPHighThroughput All2All kernels + Torch Inductor pass yielded incorrect results for deepseek-v2-lite models. The Inductor pass was disabled as a result. This PR enables it again as we don't see any issues now.

## Test Plan
e2e tests: 
server command : `VLLM_ALL2ALL_BACKEND="deepep_high_throughput" VLLM_USE_DEEP_GEMM=1  canhazgpu run -g 2 --  vllm serve $MODEL  --trust-remote-code --enable-expert-parallel --data-parallel-size 2 --port 9010 --no-enable-prefix-caching`
lm_eval command : `lm_eval --model local-completions --tasks gsm8k --model_args model=$MODEL,base_url=http://127.0.0.1:9010/v1/completions,num_concurrent=30,max_retries=3 --limit 100`

## Test Result
Model = `deepseek-ai/DeepSeek-V2-Lite`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.29|±  |0.0456|
|     |       |strict-match    |     5|exact_match|↑  | 0.29|±  |0.0456|
```
Model = `Qwen/Qwen3-30B-A3B-FP8`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.85|±  |0.0359|
|     |       |strict-match    |     5|exact_match|↑  | 0.94|±  |0.0239|
```
Results are similar to what we see on `main`
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
