### PR TITLE
[CI] Parallelize Kernels MoE Test

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -403,17 +403,18 @@ steps:
   - vllm/model_executor/layers/quantization
   - tests/kernels/quantization
   commands:
-    - pytest -v -s kernels/quantization  --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+    - pytest -v -s kernels/quantization --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
   parallelism: 2
 
-- label: Kernels MoE Test
+- label: Kernels MoE Test %N
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
   - csrc/moe/
   - tests/kernels/moe
   - vllm/model_executor/layers/fused_moe/
   commands:
-    - pytest -v -s kernels/moe
+    - pytest -v -s kernels/moe --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+  parallelism: 2
 
 - label: Kernels Mamba Test
   mirror_hardwares: [amdexperimental, amdproduction]


### PR DESCRIPTION
## Purpose

The `Kernels MoE Test` takes 3 hours now, so let's at least split it in half.

https://buildkite.com/vllm/ci/builds/25087/steps/canvas?sid=01984c37-20b7-47a1-b05e-6b3f88102b93
<img width="749" height="452" alt="Screenshot 2025-07-28 at 10 38 25 AM" src="https://github.com/user-attachments/assets/1a2bc585-a582-4d11-b453-37cc46e9ad4f" />


## Test Plan

CI