### PR TITLE
[Speculators][Speculative Decoding] Add Qwen Eagle3 Support

### DIFF
--- a/tests/speculative_decoding/speculators/test_eagle3.py
+++ b/tests/speculative_decoding/speculators/test_eagle3.py
@@ -6,8 +6,7 @@ import torch
 
 @pytest.mark.parametrize(
     "model_path",
-    [("nm-testing/SpeculatorLlama3-1-8B-Eagle3-converted-0717"),
-     ("nm-testing/SpeculatorLlama3-1-8B-Eagle3-converted-0717-quantized")])
+    [("nm-testing/SpeculatorLlama3-1-8B-Eagle3-converted-0717-quantized")])
 def test_llama(vllm_runner, example_prompts, model_path):
     with vllm_runner(model_path, dtype=torch.bfloat16) as vllm_model:
         vllm_outputs = vllm_model.generate_greedy(example_prompts,
@@ -18,8 +17,7 @@ def test_llama(vllm_runner, example_prompts, model_path):
 
 @pytest.mark.parametrize(
     "model_path",
-    [("nm-testing/Speculator-Qwen3-8B-Eagle3-converted-0717"),
-     ("nm-testing/Speculator-Qwen3-8B-Eagle3-converted-071-quantized")])
+    [("nm-testing/Speculator-Qwen3-8B-Eagle3-converted-071-quantized")])
 def test_qwen(vllm_runner, example_prompts, model_path):
     with vllm_runner(model_path, dtype=torch.bfloat16) as vllm_model:
         vllm_outputs = vllm_model.generate_greedy(example_prompts,

--- a/tests/speculative_decoding/speculators/test_eagle3.py
+++ b/tests/speculative_decoding/speculators/test_eagle3.py
@@ -14,3 +14,15 @@ def test_llama(vllm_runner, example_prompts, model_path):
                                                   max_tokens=20)
         print(vllm_outputs)
         assert vllm_outputs
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [("nm-testing/Speculator-Qwen3-8B-Eagle3-converted-0717"),
+     ("nm-testing/Speculator-Qwen3-8B-Eagle3-converted-071-quantized")])
+def test_qwen(vllm_runner, example_prompts, model_path):
+    with vllm_runner(model_path, dtype=torch.bfloat16) as vllm_model:
+        vllm_outputs = vllm_model.generate_greedy(example_prompts,
+                                                  max_tokens=20)
+        print(vllm_outputs)
+        assert vllm_outputs

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3178,7 +3178,8 @@ class SpeculativeConfig:
         from vllm.transformers_utils.configs import SpeculatorsConfig
 
         eagle3_target_supported = ["llama"]
-        if isinstance(self.draft_model_config.hf_config, SpeculatorsConfig):
+        if self.draft_model_config and isinstance(
+                self.draft_model_config.hf_config, SpeculatorsConfig):
             eagle3_target_supported.append("qwen")
 
         if self.method == "eagle3" and self.target_model_config and not any(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3184,9 +3184,10 @@ class SpeculativeConfig:
         if self.method == "eagle3" and self.target_model_config:
             found_match = False
             for supported_model in eagle3_target_supported:
-                found_match = (
-                    supported_model
-                    in self.target_model_config.hf_text_config.model_type)
+                if (supported_model
+                        in self.target_model_config.hf_text_config.model_type):
+                    found_match = True
+
             if not found_match:
                 raise ValueError(
                     f"Eagle3 is only supported for {eagle3_target_supported} models. "  # noqa: E501

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3175,11 +3175,23 @@ class SpeculativeConfig:
                              "speculative decoding is > 1, but got "
                              f"{self.disable_by_batch_size=}")
 
-        if self.method == "eagle3" and self.target_model_config and \
-            "llama" not in self.target_model_config.hf_text_config.model_type:
-            raise ValueError(
-                "Eagle3 is only supported for Llama models. "
-                f"Got {self.target_model_config.hf_text_config.model_type=}")
+        from vllm.transformers_utils.configs import SpeculatorsConfig
+
+        eagle3_target_supported = ["llama"]
+        if isinstance(self.draft_model_config.hf_config, SpeculatorsConfig):
+            eagle3_target_supported.append("qwen")
+
+        if self.method == "eagle3" and self.target_model_config:
+            found_match = False
+            for supported_model in eagle3_target_supported:
+                found_match = (
+                    supported_model
+                    in self.target_model_config.hf_text_config.model_type)
+            if not found_match:
+                raise ValueError(
+                    f"Eagle3 is only supported for {eagle3_target_supported} models. "  # noqa: E501
+                    f"Got {self.target_model_config.hf_text_config.model_type=}"
+                )
 
         return self
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3181,18 +3181,13 @@ class SpeculativeConfig:
         if isinstance(self.draft_model_config.hf_config, SpeculatorsConfig):
             eagle3_target_supported.append("qwen")
 
-        if self.method == "eagle3" and self.target_model_config:
-            found_match = False
-            for supported_model in eagle3_target_supported:
-                if (supported_model
-                        in self.target_model_config.hf_text_config.model_type):
-                    found_match = True
-
-            if not found_match:
-                raise ValueError(
-                    f"Eagle3 is only supported for {eagle3_target_supported} models. "  # noqa: E501
-                    f"Got {self.target_model_config.hf_text_config.model_type=}"
-                )
+        if self.method == "eagle3" and self.target_model_config and not any(
+                supported_model in
+                self.target_model_config.hf_text_config.model_type
+                for supported_model in eagle3_target_supported):
+            raise ValueError(
+                f"Eagle3 is only supported for {eagle3_target_supported} models. "  # noqa: E501
+                f"Got {self.target_model_config.hf_text_config.model_type=}")
 
         return self
 

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -330,6 +330,8 @@ class Qwen2Model(nn.Module):
         else:
             self.norm = PPMissingLayer()
 
+        self.aux_hidden_state_layers: tuple[int] = tuple()
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -350,18 +352,25 @@ class Qwen2Model(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
-        for layer in self.layers[self.start_layer:self.end_layer]:
-            hidden_states, residual = layer(
-                positions,
-                hidden_states,
-                residual,
-            )
+
+        aux_hidden_states = []
+        for idx, layer in enumerate(
+                self.layers[self.start_layer:self.end_layer]):
+            if idx in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states + residual)
+            hidden_states, residual = layer(positions, hidden_states, residual)
+
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({
                 "hidden_states": hidden_states,
                 "residual": residual
             })
+
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str,

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -288,6 +288,13 @@ class Qwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)
 
+    def set_aux_hidden_state_layers(self, layers: tuple[int]) -> None:
+        self.model.aux_hidden_state_layers = layers
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int]:
+        num_layers = len(self.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 


### PR DESCRIPTION
## Purpose

- Extends the Qwen3 definition to work as a target model for Eagle3
- Requires: https://github.com/vllm-project/vllm/pull/21345

## Test Plan
- Adds smoke tests to test the speculator with a  quantized target model
- Tested performance with the dense target model:

```
[0.713 0.469]
conditional
[0.713 0.657]
```