### PR TITLE
[Docs] Fix `site_url` for RunLLM

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,5 +1,5 @@
 site_name: vLLM
-site_url: https://docs.vllm.ai
+site_url: !ENV READTHEDOCS_CANONICAL_URL
 repo_url: https://github.com/vllm-project/vllm
 edit_uri: edit/main/docs/
 exclude_docs: |


### PR DESCRIPTION
This change should fix the `sitemap.xml` for RunLLM (and other crawlers).

https://docs.readthedocs.com/platform/stable/intro/mkdocs.html#set-the-canonical-url