### PR TITLE
Fix typo for limit-mm-per-prompt in docs

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3145,7 +3145,7 @@ class MultiModalConfig:
     Defaults to 1 (V0) or 999 (V1) for each modality.
 
     For example, to allow up to 16 images and 2 videos per prompt:
-    `{"images": 16, "videos": 2}`
+    `{"image": 16, "video": 2}`
     """
 
     media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)


### PR DESCRIPTION
## Purpose
Fixing a tiny typo in the docs for engine arg `limit-mm-per-prompt` where new format of arg seems to be `{"image": 16}` and not `{"images": 16}`

## Test Plan
I tested and it works!

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
