### PR TITLE
[Core] Add basic unit test for maybe_evict_cached_block

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1097,6 +1097,73 @@ def test_prefix_cache_stats_disabled():
     assert manager.prefix_cache_stats is None
 
 
+def test_maybe_evict_cached_block():
+    pool = BlockPool(num_gpu_blocks=4, enable_caching=True)
+    block_hash0 = BlockHashWithGroupId(block_hash=BlockHash(hash_value=10,
+                                                            token_ids=(100, )),
+                                       group_id=1000)
+    block_hash1 = BlockHashWithGroupId(block_hash=BlockHash(hash_value=20,
+                                                            token_ids=(200, )),
+                                       group_id=2000)
+    block_hash2 = BlockHashWithGroupId(block_hash=BlockHash(hash_value=30,
+                                                            token_ids=(300, )),
+                                       group_id=3000)
+    block_hashes = [
+        block_hash0,
+        block_hash1,
+        block_hash2,
+        # block3 had the exact same block_hash as the first block
+        block_hash0,
+    ]
+    assert len(pool.blocks) == len(block_hashes)
+    # Manually add all blocks to cached_blocks
+    for block, block_hash in zip(pool.blocks, block_hashes):
+        block.block_hash = block_hash
+        pool.cached_block_hash_to_block[block_hash][block.block_id] = block
+
+    block0, block1, block2, block3 = pool.blocks
+    assert pool.cached_block_hash_to_block == {
+        block_hash0: {
+            0: block0,
+            3: block3
+        },
+        block_hash1: {
+            1: block1
+        },
+        block_hash2: {
+            2: block2
+        }
+    }
+    # Evict block1
+    pool._maybe_evict_cached_block(block1)
+    assert pool.cached_block_hash_to_block == {
+        block_hash0: {
+            0: block0,
+            3: block3
+        },
+        block_hash2: {
+            2: block2
+        }
+    }
+    # Evict block0: block_hash0 entry should NOT be removed, as block3
+    # also use the same hash
+    pool._maybe_evict_cached_block(block0)
+    assert pool.cached_block_hash_to_block == {
+        block_hash0: {
+            3: block3
+        },
+        block_hash2: {
+            2: block2
+        }
+    }
+    # Evict block2
+    pool._maybe_evict_cached_block(block2)
+    assert pool.cached_block_hash_to_block == {block_hash0: {3: block3}}
+    # Evict block3
+    pool._maybe_evict_cached_block(block3)
+    assert pool.cached_block_hash_to_block == {}
+
+
 @pytest.mark.parametrize("blocks_to_cache", [2, 3, 10])
 def test_kv_cache_events(blocks_to_cache: int):
     block_size = 16

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1124,25 +1124,25 @@ def test_maybe_evict_cached_block():
     block0, block1, block2, block3 = pool.blocks
     assert pool.cached_block_hash_to_block == {
         block_hash0: {
-            0: block0,
-            3: block3
+            block0.block_id: block0,
+            block3.block_id: block3
         },
         block_hash1: {
-            1: block1
+            block1.block_id: block1
         },
         block_hash2: {
-            2: block2
+            block2.block_id: block2
         }
     }
     # Evict block1
     pool._maybe_evict_cached_block(block1)
     assert pool.cached_block_hash_to_block == {
         block_hash0: {
-            0: block0,
-            3: block3
+            block0.block_id: block0,
+            block3.block_id: block3
         },
         block_hash2: {
-            2: block2
+            block2.block_id: block2
         }
     }
     # Evict block0: block_hash0 entry should NOT be removed, as block3
@@ -1150,10 +1150,10 @@ def test_maybe_evict_cached_block():
     pool._maybe_evict_cached_block(block0)
     assert pool.cached_block_hash_to_block == {
         block_hash0: {
-            3: block3
+            block3.block_id: block3
         },
         block_hash2: {
-            2: block2
+            block2.block_id: block2
         }
     }
     # Evict block2


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
https://github.com/vllm-project/vllm/pull/21281 breaks the cache block eviction logic which was fixed by https://github.com/vllm-project/vllm/pull/21357 (Kudos to @simon-mo)

Introduce a unit test to at least cover some basic logic for _maybe_evict_cached_block.

## Test Plan
Reject the error to ensure unit test failed.

## Test Result
Test failed after locally reverted the fix PR.

<img width="1065" height="411" alt="Screenshot 2025-07-22 at 11 50 26 AM" src="https://github.com/user-attachments/assets/1f8723f6-5087-44f0-bac6-71743b29f839" />


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
