### PR TITLE
[Bug] Warning for Deprecated Device Param

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -241,6 +241,12 @@ class LLM:
         else:
             compilation_config_instance = CompilationConfig()
 
+        if 'device' in kwargs:
+            logger.warning_once(
+                "`device` parameter for EngineArgs is deprecated since vllm "
+                "0.10.0, it will be ignored")
+            del kwargs['device']
+
         engine_args = EngineArgs(
             model=model,
             task=task,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -243,8 +243,8 @@ class LLM:
 
         if 'device' in kwargs:
             logger.warning_once(
-                "`device` parameter for EngineArgs is deprecated since vllm "
-                "0.10.0, it will be ignored")
+                "`device` parameter for LLM (EngineArgs) is deprecated since "
+                "vllm 0.10.0, it will be ignored")
             del kwargs['device']
 
         engine_args = EngineArgs(


### PR DESCRIPTION
## Purpose

A fix for https://github.com/vllm-project/vllm/pull/21349

## Test Plan

Originally: 

```bash
  File "/home/wentao/.wentao_env/lib/python3.12/site-packages/lm_eval/models/vllm_causallms.py", line 177, in __init__
    self.model = LLM(**self.model_args)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wentao/vllm-source/vllm/entrypoints/llm.py", line 244, in __init__
    engine_args = EngineArgs(
                  ^^^^^^^^^^^
TypeError: EngineArgs.__init__() got an unexpected keyword argument 'device'
```

Now:

```bash
WARNING 07-22 14:30:40 [llm.py:245] `device` parameter for EngineArgs is deprecated since vllm 0.10.0, it will be ignored
2025-07-22:14:28:35 INFO     [loggers.evaluation_tracker:280] Output path not provided, skipping saving results aggregated
vllm (pretrained=Qwen/Qwen3-30B-A3B-FP8,max_model_len=32768,enforce_eager=True,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.815|±  |0.0107|
|     |       |strict-match    |     5|exact_match|↑  |0.887|±  |0.0087|
```