### PR TITLE
[CI/Build] Fix failing tensorizer tests on AMD

### DIFF
--- a/tests/entrypoints/openai/test_tensorizer_entrypoint.py
+++ b/tests/entrypoints/openai/test_tensorizer_entrypoint.py
@@ -44,7 +44,7 @@ def model_uri(tmp_dir):
 def tensorize_model_and_lora(tmp_dir, model_uri):
     tensorizer_config = TensorizerConfig(tensorizer_uri=model_uri,
                                          lora_dir=tmp_dir)
-    args = EngineArgs(model=MODEL_NAME, device="cuda")
+    args = EngineArgs(model=MODEL_NAME)
 
     tensorize_lora_adapter(LORA_PATH, tensorizer_config)
     tensorize_vllm_model(args, tensorizer_config)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
See this failing on https://github.com/vllm-project/vllm/pull/21429
```
 args = EngineArgs(model=MODEL_NAME, device="cuda")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: EngineArgs.__init__() got an unexpected keyword argument 'device'
```

## Test Plan
```
pytest tests/entrypoints/openai/test_tensorizer_entrypoint.py::test_single_completion
```

## Test Result
it passed

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
