### PR TITLE
[DP] Support api-server-count > 0 in hybrid DP LB mode

### DIFF
--- a/tests/v1/test_hybrid_lb_dp.py
+++ b/tests/v1/test_hybrid_lb_dp.py
@@ -147,7 +147,7 @@ def default_server_args():
     ]
 
 
-@pytest.fixture(scope="module", params=[1])  # Only 1 API server for now
+@pytest.fixture(scope="module", params=[1, 4])
 def servers(request, default_server_args):
     api_server_count = request.param
     with HybridLBServerManager(MODEL_NAME, DP_SIZE, api_server_count,


### PR DESCRIPTION
Follow-on to https://github.com/vllm-project/vllm/pull/21238.

Includes test coverage.