### PR TITLE
Delete useless allgather in qwen2_5_vl vit attention

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -196,25 +196,6 @@ class Qwen2_5_VisionMLP(nn.Module):
         return x_down
 
 
-def all_gather_interleave(local_tensor, hidden_size: int, tp_size: int):
-    """All-gather the input tensor interleavely across model parallel group."""
-    import torch.distributed as dist
-    gathered_tensors = [torch.zeros_like(local_tensor) for _ in range(tp_size)]
-    dist.all_gather(gathered_tensors,
-                    local_tensor,
-                    group=parallel_state.get_tp_group().device_group)
-
-    gathered_tensors_split = [
-        torch.split(tensor, hidden_size // tp_size, -1)
-        for tensor in gathered_tensors
-    ]
-    ordered_tensors = [
-        tensor for pair in zip(*gathered_tensors_split) for tensor in pair
-    ]
-    result_tensor = torch.cat(ordered_tensors, dim=-1)
-    return result_tensor
-
-
 class Qwen2_5_VisionAttention(nn.Module):
 
     def __init__(
@@ -259,20 +240,9 @@ class Qwen2_5_VisionAttention(nn.Module):
     def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
         # [s, b, 3 * head * head_dim]
         seq_len, bs, _ = qkv.shape
-        if self.tp_size > 1:
-            qkv = all_gather_interleave(qkv, self.qkv.hidden_size,
-                                        self.tp_size)
 
         # [s, b, 3 * head * head_dim] -> 3 * [s, b, head * head_dim]
         q, k, v = qkv.chunk(3, dim=2)
-
-        # 3 * [s, b, head * head_dim]
-        if self.tp_size > 1:
-            splitter = partial(dist_utils.split_tensor_along_last_dim,
-                               num_partitions=self.tp_size)
-            q = splitter(q)[self.tp_rank]
-            k = splitter(k)[self.tp_rank]
-            v = splitter(v)[self.tp_rank]
 
         # 3 * [s, b, head * head_dim] -> 3 * [s, b, head, head_dim]
         new_shape = (seq_len, bs, self.num_attention_heads_per_partition,


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
The allgator+split_tensor-alond_last-dim operation after qkv fusion calculation can be optimized to split according to the last dimension. Redundant communication can be removed to improve inference performance.

## Test Plan
vllm serve --model=/home/jenkins/Qwen2.5-VL-3B-Instruct/ --trust_remote_code --tensor_parallel_size=8 --max_model_len=32768 --max-num-seqs 64



## Test Result

1080P picture，parallel-num=64  output-tokens=256，verify the tokens throughput

before optimization
<img width="2164" height="58" alt="image" src="https://github.com/user-attachments/assets/261585ca-72b4-439d-8738-53a1df433716" />

<img width="948" height="207" alt="image" src="https://github.com/user-attachments/assets/45a353cc-889e-4728-8044-bf4827b5438c" />


after optimization
<img width="2159" height="55" alt="image" src="https://github.com/user-attachments/assets/e8c24418-78c6-4b79-b28d-a81dbdfe4c1f" />

<img width="927" height="208" alt="image" src="https://github.com/user-attachments/assets/470b66a8-7803-42e7-9bdf-8ef84469dd23" />


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
