### PR TITLE
[TPU][Bugfix] fix moe layer

### DIFF
--- a/tests/v1/tpu/test_basic.py
+++ b/tests/v1/tpu/test_basic.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 MODELS = [
     "Qwen/Qwen2.5-1.5B-Instruct",
+    "Qwen/Qwen1.5-MoE-A2.7B",
     # TODO: Enable this models with v6e
     # "Qwen/Qwen2-7B-Instruct",
     # "meta-llama/Llama-3.1-8B",

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -481,8 +481,16 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         e_score_correction_bias: Optional[torch.Tensor] = None,
         apply_router_weight_on_input: bool = False,
         activation: str = "silu",
-        **kwargs,
+        enable_eplb: bool = False,
+        expert_load_view: Optional[torch.Tensor] = None,
+        logical_to_physical_map: Optional[torch.Tensor] = None,
+        logical_replica_count: Optional[torch.Tensor] = None,
     ):
+        if enable_eplb is not False or expert_load_view is not None or \
+                logical_to_physical_map is not None or \
+                logical_replica_count is not None:
+            raise NotImplementedError("Expert load balancing is not supported "
+                                      "for TPU.")
         return layer.cpu_fused_moe(
             layer,
             x,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -518,7 +518,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         e_score_correction_bias: Optional[torch.Tensor] = None,
         apply_router_weight_on_input: bool = False,
         activation: str = "silu",
-        **kwargs,
+        enable_eplb: bool = False,
+        expert_load_view: Optional[torch.Tensor] = None,
+        logical_to_physical_map: Optional[torch.Tensor] = None,
+        logical_replica_count: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         assert not use_grouped_topk
         assert num_expert_group is None
@@ -532,6 +535,11 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             raise NotImplementedError(
                 "Expert score correction bias is not supported for TPU.")
         assert activation == "silu", f"{activation} is not supported for TPU."
+        if enable_eplb is not False or expert_load_view is not None or \
+                logical_to_physical_map is not None or \
+                logical_replica_count is not None:
+            raise NotImplementedError("Expert load balancing is not supported "
+                                      "for TPU.")
         return fused_moe_pallas(hidden_states=x,
                                 w1=layer.w13_weight,
                                 w2=layer.w2_weight,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -490,7 +490,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 logical_to_physical_map is not None or \
                 logical_replica_count is not None:
             raise NotImplementedError("Expert load balancing is not supported "
-                                      "for TPU.")
+                                      "for CPU.")
         return layer.cpu_fused_moe(
             layer,
             x,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -518,6 +518,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         e_score_correction_bias: Optional[torch.Tensor] = None,
         apply_router_weight_on_input: bool = False,
         activation: str = "silu",
+        **kwargs,
     ) -> torch.Tensor:
         assert not use_grouped_topk
         assert num_expert_group is None


### PR DESCRIPTION
## Purpose
To fix the issue on TPU introduced by https://github.com/vllm-project/vllm/pull/20775, where several new arguments in moe layer are introduced, but `forward_tpu` doesn't handle them.

- fix moe layer
- add a TPU MoE test

## Test Plan
```
pytest -s -v tests/v1/tpu/test_basic.py
```

## Test Result
Passed

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
