### PR TITLE
[Kernel] Improve machete memory bound perf

### DIFF
--- a/csrc/quantization/machete/machete_prepacked_layout.cuh
+++ b/csrc/quantization/machete/machete_prepacked_layout.cuh
@@ -187,8 +187,12 @@ struct PrepackedLayoutBTemplate {
   CUTE_HOST_DEVICE static constexpr auto TVbNbKL_to_offset_copy(
       Shape_NKL shape_mkl) {
     auto layout = TVbNbKL_to_offset(shape_mkl);
-    return make_layout(coalesce(get<0>(layout)), get<1>(layout),
-                       get<2>(layout));
+    // for 4-bit elements, having >= 64 values per column
+    // allows TMA to load full 32-byte sectors
+    auto inner_layout =
+        make_layout(make_shape(_256{}, size<0>(layout) / _256{}));
+
+    return make_layout(inner_layout, get<1>(layout), get<2>(layout));
   }
 
   // ((BlockN, BlockK), (BlocksN, BlocksK), L) -> (storage_idx)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Thanks @LucasWilkinson for tips and guidance on this!

TL;DR - Improve the memory-bound performance of Machete kernel by fixing TMA load memory alignment (see test result for performance comparison before/after this change)

Machete kernel uses TMA load instruction to copy matrices from global memory to shared memory ([ref](https://github.com/vllm-project/vllm/blob/main/csrc/quantization/machete/machete_mainloop.cuh#L871)). In memory-bound settings, this part dominates the total runtime; specifically, loading of the quantized weight matrix. Previously, [this code](https://github.com/vllm-project/vllm/blob/main/csrc/quantization/machete/machete_prepacked_layout.cuh#L190) is used to determine the bounding box size of the TMA load, which coalesces to `(256, 32):(32, 1)`. Because the weights are 4-bit, this ends up only being 16 bytes per row, which is below the granularity of the 32-byte sector. This results in TMA moving 2x the number of bytes it needs to, causing higher latency in memory-bound settings.

To illustrate this point concretely, the following is `ncu` profile of a simple `copyTMA` kernel which uses TMA instruction to load tiles of the 4-bit weight matrix into shared memory.
```
data type: cutlass::int4b_t
matrix shape: 16384 x 16384 

128x64
--------------------------------------------------------- ----------- ------------
Metric Name                                               Metric Unit Metric Value
--------------------------------------------------------- ----------- ------------
l1tex__m_xbar2l1tex_read_sectors_mem_global_op_tma_ld.sum      sector      4194304
smsp__inst_executed_op_tma_ld.sum                                inst        32768
--------------------------------------------------------- ----------- ------------

256x32
--------------------------------------------------------- ----------- ------------
Metric Name                                               Metric Unit Metric Value
--------------------------------------------------------- ----------- ------------
l1tex__m_xbar2l1tex_read_sectors_mem_global_op_tma_ld.sum      sector      8388608
smsp__inst_executed_op_tma_ld.sum                                inst        32768
--------------------------------------------------------- ----------- ------------
```
Even though the overall number of instructions and tile size is the same, the 256x32 tile needs to load 2x the number of sectors.

To fix this we enforced each column to have 256 values = 128 bytes so it is a multiple of the 32-byte sectors.

## Test Plan
- numerical test: `pytest tests/kernels/quantization/test_machete_mm.py`
- performance benchmark: `python3 benchmarks/kernels/benchmark_machete.py \ --act-type bfloat16 \ --group-scale-type bfloat16 \ --out-type bfloat16 \ model_bench`
- e2e correctness check using `lm_eval` with `gsm8k` task

## Test Result
numerical test
```
pytest tests/kernels/quantization/test_machete_mm.py
all pass
```

e2e correctness (using 4-bit quantized checkpoint based on Cohere Command A)
```
before
gsm8k: {'alias': 'gsm8k', 'exact_match,strict-match': np.float64(0.7), 'exact_match_stderr,strict-match': 0.046056618647183814, 'exact_match,flexible-extract': np.float64(0.84), 'exact_match_stderr,flexible-extract': 0.03684529491774711}

after
gsm8k: {'alias': 'gsm8k', 'exact_match,strict-match': np.float64(0.71), 'exact_match_stderr,strict-match': 0.04560480215720684, 'exact_match,flexible-extract': np.float64(0.84), 'exact_match_stderr,flexible-extract': 0.03684529491774711}
```

performance benchmark
```
| shape (Wuint4b8-Abf16-GSbf16-G128) | torch.matmul (fp16) | marlin | machete original | machete optimized | speedup factor |
| ---------------------------------- | ------------------- | ------ | ---------------- | ----------------- | -------------- |
| MKN=(1x12288x36864), L=1           | 313                 | 94     | 132.8            | 103.5             | 1.28           |
| MKN=(1x36864x12288), L=1           | 303.5               | 92.6   | 162.9            | 132.1             | 1.23           |
| MKN=(16x12288x36864), L=1          | 301.3               | 100.1  | 135.9            | 107.1             | 1.27           |
| MKN=(16x36864x12288), L=1          | 300.1               | 97     | 161.5            | 133.2             | 1.21           |
| MKN=(32x12288x36864), L=1          | 301                 | 113.9  | 138.4            | 106.6             | 1.30           |
| MKN=(32x36864x12288), L=1          | 302.5               | 114.1  | 132.9            | 106.4             | 1.25           |
| MKN=(64x12288x36864), L=1          | 305.2               | 172.7  | 167.1            | 150.7             | 1.11           |
| MKN=(64x36864x12288), L=1          | 307.9               | 172.5  | 148.5            | 136               | 1.09           |
| MKN=(128x12288x36864), L=1         | 306                 | 343.8  | 197.6            | 186.6             | 1.06           |
| MKN=(128x36864x12288), L=1         | 321                 | 332.8  | 204.1            | 193.7             | 1.05           |
| MKN=(256x12288x36864), L=1         | 353                 | 619    | 339.6            | 330.3             | 1.03           |
| MKN=(256x36864x12288), L=1         | 347.1               | 630.5  | 397.8            | 383.2             | 1.04           |
| MKN=(512x12288x36864), L=1         | 668                 | 1240.4 | 656.4            | 642.7             | 1.02           |
| MKN=(512x36864x12288), L=1         | 663.6               | 1292.8 | 662.4            | 637.3             | 1.04           |
| MKN=(1024x12288x36864), L=1        | 1270.3              | 2663.6 | 1327.3           | 1265.9            | 1.05           |
| MKN=(1024x36864x12288), L=1        | 1289.1              | 2778.5 | 1299.1           | 1257.2            | 1.03           |
| MKN=(2048x12288x36864), L=1        | 2561.6              | 5323.2 | 2612.8           | 2547.9            | 1.03           |
| MKN=(2048x36864x12288), L=1        | 2517.2              | 5553.8 | 2603.5           | 2533.9            | 1.03           |
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
