### PR TITLE
[Bug] Fix `has_flashinfer_moe` Import Error when it is not installed

### DIFF
--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -82,7 +82,9 @@ autotune = _lazy_import_wrapper(
 @functools.cache
 def has_flashinfer_moe() -> bool:
     """Return ``True`` if FlashInfer MoE module is available."""
-    return importlib.util.find_spec("flashinfer.fused_moe") is not None
+    if importlib.util.find_spec("flashinfer") is not None:
+        return importlib.util.find_spec("flashinfer.fused_moe") is not None
+    return False
 
 
 @functools.cache

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -82,9 +82,8 @@ autotune = _lazy_import_wrapper(
 @functools.cache
 def has_flashinfer_moe() -> bool:
     """Return ``True`` if FlashInfer MoE module is available."""
-    if importlib.util.find_spec("flashinfer") is not None:
-        return importlib.util.find_spec("flashinfer.fused_moe") is not None
-    return False
+    return has_flashinfer() and importlib.util.find_spec(
+        "flashinfer.fused_moe") is not None
 
 
 @functools.cache


### PR DESCRIPTION
## Purpose

Originally, if user doesn't install flashinfer, this will raise an error:

```bash
[rank0]:     return importlib.util.find_spec("flashinfer.fused_moe") is not None
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "<frozen importlib.util>", line 92, in find_spec
[rank0]: ModuleNotFoundError: No module named 'flashinfer'
```

Because `find_spec("flashinfer.fused_moe")` is different with `find_spec("flashinfer")`

This PR fixes this issue

## Test

```bash
INFO 07-25 12:55:35 [gpu_model_runner.py:1856] Loading model from scratch...
WARNING 07-25 12:55:35 [cuda.py:280] FlashInfer failed to import for V1 engine on Blackwell (SM 10.0) GPUs; it is recommended to install FlashInfer for better performance.
INFO 07-25 12:55:35 [cuda.py:290] Using Flash Attention backend on V1 engine.
```