### PR TITLE
feat: Add Support GPTQ Quantization MOE on ROCM vllm serve

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -758,6 +758,8 @@ def get_moe_wna16_block_config(config: dict[str,
 
 def should_moe_wna16_use_cuda(num_valid_tokens: int, group_size: int,
                               num_experts: int, bit: int):
+    if current_platform.is_rocm():
+        return False
     return bit == 4 and group_size in [32, 64, 128] and \
         num_valid_tokens / num_experts <= 6
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -758,9 +758,8 @@ def get_moe_wna16_block_config(config: dict[str,
 
 def should_moe_wna16_use_cuda(num_valid_tokens: int, group_size: int,
                               num_experts: int, bit: int):
-    if current_platform.is_cuda():
-        return bit == 4 and group_size in [32, 64, 128] and \
-        num_valid_tokens / num_experts <= 6
+    return current_platform.is_cuda() and bit == 4 and \
+        group_size in [32, 64, 128] and num_valid_tokens / num_experts <= 6
 
 
 def get_default_config(

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -758,9 +758,8 @@ def get_moe_wna16_block_config(config: dict[str,
 
 def should_moe_wna16_use_cuda(num_valid_tokens: int, group_size: int,
                               num_experts: int, bit: int):
-    if current_platform.is_rocm():
-        return False
-    return bit == 4 and group_size in [32, 64, 128] and \
+    if current_platform.is_cuda():
+        return bit == 4 and group_size in [32, 64, 128] and \
         num_valid_tokens / num_experts <= 6
 
 

--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -14,13 +14,14 @@ from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.linear import LinearMethodBase
 from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (
-    QuantizationConfig,QuantizeMethodBase)
+    QuantizationConfig, QuantizeMethodBase)
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
     get_linear_quant_method)
 from vllm.model_executor.parameter import (ChannelQuantScaleParameter,
                                            GroupQuantScaleParameter,
                                            PackedColumnParameter,
-                                           PackedvLLMParameter, RowvLLMParameter)
+                                           PackedvLLMParameter,
+                                           RowvLLMParameter)
 
 
 class GPTQConfig(QuantizationConfig):
@@ -165,8 +166,8 @@ class GPTQLinearMethod(LinearMethodBase):
                 "weight shape. This can be caused by too large "
                 "tensor parallel size.")
         output_size_per_partition = sum(output_partition_sizes)
-        if (output_size_per_partition %
-                self.quant_config.pack_factor.numerator != 0):
+        if (output_size_per_partition % self.quant_config.pack_factor.numerator
+                != 0):
             raise ValueError(
                 "The output size is not aligned with the quantized "
                 "weight shape. This can be caused by too large "
@@ -201,14 +202,15 @@ class GPTQLinearMethod(LinearMethodBase):
             packed_factor=self.quant_config.pack_factor,
             weight_loader=weight_loader)
 
-        g_idx = RowvLLMParameter(
-            data=torch.tensor([
+        g_idx = RowvLLMParameter(data=torch.tensor(
+            [
                 i // self.quant_config.group_size
                 for i in range(input_size_per_partition)
             ],
-                              dtype=torch.int32, ),
-            input_dim=0,
-            weight_loader=weight_loader)
+            dtype=torch.int32,
+        ),
+                                 input_dim=0,
+                                 weight_loader=weight_loader)
         qzeros_args = {
             "data":
             torch.empty(
@@ -290,4 +292,3 @@ class GPTQLinearMethod(LinearMethodBase):
         if bias is not None:
             output.add_(bias)
         return output.reshape(out_shape)
-    

--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -10,17 +10,17 @@ import torch
 from torch.nn.parameter import Parameter
 
 from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.linear import LinearMethodBase
 from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (
-    QuantizationConfig)
+    QuantizationConfig,QuantizeMethodBase)
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
     get_linear_quant_method)
 from vllm.model_executor.parameter import (ChannelQuantScaleParameter,
                                            GroupQuantScaleParameter,
                                            PackedColumnParameter,
-                                           PackedvLLMParameter,
-                                           RowvLLMParameter)
+                                           PackedvLLMParameter, RowvLLMParameter)
 
 
 class GPTQConfig(QuantizationConfig):
@@ -110,8 +110,23 @@ class GPTQConfig(QuantizationConfig):
         return cls(weight_bits, group_size, desc_act, lm_head_quantized,
                    dynamic)
 
-    def get_quant_method(self, layer: torch.nn.Module,
-                         prefix: str) -> Optional["GPTQLinearMethod"]:
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> Optional[Union["GPTQLinearMethod", "QuantizeMethodBase"]]:
+        if isinstance(layer, FusedMoE):
+            # GPTQ MoE support: fall back to MoeWNA16 for broad compatibility
+            from .moe_wna16 import MoeWNA16Config
+
+            config = {
+                "quant_method": "gptq",
+                "bits": self.weight_bits,
+                "group_size": self.group_size,
+                "sym": True,  # GPTQ typically uses symmetric quantization
+                "lm_head": False,
+            }
+            return MoeWNA16Config.from_config(config).get_quant_method(
+                layer, prefix)
+
         return get_linear_quant_method(self, layer, prefix, GPTQLinearMethod)
 
 
@@ -150,8 +165,8 @@ class GPTQLinearMethod(LinearMethodBase):
                 "weight shape. This can be caused by too large "
                 "tensor parallel size.")
         output_size_per_partition = sum(output_partition_sizes)
-        if (output_size_per_partition % self.quant_config.pack_factor.numerator
-                != 0):
+        if (output_size_per_partition %
+                self.quant_config.pack_factor.numerator != 0):
             raise ValueError(
                 "The output size is not aligned with the quantized "
                 "weight shape. This can be caused by too large "
@@ -186,15 +201,14 @@ class GPTQLinearMethod(LinearMethodBase):
             packed_factor=self.quant_config.pack_factor,
             weight_loader=weight_loader)
 
-        g_idx = RowvLLMParameter(data=torch.tensor(
-            [
+        g_idx = RowvLLMParameter(
+            data=torch.tensor([
                 i // self.quant_config.group_size
                 for i in range(input_size_per_partition)
             ],
-            dtype=torch.int32,
-        ),
-                                 input_dim=0,
-                                 weight_loader=weight_loader)
+                              dtype=torch.int32, ),
+            input_dim=0,
+            weight_loader=weight_loader)
         qzeros_args = {
             "data":
             torch.empty(
@@ -276,3 +290,4 @@ class GPTQLinearMethod(LinearMethodBase):
         if bias is not None:
             output.add_(bias)
         return output.reshape(out_shape)
+    


### PR DESCRIPTION
Description
This PR fixes an issue where some quantized models — including but not limited to Qwen/Qwen3-30B-A3B-GPTQ-Int4 — failed to load using vllm serve

Two root causes were identified:

Lack of explicit recognition of the gptq quantization method within vLLM, preventing vllm serve from configuring the model correctly.

Incorrect use of CUDA-optimized kernels in ROCm environments within the logic handling Mixture of Experts (MoE) layers.

Proposed Changes
GPTQ Quantization Method Registration:
Logic has been added so that vLLM properly detects and configures models that use the gptq quantization method. This allows vllm serve to initialize these models correctly.

MoE Logic Adaptation for ROCm:
The logic that selects optimized kernels in MoE layers has been updated. If a ROCm platform is detected, vLLM will now forcibly use the fused_moe_kernel_gptq_awq implementation instead of attempting to use CUDA-specific kernels.
The affected logic is located in [fused_moe.py](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fused_moe/fused_moe.py), where the kernel selection mechanism was updated to ensure compatibility with ROCm.

Impact
Enables successful loading and operation of GPTQ-quantized models (e.g., Qwen/Qwen3-30B-A3B-GPTQ-Int4) using vllm serve.

Improves vLLM's compatibility and stability on ROCm platforms, especially for models using MoE layers.

Testing
These changes were verified using the Qwen/Qwen3-30B-A3B-GPTQ-Int4 model. The model now loads and runs correctly with vllm serve, matching the successful behavior previously observed only with the OpenAI entrypoint.

This PR should be resolve this issue:

https://github.com/vllm-project/vllm/issues/21687