### PR TITLE
[Bugfix] fix max-file-size type from str to int

### DIFF
--- a/examples/offline_inference/save_sharded_state.py
+++ b/examples/offline_inference/save_sharded_state.py
@@ -47,7 +47,7 @@ def parse_args():
     )
     parser.add_argument(
         "--max-file-size",
-        type=str,
+        type=int,
         default=5 * 1024**3,
         help="max size (in bytes) of each safetensors file",
     )


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

`max-file-size` argument type should be `int` instead of `str`. Otherwise, the invocation of `save_sharded_loader` will complains about the type of `max_size` with error like this: 
```
ERROR 07-27 22:33:45 [core.py:715]     if max_size is not None and total_size + param_size > max_size:
ERROR 07-27 22:33:45 [core.py:715]                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 07-27 22:33:45 [core.py:715] TypeError: '>' not supported between instances of 'int' and 'str'
```
## Purpose
NA
## Test Plan
NA
## Test Result
NA
## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
