### PR TITLE
[Misc] Improve memory profiling debug message

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -239,11 +239,9 @@ class Worker(WorkerBase):
         unrequested_memory = self.init_snapshot.free_memory \
             - self.requested_memory
         logger.debug(
-            "Initial free memory: %.2f GiB",
-            GiB(self.init_snapshot.free_memory),
-        )
-        logger.debug(
+            "Initial free memory: %.2f GiB; "
             "Requested memory: %.2f (util), %.2f GiB",
+            GiB(self.init_snapshot.free_memory),
             self.cache_config.gpu_memory_utilization,
             GiB(self.requested_memory),
         )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -239,16 +239,17 @@ class Worker(WorkerBase):
         unrequested_memory = self.init_snapshot.free_memory \
             - self.requested_memory
         logger.debug(
-            "Requested GPU memory utilization: %.2f, "
-            "requested GPU memory: %.2f GiB",
+            "Initial free memory: %.2f GiB",
+            GiB(self.init_snapshot.free_memory),
+        )
+        logger.debug(
+            "Requested memory: %.2f (util), %.2f GiB",
             self.cache_config.gpu_memory_utilization,
             GiB(self.requested_memory),
         )
         logger.debug(
-            "Total free memory: %.2f GiB, "
-            "free memory after profile (total): %.2f GiB, "
-            "free memory after profile (within requested): %.2f GiB",
-            GiB(self.init_snapshot.free_memory),
+            "Free memory after profiling: %.2f GiB (total), "
+            "%.2f GiB (within requested)",
             GiB(free_gpu_memory),
             GiB(free_gpu_memory - unrequested_memory),
         )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -239,16 +239,18 @@ class Worker(WorkerBase):
         unrequested_memory = self.init_snapshot.free_memory \
             - self.requested_memory
         logger.debug(
+            "Requested GPU memory utilization: %.2f, "
+            "requested GPU memory: %.2f GiB",
+            self.cache_config.gpu_memory_utilization,
+            GiB(self.requested_memory),
+        )
+        logger.debug(
             "Total free memory: %.2f GiB, "
             "free memory after profile (total): %.2f GiB, "
-            "free memory after profile (within requested): %.2f GiB, "
-            "requested GPU memory utilization: %.2f, "
-            "requested GPU memory: %.2f GiB, ",
+            "free memory after profile (within requested): %.2f GiB",
             GiB(self.init_snapshot.free_memory),
             GiB(free_gpu_memory),
             GiB(free_gpu_memory - unrequested_memory),
-            self.cache_config.gpu_memory_utilization,
-            GiB(self.requested_memory),
         )
         logger.debug(profile_result)
         logger.info("Available KV cache memory: %.2f GiB",

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -236,11 +236,20 @@ class Worker(WorkerBase):
         available_kv_cache_memory = self.requested_memory \
             - profile_result.non_kv_cache_memory
 
+        unrequested_memory = self.init_snapshot.free_memory \
+            - self.requested_memory
         logger.debug(
-            "Initial free memory: %.2f GiB, free memory: %.2f GiB, "
-            "requested GPU memory: %.2f GiB",
-            GiB(self.init_snapshot.free_memory), GiB(free_gpu_memory),
-            GiB(self.requested_memory))
+            "Total free memory: %.2f GiB, "
+            "free memory after profile (total): %.2f GiB, "
+            "free memory after profile (within requested): %.2f GiB, "
+            "requested GPU memory utilization: %.2f, "
+            "requested GPU memory: %.2f GiB, ",
+            GiB(self.init_snapshot.free_memory),
+            GiB(free_gpu_memory),
+            GiB(free_gpu_memory - unrequested_memory),
+            self.cache_config.gpu_memory_utilization,
+            GiB(self.requested_memory),
+        )
         logger.debug(profile_result)
         logger.info("Available KV cache memory: %.2f GiB",
                     GiB(available_kv_cache_memory))


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
While looking into https://github.com/vllm-project/vllm/issues/21348, existing message is confusing.

## Test Plan
Run
```
VLLM_LOGGING_LEVEL=DEBUG CUDA_VISIBLE_DEVICES=0,1,2,3 \
vllm serve Qwen/Qwen3-235B-A22B-FP8 \
  --tensor-parallel-size 4 --gpu-memory-utilization 0.5
```

## Test Result
Before
```
(VllmWorker rank=2 pid=1608647) DEBUG 07-22 20:09:04 [gpu_worker.py:239] Initial free memory: 139.12 GiB, free memory: 81.52 GiB, requested GPU memory: 69.86 GiB
(VllmWorker rank=2 pid=1608647) DEBUG 07-22 20:09:04 [gpu_worker.py:244] Memory profiling takes 40.46 seconds. Total non KV cache memory: 62.79GiB; torch peak memory increase: 5.62GiB; non-torch forward increase memory: 2.04GiB; weights memory: 55.13GiB.
(VllmWorker rank=2 pid=1608647) INFO 07-22 20:09:04 [gpu_worker.py:245] Available KV cache memory: 7.07 GiB
```
After
```
(VllmWorker rank=1 pid=3534714) DEBUG 07-22 22:51:36 [gpu_worker.py:241] Requested GPU memory utilization: 0.50, requested GPU memory: 69.86 GiB
(VllmWorker rank=1 pid=3534714) DEBUG 07-22 22:51:36 [gpu_worker.py:247] Total free memory: 139.12 GiB, free memory after profile (total): 81.55 GiB, free memory after profile (within requested): 12.29 GiB
(VllmWorker rank=1 pid=3534714) DEBUG 07-22 22:51:36 [gpu_worker.py:255] Memory profiling takes 39.77 seconds. Total non KV cache memory: 62.79GiB; torch peak memory increase: 5.62GiB; non-torch forward increase memory: 2.04GiB; weights memory: 55.13GiB.
(VllmWorker rank=1 pid=3534714) INFO 07-22 22:51:36 [gpu_worker.py:256] Available KV cache memory: 7.07 GiB
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
