### PR TITLE
[Bugfix] Scheduler: only schedule prefill chunks when entire context fits

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -782,20 +782,12 @@ class Scheduler(SchedulerInterface):
         # Calculate total existing tokens (prompt + already generated tokens)
         # request.num_tokens includes both prompt and generated tokens
         total_existing_tokens = request.num_tokens
-
-        # Get the new computed blocks in the right format
-        if new_computed_blocks is not None:
-            new_computed_block_list = new_computed_blocks.blocks
-        else:
-            new_computed_block_list = tuple([] for _ in range(
-                len(self.kv_cache_manager.kv_cache_config.kv_cache_groups)))
-
         # Check how many blocks would be needed for the full existing context
         num_blocks_needed = (
             self.kv_cache_manager.coordinator.get_num_blocks_to_allocate(
                 request_id=request.request_id,
                 num_tokens=total_existing_tokens,
-                new_computed_blocks=new_computed_block_list))
+                new_computed_blocks=new_computed_blocks.blocks))
 
         # Check if we have enough free blocks
         num_free_blocks = self.kv_cache_manager.block_pool.get_num_free_blocks(


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
I observed that v1 behaves weirdly when preempting long context requests when prefix caching is disabled and chunked prefill is enabled, see [#18115](https://github.com/vllm-project/vllm/issues/18115#issuecomment-3125957093). The root cause is that the v1 scheduler preempts requests when KV cache is full (intended) but then immediately tries to reschedule them based only on the next chunked prefill step size, not checking if there's enough memory for their entire existing context. This creates a cycle where requests restart, partially fill memory, get preempted again, and repeat indefinitely (not intended).

More generally, unless we do prefix caching, we should not schedule prefill chunks unless the full context will be able to fit. Otherwise, those request get preempted and we thrash the compute (and added latency for the other running requests).


Happy to have feedback on other solutions, but I think this should be addressed.

## Test Plan and Results
I added a new unit tests, that fails before the fix and passes with the fix.

Furthermore, I verified that in practice, when preemption happens it now works correclty

<details>

<summary>Before fix the generation throughput drops and the KV utilization oscillates, because the preempted requests wrongly schedules chunks again. The preempted request never enters the waiting state</summary>

```text
INFO 07-28 06:39:09 [loggers.py:118] Engine 000: Avg prompt throughput: 6851.4 tokens/s, Avg generation throughput: 0.8 tokens/s, Running: 2 reqs, Waiting: 6 reqs, GPU KV cache usage: 21.1%, Prefix cache hit rate: 0.0%
INFO 07-28 06:39:19 [loggers.py:118] Engine 000: Avg prompt throughput: 13695.9 tokens/s, Avg generation throughput: 3.3 tokens/s, Running: 4 reqs, Waiting: 4 reqs, GPU KV cache usage: 39.6%, Prefix cache hit rate: 0.0%
INFO 07-28 06:39:29 [loggers.py:118] Engine 000: Avg prompt throughput: 13694.3 tokens/s, Avg generation throughput: 5.1 tokens/s, Running: 6 reqs, Waiting: 2 reqs, GPU KV cache usage: 56.8%, Prefix cache hit rate: 0.0%
INFO 07-28 06:39:39 [loggers.py:118] Engine 000: Avg prompt throughput: 6843.5 tokens/s, Avg generation throughput: 7.1 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 74.0%, Prefix cache hit rate: 0.0%
INFO 07-28 06:39:49 [loggers.py:118] Engine 000: Avg prompt throughput: 13701.8 tokens/s, Avg generation throughput: 50.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 88.5%, Prefix cache hit rate: 0.0%
INFO 07-28 06:39:59 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 243.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 88.9%, Prefix cache hit rate: 0.0%
INFO 07-28 06:40:09 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 241.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 89.2%, Prefix cache hit rate: 0.0%
INFO 07-28 06:40:19 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 89.6%, Prefix cache hit rate: 0.0%
INFO 07-28 06:40:29 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 90.0%, Prefix cache hit rate: 0.0%
INFO 07-28 06:40:39 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 90.4%, Prefix cache hit rate: 0.0%
INFO 07-28 06:40:49 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 239.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 90.8%, Prefix cache hit rate: 0.0%
INFO 07-28 06:40:59 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 239.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 91.2%, Prefix cache hit rate: 0.0%
INFO 07-28 06:41:09 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 239.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 91.6%, Prefix cache hit rate: 0.0%
INFO 07-28 06:41:19 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 91.9%, Prefix cache hit rate: 0.0%
INFO 07-28 06:41:29 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 92.3%, Prefix cache hit rate: 0.0%
INFO 07-28 06:41:39 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 92.7%, Prefix cache hit rate: 0.0%
INFO 07-28 06:41:49 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 93.1%, Prefix cache hit rate: 0.0%
INFO 07-28 06:41:59 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 241.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 93.5%, Prefix cache hit rate: 0.0%
INFO 07-28 06:42:09 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 93.9%, Prefix cache hit rate: 0.0%
INFO 07-28 06:42:19 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 241.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 94.3%, Prefix cache hit rate: 0.0%
INFO 07-28 06:42:29 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 241.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 94.7%, Prefix cache hit rate: 0.0%
INFO 07-28 06:42:39 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 95.0%, Prefix cache hit rate: 0.0%
INFO 07-28 06:42:49 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 95.4%, Prefix cache hit rate: 0.0%
INFO 07-28 06:42:59 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 95.8%, Prefix cache hit rate: 0.0%
INFO 07-28 06:43:09 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 96.2%, Prefix cache hit rate: 0.0%
INFO 07-28 06:43:19 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 96.6%, Prefix cache hit rate: 0.0%
INFO 07-28 06:43:29 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 97.0%, Prefix cache hit rate: 0.0%
INFO 07-28 06:43:39 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 239.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 97.4%, Prefix cache hit rate: 0.0%
INFO 07-28 06:43:49 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 240.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 97.8%, Prefix cache hit rate: 0.0%
INFO 07-28 06:43:59 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 238.4 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 98.1%, Prefix cache hit rate: 0.0%
INFO 07-28 06:44:09 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 238.4 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 98.5%, Prefix cache hit rate: 0.0%
INFO 07-28 06:44:19 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 237.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 98.9%, Prefix cache hit rate: 0.0%
INFO 07-28 06:44:29 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 236.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 99.3%, Prefix cache hit rate: 0.0%
INFO 07-28 06:44:39 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 237.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 99.7%, Prefix cache hit rate: 0.0%
INFO 07-28 06:44:49 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 207.7 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 90.1%, Prefix cache hit rate: 0.0%
INFO 07-28 06:44:59 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 9.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 95.5%, Prefix cache hit rate: 0.0%
INFO 07-28 06:45:09 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 10.5 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 88.9%, Prefix cache hit rate: 0.0%
INFO 07-28 06:45:19 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 9.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 94.2%, Prefix cache hit rate: 0.0%
INFO 07-28 06:45:29 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 9.1 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 98.1%, Prefix cache hit rate: 0.0%
INFO 07-28 06:45:39 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 11.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 92.9%, Prefix cache hit rate: 0.0%
INFO 07-28 06:45:49 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 9.1 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 96.8%, Prefix cache hit rate: 0.0%
```

</details>

<details>

<summary>After fix, one request is correctly preempted and put into the waiting queue. The other request continue with unaffected generation output.</summary>

```text
INFO 07-28 09:05:55 [loggers.py:118] Engine 000: Avg prompt throughput: 7535.7 tokens/s, Avg generation throughput: 0.3 tokens/s, Running: 2 reqs, Waiting: 6 reqs, GPU KV cache usage: 15.9%, Prefix cache hit rate: 0.0%
INFO 07-28 09:06:05 [loggers.py:118] Engine 000: Avg prompt throughput: 7528.3 tokens/s, Avg generation throughput: 1.8 tokens/s, Running: 3 reqs, Waiting: 5 reqs, GPU KV cache usage: 31.7%, Prefix cache hit rate: 0.0%
INFO 07-28 09:06:15 [loggers.py:118] Engine 000: Avg prompt throughput: 7536.1 tokens/s, Avg generation throughput: 3.3 tokens/s, Running: 4 reqs, Waiting: 4 reqs, GPU KV cache usage: 47.6%, Prefix cache hit rate: 0.0%
INFO 07-28 09:06:25 [loggers.py:118] Engine 000: Avg prompt throughput: 15063.8 tokens/s, Avg generation throughput: 6.1 tokens/s, Running: 6 reqs, Waiting: 2 reqs, GPU KV cache usage: 66.1%, Prefix cache hit rate: 0.0%
INFO 07-28 09:06:35 [loggers.py:118] Engine 000: Avg prompt throughput: 7527.7 tokens/s, Avg generation throughput: 7.3 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 83.2%, Prefix cache hit rate: 0.0%
INFO 07-28 09:06:45 [loggers.py:118] Engine 000: Avg prompt throughput: 15071.9 tokens/s, Avg generation throughput: 36.5 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 97.3%, Prefix cache hit rate: 0.0%
INFO 07-28 09:06:55 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 237.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 97.6%, Prefix cache hit rate: 0.0%
INFO 07-28 09:07:05 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 236.8 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 98.0%, Prefix cache hit rate: 0.0%
INFO 07-28 09:07:15 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 236.0 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 98.4%, Prefix cache hit rate: 0.0%
INFO 07-28 09:07:25 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 235.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 98.8%, Prefix cache hit rate: 0.0%
INFO 07-28 09:07:35 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 235.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 99.2%, Prefix cache hit rate: 0.0%
INFO 07-28 09:07:45 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 233.6 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 99.5%, Prefix cache hit rate: 0.0%
INFO 07-28 09:07:55 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 235.2 tokens/s, Running: 8 reqs, Waiting: 0 reqs, GPU KV cache usage: 99.9%, Prefix cache hit rate: 0.0%
INFO 07-28 09:08:05 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 216.2 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 87.8%, Prefix cache hit rate: 0.0%
INFO 07-28 09:08:15 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 211.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 88.1%, Prefix cache hit rate: 0.0%
INFO 07-28 09:08:25 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 210.7 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 88.5%, Prefix cache hit rate: 0.0%
INFO 07-28 09:08:35 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 210.7 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 88.8%, Prefix cache hit rate: 0.0%
```

</details>



## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
