### PR TITLE
[Bugfix] fix modelscope snapshot_download serialization

### DIFF
--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -69,10 +69,10 @@ class DefaultModelLoader(BaseModelLoader):
             # pylint: disable=C.
             from modelscope.hub.snapshot_download import snapshot_download
 
-            if not os.path.exists(model):
-                # Use file lock to prevent multiple processes from
-                # downloading the same model weights at the same time.
-                with get_lock(model, self.load_config.download_dir):
+            # Use file lock to prevent multiple processes from
+            # downloading the same model weights at the same time.
+            with get_lock(model, self.load_config.download_dir):
+                if not os.path.exists(model):
                     model_path = snapshot_download(
                         model_id=model,
                         cache_dir=self.load_config.download_dir,
@@ -81,8 +81,8 @@ class DefaultModelLoader(BaseModelLoader):
                         revision=revision,
                         ignore_file_pattern=self.load_config.ignore_patterns,
                     )
-            else:
-                model_path = model
+                else:
+                    model_path = model
             return model_path
         return None
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Currently, path existence check is outside file lock. If there are two process, they both invoke `_maybe_download_from_modelscope` method, and
1. the 1 process find path not exist and it will get the file lock and start to download weight, this may take some seconds at least,
2. the 2 process find path not exist and it will try to get file lock and will be blocked, 
After process 1 download the weights, process 2 will get the lock and also try to invoke the `snapshot_download`. This is not the desired behavior. The serialization logic should be:
1. the 1 process get the file lock and start to download weight, this may take some seconds at least,
2. the 2 process will try to get the file lock and will be blocked,
After process 1 download the weights, process will get the lock and check for the existence of the model, if the model exists, process 2 do not need to call `snapshot_download`.



## Test Plan
NA
## Test Result
NA
## (Optional) Documentation Update
NA
<!--- pyml disable-next-line no-emphasis-as-heading -->
