### PR TITLE
[Bugfix] Fix comment typo of get_num_common_prefix_blocks()

### DIFF
--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -129,10 +129,10 @@ class KVCacheCoordinator(ABC):
 
         Args:
             request_id: The request ID.
-            block_hashes: The block hashes of the request.
+            num_running_requests: The number of requests in the RUNNING state.
 
         Returns:
-            The number of common prefix blocks.
+            list[int]: The number of common prefix blocks.
         """
         num_blocks_per_group = [
             manager.get_num_common_prefix_blocks(request_id,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -181,7 +181,7 @@ class SingleTypeKVCacheManager(ABC):
 
         Args:
             request_id: The request ID.
-            block_hashes: The block hashes of the request.
+            num_running_requests: The number of requests in the RUNNING state.
 
         Returns:
             The number of common prefix blocks.


### PR DESCRIPTION
## Purpose
Fix comment typo of get_num_common_prefix_blocks()


