### PR TITLE
Limit concurrent long partial prefills via max_long_partial_prefills

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -346,10 +346,13 @@ class PartialPrefillMetadata:
         we limit the number of long requests and only accept
         shorter requests from the queue while running them
         concurrently"""
+        max_long_partial_prefills = \
+            self.scheduler_config.max_long_partial_prefills
+        if max_long_partial_prefills is None:
+            max_long_partial_prefills = 1
         return not (seq_group.first_seq.get_num_new_tokens()
                     > self.scheduler_config.long_prefill_token_threshold
-                    and self.long_prefills
-                    >= self.scheduler_config.max_long_partial_prefills
+                    and self.long_prefills >= max_long_partial_prefills
                     and self.scheduler_config.max_num_partial_prefills > 1)
 
     def maybe_increment_partial_prefills(self,
@@ -395,8 +398,12 @@ class PartialPrefillMetadata:
             # going to schedule them anyway
             if (sg.first_seq.get_num_new_tokens()
                     > scheduler_config.long_prefill_token_threshold):
+                max_long_partial_prefills = \
+                    scheduler_config.max_long_partial_prefills
+                if max_long_partial_prefills is None:
+                    max_long_partial_prefills = 1
                 if (long_prefills + waiting_long_prefills
-                        >= scheduler_config.max_long_partial_prefills):
+                        >= max_long_partial_prefills):
                     continue
                 waiting_long_prefills += 1
             prefills += 1

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1458,9 +1458,7 @@ class EngineArgs:
 
         # No Concurrent Partial Prefills so far.
         if (self.max_num_partial_prefills
-                != SchedulerConfig.max_num_partial_prefills
-                or self.max_long_partial_prefills
-                != SchedulerConfig.max_long_partial_prefills):
+                != SchedulerConfig.max_num_partial_prefills):
             _raise_or_fallback(feature_name="Concurrent Partial Prefill",
                                recommend_to_remove=False)
             return False

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -7,9 +7,10 @@ import itertools
 import time
 from collections import defaultdict
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any, Optional, Union
 
-from vllm.config import VllmConfig
+from vllm.config import SchedulerConfig, VllmConfig
 from vllm.distributed.kv_events import EventPublisherFactory, KVEventBatch
 from vllm.distributed.kv_transfer.kv_connector.factory import (
     KVConnectorFactory)
@@ -36,6 +37,58 @@ from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class LongPartialPrefillMetadata:
+    enable_lpp: bool
+
+    # The number of prompts longer than the `long_prefill_token_threshold`
+    # that will be prefilled concurrently.
+    cur_long_prefills: int
+    long_prefills: set
+
+    scheduler_config: SchedulerConfig
+
+    @classmethod
+    def from_queues(
+        cls,
+        scheduler_config: SchedulerConfig,
+    ) -> LongPartialPrefillMetadata:
+        enable_lpp = (scheduler_config.long_prefill_token_threshold > 0 and
+                      scheduler_config.max_long_partial_prefills is not None)
+
+        return LongPartialPrefillMetadata(
+            enable_lpp=enable_lpp,
+            cur_long_prefills=0,
+            long_prefills=set(),
+            scheduler_config=scheduler_config,
+        )
+
+    def can_schedule(self, request: Request, num_new_tokens: int) -> bool:
+        if not self.enable_lpp:
+            return True
+
+        if (num_new_tokens
+                <= self.scheduler_config.long_prefill_token_threshold):
+            return True
+
+        can_schedule = (self.cur_long_prefills
+                        < self.scheduler_config.max_long_partial_prefills)
+
+        if can_schedule:
+            self.long_prefills.add(request.request_id)
+            self.cur_long_prefills += 1
+
+        return can_schedule
+
+    def revoke(self, request: Request) -> None:
+        if not self.enable_lpp:
+            return
+
+        if request.request_id in self.long_prefills:
+            self.long_prefills.remove(request.request_id)
+            self.cur_long_prefills -= 1
 
 
 class Scheduler(SchedulerInterface):
@@ -190,6 +243,8 @@ class Scheduler(SchedulerInterface):
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
 
+        lppm = LongPartialPrefillMetadata.from_queues(self.scheduler_config)
+
         # For logging.
         scheduled_timestamp = time.monotonic()
 
@@ -201,6 +256,11 @@ class Scheduler(SchedulerInterface):
             num_new_tokens = (request.num_tokens_with_spec +
                               request.num_output_placeholders -
                               request.num_computed_tokens)
+
+            if not lppm.can_schedule(request, num_new_tokens):
+                req_index += 1
+                continue
+
             if (0 < self.scheduler_config.long_prefill_token_threshold <
                     num_new_tokens):
                 num_new_tokens = (
@@ -237,6 +297,7 @@ class Scheduler(SchedulerInterface):
                 # we do not strictly follow the FCFS scheduling policy and
                 # allow the lower-priority requests to be scheduled.
                 req_index += 1
+                lppm.revoke(request)
                 continue
 
             while True:
@@ -265,6 +326,7 @@ class Scheduler(SchedulerInterface):
                     if self.log_stats:
                         preempted_req.record_event(
                             EngineCoreEventType.PREEMPTED, scheduled_timestamp)
+                    lppm.revoke(preempted_req)
 
                     self.waiting.prepend_request(preempted_req)
                     preempted_reqs.append(preempted_req)
@@ -401,6 +463,12 @@ class Scheduler(SchedulerInterface):
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
+
+                    if not lppm.can_schedule(request, num_new_tokens):
+                        self.waiting.pop_request()
+                        skipped_waiting_requests.prepend_request(request)
+                        continue
+
                     if (0 < self.scheduler_config.long_prefill_token_threshold
                             < num_new_tokens):
                         num_new_tokens = (
@@ -412,6 +480,7 @@ class Scheduler(SchedulerInterface):
                         num_new_tokens > token_budget:
                         self.waiting.pop_request()
                         skipped_waiting_requests.prepend_request(request)
+                        lppm.revoke(request)
                         continue
 
                     num_new_tokens = min(num_new_tokens, token_budget)
@@ -486,6 +555,7 @@ class Scheduler(SchedulerInterface):
                     # into the WAITING_FOR_REMOTE_KV state.
                     skipped_waiting_requests.prepend_request(request)
                     request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    lppm.revoke(request)
                     continue
 
                 req_index += 1


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

To further address https://github.com/vllm-project/vllm/issues/14003

As mentioned in https://github.com/vllm-project/vllm/pull/10235, extremely long texts may cause blocking (when long texts consume the entire budget) or slowdowns (when short and long requests are batched together), which can significantly increase TTFT for short requests.

While using smaller chunk sizes helps maintain TTFT and ITL for short texts in mixed workloads, it doesn't resolve the issue of long text prefills monopolizing the budget and blocking short text prefills.

This PR leverages `max_long_partial_prefills` in V1 to limit the number of concurrent long text prefills per step, reserving capacity for short texts to be prioritized. This optimization aims to improve P50-P90 TTFT metrics.

## Test Plan

Referencing the medium dataset results from https://github.com/vllm-project/vllm/pull/10235:

Tested with 1,000 requests (900 small requests: <50 prompt tokens; 100 large requests: 10k–20k tokens).
Compared main branch d1fb65bde367aa6e3d72520c84b60be3d1539917 against this PR.

```shell
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_USE_V1=1 \
vllm serve /data/models/Meta-Llama-3.1-8B-Instruct --disable-log-requests \
--long-prefill-token-threshold $THRESHOLD \
--max-long-partial-prefills $MAX_LONG_PREFILLS
```

```shell
python3 benchmarks/benchmark_serving.py --model /data/models/Meta-Llama-3.1-8B-Instruct --dataset-name custom \
--dataset-path /vllm-workspace/benchmarks/medium.jsonl --metric-percentiles 50,80,85,90,95,99 --request-rate 12
```

## Test Result

<img width="2604" height="1536" alt="image" src="https://github.com/user-attachments/assets/b7eabc70-945f-4dcb-83fc-34f9dc6f3a40" />

To achieve optimal throughput and TTFT, thorough tuning of both parameters is required:
- long_prefill_token_threshold: High values limit TTFT improvements.
- max_long_partial_prefills: Low values risk underutilizing computational resources and causing long-request queueing.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
