### PR TITLE
[P/D] Log warnings related to prefill KV expiry

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1025,6 +1025,11 @@ class NixlConnectorWorker:
             # Sorted dict, oldest requests are put first so we can exit early.
             if now < expires:
                 break
+            count = self.consumer_notification_counts_by_req.pop(req_id, 0)
+            logger.warning(
+                "Releasing expired KV blocks for request %d which were "
+                "retrieved by %d decode worker(s) within %d seconds.", req_id,
+                count, envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT)
             del self._reqs_to_send[req_id]
             done_sending.add(req_id)
 
@@ -1040,6 +1045,11 @@ class NixlConnectorWorker:
         for notifs in self.nixl_wrapper.get_new_notifs().values():
             for notif in notifs:
                 req_id, tp_ratio = notif.decode("utf-8").rsplit(":", 1)
+                if req_id not in self._reqs_to_send:
+                    logger.warning("Potentially invalid KV blocks for "
+                                   "unrecognized request %d were retrieved by "
+                                   "a decode worker. They may have expired.")
+
                 self.consumer_notification_counts_by_req[req_id] += 1
                 # Wait all consumers (D) to be done reading before freeing.
                 if self.consumer_notification_counts_by_req[req_id] == int(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1027,7 +1027,7 @@ class NixlConnectorWorker:
                 break
             count = self.consumer_notification_counts_by_req.pop(req_id, 0)
             logger.warning(
-                "Releasing expired KV blocks for request %d which were "
+                "Releasing expired KV blocks for request %s which were "
                 "retrieved by %d decode worker(s) within %d seconds.", req_id,
                 count, envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT)
             del self._reqs_to_send[req_id]
@@ -1046,9 +1046,10 @@ class NixlConnectorWorker:
             for notif in notifs:
                 req_id, tp_ratio = notif.decode("utf-8").rsplit(":", 1)
                 if req_id not in self._reqs_to_send:
-                    logger.warning("Potentially invalid KV blocks for "
-                                   "unrecognized request %d were retrieved by "
-                                   "a decode worker. They may have expired.")
+                    logger.warning(
+                        "Potentially invalid KV blocks for "
+                        "unrecognized request %s were retrieved by "
+                        "a decode worker. They may have expired.", req_id)
 
                 self.consumer_notification_counts_by_req[req_id] += 1
                 # Wait all consumers (D) to be done reading before freeing.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1046,10 +1046,11 @@ class NixlConnectorWorker:
             for notif in notifs:
                 req_id, tp_ratio = notif.decode("utf-8").rsplit(":", 1)
                 if req_id not in self._reqs_to_send:
-                    logger.warning(
+                    logger.error(
                         "Potentially invalid KV blocks for "
                         "unrecognized request %s were retrieved by "
                         "a decode worker. They may have expired.", req_id)
+                    continue
 
                 self.consumer_notification_counts_by_req[req_id] += 1
                 # Wait all consumers (D) to be done reading before freeing.


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/20139 added a safety-net for releasing prefill blocks that weren't retrieved or notified by a decode worker within a time window (default two minutes).

This PR adds some warning logs both when such expiries occur and when notifications for unrecognized request ids are received.

Also fixes a small leak for the TP case where we don't also flush `consumer_notification_counts_by_req` for expired requests.

cc @NickLucche 