### PR TITLE
[Misc] Integration of FlashInfer fused AR+RMS+FP8

### DIFF
--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -229,8 +229,7 @@ def all_reduce_fusion_pass_on_test_model(local_rank: int, world_size: int,
 
     # residual is updated in-place by rms+add, so clone it
     ref = model(hidden_states, residual.clone())
-    res = compiled_model(hidden_states, residual)
-
+    res = compiled_model(hidden_states, residual.clone())
     torch.testing.assert_close(res, ref, atol=1e-2, rtol=1e-2)
 
     backend.check_before_ops(model.ops_in_model_before(), fully_replaced=True)

--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -73,7 +73,11 @@ class TestAllReduceRMSNormModel(torch.nn.Module):
         return ops_to_replace
 
     def ops_in_model_after(self):
-        return [torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default]
+        return [
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
+            if not self.quant else
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_fp8.default
+        ]
 
 
 class TestAllReduceFusedAddRMSNormModel(torch.nn.Module):
@@ -123,7 +127,11 @@ class TestAllReduceFusedAddRMSNormModel(torch.nn.Module):
         return ops_to_replace
 
     def ops_in_model_after(self):
-        return [torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default]
+        return [
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
+            if not self.quant else
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_fp8.default
+        ]
 
 
 @multi_gpu_test(num_gpus=2)

--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -139,7 +139,8 @@ class TestAllReduceFusedAddRMSNormModel(torch.nn.Module):
     "test_model",
     [TestAllReduceRMSNormModel, TestAllReduceFusedAddRMSNormModel])
 @pytest.mark.parametrize("batch_size", [8])
-@pytest.mark.parametrize("seq_len", [8])
+@pytest.mark.parametrize("seq_len",
+                         [8, 64, 256])  # oneshot, twoshot, non-flashinfer
 @pytest.mark.parametrize("hidden_size", [4096])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("quant", [False, True])

--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -231,7 +231,7 @@ def all_reduce_fusion_pass_on_test_model(local_rank: int, world_size: int,
     ref = model(hidden_states, residual.clone())
     res = compiled_model(hidden_states, residual)
 
-    torch.testing.assert_close(res, ref, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(res, ref, atol=1e-2, rtol=1e-2)
 
     backend.check_before_ops(model.ops_in_model_before(), fully_replaced=True)
     backend.check_after_ops(model.ops_in_model_after())

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -635,6 +635,11 @@ class AllReduceFusionPass(VllmInductorPass):
                 "Flashinfer is not installed or comm module not found, "
                 "skipping allreduce fusion pass")
             return
+        if not current_platform.has_capability(90):
+            logger.warning(
+                "Flashinfer fusions are only available for sm90 and above, "
+                "skipping allreduce fusion pass")
+            return
         # Check if the world size is supported
         if self.tp_size not in _FI_MAX_SIZES:
             logger.warning(

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -292,8 +292,6 @@ if flashinfer_comm is not None:
             assert (_FI_WORKSPACE_TENSOR is not None
                     ), "Flashinfer must be enabled when using flashinfer"
 
-            # For the sizes that are smaller than the max size,
-            # we only use flashinfer one shot allreduce
             fusion_pattern = (flashinfer_comm.AllReduceFusionPattern.
                               kARResidualRMSNormFP8Quant)
 

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -165,6 +165,11 @@ if flashinfer_comm is not None:
     # when world size is not in _FI_MAX_SIZES
     _DEFAULT_FI_MAX_SIZE = MiB // 2
 
+    ONESHOT_MAX_TOKENS = 128
+
+    def use_oneshot(allreduce_in: torch.Tensor) -> bool:
+        return allreduce_in.size(0) <= ONESHOT_MAX_TOKENS
+
     def call_trtllm_fused_allreduce_norm(
         allreduce_in: torch.Tensor,
         residual: torch.Tensor,
@@ -217,7 +222,7 @@ if flashinfer_comm is not None:
                 hidden_dim=allreduce_in.shape[-1],
                 workspace_ptrs=_FI_WORKSPACE_TENSOR,
                 launch_with_pdl=launch_with_pdl,
-                use_oneshot=True,
+                use_oneshot=use_oneshot(allreduce_in),
                 trigger_completion_at_end=trigger_completion_at_end,
                 fp32_acc=fp32_acc,
                 pattern_code=fusion_pattern,
@@ -303,7 +308,7 @@ if flashinfer_comm is not None:
                 hidden_dim=allreduce_in.shape[-1],
                 workspace_ptrs=_FI_WORKSPACE_TENSOR,
                 launch_with_pdl=launch_with_pdl,
-                use_oneshot=True,
+                use_oneshot=use_oneshot(allreduce_in),
                 trigger_completion_at_end=trigger_completion_at_end,
                 fp32_acc=fp32_acc,
                 pattern_code=fusion_pattern,

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -230,6 +230,7 @@ if flashinfer_comm is not None:
                 quant_out=None,
                 scale_out=None,
                 layout_code=None,
+                scale_factor=None,
             )
         else:
             allreduce_out = tensor_model_parallel_all_reduce(allreduce_in)

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -635,7 +635,7 @@ class AllReduceFusionPass(VllmInductorPass):
                 "Flashinfer is not installed or comm module not found, "
                 "skipping allreduce fusion pass")
             return
-        if not current_platform.has_capability(90):
+        if not current_platform.has_device_capability(90):
             logger.warning(
                 "Flashinfer fusions are only available for sm90 and above, "
                 "skipping allreduce fusion pass")

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1655,8 +1655,8 @@ class CacheConfig:
     - "builtin" is Python's built-in hash.\n
     - "sha256" is collision resistant but with certain overheads.
     This option uses Pickle for object serialization before hashing.\n
-    - "sha256_cbor_64bit" provides a reproducible, cross-language compatible 
-    hash. It serializes objects using canonical CBOR and hashes them with 
+    - "sha256_cbor_64bit" provides a reproducible, cross-language compatible
+    hash. It serializes objects using canonical CBOR and hashes them with
     SHA-256. The resulting hash consists of the lower 64 bits of the SHA-256
     digest."""
     cpu_offload_gb: float = 0
@@ -3957,6 +3957,10 @@ class PassConfig:
                 logger.warning_once(
                     "Fusion enabled but reshape elimination disabled. "
                     "Attention + quant (fp8) fusion might not work")
+        if not self.enable_fusion and self.enable_fi_allreduce_fusion:
+            logger.warning_once(
+                "Flashinfer allreduce fusion is enabled but fusion is disabled. "  # noqa: E501
+                "Allreduce+RMSNorm+Quant fusion might not work")
 
 
 @config


### PR DESCRIPTION
* This is still a draft until the correctness isue is fixed! *

## Purpose
This PR builds on the great work of @ilmarkov in #20691 and integrates flashinfer's allreduce + RMSNorm + FP8 Quant fusion.
This new fusion relies on the existing RMNorm + FP8 Quant fusion in order to not collide with the non-FP8 fusion. Therefore, to enable this fusion we must also enable `fusion` and `noop`: `--compilation-config='{"pass_config": {"enable_noop": true, "enable_fusion": true, "enable_flashinfer_allreduce_fusion": true}, "custom_ops": ["+rms_norm", "+quant_fp8"], "level":3}'`

In addition, this PR modifies so of the guards that determined when the flashinfer path should be taken, and matches them to the TRTLLM source.

## Test Plan
`tests/compile/test_fusion_all_reduce.py` was expanded to also test modules with FP8 quant, as well as multiple sequence lengths to test all possible execution paths (FI oneshot, FI twoshot, non-FI).

## Test Result
Llama-3.3-70B-Instruct-FP8 (modelopt) TP=4 on B200 GPUs.
Flashinfer commit `7253d74`.

### Benchmark E2E:

#### Client
```
DURATION_SECONDS=60;
vllm bench serve --model nvidia/Llama-3.3-70B-Instruct-FP8 --dataset-name sonnet --dataset-path benchmarks/sonnet.txt --request-rate "$qps" --num-prompts $((DURATION_SECONDS * qps))`
```

#### Server
* No Fusion:
```
python -m vllm.entrypoints.openai.api_server --disable-log-requests --no-enable-prefix-caching --dtype auto --kv-cache-dtype fp8 --quantization modelopt -tp 4 --model nvidia/Llama-3.3-70B-Instruct-FP8
```

| QPS | Mean TTFT (ms) | Median TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) |
|--------:|------------------------:|---------------------------:|------------------------:|---------------------------:|
| 1 | 39.84 | 39.92 | 10.66 | 10.70 |
| 5 | 44.10 | 42.62 | 11.44 | 11.36 |
| 10 | 49.24 | 45.67 | 14.10 | 14.16 | 

* AR+RMS:
```
python -m vllm.entrypoints.openai.api_server --disable-log-requests --no-enable-prefix-caching --dtype auto --kv-cache-dtype fp8 --quantization modelopt -tp 4 --model nvidia/Llama-3.3-70B-Instruct-FP8 --compilation-config '{"pass_config": {"enable_noop": true, "enable_fusion": true, "enable_fi_allreduce_fusion": true}, "custom_ops": ["+rms_norm"], "level": 3}'
```

| QPS | Mean TTFT (ms) | Median TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) |
|--------:|------------------------:|---------------------------:|------------------------:|---------------------------:|
| 1 | 41.73 | 42.04 | 9.65 | 9.63 |
| 5 | 45.80 | 44.08 | 10.91 | 10.85 |
| 10 | 51.87 | 48.03 | 13.82 | 13.88 | 

* AR+RMS+FP8:
```
vllm serve --disable-log-requests --no-enable-prefix-caching --dtype auto --kv-cache-dtype fp8 --quantization modelopt -tp 4 --model nvidia/Llama-3.3-70B-Instruct-FP8 --compilation-config '{"pass_config": {"enable_noop": true, "enable_fusion": true, "enable_fi_allreduce_fusion": true}, "custom_ops": ["+rms_norm", "+quant_fp8"], "level": 3}'
```

| QPS | Mean TTFT (ms) | Median TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) |
|--------:|------------------------:|---------------------------:|------------------------:|---------------------------:|
| 1 | 40.09 | 39.66 | 9.72 | 9.68 |
| 5 | 45.31 | 43.53 | 10.93 | 10.85 |
| 10 | 50.94 | 47.10 | 13.37 | 13.36 | 

### GSM8K

#### Client
```
lm_eval --model local-completions --tasks gsm8k --model_args model=nvidia/Llama-3.3-70B-Instruct-FP8,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=1,max_retries=3,tokenized_requests=False
```

| Filter | No Fusion | AR+RMS | AR+RMS+FP8 |
|:-------|---------------:|--------------:|--------------------:|
| flexible-extract | 0.9393 | 0.9386 | 0.2790 |
| strict-match | 0.7612 | 0.7817 | 0.0273 |

