### PR TITLE
[Bugfix] Fix isinstance check for tensor types in _load_prompt_embeds to use dtype comparison

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -947,9 +947,7 @@ class OpenAIServing:
         def _load_and_validate_embed(embed: bytes) -> EmbedsPrompt:
             tensor = torch.load(io.BytesIO(base64.b64decode(embed)),
                                 weights_only=True)
-            assert isinstance(
-                tensor,
-                (torch.FloatTensor, torch.BFloat16Tensor, torch.HalfTensor))
+            assert tensor.dtype in (torch.float32, torch.bfloat16, torch.float16)
             if tensor.dim() > 2:
                 tensor = tensor.squeeze(0)
                 assert tensor.dim() == 2

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -947,8 +947,11 @@ class OpenAIServing:
         def _load_and_validate_embed(embed: bytes) -> EmbedsPrompt:
             tensor = torch.load(io.BytesIO(base64.b64decode(embed)),
                                 weights_only=True)
-            assert isinstance(tensor, torch.Tensor) and \
-                   tensor.dtype in (torch.float32, torch.bfloat16, torch.float16)
+            assert isinstance(tensor, torch.Tensor) and tensor.dtype in (
+                torch.float32,
+                torch.bfloat16,
+                torch.float16,
+            )
             if tensor.dim() > 2:
                 tensor = tensor.squeeze(0)
                 assert tensor.dim() == 2

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -947,7 +947,8 @@ class OpenAIServing:
         def _load_and_validate_embed(embed: bytes) -> EmbedsPrompt:
             tensor = torch.load(io.BytesIO(base64.b64decode(embed)),
                                 weights_only=True)
-            assert tensor.dtype in (torch.float32, torch.bfloat16, torch.float16)
+            assert isinstance(tensor, torch.Tensor) and \
+                   tensor.dtype in (torch.float32, torch.bfloat16, torch.float16)
             if tensor.dim() > 2:
                 tensor = tensor.squeeze(0)
                 assert tensor.dim() == 2


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

This PR fixes an issue in the `_load_prompt_embeds` function where the `isinstance` check for tensor types causes an internal error when processing `torch.float16` tensors, especially when they are moved to CUDA devices. The change replaces the `isinstance` check with a `dtype` comparison to ensure robust validation of tensor data types.

The current implementation of `_load_prompt_embeds` uses the following isinstance check to validate the tensor type:

This approach relies on legacy PyTorch tensor type classes (`torch.FloatTensor`, `torch.BFloat16Tensor`, `torch.HalfTensor`). However, these classes are not always reliable for type checking, especially when tensors are moved to CUDA devices. For example when a tensor is moved to CUDA device, its type becomes `torch.cuda.Float16Tensor`, which is not included in the `isinstance` check.

## Test Plan

vllm server:
```bash
VLLM_USE_V1=0 vllm serve Qwen/Qwen2.5-VL-3B-Instruct-AWQ --max-model-len 4096 --max-model-len 4096 --task generate --enable-prompt-embeds
```

client
```py
import base64
import io

import openai
import torch
import transformers
from transformers import Qwen2_5_VLForConditionalGeneration

def main():
    model_name = "Qwen/Qwen2.5-VL-3B-Instruct-AWQ"
    tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
    transformers_model = Qwen2_5_VLForConditionalGeneration.from_pretrained(model_name, device_map="auto", trust_remote_code=True)

    chat = [{"role": "user", "content": "Please tell me about the capital of France."}]
    token_ids = tokenizer.apply_chat_template(
        chat, add_generation_prompt=True, return_tensors="pt"
    )

    openai_client = openai.OpenAI(
    base_url="http://localhost:8000/v1",
        api_key="your-api-key-here"
    )


    embedding_layer = transformers_model.get_input_embeddings()
    prompt_embeds = embedding_layer(token_ids).squeeze(0).cuda() # <---- This is the CUDA tensor that provokes the internal error

    buffer = io.BytesIO()
    torch.save(prompt_embeds, buffer)
    buffer.seek(0)
    binary_data = buffer.read()
    encoded_embeds = base64.b64encode(binary_data).decode('utf-8')

    completion = openai_client.completions.create(
        model=model_name,
        # NOTE: The OpenAI client does not allow `None` as an input to
        # `prompt`. Use an empty string if you have no text prompts.
        prompt="",
        max_tokens=100,
        temperature=0.0,
        # NOTE: The OpenAI client allows passing in extra JSON body via the
        # `extra_body` argument.
        extra_body={"prompt_embeds": encoded_embeds},
    )
    print(completion.choices[0].text)

if __name__ == "__main__":
    main()
```

leads to:
```
Exception has occurred: AssertionError
exception: no description
  File ".../vllm/vllm/entrypoints/openai/serving_engine.py", line 950, in _load_and_validate_embed
    tensor,

                (torch.FloatTensor, torch.BFloat16Tensor, torch.HalfTensor))
AssertionError: 
```

```
INFO:     127.0.0.1:53030 - "POST /v1/completions HTTP/1.1" 500 Internal Server Error
INFO:     127.0.0.1:53030 - "POST /v1/completions HTTP/1.1" 500 Internal Server Error
INFO:     127.0.0.1:53030 - "POST /v1/completions HTTP/1.1" 500 Internal Server Error
```

## Test Result

After the fix, no Internal Error, it works.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
