### PR TITLE
Add TNG Tool Call Parser

### DIFF
--- a/tests/tool_use/test_tng_tool_parser.py
+++ b/tests/tool_use/test_tng_tool_parser.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from collections.abc import AsyncIterator
+from typing import Union
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.entrypoints.openai.tool_parsers.utils import run_tool_extraction
+from vllm import CompletionOutput, RequestOutput
+from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                              ChatCompletionToolsParam,
+                                              DeltaFunctionCall, DeltaMessage,
+                                              DeltaToolCall, FunctionCall,
+                                              FunctionDefinition)
+from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+from vllm.entrypoints.openai.tool_parsers import (TngToolParser,
+                                                  ToolParserManager)
+from vllm.transformers_utils.tokenizer import AnyTokenizer, get_tokenizer
+
+# Use a common model that is likely to be available
+MODEL = "tngtech/DeepSeek-TNG-R1T2-Chimera"
+
+
+@pytest.fixture(scope="module")
+def tng_tokenizer() -> AnyTokenizer:
+    return get_tokenizer(tokenizer_name=MODEL)
+
+
+@pytest.fixture
+def tng_tool_parser(tng_tokenizer: AnyTokenizer) -> TngToolParser:
+    return TngToolParser(tng_tokenizer)
+
+
+SIMPLE_WEATHER_TOOL = ChatCompletionToolsParam(
+    function=FunctionDefinition(name="get_current_weather",
+                                parameters={
+                                    "type": "object",
+                                    "properties": {
+                                        "location": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }))
+
+NESTED_WEATHER_TOOL = ChatCompletionToolsParam(function=FunctionDefinition(
+    name="get_weather_with_details",
+    parameters={
+        "type": "object",
+        "properties": {
+            "location": {
+                "type": "string"
+            },
+            "coordinates": {
+                "type": "object",
+                "properties": {
+                    "latitude": {
+                        "type": "number",
+                        "description": "Latitude coordinate"
+                    },
+                    "longitude": {
+                        "type": "number",
+                        "description": "Longitude coordinate"
+                    },
+                },
+            }
+        }
+    }))
+
+MODEL_OUTPUT_SINGLE_TOOL_CALL_NO_CONTENT = """<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n</tool_call>"""  # noqa: E501
+MODEL_OUTPUT_SINGLE_TOOL_CALL = """<think>Okay, ...</think>\nSome prefix\n<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n</tool_call>\nSome suffix"""  # noqa: E501
+MODEL_OUTPUT_SINGLE_TOOL_CALL_NO_THINK = """Some prefix\n<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n</tool_call>\nSome suffix"""  # noqa: E501
+MODEL_OUTPUT_MULTIPLE_TOOL_CALLS = """<think>Okay, ...</think>\nSome prefix\n<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n</tool_call>\nSome middle\n<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Munich"}}\n</tool_call>\nSome suffix"""  # noqa: E501
+MODEL_OUTPUT_SINGLE_TOOL_CALL_NESTED = """<think>Okay, ...</think>\nSome prefix\n<tool_call>\n{"name": "get_weather_with_details", "arguments": {"location": "Seattle", "coordinates": {"latitude": 47.6062, "longitude": 122.3321}}}\n</tool_call>\nSome suffix"""  # noqa: E501
+MODEL_OUTPUT_SINGLE_TOOL_CALL_LIST = """<think>Okay, ...</think>\nSome prefix\n<tool_call>\n[ {"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n,\n{"name": "get_current_weather", "arguments": {"location": "Munich"}} ]\n</tool_call>\nSome suffix"""  # noqa: E501
+MODEL_OUTPUT_MULTIPLE_TOOL_CALL_LISTS = """<think>Okay, ...</think>\nSome prefix\n<tool_call>\n[{"name": "get_weather_with_details", "arguments": {"location": "Seattle", "coordinates": {"latitude": 47.6062, "longitude": 122.3321}}}]\n</tool_call>\nSome middle<tool_call>[{"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n,\n{"name": "get_current_weather", "arguments": {"location": "Munich"}}]</tool_call>Some suffix"""  # noqa: E501
+MODEL_OUTPUT_WITH_TOOL_CALL_IN_THINK = """<think>Okay, ...<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n</tool_call>\n</think>After think\n<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Munich"}}\n</tool_call>\nSome suffix"""  # noqa: E501
+MODEL_OUTPUT_WITH_TOOL_CALL_WITHOUT_ARGS = """<tool_call>{"name": "refresh", "arguments": {}}</tool_call>"""  # noqa: E501
+MODEL_OUTPUT_WITH_TOOL_CALL_WIKIPEDIA = """<think>\nOkay, this is a reasoning trace.\n</think>\n\n<tool_call>\n[{"name": "Wikipedia", "arguments": {"query": "Joe Biden"}}]\n</tool_call>"""  # noqa: E501
+
+TOOL_CALL_WEATHER_SEATTLE = FunctionCall(
+    name="get_current_weather",
+    arguments='{"location": "Seattle"}',
+)
+TOOL_CALL_WEATHER_MUNICH = FunctionCall(
+    name="get_current_weather",
+    arguments='{"location": "Munich"}',
+)
+TOOL_CALL_WEATHER_DETAILS_SEATTLE = FunctionCall(
+    name="get_weather_with_details",
+    arguments=
+    '{"location": "Seattle", "coordinates": {"latitude": 47.6062, "longitude": 122.3321}}',  # noqa: E501
+)
+TOOL_CALL_REFRESH = FunctionCall(
+    name="refresh",
+    arguments='{}',
+)
+
+
+def _chunked(text: str, chunk_length: int) -> list[str]:
+    return [
+        text[i:i + chunk_length] for i in range(0, len(text), chunk_length)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("model_output", "expected_tool_calls", "expected_content"),
+    [
+        pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL_NO_CONTENT,
+                     [TOOL_CALL_WEATHER_SEATTLE],
+                     None,
+                     id="single_tool_call_no_content"),
+        pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL,
+                     [TOOL_CALL_WEATHER_SEATTLE],
+                     "<think>Okay, ...</think>\nSome prefix\n\nSome suffix",
+                     id="single_tool_call"),
+        pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL_NO_THINK,
+                     [TOOL_CALL_WEATHER_SEATTLE],
+                     "Some prefix\n\nSome suffix",
+                     id="single_tool_call_no_think"),
+        pytest.param(
+            MODEL_OUTPUT_MULTIPLE_TOOL_CALLS,
+            [TOOL_CALL_WEATHER_SEATTLE, TOOL_CALL_WEATHER_MUNICH],
+            "<think>Okay, ...</think>\nSome prefix\n\nSome middle\n\nSome suffix",  # noqa: E501
+            id="multiple_tool_calls"),
+        pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL_NESTED,
+                     [TOOL_CALL_WEATHER_DETAILS_SEATTLE],
+                     "<think>Okay, ...</think>\nSome prefix\n\nSome suffix",
+                     id="single_tool_call_with_nested_arguments"),
+        pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL_LIST,
+                     [TOOL_CALL_WEATHER_SEATTLE, TOOL_CALL_WEATHER_MUNICH],
+                     "<think>Okay, ...</think>\nSome prefix\n\nSome suffix",
+                     id="single_json_list_of_tool_calls"),
+        pytest.param(
+            MODEL_OUTPUT_MULTIPLE_TOOL_CALL_LISTS, [
+                TOOL_CALL_WEATHER_DETAILS_SEATTLE, TOOL_CALL_WEATHER_SEATTLE,
+                TOOL_CALL_WEATHER_MUNICH
+            ],
+            "<think>Okay, ...</think>\nSome prefix\n\nSome middleSome suffix",
+            id="multiple_json_lists_of_tool_calls"),
+        pytest.param(
+            MODEL_OUTPUT_WITH_TOOL_CALL_IN_THINK,
+            [TOOL_CALL_WEATHER_MUNICH],
+            """<think>Okay, ...<tool_call>\n{"name": "get_current_weather", "arguments": {"location": "Seattle"}}\n</tool_call>\n</think>After think\n\nSome suffix""",  # noqa: E501
+            id="ignore_tool_call_in_think_trace"),
+        pytest.param(MODEL_OUTPUT_WITH_TOOL_CALL_WITHOUT_ARGS,
+                     [TOOL_CALL_REFRESH],
+                     """""",
+                     id="tool_call_without_args"),
+        pytest.param("model output with no tool call", [],
+                     "model output with no tool call",
+                     id="no_tool_call"),
+    ])
+@pytest.mark.parametrize("chunk_length", [1, 3, 15, 0, None])
+def test_streaming_and_non_streaming(model_output: str,
+                                     expected_tool_calls: list[FunctionCall],
+                                     expected_content: str,
+                                     chunk_length: Union[int, None]):
+    """Test model outputs in streaming mode with different chunk lengths
+    and in non-streaming mode. Only check re-assembled tool calls,
+    not their chunked representations."""
+    tool_parser = TngToolParser(tokenizer=MagicMock())
+    if chunk_length:
+        model_output = _chunked(model_output,
+                                chunk_length=chunk_length)  # type: ignore
+    streaming = chunk_length is not None
+
+    actual_content, actual_tool_calls = run_tool_extraction(
+        tool_parser, model_output, streaming=streaming)
+
+    assert len(actual_tool_calls) == len(expected_tool_calls)
+    for actual_tool_call, expected_tool_call in zip(actual_tool_calls,
+                                                    expected_tool_calls):
+        assert actual_tool_call.function == expected_tool_call
+    if expected_content:
+        assert actual_content == expected_content
+    else:
+        assert not actual_content  # may be "" or None
+
+
+@pytest.mark.parametrize(
+    ("model_output", "expected_stream"), [
+        pytest.param(
+            [
+                "<think>", "Okay", ", ", "...", "</think>", "\n", "<", "tool_",
+                "call", ">", "\n", "{\"", "name", "\": ", "\"get",
+                "_current_weather\"", ", \"arguments\"", ": ", "{\"", "locat",
+                "ion", "\": ", "\"Seat", "tle", "\"", "}", "}", "\n", "</",
+                "tool_", "call", ">"
+            ],
+            [
+                DeltaMessage(content=chunk) for chunk in
+                ["<think>", "Okay", ", ", "...", "</think>", "\n"]
+            ] + [
+                DeltaMessage(tool_calls=[
+                    DeltaToolCall(index=0,
+                                  function=DeltaFunctionCall(
+                                      name="get_current_weather",
+                                      arguments="{\""))
+                ])
+            ] + [
+                DeltaMessage(tool_calls=[
+                    DeltaToolCall(index=0,
+                                  function=DeltaFunctionCall(arguments=chunk))
+                ]) for chunk in
+                ["locat", "ion", "\": ", "\"Seat", "tle", "\"", "}"]
+            ],
+            id="think_trace_and_single_tool_call"),
+    ])
+def test_streamed_tool_call_chunks(tng_tool_parser, model_output: list[str],
+                                   expected_stream: list):
+    """Test that model output is streamed in correct chunks"""
+    mock_request = MagicMock(ChatCompletionRequest)
+    mock_request.tools = [SIMPLE_WEATHER_TOOL, NESTED_WEATHER_TOOL]
+    previous_text = ""
+    actual_stream: list[DeltaMessage] = []
+    for chunk in model_output:
+        result = tng_tool_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=previous_text + chunk,
+            delta_text=chunk,
+            previous_token_ids=[],  # token ids do not matter for TngToolParser
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=mock_request,
+        )
+        previous_text += chunk
+        if result and (result.content is not None or result.reasoning_content
+                       is not None or result.tool_calls != []):
+            actual_stream.append(result)
+
+    assert len(actual_stream) == len(expected_stream)
+    for expected_chunk, actual_chunk in zip(expected_stream, actual_stream):
+        assert actual_chunk.content == expected_chunk.content
+        assert (
+            actual_chunk.reasoning_content == expected_chunk.reasoning_content)
+        if expected_chunk.tool_calls:
+            assert (len(actual_chunk.tool_calls) == len(
+                expected_chunk.tool_calls))
+            for expected_call, actual_call in zip(expected_chunk.tool_calls,
+                                                  actual_chunk.tool_calls):
+                assert actual_call.index == expected_call.index
+                assert actual_call.function == expected_call.function
+
+
+@pytest.mark.parametrize(
+    ("model_output", ),
+    [
+        pytest.param("""<tool_call>{"name": "mytool""}</tool_call>""",
+                     id="tool_call_json_syntax_error"),
+        pytest.param("""<tool_call>{"name": "mytool"}</tool_call>""",
+                     id="tool_call_no_arguments"),
+        pytest.param(
+            """<tool_call>{"name": "mytool", "arguments": {"param": "test"}}""",
+            id="tool_call_no_closing_tag"),
+        pytest.param(
+            """<tool_call>{"name": "mytool", "arguments": {}} Some additional text</tool_call>""",  # noqa: E501
+            id="tool_call_text_after_json"),
+        pytest.param(
+            """<tool_call>prefix{"name": "mytool", "arguments": {}}</tool_call>""",  # noqa: E501
+            id="tool_call_text_before_json"),
+        pytest.param("""<tool_call>text-only</tool_call>""",
+                     id="tool_call_no_json"),
+        pytest.param("""<tool_call> </tool_call>""", id="tool_call_empty"),
+        pytest.param("""<tool_call>{"name": "mytool", "arguments": "test"}""",
+                     id="tool_call_text_arguments"),
+    ])
+@pytest.mark.parametrize("chunk_length", [1, 3, 15, 0, None])
+def test_streaming_and_non_streaming_error_scenarios(
+        model_output: str, chunk_length: Union[int, None]):
+    tool_parser = TngToolParser(tokenizer=MagicMock())
+    if chunk_length:
+        model_output = _chunked(model_output,
+                                chunk_length=chunk_length)  # type: ignore
+    streaming = chunk_length is not None
+
+    # just make sure no exceptions are raised
+    _, _ = run_tool_extraction(tool_parser, model_output, streaming=streaming)
+
+
+@pytest.mark.parametrize(("full_model_output", ), [
+    pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL_NO_CONTENT,
+                 id="end_with_tool_call_end_tag"),
+    pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL_NO_CONTENT + "\n\n\n\n",
+                 id="end_with_tool_call_end_tag_and_trailing_whitespace"),
+    pytest.param(MODEL_OUTPUT_SINGLE_TOOL_CALL,
+                 id="end_with_content_after_tool_call"),
+    pytest.param(MODEL_OUTPUT_WITH_TOOL_CALL_WIKIPEDIA,
+                 id="realistic_tool_call"),
+    pytest.param((
+        MODEL_OUTPUT_SINGLE_TOOL_CALL_NO_CONTENT.removesuffix("</tool_call>")),
+                 id="end_with_tool_call_without_end_tag"),
+])
+@pytest.mark.parametrize("chunk_length", [1, 3, 15])
+@pytest.mark.parametrize("trailing_empty_chunk", [False, True])
+@pytest.mark.asyncio
+async def test_chat_completion_serving(full_model_output: str,
+                                       chunk_length: int,
+                                       trailing_empty_chunk: bool):
+    # Some streaming logic is hidden in entrypoints/openai/serving_chat.py,
+    # here we test the full streaming behavior
+    ToolParserManager.register_module("tng", module=TngToolParser)
+    serving = OpenAIServingChat(engine_client=MagicMock(),
+                                model_config=MagicMock(),
+                                models=MagicMock(),
+                                response_role="assistant",
+                                request_logger=None,
+                                chat_template=None,
+                                chat_template_content_format="auto",
+                                enable_auto_tools=True,
+                                tool_parser="tng")
+    request = ChatCompletionRequest(
+        messages=[],  # irrelevant
+        seed=0,
+        tools=[SIMPLE_WEATHER_TOOL],
+        tool_choice="auto",
+        stream=True,
+    )
+    request_id = "my-request-id"
+    model_output = _chunked(full_model_output, chunk_length=chunk_length)
+    if trailing_empty_chunk:
+        # this simulates an empty chunk for the eot token
+        model_output += [""]
+    chunks = [
+        RequestOutput(
+            request_id=request_id,
+            prompt=None,
+            prompt_token_ids=None,
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text=output_chunk,
+                    token_ids=[idx],
+                    cumulative_logprob=None,
+                    logprobs=None,
+                    finish_reason=("length" if
+                                   (idx == len(model_output) - 1) else None),
+                )
+            ],
+            finished=(idx == len(model_output) - 1),
+        ) for idx, output_chunk in enumerate(model_output)
+    ]
+
+    async def result_generator() -> AsyncIterator[RequestOutput]:
+        for chunk in chunks:
+            yield chunk
+
+    async for response in serving.chat_completion_stream_generator(
+            request=request,
+            result_generator=result_generator(),
+            request_id=request_id,
+            model_name=MODEL,
+            conversation=[],  # irrelevant
+            tokenizer=MagicMock(),
+            request_metadata=MagicMock(),
+            enable_force_include_usage=False,
+    ):
+        if response.strip() == "data: [DONE]":
+            continue
+        response_json = json.loads(response.removeprefix("data:").strip())
+        choices = response_json["choices"]
+        if len(choices) and choices[0].get("finish_reason"):
+            return  # success
+    pytest.fail("Stream must end with finish_reason")

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -814,9 +814,13 @@ class OpenAIServingChat(OpenAIServing):
 
                     # if the message delta is None (e.g. because it was a
                     # "control token" for tool calls or the parser otherwise
-                    # wasn't ready to send a token, then
-                    #   get the next token without streaming a chunk
-                    if delta_message is None:
+                    # wasn't ready to send a token), then get the next token
+                    # without streaming a chunk, except for the last chunk
+                    # that carries relevant finish_reason information.
+                    if (delta_message is None
+                            and output.finish_reason is not None):
+                        delta_message = DeltaMessage()
+                    elif delta_message is None:
                         continue
 
                     if output.finish_reason is None:

--- a/vllm/entrypoints/openai/tool_parsers/__init__.py
+++ b/vllm/entrypoints/openai/tool_parsers/__init__.py
@@ -19,6 +19,7 @@ from .phi4mini_tool_parser import Phi4MiniJsonToolParser
 from .pythonic_tool_parser import PythonicToolParser
 from .qwen3coder_tool_parser import Qwen3CoderToolParser
 from .step3_tool_parser import Step3ToolParser
+from .tng_tool_parser import TngToolParser
 from .xlam_tool_parser import xLAMToolParser
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "Glm4MoeModelToolParser",
     "Qwen3CoderToolParser",
     "Step3ToolParser",
+    "TngToolParser",
 ]

--- a/vllm/entrypoints/openai/tool_parsers/tng_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/tng_tool_parser.py
@@ -1,0 +1,583 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa
+import json
+from collections.abc import Sequence
+from enum import Enum
+from typing import Any, Union
+
+import partial_json_parser
+import regex as re
+from partial_json_parser.core.options import Allow
+
+from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                              DeltaFunctionCall, DeltaMessage,
+                                              DeltaToolCall,
+                                              ExtractedToolCallInformation,
+                                              FunctionCall, ToolCall)
+from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
+    ToolParser, ToolParserManager)
+from vllm.logger import init_logger
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+from vllm.utils import random_uuid
+
+logger = init_logger(__name__)
+
+
+class ParsedStructure(Enum):
+    CONTENT = 1
+    REASONING_CONTENT = 2
+    TOOL_CALL = 3
+    TOOL_CALL_DELIMITER = 4
+    TOOL_CALL_START_TAG = 5
+    TOOL_CALL_END_TAG = 6
+
+
+@ToolParserManager.register_module("tng")
+class TngToolParser(ToolParser):
+    """Tool Parser for models like tngtech/DeepSeek-TNG-R1T2-Chimera,
+    It is compatible with hermes tool call templates
+    but does not require <tool_call> and </tool_call>
+    to be single tokens in the vocabulary;
+    instead only the string representation of the model output
+    is parsed, making this tool call parser robust and versatile."""
+
+    def __init__(self, tokenizer: AnyTokenizer):
+        super().__init__(tokenizer)
+
+        # For backward compatibility with serving code
+        self.prev_tool_call_arr: list[dict] = []
+        self.streamed_args_for_tool: list[str] = []
+
+        self.think_tag_pattern = r"(<think>[\s\S]*?</think>)"
+        self.think_start_tag = "<think>"
+        self.think_end_tag = "</think>"
+
+        self.tool_call_tag_pattern = r"<tool_call>([\s\S]*?)</tool_call>"
+        self.tool_call_start_tag = "<tool_call>"
+        self.tool_call_end_tag = "</tool_call>"
+
+        # Define streaming state type to be initialized later
+        self.streaming_state: dict[str, Any] = {
+            "streamed_tool_calls": [],
+            "buffer": "",
+            "parsed_structure": ParsedStructure.CONTENT,
+        }
+
+    def extract_tool_call_from_nonthink_output(
+            self, raw_text: str) -> tuple[str, list[dict]]:
+        parts = re.split(self.tool_call_tag_pattern, raw_text)
+        content = ""
+        tool_calls: list[dict] = []
+        for i, part in enumerate(parts):
+            is_potential_tool_call = i % 2 == 1
+            if is_potential_tool_call:
+                try:
+                    more_tool_calls = json.loads(part)
+                    if isinstance(more_tool_calls, list):
+                        tool_calls.extend(more_tool_calls)
+                    else:
+                        tool_calls.extend([more_tool_calls])
+                except json.JSONDecodeError:
+                    logger.warning("Invalid tool call json "
+                                   "-> parse as text content")
+                    content += part
+                    continue
+            else:
+                content += part
+        return content, tool_calls
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete model output.
+        """
+        # split at think traces -> those will not be parsed for tool calls
+        think_parts = re.split(self.think_tag_pattern, model_output)
+        content = ""
+        tool_calls = []
+        for i, part in enumerate(think_parts):
+            parse_output = i % 2 == 0
+            if parse_output:
+                more_content, more_tool_calls = (
+                    self.extract_tool_call_from_nonthink_output(part))
+                content += more_content
+                tool_calls += more_tool_calls
+            else:
+                content += part
+
+        if not tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=content,
+            )
+
+        tool_call_objs: list[ToolCall] = []
+
+        for idx, call in enumerate(tool_calls):
+            if (not isinstance(call, dict) or "name" not in call
+                    or "arguments" not in call):
+                logger.warning("Invalid tool call format, ignore.")
+                continue
+
+            tool_call = ToolCall(
+                id=f"call_{idx}_{random_uuid()}",
+                type="function",
+                function=FunctionCall(
+                    name=call["name"],
+                    arguments=(json.dumps(call["arguments"]) if isinstance(
+                        call["arguments"], dict) else call["arguments"]),
+                ),
+            )
+            tool_call_objs.append(tool_call)
+
+        return ExtractedToolCallInformation(
+            tools_called=len(tool_call_objs) > 0,
+            tool_calls=tool_call_objs,
+            content=content,
+        )
+
+    def _parse_think_trace(self, raw_text: str) -> tuple[str, bool, str]:
+        """
+        Returns: (unambiguous_text_content, found_think_end, rest_string)
+        """
+        # Either a complete think_end_tag can be somewhere in raw_text
+        think_end_pos = raw_text.find(self.think_end_tag)
+        if think_end_pos >= 0:
+            # in contrast to tool_call_start_tags, </think> remains part of content
+            think_end_tag_end_pos = think_end_pos + len(self.think_end_tag)
+            return (raw_text[:think_end_tag_end_pos], True,
+                    raw_text[think_end_tag_end_pos:])
+
+        # or the end of raw_text can be continued to a complete think_end_tag
+        think_end_pos = (
+            len(raw_text) -
+            self._ends_with_partial_token(raw_text, self.think_end_tag))
+        return raw_text[:think_end_pos], False, raw_text[think_end_pos:]
+
+    def _parse_unambiguous_text_content(
+            self, raw_text: str) -> tuple[str, Union[str, None], str]:
+        """
+        Returns: (unambiguous_text_content, interrupting_tag, rest_string)
+        """
+        # Either a complete tool_call_start_tag or think_start can be somewhere in raw_text
+        search_tags = [self.think_start_tag, self.tool_call_start_tag]
+        tag_positions = [(tag, pos) for tag in search_tags
+                         if (pos := raw_text.find(tag)) >= 0]
+        tag_positions.sort(key=lambda tag_and_pos: tag_and_pos[1])
+        if len(tag_positions) > 0:
+            first_tag, tag_pos = tag_positions[0]
+            return raw_text[:tag_pos], first_tag, raw_text[tag_pos:]
+
+        # or the end of raw_text can be continued to a complete tag
+        tag_positions = [
+            (tag, len(raw_text) - self._ends_with_partial_token(raw_text, tag))
+            for tag in search_tags
+        ]
+        tag_positions.sort(key=lambda tag_and_pos: tag_and_pos[1])
+        first_tag, tag_pos = tag_positions[0]
+        if tag_pos < len(raw_text):
+            return raw_text[:tag_pos], None, raw_text[tag_pos:]
+        return raw_text, None, ""
+
+    def _parse_tool_call_start_tag(self, raw_text: str) -> tuple[bool, str]:
+        """
+        Removes tool_call_start_tag from the beginning of raw_text,
+        and an optional "[", and leading whitespace.
+        Returns: (found_complete_tool_call_start_tag, rest_string)
+        """
+        if not raw_text.startswith(self.tool_call_start_tag):
+            return False, raw_text
+        rest = raw_text[len(self.tool_call_start_tag):].lstrip()
+        if rest.startswith("["):
+            rest = rest[1:].lstrip()
+        return True, rest
+
+    def _parse_tool_call_end_tag(
+            self, raw_text: str) -> tuple[Union[bool, None], str]:
+        """
+        Removes tool_call_end_tag from the beginning of raw_text,
+        and an optional "]" before it, and leading whitespace.
+        Returns: tuple
+            found_complete_tool_call_end_tag (or None if not decidable yet)
+            rest_string
+        """
+        # remove optional whitespace and closing ] bracket from json list notation
+        rest = raw_text.lstrip()
+        if rest.startswith("]"):
+            rest = rest[1:].lstrip()
+
+        if rest.startswith(self.tool_call_end_tag):
+            # found a complete tool call end tag
+            return True, rest[len(self.tool_call_end_tag):]
+        if (len(rest) >= len(self.tool_call_end_tag)
+                or rest != self.tool_call_end_tag[:len(rest)]):
+            # evidence that rest_string does not start with a tool call end tag
+            return False, raw_text
+        # incomplete tool call end tag, can not be decided yet
+        return None, raw_text
+
+    def _extract_arguments_from_partial_tool_call(
+            self, raw_text: str) -> Union[str, None]:
+        """
+        Extracts the raw text of the "arguments" field of a complete
+        or partial tool call.
+        Args:
+            raw_text: tool call raw text,
+                      e.g `{"name": "my_tool", "arguments": {"firstarg": "some`
+
+        Returns:
+            raw text of the "arguments" field, which is not valid JSON
+            unless the tool call is complete,
+            e.g. `{"firstarg": "some` for the example raw_text above
+        """
+        # assumptions:
+        # - "arguments" is always an object
+        # - there is no other field of type object in the function call
+        # - `raw_text` contains first "name", then "arguments" (otherwise,
+        #   we'd have to find the end of "arguments" before returning its
+        #   raw text value)
+
+        # typically, at position 0, but there might be leading whitespace
+        tool_call_start_pos = raw_text.find("{")
+        assert raw_text[:tool_call_start_pos].strip() == ""
+        arguments_start_pos = raw_text.find("{", tool_call_start_pos + 1)
+        if arguments_start_pos < 0:
+            return None
+        arguments_raw_text = raw_text[arguments_start_pos:]
+        return arguments_raw_text
+
+    def _parse_complete_tool_call(
+            self, raw_text: str) -> tuple[Union[dict, None], str]:
+        """
+        Returns: tuple
+            parsed tool call if complete, None otherwise
+            rest_string that needs to be parsed again or may contain
+                        a partial tool call
+        """
+        # raw_text must start without whitespace for correct parsing
+        obj, end_pos = self.extract_complete_json_dict(raw_text)
+        if obj is None:
+            return None, raw_text
+        tool_call_raw_text = raw_text[:end_pos]
+        # `tool_call_raw_text` is something like:
+        #   '{"name": "tool-name", "arguments": {...xyz...} }'
+        # we want to extract `{...xyz...}`,
+        # but `extract_arguments_from_partial_tool_call` would return
+        # everything after the second '{', i.e. `{...xyz...} }`
+        arguments_raw_text = self._extract_arguments_from_partial_tool_call(
+            tool_call_raw_text.removesuffix("}").rstrip())
+        tool_call = {
+            "name": obj.get("name"),
+            "arguments": obj.get("arguments"),
+            "arguments_raw_text": arguments_raw_text,
+            "is_complete": True,
+        }
+        return tool_call, raw_text[end_pos:]
+
+    def _parse_partial_tool_call(self, raw_text: str) -> Union[dict, None]:
+        # raw_text must start without whitespace for correct parsing
+        obj = partial_json_parser.loads(raw_text, Allow.ALL)
+        arguments_raw_text = (
+            self._extract_arguments_from_partial_tool_call(raw_text))
+        tool_call = {
+            "name": obj.get("name"),
+            "arguments": obj.get("arguments"),
+            "arguments_raw_text": arguments_raw_text,
+            "is_complete": False,
+        }
+        return tool_call
+
+    def _parse_tool_call(
+            self,
+            raw_text: str) -> tuple[Union[bool, None], Union[dict, None], str]:
+        # remove optional whitespace and closing ] bracket
+        # from json list notation
+        rest = raw_text.lstrip()
+        if rest == "":
+            # no json has been received yet
+            # -> can't tell if this will be a valid tool call
+            return None, None, raw_text
+        if not rest.startswith("{"):
+            # can't be a tool call json
+            return False, None, raw_text
+
+        tool_call, rest = self._parse_complete_tool_call(rest)
+        if tool_call:
+            return True, tool_call, rest
+
+        try:
+            tool_call = self._parse_partial_tool_call(rest)
+            # need to re-parse partial tool call later again
+            # -> return None, not True
+            return None, tool_call, rest
+        except json.JSONDecodeError:
+            # invalid json -> neither complete nor partial tool call
+            return False, None, rest
+
+    def _parse_tool_call_delimiter(
+            self, raw_text: str) -> tuple[Union[bool, None], str]:
+        """
+        Returns: tuple
+            does raw_text start with tool call delimiter?
+                (None if undecidable/incomplete)
+            rest_string
+        """
+        rest = raw_text.lstrip()
+        if rest == "":
+            return None, raw_text
+        has_next_tool_call = rest.startswith(",")
+        if not has_next_tool_call:
+            return False, raw_text
+
+        rest = rest[1:].lstrip()
+        if rest == "":
+            return None, raw_text
+        has_next_tool_call = rest.startswith("{")
+        if not has_next_tool_call:
+            return False, raw_text
+        return True, rest
+
+    def _parse_all(
+        self, raw_text: str, start_mode: ParsedStructure
+    ) -> tuple[str, list[dict], str, ParsedStructure]:
+        if start_mode == ParsedStructure.REASONING_CONTENT:
+            content, found_closing_think, rest = self._parse_think_trace(
+                raw_text)
+            if found_closing_think:
+                more_content, tool_calls, rest, structure = self._parse_all(
+                    rest, start_mode=ParsedStructure.CONTENT)
+                return content + more_content, tool_calls, rest, structure
+            return content, [], rest, ParsedStructure.REASONING_CONTENT
+
+        elif start_mode == ParsedStructure.CONTENT:
+            content, interrupting_tag, rest = self._parse_unambiguous_text_content(
+                raw_text)
+
+            # rest might contain a tool call start tag or a think start tag
+            if interrupting_tag == self.tool_call_start_tag:
+                more_content, tool_calls, rest, structure = self._parse_all(
+                    rest, start_mode=ParsedStructure.TOOL_CALL_START_TAG)
+                return content + more_content, tool_calls, rest, structure
+            elif interrupting_tag == self.think_start_tag:
+                more_content, tool_calls, rest, structure = self._parse_all(
+                    rest, start_mode=ParsedStructure.REASONING_CONTENT)
+                return content + more_content, tool_calls, rest, structure
+            else:
+                return content, [], rest, ParsedStructure.CONTENT
+
+        elif start_mode == ParsedStructure.TOOL_CALL_START_TAG:
+            found_tool_call_start_tag, rest = self._parse_tool_call_start_tag(
+                raw_text)
+            if not found_tool_call_start_tag:
+                return "", [], raw_text, ParsedStructure.CONTENT
+            # we found a complete start tag, but we haven't seen the begin of a tool call json yet
+            content, tool_calls, rest, structure = self._parse_all(
+                rest, start_mode=ParsedStructure.TOOL_CALL)
+            if not content and not tool_calls:
+                # We haven't reached the opening "{" of the tool call yet.
+                # We might see a "[" before the "{", so let's process the start tag again next chunk.
+                return content, [], raw_text, ParsedStructure.CONTENT
+            return content, tool_calls, rest, structure
+
+        elif start_mode == ParsedStructure.TOOL_CALL:
+            found_tool_call, tool_call, rest = self._parse_tool_call(raw_text)
+            if found_tool_call is True:
+                tool_calls = [tool_call] if tool_call else []
+                content, more_tool_calls, rest, structure = self._parse_all(
+                    rest, start_mode=ParsedStructure.TOOL_CALL_DELIMITER)
+                return (content, tool_calls + more_tool_calls, rest, structure)
+            elif found_tool_call is None:
+                # partial tool call -> need to parse again with next chunk
+                tool_calls = ([tool_call] if tool_call is not None else [])
+                return "", tool_calls, rest, ParsedStructure.TOOL_CALL
+            else:
+                logger.warning(
+                    "Invalid tool call -> continue with parsing model output as text content"
+                )
+                return self._parse_all(raw_text,
+                                       start_mode=ParsedStructure.CONTENT)
+
+        elif start_mode == ParsedStructure.TOOL_CALL_DELIMITER:
+            found_tool_call_delimiter, rest = self._parse_tool_call_delimiter(
+                raw_text)
+            if found_tool_call_delimiter is True:
+                return self._parse_all(rest,
+                                       start_mode=ParsedStructure.TOOL_CALL)
+            elif found_tool_call_delimiter is None:
+                # could neither confirm nor deny that raw_text starts with a tool call delimiter
+                return "", [], rest, ParsedStructure.TOOL_CALL_DELIMITER
+            else:
+                return self._parse_all(
+                    raw_text, start_mode=ParsedStructure.TOOL_CALL_END_TAG)
+
+        elif start_mode == ParsedStructure.TOOL_CALL_END_TAG:
+            found_tool_call_end_tag, rest = self._parse_tool_call_end_tag(
+                raw_text)
+            if found_tool_call_end_tag is True:
+                return self._parse_all(rest,
+                                       start_mode=ParsedStructure.CONTENT)
+            elif found_tool_call_end_tag is None:
+                return "", [], rest, ParsedStructure.TOOL_CALL_END_TAG
+            else:
+                return self._parse_all(raw_text,
+                                       start_mode=ParsedStructure.CONTENT)
+
+        logger.warning(
+            f"Unknown tool call parser start_mode '{start_mode}'. Falling back to text content."
+        )
+        return self._parse_all(raw_text, start_mode=ParsedStructure.CONTENT)
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> Union[DeltaMessage, None]:
+        """
+        Extract tool calls for streaming mode.
+        """
+        raw_text = self.streaming_state["buffer"] + delta_text
+        structure = self.streaming_state["parsed_structure"]
+
+        content, tool_calls, rest, new_structure = self._parse_all(
+            raw_text, start_mode=structure)
+        self.streaming_state["buffer"] = rest
+        self.streaming_state["parsed_structure"] = new_structure
+
+        already_streamed_tool_calls = (
+            self.streaming_state["streamed_tool_calls"])
+        already_streamed_complete_tool_calls = [
+            tool_call for tool_call in already_streamed_tool_calls
+            if tool_call["is_complete"]
+        ]
+        all_tool_calls = (already_streamed_complete_tool_calls +
+                          (tool_calls or []))
+        to_be_streamed_tool_calls = self._calculate_delta_tool_calls(
+            all_tool_calls, already_streamed_tool_calls)
+
+        if not content and not to_be_streamed_tool_calls:
+            return None
+        self.update_state_vars(all_tool_calls)
+        return DeltaMessage(content=content if content else None,
+                            tool_calls=to_be_streamed_tool_calls)
+
+    def _calculate_delta_tool_calls(
+            self, current_tool_calls: Union[list[dict], None],
+            already_streamed_tool_calls: list[dict]) -> list[DeltaToolCall]:
+        if not current_tool_calls:
+            return []
+
+        new_deltas = []
+        for tool_call_idx, partial_tool_call in enumerate(current_tool_calls):
+            if (partial_tool_call.get("name") is None
+                    or partial_tool_call.get("arguments") is None):
+                # do not stream arguments for an unknown tool name;
+                # and unless arguments appear in the partial json,
+                # it might be that "name" has not been received completely
+                # (assuming a template like `{"name": "mytool", "arguments": ...}`)
+                continue
+            partial_tool_call["tool_call_idx"] = tool_call_idx
+            partial_tool_call["arguments_raw_text"] = (
+                partial_tool_call.get('arguments_raw_text') or "")
+
+            if len(already_streamed_tool_calls) > tool_call_idx:
+                # parts of this tool_call_idx have already been streamed
+                already_streamed_tool_call = already_streamed_tool_calls[
+                    tool_call_idx]
+                delta_tool_call = self._delta_for_partial_tool_call(
+                    partial_tool_call, already_streamed_tool_call)
+                if delta_tool_call is not None:
+                    new_deltas.append(delta_tool_call)
+                already_streamed_tool_calls[tool_call_idx] = (
+                    already_streamed_tool_call | partial_tool_call)
+            else:
+                # no parts of this tool_call_idx have been streamed yet
+                tool_call = self._delta_for_new_tool_call(partial_tool_call)
+                new_deltas.append(tool_call)
+                already_streamed_tool_calls.append(partial_tool_call)
+
+        return new_deltas
+
+    def _delta_for_new_tool_call(self, tool_call_dict: dict) -> DeltaToolCall:
+        """constructs DeltaToolCall for new tool call,
+        with tool_call_id, name, and all arguments seen so far.
+        Updates tool_call dictionary with tool_call_id.
+        """
+        tool_call_idx = tool_call_dict["tool_call_idx"]
+        tool_call_dict[
+            "tool_call_id"] = f"call_{tool_call_idx}_{random_uuid()}"
+        tool_call_dict["arguments_raw_text"] = tool_call_dict.get(
+            'arguments_raw_text') or ""
+        delta_tool_call = DeltaToolCall(
+            index=tool_call_idx,
+            type="function",
+            id=tool_call_dict["tool_call_id"],
+            function=DeltaFunctionCall(
+                name=tool_call_dict.get("name"),
+                arguments=tool_call_dict["arguments_raw_text"]))
+        return delta_tool_call
+
+    def _delta_for_partial_tool_call(
+            self, new_tool_call: dict,
+            already_streamed_tool_call: dict) -> Union[DeltaToolCall, None]:
+        """Calculate delta for a tool call of which some parts have already been streamed."""
+        assert new_tool_call["name"] == already_streamed_tool_call["name"]
+        assert already_streamed_tool_call.get("tool_call_id")
+        if already_streamed_tool_call.get("is_complete"):
+            return None
+
+        to_be_streamed_arguments = (
+            new_tool_call["arguments_raw_text"].removeprefix(
+                already_streamed_tool_call["arguments_raw_text"]))
+        if not to_be_streamed_arguments:
+            return None
+
+        delta_tool_call = DeltaToolCall(
+            index=new_tool_call["tool_call_idx"],
+            type="function",
+            function=DeltaFunctionCall(arguments=to_be_streamed_arguments))
+        return delta_tool_call
+
+    def update_state_vars(self, all_tools: list[dict]) -> None:
+        # `tool_parser.streamed_args_for_tool` and
+        # `tool_parser.prev_tool_call_arr` are checked in serving_chat.py
+
+        # relevant is {"arguments": {...}}
+        self.prev_tool_call_arr = all_tools
+
+        # json-serialized argument
+        self.streamed_args_for_tool = [
+            tool_call.get("arguments_raw_text", "") for tool_call in all_tools
+        ]
+
+    @classmethod
+    def _ends_with_partial_token(cls, buffer: str, tag: str) -> int:
+        """
+        Check if buffer ends with a partial tag.
+        Return the length of the partial tag.
+        """
+        for i in range(1, min(len(buffer) + 1, len(tag))):
+            if tag.startswith(buffer[-i:]):
+                return i
+        return 0
+
+    @classmethod
+    def extract_complete_json_dict(cls, json_str: str):
+        try:
+            decoder = json.JSONDecoder()
+            obj, end_pos = decoder.raw_decode(
+                json_str)  # ignore any text after the end of the json object
+            if isinstance(obj, dict):
+                return obj, end_pos
+            return None, 0
+        except json.JSONDecodeError:
+            return None, 0


### PR DESCRIPTION
This PR adds a tool call parser "tng" for models like tngtech/DeepSeek-TNG-R1T2-Chimera, which do not generate tool calls with dedicated tokens but instead need a string-matching tool parser. 
The supported tool call format is compatible with hermes, i.e. `<tool_call>{"name": "my_tool", "arguments": {...}}</tool_call>` to a degree that you could run Qwen3-32B with tool call parser tng instead. But "hermes" tool parser requires `<tool_call>` and `</tool_call>` to have single-token representations, which other models like tngtech/DeepSeek-TNG-R1T2-Chimera do no have.

Using this tool call parser and a (yet unpublished) chat template for DeepSeek-TNG-R1T2-Chimera, we could measure BFCL benchmarks
- simple: 0.936(2)
- multiple: 0.942(2)
- parallel_multiple: 0.882(4)
- parallel: 0.927(9)
