### PR TITLE
Add support for Prithvi in Online serving mode

### DIFF
--- a/tests/entrypoints/openai/test_skip_tokenizer.py
+++ b/tests/entrypoints/openai/test_skip_tokenizer.py
@@ -33,7 +33,9 @@ def server():
         DTYPE,
         "--enforce-eager",
         "--trust-remote-code",
-        "--skip-tokenizer-init"
+        "--skip-tokenizer-init",
+        "--max-num-seqs",
+        "32"
     ]
 
     with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:

--- a/tests/entrypoints/openai/test_skip_tokenizer.py
+++ b/tests/entrypoints/openai/test_skip_tokenizer.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import base64
+
+import numpy as np
+import pytest
+import requests
+import torch
+import io
+
+
+from ...utils import RemoteOpenAIServer
+
+MODEL_NAME = "christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM"
+DTYPE = "float16"
+
+
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
+
+
+@pytest.fixture(scope="module")
+def server():
+    args = [
+        "--task",
+        "embed",
+        # use half precision for speed and memory savings in CI environment
+        "--dtype",
+        DTYPE,
+        "--enforce-eager",
+        "--trust-remote-code",
+        "--skip-tokenizer-init"
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_single_request(server: RemoteOpenAIServer, model_name: str):
+
+    pixel_values = torch.full((6, 512, 512), 1.0,dtype=torch.float16)
+    location_coords = torch.full((1, 2), 1.0,dtype=torch.float16)
+
+    buffer_tiff = io.BytesIO()
+    torch.save(pixel_values, buffer_tiff)
+    buffer_tiff.seek(0)
+    binary_data = buffer_tiff.read()
+    base64_tensor_embedding = base64.b64encode(binary_data).decode('utf-8')
+
+    buffer_coord = io.BytesIO()
+    torch.save(location_coords, buffer_coord)
+    buffer_coord.seek(0)
+    binary_data = buffer_coord.read()
+    base64_coord_embedding = base64.b64encode(binary_data).decode('utf-8')
+
+    prompt={
+        "model":model_name,
+        "additional_data":{
+            "prompt_token_ids": [1]
+        },
+        "encoding_format": "base64",
+        "messages":[
+            {
+                "role": "user",
+                "content": [
+                        { "type": "image_embeds",
+                        "image_embeds": {
+                            "pixel_values": base64_tensor_embedding,
+                            "location_coords": base64_coord_embedding,
+                            },
+                        }
+                        ],
+            }]}
+
+    # test single pooling
+    response = requests.post(
+        server.url_for("pooling"),
+        json=prompt
+    )
+    response.raise_for_status()
+
+    output = response.json()["data"][0]['data']
+
+    np_response = np.frombuffer(
+        base64.b64decode(output), dtype=np.float32)
+
+    assert len(np_response) == 524288
+
+
+    
+    

--- a/tests/entrypoints/openai/test_skip_tokenizer.py
+++ b/tests/entrypoints/openai/test_skip_tokenizer.py
@@ -2,13 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import base64
+import io
 
 import numpy as np
 import pytest
 import requests
 import torch
-import io
-
 
 from ...utils import RemoteOpenAIServer
 
@@ -40,12 +39,13 @@ def server():
     with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
         yield remote_server
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 async def test_single_request(server: RemoteOpenAIServer, model_name: str):
 
-    pixel_values = torch.full((6, 512, 512), 1.0,dtype=torch.float16)
-    location_coords = torch.full((1, 2), 1.0,dtype=torch.float16)
+    pixel_values = torch.full((6, 512, 512), 1.0, dtype=torch.float16)
+    location_coords = torch.full((1, 2), 1.0, dtype=torch.float16)
 
     buffer_tiff = io.BytesIO()
     torch.save(pixel_values, buffer_tiff)
@@ -59,39 +59,33 @@ async def test_single_request(server: RemoteOpenAIServer, model_name: str):
     binary_data = buffer_coord.read()
     base64_coord_embedding = base64.b64encode(binary_data).decode('utf-8')
 
-    prompt={
-        "model":model_name,
-        "additional_data":{
+    prompt = {
+        "model":
+        model_name,
+        "additional_data": {
             "prompt_token_ids": [1]
         },
-        "encoding_format": "base64",
-        "messages":[
-            {
-                "role": "user",
-                "content": [
-                        { "type": "image_embeds",
-                        "image_embeds": {
-                            "pixel_values": base64_tensor_embedding,
-                            "location_coords": base64_coord_embedding,
-                            },
-                        }
-                        ],
-            }]}
+        "encoding_format":
+        "base64",
+        "messages": [{
+            "role":
+            "user",
+            "content": [{
+                "type": "image_embeds",
+                "image_embeds": {
+                    "pixel_values": base64_tensor_embedding,
+                    "location_coords": base64_coord_embedding,
+                },
+            }],
+        }]
+    }
 
     # test single pooling
-    response = requests.post(
-        server.url_for("pooling"),
-        json=prompt
-    )
+    response = requests.post(server.url_for("pooling"), json=prompt)
     response.raise_for_status()
 
     output = response.json()["data"][0]['data']
 
-    np_response = np.frombuffer(
-        base64.b64decode(output), dtype=np.float32)
+    np_response = np.frombuffer(base64.b64decode(output), dtype=np.float32)
 
     assert len(np_response) == 524288
-
-
-    
-    

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -380,7 +380,10 @@ class MQLLMEngineClient(EngineClient):
         return self.input_preprocessor
 
     async def get_tokenizer(self, lora_request: Optional[LoRARequest] = None):
-        return await self.tokenizer.get_lora_tokenizer_async(lora_request)
+        if self.tokenizer is None:
+            return None
+        else:
+            return await self.tokenizer.get_lora_tokenizer_async(lora_request)
 
     async def get_vllm_config(self) -> VllmConfig:
         return self.vllm_config

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -97,11 +97,16 @@ class MQLLMEngineClient(EngineClient):
         self.model_config = engine_config.model_config
         self.decoding_config = engine_config.decoding_config
 
-        # Create the tokenizer group.
-        self.tokenizer = init_tokenizer_from_configs(
-            model_config=self.model_config,
-            scheduler_config=engine_config.scheduler_config,
-            lora_config=engine_config.lora_config)
+        if self.vllm_config.model_config.skip_tokenizer_init:
+            self.tokenizer = None
+
+        else:
+            # Create the tokenizer group.
+            self.tokenizer = init_tokenizer_from_configs(
+                model_config=self.model_config,
+                scheduler_config=engine_config.scheduler_config,
+                lora_config=engine_config.lora_config)
+
         self.input_preprocessor = InputPreprocessor(self.model_config,
                                                     self.tokenizer)
 

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -914,9 +914,12 @@ class OpenAIServing:
                 request=request)
 
         if tokenizer is None:
+            assert isinstance(request_prompt, str), (
+                "Prompt has to be a string", \
+                "when the tokenizer is not initialised"
+            )
             prompt_inputs = TextTokensPrompt(prompt=request_prompt,
                                              prompt_token_ids=[1])
-
         elif isinstance(request_prompt, str):
             prompt_inputs = await self._tokenize_prompt_input_async(
                 request,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -880,7 +880,10 @@ class OpenAIServing:
         _chat_template_kwargs.update(chat_template_kwargs or {})
 
         request_prompt: Union[str, list[int]]
-        if isinstance(tokenizer, MistralTokenizer):
+
+        if tokenizer is None:
+            request_prompt = "placeholder"
+        elif isinstance(tokenizer, MistralTokenizer):
             request_prompt = apply_mistral_chat_template(
                 tokenizer,
                 messages=messages,
@@ -911,7 +914,7 @@ class OpenAIServing:
                 request=request)
 
         if tokenizer is None:
-            prompt_inputs = TextTokensPrompt(prompt="placeholder",
+            prompt_inputs = TextTokensPrompt(prompt=request_prompt,
                                              prompt_token_ids=[1])
 
         elif isinstance(request_prompt, str):

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -880,9 +880,7 @@ class OpenAIServing:
         _chat_template_kwargs.update(chat_template_kwargs or {})
 
         request_prompt: Union[str, list[int]]
-        if tokenizer is None:
-            request_prompt = "placeholder"
-        elif isinstance(tokenizer, MistralTokenizer):
+        if isinstance(tokenizer, MistralTokenizer):
             request_prompt = apply_mistral_chat_template(
                 tokenizer,
                 messages=messages,
@@ -913,14 +911,11 @@ class OpenAIServing:
                 request=request)
 
         if tokenizer is None:
-            prompt_inputs = {}
-            if "prompt_token_ids" not in request.additional_data:
-                raise Exception("Request must contain "
-                                "additional_data['prompt_token_ids'] "
-                                "when the tokenizer is not initialised")
+            prompt_inputs = TextTokensPrompt(
+                prompt="placeholder",
+                prompt_token_ids= [1]
+            )
 
-            prompt_inputs["prompt_token_ids"] = request.additional_data[
-                "prompt_token_ids"]
 
         elif isinstance(request_prompt, str):
             prompt_inputs = await self._tokenize_prompt_input_async(

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -911,11 +911,8 @@ class OpenAIServing:
                 request=request)
 
         if tokenizer is None:
-            prompt_inputs = TextTokensPrompt(
-                prompt="placeholder",
-                prompt_token_ids= [1]
-            )
-
+            prompt_inputs = TextTokensPrompt(prompt="placeholder",
+                                             prompt_token_ids=[1])
 
         elif isinstance(request_prompt, str):
             prompt_inputs = await self._tokenize_prompt_input_async(

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -99,7 +99,8 @@ class OpenAIServingPooling(OpenAIServing):
             if self.model_config.skip_tokenizer_init:
                 tokenizer = None
             else:
-                tokenizer = await self.engine_client.get_tokenizer(lora_request)
+                tokenizer = await self.engine_client.get_tokenizer(lora_request
+                                                                   )
 
             if isinstance(request, PoolingChatRequest):
                 (

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -96,7 +96,10 @@ class OpenAIServingPooling(OpenAIServing):
                 self.max_model_len, truncate_prompt_tokens)
             lora_request = self._maybe_get_adapters(request)
 
-            tokenizer = await self.engine_client.get_tokenizer(lora_request)
+            if self.model_config.skip_tokenizer_init:
+                tokenizer = None
+            else:
+                tokenizer = await self.engine_client.get_tokenizer(lora_request)
 
             if isinstance(request, PoolingChatRequest):
                 (

--- a/vllm/model_executor/models/prithvi_geospatial_mae.py
+++ b/vllm/model_executor/models/prithvi_geospatial_mae.py
@@ -104,8 +104,7 @@ class PrithviGeoSpatialMAEMultiModalProcessor(BaseMultiModalProcessor):
 
         for k, v in mm_data.items():
             if isinstance(v,dict) and k == "image":
-                for tensor_name,tensor in v.items():
-                    mm_kwargs[tensor_name] = tensor
+                mm_kwargs.update(v)
             else:
                 mm_kwargs[k] = v
         mm_placeholders = {"image": [PlaceholderRange(offset=0, length=0)]}

--- a/vllm/model_executor/models/prithvi_geospatial_mae.py
+++ b/vllm/model_executor/models/prithvi_geospatial_mae.py
@@ -103,7 +103,7 @@ class PrithviGeoSpatialMAEMultiModalProcessor(BaseMultiModalProcessor):
         mm_kwargs = {}
 
         for k, v in mm_data.items():
-            if isinstance(v,dict) and k == "image":
+            if isinstance(v, dict) and k == "image":
                 mm_kwargs.update(v)
             else:
                 mm_kwargs[k] = v

--- a/vllm/model_executor/models/prithvi_geospatial_mae.py
+++ b/vllm/model_executor/models/prithvi_geospatial_mae.py
@@ -103,7 +103,11 @@ class PrithviGeoSpatialMAEMultiModalProcessor(BaseMultiModalProcessor):
         mm_kwargs = {}
 
         for k, v in mm_data.items():
-            mm_kwargs[k] = v
+            if isinstance(v,dict) and k == "image":
+                for tensor_name,tensor in v.items():
+                    mm_kwargs[tensor_name] = tensor
+            else:
+                mm_kwargs[k] = v
         mm_placeholders = {"image": [PlaceholderRange(offset=0, length=0)]}
 
         # This model receives in input a multi-dimensional tensor representing


### PR DESCRIPTION
This PR builds on top of #20072 and it enables the execution of Prithvi in online serving mode.

This is achieved by increasing the level of support for models that skip the tokenizer initialisation.

A longer description of the what we are trying to achieve is available in #20234. 

This supersedes #20307

## Test Plan
The PR can be tested as following
```
pytest  tests/entrypoints/openai/test_skip_tokenizer.py
```

## Additional information

Prithvi in serving mode can be started with the following command:
```
vllm serve --model='christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM' --task embed --trust-remote-code --dtype float16 --skip-tokenizer-init --enforce-eager
```

The following script provides an example of prompt that can be used to perform an inference (the same is used during the test linked above):

```python
import base64
import requests
import torch
import io
import numpy as np

torch.set_default_dtype(torch.float16)


def post_http_request(prompt: dict, api_url: str) -> requests.Response:
    headers = {"User-Agent": "Test Client","Content-Type": "application/json"}
    response = requests.post(api_url, headers=headers, json=prompt)
    return response


def decompress(output):
    np_result = np.frombuffer(
        base64.b64decode(output), dtype=np.float32)
    return np_result.reshape(1, 2, 512, 512)


def main():
    api_url = f"http://localhost:8000/pooling"
    model_name = 'christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM'

    pixel_values = torch.full((6, 512, 512), 1.0,dtype=torch.float16)
    location_coords = torch.full((1, 2), 1.0,dtype=torch.float16)

    buffer_tiff = io.BytesIO()
    torch.save(pixel_values, buffer_tiff)
    buffer_tiff.seek(0)
    binary_data = buffer_tiff.read()
    base64_tensor_embedding = base64.b64encode(binary_data).decode('utf-8')

    buffer_coord = io.BytesIO()
    torch.save(location_coords, buffer_coord)
    buffer_coord.seek(0)
    binary_data = buffer_coord.read()
    base64_coord_embedding = base64.b64encode(binary_data).decode('utf-8')

    prompt={
        "model":model_name,
        "additional_data":{
            "prompt_token_ids": [1]
        },
        "encoding_format": "base64",
        "messages":[
            {
                "role": "user",
                "content": [
                        { "type": "image_embeds",
                        "image_embeds": {
                            "pixel_values": base64_tensor_embedding,
                            "location_coords": base64_coord_embedding,
                            },
                        }
                        ],
            }]}

    pooling_response = post_http_request(prompt=prompt, api_url=api_url)
    numpy_data = decompress(pooling_response.json()["data"][0]["data"])
    print(f"Returned result: {numpy_data}")


if __name__ == "__main__":
    main()
```

@DarkLight1337 @maxdebayser @njhill @christian-pinto 