### PR TITLE
[Bugfix][Apple Silicon] fix missing symbols when build from source on Mac with Apple Silicon

### DIFF
--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -151,7 +151,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("rotary_embedding", torch::kCPU, &rotary_embedding);
 
   // Quantization
-#if defined(__AVX512F__) || defined(__aarch64__)
+#if defined(__AVX512F__) || (defined(__aarch64__) && !defined(__APPLE__))
   at::Tag stride_tag = at::Tag::needs_fixed_stride_order;
 
   // Compute int8 quantized tensor for given scaling factor.


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] Fix the bug that the package built from source on Mac with Apple Silicon fails to load int8 quant function symbols when trying to `import vllm._C`

## The bug
The macro `__aarch64__` fails to filter out Mac with Apple Silicon, so that some int8 quantization functions are compiled without linking to runnable source files. The build process should work good, but error occurs at  running time when trying to `import vllm._C` and throws the message `Failed to import from vllm._C with ImportError("dlopen(....../vllm/vllm/_C.abi3.so, 0x0002): symbol not found in flat namespace '__Z14int8_scaled_mmRN2at6TensorERKS0_S3_S3_S3_RKNSt3__18optionalIS0_EE'")`

<img width="931" height="62" alt="screenshot_macos_error" src="https://github.com/user-attachments/assets/f3c7ef09-5455-4370-a1b9-ce832e34496c" />

## Bugfix
Filter out Apple Silicon with an extra macro `__APPLE__` in the torch binding source file.

## Test Plan
- [x] succeed to `import vllm._C` after building from source on Mac M4.

```
% pip install -v -e .

% python
% Python 3.12.11 | packaged by Anaconda, Inc. | (main, Jun  5 2025, 08:03:38) [Clang 14.0.6 ] on darwin
>>> import vllm._C    # without error
```

@nishith-fujitsu @DarkLight1337 