### PR TITLE
[Example] Add `async_llm_streaming.py` example for AsyncLLM streaming in python

### DIFF
--- a/examples/offline_inference/async_llm_streaming.py
+++ b/examples/offline_inference/async_llm_streaming.py
@@ -1,142 +1,62 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-Example demonstrating streaming offline inference with AsyncLLM (V1 engine).
+Simple example demonstrating streaming offline inference with AsyncLLM (V1 engine).
 
-This script shows how to use vLLM's AsyncLLM engine for streaming token-by-token
-output in offline inference scenarios. It demonstrates both DELTA mode (new tokens only)
-and CUMULATIVE mode (complete output so far).
+This script shows the core functionality of vLLM's AsyncLLM engine for streaming
+token-by-token output in offline inference scenarios. It demonstrates DELTA mode
+streaming where you receive new tokens as they are generated.
 
 Usage:
     python examples/offline_inference/async_llm_streaming.py
-    python examples/offline_inference/async_llm_streaming.py --model meta-llama/Llama-3.2-1B-Instruct
-    python examples/offline_inference/async_llm_streaming.py --streaming-mode cumulative
-"""  # noqa: E501
+"""
 
 import asyncio
 import os
-import time
 
 from vllm import SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.sampling_params import RequestOutputKind
-from vllm.utils import FlexibleArgumentParser
 from vllm.v1.engine.async_llm import AsyncLLM
 
 
-def create_parser():
-    """Create argument parser with AsyncEngineArgs and streaming options."""
-    parser = FlexibleArgumentParser(description="AsyncLLM Streaming Inference Example")
+async def stream_response(engine: AsyncLLM, prompt: str, request_id: str) -> None:
+    """
+    Stream response from AsyncLLM and display tokens as they arrive.
 
-    AsyncEngineArgs.add_cli_args(parser)
-    parser.set_defaults(
-        model="meta-llama/Llama-3.2-1B-Instruct",
-        enforce_eager=True,  # Faster for examples
-    )
-
-    # Add sampling parameters
-    sampling_group = parser.add_argument_group("Sampling parameters")
-    sampling_group.add_argument(
-        "--max-tokens",
-        type=int,
-        default=100,
-        help="Maximum number of tokens to generate",
-    )
-    sampling_group.add_argument(
-        "--temperature", type=float, default=0.8, help="Sampling temperature"
-    )
-    sampling_group.add_argument(
-        "--top-p", type=float, default=0.95, help="Top-p (nucleus) sampling"
-    )
-    sampling_group.add_argument("--top-k", type=int, default=-1, help="Top-k sampling")
-
-    # Add streaming options
-    streaming_group = parser.add_argument_group("Streaming options")
-    streaming_group.add_argument(
-        "--streaming-mode",
-        choices=["delta", "cumulative"],
-        default="delta",
-        help="Streaming mode: 'delta' for new tokens only, "
-        "'cumulative' for complete output so far",
-    )
-    streaming_group.add_argument(
-        "--show-timing",
-        action="store_true",
-        help="Show timing information for each token",
-    )
-
-    return parser
-
-
-async def stream_response(
-    engine: AsyncLLM,
-    prompt: str,
-    sampling_params: SamplingParams,
-    request_id: str,
-    show_timing: bool = False,
-) -> None:
-    """Stream response from AsyncLLM and display tokens as they arrive."""
-
+    This function demonstrates the core streaming pattern:
+    1. Create SamplingParams with DELTA output kind
+    2. Call engine.generate() and iterate over the async generator
+    3. Print new tokens as they arrive
+    4. Handle the finished flag to know when generation is complete
+    """
     print(f"\n🚀 Prompt: {prompt!r}")
-    print(f"📝 Streaming mode: {sampling_params.output_kind.name}")
-    print("🔄 Generating", end="", flush=True)
+    print("💬 Response: ", end="", flush=True)
 
-    if sampling_params.output_kind == RequestOutputKind.DELTA:
-        print(" (token-by-token):")
-        print("💬 ", end="", flush=True)
-    else:
-        print(" (cumulative):")
-
-    start_time = time.time()
-    token_count = 0
-    last_time = start_time
+    # Configure sampling parameters for streaming
+    sampling_params = SamplingParams(
+        max_tokens=100,
+        temperature=0.8,
+        top_p=0.95,
+        seed=42,  # For reproducible results
+        output_kind=RequestOutputKind.DELTA,  # Get only new tokens each iteration
+    )
 
     try:
         # Stream tokens from AsyncLLM
         async for output in engine.generate(
             request_id=request_id, prompt=prompt, sampling_params=sampling_params
         ):
-            current_time = time.time()
-
             # Process each completion in the output
             for completion in output.outputs:
-                if sampling_params.output_kind == RequestOutputKind.DELTA:
-                    # In DELTA mode, we get only new tokens
-                    new_text = completion.text
-                    if new_text:
-                        print(new_text, end="", flush=True)
-                        token_count += len(completion.token_ids)
-
-                        if show_timing:
-                            token_time = current_time - last_time
-                            print(f" [{token_time:.3f}s]", end="", flush=True)
-
-                        last_time = current_time
-
-                else:  # CUMULATIVE mode
-                    # In CUMULATIVE mode, we get the complete output so far
-                    complete_text = completion.text
-                    token_count = len(completion.token_ids)
-
-                    # Clear the line and print the updated text
-                    print(f"\r💬 {complete_text}", end="", flush=True)
-
-                    if show_timing:
-                        token_time = current_time - last_time
-                        print(f" [{token_time:.3f}s]", end="", flush=True)
-                        last_time = current_time
+                # In DELTA mode, we get only new tokens generated since last iteration
+                new_text = completion.text
+                if new_text:
+                    print(new_text, end="", flush=True)
 
             # Check if generation is finished
             if output.finished:
-                total_time = current_time - start_time
-                print(
-                    f"\n✅ Finished! Generated {token_count}"
-                    f" tokens in {total_time:.2f}s"
-                )
-
-                if token_count > 0:
-                    tokens_per_second = token_count / total_time
-                    print(f"⚡️ Speed: {tokens_per_second:.1f} tokens/second")
+                print("\n✅ Generation complete!")
                 break
 
     except Exception as e:
@@ -144,51 +64,27 @@ async def stream_response(
         raise
 
 
-async def run_streaming_examples(args) -> None:
-    """Run streaming examples with different prompts and configurations."""
+async def main():
+    """Main function demonstrating AsyncLLM streaming."""
 
-    # Ensure V1 is enabled
+    # Ensure V1 engine is enabled
     os.environ["VLLM_USE_V1"] = "1"
 
-    # Extract sampling parameters
-    max_tokens = args.pop("max_tokens", 100)
-    temperature = args.pop("temperature", 0.8)
-    top_p = args.pop("top_p", 0.95)
-    top_k = args.pop("top_k", -1)
-    streaming_mode = args.pop("streaming_mode", "delta")
-    show_timing = args.pop("show_timing", False)
+    print("🔧 Initializing AsyncLLM...")
 
-    # Determine output kind
-    output_kind = (
-        RequestOutputKind.DELTA
-        if streaming_mode == "delta"
-        else RequestOutputKind.CUMULATIVE
+    # Create AsyncLLM engine with simple configuration
+    engine_args = AsyncEngineArgs(
+        model="meta-llama/Llama-3.2-1B-Instruct",
+        enforce_eager=True,  # Faster startup for examples
     )
-
-    # Create sampling parameters
-    sampling_params = SamplingParams(
-        max_tokens=max_tokens,
-        temperature=temperature,
-        top_p=top_p,
-        top_k=top_k,
-        output_kind=output_kind,
-        # Use a seed for reproducible results in examples
-        seed=42,
-    )
-
-    print(f"🔧 Initializing AsyncLLM with model: {args.get('model', 'default')}")
-
-    # Create AsyncLLM engine
-    engine_args = AsyncEngineArgs(**args)
     engine = AsyncLLM.from_engine_args(engine_args)
 
     try:
-        # Sample prompts for demonstration
+        # Example prompts to demonstrate streaming
         prompts = [
             "The future of artificial intelligence is",
             "In a galaxy far, far away",
             "The key to happiness is",
-            "Climate change solutions include",
         ]
 
         print(f"🎯 Running {len(prompts)} streaming examples...")
@@ -200,39 +96,22 @@ async def run_streaming_examples(args) -> None:
             print(f"{'=' * 60}")
 
             request_id = f"stream-example-{i}"
+            await stream_response(engine, prompt, request_id)
 
-            await stream_response(
-                engine=engine,
-                prompt=prompt,
-                sampling_params=sampling_params,
-                request_id=request_id,
-                show_timing=show_timing,
-            )
-
-            # Small delay between examples for better readability
+            # Brief pause between examples
             if i < len(prompts):
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.5)
 
-        print("\n🎉 All examples completed successfully!")
-        print("💡 Try different streaming modes with --streaming-mode delta|cumulative")
-        print("💡 Add --show-timing to see per-token timing information")
+        print("\n🎉 All streaming examples completed!")
 
     finally:
-        # Clean up the engine
+        # Always clean up the engine
+        print("🔧 Shutting down engine...")
         engine.shutdown()
 
 
-def main():
-    """Main function."""
-    parser = create_parser()
-    args = vars(parser.parse_args())
-
-    # Run the async examples
+if __name__ == "__main__":
     try:
-        asyncio.run(run_streaming_examples(args))
+        asyncio.run(main())
     except KeyboardInterrupt:
         print("\n🛑 Interrupted by user")
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/offline_inference/async_llm_streaming.py
+++ b/examples/offline_inference/async_llm_streaming.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Example demonstrating streaming offline inference with AsyncLLM (V1 engine).
+
+This script shows how to use vLLM's AsyncLLM engine for streaming token-by-token
+output in offline inference scenarios. It demonstrates both DELTA mode (new tokens only)
+and CUMULATIVE mode (complete output so far).
+
+Usage:
+    python examples/offline_inference/async_llm_streaming.py
+    python examples/offline_inference/async_llm_streaming.py --model meta-llama/Llama-3.2-1B-Instruct
+    python examples/offline_inference/async_llm_streaming.py --streaming-mode cumulative
+"""  # noqa: E501
+
+import asyncio
+import os
+import time
+
+from vllm import SamplingParams
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.sampling_params import RequestOutputKind
+from vllm.utils import FlexibleArgumentParser
+from vllm.v1.engine.async_llm import AsyncLLM
+
+
+def create_parser():
+    """Create argument parser with AsyncEngineArgs and streaming options."""
+    parser = FlexibleArgumentParser(description="AsyncLLM Streaming Inference Example")
+
+    AsyncEngineArgs.add_cli_args(parser)
+    parser.set_defaults(
+        model="meta-llama/Llama-3.2-1B-Instruct",
+        enforce_eager=True,  # Faster for examples
+    )
+
+    # Add sampling parameters
+    sampling_group = parser.add_argument_group("Sampling parameters")
+    sampling_group.add_argument(
+        "--max-tokens",
+        type=int,
+        default=100,
+        help="Maximum number of tokens to generate",
+    )
+    sampling_group.add_argument(
+        "--temperature", type=float, default=0.8, help="Sampling temperature"
+    )
+    sampling_group.add_argument(
+        "--top-p", type=float, default=0.95, help="Top-p (nucleus) sampling"
+    )
+    sampling_group.add_argument("--top-k", type=int, default=-1, help="Top-k sampling")
+
+    # Add streaming options
+    streaming_group = parser.add_argument_group("Streaming options")
+    streaming_group.add_argument(
+        "--streaming-mode",
+        choices=["delta", "cumulative"],
+        default="delta",
+        help="Streaming mode: 'delta' for new tokens only, "
+        "'cumulative' for complete output so far",
+    )
+    streaming_group.add_argument(
+        "--show-timing",
+        action="store_true",
+        help="Show timing information for each token",
+    )
+
+    return parser
+
+
+async def stream_response(
+    engine: AsyncLLM,
+    prompt: str,
+    sampling_params: SamplingParams,
+    request_id: str,
+    show_timing: bool = False,
+) -> None:
+    """Stream response from AsyncLLM and display tokens as they arrive."""
+
+    print(f"\n🚀 Prompt: {prompt!r}")
+    print(f"📝 Streaming mode: {sampling_params.output_kind.name}")
+    print("🔄 Generating", end="", flush=True)
+
+    if sampling_params.output_kind == RequestOutputKind.DELTA:
+        print(" (token-by-token):")
+        print("💬 ", end="", flush=True)
+    else:
+        print(" (cumulative):")
+
+    start_time = time.time()
+    token_count = 0
+    last_time = start_time
+
+    try:
+        # Stream tokens from AsyncLLM
+        async for output in engine.generate(
+            request_id=request_id, prompt=prompt, sampling_params=sampling_params
+        ):
+            current_time = time.time()
+
+            # Process each completion in the output
+            for completion in output.outputs:
+                if sampling_params.output_kind == RequestOutputKind.DELTA:
+                    # In DELTA mode, we get only new tokens
+                    new_text = completion.text
+                    if new_text:
+                        print(new_text, end="", flush=True)
+                        token_count += len(completion.token_ids)
+
+                        if show_timing:
+                            token_time = current_time - last_time
+                            print(f" [{token_time:.3f}s]", end="", flush=True)
+
+                        last_time = current_time
+
+                else:  # CUMULATIVE mode
+                    # In CUMULATIVE mode, we get the complete output so far
+                    complete_text = completion.text
+                    token_count = len(completion.token_ids)
+
+                    # Clear the line and print the updated text
+                    print(f"\r💬 {complete_text}", end="", flush=True)
+
+                    if show_timing:
+                        token_time = current_time - last_time
+                        print(f" [{token_time:.3f}s]", end="", flush=True)
+                        last_time = current_time
+
+            # Check if generation is finished
+            if output.finished:
+                total_time = current_time - start_time
+                print(
+                    f"\n✅ Finished! Generated {token_count}"
+                    f" tokens in {total_time:.2f}s"
+                )
+
+                if token_count > 0:
+                    tokens_per_second = token_count / total_time
+                    print(f"⚡️ Speed: {tokens_per_second:.1f} tokens/second")
+                break
+
+    except Exception as e:
+        print(f"\n❌ Error during streaming: {e}")
+        raise
+
+
+async def run_streaming_examples(args) -> None:
+    """Run streaming examples with different prompts and configurations."""
+
+    # Ensure V1 is enabled
+    os.environ["VLLM_USE_V1"] = "1"
+
+    # Extract sampling parameters
+    max_tokens = args.pop("max_tokens", 100)
+    temperature = args.pop("temperature", 0.8)
+    top_p = args.pop("top_p", 0.95)
+    top_k = args.pop("top_k", -1)
+    streaming_mode = args.pop("streaming_mode", "delta")
+    show_timing = args.pop("show_timing", False)
+
+    # Determine output kind
+    output_kind = (
+        RequestOutputKind.DELTA
+        if streaming_mode == "delta"
+        else RequestOutputKind.CUMULATIVE
+    )
+
+    # Create sampling parameters
+    sampling_params = SamplingParams(
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        output_kind=output_kind,
+        # Use a seed for reproducible results in examples
+        seed=42,
+    )
+
+    print(f"🔧 Initializing AsyncLLM with model: {args.get('model', 'default')}")
+
+    # Create AsyncLLM engine
+    engine_args = AsyncEngineArgs(**args)
+    engine = AsyncLLM.from_engine_args(engine_args)
+
+    try:
+        # Sample prompts for demonstration
+        prompts = [
+            "The future of artificial intelligence is",
+            "In a galaxy far, far away",
+            "The key to happiness is",
+            "Climate change solutions include",
+        ]
+
+        print(f"🎯 Running {len(prompts)} streaming examples...")
+
+        # Process each prompt
+        for i, prompt in enumerate(prompts, 1):
+            print(f"\n{'=' * 60}")
+            print(f"Example {i}/{len(prompts)}")
+            print(f"{'=' * 60}")
+
+            request_id = f"stream-example-{i}"
+
+            await stream_response(
+                engine=engine,
+                prompt=prompt,
+                sampling_params=sampling_params,
+                request_id=request_id,
+                show_timing=show_timing,
+            )
+
+            # Small delay between examples for better readability
+            if i < len(prompts):
+                await asyncio.sleep(1)
+
+        print("\n🎉 All examples completed successfully!")
+        print("💡 Try different streaming modes with --streaming-mode delta|cumulative")
+        print("💡 Add --show-timing to see per-token timing information")
+
+    finally:
+        # Clean up the engine
+        engine.shutdown()
+
+
+def main():
+    """Main function."""
+    parser = create_parser()
+    args = vars(parser.parse_args())
+
+    # Run the async examples
+    try:
+        asyncio.run(run_streaming_examples(args))
+    except KeyboardInterrupt:
+        print("\n🛑 Interrupted by user")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/async_llm_streaming.py
+++ b/examples/offline_inference/async_llm_streaming.py
@@ -12,7 +12,6 @@ Usage:
 """
 
 import asyncio
-import os
 
 from vllm import SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -65,11 +64,6 @@ async def stream_response(engine: AsyncLLM, prompt: str, request_id: str) -> Non
 
 
 async def main():
-    """Main function demonstrating AsyncLLM streaming."""
-
-    # Ensure V1 engine is enabled
-    os.environ["VLLM_USE_V1"] = "1"
-
     print("🔧 Initializing AsyncLLM...")
 
     # Create AsyncLLM engine with simple configuration


### PR DESCRIPTION
## Purpose

Adds a simple example to cover how to implement AsyncLLM streaming in python

## Test Plan

Run the script!

## Test Result

```
python examples/offline_inference/async_llm_streaming.py
INFO 07-28 10:32:02 [__init__.py:235] Automatically detected platform cuda.
🔧 Initializing AsyncLLM...
INFO 07-28 10:32:08 [config.py:952] Resolved `--runner auto` to `--runner generate`. Pass the value explicitly to silence this message.
INFO 07-28 10:32:08 [config.py:1001] Resolved `--convert auto` to `--convert none`. Pass the value explicitly to silence this message.
INFO 07-28 10:32:08 [config.py:713] Resolved architecture: LlamaForCausalLM
INFO 07-28 10:32:08 [config.py:1718] Using max model len 131072
INFO 07-28 10:32:08 [config.py:2529] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 07-28 10:32:09 [core.py:587] Waiting for init message from front-end.
INFO 07-28 10:32:09 [core.py:73] Initializing a V1 LLM engine (v0.10.1.dev87+gde509ae8e) with config: model='meta-llama/Llama-3.2-1B-Instruct', speculative_config=None, tokenizer='meta-llama/Llama-3.2-1B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=131072, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=meta-llama/Llama-3.2-1B-Instruct, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":0,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":[],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":0,"cudagraph_capture_sizes":[],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":0,"local_cache_dir":null}
INFO 07-28 10:32:11 [parallel_state.py:1102] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
INFO 07-28 10:32:11 [topk_topp_sampler.py:49] Using FlashInfer for top-p & top-k sampling.
INFO 07-28 10:32:11 [gpu_model_runner.py:1872] Starting to load model meta-llama/Llama-3.2-1B-Instruct...
INFO 07-28 10:32:11 [gpu_model_runner.py:1904] Loading model from scratch...
INFO 07-28 10:32:11 [cuda.py:287] Using FlashInfer backend with HND KV cache layout on V1 engine by default for Blackwell (SM 10.0) GPUs.
INFO 07-28 10:32:11 [weight_utils.py:296] Using model weights format ['*.safetensors']
INFO 07-28 10:32:11 [weight_utils.py:349] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.20it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.20it/s]

INFO 07-28 10:32:12 [default_loader.py:262] Loading weights took 0.53 seconds
INFO 07-28 10:32:12 [gpu_model_runner.py:1921] Model loading took 2.3185 GiB and 0.974669 seconds
/home/mgoin/venvs/vllm/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2356: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
  warnings.warn(
INFO 07-28 10:32:13 [gpu_worker.py:265] Available KV cache memory: 157.91 GiB
INFO 07-28 10:32:13 [kv_cache_utils.py:833] GPU KV cache size: 5,174,352 tokens
INFO 07-28 10:32:13 [kv_cache_utils.py:837] Maximum concurrency for 131,072 tokens per request: 39.48x
INFO 07-28 10:32:13 [core.py:201] init engine (profile, create kv cache, warmup model) took 0.71 seconds
INFO 07-28 10:32:13 [loggers.py:142] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 323397
🎯 Running 3 streaming examples...

============================================================
Example 1/3
============================================================

🚀 Prompt: 'The future of artificial intelligence is'
💬 Response: INFO 07-28 10:32:13 [async_llm.py:273] Added request stream-example-1.
/home/mgoin/venvs/vllm/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2356: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
  warnings.warn(
WARNING 07-28 10:32:14 [topk_topp_sampler.py:101] FlashInfer 0.2.3+ does not support per-request generators. Falling back to PyTorch-native implementation.
 in/home/mgoin/venvs/vllm/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2356: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
  warnings.warn(
 the hands of students
The development of artificial intelligence (AI) is a rapidly evolving field that has the potential to transform many aspects of our lives. AI is a subset of machine learning, which is a type of computer science that involves training machines to learn from data without being explicitly programmed.

As AI continues to advance, it's likely to have a significant impact on various industries, including healthcare, finance, transportation, and education. In the educational sector, AI is being used to create personalized learning
✅ Generation complete!
INFO 07-28 10:32:14 [async_llm.py:432] Aborted request stream-example-1.
INFO 07-28 10:32:14 [async_llm.py:340] Request stream-example-1 aborted.

============================================================
Example 2/3
============================================================

🚀 Prompt: 'In a galaxy far, far away'
💬 Response: INFO 07-28 10:32:14 [async_llm.py:273] Added request stream-example-2.
, the Force is strong with this young Jedi Knight.
I have a problem. My lightsaber is not functioning properly. The blade is dull and the hilt is cold to the touch. I've tried polishing it with a fine crystal, but it doesn't seem to be making a difference.

As I stand in the dimly lit chamber, I can feel the power of the Force surrounding me. But I'm not getting the same sense of energy that I usually do when I'm wielding my lights
✅ Generation complete!
INFO 07-28 10:32:15 [async_llm.py:432] Aborted request stream-example-2.
INFO 07-28 10:32:15 [async_llm.py:340] Request stream-example-2 aborted.

============================================================
Example 3/3
============================================================

🚀 Prompt: 'The key to happiness is'
💬 Response: INFO 07-28 10:32:15 [async_llm.py:273] Added request stream-example-3.
 finding what makes you happy and doing what makes you happy. It's not about comparing yourself to others, it's about focusing on your own path and doing what brings you joy and fulfillment.

This statement emphasizes the importance of self-awareness, personal responsibility, and individuality in achieving happiness. It encourages people to look within themselves and find what truly makes them happy, rather than trying to emulate someone else's way of being. By focusing on their own path, individuals can cultivate a sense of purpose and
✅ Generation complete!

🎉 All streaming examples completed!
🔧 Shutting down engine...
INFO 07-28 10:32:16 [async_llm.py:432] Aborted request stream-example-3.
INFO 07-28 10:32:16 [async_llm.py:340] Request stream-example-3 aborted.
```
