### PR TITLE
[ROCm] Add flag to avoid `invalid device ordinal` HIP error

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -102,6 +102,7 @@ COPY --from=export_vllm /benchmarks ${COMMON_WORKDIR}/vllm/benchmarks
 COPY --from=export_vllm /examples ${COMMON_WORKDIR}/vllm/examples
 
 ENV RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
+# Fix for 'HIP error: invalid device ordinal' with Ray on ROCm. See #21457, #12572
 ENV RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=1
 ENV TOKENIZERS_PARALLELISM=false
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -102,6 +102,7 @@ COPY --from=export_vllm /benchmarks ${COMMON_WORKDIR}/vllm/benchmarks
 COPY --from=export_vllm /examples ${COMMON_WORKDIR}/vllm/examples
 
 ENV RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
+ENV RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=1
 ENV TOKENIZERS_PARALLELISM=false
 
 # ENV that can improve safe tensor loading, and end-to-end time


### PR DESCRIPTION
Fix for RuntimeError: HIP error: invalid device ordinal

## Purpose
The issue was reported in 
- https://github.com/vllm-project/vllm/issues/21457
- https://github.com/vllm-project/vllm/issues/12572

Visibility to GPU devices is altered when using Ray backend. 
As a fix in one of the above mentioned issues it was advised to set `RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1` which is set currently in Dockerfile.rocm, but it doesn't resolve the problem.
Setting `RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=1` resolves the problem.
On AMD GPU MI250 the command
```
vllm serve meta-llama/Llama-3.1-8B-Instruct --distributed-executor-backend="ray" --tensor-parallel-size 2
```
throws error `
RuntimeError: HIP error: invalid device ordinal` and 
```
RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=1 vllm serve meta-llama/Llama-3.1-8B-Instruct --distributed-executor-backend="ray" --tensor-parallel-size 2
```
works.
<!--- pyml disable-next-line no-emphasis-as-heading -->
