### PR TITLE
Revert "[Refactor] Fix Compile Warning #1444-D (#21208)"

### DIFF
--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -20,7 +20,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include "../cuda_compat.h"
-#include <cuda/std/functional>
 
 #ifndef USE_ROCM
     #include <cub/util_type.cuh>
@@ -63,7 +62,7 @@ __launch_bounds__(TPB) __global__
 
     const int thread_row_offset = blockIdx.x * num_cols;
 
-    cuda::std::plus<float> sum;
+    cub::Sum sum;
     float threadData(-FLT_MAX);
 
     // Don't touch finished rows.


### PR DESCRIPTION
This reverts commit 6e5b5ca580e60a3b7a6c5613ae7d8676f2c8cbc6.

## Purpose

https://github.com/vllm-project/vllm/pull/21208

Seems this break the compilation on AMD device, let's revert this first. And I will have another pr fixing the warning, and the same time having the AMD support as well, but it needs some time to set up the env for amd server, so let's just revert it first so that we don't block users