### PR TITLE
Migrate FuyuImagePatchInputs to TensorSchema

### DIFF
--- a/tests/standalone_tests/test_tensor_schema.py
+++ b/tests/standalone_tests/test_tensor_schema.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from vllm.model_executor.models.fuyu import FuyuImagePatchInputs
 from vllm.model_executor.models.phi3v import Phi3VImagePixelInputs
 
 
@@ -123,4 +124,25 @@ def test_tensor_schema_with_invalid_resolve_binding_dims():
                 "h": 336,
                 "w": 336
             },
+        )
+
+
+def test_tensor_schema_with_list_of_symbolic_dim():
+    flat_data = [torch.randn(768) for _ in range(3)]  # (bn=3, fn)
+    patches_per_image = [64, 64, 64]  # len = bn = 3
+
+    FuyuImagePatchInputs(
+        flat_data=flat_data,
+        patches_per_image=patches_per_image,
+    )
+
+
+def test_tensor_schema_with_list_of_symbolic_dim_mismatch_in_length():
+    flat_data = [torch.randn(768) for _ in range(4)]  # (bn=4, fn)
+    patches_per_image = [64, 64, 64]  # len = 3 ≠ bn
+
+    with pytest.raises(ValueError, match="expected 'bn'=4, got 3"):
+        FuyuImagePatchInputs(
+            flat_data=flat_data,
+            patches_per_image=patches_per_image,
         )

--- a/tests/standalone_tests/test_tensor_schema.py
+++ b/tests/standalone_tests/test_tensor_schema.py
@@ -128,7 +128,7 @@ def test_tensor_schema_with_invalid_resolve_binding_dims():
 
 
 def test_tensor_schema_with_list_of_symbolic_dim():
-    flat_data = [torch.randn(768) for _ in range(3)]  # (bn=3, fn)
+    flat_data = torch.stack([torch.randn(768) for _ in range(3)])  # (bn=3, fn)
     patches_per_image = [64, 64, 64]  # len = bn = 3
 
     FuyuImagePatchInputs(
@@ -138,7 +138,7 @@ def test_tensor_schema_with_list_of_symbolic_dim():
 
 
 def test_tensor_schema_with_list_of_symbolic_dim_mismatch_in_length():
-    flat_data = [torch.randn(768) for _ in range(4)]  # (bn=4, fn)
+    flat_data = torch.stack([torch.randn(768) for _ in range(4)])  # (bn=4, fn)
     patches_per_image = [64, 64, 64]  # len = 3 ≠ bn
 
     with pytest.raises(ValueError, match="expected 'bn'=4, got 3"):

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -86,9 +86,6 @@ class TensorSchema:
             expected_shape: tuple[Union[int, str], ...],
             dynamic_dims: set[str, ...]) -> tuple[int, ...]:
         """Validate a list/tuple of tensors and return the actual shape."""
-        if not value:
-            raise ValueError(f"{field_name} is an empty list")
-
         # Ensure all tensors in the list have the same
         # shape, besides dynamic dimensions
         first = value[0]
@@ -117,6 +114,7 @@ class TensorSchema:
                                                                          int],
                                         dynamic_dims: set[str, ...]) -> None:
         """Validate that the actual tensor shape matches the expected shape."""
+
         if len(actual_shape) != len(expected_shape):
             raise ValueError(f"{field_name} has rank {len(actual_shape)} "
                              f"but expected {len(expected_shape)}")
@@ -160,12 +158,12 @@ class TensorSchema:
                     # Skip validation when Union contains None
                     if type(None) in args:
                         continue
-                # If not optional, raise error
+                # Otherwise field is required, raise error
                 raise ValueError(f"Required field '{field_name}' is missing")
 
             # Field exists, proceed with validation
             value = getattr(self, field_name)
-
+            #
             if get_origin(field_type) is not None:
                 args = get_args(field_type)
 
@@ -173,13 +171,23 @@ class TensorSchema:
                     if isinstance(arg, TensorShape):
                         expected_shape = arg.resolve(**self._resolve_bindings)
                         if isinstance(value, (list, tuple)):
-                            actual_shape = self._validate_nested_tensors(
-                                value, field_name, expected_shape,
-                                arg.dynamic_dims)
+                            # list/tuple of Tensors → shape = (len(value), ...)
+                            if value and isinstance(value[0], torch.Tensor):
+                                actual_shape = self._validate_nested_tensors(
+                                    value, field_name, expected_shape,
+                                    arg.dynamic_dims)
+                            elif value:
+                                # list/tuple of scalars → shape = (len(value),)
+                                actual_shape = (len(value), )
+                            else:
+                                raise ValueError(
+                                    f"{field_name} is an empty list")
 
+                        # Tensor → shape = tensor.shape
                         elif isinstance(value, torch.Tensor):
                             actual_shape = value.shape
 
+                        # Otherwise, it's an unsupported type
                         else:
                             type_names = []
                             for arg in args:
@@ -192,7 +200,7 @@ class TensorSchema:
                             raise ValueError(
                                 f"{field_name} is not one of the expected "
                                 f"types: {expected_types}")
-
+                        # print('performed validation')
                         self._validate_tensor_shape_expected(
                             actual_shape, expected_shape, field_name,
                             shape_env, arg.dynamic_dims)

--- a/vllm/utils/tensor_schema.py
+++ b/vllm/utils/tensor_schema.py
@@ -163,7 +163,6 @@ class TensorSchema:
 
             # Field exists, proceed with validation
             value = getattr(self, field_name)
-            #
             if get_origin(field_type) is not None:
                 args = get_args(field_type)
 
@@ -200,7 +199,7 @@ class TensorSchema:
                             raise ValueError(
                                 f"{field_name} is not one of the expected "
                                 f"types: {expected_types}")
-                        # print('performed validation')
+
                         self._validate_tensor_shape_expected(
                             actual_shape, expected_shape, field_name,
                             shape_env, arg.dynamic_dims)


### PR DESCRIPTION
## Purpose
This PR migrates FuyuImagePatchInputs from a TypedDict-based definition to a structured TensorSchema model with runtime shape validation. This brings it in line with recent changes to Phi3VImagePixelInputs, and is part of a broader effort to improve input contract enforcement and debug-ability across multi-modal models.

## Test Plan

Confirm validation works via standalone tests in tests/standalone_test/test_tensor_schema.py.

## Test Result

```
(venv) benjibeck@Benjis-MBP vllm % python3 -m pytest tests/standalone_tests/test_tensor_schema.py -v --log-cli-level=DEBUG
=========================================================================================================== test session starts ===========================================================================================================
platform darwin -- Python 3.9.6, pytest-8.4.1, pluggy-1.6.0 -- /Users/benjibeck/Projects/vllm/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/benjibeck/Projects/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 14 items                                                                                                                                                                                                                        

tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_valid_tensor PASSED                                                                                                                                                [  7%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_optional_fields PASSED                                                                                                                                             [ 14%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_constant_dim_failure PASSED                                                                                                                                        [ 21%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_symbolic_dim_mismatch PASSED                                                                                                                                       [ 28%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_list_tensor_valid PASSED                                                                                                                                           [ 35%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_variable_patch_counts_valid PASSED                                                                                                                                 [ 42%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_tuple_tensor_valid PASSED                                                                                                                                          [ 50%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_inconsistent_shapes_in_list PASSED                                                                                                                                 [ 57%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_empty_list PASSED                                                                                                                                                  [ 64%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_validation_disabled_skips_shape_check PASSED                                                                                                                       [ 71%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_with_valid_resolve_binding_dims PASSED                                                                                                                             [ 78%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_with_invalid_resolve_binding_dims PASSED                                                                                                                           [ 85%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_with_list_of_symbolic_dim PASSED                                                                                                                                   [ 92%]
tests/standalone_tests/test_tensor_schema.py::test_tensor_schema_with_list_of_symbolic_dim_mismatch_in_length PASSED                                                                                                                [100%]
```