### PR TITLE
[NVIDIA] Explicitly disable shuffled weights for flashinfer blockscale moe fp8 kernels

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1127,6 +1127,7 @@ def flashinfer_fused_moe_blockscale_fp8(
         tile_tokens_dim=_get_tile_tokens_dim(x.shape[0], top_k,
                                              global_num_experts),
         routing_method_type=2,  # DeepSeek-styled routing method
+        use_shuffled_weight=False,
     )
 
 


### PR DESCRIPTION
The latest Flashinfer ([PR](https://github.com/flashinfer-ai/flashinfer/commit/39d81f779b20766f28022e815d3a173ddb9b38ac)) introduces a new flag to the `trtllm_fp8_block_scale_moe` API, which defaults to `True`. This PR explicitly disables it to restore the previous behavior.

I have verified the perf and accuracy with the [tot](https://github.com/flashinfer-ai/flashinfer/commit/04b9a2a459bce4beaa25c6a49486f3f6414ded1a) and we recommend to use flashinfer v0.2.9.

cc. @kushanam @mgoin