### PR TITLE
[V1] port xformers backend to v1

### DIFF
--- a/tests/v1/attention/utils.py
+++ b/tests/v1/attention/utils.py
@@ -128,6 +128,8 @@ def get_attention_backend(backend_name: _Backend):
         "vllm.v1.attention.backends.triton_attn.TritonAttentionBackend",
         _Backend.TREE_ATTN:
         "vllm.v1.attention.backends.tree_attn.TreeAttentionBackend",
+        _Backend.XFORMERS_VLLM_V1:
+        "vllm.v1.attention.backends.xformers.XFormersAttentionBackend",
     }
 
     if backend_name not in backend_map:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1469,6 +1469,7 @@ class EngineArgs:
             "TORCH_SDPA_VLLM_V1",
             "FLEX_ATTENTION",
             "TREE_ATTN",
+            "XFORMERS_VLLM_V1",
         ]
         if (envs.is_set("VLLM_ATTENTION_BACKEND")
                 and envs.VLLM_ATTENTION_BACKEND not in V1_BACKENDS):

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -271,6 +271,7 @@ class CudaPlatformBase(Platform):
             TRITON_ATTN_VLLM_V1 = "vllm.v1.attention.backends.triton_attn.TritonAttentionBackend"  # noqa: E501
             FLASH_ATTN_V1 = "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend"  # noqa: E501
             TREE_ATTN_V1 = "vllm.v1.attention.backends.tree_attn.TreeAttentionBackend"  # noqa: E501
+            XFORMERS_V1 = "vllm.v1.attention.backends.xformers.XFormersAttentionBackend"  # noqa: E501
 
             if selected_backend == _Backend.FLASHINFER:
                 logger.info_once("Using FlashInfer backend on V1 engine.")
@@ -291,6 +292,9 @@ class CudaPlatformBase(Platform):
             elif selected_backend == _Backend.TREE_ATTN:
                 logger.info_once("Using Tree Attention backend on V1 engine.")
                 return TREE_ATTN_V1
+            elif selected_backend == _Backend.XFORMERS_VLLM_V1:
+                logger.info_once("Using XFormers backend on V1 engine.")
+                return XFORMERS_V1
 
             from vllm.attention.selector import is_attn_backend_supported
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -63,6 +63,7 @@ class _Backend(enum.Enum):
     NO_ATTENTION = enum.auto()
     FLEX_ATTENTION = enum.auto()
     TREE_ATTN = enum.auto()
+    XFORMERS_VLLM_V1 = enum.auto()
 
 
 class PlatformEnum(enum.Enum):


### PR DESCRIPTION
# Purpose
Port over the xformers backend to the v1 engine. There are several benefits to using XFormers, including:
1. Built-in heursitic which determines which attention implementation is best suited for the given inputs.
2. AMD kernel support
3. Well suited for certain Meta models.

# Test Plan
Added test case to `test_attention_backends` which verifies correctness of the xformers v1 backend attention output.
```
(py312conda) bash-5.1$ pytest tests/v1/attention/test_attention_backends.py -k test_backend_correctness
================================================================================ test session starts ================================================================================
platform linux -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /data/users/gdelfin/gitrepos/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 6 items                                                                                                                                                                   

tests/v1/attention/test_attention_backends.py ......                                                                                                                          [100%]

================================================================================= warnings summary ==================================================================================
tests/v1/attention/test_attention_backends.py::test_backend_correctness[meta-llama/Meta-Llama-3-8B-small_decode]
tests/v1/attention/test_attention_backends.py::test_backend_correctness[meta-llama/Meta-Llama-3-8B-small_decode]
tests/v1/attention/test_attention_backends.py::test_backend_correctness[meta-llama/Meta-Llama-3-8B-small_decode]
tests/v1/attention/test_attention_backends.py::test_backend_correctness[meta-llama/Meta-Llama-3-8B-small_decode]
  /home/gdelfin/.conda/envs/py312conda/lib/python3.12/site-packages/triton/runtime/autotuner.py:108: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 6 passed, 4 warnings in 18.72s ===========================================================================
```

## Benchmark
In addition, I used the following command to run the LLM service and benchmark TreeAttentionBackend vs FlashAttentionBackend:
**Server**
```
export VLLM_TORCH_PROFILER_DIR=~/traces/vllm
export LLAMA_MODEL=meta-llama/Llama-3.1-8B-Instruct
export DRAFT_MODEL=yuhuili/EAGLE-LLaMA3.1-Instruct-8B
export VLLM_USE_V1=1
export VLLM_ATTENTION_BACKEND=<backend>
python -m vllm.entrypoints.openai.api_server --model $LLAMA_MODEL --disable-log-requests --tensor-parallel-size=1 --max-num-seqs=64 --max-model-len=32768 --block-size=128 --no-enable-prefix-caching --speculative-config="$SPEC_DEC_CONFIG" 2>&1 | tee ~/server_logs/vllm_server.log
```

**Client**
```
export LLAMA_MODEL=meta-llama/Llama-3.1-8B-Instruct
python benchmarks/benchmark_serving.py --model $LLAMA_MODEL --tokenizer $LLAMA_MODEL --host 0.0.0.0 --dataset-name random --ignore-eos --request-rate inf --random-input-len 1000 --random-output-len 300 --max-concurrency 64 --num-prompts 128
```

**Results**
Serving Benchmark Result | Flash Attention 3 | Triton Attention | XFormers Attention
-- | -- | -- | --
Successful requests | 128 | 128 | 128
Benchmark duration (s) | 15.94 | 13.23 | 13.22
Total input tokens | 127731 | 127731 | 127731
Total generated tokens | 38400 | 38400 | 38400
Request throughput (req/s) | 8.03 | 9.68 | 9.68
Output token throughput (tok/s) | 2408.88 | 2903.54 | 2905.24
Total Token throughput (tok/s) | 10421.59 | 12561.66 | 12569.01
Time to First Token
Mean TTFT (ms) | 894.77 | 920.44 | 929.93
Median TTFT (ms) | 856.32 | 769.44 | 776.85
P99 TTFT (ms) | 1817.60 | 2063.83 | 2080.56
Time per Output Token (excl. 1st token)
Mean TPOT (ms) | 23.49 | 18.94 | 18.87
Median TPOT (ms) | 22.67 | 19.34 | 19.24
P99 TPOT (ms) | 30.50 | 21.57 | 21.51
Inter-token Latency
Mean ITL (ms) | 23.49 | 18.94 | 18.87
Median ITL (ms) | 15.14 | 15.48 | 15.35
P99 ITL (ms) | 222.39 | 252.56 | 256.01

The v1 XFormers backend performs better than FA3, and is on par with Triton split-k.

<!--- pyml disable-next-line no-emphasis-as-heading -->
