### PR TITLE
[DBO] Adding the `UBatchContext` class for DBO support

### DIFF
--- a/tests/v1/worker/test_ubatching.py
+++ b/tests/v1/worker/test_ubatching.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+
+import torch
+import torch.nn.functional as F
+
+from vllm.v1.worker.ubatching import (make_ubatch_contexts,
+                                      yield_and_switch_from_comm_to_compute,
+                                      yield_and_switch_from_compute_to_comm)
+
+
+def layer(static_input, weight, static_output):
+    intermediate_output_1 = F.linear(static_input, weight)
+    intermediate_output_2 = F.linear(static_input, weight)
+    static_output.copy_(intermediate_output_1 + intermediate_output_2)
+
+
+def ubatch_layer(static_input, weight, static_output):
+    intermediate_output_1 = F.linear(static_input, weight)
+    yield_and_switch_from_compute_to_comm()
+    intermediate_output_2 = F.linear(static_input, weight)
+    yield_and_switch_from_comm_to_compute()
+    static_output.copy_(intermediate_output_1 + intermediate_output_2)
+
+
+def ubatch_thread_fn(static_input, weight, static_output, ubatch_context):
+    with ubatch_context:
+        ubatch_layer(static_input, weight, static_output)
+
+
+def test_ubatch_context():
+    M = 128
+    N = 256
+    K = 512
+
+    input_ids = torch.randn(M, K, device='cuda')
+    weight = torch.randn(N, K, device='cuda')
+
+    # Static tensors for graph
+    outputs = torch.empty(M, N, device='cuda')
+    test_outputs = torch.empty(M, N, device='cuda')
+
+    num_ubatches = 2
+
+    compute_stream: torch.cuda.Stream = torch.cuda.Stream()  #type: ignore
+    comm_stream: torch.cuda.Stream = torch.cuda.Stream()  # type: ignore
+
+    ubatch_contexts = make_ubatch_contexts(num_ubatches, compute_stream,
+                                           comm_stream, None)
+    ubatch_inputs = [input_ids[:M // 2], input_ids[M // 2:]]
+    ubatch_outputs = [outputs[:M // 2], outputs[M // 2:]]
+
+    threads = []
+    for i, ubatch_context in enumerate(ubatch_contexts):
+        thread = threading.Thread(target=ubatch_thread_fn,
+                                  args=(
+                                      ubatch_inputs[i],
+                                      weight,
+                                      ubatch_outputs[i],
+                                      ubatch_context,
+                                  ))
+        thread.start()
+        threads.append(thread)
+
+    ubatch_contexts[0].cpu_wait_event.set()
+    for thread in threads:
+        thread.join()
+
+    layer(input_ids, weight, test_outputs)
+    max_diff = torch.max(torch.abs(test_outputs - outputs)).item()
+    print(f"Max Diff: {max_diff}")
+    rtol = 1e-5
+    atol = 1e-5
+    all_close = torch.allclose(test_outputs, outputs, rtol=rtol, atol=atol)
+    assert all_close

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -13,6 +13,9 @@ from vllm.utils import current_stream
 class UBatchContext:
     """
     Context manager for micro-batching synchronization using threading events.
+    Should only be instantiated in make_ubatch_contexts.
+
+    There will be one UBatchContext per micro-batch.
     """
 
     def __init__(self, id_: int, comm_stream: torch.cuda.Stream,
@@ -134,10 +137,11 @@ def make_ubatch_contexts(
     comm_stream: torch.cuda.Stream,
     forward_context: Optional[ForwardContext],
 ) -> list[UBatchContext]:
+    """
+    Creates a list of context managers for micro-batch synchronization. 
+    """
+
     assert num_micro_batches == 2, "only been tested with 2 micro-batches"
-    """
-    Create a context manager for micro-batching synchronization.
-    """
 
     # initialize cpu events to synchronize the two threads
     cpu_events = [threading.Event() for _ in range(num_micro_batches)]

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+from typing import Optional
+
+import torch
+
+from vllm import forward_context
+from vllm.forward_context import ForwardContext
+from vllm.utils import current_stream
+
+
+class UBatchContext:
+    """
+    Context manager for micro-batching synchronization using threading events.
+    """
+
+    def __init__(self, id_: int, comm_stream: torch.cuda.Stream,
+                 compute_stream: torch.cuda.Stream,
+                 forward_context: Optional[ForwardContext],
+                 cpu_wait_event: threading.Event,
+                 cpu_signal_event: threading.Event,
+                 gpu_comm_done_event: torch.cuda.Event,
+                 gpu_compute_done_event: torch.cuda.Event):
+        self.id = id_
+        self.comm_stream = comm_stream
+        self.compute_stream = compute_stream
+        self.forward_context = forward_context
+        self.cpu_wait_event = cpu_wait_event
+        self.cpu_signal_event = cpu_signal_event
+        self.current_stream = compute_stream
+        self.gpu_comm_done_event = gpu_comm_done_event
+        self.gpu_compute_done_event = gpu_compute_done_event
+
+    def __enter__(self):
+        global _CURRENT_CONTEXT
+        _CURRENT_CONTEXT[threading.get_ident()] = self
+
+        self.cpu_wait_event.clear()
+        self.cpu_wait_event.wait()
+        self.cpu_wait_event.clear()
+        self._restore_context()
+        # Assume we start on the compute stream
+        assert current_stream() == self.compute_stream
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        global _CURRENT_CONTEXT
+        _CURRENT_CONTEXT[threading.get_ident()] = None
+        self.cpu_signal_event.set()
+        self.cpu_wait_event.clear()
+        self.current_stream = self.compute_stream
+        torch.cuda.set_stream(self.current_stream)
+        return False
+
+    def _restore_context(self):
+        forward_context._forward_context = self.forward_context
+        torch.cuda.set_stream(self.current_stream)
+
+    def update_stream(self, stream):
+        self.current_stream = stream
+        torch.cuda.set_stream(self.current_stream)
+
+    def _signal_comm_done(self):
+        self.gpu_comm_done_event.record(self.comm_stream)
+
+    def _signal_compute_done(self):
+        self.gpu_compute_done_event.record(self.compute_stream)
+
+    def _wait_compute_done(self):
+        self.gpu_compute_done_event.wait(self.comm_stream)
+
+    def _wait_comm_done(self):
+        self.gpu_comm_done_event.wait(self.compute_stream)
+
+    def _cpu_yield(self):
+        # It is critical for correctness that only one thread is running
+        # at a time. These asserts just make sure that this is the only
+        # thread running before waking the other one up and going to sleep
+        assert forward_context._forward_context == self.forward_context
+        assert current_stream() == self.current_stream
+        assert not self.cpu_wait_event.is_set()
+
+        self.cpu_signal_event.set()
+        self.cpu_wait_event.wait()
+        self.cpu_wait_event.clear()
+        self._restore_context()
+
+    def yield_and_switch_from_compute_to_comm(self):
+        assert current_stream() == self.compute_stream
+        self._signal_compute_done()
+        self._cpu_yield()
+        assert self.current_stream == self.compute_stream
+        self.update_stream(self.comm_stream)
+        self._wait_compute_done()
+
+    def yield_and_switch_from_comm_to_compute(self):
+        assert current_stream() == self.comm_stream
+        self._signal_comm_done()
+        self._cpu_yield()
+        assert self.current_stream == self.comm_stream
+        self.update_stream(self.compute_stream)
+        self._wait_comm_done()
+
+
+_CURRENT_CONTEXT: dict = {}
+
+
+def get_current_ubatch_context() -> Optional[UBatchContext]:
+    global _CURRENT_CONTEXT
+    """
+    Get the current UBatchContext for the current thread.
+    """
+    return _CURRENT_CONTEXT.get(threading.get_ident(), None)
+
+
+def yield_and_switch_from_compute_to_comm():
+    # Perform the barrier if a context exists for this thread
+    ctx = get_current_ubatch_context()
+    if ctx is not None:
+        ctx.yield_and_switch_from_compute_to_comm()
+
+
+def yield_and_switch_from_comm_to_compute():
+    # Perform the barrier if a context exists for this thread
+    ctx = get_current_ubatch_context()
+    if ctx is not None:
+        ctx.yield_and_switch_from_comm_to_compute()
+
+
+def make_ubatch_contexts(
+    num_micro_batches: int,
+    compute_stream: torch.cuda.Stream,
+    comm_stream: torch.cuda.Stream,
+    forward_context: Optional[ForwardContext],
+) -> list[UBatchContext]:
+    assert num_micro_batches == 2, "only been tested with 2 micro-batches"
+    """
+    Create a context manager for micro-batching synchronization.
+    """
+
+    # initialize cpu events to synchronize the two threads
+    cpu_events = [threading.Event() for _ in range(num_micro_batches)]
+
+    # initialize the gpu events to synchronize the two streams
+    gpu_comm_done_events: list[torch.cuda.Event] = [
+        torch.cuda.Event() for _ in range(num_micro_batches)
+    ]  #type: ignore
+    gpu_compute_done_events: list[torch.cuda.Event] = [
+        torch.cuda.Event() for _ in range(num_micro_batches)
+    ]  #type: ignore
+
+    ctxs = []
+    for i in range(num_micro_batches):
+        ctx = UBatchContext(id_=i,
+                            compute_stream=compute_stream,
+                            comm_stream=comm_stream,
+                            forward_context=forward_context,
+                            cpu_wait_event=cpu_events[i],
+                            cpu_signal_event=cpu_events[(i + 1) %
+                                                        num_micro_batches],
+                            gpu_comm_done_event=gpu_comm_done_events[i],
+                            gpu_compute_done_event=gpu_compute_done_events[i])
+        ctxs.append(ctx)
+
+    return ctxs


### PR DESCRIPTION
## Purpose
This PR adds the `UBatchContext` class which is an essential piece of infrastructure for supporting Dual Batch Overlap in vllm (#20448). This class is currently unused outside of the unit test in this PR.

The `UBatchContext` class is designed such that the callers will have two instances of this class, one per micro-batch. The test serves as a relatively straight-forward example of how this class will be used. The caller will instantiate two threads, one for each micro-batch, slice up the input and output tensors for the model, and then "assign" each thread one of the slices.

Additionally, the `UBatchContext` class has this notion of "yielding". The `UBatchContext` maintains two shared streams. The first is for compute and the second is for communication. The idea is that the two micro-batching threads will dispatch all of their compute intensive kernels to the `compute_stream` and all of their communication kernels to the `comm_stream`. 

It's important to keep in mind that both threads are running exactly the same code. It is also important to understand that only one thread is running at a time.

When a thread (thread A) reaches a yield point, let's say `yield_and_switch_from_compute_to_comm`, it will immediately yield the cpu to the second thread (thread B). When thread B reaches the same yield point, thread A will resume but will swap it's current cuda stream to the `comm_stream` before continuing to dispatch kernels. This pattern repeats over the course of the model's execution with the two streams being synchronized with cuda events.

## Test Plan
There is an included unit test
