### PR TITLE
[Bugfix]: fix metadata file copy in test_sharded_state_loader

### DIFF
--- a/tests/test_sharded_state_loader.py
+++ b/tests/test_sharded_state_loader.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import fnmatch
 import multiprocessing as mp
 import os
 import shutil
@@ -64,9 +65,10 @@ def _run_writer(input_dir, output_dir, weights_patterns, **kwargs):
     # Copy metadata files to output directory
     for file in os.listdir(input_dir):
         if os.path.isdir(os.path.join(input_dir, file)):
-            continue
-        if not any(file.endswith(ext) for ext in weights_patterns):
-            shutil.copy(f"{input_dir}/{file}", output_dir)
+            shutil.copytree(os.path.join(input_dir, file),
+                            os.path.join(output_dir, file))
+        elif not any(fnmatch.fnmatch(file, ext) for ext in weights_patterns):
+            shutil.copy(os.path.join(input_dir, file), output_dir)
 
 
 def _run_generate(input_dir, queue: mp.Queue, **kwargs):


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
currently, `weights_patterns` is `["*.safetensors"]` and if `file` is `model.safetensors`, then ext is `*.safetensors` and  `file.endswith(ext)` will be false. As `*.safetensors` is a pattern, then we should use `fnmatch` to check whether a file matches the pattern like [how `ignore_patterns` is implemented in huggingface_cli](https://github.com/huggingface/huggingface_hub/blob/ddfeff2f404decbe31f3c27a595a176c30a958a2/src/huggingface_hub/utils/_paths.py#L124-L135). 
## Test Plan
NA
## Test Result
NA
## (Optional) Documentation Update
NA
<!--- pyml disable-next-line no-emphasis-as-heading -->
