### PR TITLE
[Bugfix] Add startup probe and fix disable extraInit container in online deploy helm chart

### DIFF
--- a/examples/online_serving/chart-helm/templates/_helpers.tpl
+++ b/examples/online_serving/chart-helm/templates/_helpers.tpl
@@ -90,6 +90,12 @@ livenessProbe:
 {{-       toYaml . | nindent 2 }}
 {{-     end }}
 {{-   end }}
+{{-   if .Values.startupProbe  }}
+startupProbe:
+{{-     with .Values.startupProbe }}
+{{-       toYaml . | nindent 2 }}
+{{-     end }}
+{{-   end }}
 {{- end }}
 
 {{/*

--- a/examples/online_serving/chart-helm/templates/deployment.yaml
+++ b/examples/online_serving/chart-helm/templates/deployment.yaml
@@ -64,9 +64,11 @@ spec:
             {{- include "chart.extraPorts" . | nindent 12 }}
           {{- include "chart.probes" . | indent 10 }}
           resources: {{- include "chart.resources" . | nindent 12 }}
+          {{-   if .Values.extraInit  }}
           volumeMounts:
           - name: {{ .Release.Name }}-storage
             mountPath: /data
+          {{- end }}
 
         {{- with .Values.extraContainers }}
         {{ toYaml . | nindent 8 }}
@@ -92,11 +94,11 @@ spec:
         volumeMounts:
         - name: {{ .Release.Name }}-storage
           mountPath: /data
-      {{- end }}
       volumes:
         - name: {{ .Release.Name }}-storage
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-storage-claim     
+      {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/examples/online_serving/chart-helm/values.yaml
+++ b/examples/online_serving/chart-helm/values.yaml
@@ -114,6 +114,18 @@ livenessProbe:
     # -- Name or number of the port to access on the container, on which the server is listening
     port: 8000
 
+startupProbe:
+  # -- Number of times after which if a probe fails in a row, Kubernetes considers that the overall check has failed: the container has failed to start
+  failureThreshold: 14
+  # -- How often (in seconds) to perform the liveness probe
+  periodSeconds: 10
+  # -- Configuration of the Kubelet http request on the server
+  httpGet:
+    # -- Path to access on the HTTP server
+    path: /health
+    # -- Name or number of the port to access on the container, on which the server is listening
+    port: 8000
+
 labels:
   environment: "test"
   release: "test"


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Enhance online deploy helm chart: add startup probe so that vllm server will not be killed prematurely when loading the model. Also fix extraInit parameter logic: volumeMount should not be present in deployment manifest if extraInit is disabled
## Test Plan
Perform a `helm install` to test that the chart deploys properly
## Test Result
Helm chart works with `extraInit` parameter turned off, also kubernetes doesn't kill container too soon
## (Optional) Documentation Update
- docs/deployment/frameworks/helm.md - info about new values for startup probe
- examples/online_serving/chart-helm/README.md
<!--- pyml disable-next-line no-emphasis-as-heading -->
