### PR TITLE
[Bugfix][PD] set max_completion_tokens=1 if req has this value

### DIFF
--- a/examples/online_serving/disaggregated_serving/disagg_proxy_demo.py
+++ b/examples/online_serving/disaggregated_serving/disagg_proxy_demo.py
@@ -293,6 +293,8 @@ class Proxy:
             # add params to request
             kv_prepare_request = request.copy()
             kv_prepare_request["max_tokens"] = 1
+            if "max_completion_tokens" in kv_prepare_request:
+                kv_prepare_request["max_completion_tokens"] = 1
 
             # prefill stage
             prefill_instance = self.schedule(self.prefill_cycler)

--- a/examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
+++ b/examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
@@ -128,6 +128,8 @@ async def handle_request():
         prefill_request = original_request_data.copy()
         # change max_tokens = 1 to let it only do prefill
         prefill_request["max_tokens"] = 1
+        if "max_completion_tokens" in prefill_request:
+            prefill_request["max_completion_tokens"] = 1
 
         global count
         global prefill_instances


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->

Fix #21712

https://github.com/vllm-project/vllm/blob/04e38500eeaa683f107fc16011aee65981afc6cd/vllm/entrypoints/utils.py#L289-L294

func `get_max_tokens` used in chat or completions, It first looks for the value of `max_completion_tokens`, followed by the value of `max_tokens`, which means that if `max_completion_tokens` has a value, no matter how much `max_tokens` is set, it will not take effect.

when use `python3 benchmark_serving.py --backend openai-chat --endpoint /v1/chat/completions` the req has `max_completion_tokens`. Therefore, the proxy.py setting `max_tokens=1` becomes useless, and only the value of `max_completion_tokens` is used in vllm serve. : https://github.com/vllm-project/vllm/blob/ad341c519457fa706c549c9b7edc8438c35fd8d1/benchmarks/backend_request_func.py#L376