### PR TITLE
Handle non-serializable objects in vllm bench

### DIFF
--- a/vllm/benchmarks/utils.py
+++ b/vllm/benchmarks/utils.py
@@ -67,4 +67,9 @@ class InfEncoder(json.JSONEncoder):
 
 def write_to_json(filename: str, records: list) -> None:
     with open(filename, "w") as f:
-        json.dump(records, f, cls=InfEncoder)
+        json.dump(
+            records,
+            f,
+            cls=InfEncoder,
+            default=lambda o: f"<{type(o).__name__} is not JSON serializable>",
+        )


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

## Purpose

https://github.com/vllm-project/vllm/pull/13993 added `vllm bench` cli but it has a small bug in how it fails to handle non-serializable objects when writing the benchmark results.  The bug has been fixed in the nightly benchmark script in https://github.com/vllm-project/vllm/pull/19114, but `vllm bench` command didn't have the fix yet.  This PR brings the same fix from https://github.com/vllm-project/vllm/pull/19114 over.

The issue https://github.com/pytorch/pytorch-integration-testing/actions/runs/16541559146/job/46783496249#step:14:3335 manifested in nightly benchmark run after https://github.com/vllm-project/vllm/pull/21355 started to switch to `vllm bench` in nightly benchmark without bringing over the fix in https://github.com/vllm-project/vllm/pull/19114.  The code under `benchmarks` will be cleaned up in the future anyway, but I leave it to @yeqcharlotte to decide on the timing instead of cleaning them up here.

## Test Plan

I'll post the benchmark run using the code from this PR in a min.

cc @yeqcharlotte @houseroad @simon-mo 