### PR TITLE
[Core] allocate all prefill kv greedily

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -142,7 +142,9 @@ class BlockPool:
         new_hashes: Optional[list[int]] = ([] if self.enable_kv_cache_events
                                            else None)
         for i, blk in enumerate(new_full_blocks):
-            assert blk.block_hash is None
+            if blk.block_hash is not None:
+                prev_block_hash_value = blk.block_hash.get_hash_value()
+                continue
 
             if i < len(new_block_hashes):
                 # The block hash may already be computed in

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -426,6 +426,7 @@ class Scheduler(SchedulerInterface):
                         skipped_waiting_requests.prepend_request(request)
                         continue
 
+                    num_new_tokens_to_kv_allocate = num_new_tokens
                     num_new_tokens = min(num_new_tokens, token_budget)
                     assert num_new_tokens > 0
 
@@ -442,7 +443,7 @@ class Scheduler(SchedulerInterface):
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
-                    num_new_tokens + num_external_computed_tokens,
+                    num_new_tokens_to_kv_allocate + num_external_computed_tokens,
                     num_new_local_computed_tokens,
                     new_computed_blocks,
                     num_lookahead_tokens=self.num_lookahead_tokens,


### PR DESCRIPTION
This PR improves the V1 scheduler performance for long context requests with chunked prefill.

## Details

When KV cache space is constrained, and we have long context requests with chunked prefill, the current V1 scheduler behavior can lead to a loop of requests getting scheduled for a few iterations, then getting preempted, then trying to get scheduled again and get preempted again, etc. This leads to wasteful work and slower iterations while the first tokens of these preempted requests are getting processed repeatedly.

This is because a request is allowed to be scheduled even if the free KV cache space doesn't allow the full prefix to fit (only the space for `max_num_batched_tokens` is checked). The request is scheduled, and only later after a few chunked prefill iterations it realizes there is no more cache space, and the request is thrown away/preempted. This happens again in a loop, and slows down other running generation requests in the decode phase.

This PR changes the scheduler logic to check and ask for the whole prefill kv cache when a request is getting tested for scheduling.


## Benchmarks

On a 1xL40S

```
vllm serve meta-llama/Llama-3.1-8B-Instruct --no-enable-prefix-caching

vllm bench serve --random-input-len 120000 --random-output-len 1000 --model meta-llama/Llama-3.1-8B-Instruct  --num-prompts  2 --max-concurrency 2 --request-rate inf
```

Before this fix, the second request would try to get scheduled and run a few chunked prefill iterations before getting preempted, in a loop. This slows down the decode phase of the first request.

```
INFO 07-28 17:01:32 [gpu_worker.py:232] Available KV cache memory: 24.55 GiB
INFO 07-28 17:01:33 [kv_cache_utils.py:716] GPU KV cache size: 201,072 tokens
```


### Before this PR

```
============ Serving Benchmark Result ============
Successful requests:                     2
Benchmark duration (s):                  519.73
Total input tokens:                      239998
Total generated tokens:                  2000
Request throughput (req/s):              0.00
Output token throughput (tok/s):         3.85
Total Token throughput (tok/s):          465.63
---------------Time to First Token----------------
Mean TTFT (ms):                          252761.35
Median TTFT (ms):                        252761.35
P99 TTFT (ms):                           471005.80
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          237.71
Median TPOT (ms):                        237.71
P99 TPOT (ms):                           427.24
---------------Inter-token Latency----------------
Mean ITL (ms):                           237.71
Median ITL (ms):                         44.95
P99 ITL (ms):                            644.59
==================================================
```

### After this PR

```
============ Serving Benchmark Result ============
Successful requests:                     2
Benchmark duration (s):                  148.11
Total input tokens:                      239998
Total generated tokens:                  2000
Request throughput (req/s):              0.01
Output token throughput (tok/s):         13.50
Total Token throughput (tok/s):          1633.87
---------------Time to First Token----------------
Mean TTFT (ms):                          66931.18
Median TTFT (ms):                        66931.18
P99 TTFT (ms):                           103139.89
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          44.27
Median TPOT (ms):                        44.27
P99 TPOT (ms):                           44.27
---------------Inter-token Latency----------------
Mean ITL (ms):                           44.27
Median ITL (ms):                         44.27
P99 ITL (ms):                            44.79
==================================================
```
