### PR TITLE
[Docs] Update docker.md with HF_TOKEN, new model, and podman fix

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -10,11 +10,11 @@ The image can be used to run OpenAI compatible server and is available on Docker
 ```bash
 docker run --runtime nvidia --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    --env "HUGGING_FACE_HUB_TOKEN=<secret>" \
+    --env "HUGGING_FACE_HUB_TOKEN=$HF_TOKEN" \
     -p 8000:8000 \
     --ipc=host \
     vllm/vllm-openai:latest \
-    --model mistralai/Mistral-7B-v0.1
+    --model Qwen/Qwen-0.6B
 ```
 
 This image can also be used with other container engines such as [Podman](https://podman.io/).
@@ -25,8 +25,8 @@ podman run --gpus all \
   --env "HUGGING_FACE_HUB_TOKEN=$HF_TOKEN" \
   -p 8000:8000 \
   --ipc=host \
-  vllm/vllm-openai:latest \
-  --model mistralai/Mistral-7B-v0.1
+  docker.io/vllm/vllm-openai:latest \
+  --model Qwen/Qwen-0.6B
 ```
 
 You can add any other [engine-args](../configuration/engine_args.md) you need after the image tag (`vllm/vllm-openai:latest`).

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -20,7 +20,7 @@ docker run --runtime nvidia --gpus all \
 This image can also be used with other container engines such as [Podman](https://podman.io/).
 
 ```bash
-podman run --gpus all \
+podman run --device nvidia.com/gpu=all \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   --env "HUGGING_FACE_HUB_TOKEN=$HF_TOKEN" \
   -p 8000:8000 \

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -14,7 +14,7 @@ docker run --runtime nvidia --gpus all \
     -p 8000:8000 \
     --ipc=host \
     vllm/vllm-openai:latest \
-    --model Qwen/Qwen-0.6B
+    --model Qwen/Qwen3-0.6B
 ```
 
 This image can also be used with other container engines such as [Podman](https://podman.io/).
@@ -26,7 +26,7 @@ podman run --gpus all \
   -p 8000:8000 \
   --ipc=host \
   docker.io/vllm/vllm-openai:latest \
-  --model Qwen/Qwen-0.6B
+  --model Qwen/Qwen3-0.6B
 ```
 
 You can add any other [engine-args](../configuration/engine_args.md) you need after the image tag (`vllm/vllm-openai:latest`).


### PR DESCRIPTION
Previously if you ran the podman command, it would fail because it doesn't default to dockerhub as a registry
```
Error: short-name "vllm/vllm-openai:latest" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```
But there are other issues like gpu passthrough. 