### PR TITLE
[Model] Fix for Granite 4 to work with compressed_tensors

### DIFF
--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -80,7 +80,7 @@ class GraniteMoeMoE(nn.Module):
                                      num_experts,
                                      bias=False,
                                      params_dtype=params_dtype,
-                                     quant_config=None,
+                                     quant_config=quant_config,
                                      prefix=f"{prefix}.gate")
 
         self.experts = FusedMoE(num_experts=num_experts,

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -497,6 +497,11 @@ class GraniteMoeHybridModel(nn.Module):
                 gate_name = n.replace('.block_sparse_moe.router.layer.weight',
                                       ".block_sparse_moe.gate.weight")
                 _load(gate_name, p)
+            elif n.endswith('.block_sparse_moe.router.layer.weight_scale'):
+                gate_name = n.replace(
+                    '.block_sparse_moe.router.layer.weight_scale',
+                    ".block_sparse_moe.gate.weight_scale")
+                _load(gate_name, p)
             else:
                 loaded = False
                 for param_name, weight_name, shard_id in stacked_params_mapping:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

A few minor fixes to enable us to run Granite 4.0 Hybrid models that have been quantized using `compressed_tensors`.

## Test Plan

Trying to deploy Granite 4.0 model compressed using `compressed_tensors`:
```
VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER vllm serve ./G4-FP8-Dynamic/ --enforce-eager --no-enable-prefix-caching
```
leads to:
```
  File "/home/zrltpa/vllm/vllm/model_executor/models/utils.py", line 291, in load_weights
    autoloaded_weights = set(self._load_module("", self.module, weights))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zrltpa/vllm/vllm/model_executor/models/utils.py", line 249, in _load_module
    yield from self._load_module(prefix,
  File "/home/zrltpa/vllm/vllm/model_executor/models/utils.py", line 222, in _load_module
    loaded_params = module_load_weights(weights)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zrltpa/vllm/vllm/model_executor/models/granitemoehybrid.py", line 509, in load_weights
    _load(n, p)
  File "/home/zrltpa/vllm/vllm/model_executor/models/granitemoehybrid.py", line 432, in _load
    param = params_dict[n]
            ~~~~~~~~~~~^^^
KeyError: 'layers.10.block_sparse_moe.router.layer.weight_scale'
```

## Test Result

After the fix, it works. 

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
