### PR TITLE
[Bugfix] Fix shape mismatch assertion error when loading Gemma3n model with BitsAndBytes quantization

### DIFF
--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -167,22 +167,33 @@ class Gemma3nAltUp(nn.Module):
 class Gemma3nLaurelBlock(nn.Module):
     """Learned Augmented Residual Layer"""
 
-    def __init__(self, hidden_size: int, laurel_rank: int, rms_norm_eps: float,
-                 prefix: str):
+    def __init__(
+        self,
+        hidden_size: int,
+        laurel_rank: int,
+        rms_norm_eps: float,
+        *,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str,
+    ) -> None:
         super().__init__()
 
         self.linear_left = ColumnParallelLinear(
             hidden_size,
             laurel_rank,
             bias=False,
+            quant_config=quant_config,
             prefix=f"{prefix}.linear_left",
             return_bias=False,
         )
-        self.linear_right = RowParallelLinear(laurel_rank,
-                                              hidden_size,
-                                              bias=False,
-                                              prefix=f"{prefix}.linear_right",
-                                              return_bias=False)
+        self.linear_right = RowParallelLinear(
+            laurel_rank,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_right",
+            return_bias=False,
+        )
         self.post_laurel_norm = RMSNorm(
             hidden_size=hidden_size,
             eps=rms_norm_eps,
@@ -412,6 +423,7 @@ class Gemma3nDecoderLayer(nn.Module):
             hidden_size=config.hidden_size,
             laurel_rank=config.laurel_rank,
             rms_norm_eps=config.rms_norm_eps,
+            quant_config=quant_config,
             prefix=f"{prefix}.laurel",
         )
 
@@ -422,6 +434,7 @@ class Gemma3nDecoderLayer(nn.Module):
             config.hidden_size,
             config.hidden_size_per_layer_input,
             bias=False,
+            quant_config=quant_config,
             prefix=f"{prefix}.per_layer_input_gate",
             return_bias=False,
         )
@@ -429,6 +442,7 @@ class Gemma3nDecoderLayer(nn.Module):
             config.hidden_size_per_layer_input,
             config.hidden_size,
             bias=False,
+            quant_config=quant_config,
             prefix=f"{prefix}.per_layer_projection",
             return_bias=False,
         )
@@ -542,6 +556,7 @@ class Gemma3nTextModel(nn.Module):
             bias=False,
             gather_output=True,
             return_bias=False,
+            quant_config=quant_config,
             prefix=f"{prefix}.per_layer_model_projection",
         )
         self.per_layer_projection_norm = RMSNorm(
@@ -561,6 +576,7 @@ class Gemma3nTextModel(nn.Module):
                 bias=False,
                 gather_output=True,
                 return_bias=False,
+                quant_config=quant_config,
                 prefix=f"{prefix}.{idx-1}.altup_projections",
             ) for idx in range(1, self.config.altup_num_inputs)
         ])
@@ -571,6 +587,7 @@ class Gemma3nTextModel(nn.Module):
                 bias=False,
                 gather_output=True,
                 return_bias=False,
+                quant_config=quant_config,
                 prefix=f"{prefix}.{idx-1}.altup_unembed_projections",
             ) for idx in range(1, self.config.altup_num_inputs)
         ])


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Fix #21743

## Test Plan
```python
import torch
from vllm import LLM, SamplingParams

model_path = "unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit"
llm = LLM(
    model=model_path,
    trust_remote_code=True,
    dtype=torch.bfloat16,
    max_model_len=4000,
    enforce_eager=True
)

# Example usage
sampling_params = SamplingParams(
    temperature=0.7,
    top_p=0.9,
    max_tokens=512
)
prompts = ["Hello, how are you today?"]
outputs = llm.generate(prompts, sampling_params)
for output in outputs:
    generated_text = output.outputs[0].text
    print(f"Generated: {generated_text}")
```

## Test Result
### Before
```text
/home/ec2-user/venv/lib64/python3.9/site-packages/networkx/utils/backends.py:135: RuntimeWarning: networkx backend defined more than once: nx-loopback
  backends.update(_get_backends("networkx.backends"))
INFO 07-28 10:44:49 [__init__.py:235] Automatically detected platform cuda.
INFO 07-28 10:44:53 [utils.py:326] non-default args: {'model': 'unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit', 'trust_remote_code': True, 'dtype': torch.bfloat16, 'max_model_len': 4000, 'gpu_memory_utilization': 0.6, 'disable_log_stats': True, 'quantization': 'bitsandbytes', 'enforce_eager': True}
WARNING 07-28 10:44:53 [config.py:531] The global random seed is set to 0. Since VLLM_ENABLE_V1_MULTIPROCESSING is set to False, this may affect the random state of the Python process that launched vLLM.
INFO 07-28 10:45:01 [config.py:952] Resolved `--runner auto` to `--runner generate`. Pass the value explicitly to silence this message.
INFO 07-28 10:45:01 [config.py:1001] Resolved `--convert auto` to `--convert none`. Pass the value explicitly to silence this message.
INFO 07-28 10:45:01 [config.py:713] Resolved architecture: Gemma3nForConditionalGeneration
INFO 07-28 10:45:01 [config.py:1718] Using max model len 4000
WARNING 07-28 10:45:04 [config.py:1173] bitsandbytes quantization is not fully optimized yet. The speed can be slower than non-quantized models.
INFO 07-28 10:45:04 [config.py:2529] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 07-28 10:45:06 [core.py:73] Initializing a V1 LLM engine (v0.10.1.dev125+g2cc571199) with config: model='unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit', speculative_config=None, tokenizer='unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4000, download_dir=None, load_format=bitsandbytes, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=bitsandbytes, enforce_eager=True, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":0,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":[],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":0,"cudagraph_capture_sizes":[],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":0,"local_cache_dir":null}
INFO 07-28 10:45:07 [parallel_state.py:1102] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
WARNING 07-28 10:45:07 [topk_topp_sampler.py:59] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
INFO 07-28 10:45:07 [gpu_model_runner.py:1872] Starting to load model unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit...
INFO 07-28 10:45:07 [gpu_model_runner.py:1904] Loading model from scratch...
INFO 07-28 10:45:07 [cuda.py:305] Using Flash Attention backend on V1 engine.
INFO 07-28 10:45:07 [bitsandbytes_loader.py:733] Loading weights with BitsAndBytes quantization. May take a while ...
INFO 07-28 10:45:07 [weight_utils.py:296] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  67% Completed | 2/3 [00:00<00:00, 18.99it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:00<00:00, 27.74it/s]

Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/ec2-user/src/synoptia/engine/test.py", line 6, in <module>
[rank0]:     llm = LLM(
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/entrypoints/llm.py", line 280, in __init__
[rank0]:     self.llm_engine = LLMEngine.from_engine_args(
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/v1/engine/llm_engine.py", line 153, in from_engine_args
[rank0]:     return cls(vllm_config=vllm_config,
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/v1/engine/llm_engine.py", line 104, in __init__
[rank0]:     self.engine_core = EngineCoreClient.make_client(
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/v1/engine/core_client.py", line 80, in make_client
[rank0]:     return InprocClient(vllm_config, executor_class, log_stats)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/v1/engine/core_client.py", line 242, in __init__
[rank0]:     self.engine_core = EngineCore(*args, **kwargs)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/v1/engine/core.py", line 79, in __init__
[rank0]:     self.model_executor = executor_class(vllm_config)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/executor/executor_base.py", line 53, in __init__
[rank0]:     self._init_executor()
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/executor/uniproc_executor.py", line 49, in _init_executor
[rank0]:     self.collective_rpc("load_model")
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
[rank0]:     answer = run_method(self.driver_worker, method, args, kwargs)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/utils/__init__.py", line 2987, in run_method
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/v1/worker/gpu_worker.py", line 201, in load_model
[rank0]:     self.model_runner.load_model(eep_scale_up=eep_scale_up)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1905, in load_model
[rank0]:     self.model = model_loader.load_model(
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/model_loader/base_loader.py", line 49, in load_model
[rank0]:     self.load_weights(model, model_config)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/model_loader/bitsandbytes_loader.py", line 741, in load_weights
[rank0]:     loaded_weights = model.load_weights(qweight_iterator)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/models/gemma3n.py", line 811, in load_weights
[rank0]:     return loader.load_weights(weights)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/models/utils.py", line 291, in load_weights
[rank0]:     autoloaded_weights = set(self._load_module("", self.module, weights))
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/models/utils.py", line 249, in _load_module
[rank0]:     yield from self._load_module(prefix,
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/models/utils.py", line 249, in _load_module
[rank0]:     yield from self._load_module(prefix,
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/models/utils.py", line 222, in _load_module
[rank0]:     loaded_params = module_load_weights(weights)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/models/gemma3n.py", line 727, in load_weights
[rank0]:     weight_loader(param, loaded_weight)
[rank0]:   File "/home/ec2-user/venv/lib64/python3.9/site-packages/vllm/model_executor/layers/linear.py", line 570, in weight_loader
[rank0]:     assert param_data.shape == loaded_weight.shape
[rank0]: AssertionError
Loading safetensors checkpoint shards:  33% Completed | 1/3 [00:00<00:01,  1.19it/s]

[rank0]:[W728 10:45:09.573027677 ProcessGroupNCCL.cpp:1479] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

### After
```text
/home/ec2-user/venv/lib64/python3.9/site-packages/networkx/utils/backends.py:135: RuntimeWarning: networkx backend defined more than once: nx-loopback
  backends.update(_get_backends("networkx.backends"))
INFO 07-29 05:58:49 [__init__.py:235] Automatically detected platform cuda.
INFO 07-29 05:58:53 [utils.py:326] non-default args: {'model': 'unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit', 'trust_remote_code': True, 'dtype': torch.bfloat16, 'max_model_len': 4000, 'disable_log_stats': True, 'enforce_eager': True}
INFO 07-29 05:59:09 [config.py:952] Resolved `--runner auto` to `--runner generate`. Pass the value explicitly to silence this message.
INFO 07-29 05:59:09 [config.py:1001] Resolved `--convert auto` to `--convert none`. Pass the value explicitly to silence this message.
INFO 07-29 05:59:09 [config.py:713] Resolved architecture: Gemma3nForConditionalGeneration
INFO 07-29 05:59:09 [config.py:1718] Using max model len 4000
WARNING 07-29 05:59:12 [config.py:1173] bitsandbytes quantization is not fully optimized yet. The speed can be slower than non-quantized models.
INFO 07-29 05:59:12 [config.py:2529] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 07-29 05:59:14 [core.py:587] Waiting for init message from front-end.
INFO 07-29 05:59:14 [core.py:73] Initializing a V1 LLM engine (v0.10.1.dev125+g2cc571199) with config: model='unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit', speculative_config=None, tokenizer='unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4000, download_dir=None, load_format=bitsandbytes, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=bitsandbytes, enforce_eager=True, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":0,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":[],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":0,"cudagraph_capture_sizes":[],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":0,"local_cache_dir":null}
INFO 07-29 05:59:15 [parallel_state.py:1102] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
WARNING 07-29 05:59:15 [topk_topp_sampler.py:59] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
INFO 07-29 05:59:15 [gpu_model_runner.py:1872] Starting to load model unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit...
INFO 07-29 05:59:15 [gpu_model_runner.py:1904] Loading model from scratch...
INFO 07-29 05:59:16 [cuda.py:305] Using Flash Attention backend on V1 engine.
INFO 07-29 05:59:16 [bitsandbytes_loader.py:733] Loading weights with BitsAndBytes quantization. May take a while ...
INFO 07-29 05:59:16 [weight_utils.py:296] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  67% Completed | 2/3 [00:00<00:00, 12.26it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:00<00:00, 17.94it/s]

Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  67% Completed | 2/3 [00:00<00:00,  2.50it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:01<00:00,  1.76it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:01<00:00,  1.87it/s]

INFO 07-29 05:59:19 [gpu_model_runner.py:1921] Model loading took 7.5565 GiB and 2.766893 seconds
INFO 07-29 05:59:21 [gpu_worker.py:265] Available KV cache memory: 9.86 GiB
INFO 07-29 05:59:21 [kv_cache_utils.py:833] GPU KV cache size: 258,512 tokens
INFO 07-29 05:59:21 [kv_cache_utils.py:837] Maximum concurrency for 4,000 tokens per request: 64.37x
INFO 07-29 05:59:22 [core.py:201] init engine (profile, create kv cache, warmup model) took 3.03 seconds
INFO 07-29 05:59:24 [llm.py:293] Supported_tasks: ['generate']
Adding requests: 100%|█████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 549.93it/s]
Processed prompts: 100%|███████████| 1/1 [00:04<00:00,  4.62s/it, est. speed input: 1.73 toks/s, output: 12.12 toks/s]
Generated:  I hope you're having a good day!

I'm doing well, thank you for asking! I appreciate you reaching out. I'm ready to assist you.  How can I help you today?  Let me know what you have in mind!




```


## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
