### PR TITLE
[xpu] disable cudagraph for xpu platform

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -90,13 +90,6 @@ class XPUPlatform(Platform):
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = 64
 
-        # FIXME: Temporarily forcing eager mode
-        # remove after t.compile support stabilizes.
-        if (envs.VLLM_USE_V1 and model_config is not None
-                and not vllm_config.model_config.enforce_eager):
-            from vllm.config import CompilationLevel
-            vllm_config.compilation_config.level = CompilationLevel.NO_COMPILATION  # noqa: E501
-
         # Instances created using VllmConfig() typically have model_config as
         # None by default. The modification involves adding a check to prevent
         # potential null exceptions check and update model config.

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -86,6 +86,7 @@ class XPUPlatform(Platform):
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
+        vllm_config.compilation_config.use_cudagraph = False
         # in V1(or with ipex chunked prefill) block_size is 64
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = 64


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
When running certain models in torch.compile mode, the system might try to use CUDA Graph-related code. This isn't supported on XPU platforms, so we've disabled it here.
## Test Plan
VLLM_USE_V1=1 python examples/offline_inference/audio_language.py -m granite_speech
## Test Result
Without this PR: 
lora_b_stacked_2_ = None
  File "/home/chaojun/vllm/vllm/compilation/cuda_piecewise_backend.py", line 164, in __call__
    cudagraph = torch.cuda.CUDAGraph()
  File "/home/chaojun/.local/lib/python3.10/site-packages/torch/cuda/graphs.py", line 74, in __new__
    return super().__new__(cls, keep_graph)
  File "/home/chaojun/.local/lib/python3.10/site-packages/torch/_utils.py", line 996, in err_fn
    raise RuntimeError(f"Tried to instantiate dummy base class {class_name}")
RuntimeError: Tried to instantiate dummy base class CUDAGraph

With this PR:

Adding requests: 100%|███████████████████████████████████████████████████████████████████| 1/1 [00:10<00:00, 10.00s/it]
Fetching 25 files: 100%|████████████████████████████████████████████████████████████| 25/25 [00:00<00:00, 23101.48it/s]
Processed prompts: 100%|███████████| 1/1 [00:03<00:00,  3.68s/it, est. speed input: 61.98 toks/s, output: 12.50 toks/s]
the first words i spoke in the original phonograph a little piece of practical poetry mary had a little lamb its fleece was white as snow and everywhere that mary went the lamb was sure to go

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
