### PR TITLE
[Bugfix]  v1  fix current scheduling defects and enhance the scheduling preemption logic.

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1918,10 +1918,10 @@ def test_priority_scheduling_preemption_victim_no_scheduled():
     running_priorities = [req.priority for req in scheduler.running]
     running_req_ids = [req.request_id for req in scheduler.running]
 
-    assert running_priorities == [3, 4, 5, 1]
-    assert running_req_ids == ["1", "2", "3", "4"]
+    assert running_priorities == [1, 3, 4, 5]
+    assert running_req_ids == ["4", "1", "2", "3"]
     assert scheduler.waiting.peek_request().priority == 2
-    assert scheduler.waiting.peek_request().request_id == 5
+    assert scheduler.waiting.peek_request().request_id == "5"
 
 
 def test_priority_scheduling_preemption_victim_subsequent_high():
@@ -1962,7 +1962,7 @@ def test_priority_scheduling_preemption_victim_subsequent_high():
 
     # Add a high priority request.
     high_priority_requests = create_requests_with_priority(
-        num_requests=2,
+        num_requests=1,
         priorities=[1],
         arrival_times=[4.0],
         num_tokens=16,
@@ -2003,8 +2003,7 @@ def test_priority_scheduling_preemption_victim_subsequent_high():
     running_priorities = [req.priority for req in scheduler.running]
     running_req_ids = [req.request_id for req in scheduler.running]
 
-    assert running_priorities == [2, 3, 1]
-    assert running_req_ids == ["1", "2", "4"]
+    assert running_priorities == [1, 2, 3]
+    assert running_req_ids == ["4", "1", "2"]
     assert scheduler.waiting.peek_request().priority == 4
-    assert scheduler.waiting.peek_request().request_id == 3
-
+    assert scheduler.waiting.peek_request().request_id == "3"

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1310,13 +1310,18 @@ def create_requests_with_priority(
         mm_positions: Optional[list[PlaceholderRange]] = None,
         max_tokens: int = 16,
         stop_token_ids: Optional[list[int]] = None,
-        prompt_logprobs: Optional[int] = None):
+        prompt_logprobs: Optional[int] = None,
+        request_ids: Optional[list[str]] = None):
     """Create requests with specified priorities and arrival times."""
     assert len(priorities) == num_requests
     if arrival_times is not None:
         assert len(arrival_times) == num_requests
     else:
         arrival_times = [float(i) for i in range(num_requests)]
+    if request_ids is not None:
+        assert len(request_ids) == num_requests
+    else:
+        request_ids = [f"{i}" for i in range(num_requests)]
 
     sampling_params = SamplingParams(ignore_eos=False,
                                      max_tokens=max_tokens,
@@ -1331,7 +1336,7 @@ def create_requests_with_priority(
             mm_position = None
             mm_inputs = None
         request = Request(
-            request_id=f"{i}",
+            request_id=request_ids[i],
             prompt_token_ids=[i] * num_tokens,
             sampling_params=sampling_params,
             pooling_params=None,
@@ -1832,3 +1837,174 @@ def test_schedule_skip_tokenizer_init_structured_output_request():
     assert len(output.scheduled_new_reqs) == 0
     assert len(scheduler.running) == 0
     assert len(scheduler.waiting) == 1
+
+
+def test_priority_scheduling_preemption_victim_no_scheduled():
+    """Test that during scheduling,
+    only currently unscheduled requests are selected for preemption."""
+    scheduler = create_scheduler_with_priority(
+        max_num_batched_tokens=200,
+        num_blocks=9,
+    )
+    # Add three priority requests first.
+    priority_requests = create_requests_with_priority(
+        num_requests=3,
+        priorities=[3, 4, 5],
+        arrival_times=[1.0, 2.0, 3.0],
+        num_tokens=15,
+        request_ids=["1", "2", "3"],
+    )
+
+    for request in priority_requests:
+        scheduler.add_request(request)
+    # After scheduling, transfer from the waiting queue to the running queue.
+    # At this time, 3 blocks have been allocated, and 5 available blocks remain.
+    output = scheduler.schedule()
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id for req in priority_requests],
+        req_id_to_index={
+            req.request_id: i
+            for i, req in enumerate(priority_requests)
+        },
+        sampled_token_ids=[[15] for _ in priority_requests],
+        spec_token_ids=None,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # Add tow high priority requests.
+    high_priority_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[1, 2],
+        arrival_times=[4.0, 5.0],
+        num_tokens=16,
+        request_ids=["4", "5"],
+    )
+    for request in high_priority_requests:
+        scheduler.add_request(request)
+
+    # After scheduling, transfer the two high-priority requests from the waiting queue to the running queue.
+    # the IDs of the requests in the running queue are: 1, 2, 3, 4, 5.
+    # At this time, 3+2 blocks have been allocated, and 3 available blocks remain.
+    output = scheduler.schedule()
+
+    merge_requests = priority_requests + high_priority_requests
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id for req in merge_requests],
+        req_id_to_index={
+            req.request_id: i
+            for i, req in enumerate(merge_requests)
+        },
+        sampled_token_ids=[[1] for _ in merge_requests],
+        spec_token_ids=None,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+    # When allocating resources to the fourth request, preemption is triggered.
+    # At this time, the request with the lowest priority (request.id = 5) will be preempted, freeing up 1 blocks,
+    # which exactly meets the resource allocation requirements for request.id = 4
+    output = scheduler.schedule()
+
+    # Should schedule the new request without preemption
+    assert len(scheduler.running) == 4  #
+    assert len(scheduler.waiting) == 1  #
+
+    running_priorities = [req.priority for req in scheduler.running]
+    running_req_ids = [req.request_id for req in scheduler.running]
+
+    assert running_priorities == [3, 4, 5, 1]
+    assert running_req_ids == ["1", "2", "3", "4"]
+    assert scheduler.waiting.peek_request().priority == 2
+    assert scheduler.waiting.peek_request().request_id == 5
+
+
+def test_priority_scheduling_preemption_victim_subsequent_high():
+    """Test that when the current request has the lowest priority and is not the last request,
+    it is preempted to allow scheduling of subsequent higher-priority requests."""
+    scheduler = create_scheduler_with_priority(
+        max_num_batched_tokens=200,
+        num_blocks=7,
+    )
+    # Add three priority requests first.
+    priority_requests = create_requests_with_priority(
+        num_requests=3,
+        priorities=[2, 3, 4],
+        arrival_times=[1.0, 2.0, 3.0],
+        num_tokens=15,
+        request_ids=["1", "2", "3"],
+    )
+
+    for request in priority_requests:
+        scheduler.add_request(request)
+    # After scheduling, transfer from the waiting queue to the running queue.
+    # At this time, 3 blocks have been allocated, and 3 available blocks remain.
+    output = scheduler.schedule()
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id for req in priority_requests],
+        req_id_to_index={
+            req.request_id: i
+            for i, req in enumerate(priority_requests)
+        },
+        sampled_token_ids=[[15] for _ in priority_requests],
+        spec_token_ids=None,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # Add a high priority request.
+    high_priority_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[1],
+        arrival_times=[4.0],
+        num_tokens=16,
+        request_ids=["4"],
+    )
+    for request in high_priority_requests:
+        scheduler.add_request(request)
+
+    # After scheduling, transfer the high-priority request from the waiting queue to the running queue.
+    # the IDs of the requests in the running queue are: 1, 2, 3, 4.
+    # At this time, 3+1 blocks have been allocated, and 2 available blocks remain.
+    output = scheduler.schedule()
+
+    merge_requests = priority_requests + high_priority_requests
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id for req in merge_requests],
+        req_id_to_index={
+            req.request_id: i
+            for i, req in enumerate(merge_requests)
+        },
+        sampled_token_ids=[[1] for _ in merge_requests],
+        spec_token_ids=None,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+    # When allocating resources to the fourth request, preemption is triggered.
+    # At this time, the request with the lowest priority (request.id = 3) will be preempted, freeing up 1 blocks,
+    # which exactly meets the resource allocation requirements for request.id = 4.
+    output = scheduler.schedule()
+
+    # Should schedule the new request without preemption
+    assert len(scheduler.running) == 3  #
+    assert len(scheduler.waiting) == 1  #
+
+    running_priorities = [req.priority for req in scheduler.running]
+    running_req_ids = [req.request_id for req in scheduler.running]
+
+    assert running_priorities == [2, 3, 1]
+    assert running_req_ids == ["1", "2", "4"]
+    assert scheduler.waiting.peek_request().priority == 4
+    assert scheduler.waiting.peek_request().request_id == 3
+

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1886,7 +1886,6 @@ def test_priority_scheduling_preemption_victim_no_scheduled():
     for request in high_priority_requests:
         scheduler.add_request(request)
 
-    # After scheduling, transfer the two high-priority requests from the waiting queue to the running queue.
     # the IDs of the requests in the running queue are: 1, 2, 3, 4, 5.
     # At this time, 3+2 blocks have been allocated, and 3 available blocks remain.
     output = scheduler.schedule()
@@ -1906,8 +1905,9 @@ def test_priority_scheduling_preemption_victim_no_scheduled():
         pooler_output=[],
     )
     scheduler.update_from_output(output, model_output)
-    # When allocating resources to the fourth request, preemption is triggered.
-    # At this time, the request with the lowest priority (request.id = 5) will be preempted, freeing up 1 blocks,
+
+    # At this time, the request with the lowest priority (request.id = 5) 
+    # will be preempted, freeing up 1 blocks.
     # which exactly meets the resource allocation requirements for request.id = 4
     output = scheduler.schedule()
 
@@ -1925,8 +1925,9 @@ def test_priority_scheduling_preemption_victim_no_scheduled():
 
 
 def test_priority_scheduling_preemption_victim_subsequent_high():
-    """Test that when the current request has the lowest priority and is not the last request,
-    it is preempted to allow scheduling of subsequent higher-priority requests."""
+    """Test that when the current request has the lowest priority
+    and is not the last request,it is preempted to allow scheduling
+    of subsequent higher-priority requests."""
     scheduler = create_scheduler_with_priority(
         max_num_batched_tokens=200,
         num_blocks=7,
@@ -1971,7 +1972,6 @@ def test_priority_scheduling_preemption_victim_subsequent_high():
     for request in high_priority_requests:
         scheduler.add_request(request)
 
-    # After scheduling, transfer the high-priority request from the waiting queue to the running queue.
     # the IDs of the requests in the running queue are: 1, 2, 3, 4.
     # At this time, 3+1 blocks have been allocated, and 2 available blocks remain.
     output = scheduler.schedule()
@@ -1991,8 +1991,9 @@ def test_priority_scheduling_preemption_victim_subsequent_high():
         pooler_output=[],
     )
     scheduler.update_from_output(output, model_output)
-    # When allocating resources to the fourth request, preemption is triggered.
-    # At this time, the request with the lowest priority (request.id = 3) will be preempted, freeing up 1 blocks,
+
+    # At this time, the request with the lowest priority (request.id = 3) 
+    # will be preempted, freeing up 1 blocks.
     # which exactly meets the resource allocation requirements for request.id = 4.
     output = scheduler.schedule()
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -252,6 +252,7 @@ class Scheduler(SchedulerInterface):
                 if new_blocks is None:
                     # The request cannot be scheduled.
                     # Preempt the lowest-priority request.
+                    last_req = self.running[-1]
                     if self.policy == SchedulingPolicy.PRIORITY:
                         # Check if all the preceding requests have been scheduled.
                         if req_index == len(scheduled_running_reqs):
@@ -272,7 +273,7 @@ class Scheduler(SchedulerInterface):
                         preempted_req = self.running.pop()
 
                     if preempted_req == request:
-                        if preempted_req == self.running[-1]:
+                        if preempted_req == last_req:
                             if len(self.waiting) > 0:
                                 self._preempt_request(request)
                                 preempted_reqs.append(request)


### PR DESCRIPTION
[issue](https://github.com/vllm-project/vllm/issues/21594)

### **Context 1: Current Priority Scheduling Policy** 
### **Problem 1: State Inconsistency After Preempting Scheduled Requests**  
When a preempted request has already been scheduled, critical state-tracking operations fail to roll back, including updates to:  
- `scheduled_running_reqs`  
- `req_to_new_block_ids`  
- `num_scheduled_tokens`  

This inconsistency causes various anomalies.  

**Example Failure**:  
The assertion below fails due to state mismatch:  
```python
vllm/v1/core/sched/scheduler.py#schedule
assert (len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + 
        len(scheduled_running_reqs) <= len(self.running))
```  

**Root Cause**: Preempted requests are not removed from `scheduled_running_reqs`.  


### **Proposed Solution: Simplify Logic & Enhance Scheduling**  
**Core Strategy**:  
Preempt only unscheduled requests in the running queue.  
→ Eliminates the need to roll back state for already scheduled requests, reducing complexity.  


**New Challenge**:  

How to ensure that when a lower-priority request has already been scheduled, the current higher-priority request, which is the last unscheduled one, can preempt it?



**Resolution**:  
1. **Post-Scheduling Priority Adjustment**:  
   After completing a scheduling cycle where preemption occurred:  
   → Re-sort the running queue by priority.  

2. **Guarantee**:  
   Ensures higher-priority requests are scheduled first in the next cycle.  

Resolution Example:

Before: [priority=2, 3, 4, 1] ， 

After preemption: [priority=1, 2, 3, 4]

Next scheduling cycle: High-priority request processed first

### **Context 2: Flawed Scheduling Exit Condition**  
**Current Behavior**:  
When encountering the lowest-priority request during scheduling, resources are released and the scheduling loop exits.  


**Problem 2**:  
The running queue is not strictly ordered by priority, meaning higher-priority unscheduled requests may exist after the current request.  

**Example Case**:  
Running queue priorities: `[2, 3, 4, 1]` (where `1` = highest priority).  
- When scheduling request "4" (lowest in the current subset):  
  - If resources are insufficient, the current logic exits.  
  - **Error**: The priority-"1" request remains unscheduled.

### **Summary of Changes**  
1. **Preemption Scope**: Restrict to unscheduled requests only.  
2. **Post-Scheduling Sorting**: Reorder running queue by priority after preemptions.  
3. **Exit Condition**: Refine to check for remaining higher-priority requests before exiting.  


### This is the complete design scheme.

<img width="445" height="766" alt="image" src="https://github.com/user-attachments/assets/b33396f9-1c5f-45d4-837c-dc337c62b16d" />