### PR TITLE
fix the mxfp4 packed qk weight loading issue for llama4

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -564,6 +564,9 @@ class Llama4ForCausalLM(LlamaForCausalLM):
             attn_in = self.config.head_dim * n_heads
             attn_out = self.config.hidden_size
 
+            if w.dtype in [torch.uint8, torch.int8]:
+                attn_out = attn_out // 2
+
             return w.view(n_heads, attn_in // n_heads // 2, 2,
                           attn_out).transpose(1, 2).reshape(attn_in, attn_out)
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

**Error**:
```
 File "/home/xuebwang/vllm-project/vllm/vllm/model_executor/models/llama4.py", line 617, in permute
    return w.view(n_heads, attn_in // n_heads // 2, 2,
RuntimeError: shape '[8, 64, 2, 5120]' is invalid for input of size 2621440
```
**Model configuration**:
- MXFP4 quantization on Llama4 scout model using `amd-quark`.
- This issue happens on layers `language_model.model.layers.*.self_attn.q_proj` and `language_model.model.layers.*.self_attn.k_proj`.

**Root cause analysis**:
-  For MXFP4 quantization, the exported weights are packed into uint8 in column wise compression, i.e., from `[M, N]` to `[M, N/2]`.  Therefore, the weight `w`  is in shape of `[attn_in, attn_out//2]`.

-  On the other hand, the permutation for qk weight is doing something like swap adjacent rows. The data order of the columns given a row would not be broken.

-  Therefore, one can safely and simply half the attn_out dimension as `attn_out = attn_out // 2`.

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
