### PR TITLE
[v1][spec decode] Run eagle with full cudagraph support

### DIFF
--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+
 from transformers import AutoTokenizer
 
 from vllm import LLM, SamplingParams
@@ -68,6 +70,7 @@ def parse_args():
     parser.add_argument("--model-dir", type=str, default=None)
     parser.add_argument("--eagle-dir", type=str, default=None)
     parser.add_argument("--custom-mm-prompts", action="store_true")
+    parser.add_argument("--compilation-config", type=str, default="")
     return parser.parse_args()
 
 
@@ -132,6 +135,9 @@ def main():
         max_model_len=16384,
         limit_mm_per_prompt={"image": 5},
         disable_chunked_mm_input=True,
+        compilation_config=(
+            json.loads(args.compilation_config) if args.compilation_config else None
+        ),
     )
 
     sampling_params = SamplingParams(temperature=args.temp, max_tokens=args.output_len)

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -155,12 +155,14 @@ def test_ngram_correctness(
     ])
 @pytest.mark.parametrize("attn_backend",
                          get_attn_backend_list_based_on_platform())
+@pytest.mark.parametrize("full_cuda_graph", [True, False])
 def test_eagle_correctness(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
     model_setup: tuple[str, str, str, int],
     mm_enabled: bool,
     attn_backend: str,
+    full_cuda_graph: bool,
 ):
     # Generate test prompts inside the function instead of using fixture
     test_prompts = get_test_prompts(mm_enabled)
@@ -202,6 +204,7 @@ def test_eagle_correctness(
                 "max_model_len": 2048,
             },
             max_model_len=2048,
+            compilation_config={"full_cuda_graph": full_cuda_graph},
         )
         spec_outputs = spec_llm.chat(test_prompts, sampling_config)
         matches = 0

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from __future__ import annotations
 
+import math
 import random
 from typing import Any, Union
 
@@ -14,6 +15,7 @@ from vllm.assets.base import VLLM_S3_BUCKET_URL
 from vllm.assets.image import VLM_IMAGES_DIR
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.platforms import current_platform
+from vllm.v1.metrics.reader import Counter, Metric, Vector
 
 
 def get_test_prompts(mm_enabled: bool):
@@ -65,6 +67,23 @@ def get_test_prompts(mm_enabled: bool):
         prompts.append([{"role": "user", "content": prompt}])
 
     return prompts
+
+
+def get_acceptance_rate(metrics: list[Metric]):
+    num_drafts = num_accepted = 0
+    acceptance_counts = [0] * 3
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens":
+            assert isinstance(metric, Counter)
+            num_accepted += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                acceptance_counts[pos] += metric.values[pos]
+    return 1.0 * num_accepted / num_drafts + 1
 
 
 @pytest.fixture
@@ -155,14 +174,12 @@ def test_ngram_correctness(
     ])
 @pytest.mark.parametrize("attn_backend",
                          get_attn_backend_list_based_on_platform())
-@pytest.mark.parametrize("full_cuda_graph", [True, False])
 def test_eagle_correctness(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
     model_setup: tuple[str, str, str, int],
     mm_enabled: bool,
     attn_backend: str,
-    full_cuda_graph: bool,
 ):
     # Generate test prompts inside the function instead of using fixture
     test_prompts = get_test_prompts(mm_enabled)
@@ -204,7 +221,6 @@ def test_eagle_correctness(
                 "max_model_len": 2048,
             },
             max_model_len=2048,
-            compilation_config={"full_cuda_graph": full_cuda_graph},
         )
         spec_outputs = spec_llm.chat(test_prompts, sampling_config)
         matches = 0
@@ -221,5 +237,95 @@ def test_eagle_correctness(
         # Upon failure, inspect the outputs to check for inaccuracy.
         assert matches > int(0.66 * len(ref_outputs))
         del spec_llm
+        torch.cuda.empty_cache()
+        cleanup_dist_env_and_memory()
+
+
+@pytest.mark.parametrize(
+    "model_setup",
+    [
+        ("eagle", "meta-llama/Llama-3.1-8B-Instruct",
+         "yuhuili/EAGLE-LLaMA3.1-Instruct-8B", 1),
+    ],
+)
+def test_full_vs_piecewise_cudagraph(
+    monkeypatch: pytest.MonkeyPatch,
+    sampling_config: SamplingParams,
+    model_setup: tuple[str, str, str, int],
+):
+    test_prompts = get_test_prompts(mm_enabled=False)
+    '''
+    Compare the eagle speculative decoding outputs and acceptance
+    rate should match between piecewise and full cudagraph mode
+    model_setup: (method, model_name, eagle_model_name, tp_size)
+    '''
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+        m.setenv("VLLM_GPU_MEMORY_UTILIZATION", "0.8")
+        if current_platform.is_rocm():
+            m.setenv("VLLM_ROCM_USE_AITER", "1")
+
+        method, model_name, spec_model_name, tp_size = model_setup
+
+        spec_llm_piecewise_cudagraph = LLM(
+            model=model_name,
+            trust_remote_code=True,
+            tensor_parallel_size=tp_size,
+            speculative_config={
+                "method": method,
+                "model": spec_model_name,
+                "num_speculative_tokens": 3,
+                "max_model_len": 2048,
+            },
+            max_model_len=2048,
+            compilation_config={"full_cuda_graph": False},
+            disable_log_stats=False,
+        )
+        piecewise_cudagraph_outputs = spec_llm_piecewise_cudagraph.chat(
+            test_prompts, sampling_config)
+        piecewise_cudagraph_metrics = spec_llm_piecewise_cudagraph.get_metrics(
+        )
+        del spec_llm_piecewise_cudagraph
+        torch.cuda.empty_cache()
+        cleanup_dist_env_and_memory()
+
+        spec_llm_full_cudagraph = LLM(
+            model=model_name,
+            trust_remote_code=True,
+            tensor_parallel_size=tp_size,
+            speculative_config={
+                "method": method,
+                "model": spec_model_name,
+                "num_speculative_tokens": 3,
+                "max_model_len": 2048,
+            },
+            max_model_len=2048,
+            compilation_config={"full_cuda_graph": True},
+            disable_log_stats=False,
+        )
+        full_cudagraph_outputs = spec_llm_full_cudagraph.chat(
+            test_prompts, sampling_config)
+        full_cudagraph_metrics = spec_llm_full_cudagraph.get_metrics()
+        matches = 0
+        misses = 0
+        for piecewise, full in zip(piecewise_cudagraph_outputs,
+                                   full_cudagraph_outputs):
+            if piecewise.outputs[0].text == full.outputs[0].text:
+                matches += 1
+            else:
+                misses += 1
+                print(
+                    f"piecewise_cudagraph_output: {piecewise.outputs[0].text}")
+                print(f"full_cudagraph_output: {full.outputs[0].text}")
+
+        # Heuristic: expect at least 66% of the prompts to match exactly between
+        # piecewise and full cudagraph mode, and acceptance rate to be within
+        # 0.1 atol
+        # Upon failure, inspect the outputs to check for inaccuracy.
+        assert matches > int(0.66 * len(piecewise_cudagraph_outputs))
+        piecewise_acceptance = get_acceptance_rate(piecewise_cudagraph_metrics)
+        full_acceptance = get_acceptance_rate(full_cudagraph_metrics)
+        assert math.isclose(piecewise_acceptance, full_acceptance, abs_tol=0.1)
+        del spec_llm_full_cudagraph
         torch.cuda.empty_cache()
         cleanup_dist_env_and_memory()

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -264,6 +264,8 @@ def test_full_vs_piecewise_cudagraph(
         m.setenv("VLLM_GPU_MEMORY_UTILIZATION", "0.8")
         if current_platform.is_rocm():
             m.setenv("VLLM_ROCM_USE_AITER", "1")
+        else:
+            m.setenv("VLLM_FLASH_ATTN_VERSION", "3")
 
         method, model_name, spec_model_name, tp_size = model_setup
 

--- a/vllm/v1/attention/backends/tree_attn.py
+++ b/vllm/v1/attention/backends/tree_attn.py
@@ -228,6 +228,7 @@ class TreeAttentionMetadataBuilder(
         self,
         common_attn_metadata: CommonAttentionMetadata,
         draft_index: int,
+        fast_build: bool = True,
     ) -> TreeAttentionMetadata:
         # Cache the original tree attention bias.
         orig_tree_attn_bias = self.tree_attn_bias
@@ -243,7 +244,9 @@ class TreeAttentionMetadataBuilder(
                                                       start:end].contiguous()
 
         # Build attention bias.
-        attn_metadata = self.build(0, common_attn_metadata, fast_build=True)
+        attn_metadata = self.build(0,
+                                   common_attn_metadata,
+                                   fast_build=fast_build)
 
         # Reset the tree attention bias to the original value.
         self.tree_attn_bias = orig_tree_attn_bias

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -36,7 +36,7 @@ class CommonAttentionMetadata:
     """
     Per-batch attention metadata, shared across layers and backends.
     AttentionMetadataBuilder instances use it to construct per-layer metadata.
-    
+
     For many of the tensors we keep both GPU and CPU versions.
     """
 
@@ -76,7 +76,7 @@ def slice_query_start_locs(
     request_slice: slice,
 ) -> torch.Tensor:
     """
-    Creates a new query_start_loc that corresponds to the requests in 
+    Creates a new query_start_loc that corresponds to the requests in
     request_slice.
 
     Note: This function creates a new tensor to hold the new query_start_locs.
@@ -90,7 +90,7 @@ def _make_metadata_with_slice(
         ubatch_slice: UbatchSlice,
         attn_metadata: CommonAttentionMetadata) -> CommonAttentionMetadata:
     """
-    This function creates a new CommonAttentionMetadata that corresponds to 
+    This function creates a new CommonAttentionMetadata that corresponds to
     the requests included in ubatch_slice
     """
 
@@ -138,7 +138,7 @@ def split_attn_metadata(
     common_attn_metadata: CommonAttentionMetadata,
 ) -> list[CommonAttentionMetadata]:
     """
-    Creates a new CommonAttentionMetadata instance that corresponds to the 
+    Creates a new CommonAttentionMetadata instance that corresponds to the
     requests for each UbatchSlice in ubatch_slices.
 
     Note: This function does not modify common_attn_metadata
@@ -189,7 +189,7 @@ class AttentionMetadataBuilder(abc.ABC, Generic[M]):
         """
         Central method that builds attention metadata.
         Some builders (MLA) require reorder_batch to be called prior to build.
-        
+
         Args:
             common_prefix_len: The length of the common prefix of the batch.
             common_attn_metadata: The common attention metadata.
@@ -220,10 +220,11 @@ class AttentionMetadataBuilder(abc.ABC, Generic[M]):
         self,
         common_attn_metadata: CommonAttentionMetadata,
         draft_index: int,
+        fast_build: bool = True,
     ) -> M:
         """
         Build attention metadata for draft model. Uses build by default.
-        
+
         Args:
             common_attn_metadata: The common attention metadata.
             draft_index: The index of the current draft operation.
@@ -234,7 +235,7 @@ class AttentionMetadataBuilder(abc.ABC, Generic[M]):
         """
         return self.build(common_prefix_len=0,
                           common_attn_metadata=common_attn_metadata,
-                          fast_build=True)
+                          fast_build=fast_build)
 
     def use_cascade_attention(
         self,
@@ -629,7 +630,7 @@ def reorder_batch_to_split_decodes_and_prefills(
     """
     Reorders the batch to split into prefill and decode requests; places all
     requests with <= decode_threshold tokens at the front of the batch.
-    
+
     Returns:
         True if the batch was modified, False otherwise.
     """

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -159,10 +159,10 @@ class EagleProposer:
         assert self.runner is not None
 
         # FIXME: need to consider multiple kv_cache_groups
-        attn_metadata = self.runner.attn_metadata_builders[
-            0].build_for_drafting(common_attn_metadata=common_attn_metadata,
-                                  draft_index=0,
-                                  fast_build=not self.use_full_cuda_graph)
+        attn_metadata = self.runner.attn_groups[0][0].metadata_builder\
+            .build_for_drafting(common_attn_metadata=common_attn_metadata,
+                                draft_index=0,
+                                fast_build=not self.use_full_cuda_graph)
 
         # At this moment, we assume all eagle layers belong to the same KV
         # cache group, thus using the same attention metadata.

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -159,9 +159,10 @@ class EagleProposer:
         assert self.runner is not None
 
         # FIXME: need to consider multiple kv_cache_groups
-        attn_metadata = self.runner.attn_groups[0][0].metadata_builder\
-            .build_for_drafting(common_attn_metadata=common_attn_metadata,
-                                draft_index=0)
+        attn_metadata = self.runner.attn_metadata_builders[
+            0].build_for_drafting(common_attn_metadata=common_attn_metadata,
+                                  draft_index=0,
+                                  fast_build=not self.use_full_cuda_graph)
 
         # At this moment, we assume all eagle layers belong to the same KV
         # cache group, thus using the same attention metadata.

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -335,6 +335,8 @@ class EagleProposer:
                                                                      .
                                                                      query_start_loc
                                                                  )
+                    self.attn_metadata_cudagraph.block_table[:batch_size] = (
+                        attn_metadata.block_table)
 
             # Run the model.
             with set_forward_context(per_layer_attn_metadata,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2320,7 +2320,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             if self.speculative_config and self.speculative_config.use_eagle():
                 assert isinstance(self.drafter, EagleProposer)
-                self.drafter.dummy_run(num_tokens)
+                self.drafter.dummy_run(num_tokens, attn_metadata)
 
         # This is necessary to avoid blocking DP.
         # For dummy runs, we typically skip EPLB since we don't have any real


### PR DESCRIPTION
## Purpose
Support running eagle speculative decoding draft model in full cudagraph mode for v1 (referencing https://github.com/vllm-project/vllm/pull/16072). On H100 TP1 with Llama3.1 8B model, the full cudagraph version shows on par (or marginal improvement) on performance.

- trace with piecewise cudagraph
<img width="1582" height="912" alt="Screenshot 2025-07-23 at 2 11 23 PM" src="https://github.com/user-attachments/assets/b03897dc-640a-42e8-b78a-42788247a2cd" />
- benchmark with piecewise cudagraph (1 * H100, Llama3.1 8B, max bs = 2, acceptance rate = 0)

```
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  135.05    
Total input tokens:                      9568      
Total generated tokens:                  21269     
Request throughput (req/s):              0.74      
Output token throughput (tok/s):         157.49    
Total Token throughput (tok/s):          228.33    
---------------Time to First Token----------------
Mean TTFT (ms):                          27.53     
Median TTFT (ms):                        24.96     
P99 TTFT (ms):                           46.25     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.47     
Median TPOT (ms):                        12.40     
P99 TPOT (ms):                           13.37     
---------------Inter-token Latency----------------
Mean ITL (ms):                           12.47     
Median ITL (ms):                         12.37     
P99 ITL (ms):                            13.71     
==================================================
```

- trace with full cudagraph
<img width="1572" height="851" alt="Screenshot 2025-07-23 at 1 56 36 PM" src="https://github.com/user-attachments/assets/a90aaa96-f26d-44a6-b2b7-1063c9e62144" />
- benchmark with piecewise cudagraph (1 * H100, Llama3.1 8B, max bs = 2, acceptance rate = 0)

```
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  132.64    
Total input tokens:                      9568      
Total generated tokens:                  21087     
Request throughput (req/s):              0.75      
Output token throughput (tok/s):         158.97    
Total Token throughput (tok/s):          231.11    
---------------Time to First Token----------------
Mean TTFT (ms):                          27.23     
Median TTFT (ms):                        24.89     
P99 TTFT (ms):                           45.50     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.39     
Median TPOT (ms):                        12.30     
P99 TPOT (ms):                           13.36     
---------------Inter-token Latency----------------
Mean ITL (ms):                           12.39     
Median ITL (ms):                         12.26     
P99 ITL (ms):                            13.80     
==================================================
```

## Test Plan & Result
- Acceptance rate comparison between full and piecewise cudagraph:
> VLLM_USE_V1=1 python examples/offline_inference/spec_decode.py --num_spec_tokens 5 --num_prompts 80 --dataset-name hf --dataset-path philschmid/mt-bench --compilation_config '{"full_cuda_graph": false}'

```
--------------------------------------------------
total_num_output_tokens: 17059
num_drafts: 6988
num_draft_tokens: 34940
num_accepted_tokens: 10091
mean acceptance length: 2.44
--------------------------------------------------
acceptance at token 0: 0.68
acceptance at token 1: 0.39
acceptance at token 2: 0.21
acceptance at token 3: 0.11
acceptance at token 4: 0.05
```

> VLLM_USE_V1=1 python examples/offline_inference/spec_decode.py --num_spec_tokens 5 --num_prompts 80 --dataset-name hf --dataset-path philschmid/mt-bench --compilation_config '{"full_cuda_graph": true}'

```
--------------------------------------------------
total_num_output_tokens: 17006
num_drafts: 6986
num_draft_tokens: 34930
num_accepted_tokens: 10038
mean acceptance length: 2.44
--------------------------------------------------
acceptance at token 0: 0.68
acceptance at token 1: 0.39
acceptance at token 2: 0.21
acceptance at token 3: 0.11
acceptance at token 4: 0.05
```

- unit test with full cudagraph {True, False}
> pytest -v tests/v1/e2e/test_spec_decode.py::test_eagle_correctness

```
tests/v1/e2e/test_spec_decode.py::test_eagle_correctness[True-llama3_eagle] PASSED                                                                                                                                            [ 16%]
tests/v1/e2e/test_spec_decode.py::test_eagle_correctness[True-llama3_eagle3] PASSED                                                                                                                                           [ 33%]
tests/v1/e2e/test_spec_decode.py::test_eagle_correctness[True-llama4_eagle] SKIPPED (Skipping due to CI OOM issues)                                                                                                           [ 50%]
tests/v1/e2e/test_spec_decode.py::test_eagle_correctness[False-llama3_eagle] PASSED                                                                                                                                           [ 66%]
tests/v1/e2e/test_spec_decode.py::test_eagle_correctness[False-llama3_eagle3] PASSED                                                                                                                                          [ 83%]
tests/v1/e2e/test_spec_decode.py::test_eagle_correctness[False-llama4_eagle] SKIPPED (Skipping due to CI OOM issues)                                                                                                          [100%]

```

### Side Note
In previous draft PR (https://github.com/vllm-project/vllm/pull/20190#discussion_r2211819901) a numerical difference between full and piecewise cudagraph mode was identified, @zou3519 helped identified the root cause to be rms_norm kernel selected by inductor having slightly better numerics than eager version (https://github.com/pytorch/pytorch/issues/158699) which is expected behavior.


<!--- pyml disable-next-line no-emphasis-as-heading -->
