### PR TITLE
[Perf] Disable chunked local attention by default with llama4

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -4763,12 +4763,23 @@ class VllmConfig:
                 # Hybrid KV cache manager is not compatible with KV events.
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True
             if self.model_config is not None and \
-                self.model_config.attention_chunk_size is not None and \
-                self.speculative_config is not None and \
-                self.speculative_config.use_eagle():
-                # Hybrid KV cache manager is not yet supported with chunked
-                # local attention + eagle.
-                self.scheduler_config.disable_hybrid_kv_cache_manager = True
+                self.model_config.attention_chunk_size is not None:
+                if self.speculative_config is not None and \
+                    self.speculative_config.use_eagle():
+                    # Hybrid KV cache manager is not yet supported with chunked
+                    # local attention + eagle.
+                    self.scheduler_config.disable_hybrid_kv_cache_manager = True
+                elif \
+                    not envs.VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE:
+                    logger.warning(
+                        "There is a latency regression when using chunked local"
+                        " attention with the hybrid KV cache manager. Disabling"
+                        " it, by default. To enable it, set the environment "
+                        "VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE=1."
+                    )
+                    # Hybrid KV cache manager is not yet supported with chunked
+                    # local attention.
+                    self.scheduler_config.disable_hybrid_kv_cache_manager = True
 
     def update_sizes_for_sequence_parallelism(self,
                                               possible_sizes: list) -> list:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -143,6 +143,7 @@ if TYPE_CHECKING:
     VLLM_USE_CUDNN_PREFILL: bool = False
     VLLM_ENABLE_CUDAGRAPH_GC: bool = False
     VLLM_LOOPBACK_IP: str = ""
+    VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = False
 
 
 def get_default_cache_root():
@@ -991,6 +992,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # The default value is "VLLM".
     "VLLM_PROCESS_NAME_PREFIX":
     lambda: os.getenv("VLLM_PROCESS_NAME_PREFIX", "VLLM"),
+
+    # Allow chunked local attention with hybrid kv cache manager.
+    # Currently using the Hybrid KV cache manager with chunked local attention
+    # in the Llama4 models (the only models currently using chunked local attn)
+    # causes a latency regression. For this reason, we disable it by default.
+    # This flag is used to allow users to enable it if they want to (to save on
+    # kv-cache memory usage and enable longer contexts)
+    # TODO(lucas): Remove this flag once latency regression is resolved.
+    "VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE":
+    lambda: bool(int(os.getenv(\
+            "VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE", "0"))),
 }
 
 # --8<-- [end:env-vars-definition]


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Currently using the hybrid kv-cache with llama4s chunked local attention causes a latency ~2ms since when the hybrid kv-cache manager is used we end up with 3 ChunkedLocalAttention kv-cache spec groups. We end up with the following groups:

```
(FullAttention x 12) (ChunkedLocalAttention x 12) (ChunkedLocalAttention x 12) (ChunkedLocalAttention x 12)
```

This results in attn metadata and local virtual batches for the local layers being constructed 3 times adding latency: 


```
Enabled: 

vllm serve meta-llama/Llama-4-Scout-17B-16E-Instruct -tp 4 --trust-remote-code --max-model-len 16384 --port 8081  --disable-log-requests

============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  9.11      
Total input tokens:                      6299      
Total generated tokens:                  12509     
Request throughput (req/s):              10.97     
Output token throughput (tok/s):         1372.85   
Total Token throughput (tok/s):          2064.16   
---------------Time to First Token----------------
Mean TTFT (ms):                          61.84     
Median TTFT (ms):                        61.53     
P99 TTFT (ms):                           106.66    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.46     
Median TPOT (ms):                        29.17     
P99 TPOT (ms):                           30.99     
---------------Inter-token Latency----------------
Mean ITL (ms):                           28.44     
Median ITL (ms):                         28.65     
P99 ITL (ms):                            38.05     
==================================================


Disabled:

vllm serve meta-llama/Llama-4-Scout-17B-16E-Instruct -tp 4 --trust-remote-code --max-model-len 16384 --port 8081  --disable-log-requests --disable-hybrid-kv-cache-manager

============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  8.84      
Total input tokens:                      6299      
Total generated tokens:                  12297     
Request throughput (req/s):              11.32     
Output token throughput (tok/s):         1391.49   
Total Token throughput (tok/s):          2104.26   
---------------Time to First Token----------------
Mean TTFT (ms):                          58.69     
Median TTFT (ms):                        59.23     
P99 TTFT (ms):                           90.65     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          26.48     
Median TPOT (ms):                        27.32     
P99 TPOT (ms):                           28.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           26.55     
Median ITL (ms):                         26.54     
P99 ITL (ms):                            39.40     
==================================================
```

## Test Plan

see: https://github.com/vllm-project/vllm/pull/21707

## Test Result

see: https://github.com/vllm-project/vllm/pull/21707

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
