### PR TITLE
[Bugfix] Actually disable processing cache when API server is scaled out

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -140,10 +140,15 @@ def run_multi_api_server(args: argparse.Namespace):
     num_api_servers = args.api_server_count
     assert num_api_servers > 0
 
+    orig_disable_mm_preprocessor_cache = args.disable_mm_preprocessor_cache
+
     # set_process_title("ProcManager")
 
     if num_api_servers > 1:
         setup_multiprocess_prometheus()
+
+        # Not compatible with API server scale-out
+        args.disable_mm_preprocessor_cache = True
 
     listen_address, sock = setup_server(args)
 
@@ -161,16 +166,9 @@ def run_multi_api_server(args: argparse.Namespace):
                              "with api_server_count > 1")
 
         if model_config.is_multimodal_model and not (
-                model_config.disable_mm_preprocessor_cache):
-            logger.warning(
-                "Multi-model preprocessor cache will be disabled for"
-                " api_server_count > 1")
-            model_config.disable_mm_preprocessor_cache = True
-            mm_config = model_config.get_multimodal_config()
-            mm_config.disable_mm_preprocessor_cache = True
-
-            # Need to set this for the API server processes
-            args.disable_mm_preprocessor_cache = True
+                orig_disable_mm_preprocessor_cache):
+            logger.warning("Multi-model preprocessor cache will be disabled "
+                           "for api_server_count > 1")
 
     executor_class = Executor.get_class(vllm_config)
     log_stats = not engine_args.disable_log_stats

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -166,6 +166,11 @@ def run_multi_api_server(args: argparse.Namespace):
                 "Multi-model preprocessor cache will be disabled for"
                 " api_server_count > 1")
             model_config.disable_mm_preprocessor_cache = True
+            mm_config = model_config.get_multimodal_config()
+            mm_config.disable_mm_preprocessor_cache = True
+
+            # Need to set this for the API server processes
+            args.disable_mm_preprocessor_cache = True
 
     executor_class = Executor.get_class(vllm_config)
     log_stats = not engine_args.disable_log_stats


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

While performing some benchmarks, I found that the processing cache isn't correctly disabled when `api_server_count > 1`. This PR fixes the issue

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
