### PR TITLE
[Doc] Added unmentioned required option "method" in the usage of EAGLE-3 based models

### DIFF
--- a/docs/features/spec_decode.md
+++ b/docs/features/spec_decode.md
@@ -199,6 +199,7 @@ an [EAGLE (Extrapolation Algorithm for Greater Language-model Efficiency)](https
             "model": "yuhuili/EAGLE-LLaMA3-Instruct-8B",
             "draft_tensor_parallel_size": 1,
             "num_speculative_tokens": 2,
+            "method": "eagle",
         },
     )
 
@@ -226,6 +227,9 @@ A few important things to consider when using the EAGLE based draft models:
 3. When using EAGLE-based speculators with vLLM, the observed speedup is lower than what is
    reported in the reference implementation [here](https://github.com/SafeAILab/EAGLE). This issue is under
    investigation and tracked here: <gh-issue:9565>.
+
+4. When using EAGLE-3 based draft model, option "method" must be set to "eagle3".
+   That is, to specify `"method": "eagle3"` in `speculative_config`.
 
 A variety of EAGLE draft models are available on the Hugging Face hub:
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

When using EAGLE-3 based draft models, it is necessary to specify "method=eagle3", which was not mentioned in the document. 

Fixes #21447

## Test Plan

Run the updated example code and modified the model to EAGLE-3 models, also specify the method.

```python
from vllm import LLM, SamplingParams

prompts = [
    "The future of AI is",
]
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

llm = LLM(
    model="/workspace/l50051814/Meta-Llama-3.1-8B-Instruct-main",
    # tensor_parallel_size=2,
    speculative_config={
        "model": "/workspace/l50051814/EAGLE3-LLaMA3.1-Instruct-8B-1",
        "draft_tensor_parallel_size": 1,
        "num_speculative_tokens": 2,
        "method": "eagle"
    },
)

outputs = llm.generate(prompts, sampling_params)

for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

## Test Result

```
root@42-85:/workspace/l50051814# python test-eagle3.py
INFO 07-28 08:29:50 [__init__.py:244] Automatically detected platform cuda.
INFO 07-28 08:30:13 [config.py:841] This model supports multiple tasks: {'embed', 'generate', 'reward', 'classify'}. Defaulting to 'generate'.
INFO 07-28 08:30:13 [config.py:1472] Using max model len 131072
WARNING 07-28 08:30:14 [config.py:3371] Casting torch.float16 to torch.bfloat16.
INFO 07-28 08:30:14 [config.py:1472] Using max model len 2048
INFO 07-28 08:30:14 [config.py:2285] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 07-28 08:30:15 [core.py:526] Waiting for init message from front-end.
INFO 07-28 08:30:15 [core.py:69] Initializing a V1 LLM engine (v0.9.2) with config: model='/workspace/l50051814/Meta-Llama-3.1-8B-Instruct-main', speculative_config=SpeculativeConfig(method='eagle3', model='/workspace/l50051814/EAGLE3-LLaMA3.1-Instruct-8B-1', num_spec_tokens=2), tokenizer='/workspace/l50051814/Meta-Llama-3.1-8B-Instruct-main', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=131072, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=/workspace/l50051814/Meta-Llama-3.1-8B-Instruct-main, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=False, pooler_config=None, compilation_config={"level":3,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":1,"cudagraph_capture_sizes":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":512,"local_cache_dir":null}
INFO 07-28 08:30:20 [parallel_state.py:1076] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
WARNING 07-28 08:30:20 [topk_topp_sampler.py:59] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
INFO 07-28 08:30:20 [gpu_model_runner.py:1770] Starting to load model /workspace/l50051814/Meta-Llama-3.1-8B-Instruct-main...
INFO 07-28 08:30:20 [gpu_model_runner.py:1775] Loading model from scratch...
INFO 07-28 08:30:23 [cuda.py:284] Using Flash Attention backend on V1 engine.
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:01<00:04,  1.66s/it]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:03<00:03,  1.96s/it]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:05<00:02,  2.02s/it]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:06<00:00,  1.45s/it]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:06<00:00,  1.63s/it]

INFO 07-28 08:30:30 [default_loader.py:272] Loading weights took 6.58 seconds
INFO 07-28 08:30:30 [gpu_model_runner.py:1794] Loading drafter model...
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.23it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.23it/s]

INFO 07-28 08:30:31 [default_loader.py:272] Loading weights took 1.54 seconds
INFO 07-28 08:30:31 [eagle.py:347] Assuming the EAGLE head shares the same vocab embedding with the target model.
INFO 07-28 08:30:32 [gpu_model_runner.py:1801] Model loading took 15.7807 GiB and 10.687740 seconds
INFO 07-28 08:30:46 [backends.py:508] Using cache directory: /root/.cache/vllm/torch_compile_cache/98e4ef2500/rank_0_0/backbone for vLLM's torch.compile
INFO 07-28 08:30:46 [backends.py:519] Dynamo bytecode transform time: 13.33 s
INFO 07-28 08:31:02 [backends.py:155] Directly load the compiled graph(s) for shape None from the cache, took 13.864 s
INFO 07-28 08:31:05 [monitor.py:34] torch.compile takes 13.33 s in total
INFO 07-28 08:31:05 [backends.py:508] Using cache directory: /root/.cache/vllm/torch_compile_cache/98e4ef2500/rank_0_0/eagle_head for vLLM's torch.compile
INFO 07-28 08:31:05 [backends.py:519] Dynamo bytecode transform time: 0.59 s
INFO 07-28 08:31:07 [backends.py:155] Directly load the compiled graph(s) for shape None from the cache, took 1.366 s
INFO 07-28 08:31:07 [monitor.py:34] torch.compile takes 13.92 s in total
INFO 07-28 08:31:10 [gpu_worker.py:232] Available KV cache memory: 18.35 GiB
INFO 07-28 08:31:11 [kv_cache_utils.py:716] GPU KV cache size: 145,728 tokens
INFO 07-28 08:31:11 [kv_cache_utils.py:720] Maximum concurrency for 131,072 tokens per request: 1.11x
Capturing CUDA graph shapes: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [02:35<00:00,  2.31s/it]
INFO 07-28 08:33:46 [gpu_model_runner.py:2326] Graph capturing finished in 155 secs, took 0.57 GiB
INFO 07-28 08:33:46 [core.py:172] init engine (profile, create kv cache, warmup model) took 193.55 seconds
Adding requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 16.10it/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.56it/s, est. speed input: 7.82 toks/s, output: 25.02 toks/s]
Prompt: 'The future of AI is', Generated text: ' bright and exciting. I am looking forward to seeing the exciting developments that will come'
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
