### PR TITLE
[AMD][CI/Build][Bugfix] Guarding CUDA specific functions by ifndef ROCM

### DIFF
--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -1,7 +1,9 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/all.h>
 
-#include "../per_token_group_quant_8bit.h"
+#ifndef USE_ROCM
+  #include "../per_token_group_quant_8bit.h"
+#endif
 
 #include <cmath>
 
@@ -339,6 +341,7 @@ void dynamic_scaled_int8_quant(
       });
 }
 
+#ifndef USE_ROCM
 void per_token_group_quant_int8(const torch::Tensor& input,
                                 torch::Tensor& output_q,
                                 torch::Tensor& output_s, int64_t group_size,
@@ -346,3 +349,4 @@ void per_token_group_quant_int8(const torch::Tensor& input,
   per_token_group_quant_8bit(input, output_q, output_s, group_size, eps,
                              int8_min, int8_max);
 }
+#endif


### PR DESCRIPTION
An extension over #21647 to fix a regression from #21476 
~Need to guard the functions as well, not only the file in CMakeLists~
Just putting the new function, referencing CUDA specific code in the ifndef seems to be enough