### PR TITLE
[Cleanup] Only log MoE DP setup warning if DP is enabled

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -464,10 +464,11 @@ class FusedMoEConfig:
                 )
             else:
                 _quant_config = FusedMoEQuantConfig()
-                logger.warning_once("MoE DP setup unable to determine "
-                                    "quantization scheme or unsupported "
-                                    "quantization type. This model will "
-                                    "not run with DP enabled.")
+                if moe_parallel_config.dp_size > 1:
+                    logger.warning_once("MoE DP setup unable to determine "
+                                        "quantization scheme or unsupported "
+                                        "quantization type. This model will "
+                                        "not run with DP enabled.")
         else:
             _quant_config = quant_config
 


### PR DESCRIPTION
## Purpose

Before this change, any deployment of an MoE kernel that isn't setup to use DP would print a warning about this even if DP wasn't being used at all. I just want to restrict this to only trigger if DP is used.

## Test Plan

## Test Result
