### PR TITLE
[Bugfix] Fix retrieve_process not ending normally and resources not being released properly

### DIFF
--- a/examples/others/lmcache/kv_cache_sharing_lmcache_v1.py
+++ b/examples/others/lmcache/kv_cache_sharing_lmcache_v1.py
@@ -124,7 +124,7 @@ def main():
 
     # Clean up the processes
     store_process.join()
-    retrieve_process.terminate()
+    retrieve_process.join()
     lmcache_server_process.terminate()
     lmcache_server_process.wait()
 

--- a/examples/others/lmcache/kv_cache_sharing_lmcache_v1.py
+++ b/examples/others/lmcache/kv_cache_sharing_lmcache_v1.py
@@ -91,7 +91,7 @@ def run_retrieve(store_done, prompts, timeout=1):
     )
 
     print("Waiting for KV cache store to finish...")
-    store_done.wait()
+    store_done.wait(timeout=60)
     time.sleep(timeout)
 
     outputs = llm.generate(prompts, sampling_params)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
### Bug Description
In `kv_cache_sharing_lmcache_v1.py`, `retrieve_process` sometimes terminates unexpectedly without releasing the resources. This is because when `store_process` terminates normally, the main function executes  `retrieve_process.terminate()` immediately.

### Solution
Change `retrieve_process.terminate()` to `retrieve_process.join()`, to wait `retrieve_process` to finish as expected.

## Test Plan
1. Change the parameter `timeout` in run_retrieve function to be 5. (Increase the execution time of `retrieve_process`)
2. Change the model path to local model path. (`~/models/Mistral-7B-Instruct-v0.3`)
3. Run the command `python kv_cache_sharing_lmcache_v1.py` in the terminal.
4. Check the logs and `nvidia-smi` output.

## Test Result
### Partial logs before bug fix
```
[2025-07-24 05:54:04,217] LMCache INFO: LMCache Configuration: {'chunk_size': 256, 'cufile_buffer_size': 0, 'local_cpu': False, 'max_local_cpu_size': '5.0 GB', 'local_disk': None, 'max_local_disk_size': '0.0 GB', 'remote_url': 'lm://localhost:8100', 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'enable_blending': False, 'blend_recompute_ratio': 0.15, 'blend_min_tokens': 256, 'enable_p2p': False, 'lookup_url': None, 'distributed_url': None, 'error_handling': False, 'enable_controller': False, 'lmcache_instance_id': 'lmcache_default_instance', 'pre_caching_hash_algorithm': 'builtin', 'enable_nixl': False, 'nixl_role': None, 'nixl_receiver_host': None, 'nixl_receiver_port': 0, 'nixl_buffer_size': 0, 'nixl_buffer_device': None, 'nixl_enable_gc': False, 'enable_xpyd': False, 'nixl_peer_host': None, 'nixl_peer_init_port': None, 'nixl_peer_alloc_port': None, 'nixl_proxy_host': None, 'nixl_proxy_port': 0, 'weka_path': None, 'gds_path': None, 'extra_config': None, 'save_unfull_chunk': True, 'blocking_timeout_secs': 10, 'external_lookup_client': None} (config.py:774:lmcache.v1.config)
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 26.75it/s]
Processed prompts:   0%|                             | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s][2025-07-24 05:54:04,304] LMCache INFO: Reqid: 0, Total tokens 6001, LMCache hit tokens: 0, need to load: 0 (vllm_v1_adapter.py:813:lmcache.integration.vllm.vllm_v1_adapter)
[2025-07-24 05:54:04,315] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:160:lmcache.v1.cache_engine)
INFO 07-24 05:54:05 [gpu_model_runner.py:1782] Model loading took 13.5084 GiB and 6.474449 seconds
[2025-07-24 05:54:05,415] LMCache INFO: Storing KV cache for 6001 out of 6001 tokens (skip_leading_tokens=0) for request 0 (vllm_v1_adapter.py:719:lmcache.integration.vllm.vllm_v1_adapter)
[2025-07-24 05:54:05,524] LMCache INFO: Stored 6001 out of total 6001 tokens. size: 0.7325 gb, cost 108.0674 ms, throughput: 6.7786 GB/s; offload_time: 106.9039 ms, put_time: 1.1635 ms (cache_engine.py:263:lmcache.v1.cache_engine)
[2025-07-24 05:54:05,747] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:456:lmcache.integration.vllm.vllm_v1_adapter)
Processed prompts: 100%|██████████████████| 1/1 [00:01<00:00,  1.47s/it, est. speed input: 4073.13 toks/s, output: 6.79 toks/s]
Generated text: 'Hello, how are you?Hello, how are'
KV cache store is finished.
INFO 07-24 05:54:07 [gpu_worker.py:233] Available KV cache memory: 17.11 GiB
INFO 07-24 05:54:07 [kv_cache_utils.py:716] GPU KV cache size: 140,144 tokens
INFO 07-24 05:54:07 [kv_cache_utils.py:720] Maximum concurrency for 8,000 tokens per request: 17.52x
INFO 07-24 05:54:07 [core.py:172] init engine (profile, create kv cache, warmup model) took 2.59 seconds
INFO 07-24 05:54:08 [factory.py:74] Creating v1 connector with name: LMCacheConnectorV1 and engine_id: 7de84a77-0ada-4dbd-8a0b-74c5b5961d1c
WARNING 07-24 05:54:08 [base.py:71] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
[2025-07-24 05:54:08,374] LMCache WARNING: No LMCache configuration file is set. Trying to read configurations from the environment variables. (utils.py:59:lmcache.integration.vllm.utils)
[2025-07-24 05:54:08,374] LMCache WARNING: You can set the configuration file through the environment variable: LMCACHE_CONFIG_FILE (utils.py:63:lmcache.integration.vllm.utils)
[2025-07-24 05:54:08,375] LMCache INFO: LMCache Configuration: {'chunk_size': 256, 'cufile_buffer_size': 0, 'local_cpu': False, 'max_local_cpu_size': '5.0 GB', 'local_disk': None, 'max_local_disk_size': '0.0 GB', 'remote_url': 'lm://localhost:8100', 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'enable_blending': False, 'blend_recompute_ratio': 0.15, 'blend_min_tokens': 256, 'enable_p2p': False, 'lookup_url': None, 'distributed_url': None, 'error_handling': False, 'enable_controller': False, 'lmcache_instance_id': 'lmcache_default_instance', 'pre_caching_hash_algorithm': 'builtin', 'enable_nixl': False, 'nixl_role': None, 'nixl_receiver_host': None, 'nixl_receiver_port': 0, 'nixl_buffer_size': 0, 'nixl_buffer_device': None, 'nixl_enable_gc': False, 'enable_xpyd': False, 'nixl_peer_host': None, 'nixl_peer_init_port': None, 'nixl_peer_alloc_port': None, 'nixl_proxy_host': None, 'nixl_proxy_port': 0, 'weka_path': None, 'gds_path': None, 'extra_config': None, 'save_unfull_chunk': True, 'blocking_timeout_secs': 10, 'external_lookup_client': None} (config.py:774:lmcache.v1.config)
[2025-07-24 05:54:08,375] LMCache WARNING: No LMCache configuration file is set. Trying to read configurations from the environment variables. (utils.py:59:lmcache.integration.vllm.utils)
[2025-07-24 05:54:08,375] LMCache WARNING: You can set the configuration file through the environment variable: LMCACHE_CONFIG_FILE (utils.py:63:lmcache.integration.vllm.utils)
[2025-07-24 05:54:08,375] LMCache INFO: LMCache Configuration: {'chunk_size': 256, 'cufile_buffer_size': 0, 'local_cpu': False, 'max_local_cpu_size': '5.0 GB', 'local_disk': None, 'max_local_disk_size': '0.0 GB', 'remote_url': 'lm://localhost:8100', 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'enable_blending': False, 'blend_recompute_ratio': 0.15, 'blend_min_tokens': 256, 'enable_p2p': False, 'lookup_url': None, 'distributed_url': None, 'error_handling': False, 'enable_controller': False, 'lmcache_instance_id': 'lmcache_default_instance', 'pre_caching_hash_algorithm': 'builtin', 'enable_nixl': False, 'nixl_role': None, 'nixl_receiver_host': None, 'nixl_receiver_port': 0, 'nixl_buffer_size': 0, 'nixl_buffer_device': None, 'nixl_enable_gc': False, 'enable_xpyd': False, 'nixl_peer_host': None, 'nixl_peer_init_port': None, 'nixl_peer_alloc_port': None, 'nixl_proxy_host': None, 'nixl_proxy_port': 0, 'weka_path': None, 'gds_path': None, 'extra_config': None, 'save_unfull_chunk': True, 'blocking_timeout_secs': 10, 'external_lookup_client': None} (config.py:774:lmcache.v1.config)
Waiting for KV cache store to finish...
[2025-07-24 05:54:10,829] LMCache INFO: Client disconnected (__main__.py:142:__main__)
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 24.25it/s]
Processed prompts:   0%|                             | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s][2025-07-24 05:54:13,452] LMCache INFO: Reqid: 0, Total tokens 6001, LMCache hit tokens: 6001, need to load: 6000 (vllm_v1_adapter.py:813:lmcache.integration.vllm.vllm_v1_adapter)
[2025-07-24 05:54:13,458] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:160:lmcache.v1.cache_engine)
[2025-07-24 05:54:13,879] LMCache INFO: Retrieved 6001 out of 6001 out of total 6001 tokens (cache_engine.py:512:lmcache.v1.cache_engine)
[2025-07-24 05:54:14,134] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:456:lmcache.integration.vllm.vllm_v1_adapter)
```
We can see that `retrieve_process` does not process the prompts successfully, and terminate unexpectedly.

### nvidia-smi output before bug fix
<img width="646" height="628" alt="image" src="https://github.com/user-attachments/assets/b7f122c9-6014-4f3c-ad17-71b422bc9922" />

We can see from the figure that the resources are not released.

### Partial logs after bug fix
```
Adding requests: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 43.99it/s]
Processed prompts:   0%|                                                                                                          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s][2025-07-24 06:06:52,488] LMCache INFO: Reqid: 0, Total tokens 6001, LMCache hit tokens: 0, need to load: 0 (vllm_v1_adapter.py:813:lmcache.integration.vllm.vllm_v1_adapter)
[2025-07-24 06:06:52,496] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:160:lmcache.v1.cache_engine)
[2025-07-24 06:06:53,668] LMCache INFO: Storing KV cache for 6001 out of 6001 tokens (skip_leading_tokens=0) for request 0 (vllm_v1_adapter.py:719:lmcache.integration.vllm.vllm_v1_adapter)
[2025-07-24 06:06:53,778] LMCache INFO: Stored 6001 out of total 6001 tokens. size: 0.7325 gb, cost 109.1049 ms, throughput: 6.7141 GB/s; offload_time: 107.9503 ms, put_time: 1.1547 ms (cache_engine.py:263:lmcache.v1.cache_engine)
[2025-07-24 06:06:54,088] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:456:lmcache.integration.vllm.vllm_v1_adapter)
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.61s/it, est. speed input: 3734.63 toks/s, output: 6.22 toks/s]
Generated text: 'Hello, how are you?Hello, how are'
KV cache store is finished.
INFO 07-24 06:06:55 [gpu_worker.py:233] Available KV cache memory: 17.11 GiB
INFO 07-24 06:06:55 [kv_cache_utils.py:716] GPU KV cache size: 140,144 tokens
INFO 07-24 06:06:55 [kv_cache_utils.py:720] Maximum concurrency for 8,000 tokens per request: 17.52x
INFO 07-24 06:06:55 [core.py:172] init engine (profile, create kv cache, warmup model) took 4.07 seconds
INFO 07-24 06:06:56 [factory.py:74] Creating v1 connector with name: LMCacheConnectorV1 and engine_id: ea7cbfd6-45dc-4a4a-a81e-22391ef3ea05
WARNING 07-24 06:06:56 [base.py:71] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
[2025-07-24 06:06:56,242] LMCache WARNING: No LMCache configuration file is set. Trying to read configurations from the environment variables. (utils.py:59:lmcache.integration.vllm.utils)
[2025-07-24 06:06:56,242] LMCache WARNING: You can set the configuration file through the environment variable: LMCACHE_CONFIG_FILE (utils.py:63:lmcache.integration.vllm.utils)
[2025-07-24 06:06:56,242] LMCache INFO: LMCache Configuration: {'chunk_size': 256, 'cufile_buffer_size': 0, 'local_cpu': False, 'max_local_cpu_size': '5.0 GB', 'local_disk': None, 'max_local_disk_size': '0.0 GB', 'remote_url': 'lm://localhost:8101', 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'enable_blending': False, 'blend_recompute_ratio': 0.15, 'blend_min_tokens': 256, 'enable_p2p': False, 'lookup_url': None, 'distributed_url': None, 'error_handling': False, 'enable_controller': False, 'lmcache_instance_id': 'lmcache_default_instance', 'pre_caching_hash_algorithm': 'builtin', 'enable_nixl': False, 'nixl_role': None, 'nixl_receiver_host': None, 'nixl_receiver_port': 0, 'nixl_buffer_size': 0, 'nixl_buffer_device': None, 'nixl_enable_gc': False, 'enable_xpyd': False, 'nixl_peer_host': None, 'nixl_peer_init_port': None, 'nixl_peer_alloc_port': None, 'nixl_proxy_host': None, 'nixl_proxy_port': 0, 'weka_path': None, 'gds_path': None, 'extra_config': None, 'save_unfull_chunk': True, 'blocking_timeout_secs': 10, 'external_lookup_client': None} (config.py:774:lmcache.v1.config)
[2025-07-24 06:06:56,242] LMCache WARNING: No LMCache configuration file is set. Trying to read configurations from the environment variables. (utils.py:59:lmcache.integration.vllm.utils)
[2025-07-24 06:06:56,242] LMCache WARNING: You can set the configuration file through the environment variable: LMCACHE_CONFIG_FILE (utils.py:63:lmcache.integration.vllm.utils)
[2025-07-24 06:06:56,242] LMCache INFO: LMCache Configuration: {'chunk_size': 256, 'cufile_buffer_size': 0, 'local_cpu': False, 'max_local_cpu_size': '5.0 GB', 'local_disk': None, 'max_local_disk_size': '0.0 GB', 'remote_url': 'lm://localhost:8101', 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'enable_blending': False, 'blend_recompute_ratio': 0.15, 'blend_min_tokens': 256, 'enable_p2p': False, 'lookup_url': None, 'distributed_url': None, 'error_handling': False, 'enable_controller': False, 'lmcache_instance_id': 'lmcache_default_instance', 'pre_caching_hash_algorithm': 'builtin', 'enable_nixl': False, 'nixl_role': None, 'nixl_receiver_host': None, 'nixl_receiver_port': 0, 'nixl_buffer_size': 0, 'nixl_buffer_device': None, 'nixl_enable_gc': False, 'enable_xpyd': False, 'nixl_peer_host': None, 'nixl_peer_init_port': None, 'nixl_peer_alloc_port': None, 'nixl_proxy_host': None, 'nixl_proxy_port': 0, 'weka_path': None, 'gds_path': None, 'extra_config': None, 'save_unfull_chunk': True, 'blocking_timeout_secs': 10, 'external_lookup_client': None} (config.py:774:lmcache.v1.config)
Waiting for KV cache store to finish...
[2025-07-24 06:06:59,145] LMCache INFO: Client disconnected (__main__.py:142:__main__)
Adding requests: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 24.27it/s]
Processed prompts:   0%|                                                                                                          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s][2025-07-24 06:07:01,323] LMCache INFO: Reqid: 0, Total tokens 6001, LMCache hit tokens: 6001, need to load: 6000 (vllm_v1_adapter.py:813:lmcache.integration.vllm.vllm_v1_adapter)
[2025-07-24 06:07:01,330] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:160:lmcache.v1.cache_engine)
[2025-07-24 06:07:01,821] LMCache INFO: Retrieved 6001 out of 6001 out of total 6001 tokens (cache_engine.py:512:lmcache.v1.cache_engine)
[2025-07-24 06:07:02,093] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:456:lmcache.integration.vllm.vllm_v1_adapter)
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.27it/s, est. speed input: 7604.26 toks/s, output: 12.67 toks/s]
Generated text: 'Hello, how are you?Hello, how are'
[2025-07-24 06:07:07,172] LMCache INFO: Client disconnected (__main__.py:142:__main__)
```
We can see that `retrieve_process` processes the prompts successfully, and terminate as expected.

### nvidia-smi output after bug fix
<img width="647" height="616" alt="image" src="https://github.com/user-attachments/assets/a91e8cf0-3f94-4ac3-8cef-887b0aad9c35" />

We can see from the figure that the resources are released successfully.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
