### PR TITLE
[V1][Hybrid] Make KV cache layout of triton_attn compatible with hybrid models

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -180,7 +180,7 @@ class TritonAttentionBackend(AttentionBackend):
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")
-        return (2, num_blocks, block_size, num_kv_heads, head_size)
+        return (num_blocks, 2, block_size, num_kv_heads, head_size)
 
     @staticmethod
     def use_cascade_attention(*args, **kwargs) -> bool:
@@ -289,7 +289,7 @@ class TritonAttentionImpl(AttentionImpl):
             key_cache, value_cache = PagedAttention.split_kv_cache(
                 kv_cache, self.num_kv_heads, self.head_size)
         else:
-            key_cache, value_cache = kv_cache.unbind(0)
+            key_cache, value_cache = kv_cache.unbind(1)
 
         if self.kv_sharing_target_layer_name is None:
             # Reshape the input keys and values and store them in the cache.

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -180,6 +180,8 @@ class TritonAttentionBackend(AttentionBackend):
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")
+        if envs.VLLM_V1_USE_PREFILL_DECODE_ATTENTION:
+            return (2, num_blocks, block_size, num_kv_heads, head_size)
         return (num_blocks, 2, block_size, num_kv_heads, head_size)
 
     @staticmethod


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Making the Triton Attention backend compatible with hybrid models such as Bamba. 
CC @jvlunteren @tdoublep @LucasWilkinson  

## Test Plan

lm_eval and vllm serve. 

## Test Result

### Correctness

```
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1 lm_eval --model vllm \
    --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct/ \
    --tasks gsm8k --num_fewshot 5 --batch_size auto --limit 500
```

With main:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.798|±  |0.0180|
|     |       |strict-match    |     5|exact_match|↑  |0.782|±  |0.0185|
```

With this PR:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.796|±  |0.0180|
|     |       |strict-match    |     5|exact_match|↑  |0.780|±  |0.0185|

```

### Performance

on one H100: 
```
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1 vllm serve meta-llama/Llama-3.1-8B-Instruct \
    --disable-log-requests --no-enable-prefix-caching
python benchmarks/benchmark_serving.py --model meta-llama/Llama-3.1-8B-Instruct/ \
    --dataset-name sharegpt --dataset-path vllm-triton-backend/ShareGPT_V3_unfiltered_cleaned_split.json
```

main
```
============ Serving Benchmark Result ============
Successful requests:                     983       
Benchmark duration (s):                  20.90     
Total input tokens:                      211947    
Total generated tokens:                  195465    
Request throughput (req/s):              47.04     
Output token throughput (tok/s):         9354.36   
Total Token throughput (tok/s):          19497.50  
---------------Time to First Token----------------
Mean TTFT (ms):                          3607.50   
Median TTFT (ms):                        3481.39   
P99 TTFT (ms):                           6636.78   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          84.26     
Median TPOT (ms):                        47.19     
P99 TPOT (ms):                           223.04    
---------------Inter-token Latency----------------
Mean ITL (ms):                           37.22     
Median ITL (ms):                         24.02     
P99 ITL (ms):                            228.15    
==================================================
```

This PR
```
============ Serving Benchmark Result ============
Successful requests:                     983       
Benchmark duration (s):                  20.39     
Total input tokens:                      210898    
Total generated tokens:                  195251    
Request throughput (req/s):              48.21     
Output token throughput (tok/s):         9575.72   
Total Token throughput (tok/s):          19918.82  
---------------Time to First Token----------------
Mean TTFT (ms):                          3516.73   
Median TTFT (ms):                        3435.09   
P99 TTFT (ms):                           6476.26   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          81.26     
Median TPOT (ms):                        44.03     
P99 TPOT (ms):                           219.63    
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.92     
Median ITL (ms):                         24.02     
P99 ITL (ms):                            224.24    
==================================================
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
