### PR TITLE
[Bugfix] GGUF: fix AttributeError: 'PosixPath' object has no attribute 'startswith'

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -584,7 +584,7 @@ def get_pooling_config_name(pooling_name: str) -> Union[str, None]:
 
 
 @cache
-def get_sentence_transformer_tokenizer_config(model: str,
+def get_sentence_transformer_tokenizer_config(model: Union[str, Path],
                                               revision: Optional[str] = 'main'
                                               ):
     """
@@ -592,7 +592,7 @@ def get_sentence_transformer_tokenizer_config(model: str,
     given Sentence Transformer BERT model.
 
     Parameters:
-    - model (str): The name of the Sentence Transformer
+    - model (str|Path): The name of the Sentence Transformer
     BERT model.
     - revision (str, optional): The revision of the m
     odel to use. Defaults to 'main'.
@@ -620,7 +620,7 @@ def get_sentence_transformer_tokenizer_config(model: str,
             if encoder_dict:
                 break
 
-    if not encoder_dict and not model.startswith("/"):
+    if not encoder_dict and not Path(model).is_absolute():
         try:
             # If model is on HuggingfaceHub, get the repo files
             repo_files = list_repo_files(model,


### PR DESCRIPTION
Make sure `get_sentence_transformer_tokenizer_config` can accept both str and Path type arguments.

Fix https://github.com/vllm-project/vllm/issues/19173