### PR TITLE
[BUGFIX] deepseek-v2-lite failed due to fused_qkv_a_proj name update

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -885,13 +885,16 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
                 # for mlp.experts[0].gate_gate_up_proj, which breaks load.
                 if (("mlp.experts." in name) and name not in params_dict):
                     continue
-                name = name.replace(weight_name, param_name)
+                name_mapped = name.replace(weight_name, param_name)
 
                 # QKV fusion is optional, fall back to normal
                 # weight loading if it's not enabled
+                # if go with fusion option, then update name
                 if ((param_name == "fused_qkv_a_proj")
-                        and name not in params_dict):
+                        and name_mapped not in params_dict):
                     continue
+                else:
+                    name = name_mapped
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

BUG FIX for #21116 

For deepseek v2 lite model, which q_lora_rank is None, it will crash with 
```
ERROR 07-22 16:32:52 [core.py:613]     loaded_weights = model.load_weights(
ERROR 07-22 16:32:52 [core.py:613]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 958, in load_weights
ERROR 07-22 16:32:52 [core.py:613]     param = params_dict[name]
ERROR 07-22 16:32:52 [core.py:613] KeyError: 'model.layers.10.self_attn.fused_qkv_a_proj.weight'
```

Root cause is that [line](https://github.com/vllm-project/vllm/pull/21116/files#diff-420f1cd67991a63cb419ca0e00e6f42cbe825864d0541e0662eeed2f9ddbd021R888) has replaced the name, so fallback is not roll-back the name update.

Fix in this PR is to update the name only it passes fusion check.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
