### PR TITLE
[Bugfix] DeepGemm utils : Fix hardcoded type-cast

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -52,7 +52,7 @@ def compute_aligned_M(M: int, num_topk: int, local_num_experts: int,
 @triton.jit
 def apply_expert_map(expert_id, expert_map):
     if expert_id != -1:
-        expert_id = tl.load(expert_map + expert_id).to(tl.int64)
+        expert_id = tl.load(expert_map + expert_id).to(expert_id.dtype)
     return expert_id
 
 


### PR DESCRIPTION
## Purpose

When deploying MoE models using deepgemm, the following error occurs
```
Core_1 pid=1840067)   File "/root/vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 645, in _maybe_chunk_fused_experts                                                                                        [380/1485]
(EngineCore_0 pid=1840066)     return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
(EngineCore_1 pid=1840067)     self._do_fused_experts(
(EngineCore_0 pid=1840066)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_1 pid=1840067)   File "/root/vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 492, in _do_fused_experts
(EngineCore_1 pid=1840067)     self.fused_experts.apply(
(EngineCore_1 pid=1840067)   File "/root/vllm/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py", line 183, in apply
(EngineCore_1 pid=1840067)     a1q, a1q_scale, expert_ids, inv_perm = deepgemm_moe_permute(
(EngineCore_0 pid=1840066) triton.compiler.errors.CompilationError: at 51:28:
(EngineCore_1 pid=1840067)                                            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=1840066)         to_copy = tl.load(recv_x + token_id * recv_x_stride0 + offset_in,
(EngineCore_1 pid=1840067)   File "/root/vllm/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py", line 386, in deepgemm_moe_permute
(EngineCore_0 pid=1840066)                           mask=mask)
(EngineCore_1 pid=1840067)     ep_scatter(recv_x=aq,
(EngineCore_0 pid=1840066)         to_copy_s = tl.load(recv_x_scale + token_id * recv_x_scale_stride0 +
(EngineCore_1 pid=1840067)   File "/jeejee/miniconda3/envs/jeejee/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(EngineCore_0 pid=1840066)                             offset_in_s,
(EngineCore_1 pid=1840067)     return func(*args, **kwargs)
(EngineCore_0 pid=1840066)                             mask=mask_s)
(EngineCore_1 pid=1840067)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=1840066)
(EngineCore_1 pid=1840067)   File "/root/vllm/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py", line 204, in ep_scatter
(EngineCore_0 pid=1840066)         for topk_index in tl.range(0, topk_num, 1, num_stages=4):
(EngineCore_1 pid=1840067)     _fwd_kernel_ep_scatter_2[(grid, )](
(EngineCore_0 pid=1840066)             expert_id = tl.load(recv_topk + token_id * recv_topk_stride0 +
(EngineCore_0 pid=1840066)                                 topk_index)
(EngineCore_1 pid=1840067)   File "/jeejee/miniconda3/envs/jeejee/lib/python3.11/site-packages/triton/runtime/jit.py", line 347, in <lambda>
(EngineCore_0 pid=1840066)
(EngineCore_1 pid=1840067)     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(EngineCore_0 pid=1840066)             if HAS_EXPERT_MAP:
(EngineCore_1 pid=1840067)                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=1840066)                 expert_id = apply_expert_map(expert_id, expert_map)
(EngineCore_1 pid=1840067)   File "/jeejee/miniconda3/envs/jeejee/lib/python3.11/site-packages/triton/runtime/jit.py", line 569, in run
(EngineCore_0 pid=1840066)                             ^
(EngineCore_1 pid=1840067)     kernel = self.compile(src, target=target, options=options.__dict__)
(EngineCore_1 pid=1840067)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_1 pid=1840067)   File "/jeejee/miniconda3/envs/jeejee/lib/python3.11/site-packages/triton/compiler/compiler.py", line 278, in compile
(EngineCore_1 pid=1840067)     module = src.make_ir(options, codegen_fns, module_map, context)
(EngineCore_1 pid=1840067)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_1 pid=1840067)   File "/jeejee/miniconda3/envs/jeejee/lib/python3.11/site-packages/triton/compiler/compiler.py", line 81, in make_ir
(EngineCore_3 pid=1840069) triton.compiler.errors.CompilationError: at 2:4:
(EngineCore_1 pid=1840067)     return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
(EngineCore_3 pid=1840069) def apply_expert_map(expert_id, expert_map):
(EngineCore_1 pid=1840067)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_3 pid=1840069)     if expert_id != -1:
(EngineCore_3 pid=1840069)     ^
(EngineCore_3 pid=1840069) AssertionError('initial value for `expert_id` is of type int32[], but the then block redefines it as int64[]')
```
## Test Plan

 VLLM_ALL2ALL_BACKEND="deepep_high_throughput" VLLM_USE_DEEP_GEMM=1  vllm  serve Qwen/Qwen3-30B-A3B-FP8  --disable-log-requests --enable-expert-parallel --data-parallel-size 2 --port 9010 

VLLM_USE_DEEP_GEMM=1  vllm  serve Qwen/Qwen3-30B-A3B-FP8  --disable-log-requests --enable-expert-parallel --data-parallel-size 2 --port 9010 

## Test Result
Service starts successfully

Thanks @jeejeelee  for flagging this and putting up an initial fix at #21509 
