### PR TITLE
[Misc] fix fi ar fusion sizes to match trtllm source

### DIFF
--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -67,7 +67,7 @@ class TestAllReduceFusedAddRMSNormModel(torch.nn.Module):
     "test_model",
     [TestAllReduceRMSNormModel, TestAllReduceFusedAddRMSNormModel])
 @pytest.mark.parametrize("batch_size", [8])
-@pytest.mark.parametrize("seq_len", [8])
+@pytest.mark.parametrize("seq_len", [8, 64, 256])  # oneshot, twoshot, fallback
 @pytest.mark.parametrize("hidden_size", [4096])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"],

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -150,7 +150,9 @@ class AsyncTPPass(VllmInductorPass):
 if flashinfer_comm is not None:
     _FI_WORKSPACE_TENSOR = None
 
-    # see # see cpp/tensorrt_llm/common/customAllReduceUtils.h
+    # Max size of the input tensor per world size
+    # to use flashinfer fused allreduce
+    # see cpp/tensorrt_llm/common/customAllReduceUtils.h
     _FI_MAX_SIZES = {
         2: 16 * 1000 * 1000,
     }


### PR DESCRIPTION
## Purpose

Fix the fallback limit for flashinfer AR+RMS fusion to match the values stated in TRTLLM's source code.

## Test Plan
Extended `tests/compile/test_fusion_all_reduce.py` to cover more sequence lengths.
