### PR TITLE
[Bugfix] Fix KV Cache memory layout for MultiConnector containing NixlConnector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -114,11 +114,12 @@ def get_kv_connector_cache_layout():
             connectors = kv_config.kv_connector_extra_config.get("connectors")
             if isinstance(connectors, list):
                 nixl_in_multi = any(
-                    c.get("kv_connector") == "NixlConnector" for c in connectors)
+                    c.get("kv_connector") == "NixlConnector"
+                    for c in connectors)
 
-        nixl_detected = (kv_config.kv_connector == "NixlConnector" or
-                         nixl_in_multi)
-        
+        nixl_detected = (kv_config.kv_connector == "NixlConnector"
+                         or nixl_in_multi)
+
         if not use_mla and nixl_detected:
             logger.info_once("NixlConnector detected. Setting KV cache " \
             "layout to HND for better xfer performance.")


### PR DESCRIPTION
## Purpose
Fix KV cache layout detection when using MultiConnector that contains NixlConnector. Previously, `get_kv_connector_cache_layout()` only checked for direct NixlConnector usage, but ignored cases where NixlConnector is used within a MultiConnector configuration.

This ensures layout consistency in disaggregated scenarios where different nodes may use different connector configurations (e.g., one node uses MultiConnector with NixlConnector while another uses NixlConnector directly). Both configurations should use the same "HND" layout for compatibility.

## Test Plan
1. Test with direct NixlConnector configuration:
```python
kv_transfer_config = KVTransferConfig(
    kv_connector="NixlConnector",
    kv_role="kv_both"
)
```

2. Test with MultiConnector containing NixlConnector:
```python
kv_transfer_config = KVTransferConfig(
    kv_connector="MultiConnector",
    kv_role="kv_both",
    kv_connector_extra_config={
        "connectors": [
            {
                "kv_connector": "LMCacheConnectorV1",
                "kv_role": "kv_both"
            },
            {
                "kv_connector": "NixlConnector",
                "kv_role": "kv_both",
            }
        ]
    }
)
```
3. Test with MultiConnector without NixlConnector (should remain "NHD")
4. Verify that `get_kv_connector_cache_layout()` returns "HND" for both cases 1 and 2

## Test Result
- ✅ Direct NixlConnector usage returns "HND" layout (existing behavior preserved)
- ✅ MultiConnector with NixlConnector returns "HND" layout (new behavior)
- ✅ MultiConnector without NixlConnector returns "NHD" layout (default behavior preserved)

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
