### PR TITLE
[Bugfix] Correct max tokens for non-contiguous embeds

### DIFF
--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -184,7 +184,7 @@ class MultiModalProfiler(Generic[_I]):
         placeholders_by_modality = mm_inputs["mm_placeholders"]
 
         return {
-            modality: sum(item.get_num_embeds() for item in placeholders)
+            modality: sum(item.length for item in placeholders)
             for modality, placeholders in placeholders_by_modality.items()
         }
 

--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -180,11 +180,14 @@ class MultiModalProfiler(Generic[_I]):
     def _get_mm_num_tokens(
         self,
         mm_inputs: MultiModalInputs,
+        mm_embeddings_only: bool = True,
     ) -> Mapping[str, int]:
         placeholders_by_modality = mm_inputs["mm_placeholders"]
 
         return {
-            modality: sum(item.length for item in placeholders)
+            modality:
+            sum(item.get_num_embeds() if mm_embeddings_only else item.length
+                for item in placeholders)
             for modality, placeholders in placeholders_by_modality.items()
         }
 
@@ -257,6 +260,7 @@ class MultiModalProfiler(Generic[_I]):
         self,
         seq_len: int,
         mm_counts: Optional[Mapping[str, int]] = None,
+        mm_embeddings_only: bool = True,
     ) -> Mapping[str, int]:
         if mm_counts is None:
             mm_counts = self.get_mm_limits()
@@ -285,4 +289,14 @@ class MultiModalProfiler(Generic[_I]):
             return max_tokens_per_item
 
         mm_inputs = self._get_dummy_mm_inputs(seq_len, mm_counts)
-        return self._get_mm_num_tokens(mm_inputs)
+        return self._get_mm_num_tokens(mm_inputs,
+                                       mm_embeddings_only=mm_embeddings_only)
+
+    def get_max_placeholder_tokens(
+        self,
+        seq_len: int,
+        mm_counts: Optional[Mapping[str, int]] = None,
+    ):
+        return self.get_mm_max_tokens(seq_len,
+                                      mm_counts,
+                                      mm_embeddings_only=False)

--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -256,7 +256,7 @@ class MultiModalProfiler(Generic[_I]):
             multi_modal_placeholders=mm_inputs["mm_placeholders"],
         )
 
-    def get_mm_max_tokens(
+    def _get_mm_max_tokens(
         self,
         seq_len: int,
         mm_counts: Optional[Mapping[str, int]] = None,
@@ -292,11 +292,22 @@ class MultiModalProfiler(Generic[_I]):
         return self._get_mm_num_tokens(mm_inputs,
                                        mm_embeddings_only=mm_embeddings_only)
 
-    def get_max_placeholder_tokens(
+    def get_mm_max_contiguous_tokens(
         self,
         seq_len: int,
         mm_counts: Optional[Mapping[str, int]] = None,
     ):
-        return self.get_mm_max_tokens(seq_len,
-                                      mm_counts,
-                                      mm_embeddings_only=False)
+        """
+        Returns the maximum length of the multimodal (image placeholders+text)
+        tokens, including any break/text tokens in-between image embeddings.
+
+        <im_start> [IMG] [IMG] [IMG] <row_break> [IMG] [IMG] [IMG] <im_end>
+        Returns 9, even when the number of image embeddings is 6.
+        
+        This is important to take into account when profiling and
+        initializing the encoder cache size.
+        """
+
+        return self._get_mm_max_tokens(seq_len,
+                                       mm_counts,
+                                       mm_embeddings_only=False)

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -129,7 +129,7 @@ class MultiModalRegistry:
         seq_len = model_config.max_model_len
         mm_limits = self.get_mm_limits_per_prompt(model_config)
 
-        return profiler.get_max_placeholder_tokens(
+        return profiler.get_mm_max_contiguous_tokens(
             seq_len,
             {
                 modality: 1

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -129,7 +129,7 @@ class MultiModalRegistry:
         seq_len = model_config.max_model_len
         mm_limits = self.get_mm_limits_per_prompt(model_config)
 
-        return profiler.get_mm_max_tokens(
+        return profiler.get_max_placeholder_tokens(
             seq_len,
             {
                 modality: 1


### PR DESCRIPTION
Fixes a hang on some VLM models with large images.

Some models like Pixtral derivative do not have contiguous multimodal image embeddings, but insert text tokens in between chunks of image row embeddings.

The encoder cache manager did not take this into account, and underestimated the size of the cache to allocate. At inference time, some requests with a large image that exceed the cache size never got scheduled.

FIX #18329

## Example

```
vllm serve mistralai/Pixtral-12B-2409  --no-enable-prefix-caching --tokenizer_mode mistral --config_format mistral --load_format mistral --max_model_len 32000
```

```
curl -X 'POST' \
'http://0.0.0.0:8000/v1/chat/completions' \
    -H 'Accept: application/json' \
    -H 'Content-Type: application/json' \
    -d '{
          "model": "mistralai/Pixtral-12B-2409",
          "messages": [
            {
              "role": "user",
              "content": [
                {
                  "type": "image_url",
                  "image_url":
                    {
                      "url": "https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fsvs.gsfc.nasa.gov%2Fvis%2Fa000000%2Fa003600%2Fa003657%2Fsc09cloud_still_persp_c1440.0500.jpg&f=1&nofb=1&ipt=3aece6fc933b224b28bcab2de0586cabb5e0693be3e04d6b7815d69e7b7b265d"
                    }
                },
                {
                  "type": "text",
                  "text": "What is in this image?"
                }
              ]
            }
          ],
          "stream": false,
          "max_tokens": 256,
          "temperature": 0
    }'
```


### Before this MR:

```
INFO 07-28 18:58:14 [gpu_model_runner.py:2238] Encoder cache will be initialized with a budget of 4096 tokens, and profiled with 1 image items of the maximum feature size.   
```

Request stuck forever, never scheduled.

### After this MR

```
INFO 07-28 19:22:40 [gpu_model_runner.py:2238] Encoder cache will be initialized with a budget of 4160 tokens, and profiled with 1 image items of the maximum feature size.   
```

Request runs as expected