### PR TITLE
[Core] Avoid repeated len(block_token_ids) check in hash_request_tokens

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -567,12 +567,10 @@ def hash_request_tokens(hash_function: Any, block_size: int,
 
     ret = []
     parent_block_hash_value = None
-    for start in range(0, len(token_ids), block_size):
+    # Only full blocks will be hashed
+    for start in range(0, len(token_ids) - block_size + 1, block_size):
         end = start + block_size
         block_token_ids = token_ids[start:end]
-        # Do not hash the block if it is not full.
-        if len(block_token_ids) < block_size:
-            break
 
         if req_need_extra_keys:
             # MM and LoRA requests need extra keys for block-hash computation.


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
When analyzing profiling traces of vLLM on small models, I observed that `hash_request_tokens` has repeated `len(block_token_ids)` checks, which can be costly when prompt is long.
<img width="753" height="284" alt="image" src="https://github.com/user-attachments/assets/06f6fc1e-1814-45ca-9952-a8cc93fc8466" />


This PR removes the `len(block_token_ids)` check from the loop, while also avoiding creating the last incomplete slice.

## Test Plan
```
source /home/zebingl/uv_env/vllm/bin/activate
cd /data/users/zebingl/gitrepos/vllm
export VLLM_USE_MODELSCOPE=False;
export VLLM_TORCH_PROFILER_DIR=~/vllm_profile; # for profiling
export CUDA_VISIBLE_DEVICES=0;
VLLM_USE_V1=1 vllm serve facebook/opt-125m \
    --swap-space 16 \
    --disable-log-requests \
    --host :: \
    --dtype float16
```

```
source /home/zebingl/uv_env/vllm/bin/activate
cd /data/users/zebingl/gitrepos/vllm
VLLM_USE_V1=1 vllm bench serve \
    --dataset-name random \
    --model facebook/opt-125m \
    --served-model-name facebook/opt-125m \
    --random-input-len 700 \
    --random-output-len 1 \
    --endpoint /v1/completions \
    --ignore-eos \
    --host localhost \
    --port 8000 \
    --num-prompts 100 \
    --profile
```

## Test Result

Verified that the `len(block_token_ids)` is removed in the trace.

For block_size of 16 and input length of 700, the len check takes around 50ns, and redundant incomplete slicing takes around 100ns, this should save us at least 2.25μs for each request on paper.

However, because of removed code branching, the actual improvement is more. I did some simple benchmarks, showing ~3-7μs savings.



## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
