### PR TITLE
Keep reasoning content before applying chat template

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -192,6 +192,9 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
     content: Union[str, list[ChatCompletionContentPartParam]]
     """The contents of the message."""
 
+    reasoning_content: str
+    """The reasoning content of the message."""
+
     name: str
     """An optional name for the participant.
 
@@ -217,6 +220,9 @@ class ConversationMessage(TypedDict, total=False):
 
     content: Union[Optional[str], list[dict[str, str]]]
     """The contents of the message"""
+
+    reasoning_content: Optional[str]
+    """The reasoning content of the message"""
 
     tool_call_id: Optional[str]
     """Tool call that this message is responding to."""
@@ -1203,6 +1209,9 @@ def _parse_chat_message_content(
             if ("tool_calls" in parsed_msg
                 and parsed_msg["tool_calls"] is not None):
                 result_msg["tool_calls"] = list(parsed_msg["tool_calls"])
+            
+            if "reasoning_content" in message:
+                result_msg["reasoning_content"] = message["reasoning_content"]
         elif role == "tool":
             parsed_msg = _ToolParser(message)
             if "tool_call_id" in parsed_msg:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Currently, when vLLM converts requested chat messages into a prompt, it will not keep the `reasoning_content` field in the messages before applying the chat template.

For reasoning models that support tool calls, like Qwen3, there may be multiple messages (interleaved assistant and tool messages) after the latest user query when tool calls are performed. In the chat template of Qwen3, the reasoning contents in the history assistant messages after the *latest* user query will be kept (if not empty) during the generation of later assistant messages. In this case, the `reasoning_content` field is needed when applying the chat template.

This PR addresses this issue by introducing a `reasoning_content` field in the incoming message dict `CustomChatCompletionMessageParam` and internal message dict `ConversationMessage`, and copying the `reasoning_content` when it exists before applying the chat template.

## Test Plan

The following script calls the model threes times, the first two calls include a tool call and its follow-up response, and the last is a new user query. 

Tested with vLLM served Qwen3-1.7B, with `--tool-call-parser hermes --enable-auto-tool-choice --reasoning-parser "qwen3"`.

```python
from openai import OpenAI

client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")

tools = [
    {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get the weather of a certain location.",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string",
                        "description": "The location to query."
                    }
                },
                "required": ["location"]
            }
        }
    }
]

messages = [{"role": "user", "content": "What's the weather like in Shanghai?"}]
response = client.chat.completions.create(
    model=client.models.list().data[0].id,
    messages=messages,
    tools=tools,
    tool_choice="auto"
)
resp = response.choices[0].message
print("resp1:", resp)
tool_calls = resp.tool_calls
assert len(tool_calls) == 1
tool_call = tool_calls[0]


messages.append(resp)
messages.append({"role": "tool", "content": '{"result": "sunny"}', "tool_call_id": tool_call.id})
response = client.chat.completions.create(
    model=client.models.list().data[0].id,
    messages=messages,
    tools=tools,
    tool_choice="auto"
)
resp = response.choices[0].message
print("resp2:", resp)


messages.append(resp)
messages.append({"role": "user", "content": "Thanks."})
response = client.chat.completions.create(
    model=client.models.list().data[0].id,
    messages=messages,
    tools=tools,
    tool_choice="auto"
)
resp = response.choices[0].message
print("resp3:", resp)
```

## Test Result

**Before the PR**
Three prompts in the screen are as follows. The second prompt should keep the reasoning content from the result of the first prompt, but it didn't.
```
<|im_start|>system\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{"type": "function", "function": {"name": "get_weather", "description": "Get the weather of a certain location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The location to query."}}, "required": ["location"]}}}\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call><|im_end|>\n<|im_start|>user\nWhat\'s the weather like in Shanghai?<|im_end|>\n<|im_start|>assistant\n

<|im_start|>system\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{"type": "function", "function": {"name": "get_weather", "description": "Get the weather of a certain location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The location to query."}}, "required": ["location"]}}}\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call><|im_end|>\n<|im_start|>user\nWhat\'s the weather like in Shanghai?<|im_end|>\n<|im_start|>assistant\n\n\n\n<tool_call>\n{"name": "get_weather", "arguments": {"location": "Shanghai"}}\n</tool_call><|im_end|>\n<|im_start|>user\n<tool_response>\n{"result": "sunny"}\n</tool_response><|im_end|>\n<|im_start|>assistant\n

<|im_start|>system\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{"type": "function", "function": {"name": "get_weather", "description": "Get the weather of a certain location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The location to query."}}, "required": ["location"]}}}\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call><|im_end|>\n<|im_start|>user\nWhat\'s the weather like in Shanghai?<|im_end|>\n<|im_start|>assistant\n\n\n\n<tool_call>\n{"name": "get_weather", "arguments": {"location": "Shanghai"}}\n</tool_call><|im_end|>\n<|im_start|>user\n<tool_response>\n{"result": "sunny"}\n</tool_response><|im_end|>\n<|im_start|>assistant\n\n\nThe weather in Shanghai is currently sunny. Let me know if you need further details! 🌞<|im_end|>\n<|im_start|>user\nThanks.<|im_end|>\n<|im_start|>assistant\n
```

**After the PR**

The second prompt keeps the reasoning content of the first response since they belong to the same user query. The third prompt drops history reasoning contents since it belongs to a new user query.

```
<|im_start|>system\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{"type": "function", "function": {"name": "get_weather", "description": "Get the weather of a certain location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The location to query."}}, "required": ["location"]}}}\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call><|im_end|>\n<|im_start|>user\nWhat\'s the weather like in Shanghai?<|im_end|>\n<|im_start|>assistant\n

<|im_start|>system\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{"type": "function", "function": {"name": "get_weather", "description": "Get the weather of a certain location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The location to query."}}, "required": ["location"]}}}\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call><|im_end|>\n<|im_start|>user\nWhat\'s the weather like in Shanghai?<|im_end|>\n<|im_start|>assistant\n<think>\nOkay, the user is asking about the weather in Shanghai. Let me check the tools available. There\'s a function called get_weather that takes a location parameter. I need to call that function with "Shanghai" as the location. I\'ll make sure to structure the tool call correctly in JSON inside the XML tags.\n</think>\n\n\n<tool_call>\n{"name": "get_weather", "arguments": {"location": "Shanghai"}}\n</tool_call><|im_end|>\n<|im_start|>user\n<tool_response>\n{"result": "sunny"}\n</tool_response><|im_end|>\n<|im_start|>assistant\n

<|im_start|>system\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{"type": "function", "function": {"name": "get_weather", "description": "Get the weather of a certain location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The location to query."}}, "required": ["location"]}}}\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call><|im_end|>\n<|im_start|>user\nWhat\'s the weather like in Shanghai?<|im_end|>\n<|im_start|>assistant\n\n\n\n<tool_call>\n{"name": "get_weather", "arguments": {"location": "Shanghai"}}\n</tool_call><|im_end|>\n<|im_start|>user\n<tool_response>\n{"result": "sunny"}\n</tool_response><|im_end|>\n<|im_start|>assistant\n\n\nThe weather in Shanghai is currently **sunny**. Let me know if you need further details! 😊<|im_end|>\n<|im_start|>user\nThanks.<|im_end|>\n<|im_start|>assistant\n
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
