### PR TITLE
[Kernel][Triton] add bfloat16 support for awq

### DIFF
--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Union
 
 import torch
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
@@ -54,6 +55,8 @@ class AWQConfig(QuantizationConfig):
         return "awq"
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        if envs.VLLM_USE_TRITON_AWQ:
+            return [torch.half, torch.bfloat16]
         return [torch.half]
 
     @classmethod


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Add BF16 support to AWQ Triton kernel in order to enable BF16 AWQ on platforms that rely on Triton for AWQ.

## Test Plan

Vibe checked https://huggingface.co/mandeeplearning/Qwen2.5-0.5B-Instruct-AWQ

## Test Result

Prompt:

"The capital of France is"

Response:

" Paris. The main building in the middle of the city site is the Eiff"

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
