### PR TITLE
[Bugfix] Fix glm4.1v video_grid_thw tensor shape scheme

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -126,7 +126,6 @@ class Glm4vVideoPixelInputs(TensorSchema):
         - np: Number of patches
         - ctpp: Number of channels * temporal_patch_size *
             patch_size * patch_size
-        - nv: Number of videos
         - f: Number of frames
         - g: Grid dimensions (3 for grid_t which is usually 1 for processed 
           video, grid_h, grid_w)
@@ -134,8 +133,7 @@ class Glm4vVideoPixelInputs(TensorSchema):
     type: Literal["pixel_values_videos"] = "pixel_values_videos"
 
     pixel_values_videos: Annotated[torch.Tensor, TensorShape("np", "ctpp")]
-    # video_metadata: Union[list[VideoMetadata], list[dict]]
-    video_grid_thw: Annotated[torch.Tensor, TensorShape("nv", "f", 3)]
+    video_grid_thw: Annotated[torch.Tensor, TensorShape("f", 3)]
 
 
 class Glm4vVideoEmbeddingInputs(TensorSchema):
@@ -143,14 +141,14 @@ class Glm4vVideoEmbeddingInputs(TensorSchema):
     Dimensions:
         - p: Number of video patches across all frames
         - h: Hidden size (must match language model backbone)
-        - n: Number of videos
+        - f: Number of frames
         - g: Grid dimensions (3 for grid_t which is usually 1 for processed 
           video, grid_h, grid_w)
     """
     type: Literal["video_embeds"] = "video_embeds"
 
     video_embeds: Annotated[torch.Tensor, TensorShape("p", "h")]
-    video_grid_thw: Annotated[torch.Tensor, TensorShape("n", 1, 3)]
+    video_grid_thw: Annotated[torch.Tensor, TensorShape("f", 3)]
 
 
 Glm4vVideoInputs = Union[Glm4vVideoPixelInputs, Glm4vVideoEmbeddingInputs]
@@ -1348,7 +1346,6 @@ class Glm4vForConditionalGeneration(nn.Module, SupportsMultiModal,
 
             return Glm4vVideoPixelInputs(
                 type="pixel_values_videos",
-                # video_metadata=video_metadata,
                 pixel_values_videos=pixel_values_videos,
                 video_grid_thw=video_grid_thw,
             )


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Fix broken GLM4.1V video support because of incorrect tensor shape scheme:
```
[rank0]: ValueError: video_grid_thw has rank 2 but expected 3
```

## Test Plan
```
python examples/offline_inference/vision_language.py -m glm4_1v --modality video
```

## Test Result
- Video example should work now.

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
