### PR TITLE
Add interleaved RoPE test for Llama4 (Maverick)

### DIFF
--- a/tests/models/multimodal/generation/test_maverick.py
+++ b/tests/models/multimodal/generation/test_maverick.py
@@ -582,6 +582,7 @@ def test_dummy_maverick(
     force_recreate: bool = True,
     profile: bool = False,
 ) -> None:
+    # Disable multiprocessing allows us to access model executor from LLM engine
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 
     model_path, rope_layers = create_reduced_maverick_model(

--- a/tests/models/multimodal/generation/test_maverick.py
+++ b/tests/models/multimodal/generation/test_maverick.py
@@ -583,6 +583,7 @@ def test_dummy_maverick(
     profile: bool = False,
 ) -> None:
     # Disable multiprocessing allows us to access model executor from LLM engine
+    monkeypatch.setenv("VLLM_USE_V1", "1")
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 
     model_path, rope_layers = create_reduced_maverick_model(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Recent Llama4 interleaved RoPE (iRoPE) bug (#21419) shows that we need a unit test to check that iROPE is instantiated correctly for Llama4 family of models.

This PR adds a unit test for this. Once #21324 is merged, this will run in CI.

## Test Plan
```
pytest tests/models/multimodal/generation/test_maverick.py::test_dummy_maverick -s
```

## Test Result

Without #21419:
```
            assert len(kv_cache_specs.keys()) == num_attention_layers
            for i in range(num_attention_layers):
                if rope_layers[i] == 0:
                    expected_spec = FullAttentionSpec
                else:
                    expected_spec = ChunkedLocalAttentionSpec
E                   AssertionError: assert False
E                    +  where False = isinstance(FullAttentionSpec(block_size=16, num_kv_heads=4, head_size=32, dtype=torch.bfloat16, use_mla=False, sliding_window=None, attention_chunk_size=None), <class 'vllm.v1.kv_cache_interface.ChunkedLocalAttentionSpec'>)

tests/models/multimodal/generation/test_maverick.py:536: AssertionError
```

With iROPE (#21419) fix, test passes:
```
2 passed, 6 warnings in 162.68s (0:02:42)
```
