### PR TITLE
[Misc] Copy HF_TOKEN env var to Ray workers

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -58,6 +58,11 @@ class RayDistributedExecutor(DistributedExecutorBase):
         "VLLM_HOST_IP", "VLLM_HOST_PORT", "LOCAL_RANK", "CUDA_VISIBLE_DEVICES"
     }
 
+    # These non-vLLM env vars are copied from the driver to workers
+    ADDITIONAL_ENV_VARS = {
+        "HF_TOKEN",
+    }
+
     uses_ray: bool = True
 
     def _init_executor(self) -> None:
@@ -326,7 +331,8 @@ class RayDistributedExecutor(DistributedExecutorBase):
         # Environment variables to copy from driver to workers
         env_vars_to_copy = get_env_vars_to_copy(
             exclude_vars=self.WORKER_SPECIFIC_ENV_VARS,
-            additional_vars=set(current_platform.additional_env_vars),
+            additional_vars=set(current_platform.additional_env_vars).union(
+                self.ADDITIONAL_ENV_VARS),
             destination="workers")
 
         # Copy existing env vars to each worker's args

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -59,9 +59,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
     }
 
     # These non-vLLM env vars are copied from the driver to workers
-    ADDITIONAL_ENV_VARS = {
-        "HF_TOKEN",
-    }
+    ADDITIONAL_ENV_VARS = {"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"}
 
     uses_ray: bool = True
 

--- a/vllm/ray/ray_env.py
+++ b/vllm/ray/ray_env.py
@@ -43,6 +43,8 @@ def get_env_vars_to_copy(exclude_vars: Optional[set[str]] = None,
         exclude_vars: A set of vllm defined environment variables to exclude
             from copying.
         additional_vars: A set of additional environment variables to copy.
+            If a variable is in both exclude_vars and additional_vars, it will
+            be excluded.
         destination: The destination of the environment variables.
     Returns:
         A set of environment variables to copy.
@@ -52,10 +54,9 @@ def get_env_vars_to_copy(exclude_vars: Optional[set[str]] = None,
 
     env_vars_to_copy = {
         v
-        for v in envs.environment_variables
+        for v in set(envs.environment_variables).union(additional_vars)
         if v not in exclude_vars and v not in RAY_NON_CARRY_OVER_ENV_VARS
     }
-    env_vars_to_copy.update(additional_vars)
 
     to_destination = " to " + destination if destination is not None else ""
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fixes https://github.com/ray-project/ray/issues/54812

Currently HF_TOKEN is not automatically copied from vLLM driver to ray workers, but needs external mechanisms, which can be inconvenient or confusing. This PR fixes the issue.

Example trace:

```
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47) Process EngineCore_0:
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47) Traceback (most recent call last):
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     self.run()
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/process.py", line 108, in run
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     self._target(*self._args, **self._kwargs)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 590, in run_engine_core
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     raise e
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 577, in run_engine_core
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     engine_core = EngineCoreProc(*args, **kwargs)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 404, in __init__
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     super().__init__(vllm_config, executor_class, log_stats,
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 75, in __init__
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     self.model_executor = executor_class(vllm_config)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/executor/executor_base.py", line 287, in __init__
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     super().__init__(*args, **kwargs)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/executor/executor_base.py", line 53, in __init__
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     self._init_executor()
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/executor/ray_distributed_executor.py", line 115, in _init_executor
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     self._init_workers_ray(placement_group)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/executor/ray_distributed_executor.py", line 397, in _init_workers_ray
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     self._run_workers("load_model",
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/executor/ray_distributed_executor.py", line 522, in _run_workers
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     ray_worker_outputs = ray.get(ray_worker_outputs)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     return fn(*args, **kwargs)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)            ^^^^^^^^^^^^^^^^^^^
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     return func(*args, **kwargs)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)            ^^^^^^^^^^^^^^^^^^^^^
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 2858, in get
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 958, in get_objects
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     raise value.as_instanceof_cause()
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47) ray.exceptions.RayTaskError(GatedRepoError): ray::RayWorkerWrapper.execute_method() (pid=4774, ip=10.0.134.47, actor_id=9289734e14d5d4726cf69ec309000000, repr=<vllm.executor.ray_utils.RayWorkerWrapper object at 0x7501a70c3110>)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)   File "/home/ray/anaconda3/lib/python3.11/site-packages/requests/models.py", line 1024, in raise_for_status
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47)     raise HTTPError(http_error_msg, response=self)
(ServeReplica:llama3-app:LLMDeploymentllama-3-8B-instruct pid=4288, ip=10.0.134.47) requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct/resolve/8afb486c1db24fe5011ec46dfbe5b5dccdb575c2/model-00001-of-00004.safetensors
```

Note: currently driver to ray worker env var copy uses:
- denylist approach (by default copy) for vLLM env vars
- allowlist approach (by default not copy) for other env vars

## Test Plan

Manual testing

## Test Result

HF_TOKEN env var is copied

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
