### PR TITLE
[Core] Move EngineCoreRequest to Request conversion out of EngineCore

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -250,7 +250,8 @@ class InprocClient(EngineCoreClient):
         return self.engine_core.get_supported_tasks()
 
     def add_request(self, request: EngineCoreRequest) -> None:
-        self.engine_core.add_request(request)
+        req, request_wave = self.engine_core.preprocess_add_request(request)
+        self.engine_core.add_request(req, request_wave)
 
     def abort_requests(self, request_ids: list[str]) -> None:
         if len(request_ids) > 0:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

In engine core thread, we used 18us to convert EngineCoreRequest to Request which is on model forward critical path.

Ideally, we should be able to move the conversion from engine core thread to input request thread to relax the logic from critical path.

There's an extra benefit for making the change, as Request became available in input processing threads, which would significantly simplify the pending changes for block hashing optimization mentioned in https://github.com/vllm-project/vllm/issues/21247

<img width="1926" height="572" alt="image" src="https://github.com/user-attachments/assets/e45b35c0-ab59-4e57-bf3a-bae4b1f258e3" />

<img width="962" height="351" alt="image" src="https://github.com/user-attachments/assets/1e11e413-83dd-4fbf-9482-1beea720e8a4" />


## Test Plan
```
export VLLM_USE_MODELSCOPE=False;
export VLLM_TORCH_PROFILER_DIR=~/vllm_profile; # for profiling
export CUDA_VISIBLE_DEVICES=4;
VLLM_USE_V1=1 vllm serve facebook/opt-125m \
    --swap-space 16 \
    --disable-log-requests \
    --host :: \
    --dtype float16
```
```
VLLM_USE_V1=1 vllm bench serve \
    --dataset-name random \
    --model facebook/opt-125m \
    --served-model-name facebook/opt-125m \
    --random-input-len 700 \
    --random-output-len 1 \
    --endpoint /v1/completions \
    --ignore-eos \
    --host localhost \
    --port 8000 \
    --num-prompts 100 \
    --profile
```
## Test Result
With the change, handle_client_request in engine core thread reduced from 35us to 7us.
<img width="1443" height="486" alt="image" src="https://github.com/user-attachments/assets/ed56e120-1176-415d-8b7f-e7ffd093928f" />

As expected, right now, Request conversion is executing in parallel with model forward:
<img width="1707" height="565" alt="Screenshot 2025-07-25 at 12 11 49 PM" src="https://github.com/user-attachments/assets/d872eb2b-dfac-49ec-8632-149b3eeb49d6" />

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
