### PR TITLE
[Performance] Eliminate unnecessary H2D copies in FlashInfer decode

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -373,6 +373,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     fast_decode_plan(
                         attn_metadata.decode_wrapper,
                         attn_metadata.paged_kv_indptr[:num_decodes + 1],
+                        attn_metadata.paged_kv_indptr_cpu[:num_decodes + 1],
                         attn_metadata.paged_kv_indices,
                         attn_metadata.paged_kv_last_page_len[:num_decodes],
                         attn_metadata.num_qo_heads,
@@ -718,6 +719,7 @@ class FlashInferImpl(AttentionImpl):
 def fast_decode_plan(
     self,
     indptr: torch.Tensor,
+    indptr_host: torch.Tensor,
     indices: torch.Tensor,
     last_page_len: torch.Tensor,
     num_qo_heads: int,
@@ -779,8 +781,6 @@ def fast_decode_plan(
             self._qo_indptr_buf = qo_indptr_host.to(
                 self.device, non_blocking=non_blocking
             )
-
-    indptr_host = indptr.cpu()
 
     with torch.cuda.device(self.device):
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

In the FlashInfer backend, `BatchDecodeWithPagedKVCacheWrapper::plan()` copies tensors to device, which is unnecessary when device copies already exist. This PR refactors to eliminate these copies.

## Test Plan

Correctness:

`pytest tests/v1/attention/test_attention_backends.py`

Performance:

```
vllm bench throughput \
        --model "NousResearch/Hermes-3-Llama-3.1-8B" \
        --dataset-name "random" \
        --input-len 128 \
        --output-len 512 \
        --num-prompts 100
```

## Test Result

Correctness passes. `FlashInferMetadataBuilder::_plan()` duration reduced from 150us to 100us.

## (Optional) Documentation Update
