### PR TITLE
[Feat] Allow custom naming of vLLM processes

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,3 +48,4 @@ scipy # Required for phi-4-multimodal-instruct
 ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects
+setproctitle # Used to set process names for better debugging and monitoring

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -22,6 +22,7 @@ pillow
 psutil
 pybase64
 pydantic
+setproctitle
 torch
 transformers
 zmq

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -21,7 +21,7 @@ from vllm.entrypoints.utils import (VLLM_SUBCMD_PARSER_EPILOG,
 from vllm.executor.multiproc_worker_utils import _add_prefix
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
-from vllm.utils import FlexibleArgumentParser, get_tcp_uri
+from vllm.utils import bind_process_name, FlexibleArgumentParser, get_tcp_uri
 from vllm.v1.engine.core import EngineCoreProc
 from vllm.v1.engine.utils import CoreEngineProcManager, launch_core_engines
 from vllm.v1.executor.abstract import Executor
@@ -82,7 +82,7 @@ def run_headless(args: argparse.Namespace):
 
     if args.api_server_count > 1:
         raise ValueError("api_server_count can't be set in headless mode")
-
+    bind_process_name("APIServer_Headless")
     # Create the EngineConfig.
     engine_args = vllm.AsyncEngineArgs.from_cli_args(args)
     usage_context = UsageContext.OPENAI_API_SERVER

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -21,7 +21,7 @@ from vllm.entrypoints.utils import (VLLM_SUBCMD_PARSER_EPILOG,
 from vllm.executor.multiproc_worker_utils import _add_prefix
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
-from vllm.utils import bind_process_name, FlexibleArgumentParser, get_tcp_uri
+from vllm.utils import FlexibleArgumentParser, bind_process_name, get_tcp_uri
 from vllm.v1.engine.core import EngineCoreProc
 from vllm.v1.engine.utils import CoreEngineProcManager, launch_core_engines
 from vllm.v1.executor.abstract import Executor

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -9,6 +9,7 @@ import inspect
 import json
 import multiprocessing
 import os
+import setproctitle
 import signal
 import socket
 import tempfile
@@ -1803,7 +1804,8 @@ async def run_server_worker(listen_address,
         ToolParserManager.import_tool_parser(args.tool_parser_plugin)
 
     server_index = client_config.get("client_index", 0) if client_config else 0
-
+    setproctitle.setproctitle(
+        f"{envs.VLLM_PROCESS_NAME_PREFIX}::APIServer_{server_index}")
     # Load logging config for uvicorn if specified
     log_config = load_log_config(args.log_config_file)
     if log_config is not None:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -9,7 +9,6 @@ import inspect
 import json
 import multiprocessing
 import os
-import setproctitle
 import signal
 import socket
 import tempfile
@@ -24,6 +23,7 @@ from typing import Annotated, Any, Callable, Optional
 import prometheus_client
 import pydantic
 import regex as re
+import setproctitle
 import uvloop
 from fastapi import APIRouter, Depends, FastAPI, Form, HTTPException, Request
 from fastapi.exceptions import RequestValidationError

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -101,7 +101,7 @@ from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
 from vllm.transformers_utils.tokenizer import MistralTokenizer
 from vllm.usage.usage_lib import UsageContext
-from vllm.utils import (bind_process_name, Device, FlexibleArgumentParser,
+from vllm.utils import (Device, FlexibleArgumentParser, bind_process_name,
                         get_open_zmq_ipc_path, is_valid_ipv6_address,
                         set_ulimit)
 from vllm.v1.metrics.prometheus import get_prometheus_registry

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -23,7 +23,6 @@ from typing import Annotated, Any, Callable, Optional
 import prometheus_client
 import pydantic
 import regex as re
-import setproctitle
 import uvloop
 from fastapi import APIRouter, Depends, FastAPI, Form, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -102,8 +101,9 @@ from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
 from vllm.transformers_utils.tokenizer import MistralTokenizer
 from vllm.usage.usage_lib import UsageContext
-from vllm.utils import (Device, FlexibleArgumentParser, get_open_zmq_ipc_path,
-                        is_valid_ipv6_address, set_ulimit)
+from vllm.utils import (bind_process_name, Device, FlexibleArgumentParser,
+                        get_open_zmq_ipc_path, is_valid_ipv6_address,
+                        set_ulimit)
 from vllm.v1.metrics.prometheus import get_prometheus_registry
 from vllm.version import __version__ as VLLM_VERSION
 
@@ -1804,8 +1804,7 @@ async def run_server_worker(listen_address,
         ToolParserManager.import_tool_parser(args.tool_parser_plugin)
 
     server_index = client_config.get("client_index", 0) if client_config else 0
-    setproctitle.setproctitle(
-        f"{envs.VLLM_PROCESS_NAME_PREFIX}::APIServer_{server_index}")
+    bind_process_name("APIServer", str(server_index))
     # Load logging config for uvicorn if specified
     log_config = load_log_config(args.log_config_file)
     if log_config is not None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -971,6 +971,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Used to force set up loopback IP
     "VLLM_LOOPBACK_IP":
     lambda: os.getenv("VLLM_LOOPBACK_IP", ""),
+
+    # Used to set the process name prefix for vLLM processes.
+    # This is useful for debugging and monitoring purposes.
+    # The default value is "VLLM".
+    "VLLM_PROCESS_NAME_PREFIX":
+    lambda: os.getenv("VLLM_PROCESS_NAME_PREFIX", "VLLM"),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3297,4 +3297,3 @@ def bind_process_name(name: str, suffixe: str = "") -> None:
     if suffixe:
         name = f"{name}_{suffixe}"
     setproctitle.setproctitle(name)
-

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -58,6 +58,7 @@ import numpy as np
 import numpy.typing as npt
 import psutil
 import regex as re
+import setproctitle
 import torch
 import torch.types
 import yaml
@@ -3283,3 +3284,17 @@ def has_deep_gemm() -> bool:
     """Whether the optional `deep_gemm` package is available."""
 
     return _has_module("deep_gemm")
+
+
+def bind_process_name(name: str, suffixe: str = "") -> None:
+    """Bind the process name to a specific name with an optional suffix.
+
+    Args:
+        name: The base name to bind the process to.
+        suffixe: An optional suffix to append to the base name.
+    """
+    name = f"{envs.VLLM_PROCESS_NAME_PREFIX}::{name}"
+    if suffixe:
+        name = f"{name}_{suffixe}"
+    setproctitle.setproctitle(name)
+

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3286,14 +3286,14 @@ def has_deep_gemm() -> bool:
     return _has_module("deep_gemm")
 
 
-def bind_process_name(name: str, suffixe: str = "") -> None:
+def bind_process_name(name: str, suffix: str = "") -> None:
     """Bind the process name to a specific name with an optional suffix.
 
     Args:
         name: The base name to bind the process to.
-        suffixe: An optional suffix to append to the base name.
+        suffix: An optional suffix to append to the base name.
     """
     name = f"{envs.VLLM_PROCESS_NAME_PREFIX}::{name}"
-    if suffixe:
-        name = f"{name}_{suffixe}"
+    if suffix:
+        name = f"{name}_{suffix}"
     setproctitle.setproctitle(name)

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -6,7 +6,6 @@ import weakref
 from typing import Optional
 
 import msgspec.msgpack
-import setproctitle
 import zmq
 
 import vllm.envs as envs
@@ -15,7 +14,8 @@ from vllm.logger import init_logger
 from vllm.utils import get_mp_context, make_zmq_socket
 from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequestType
 from vllm.v1.serial_utils import MsgpackDecoder
-from vllm.v1.utils import get_engine_client_zmq_addr, shutdown
+from vllm.v1.utils import (bind_process_name, get_engine_client_zmq_addr,
+                           shutdown)
 
 logger = init_logger(__name__)
 
@@ -119,8 +119,7 @@ class DPCoordinatorProc:
     def __init__(self,
                  engine_count: int,
                  min_stats_update_interval_ms: int = 100):
-        setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}")
+        bind_process_name(self.__class__.__name__)
         self.ctx = zmq.Context()
 
         self.engines = [EngineState() for _ in range(engine_count)]

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -80,7 +80,7 @@ class DPCoordinator:
 
         context = get_mp_context()
         self.proc: multiprocessing.Process = context.Process(
-            target=CoordinatorProc.run_coordinator,
+            target=DPCoordinatorProc.run_coordinator,
             name="VLLM_DP_Coordinator",
             kwargs={
                 "engine_count": parallel_config.data_parallel_size,
@@ -114,12 +114,13 @@ class EngineState:
         self.request_counts = [0, 0]  # [waiting, running]
 
 
-class CoordinatorProc:
+class DPCoordinatorProc:
 
     def __init__(self,
                  engine_count: int,
                  min_stats_update_interval_ms: int = 100):
-
+        setproctitle.setproctitle(
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}")
         self.ctx = zmq.Context()
 
         self.engines = [EngineState() for _ in range(engine_count)]
@@ -138,9 +139,7 @@ class CoordinatorProc:
         back_publish_address: str,
         min_stats_update_interval_ms: int = 100,
     ):
-        setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::DPCoordinator")
-        coordinator = CoordinatorProc(
+        coordinator = DPCoordinatorProc(
             engine_count=engine_count,
             min_stats_update_interval_ms=min_stats_update_interval_ms)
         try:

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -8,7 +8,6 @@ from typing import Optional
 import msgspec.msgpack
 import zmq
 
-import vllm.envs as envs
 from vllm.config import ParallelConfig
 from vllm.logger import init_logger
 from vllm.utils import get_mp_context, make_zmq_socket

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -138,7 +138,8 @@ class CoordinatorProc:
         back_publish_address: str,
         min_stats_update_interval_ms: int = 100,
     ):
-        setproctitle.setproctitle(f"{envs.VLLM_PROCESS_NAME_PREFIX}::DPCoordinator")
+        setproctitle.setproctitle(
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::DPCoordinator")
         coordinator = CoordinatorProc(
             engine_count=engine_count,
             min_stats_update_interval_ms=min_stats_update_interval_ms)

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -6,8 +6,10 @@ import weakref
 from typing import Optional
 
 import msgspec.msgpack
+import setproctitle
 import zmq
 
+import vllm.envs as envs
 from vllm.config import ParallelConfig
 from vllm.logger import init_logger
 from vllm.utils import get_mp_context, make_zmq_socket
@@ -136,6 +138,7 @@ class CoordinatorProc:
         back_publish_address: str,
         min_stats_update_interval_ms: int = 100,
     ):
+        setproctitle.setproctitle(f"{envs.VLLM_PROCESS_NAME_PREFIX}::DPCoordinator")
         coordinator = CoordinatorProc(
             engine_count=engine_count,
             min_stats_update_interval_ms=min_stats_update_interval_ms)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -6,6 +6,7 @@ import signal
 import sys
 import threading
 import time
+import setproctitle
 from collections import deque
 from collections.abc import Generator
 from concurrent.futures import Future
@@ -17,6 +18,7 @@ from typing import Any, Callable, Optional, TypeVar, Union
 import msgspec
 import zmq
 
+import vllm.envs as envs
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.executor.multiproc_worker_utils import _add_prefix
@@ -572,7 +574,8 @@ class EngineCoreProc(EngineCore):
                         local_dp_rank: int = 0,
                         **kwargs):
         """Launch EngineCore busy loop in background process."""
-
+        setproctitle.setproctitle(
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::EngineCore_{dp_rank}")
         # Signal handler used for graceful termination.
         # SystemExit exception is only raised once to allow this and worker
         # processes to terminate without error

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -404,7 +404,8 @@ class EngineCoreProc(EngineCore):
         engine_index: int = 0,
     ):
         setproctitle.setproctitle(
-                f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}_{engine_index}")
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}_{engine_index}"
+        )
         self.input_queue = queue.Queue[tuple[EngineCoreRequestType, Any]]()
         self.output_queue = queue.Queue[Union[tuple[int, EngineCoreOutputs],
                                               bytes]]()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -15,10 +15,8 @@ from logging import DEBUG
 from typing import Any, Callable, Optional, TypeVar, Union
 
 import msgspec
-import setproctitle
 import zmq
 
-import vllm.envs as envs
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.executor.multiproc_worker_utils import _add_prefix
@@ -27,7 +25,8 @@ from vllm.logging_utils.dump_input import dump_engine_exception
 from vllm.lora.request import LoRARequest
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
-from vllm.utils import make_zmq_socket, resolve_obj_by_qualname
+from vllm.utils import (bind_process_name, make_zmq_socket,
+                        resolve_obj_by_qualname)
 from vllm.v1.core.kv_cache_utils import (get_kv_cache_config,
                                          unify_kv_cache_configs)
 from vllm.v1.core.sched.interface import SchedulerInterface
@@ -403,9 +402,8 @@ class EngineCoreProc(EngineCore):
         client_handshake_address: Optional[str] = None,
         engine_index: int = 0,
     ):
-        setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}_{engine_index}"
-        )
+        bind_process_name(
+            self.__class__.__name__, f"{engine_index}")
         self.input_queue = queue.Queue[tuple[EngineCoreRequestType, Any]]()
         self.output_queue = queue.Queue[Union[tuple[int, EngineCoreOutputs],
                                               bytes]]()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -6,7 +6,6 @@ import signal
 import sys
 import threading
 import time
-import setproctitle
 from collections import deque
 from collections.abc import Generator
 from concurrent.futures import Future
@@ -16,6 +15,7 @@ from logging import DEBUG
 from typing import Any, Callable, Optional, TypeVar, Union
 
 import msgspec
+import setproctitle
 import zmq
 
 import vllm.envs as envs

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -403,6 +403,8 @@ class EngineCoreProc(EngineCore):
         client_handshake_address: Optional[str] = None,
         engine_index: int = 0,
     ):
+        setproctitle.setproctitle(
+                f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}_{engine_index}")
         self.input_queue = queue.Queue[tuple[EngineCoreRequestType, Any]]()
         self.output_queue = queue.Queue[Union[tuple[int, EngineCoreOutputs],
                                               bytes]]()
@@ -574,8 +576,7 @@ class EngineCoreProc(EngineCore):
                         local_dp_rank: int = 0,
                         **kwargs):
         """Launch EngineCore busy loop in background process."""
-        setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::EngineCore_{dp_rank}")
+
         # Signal handler used for graceful termination.
         # SystemExit exception is only raised once to allow this and worker
         # processes to terminate without error

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -402,8 +402,7 @@ class EngineCoreProc(EngineCore):
         client_handshake_address: Optional[str] = None,
         engine_index: int = 0,
     ):
-        bind_process_name(
-            self.__class__.__name__, f"{engine_index}")
+        bind_process_name(self.__class__.__name__, f"{engine_index}")
         self.input_queue = queue.Queue[tuple[EngineCoreRequestType, Any]]()
         self.output_queue = queue.Queue[Union[tuple[int, EngineCoreOutputs],
                                               bytes]]()

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -19,7 +19,6 @@ from threading import Thread
 from typing import Any, Callable, Optional, Union, cast
 
 import cloudpickle
-import setproctitle
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
@@ -31,8 +30,8 @@ from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
 from vllm.executor.multiproc_worker_utils import (
     _add_prefix, set_multiprocessing_worker_envs)
 from vllm.logger import init_logger
-from vllm.utils import (get_distributed_init_method, get_loopback_ip,
-                        get_mp_context, get_open_port)
+from vllm.utils import (bind_process_name, get_distributed_init_method,
+                        get_loopback_ip, get_mp_context, get_open_port)
 from vllm.v1.executor.abstract import Executor, FailureCallback
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.worker.worker_base import WorkerWrapperBase
@@ -366,9 +365,9 @@ class WorkerProc:
         }
         wrapper.init_worker(all_kwargs)
         self.worker = wrapper
-        setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.worker.worker.__class__.__name__}_{self.rank}"
-        )
+        bind_process_name(
+            self.worker.worker.__class__.__name__, 
+            f"TP{self.rank}_DP{vllm_config.parallel_config.data_parallel_rank}")
         pid = os.getpid()
         _add_prefix(sys.stdout, f"VllmWorker rank={rank}", pid)
         _add_prefix(sys.stderr, f"VllmWorker rank={rank}", pid)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -366,7 +366,7 @@ class WorkerProc:
         wrapper.init_worker(all_kwargs)
         self.worker = wrapper
         bind_process_name(
-            self.worker.worker.__class__.__name__, 
+            self.worker.worker.__class__.__name__,
             f"TP{self.rank}_DP{vllm_config.parallel_config.data_parallel_rank}"
         )
         pid = os.getpid()

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -367,8 +367,7 @@ class WorkerProc:
         wrapper.init_worker(all_kwargs)
         self.worker = wrapper
         setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{
-                self.worker.worker.__class__.__name__}_{self.rank}")
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.worker.worker.__class__.__name__}_{self.rank}")
         pid = os.getpid()
         _add_prefix(sys.stdout, f"VllmWorker rank={rank}", pid)
         _add_prefix(sys.stderr, f"VllmWorker rank={rank}", pid)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -9,7 +9,6 @@ import threading
 import time
 import traceback
 import weakref
-import setproctitle
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -20,6 +19,7 @@ from threading import Thread
 from typing import Any, Callable, Optional, Union, cast
 
 import cloudpickle
+import setproctitle
 
 import vllm.envs as envs
 from vllm.config import VllmConfig

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -367,7 +367,8 @@ class WorkerProc:
         wrapper.init_worker(all_kwargs)
         self.worker = wrapper
         setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.worker.worker.__class__.__name__}_{self.rank}")
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.worker.worker.__class__.__name__}_{self.rank}"
+        )
         pid = os.getpid()
         _add_prefix(sys.stdout, f"VllmWorker rank={rank}", pid)
         _add_prefix(sys.stderr, f"VllmWorker rank={rank}", pid)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -367,7 +367,8 @@ class WorkerProc:
         self.worker = wrapper
         bind_process_name(
             self.worker.worker.__class__.__name__, 
-            f"TP{self.rank}_DP{vllm_config.parallel_config.data_parallel_rank}")
+            f"TP{self.rank}_DP{vllm_config.parallel_config.data_parallel_rank}"
+        )
         pid = os.getpid()
         _add_prefix(sys.stdout, f"VllmWorker rank={rank}", pid)
         _add_prefix(sys.stderr, f"VllmWorker rank={rank}", pid)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -9,6 +9,7 @@ import threading
 import time
 import traceback
 import weakref
+import setproctitle
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -365,7 +366,9 @@ class WorkerProc:
         }
         wrapper.init_worker(all_kwargs)
         self.worker = wrapper
-
+        setproctitle.setproctitle(
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{
+                self.worker.worker.__class__.__name__}_{self.rank}")
         pid = os.getpid()
         _add_prefix(sys.stdout, f"VllmWorker rank={rank}", pid)
         _add_prefix(sys.stderr, f"VllmWorker rank={rank}", pid)

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -10,15 +10,13 @@ from multiprocessing.process import BaseProcess
 from typing import (TYPE_CHECKING, Any, Callable, Generic, Optional, TypeVar,
                     Union, overload)
 
-import setproctitle
 import torch
 
-import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import (UsageContext, is_usage_stats_enabled,
                                   usage_message)
-from vllm.utils import (get_open_port, get_open_zmq_ipc_path, get_tcp_uri,
-                        kill_process_tree)
+from vllm.utils import (bind_process_name, get_open_port, get_open_zmq_ipc_path,
+                        get_tcp_uri, kill_process_tree)
 
 if TYPE_CHECKING:
     from vllm.v1.engine.coordinator import DPCoordinator
@@ -146,8 +144,7 @@ class APIServerProcessManager:
         self.listen_address = listen_address
         self.sock = sock
         self.args = args
-        setproctitle.setproctitle(
-            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}")
+        bind_process_name(self.__class__.__name__)
         # Start API servers
         spawn_context = multiprocessing.get_context("spawn")
         self.processes: list[BaseProcess] = []

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -10,8 +10,8 @@ from multiprocessing.process import BaseProcess
 from typing import (TYPE_CHECKING, Any, Callable, Generic, Optional, TypeVar,
                     Union, overload)
 
-import torch
 import setproctitle
+import torch
 
 import vllm.envs as envs
 from vllm.logger import init_logger

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -11,7 +11,9 @@ from typing import (TYPE_CHECKING, Any, Callable, Generic, Optional, TypeVar,
                     Union, overload)
 
 import torch
+import setproctitle
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import (UsageContext, is_usage_stats_enabled,
                                   usage_message)
@@ -144,7 +146,8 @@ class APIServerProcessManager:
         self.listen_address = listen_address
         self.sock = sock
         self.args = args
-
+        setproctitle.setproctitle(
+            f"{envs.VLLM_PROCESS_NAME_PREFIX}::{self.__class__.__name__}")
         # Start API servers
         spawn_context = multiprocessing.get_context("spawn")
         self.processes: list[BaseProcess] = []

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -15,8 +15,8 @@ import torch
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import (UsageContext, is_usage_stats_enabled,
                                   usage_message)
-from vllm.utils import (bind_process_name, get_open_port, get_open_zmq_ipc_path,
-                        get_tcp_uri, kill_process_tree)
+from vllm.utils import (bind_process_name, get_open_port,
+                        get_open_zmq_ipc_path, get_tcp_uri, kill_process_tree)
 
 if TYPE_CHECKING:
     from vllm.v1.engine.coordinator import DPCoordinator


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

Supports https://github.com/vllm-project/vllm/issues/21423


## Purpose


## Test Result
CUDA:
TP=4
```
# export VLLM_PROCESS_NAME_PREFIX=VLLM
# vllm serve /home/jovyan/qwen3-8b  -tp 2
# ps -ef
root       15593    9259 17 15:08 pts/4    00:00:13 VLLM::APIServer_0
root       15954   15593  0 15:09 pts/4    00:00:00 /opt/conda/envs/vllm/bin/python3.12 -c from multiprocessing.resource_trac
root       15955   15593 19 15:09 pts/4    00:00:11 VLLM::EngineCoreProc_0
root       16120   15955 33 15:09 pts/4    00:00:16 VLLM::Worker_TP0_DP0
root       16124   15955 37 15:09 pts/4    00:00:18 VLLM::Worker_TP1_DP0
root       16125   15955 35 15:09 pts/4    00:00:17 VLLM::Worker_TP2_DP0
root       16126   15955 33 15:09 pts/4    00:00:16 VLLM::Worker_TP3_DP0
```

DP=2
```
# export VLLM_PROCESS_NAME_PREFIX=VLLM
# vllm serve /home/jovyan/qwen3-8b  --data-parallel-size 2 --data-parallel-rpc-port 25555 --data-parallel-address 127.0.0.1 --api-server-count 2
# ps -ef
root      116630     734 13 10:55 pts/4    00:00:10 VLLM::APIServerProcessManager
root      117014  116630  0 10:55 pts/4    00:00:00 /opt/conda/envs/vllm/bin/python3.12 -c from multiprocessing.resource_tracker import main;main(36)
root      117015  116630 17 10:55 pts/4    00:00:10 VLLM::DPCoordinatorProc
root      117018  116630 94 10:55 pts/4    00:00:57 VLLM::DPEngineCoreProc_0
root      117019  116630 92 10:55 pts/4    00:00:56 VLLM::DPEngineCoreProc_1
root      117020  116630 18 10:55 pts/4    00:00:11 VLLM::APIServer_0
root      117021  116630 20 10:55 pts/4    00:00:12 VLLM::APIServer_1

```
TP=2. DP=2
```
# export VLLM_PROCESS_NAME_PREFIX=VLLM
# vllm serve /home/jovyan/qwen3-8b --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser qwen3 --disable-log-requests --data-parallel-size 2 --data-parallel-rpc-port 25555 --data-parallel-address 127.0.0.1 --api-server-count 2 --gpu-memory-utilization 0.4 --data-parallel-size-local 0
# vllm serve /home/jovyan/qwen3-8b --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser qwen3 --disable-log-requests --data-parallel-size 2 --data-parallel-rpc-port 25555 --data-parallel-address 127.0.0.1 --headless --gpu-memory-utilization 0.4 --data-parallel-size-local 2  -tp 2

root        6441    4359 10 15:01 pts/3    00:00:10 VLLM::APIServer_Headless
root        7046    6441  0 15:01 pts/3    00:00:00 /opt/conda/envs/vllm/bin/python3.12 -c from multiprocessing.resource_trac
root        7047    6441 13 15:01 pts/3    00:00:10 VLLM::DPEngineCoreProc_0
root        7048    6441 14 15:01 pts/3    00:00:11 VLLM::DPEngineCoreProc_1
root        7720    2688 21 15:02 pts/2    00:00:09 VLLM::APIServerProcessManager
root        8040    7720  0 15:02 pts/2    00:00:00 /opt/conda/envs/vllm/bin/python3.12 -c from multiprocessing.resource_trac
root        8041    7720 28 15:02 pts/2    00:00:09 VLLM::DPCoordinatorProc
root        8044    7720 31 15:02 pts/2    00:00:10 VLLM::APIServer_0
root        8045    7720 30 15:02 pts/2    00:00:10 VLLM::APIServer_1
root        8058    7048 37 15:02 pts/3    00:00:12 VLLM::Worker_TP0_DP1
root        8061    7047 38 15:02 pts/3    00:00:12 VLLM::Worker_TP0_DP0
root        8062    7048 38 15:02 pts/3    00:00:12 VLLM::Worker_TP1_DP1
root        8063    7047 37 15:02 pts/3    00:00:12 VLLM::Worker_TP1_DP0


nvidia-smi

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   1357293      C   VLLM::Worker_TP0_DP0                      36282MiB |
|    1   N/A  N/A   1357295      C   VLLM::Worker_TP1_DP0                      36282MiB |
|    2   N/A  N/A   1357290      C   VLLM::Worker_TP0_DP1                      36282MiB |
|    4   N/A  N/A   1357294      C   VLLM::Worker_TP1_DP1                      36282MiB |
```

Note: The process `python3.12 -c from multiprocessing.resource_tracker import main;main(36)` is automatically generated when using `from multiprocessing import shared_memory`, so there is currently no way to modify its process name.




---
Keep the process name consistent with the naming style of SGlang processes.


<img width="1874" height="900" alt="image" src="https://github.com/user-attachments/assets/470281a2-e39a-43fa-b49e-6255b91882e4" />


