### PR TITLE
[V1] Raise error if chunked prefill is explicitly disabled

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -761,8 +761,7 @@ class VllmRunner:
     - `max_model_len`: Set to `1024` instead of `None` to reduce memory usage.
     - `block_size`: To reduce memory usage, set default to `64` if on XPU
         devices, otherwise default to `16`.
-    - `enable_chunked_prefill`: Set to `False` instead of `None` for
-      test reproducibility.
+    - `enable_chunked_prefill`: Set to `None` to support V1 tests.
     - `enforce_eager`: Set to `False` to test CUDA graph.
     """
 
@@ -779,7 +778,7 @@ class VllmRunner:
         disable_log_stats: bool = True,
         tensor_parallel_size: int = 1,
         block_size: int = 16 if not torch.xpu.is_available() else 64,
-        enable_chunked_prefill: Optional[bool] = False,
+        enable_chunked_prefill: Optional[bool] = None,
         swap_space: int = 4,
         enforce_eager: Optional[bool] = False,
         **kwargs,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1529,6 +1529,9 @@ class EngineArgs:
         # for non-pooling tasks.
         # For pooling tasks the default is False
         if model_config.runner_type != "pooling":
+            if self.enable_chunked_prefill is False:
+                raise ValueError(
+                    "Cannot disable chunked prefill for V1 engine.")
             self.enable_chunked_prefill = True
             if self.enable_prefix_caching is None:
                 self.enable_prefix_caching = True


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Currently when a user specify `--no-enable-chunked-prefill` or `enable_chunked_prefill=False`, it will silently overwrite the setting to `True`. This PR raises an explicit error telling user it's not supported.
Users have asked for this behaviour e.g. in [#18547](https://github.com/vllm-project/vllm/issues/18547#issuecomment-2920326178)

## Test Plan
vllm serve:
```
$ vllm serve Qwen/Qwen3-0.6B --no-enable-chunked-prefill
INFO 07-25 21:36:36 [__init__.py:235] Automatically detected platform cuda.
INFO 07-25 21:36:38 [api_server.py:1775] vLLM API server version 0.1.dev7998+g2f6e6b3
INFO 07-25 21:36:38 [cli_args.py:264] non-default args: {'model_tag': 'Qwen/Qwen3-0.6B', 'enable_chunked_prefill': False}
INFO 07-25 21:36:42 [config.py:1605] Using max model len 40960
Traceback (most recent call last):
--- stack omitted ---
  File "/home/user/dev/vllm/vllm/engine/arg_utils.py", line 1533, in _set_default_args_v1
    raise ValueError(
ValueError: Cannot disable chunked prefill for V1 engine.
```

LLM class:
```
>>> llm = LLM(model="Qwen/Qwen3-0.6B", enable_chunked_prefill=False)
INFO 07-25 21:37:26 [config.py:1605] Using max model len 40960
Traceback (most recent call last):
...
  File "/home/user/dev/vllm/vllm/engine/arg_utils.py", line 1533, in _set_default_args_v1
    raise ValueError("Cannot disable chunked prefill for V1 engine.")
ValueError: Cannot disable chunked prefill for V1 engine.
```

## Test Result
See above

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
