### PR TITLE
[Hardware][CPU] Build fix for ARM without BF16

### DIFF
--- a/csrc/cpu/quant.cpp
+++ b/csrc/cpu/quant.cpp
@@ -16,12 +16,14 @@ struct KernelVecType<float> {
   using cvt_vec_type = vec_op::FP32Vec16;
 };
 
+#if !defined(__aarch64__) || defined(ARM_BF16_SUPPORT)
 template <>
 struct KernelVecType<c10::BFloat16> {
   using load_vec_type = vec_op::BF16Vec16;
   using azp_adj_load_vec_type = vec_op::INT32Vec16;
   using cvt_vec_type = vec_op::FP32Vec16;
 };
+#endif
 
 template <>
 struct KernelVecType<c10::Half> {


### PR DESCRIPTION
So we can build on older ARM chips like M1 that don't have bf16.

