### PR TITLE
[Intel GPU] Ray Compiled Graph avoid NCCL for Intel GPU

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -67,8 +67,8 @@ class RayDistributedExecutor(DistributedExecutorBase):
             os.environ["VLLM_USE_RAY_SPMD_WORKER"] = "1"
             os.environ["VLLM_USE_RAY_COMPILED_DAG"] = "1"
 
-            # For TPU, avoid compiling NVIDIA's NCCL
-            if current_platform.is_tpu():
+            # For TPU or XPU, avoid compiling NVIDIA's NCCL
+            if current_platform.is_tpu() or current_platform.is_xpu():
                 os.environ["VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE"] = "shm"
 
         # If the env var is set, it uses the Ray's compiled DAG API


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Ray compiled DAG causes runtime failure for PP+TP setup with XPU (Intel GPU). This is due to with_tensor_transport set to **auto** and further ray resolves this to NCCL as XPU device is a GPU, but inside ray compiled dag GPU-to-GPU transfers are only yet supported for NCCL NV GPUs. Setting to "shm" resolves the issue.
## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
