### PR TITLE
[TPU][Bugfix] fix OOM issue in CI test

### DIFF
--- a/tests/v1/tpu/test_basic.py
+++ b/tests/v1/tpu/test_basic.py
@@ -58,7 +58,7 @@ def test_basic(
                 # actually test chunked prompt
                 max_num_batched_tokens=1024,
                 max_model_len=8192,
-                gpu_memory_utilization=0.7,
+                gpu_memory_utilization=0.95,
                 max_num_seqs=max_num_seqs,
                 tensor_parallel_size=tensor_parallel_size) as vllm_model:
             vllm_outputs = vllm_model.generate_greedy(example_prompts,


### PR DESCRIPTION

## Purpose

Fix the tpu ci test: tests/v1/tpu/test_basic.py. In https://github.com/vllm-project/vllm/pull/21340, it got merged without running the TPU CI test.

## Test Plan

pytest -s -v tests/v1/tpu/test_basic.py

## Test Result

Passed

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
