### PR TITLE
[Perf] Cuda Kernel for Int8 Per Token Group Quant, 15x faster compared with triton

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -292,6 +292,11 @@ void per_token_group_quant_fp8(const torch::Tensor& input,
                                torch::Tensor& output_q, torch::Tensor& output_s,
                                int64_t group_size, double eps, double fp8_min,
                                double fp8_max, bool scale_ue8m0);
+
+void per_token_group_quant_int8(const torch::Tensor& input,
+                                torch::Tensor& output_q,
+                                torch::Tensor& output_s, int64_t group_size,
+                                double eps, double int8_min, double int8_max);
 #endif
 
 void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,

--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -1,6 +1,8 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/all.h>
 
+#include "../per_token_group_quant_8bit.h"
+
 #include <cmath>
 
 #include "../../dispatch_utils.h"
@@ -335,4 +337,12 @@ void dynamic_scaled_int8_quant(
                   hidden_size);
         }
       });
+}
+
+void per_token_group_quant_int8(const torch::Tensor& input,
+                                torch::Tensor& output_q,
+                                torch::Tensor& output_s, int64_t group_size,
+                                double eps, double int8_min, double int8_max) {
+  per_token_group_quant_8bit(input, output_q, output_s, group_size, eps,
+                             int8_min, int8_max);
 }

--- a/csrc/quantization/fp8/per_token_group_quant.cu
+++ b/csrc/quantization/fp8/per_token_group_quant.cu
@@ -1,6 +1,8 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/util/Float8_e4m3fn.h>
 
+#include "../per_token_group_quant_8bit.h"
+
 #include <cmath>
 
 #include <cuda_fp16.h>
@@ -120,7 +122,7 @@ void per_token_group_quant_8bit(const torch::Tensor& input,
                                 torch::Tensor& output_q,
                                 torch::Tensor& output_s, int64_t group_size,
                                 double eps, double min_8bit, double max_8bit,
-                                bool scale_ue8m0 = false) {
+                                bool scale_ue8m0) {
   TORCH_CHECK(input.is_contiguous());
   TORCH_CHECK(output_q.is_contiguous());
 
@@ -198,6 +200,8 @@ void per_token_group_quant_8bit(const torch::Tensor& input,
       input.scalar_type(), "per_token_group_quant_8bit", ([&] {
         if (dst_type == at::ScalarType::Float8_e4m3fn) {
           LAUNCH_KERNEL(scalar_t, c10::Float8_e4m3fn);
+        } else if (dst_type == at::ScalarType::Char) {
+          LAUNCH_KERNEL(scalar_t, int8_t);
         }
       }));
 

--- a/csrc/quantization/per_token_group_quant_8bit.h
+++ b/csrc/quantization/per_token_group_quant_8bit.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <torch/all.h>
+
+// TODO(wentao): refactor the folder to 8bit, then includes fp8 and int8 folders
+// 8-bit per-token-group quantization helper used by both FP8 and INT8
+void per_token_group_quant_8bit(const torch::Tensor& input,
+                                torch::Tensor& output_q,
+                                torch::Tensor& output_s, int64_t group_size,
+                                double eps, double min_8bit, double max_8bit,
+                                bool scale_ue8m0 = false);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -624,6 +624,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("per_token_group_fp8_quant", torch::kCUDA,
            &per_token_group_quant_fp8);
 
+  // Compute per-token-group INT8 quantized tensor and scaling factor.
+  ops.def(
+      "per_token_group_quant_int8(Tensor input, Tensor! output_q, Tensor! "
+      "output_s, int group_size, float eps, float int8_min, float int8_max) -> "
+      "()");
+  ops.impl("per_token_group_quant_int8", torch::kCUDA,
+           &per_token_group_quant_int8);
+
   // reorder weight for AllSpark Ampere W8A16 Fused Gemm kernel
   ops.def(
       "rearrange_kn_weight_as_n32k16_order(Tensor b_qweight, Tensor b_scales, "


### PR DESCRIPTION
## Purpose

Add support for int8 per-token group quant CUDA kernel

Follow up pr for https://github.com/vllm-project/vllm/pull/21083

## Test

Unit test:

```bash
(wentao) wentao@H100-GPU17:~/vllm/tests/kernels/quantization$ pytest test_per_token_group_quant.py
================================================================= test session starts =================================================================
platform linux -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/wentao/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 30 items                                                                                                                                    

test_per_token_group_quant.py ..............................                                                                                    [100%]

================================================================= 30 passed in 6.38s ==================================================================
```

Benchmark: **15x faster compared with triton**

```bash
(wentao) wentao@H100-GPU17:~/vllm/benchmarks/kernels$ python benchmark_per_token_group_quant.py 
Configuration                                           |  CUDA (ms)   |  Triton (ms)  | Speed-up
-------------------------------------------------------------------------------------------------
shape=(32, 128)  gs=64   col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.169 ms  | speed-up ×15.73
shape=(32, 128)  gs=64   col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.011 ms  | Triton   0.159 ms  | speed-up ×14.99
shape=(32, 128)  gs=64   col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.83
shape=(32, 128)  gs=64   col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.86
shape=(32, 128)  gs=128  col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.159 ms  | speed-up ×15.13
shape=(32, 128)  gs=128  col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.22
shape=(32, 128)  gs=128  col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.169 ms  | speed-up ×13.84
shape=(32, 128)  gs=128  col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.94
shape=(64, 256)  gs=64   col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×14.97
shape=(64, 256)  gs=64   col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×14.88
shape=(64, 256)  gs=64   col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.59
shape=(64, 256)  gs=64   col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.63
shape=(64, 256)  gs=128  col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.158 ms  | speed-up ×14.90
shape=(64, 256)  gs=128  col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.10
shape=(64, 256)  gs=128  col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.79
shape=(64, 256)  gs=128  col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.87
shape=(16, 512)  gs=64   col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.157 ms  | speed-up ×14.77
shape=(16, 512)  gs=64   col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.011 ms  | Triton   0.157 ms  | speed-up ×14.86
shape=(16, 512)  gs=64   col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.82
shape=(16, 512)  gs=64   col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.84
shape=(16, 512)  gs=128  col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.06
shape=(16, 512)  gs=128  col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.011 ms  | Triton   0.158 ms  | speed-up ×14.97
shape=(16, 512)  gs=128  col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.80
shape=(16, 512)  gs=128  col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.71
```

Int8

```bash
shape=(32, 128)  gs=64   col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×15.47
shape=(32, 128)  gs=128  col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.87
shape=(64, 256)  gs=64   col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.155 ms  | speed-up ×15.33
shape=(64, 256)  gs=128  col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.155 ms  | speed-up ×15.53
shape=(16, 512)  gs=64   col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×15.57
shape=(16, 512)  gs=128  col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×15.42
```

I don't know which model to test on, please let me know. But basically I think it would give similar e2e performance like fp8 (6% improvement for throughput)