### PR TITLE
[Docs][minor] Fix broken gh-file link in distributed serving docs

### DIFF
--- a/docs/serving/distributed_serving.md
+++ b/docs/serving/distributed_serving.md
@@ -62,7 +62,7 @@ If a single node lacks sufficient GPUs to hold the model, deploy vLLM across mul
 
 ### Ray cluster setup with containers
 
-The helper script `<gh-file:examples/online_serving/run_cluster.sh>` starts containers across nodes and initializes Ray. By default, the script runs Docker without administrative privileges, which prevents access to the GPU performance counters when profiling or tracing. To enable admin privileges, add the `--cap-add=CAP_SYS_ADMIN` flag to the Docker command.
+The helper script <gh-file:examples/online_serving/run_cluster.sh> starts containers across nodes and initializes Ray. By default, the script runs Docker without administrative privileges, which prevents access to the GPU performance counters when profiling or tracing. To enable admin privileges, add the `--cap-add=CAP_SYS_ADMIN` flag to the Docker command.
 
 Choose one node as the head node and run:
 


### PR DESCRIPTION
## Purpose
fixes broken link in master

<img width="989" height="410" alt="image" src="https://github.com/user-attachments/assets/2688b037-09ba-476e-911b-0b1944f65af7" />

https://docs.vllm.ai/en/latest/serving/distributed_serving.html#multi-node-deployment:~:text=%5B%3Aocticons%2Dmark%2Dgithub%2D16%3A%20examples/online_serving/run_cluster.sh%5D(https%3A//github.com/vllm%2Dproject/vllm/blob/main/examples/online_serving/run_cluster.sh)

cc @hmellor @njhill 
