### PR TITLE
[Model] Fix a check for None but the return value was empty list in Gemma3 MM vision_embeddings

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -627,7 +627,7 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
 
             inputs_embeds = self.get_input_embeddings(input_ids,
                                                       vision_embeddings)
-            if vision_embeddings is not None:
+            if (vision_embeddings is not None) and len(vision_embeddings) != 0:
                 kwargs = self.prepare_attn_masks(
                     input_ids,
                     positions,


### PR DESCRIPTION
## Purpose

No functional change.

It is best practice to check properly for empty list if the value can be an empty list.

Also in tpu_commons when we try to trace the graph without MM inputs, this check fails and causes the graph for text-only input still tries to trace the MM code path.

## Test Plan

Existing CI should still pass

## Test Result

