### PR TITLE
[Model] Support tensor parallel for timm ViT in Deepseek_vl2

### DIFF
--- a/vllm/model_executor/models/deepseek_vl2.py
+++ b/vllm/model_executor/models/deepseek_vl2.py
@@ -17,8 +17,8 @@ from vllm.config import VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.quantization import QuantizationConfig
-from vllm.model_executor.models.transformers import replace_linear_class
 from vllm.model_executor.model_loader.utils import set_default_torch_dtype
+from vllm.model_executor.models.transformers import replace_linear_class
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (MultiModalDataDict, MultiModalFieldConfig,
                                     MultiModalKwargs, NestedTensors)
@@ -390,7 +390,8 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         return parent, names[-1]
 
     #patch for timm ViT instance to support tensor parallel
-    def patch_vit_for_tp(self, vit: torch.nn.Module, quant_config: QuantizationConfig):
+    def patch_vit_for_tp(self, vit: torch.nn.Module,
+                         quant_config: QuantizationConfig):
         try:
             import timm
         except ImportError as e:
@@ -399,12 +400,14 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         for name, module in vit.named_modules():
             if isinstance(module, nn.Linear):
                 parent, attr_name = self._get_parent_and_attr(vit, name)
-                if isinstance(parent, timm.layers.Mlp) and attr_name == "fc1":         
-                    new_linear = replace_linear_class(module, "colwise", quant_config)
+                if isinstance(parent, timm.layers.Mlp) and attr_name == "fc1":
+                    new_linear = replace_linear_class(module, "colwise",
+                                                      quant_config)
                     setattr(parent, attr_name, new_linear)
-                elif isinstance(parent, 
-                                timm.layers.Mlp) and attr_name == "fc2": 
-                    new_linear = replace_linear_class(module, "rowwise", quant_config)
+                elif isinstance(parent,
+                                timm.layers.Mlp) and attr_name == "fc2":
+                    new_linear = replace_linear_class(module, "rowwise",
+                                                      quant_config)
                     setattr(parent, attr_name, new_linear)
 
         return vit
@@ -431,7 +434,7 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
             )
         
         if get_tensor_model_parallel_world_size() > 1:
-            model = self.patch_vit_for_tp(model,quant_config)
+            model = self.patch_vit_for_tp(model, quant_config)
 
         model = model.to(dtype=torch.get_default_dtype())
         return model

--- a/vllm/model_executor/models/deepseek_vl2.py
+++ b/vllm/model_executor/models/deepseek_vl2.py
@@ -380,7 +380,7 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors)
-    
+
     def _get_parent_and_attr(self, root: torch.nn.Module, dotted_name: str):
         """Return (parent_module, final_attr_name) for a dotted module path."""
         names = dotted_name.split('.')
@@ -396,7 +396,7 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
             import timm
         except ImportError as e:
             raise ImportError("Please install timm") from e
-            
+
         for name, module in vit.named_modules():
             if isinstance(module, nn.Linear):
                 parent, attr_name = self._get_parent_and_attr(vit, name)
@@ -432,7 +432,7 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
                 dynamic_img_size=True,
                 dynamic_img_pad=True,
             )
-        
+
         if get_tensor_model_parallel_world_size() > 1:
             model = self.patch_vit_for_tp(model, quant_config)
 


### PR DESCRIPTION
## Support tensor parallel for timm ViT
- [x] Wrap external ViT from timm library to support tensor parallel
- [x] Apply tensor parallel to mlp blocks
- [ ] Apply tensor parallel to attention blocks

## Purpose
The vision transformer from timm library does not support tensor parallel and has bad performance. Currently minicpmv2_0 and deepseek_vl2 are the only two models using timm ViT, but minicpmv2_6 has changed to idefics ViT. The purpose of this pr is to enhance performance of the ViT in deepseekvl2 without changing the model structure.



