### PR TITLE
[Docs] add offline serving multi-modal video input expamle Qwen2.5-VL

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -176,6 +176,7 @@ Multi-image input can be extended to perform video captioning. We show this with
 
 You can pass a list of NumPy arrays directly to the `'video'` field of the multi-modal dictionary
 instead of using multi-image input.
+
 Instead of NumPy arrays, you can also pass `'torch.Tensor'` instances, as shown in this example using Qwen2.5-VL:
 
 ??? code

--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -176,6 +176,67 @@ Multi-image input can be extended to perform video captioning. We show this with
 
 You can pass a list of NumPy arrays directly to the `'video'` field of the multi-modal dictionary
 instead of using multi-image input.
+Or you can use torch.Tensor, the following is an example of Qwen2.5-VL.
+
+??? code
+
+    ```python
+    from transformers import AutoProcessor
+    from vllm import LLM, SamplingParams
+    from qwen_vl_utils import process_vision_info
+
+    model_path = "Qwen/Qwen25-VL-3B-Instruct/"
+    video_path ="https://content.pexels.com/videos/free-videos.mp4"
+
+    llm = LLM(
+        model=model_path,
+        gpu_memory_utilization=0.8,
+        enforce_eager=True,
+        limit_mm_per_prompt={"video": 1},
+    )
+
+    sampling_params = SamplingParams(
+        max_tokens=1024,
+    )
+
+    video_messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": [
+                {"type": "text", "text": "describe this video."},
+                {
+                    "type": "video",
+                    "video": video_path,
+                    "total_pixels": 20480 * 28 * 28,
+                    "min_pixels": 16 * 28 * 28
+                }
+            ]
+        },
+    ]
+
+    messages = video_messages
+    processor = AutoProcessor.from_pretrained(model_path)
+    prompt = processor.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+    image_inputs, video_inputs = process_vision_info(messages)
+    mm_data = {}
+    if video_inputs is not None:
+        mm_data["video"] = video_inputs
+
+    llm_inputs = {
+        "prompt": prompt,
+        "multi_modal_data": mm_data,
+    }
+
+    outputs = llm.generate([llm_inputs], sampling_params=sampling_params)
+    for o in outputs:
+        generated_text = o.outputs[0].text
+        print(generated_text)
+
+    ```
 
 Full example: <gh-file:examples/offline_inference/vision_language.py>
 

--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -238,8 +238,8 @@ Instead of NumPy arrays, you can also pass `'torch.Tensor'` instances, as shown 
         print(generated_text)
     ```
 
-!!! note
-    that `'process_vision_info'` is only applicable to Qwen2.5-VL and similar models
+    !!! note
+        that `'process_vision_info'` is only applicable to Qwen2.5-VL and similar models
 
 Full example: <gh-file:examples/offline_inference/vision_language.py>
 

--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -176,7 +176,7 @@ Multi-image input can be extended to perform video captioning. We show this with
 
 You can pass a list of NumPy arrays directly to the `'video'` field of the multi-modal dictionary
 instead of using multi-image input.
-Or you can use torch.Tensor, the following is an example of Qwen2.5-VL.
+Instead of NumPy arrays, you can also pass `'torch.Tensor'` instances, as shown in this example using Qwen2.5-VL:
 
 ??? code
 
@@ -185,7 +185,7 @@ Or you can use torch.Tensor, the following is an example of Qwen2.5-VL.
     from vllm import LLM, SamplingParams
     from qwen_vl_utils import process_vision_info
 
-    model_path = "Qwen/Qwen25-VL-3B-Instruct/"
+    model_path = "Qwen/Qwen2.5-VL-3B-Instruct/"
     video_path ="https://content.pexels.com/videos/free-videos.mp4"
 
     llm = LLM(
@@ -235,8 +235,10 @@ Or you can use torch.Tensor, the following is an example of Qwen2.5-VL.
     for o in outputs:
         generated_text = o.outputs[0].text
         print(generated_text)
-
     ```
+
+!!! note
+    that `'process_vision_info'` is only applicable to Qwen2.5-VL and similar models
 
 Full example: <gh-file:examples/offline_inference/vision_language.py>
 

--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -187,7 +187,7 @@ Instead of NumPy arrays, you can also pass `'torch.Tensor'` instances, as shown 
     from qwen_vl_utils import process_vision_info
 
     model_path = "Qwen/Qwen2.5-VL-3B-Instruct/"
-    video_path ="https://content.pexels.com/videos/free-videos.mp4"
+    video_path = "https://content.pexels.com/videos/free-videos.mp4"
 
     llm = LLM(
         model=model_path,
@@ -239,7 +239,7 @@ Instead of NumPy arrays, you can also pass `'torch.Tensor'` instances, as shown 
     ```
 
     !!! note
-        that `'process_vision_info'` is only applicable to Qwen2.5-VL and similar models
+        'process_vision_info' is only applicable to Qwen2.5-VL and similar models.
 
 Full example: <gh-file:examples/offline_inference/vision_language.py>
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
add offline serving multi-modal video input expamle Qwen2.5-VL
## Test Plan
```
from transformers import AutoProcessor
from vllm import LLM, SamplingParams
from qwen_vl_utils import process_vision_info

model_path = "Qwen/Qwen25-VL-3B-Instruct/"
video_path ="https://content.pexels.com/videos/free-videos.mp4"

llm = LLM(
    model=model_path,
    gpu_memory_utilization=0.8,
    enforce_eager=True,
    limit_mm_per_prompt={"video": 1},
)

sampling_params = SamplingParams(
    max_tokens=1024,
)

video_messages = [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": [
            {"type": "text", "text": "describe this video."},
            {
                "type": "video",
                "video": video_path,
                "total_pixels": 20480 * 28 * 28,
                "min_pixels": 16 * 28 * 28
            }
        ]
    },
]

messages = video_messages
processor = AutoProcessor.from_pretrained(model_path)
prompt = processor.apply_chat_template(
    messages,
    tokenize=False,
    add_generation_prompt=True,
)

image_inputs, video_inputs = process_vision_info(messages)
mm_data = {}
if video_inputs is not None:
    mm_data["video"] = video_inputs

llm_inputs = {
    "prompt": prompt,
    "multi_modal_data": mm_data,
}

outputs = llm.generate([llm_inputs], sampling_params=sampling_params)
for o in outputs:
    generated_text = o.outputs[0].text
    print(generated_text)

```
## Test Result
```
INFO 07-24 12:10:18 [__init__.py:235] Automatically detected platform cuda.
INFO 07-24 12:10:30 [config.py:1593] Using max model len 128000
INFO 07-24 12:10:32 [config.py:2415] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 07-24 12:10:33 [core.py:553] Waiting for init message from front-end.
INFO 07-24 12:10:33 [core.py:71] Initializing a V1 LLM engine (v0.10.0rc2.dev53+gb77c7d327) with config: model='/workspace/models/Qwen2.5-VL-3B-Instruct', speculative_config=None, tokenizer='/workspace/models/Qwen2.5-VL-3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=128000, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=/workspace/models/Qwen2.5-VL-3B-Instruct, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":0,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":[],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":0,"cudagraph_capture_sizes":[],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":0,"local_cache_dir":null}
INFO 07-24 12:10:40 [parallel_state.py:1102] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
WARNING 07-24 12:10:41 [topk_topp_sampler.py:59] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
INFO 07-24 12:10:41 [gpu_model_runner.py:1793] Starting to load model /workspace/models/Qwen2.5-VL-3B-Instruct...
INFO 07-24 12:10:42 [gpu_model_runner.py:1826] Loading model from scratch...
INFO 07-24 12:10:46 [cuda.py:290] Using Flash Attention backend on V1 engine.
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  2.32it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  1.94it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  1.99it/s]

INFO 07-24 12:10:47 [default_loader.py:262] Loading weights took 1.13 seconds
INFO 07-24 12:10:48 [gpu_model_runner.py:1850] Model loading took 7.1557 GiB and 5.367345 seconds
INFO 07-24 12:10:48 [gpu_model_runner.py:2305] Encoder cache will be initialized with a budget of 98304 tokens, and profiled with 1 video items of the maximum feature size.
Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.
You have video processor config saved in `preprocessor.json` file which is deprecated. Video processor configs should be saved in their own `video_preprocessor.json` file. You can rename the file or load and save the processor back which renames it automatically. Loading from `preprocessor.json` will be removed in v5.0.
INFO 07-24 12:11:12 [gpu_worker.py:245] Available KV cache memory: 42.08 GiB
INFO 07-24 12:11:13 [kv_cache_utils.py:833] GPU KV cache size: 1,225,760 tokens
INFO 07-24 12:11:13 [kv_cache_utils.py:837] Maximum concurrency for 128,000 tokens per request: 9.58x
INFO 07-24 12:11:15 [core.py:193] init engine (profile, create kv cache, warmup model) took 27.12 seconds
Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.
You have video processor config saved in `preprocessor.json` file which is deprecated. Video processor configs should be saved in their own `video_preprocessor.json` file. You can rename the file or load and save the processor back which renames it automatically. Loading from `preprocessor.json` will be removed in v5.0.
qwen-vl-utils using torchvision to read video.
/usr/local/lib/python3.12/dist-packages/torchvision/io/_video_deprecation_warning.py:5: UserWarning: The video decoding and encoding capabilities of torchvision are deprecated from version 0.22 and will be removed in version 0.24. We recommend that you migrate to TorchCodec, where we'll consolidate the future decoding/encoding capabilities of PyTorch: https://github.com/pytorch/torchcodec
  warnings.warn(
Adding requests: 100%|█████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.52s/it]
Processed prompts: 100%|█| 1/1 [00:12<00:00, 12.39s/it, est. speed input: 1327.12 toks/s, output: 26.22 t
The video sequence is a diverse collection of aerial shots and close-ups, each with distinct themes and settings.

1. **Aerial Combatants Scene**:
   - The video opens with a high-angle shot of the sea. **Tropical Swan**ryan controls an aircraft in a neo arena. The controller is鲷ィלהun, a player who is actively engaging in aerial combat. The drone maneuvers through the sky, demonstrating skillful control and precision.

2. **Desert Road Scene**:
   - The video then transitions to a wide shot of an asphalt road in the desert. The road is long and stretches far into the distance, flanked by sandy desert on either side. The sky above is clear and sunny, creating a stark contrast to the arid landscape below. The road appears dry and unpaved, with no visible vehicles or vegetation, emphasizing the vastness and emptiness of the desert. The scene is quiet and serene, with the only movement coming from the subtle sway of the sand dunes.

3. **Cali Basketball Court Scene**:
   - The next scene is a basketball court. A young man, wearing a blue and gray basketball jersey with the number "16" on the back, is shown dribbling the ball and shooting a shot through a basketball hoop. He appears to be practicing his shooting technique, showcasing his skill and athleticism.

The video maintains a consistent theme of precision and skill, with the controller in the first scene and the basketball player in the third, reflecting a dedicated and focused atmosphere. The transitions between scenes are smooth, maintaining a coherent narrative flow.
```
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
