### PR TITLE
[Bug] Enforce contiguous input for `dynamic_scaled_fp8_quant` and `static_scaled_fp8_quant`

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1282,10 +1282,11 @@ def scaled_fp8_quant(
                 output, input.contiguous(), scale, scale_ub)
         else:
             scale = torch.zeros(1, device=input.device, dtype=torch.float32)
-            torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
+            torch.ops._C.dynamic_scaled_fp8_quant(output, input.contiguous(),
+                                                  scale)
     else:
         assert scale.numel() == 1, f"{scale.shape}"
-        torch.ops._C.static_scaled_fp8_quant(output, input, scale)
+        torch.ops._C.static_scaled_fp8_quant(output, input.contiguous(), scale)
 
     return output, scale
 


### PR DESCRIPTION
## Purpose

Similar to https://github.com/vllm-project/vllm/pull/19452, we temporally fix by enforcing input contiguous. Will work on https://github.com/vllm-project/vllm/issues/19630 later to see we can support some non-contiguous input case.

`lm_eval  --model vllm  --model_args "pretrained=nm-testing/DeepSeek-Coder-V2-Lite-Instruct-FP8,max_model_len=32768,enable_expert_parallel=True,enforce_eager=True"  --trust_remote_code  --tasks gsm8k  --num_fewshot 5  --batch_size auto`

```bash
[rank0]:   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/model_executor/layers/quantization/input_quant_fp8.py", line 60, in forward_cuda
[rank0]:     return ops.scaled_fp8_quant(
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/_custom_ops.py", line 1288, in scaled_fp8_quant
[rank0]:     torch.ops._C.static_scaled_fp8_quant(output, input, scale)
[rank0]:   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1158, in __call__
[rank0]:     return self._op(*args, **(kwargs or {}))
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: RuntimeError: Expected input.is_contiguous() to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
```

## Test

```bash
llm (pretrained=nm-testing/DeepSeek-Coder-V2-Lite-Instruct-FP8,max_model_len=32768,enable_expert_parallel=True,enforce_eager=True,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7415|±  |0.0121|
|     |       |strict-match    |     5|exact_match|↑  |0.7104|±  |0.0125|
```