### PR TITLE
[Bugfix][P/D] Fix D crashing if caching is disabled

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -380,11 +380,12 @@ class KVCacheManager:
         return KVCacheBlocks(
             self.coordinator.get_blocks(request_id)).get_block_ids()
 
-    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
-        """Cache the blocks for the request."""
-        block_hashes = self.req_to_block_hashes[request.request_id]
-        self.coordinator.cache_blocks(request, block_hashes,
-                                      num_computed_tokens)
+    def cache_blocks_if_enabled(self, request: Request, num_computed_tokens: int) -> None:
+        """Cache the blocks for the request if caching is enabled."""
+        if self.enable_caching:
+            block_hashes = self.req_to_block_hashes[request.request_id]
+            self.coordinator.cache_blocks(request, block_hashes,
+                                          num_computed_tokens)
 
     def create_empty_block_list(self) -> KVCacheBlocks:
         """Creates a new KVCacheBlocks instance with no blocks."""

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1015,7 +1015,7 @@ class Scheduler(SchedulerInterface):
         num_computed_tokens = min(num_computed_tokens, request.num_tokens)
         if num_computed_tokens == request.num_tokens:
             num_computed_tokens -= 1
-        self.kv_cache_manager.cache_blocks(request, num_computed_tokens)
+        self.kv_cache_manager.cache_blocks_if_enabled(request, num_computed_tokens)
 
         # Update the request state for scheduling.
         request.num_computed_tokens = num_computed_tokens


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

When you launch the decoder with `--no_enable_prefix_caching` on ascend devices and benchmark the system with random inputs, at least 129 tokens each, you see the following message after ~2000 tests.

```
  File "/code/vllm/vllm/v1/core/block_pool.py", line 145, in cache_full_blocks
    assert blk.block_hash is None
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Then the decoder exits and the system freezes.

What's happening is that the caching operation is delayed from immediatly after allocation to after the KVCache transportation
in decoder instances, but currently we always cache blocks after they are received from prefillers even if caching is not enabled at all and these cached blocks never get evicted since caching is disabled.

This PR is aiming at fixing the bug.

## Test Plan
[ ] Run Qwen 0.6B 1P 1D on Ascend devices with prefix cache disabled.
## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
