### PR TITLE
support `torch.compile` for bailing moe

### DIFF
--- a/vllm/model_executor/models/bailing_moe.py
+++ b/vllm/model_executor/models/bailing_moe.py
@@ -32,6 +32,7 @@ from torch import nn
 from transformers.configuration_utils import PretrainedConfig
 
 from vllm.attention import Attention
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size,
@@ -291,6 +292,7 @@ class BailingMoeBlock(nn.Module):
         return hidden_states, residual
 
 
+@support_torch_compile
 class BailingMoeModel(nn.Module):
 
     def __init__(


### PR DESCRIPTION
The BaiLing MoE model supports `torch.compile`, but the code does not include the decorator `@support_torch_compile`, which led to slow performance.