### PR TITLE
[Bugfix] [AMD] [ROCm/xformers] pd disagg for rocm fix

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -176,8 +176,7 @@ class MooncakeStoreConnector(KVConnectorBase):
                 self.kv_helper.put_kv_to_cache(model_executable, remote_k,
                                                remote_v, layer, kv_cache,
                                                slot_mapping, start_pos,
-                                               end_pos,
-                                               num_heads, head_size)
+                                               end_pos, num_heads, head_size)
 
             hidden_or_intermediate_states_for_one_req.append(hidden)
 

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -126,6 +126,7 @@ class MooncakeStoreConnector(KVConnectorBase):
         start_layer = model_executable.model.start_layer
         end_layer = model_executable.model.end_layer
         hidden_or_intermediate_states_for_one_req = []
+        num_heads, head_size = self.kv_helper.get_model_args(model_executable)
 
         for idx, slen in enumerate(seq_lens):
             start_pos = sum(seq_lens[:idx])
@@ -175,7 +176,8 @@ class MooncakeStoreConnector(KVConnectorBase):
                 self.kv_helper.put_kv_to_cache(model_executable, remote_k,
                                                remote_v, layer, kv_cache,
                                                slot_mapping, start_pos,
-                                               end_pos)
+                                               end_pos,
+                                               num_heads, head_size)
 
             hidden_or_intermediate_states_for_one_req.append(hidden)
 

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -295,8 +295,7 @@ class SimpleConnector(KVConnectorBase):
                 self.kv_helper.put_kv_to_cache(model_executable, remote_k,
                                                remote_v, layer, kv_cache,
                                                slot_mapping, start_pos,
-                                               end_pos,
-                                               num_heads, head_size)
+                                               end_pos, num_heads, head_size)
 
             hidden_or_intermediate_states_for_one_req.append(hidden)
 

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -224,6 +224,7 @@ class SimpleConnector(KVConnectorBase):
         slot_mapping = model_input.attn_metadata.slot_mapping.flatten()
         start_layer = model_executable.model.start_layer
         end_layer = model_executable.model.end_layer
+        num_heads, head_size = self.kv_helper.get_model_args(model_executable)
 
         hidden_or_intermediate_states_for_one_req = []
 
@@ -294,7 +295,8 @@ class SimpleConnector(KVConnectorBase):
                 self.kv_helper.put_kv_to_cache(model_executable, remote_k,
                                                remote_v, layer, kv_cache,
                                                slot_mapping, start_pos,
-                                               end_pos)
+                                               end_pos,
+                                               num_heads, head_size)
 
             hidden_or_intermediate_states_for_one_req.append(hidden)
 

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -88,11 +88,12 @@ class model_aware_kv_ops_helper:
         else:
             if len(kv_cache.shape) != 5:
                 if len(kv_cache.shape) != 3:
-                    raise ValueError(f"Unsupported kv_cache shape: {kv_cache.shape}. "
-                                     "Expected 3 or 5 dimensions.")
+                    raise ValueError(
+                        f"Unsupported kv_cache shape: {kv_cache.shape}. "
+                        "Expected 3 or 5 dimensions.")
                 num_kv, num_blks, last_dim_size = kv_cache.shape
                 kv_cache = kv_cache.reshape(num_kv, num_blks, -1, num_heads,
-                                              head_size)
+                                            head_size)
 
             key_cache, value_cache = kv_cache[0], kv_cache[1]
             ops.reshape_and_cache_flash(

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -87,8 +87,12 @@ class model_aware_kv_ops_helper:
             )
         else:
             if len(kv_cache.shape) != 5:
-                num_kv, num_blks, _ = kv_cache.shape
-                kv_cache = kv_cache.reshape(num_kv, num_blks,  -1, num_heads, head_size)
+                if len(kv_cache.shape) != 3:
+                    raise ValueError(f"Unsupported kv_cache shape: {kv_cache.shape}. "
+                                     "Expected 3 or 5 dimensions.")
+                num_kv, num_blks, last_dim_size = kv_cache.shape
+                kv_cache = kv_cache.reshape(num_kv, num_blks, -1, num_heads,
+                                              head_size)
 
             key_cache, value_cache = kv_cache[0], kv_cache[1]
             ops.reshape_and_cache_flash(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
This PR fixes the wrong kv  cache shape for ROCm. 

Before the PR, PD disaggregated vllm inference https://github.com/vllm-project/vllm/blob/main/examples/online_serving/disaggregated_prefill.sh emits this error on ROCm env. 
because https://github.com/vllm-project/vllm/blob/18cc33dd603cce058867f5730919041fa3617eb7/vllm/distributed/kv_transfer/kv_connector/utils.py#L88
shape is not compatible.
kv_cache.shape
torch.Size([2, 69438, 16384])

And it should be this shape. 
kv_cache.shape
torch.Size([2, 69438, 16, 8, 128])

## Test Plan
To reproduce, 
on AMD GPUs (mi300x = gfx942)

`docker run     --rm     -it     --ipc host     --name vllm_nightly     --privileged     --cap-add=CAP_SYS_ADMIN     --device=/dev/kfd     --device=/dev/dri     --device=/dev/mem     --cap-add=SYS_PTRACE     --security-opt seccomp=unconfined     -e PYTORCH_ROCM_ARCH="gfx942"     -e HSA_NO_SCRATCH_RECLAIM=1     -e SAFETENSORS_FAST_GPU=1     -e VLLM_USE_V1=0        -v "$PWD/.hf_cache/":/root/.cache/huggingface/hub/     -v "$PWD/.vllm_cache/":/root/.cache/vllm/     -v "$PWD":/workspace     -v ${PWD}/vllm:/vllm-dev     -w /workspace  rocm/vllm:rocm6.4.1_vllm_0.9.1_20250715
`
bash /app/vllm/examples/online_serving/disaggregated_prefill.sh
## Test Result

Before
```
ERROR 07-28 05:28:15 [engine.py:165]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/utils.py", line 85, in put_kv_to_cache
ERROR 07-28 05:28:15 [engine.py:165]     ops.reshape_and_cache_flash(
ERROR 07-28 05:28:15 [engine.py:165]   File "/usr/local/lib/python3.12/dist-packages/vllm/_custom_ops.py", line 1648, in reshape_and_cache_flash
ERROR 07-28 05:28:15 [engine.py:165]     torch.ops._C_cache_ops.reshape_and_cache_flash(key, value, key_cache,
ERROR 07-28 05:28:15 [engine.py:165]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1158, in __call__
ERROR 07-28 05:28:15 [engine.py:165]     return self._op(*args, **(kwargs or {}))
ERROR 07-28 05:28:15 [engine.py:165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 07-28 05:28:15 [engine.py:165] IndexError: Dimension out of range (expected to be in range of [-2, 1], but got 2)
[2025-07-28 05:28:15 +0000] [6627] [INFO] 127.0.0.1:49098 POST /v1/completions 1.1 200 - 334579
```

After 
```
+ echo 'Output of first request: {"id":"cmpl-b6fc31f3cf6b4a46b21149b98fb59711","object":"text_completion","created":1753684510,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct","choices":[{"index":0,"text":" top-heavy city, with a population of over ","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":15,"completion_tokens":10,"prompt_tokens_details":null},"kv_transfer_params":null}'
Output of first request: {"id":"cmpl-b6fc31f3cf6b4a46b21149b98fb59711","object":"text_completion","created":1753684510,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct","choices":[{"index":0,"text":" top-heavy city, with a population of over ","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":15,"completion_tokens":10,"prompt_tokens_details":null},"kv_transfer_params":null}
+ echo 'Output of second request: {"id":"cmpl-a65789787b444d309db8855bdecc1e6b","object":"text_completion","created":1753684510,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct","choices":[{"index":0,"text":" city in California, USA. The city is located","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":15,"completion_tokens":10,"prompt_tokens_details":null},"kv_transfer_params":null}'
Output of second request: {"id":"cmpl-a65789787b444d309db8855bdecc1e6b","object":"text_completion","created":1753684510,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct","choices":[{"index":0,"text":" city in California, USA. The city is located","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":15,"completion_tokens":10,"prompt_tokens_details":null},"kv_transfer_params":null}
+ echo '🎉🎉 Successfully finished 2 test requests! 🎉🎉'
🎉🎉 Successfully finished 2 test requests! 🎉🎉
+ echo ''
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
