### PR TITLE
[Misc] Update Dockerfile FlashInfer to v0.2.8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -390,7 +390,7 @@ RUN --mount=type=bind,from=build,src=/workspace/dist,target=/vllm-workspace/dist
 
 # Install FlashInfer from source
 ARG FLASHINFER_GIT_REPO="https://github.com/flashinfer-ai/flashinfer.git"
-ARG FLASHINFER_GIT_REF="v0.2.8rc1"
+ARG FLASHINFER_GIT_REF="v0.2.8"
 RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
   . /etc/environment
     git clone --depth 1 --recursive --shallow-submodules \


### PR DESCRIPTION
## Purpose

We have been using v0.2.8rc1. The full v0.2.8 release is now available, so this moves us off the release candidate to the actual v0.2.8 release.

## Test Plan

Built a container image locally and verifies basic functionality with a couple different models. CI will also add better coverage.

## Test Result

No issues observed.

## (Optional) Documentation Update

None required.