### PR TITLE
[Fix] Connect fx_graph_cache option to envs.VLLM_DISABLE_COMPILE_CACHE

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -293,7 +293,7 @@ class InductorAdaptor(CompilerInterface):
             current_config.update(compiler_config)
 
         # disable remote cache
-        current_config["fx_graph_cache"] = True
+        current_config["fx_graph_cache"] = not envs.VLLM_DISABLE_COMPILE_CACHE
         current_config["fx_graph_remote_cache"] = False
 
         set_inductor_config(current_config, runtime_shape)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Originally `fx_graph_cache` is always set to `True`, the cache will not update even if the fusion pattern changes in local dev.

This PR updated the default setting of `fx_graph_cache` from always `True` to `not envs.VLLM_DISABLE_COMPILE_CACHE`.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
