### PR TITLE
[V1] Fix local chunked attention always disabled

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -143,6 +143,8 @@ class Attention(nn.Module):
         # the backends)
         if envs.VLLM_USE_V1:
             self.use_irope = extra_impl_args.pop("use_irope", False)
+        else:
+            self.use_irope = extra_impl_args.get("use_irope", False)
 
         quant_method = quant_config.get_quant_method(
             self, prefix=prefix) if quant_config else None
@@ -177,7 +179,6 @@ class Attention(nn.Module):
                              kv_sharing_target_layer_name, **extra_impl_args)
         self.backend = backend_name_to_enum(attn_backend.get_name())
         self.dtype = dtype
-        self.use_irope = extra_impl_args.get("use_irope", False)
 
         # For cuda-alike (CUDA and ROCM) and cpu platforms, we control how
         # torch.compile works by registering the attention as one giant


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
[#21188](https://github.com/vllm-project/vllm/pull/21188) and [#19351](https://github.com/vllm-project/vllm/pull/19351) made similar and conflicting changes around `self.use_irope` in Attention layer, causing `self.use_irope` to always be `False` in V1:

```
self.use_irope = extra_impl_args.pop("use_irope", False)
...
self.use_irope = extra_impl_args.get("use_irope", False)
``` 

We should not pop `use_irope` in V0 as attention backends still expect `use_irope` as an arg ([example](https://github.com/vllm-project/vllm/blob/main/vllm/attention/backends/flash_attn.py#L621))

## Test Plan
ruler niah_multikey_2
```
VLLM_USE_V1=1 lm_eval --model vllm --tasks niah_multikey_2 --model_args pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,tensor_parallel_size=4,max_model_len=256000  --metadata='{"max_seq_lengths":[4096,8192,16384,32768]}' --batch_size auto  > /tmp/test_irope_fix.log 2>&1 &
```

## Test Result

baseline:
```
|---------------|------:|------|-----:|-----:|---|----:|---|------|
|niah_multikey_2|      1|none  |     0| 16384|↑  |0.980|±  |   N/A|
|               |       |none  |     0| 32768|↑  |0.000|±  |   N/A|
|               |       |none  |     0|  4096|↑  |1.000|±  |   N/A|
|               |       |none  |     0|  8192|↑  |0.996|±  |   N/A|
```

This PR:
```
|     Tasks     |Version|Filter|n-shot|Metric|   |Value|   |Stderr|
|---------------|------:|------|-----:|-----:|---|----:|---|------|
|niah_multikey_2|      1|none  |     0| 16384|↑  |0.980|±  |   N/A|
|               |       |none  |     0| 32768|↑  |0.944|±  |   N/A|
|               |       |none  |     0|  4096|↑  |1.000|±  |   N/A|
|               |       |none  |     0|  8192|↑  |0.996|±  |   N/A|

```

cc: @luccafong @minosfuture @houseroad @yeqcharlotte 