### PR TITLE
[XPU] IPEX-optimized Punica Wrapper on XPU

### DIFF
--- a/vllm/lora/ops/ipex_ops/__init__.py
+++ b/vllm/lora/ops/ipex_ops/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.lora.ops.ipex_ops.lora_ops import (bgmv_expand, bgmv_expand_slice,
+                                             bgmv_shrink)
+
+__all__ = ["bgmv_expand", "bgmv_expand_slice", "bgmv_shrink"]

--- a/vllm/lora/ops/ipex_ops/lora_ops.py
+++ b/vllm/lora/ops/ipex_ops/lora_ops.py
@@ -10,7 +10,7 @@ logger = init_logger(__name__)
 try:
     import intel_extension_for_pytorch as ipex
 except ImportError as e:
-    logger.warning("Import error msg: %s", e.msg)
+   raise e
 
 
 def bgmv_shrink(inputs: torch.Tensor,

--- a/vllm/lora/ops/ipex_ops/lora_ops.py
+++ b/vllm/lora/ops/ipex_ops/lora_ops.py
@@ -4,8 +4,6 @@
 import torch
 
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
-from vllm.utils import direct_register_custom_op
 
 logger = init_logger(__name__)
 
@@ -15,92 +13,32 @@ except ImportError as e:
     logger.warning("Import error msg: %s", e.msg)
 
 
-def _bgmv_shrink(inputs: torch.Tensor,
-                 lora_a_weights: torch.Tensor,
-                 output_tensor: torch.Tensor,
-                 lora_indices_tensor: torch.Tensor,
-                 scaling: float = 1.0) -> None:
+def bgmv_shrink(inputs: torch.Tensor,
+                lora_a_weights: torch.Tensor,
+                output_tensor: torch.Tensor,
+                lora_indices_tensor: torch.Tensor,
+                scaling: float = 1.0) -> None:
 
     ipex.llm.functional.bgmv_shrink(inputs, lora_a_weights, output_tensor,
                                     lora_indices_tensor, scaling)
 
 
-def _bgmv_shrink_fake(inputs: torch.Tensor,
-                      lora_a_weights: torch.Tensor,
-                      output_tensor: torch.Tensor,
-                      lora_indices_tensor: torch.Tensor,
-                      scaling: float = 1.0) -> None:
-    pass
-
-
-def _bgmv_expand(inputs: torch.Tensor,
-                 lora_b_weights: torch.Tensor,
-                 output_tensor: torch.Tensor,
-                 lora_indices_tensor: torch.Tensor,
-                 add_inputs: bool = True) -> None:
+def bgmv_expand(inputs: torch.Tensor,
+                lora_b_weights: torch.Tensor,
+                output_tensor: torch.Tensor,
+                lora_indices_tensor: torch.Tensor,
+                add_inputs: bool = True) -> None:
     ipex.llm.functional.bgmv_expand(inputs, lora_b_weights, output_tensor,
                                     lora_indices_tensor, add_inputs)
 
 
-def _bgmv_expand_fake(inputs: torch.Tensor,
+def bgmv_expand_slice(inputs: torch.Tensor,
                       lora_b_weights: torch.Tensor,
                       output_tensor: torch.Tensor,
                       lora_indices_tensor: torch.Tensor,
+                      slice_offset: int,
+                      slice_size: int,
                       add_inputs: bool = True) -> None:
-    pass
-
-
-def _bgmv_expand_slice(inputs: torch.Tensor,
-                       lora_b_weights: torch.Tensor,
-                       output_tensor: torch.Tensor,
-                       lora_indices_tensor: torch.Tensor,
-                       slice_offset: int,
-                       slice_size: int,
-                       add_inputs: bool = True) -> None:
     ipex.llm.functional.bgmv_expand_slice(inputs, lora_b_weights,
                                           output_tensor, lora_indices_tensor,
                                           slice_offset, slice_size, add_inputs)
-
-
-def _bgmv_expand_slice_fake(inputs: torch.Tensor,
-                            lora_b_weights: torch.Tensor,
-                            output_tensor: torch.Tensor,
-                            lora_indices_tensor: torch.Tensor,
-                            slice_offset: int,
-                            slice_size: int,
-                            add_inputs: bool = True) -> None:
-    pass
-
-
-try:
-    direct_register_custom_op(
-        op_name="bgmv_shrink",
-        op_func=_bgmv_shrink,
-        mutates_args=["output_tensor"],
-        fake_impl=_bgmv_shrink_fake,
-        dispatch_key=current_platform.dispatch_key,
-    )
-    bgmv_shrink = torch.ops.vllm.bgmv_shrink
-
-    direct_register_custom_op(
-        op_name="bgmv_expand",
-        op_func=_bgmv_expand,
-        mutates_args=["output_tensor"],
-        fake_impl=_bgmv_expand_fake,
-        dispatch_key=current_platform.dispatch_key,
-    )
-    bgmv_expand = torch.ops.vllm.bgmv_expand
-
-    direct_register_custom_op(
-        op_name="bgmv_expand_slice",
-        op_func=_bgmv_expand_slice,
-        mutates_args=["output_tensor"],
-        fake_impl=_bgmv_expand_slice_fake,
-        dispatch_key=current_platform.dispatch_key,
-    )
-    bgmv_expand_slice = torch.ops.vllm.bgmv_expand_slice
-
-except AttributeError:
-    bgmv_shrink = _bgmv_shrink
-    bgmv_expand = _bgmv_expand
-    bgmv_expand_slice = _bgmv_expand_slice

--- a/vllm/lora/ops/ipex_ops/lora_ops.py
+++ b/vllm/lora/ops/ipex_ops/lora_ops.py
@@ -10,7 +10,7 @@ logger = init_logger(__name__)
 try:
     import intel_extension_for_pytorch as ipex
 except ImportError as e:
-   raise e
+    raise e
 
 
 def bgmv_shrink(inputs: torch.Tensor,

--- a/vllm/lora/ops/ipex_ops/lora_ops.py
+++ b/vllm/lora/ops/ipex_ops/lora_ops.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils import direct_register_custom_op
+
+logger = init_logger(__name__)
+
+try:
+    import intel_extension_for_pytorch as ipex
+except ImportError as e:
+    logger.warning("Import error msg: %s", e.msg)
+
+
+def _bgmv_shrink(inputs: torch.Tensor,
+                 lora_a_weights: torch.Tensor,
+                 output_tensor: torch.Tensor,
+                 lora_indices_tensor: torch.Tensor,
+                 scaling: float = 1.0) -> None:
+
+    ipex.llm.functional.bgmv_shrink(inputs, lora_a_weights, output_tensor,
+                                    lora_indices_tensor, scaling)
+
+
+def _bgmv_shrink_fake(inputs: torch.Tensor,
+                      lora_a_weights: torch.Tensor,
+                      output_tensor: torch.Tensor,
+                      lora_indices_tensor: torch.Tensor,
+                      scaling: float = 1.0) -> None:
+    pass
+
+
+def _bgmv_expand(inputs: torch.Tensor,
+                 lora_b_weights: torch.Tensor,
+                 output_tensor: torch.Tensor,
+                 lora_indices_tensor: torch.Tensor,
+                 add_inputs: bool = True) -> None:
+    ipex.llm.functional.bgmv_expand(inputs, lora_b_weights, output_tensor,
+                                    lora_indices_tensor, add_inputs)
+
+
+def _bgmv_expand_fake(inputs: torch.Tensor,
+                      lora_b_weights: torch.Tensor,
+                      output_tensor: torch.Tensor,
+                      lora_indices_tensor: torch.Tensor,
+                      add_inputs: bool = True) -> None:
+    pass
+
+
+def _bgmv_expand_slice(inputs: torch.Tensor,
+                       lora_b_weights: torch.Tensor,
+                       output_tensor: torch.Tensor,
+                       lora_indices_tensor: torch.Tensor,
+                       slice_offset: int,
+                       slice_size: int,
+                       add_inputs: bool = True) -> None:
+    ipex.llm.functional.bgmv_expand_slice(inputs, lora_b_weights,
+                                          output_tensor, lora_indices_tensor,
+                                          slice_offset, slice_size, add_inputs)
+
+
+def _bgmv_expand_slice_fake(inputs: torch.Tensor,
+                            lora_b_weights: torch.Tensor,
+                            output_tensor: torch.Tensor,
+                            lora_indices_tensor: torch.Tensor,
+                            slice_offset: int,
+                            slice_size: int,
+                            add_inputs: bool = True) -> None:
+    pass
+
+
+try:
+    direct_register_custom_op(
+        op_name="bgmv_shrink",
+        op_func=_bgmv_shrink,
+        mutates_args=["output_tensor"],
+        fake_impl=_bgmv_shrink_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
+    bgmv_shrink = torch.ops.vllm.bgmv_shrink
+
+    direct_register_custom_op(
+        op_name="bgmv_expand",
+        op_func=_bgmv_expand,
+        mutates_args=["output_tensor"],
+        fake_impl=_bgmv_expand_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
+    bgmv_expand = torch.ops.vllm.bgmv_expand
+
+    direct_register_custom_op(
+        op_name="bgmv_expand_slice",
+        op_func=_bgmv_expand_slice,
+        mutates_args=["output_tensor"],
+        fake_impl=_bgmv_expand_slice_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
+    bgmv_expand_slice = torch.ops.vllm.bgmv_expand_slice
+
+except AttributeError:
+    bgmv_shrink = _bgmv_shrink
+    bgmv_expand = _bgmv_expand
+    bgmv_expand_slice = _bgmv_expand_slice

--- a/vllm/lora/punica_wrapper/punica_xpu.py
+++ b/vllm/lora/punica_wrapper/punica_xpu.py
@@ -20,7 +20,7 @@ from .punica_base import PunicaWrapperBase
 @final
 class PunicaWrapperXPU(PunicaWrapperBase):
     """
-    PunicaWrapperGPU is designed to manage and provide metadata for the punica 
+    PunicaWrapperXPU is designed to manage and provide metadata for the punica
     kernel. The main function is to maintain the state information for 
     Multi-LoRA, and to provide the interface for the punica triton kernel.
     """

--- a/vllm/lora/punica_wrapper/punica_xpu.py
+++ b/vllm/lora/punica_wrapper/punica_xpu.py
@@ -58,8 +58,8 @@ class PunicaWrapperXPU(PunicaWrapperBase):
         y: torch.Tensor,
         x: torch.Tensor,
         w_t_all: torch.Tensor,
-        y_offset: Optional[int],
-        y_slice_size: Optional[int],
+        y_offset: int,
+        y_slice_size: int,
         add_inputs: bool,
     ):
         token_lora_indices = self._get_token_lora_indices(x)

--- a/vllm/lora/punica_wrapper/punica_xpu.py
+++ b/vllm/lora/punica_wrapper/punica_xpu.py
@@ -22,7 +22,7 @@ class PunicaWrapperXPU(PunicaWrapperBase):
     """
     PunicaWrapperXPU is designed to manage and provide metadata for the punica
     kernel. The main function is to maintain the state information for 
-    Multi-LoRA, and to provide the interface for the punica triton kernel.
+    Multi-LoRA, and to provide the interface for the punica ipex kernel.
     """
 
     def __init__(self, max_num_batched_tokens: int, max_batches: int,

--- a/vllm/lora/punica_wrapper/punica_xpu.py
+++ b/vllm/lora/punica_wrapper/punica_xpu.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Based on:
+Chen, L., Ye, Z., Wu, Y., Zhuo, D., Ceze, L., & Krishnamurthy, A. (2023). 
+Punica: Multi-Tenant LoRA Serving. 
+https://arxiv.org/abs/2310.18547
+"""
+
+from typing import Optional, Union, final
+
+import torch
+
+from vllm.lora.layers import LoRAMapping
+from vllm.lora.ops.ipex_ops import bgmv_expand, bgmv_expand_slice, bgmv_shrink
+
+from .punica_base import PunicaWrapperBase
+
+
+@final
+class PunicaWrapperXPU(PunicaWrapperBase):
+    """
+    PunicaWrapperGPU is designed to manage and provide metadata for the punica 
+    kernel. The main function is to maintain the state information for 
+    Multi-LoRA, and to provide the interface for the punica triton kernel.
+    """
+
+    def __init__(self, max_num_batched_tokens: int, max_batches: int,
+                 device: Union[torch.device, str], **kwargs):
+        PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches,
+                                   device)
+        torch._dynamo.mark_dynamic(self._token_lora_indices, 0)
+        torch._dynamo.mark_dynamic(self._embeddings_indices, 1)
+        torch._dynamo.mark_dynamic(self._sampler_indices_padded, 0)
+
+    def update_metadata(self, mapping: LoRAMapping,
+                        lora_index_to_id: list[Optional[int]], max_loras: int,
+                        vocab_size: int, extra_vocab_size: int, **kwargs):
+
+        self.is_prefill = mapping.is_prefill
+        self._update_base_metadata(mapping, lora_index_to_id, max_loras,
+                                   vocab_size, extra_vocab_size)
+
+    def _get_token_lora_indices(self, x: torch.Tensor) -> torch.IntTensor:
+        return torch.narrow(self._token_lora_indices, 0, 0, x.size(0))
+
+    def _apply_shrink(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: torch.Tensor,
+        scale: float,
+    ):
+        bgmv_shrink(x, w_t_all, y, self._get_token_lora_indices(x), scale)
+
+    def _apply_expand(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: torch.Tensor,
+        y_offset: Optional[int],
+        y_slice_size: Optional[int],
+        add_inputs: bool,
+    ):
+        token_lora_indices = self._get_token_lora_indices(x)
+        bgmv_expand_slice(x, w_t_all, y, token_lora_indices, y_offset,
+                          y_slice_size, add_inputs)
+
+    def add_shrink(self, y: torch.Tensor, x: torch.Tensor,
+                   lora_a_stacked: tuple[torch.Tensor,
+                                         ...], scale: float, **kwargs):
+        """
+        Performs GEMM  for multiple slices of lora_a.
+            
+        Semantics:
+        for i in range(len(lora_a_stacked)):
+            y[i] += (x @ lora_a_stacked[i]) * scale
+        
+        Args:
+            y (torch.Tensor): Output tensors
+            x (torch.Tensor): Input tensor
+            lora_a_stacked (tuple[torch.Tensor, ...]): lora_a's weights
+            scale (float): Scaling factor for the operation
+        """
+
+        x = x.view(-1, x.shape[-1])
+        for slice_idx in range(len(lora_a_stacked)):
+            self._apply_shrink(y[slice_idx], x, lora_a_stacked[slice_idx],
+                               scale)
+
+    def add_expand(self,
+                   y: torch.Tensor,
+                   x: torch.Tensor,
+                   lora_b_stacked: tuple[torch.Tensor, ...],
+                   lora_bias_stacked: Optional[tuple[torch.Tensor, ...]],
+                   output_slices: tuple[int, ...],
+                   offset_start: int = 0,
+                   add_inputs=True,
+                   **kwargs) -> None:
+        """
+        Performs GEMM and bias addition for multiple slices of lora_b.
+      
+        Semantics:
+            for i in range(len(lora_b_stacked)):
+                slice = output_slices[i]
+                y[:, offset:offset+slice] += x[i] @ lora_b_stacked[i] + 
+                    lora_bias_stacked[i] 
+                offset += slice
+            
+        Args:
+            y (torch.Tensor): Output tensor.
+            x (torch.Tensor): Input tensors
+            lora_b_stacked (tuple[torch.Tensor, ...]): lora_b's weight
+            lora_bias_stacked (Optional[tuple[torch.Tensor, ...]]): 
+                bias's weight
+            output_slices (tuple[int, ...]): Every slice's size
+            add_inputs (bool): Defaults to True.
+        """
+        y_org = y
+        y = y.view(-1, y.shape[-1])
+        if lora_bias_stacked is not None:
+            token_lora_indices = self._get_token_lora_indices(y)
+            self._apply_bias(token_lora_indices, y, output_slices,
+                             lora_bias_stacked)
+
+        assert x.ndim == 3
+        assert x.size(0) == len(output_slices)
+
+        # TODO fuse these kernels
+        for slice_idx in range(len(lora_b_stacked)):
+            self._apply_expand(
+                y,
+                x[slice_idx],
+                lora_b_stacked[slice_idx],
+                offset_start,
+                output_slices[slice_idx],
+                add_inputs=add_inputs,
+            )
+            offset_start += output_slices[slice_idx]
+        y.view_as(y_org)
+
+    def add_lora_embedding(self,
+                           y: torch.Tensor,
+                           x: torch.Tensor,
+                           lora_b_stacked: torch.Tensor,
+                           add_inputs: bool = True,
+                           **kwargs) -> None:
+        """
+        Applies lora  specifically for VocabParallelEmbeddingWithLoRA.
+
+        Semantics:
+            y += x @ lora_b_stacked
+
+        Args:
+            y (torch.Tensor): Output tensor.
+            x (torch.Tensor): Input tensor.
+            lora_b_stacked (torch.Tensor): lora_b's weights.
+            add_inputs (bool): Default to True.
+        """
+        token_lora_indices = self._get_token_lora_indices(x)
+        bgmv_expand(x, lora_b_stacked, y, token_lora_indices, add_inputs)
+
+    def add_lora_linear(self,
+                        y: torch.Tensor,
+                        x: torch.Tensor,
+                        lora_a_stacked: tuple[torch.Tensor, ...],
+                        lora_b_stacked: tuple[torch.Tensor, ...],
+                        lora_bias_stacked: Optional[tuple[torch.Tensor, ...]],
+                        scale: float,
+                        output_slices: tuple[int, ...],
+                        *,
+                        buffer: Optional[torch.Tensor] = None,
+                        **kwargs) -> None:
+        """
+        Applicable to linear-related lora.
+
+        Semantics:
+            for i in range(len(lora_a_stacked)):
+                y[i] += (
+                    x[i].unsqueeze(0)
+                    @ lora_a_stacked[indices[i], layer_idx, :, :]
+                    @ lora_b_stacked[indices[i], layer_idx, :, :]
+                    * scale
+                    ).squeeze(0)+lora_bias_stacked[i]
+
+        Args:
+            y (torch.Tensor): Output tensor. Will be changed in-place.
+            x (torch.Tensor): Input tensor
+            lora_a_stacked (tuple[torch.Tensor, ...]): lora_a's weight.
+            lora_b_stacked (tuple[torch.Tensor, ...]): lora_b's weight.
+            lora_bias_stacked (Optional[tuple[torch.Tensor, ...]]): lora's bias.
+            scale (float): Scaling factor.
+            output_slices (tuple[int, ...]): Every slice's size.
+            buffer (Optional[torch.Tensor]): Defaults to None.
+        """
+
+        assert len(lora_a_stacked) == len(lora_b_stacked) == len(output_slices)
+        if lora_bias_stacked is not None:
+            assert len(lora_bias_stacked) == len(output_slices)
+            token_lora_indices = self._get_token_lora_indices(y)
+            y = self._apply_bias(token_lora_indices, y, output_slices,
+                                 lora_bias_stacked)
+
+        if buffer is None:
+            r = lora_b_stacked[0].size(-1)
+            # We set the buffer to be float32 by default, refer to:
+            # https://github.com/triton-lang/triton/issues/1387
+            buffer = torch.zeros(  # type: ignore
+                (len(output_slices), x.size(0), r),
+                dtype=torch.float32,
+                device=x.device,
+            )
+        self.add_shrink(
+            buffer,  # type: ignore
+            x,
+            lora_a_stacked,
+            scale,
+            **kwargs)
+        self.add_expand(
+            y,
+            buffer,  # type: ignore
+            lora_b_stacked,
+            None,
+            output_slices,
+            add_inputs=True,
+            **kwargs)
+
+    def add_lora_logits(self,
+                        y: torch.Tensor,
+                        x: torch.Tensor,
+                        lora_a_stacked: torch.Tensor,
+                        lora_b_stacked: torch.Tensor,
+                        scale,
+                        *,
+                        buffer: Optional[torch.Tensor] = None,
+                        **kwargs) -> None:
+        """
+        Applies lora  specifically for LogitsProcessorWithLoRA.
+        
+        Semantics:
+            buffer = (x @ lora_a_stacked) * scale
+            y += buffer @ lora_b_stacked
+
+        Args:
+            y (torch.Tensor): Output tensor.
+            x (torch.Tensor): Input tensor.
+            lora_a_stacked (torch.Tensor): lora_a's weights.
+            lora_b_stacked (torch.Tensor): lora_b's weights.
+            scale (float): Scaling factor.
+            buffer (Optional[torch.Tensor]): Default to None.
+        """
+        y_org = y
+        y = y.view(-1, y.shape[-1])
+        x = x.view(-1, x.shape[-1])
+        r = lora_b_stacked.size(-1)
+        if buffer is None:
+            # We set the buffer to be float32 by default, refer to:
+            # https://github.com/triton-lang/triton/issues/1387
+            buffer = torch.zeros((x.size(0), r),
+                                 dtype=torch.float32,
+                                 device=x.device)
+
+        bgmv_shrink(x, lora_a_stacked, buffer, self.sampler_indices, scale)
+        bgmv_expand(buffer,
+                    lora_b_stacked,
+                    y,
+                    self.sampler_indices,
+                    add_inputs=True)
+        return y.view_as(y_org)

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -67,11 +67,7 @@ class XPUPlatform(Platform):
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
-        xpu_use_triton_kernel = os.getenv("XPU_USE_TRITON_KERNEL", "0") == "1"
-        if not xpu_use_triton_kernel:
-            return "vllm.lora.punica_wrapper.punica_xpu.PunicaWrapperXPU"
-        else:
-            return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
+        return "vllm.lora.punica_wrapper.punica_xpu.PunicaWrapperXPU"
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -67,7 +67,7 @@ class XPUPlatform(Platform):
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
-        xpu_use_triton_kernel = os.getenv("XPU_USE_TRITION_KERNEL", "0") == "1"
+        xpu_use_triton_kernel = os.getenv("XPU_USE_TRITON_KERNEL", "0") == "1"
         if not xpu_use_triton_kernel:
             return "vllm.lora.punica_wrapper.punica_xpu.PunicaWrapperXPU"
         else:

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -67,7 +67,11 @@ class XPUPlatform(Platform):
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
-        return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
+        xpu_use_triton_kernel = os.getenv("XPU_USE_TRITION_KERNEL", "0") == "1"
+        if not xpu_use_triton_kernel:
+            return "vllm.lora.punica_wrapper.punica_xpu.PunicaWrapperXPU"
+        else:
+            return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:


### PR DESCRIPTION
**Test Plan**

XPU_USE_TRITION_KERNEL=0 VLLM_USE_V1=1 CCL_ZE_IPC_EXCHANGE=drmfd VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn python3 benchmarks/benchmark_throughput.py --model meta-llama/Llama-2-7b-hf --backend vllm --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000 --max-loras 1 --max-lora-rank 8 --enable-lora  --lora-path "yard1/llama-2-7b-sql-lora-test"  --enforce_eager  


1. xpu kernel  +  XPU_USE_TRITION_KERNEL=0

Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [00:00<00:00, 1147.75it/s]
Processed prompts:  74%|████████████████████████████████████████████████████████████████████████████████████████▋                              | 745/1000 [02:13<00:36,  6.92it/s, est. speed input: 1484.93 toks/s, output: 987.98 toks/s]WARNING 07-27 20:30:06 [_logger.py:68] Encountered invalid prefix detokenization error for request 623, resetting decode stream.
Processed prompts:  86%|█████████████████████████████████████████████████████████████████████████████████████████████████████▌                | 861/1000 [02:27<00:13, 10.22it/s, est. speed input: 1523.34 toks/s, output: 1096.47 toks/s]WARNING 07-27 20:30:20 [_logger.py:68] Encountered invalid prefix detokenization error for request 623, resetting decode stream.
Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [03:08<00:00,  5.31it/s, est. speed input: 1306.31 toks/s, output: 1249.40 toks/s]
Throughput: 5.29 requests/s, 2543.90 total tokens/s, 1243.62 output tokens/s
Total num prompt tokens:  245995
Total num output tokens:  235278


2. trition kernel  + XPU_USE_TRITION_KERNEL=1 

Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [00:00<00:00, 1356.26it/s]
Processed prompts:  38%|█████████████████████████████████████████████▋                                                                         | 384/1000 [01:20<02:13,  4.62it/s, est. speed input: 1260.77 toks/s, output: 625.78 toks/s]WARNING 07-27 20:33:58 [_logger.py:68] Encountered invalid prefix detokenization error for request 183, resetting decode stream.
Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [03:50<00:00,  4.34it/s, est. speed input: 1067.74 toks/s, output: 1021.23 toks/s]
Throughput: 4.33 requests/s, 2082.29 total tokens/s, 1017.96 output tokens/s
Total num prompt tokens:  245995
Total num output tokens:  235278



**The XPU kernel achieved a 1.22x throughput improvement (from 2082.29 to 2543.90) over the Triton kernel** 



