### PR TITLE
[V0 Deprecation] add clear messages for deprecated models

### DIFF
--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -264,10 +264,11 @@ def get_model_architecture(
 
     if any(arch in _PREVIOUSLY_SUPPORTED_MODELS for arch in architectures):
         previous_version = _PREVIOUSLY_SUPPORTED_MODELS[architectures[0]]
-        raise ValueError("Model architecture was supported in vLLM until "
-                         f" version {previous_version}, and is not supported"
-                         " anymore. Please use an older version of vLLM "
-                         "if you want to use this model architecture.")
+        raise ValueError(
+            f"Model architecture {architectures[0]} was supported"
+            f" in vLLM until version {previous_version}, and is "
+            "not supported anymore. Please use an older version"
+            " of vLLM if you want to use this model architecture.")
 
     if (model_config.model_impl == ModelImpl.TRANSFORMERS or
             model_config.model_impl == ModelImpl.AUTO and vllm_not_supported):

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -25,7 +25,8 @@ from vllm.model_executor.models.adapters import (as_embedding_model,
                                                  as_reward_model,
                                                  as_seq_cls_model)
 from vllm.model_executor.models.interfaces import SupportsQuant
-from vllm.model_executor.models.registry import _TRANSFORMERS_MODELS
+from vllm.model_executor.models.registry import (_PREVIOUSLY_SUPPORTED_MODELS,
+                                                 _TRANSFORMERS_MODELS)
 from vllm.utils import is_pin_memory_available
 
 logger = init_logger(__name__)
@@ -260,6 +261,13 @@ def get_model_architecture(
             architectures = [causal_lm_arch]
             vllm_not_supported = False
             break
+
+    if any(arch in _PREVIOUSLY_SUPPORTED_MODELS for arch in architectures):
+        previous_version = _PREVIOUSLY_SUPPORTED_MODELS[architectures[0]]
+        raise ValueError("Model architecture was supported in vLLM until "
+                         f" version {previous_version}, and is not supported"
+                         " anymore. Please use an older version of vLLM "
+                         "if you want to use this model architecture.")
 
     if (model_config.model_impl == ModelImpl.TRANSFORMERS or
             model_config.model_impl == ModelImpl.AUTO and vllm_not_supported):

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -454,6 +454,7 @@ class _ModelRegistry:
                 "to be inspected. Please check the logs for more details.")
 
         if any(arch in _PREVIOUSLY_SUPPORTED_MODELS for arch in architectures):
+            assert len(architectures) == 1 # should only have one architecture?
             previous_version = _PREVIOUSLY_SUPPORTED_MODELS[architectures[0]]
             raise ValueError(
                 "Model architecture was supported in vLLM until "

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -453,15 +453,6 @@ class _ModelRegistry:
                 f"Model architectures {architectures} failed "
                 "to be inspected. Please check the logs for more details.")
 
-        if any(arch in _PREVIOUSLY_SUPPORTED_MODELS for arch in architectures):
-            assert len(architectures) == 1 # should only have one architecture?
-            previous_version = _PREVIOUSLY_SUPPORTED_MODELS[architectures[0]]
-            raise ValueError(
-                "Model architecture was supported in vLLM until "
-                f" version {previous_version}, and is not supported"
-                " anymore. Please use an older version of vLLM "
-                "if you want to use this model architecture.")
-
         raise ValueError(
             f"Model architectures {architectures} are not supported for now. "
             f"Supported architectures: {all_supported_archs}")

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -276,6 +276,8 @@ _SUBPROCESS_COMMAND = [
     sys.executable, "-m", "vllm.model_executor.models.registry"
 ]
 
+_PREVIOUSLY_SUPPORTED_MODELS = {"Phi3SmallForCausalLM": "0.9.2"}
+
 
 @dataclass(frozen=True)
 class _ModelInfo:
@@ -450,6 +452,14 @@ class _ModelRegistry:
             raise ValueError(
                 f"Model architectures {architectures} failed "
                 "to be inspected. Please check the logs for more details.")
+
+        if any(arch in _PREVIOUSLY_SUPPORTED_MODELS for arch in architectures):
+            previous_version = _PREVIOUSLY_SUPPORTED_MODELS[architectures[0]]
+            raise ValueError(
+                "Model architecture was supported in vLLM until "
+                f" version {previous_version}, and is not supported"
+                " anymore. Please use an older version of vLLM "
+                "if you want to use this model architecture.")
 
         raise ValueError(
             f"Model architectures {architectures} are not supported for now. "


### PR DESCRIPTION
The model was deprecated in https://github.com/vllm-project/vllm/pull/21217 . Let's leave a clear error message and guide users to use which versions.