### PR TITLE
Use `uv` to create docs environment in RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,11 +10,14 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
+    pre_create_environment:
+        - asdf plugin add uv
+        - asdf install uv latest
+        - asdf global uv latest
+    create_environment:
+        - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+        - uv pip install -r requirements/docs.txt
 
 mkdocs:
   configuration: mkdocs.yaml
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-    - requirements: requirements/docs.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
     create_environment:
         - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
-        - uv pip install -r requirements/docs.txt
+        - uv pip install --no-cache -r requirements/docs.txt
 
 mkdocs:
   configuration: mkdocs.yaml


### PR DESCRIPTION
Use `uv` to create and install the Python environment for the documentation build in Read the Docs to speed up build times.