### PR TITLE
[Test] Add Benchmark and Unit Test for `per_token_group_quant`

### DIFF
--- a/benchmarks/kernels/benchmark_per_token_group_quant.py
+++ b/benchmarks/kernels/benchmark_per_token_group_quant.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+import math
+from contextlib import contextmanager
+from typing import Callable
+from unittest.mock import patch
+
+import torch
+
+from vllm.model_executor.layers.quantization.utils import fp8_utils, int8_utils
+from vllm.platforms import current_platform
+
+
+@contextmanager
+def _triton_mode():
+    """Temporarily force the Triton fallback path"""
+    with patch("vllm.platforms.current_platform.is_cuda", return_value=False):
+        yield
+
+
+def _time_cuda(
+    fn: Callable[[], tuple[torch.Tensor, torch.Tensor]],
+    warmup_iters: int,
+    bench_iters: int,
+) -> float:
+    # warmup
+    for _ in range(warmup_iters):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    start.record()
+    for _ in range(bench_iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+
+    return start.elapsed_time(end) / bench_iters  # ms/iter
+
+
+def _run_single(
+    shape: tuple[int, int],
+    group_size: int,
+    dtype: str,
+    *,
+    column_major: bool = False,
+    scale_ue8m0: bool = False,
+    warmup_iters: int,
+    bench_iters: int,
+) -> None:
+    num_tokens, hidden_dim = shape
+
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+    x = torch.randn(num_tokens, hidden_dim, device=device, dtype=torch.bfloat16) * 8
+
+    if dtype == "fp8":
+
+        def cuda_impl():
+            return fp8_utils.per_token_group_quant_fp8(
+                x,
+                group_size,
+                column_major_scales=column_major,
+                use_ue8m0=scale_ue8m0,
+            )
+
+        def triton_impl():
+            with _triton_mode():
+                return fp8_utils.per_token_group_quant_fp8(
+                    x,
+                    group_size,
+                    column_major_scales=column_major,
+                    use_ue8m0=scale_ue8m0,
+                )
+    elif dtype == "int8":
+
+        def cuda_impl():
+            return int8_utils.per_token_group_quant_int8(x, group_size)
+
+        def triton_impl():
+            with _triton_mode():
+                return int8_utils.per_token_group_quant_int8(x, group_size)
+    else:
+        raise ValueError("dtype must be 'fp8' or 'int8'")
+
+    cuda_ms = _time_cuda(cuda_impl, warmup_iters, bench_iters)
+    triton_ms = _time_cuda(triton_impl, warmup_iters, bench_iters)
+
+    speedup = triton_ms / cuda_ms if cuda_ms else math.inf
+
+    cfg_desc = (
+        f"shape={shape}  gs={group_size:<3}  col_major={column_major:<5}  "
+        f"ue8m0={scale_ue8m0:<5}  dtype={dtype}"
+    )
+    print(
+        f"{cfg_desc:55} | CUDA {cuda_ms:7.3f} ms  | Triton {triton_ms:7.3f} ms  | "
+        f"speed-up ×{speedup:5.2f}"
+    )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup-iters", type=int, default=10)
+    parser.add_argument("--bench-iters", type=int, default=100)
+    parser.add_argument("--dtype", choices=["fp8", "int8", "both"], default="both")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    if not current_platform.is_cuda():
+        raise RuntimeError("CUDA device is required to run this benchmark.")
+
+    args = parse_args()
+    warmup_iters, bench_iters = args.warmup_iters, args.bench_iters
+
+    shapes = [(32, 128), (64, 256), (16, 512)]
+    group_sizes = [64, 128]
+
+    dtypes = ["fp8", "int8"] if args.dtype == "both" else [args.dtype]
+
+    header = (
+        "Configuration".ljust(55)
+        + " | "
+        + "CUDA (ms)".center(12)
+        + " | "
+        + "Triton (ms)".center(13)
+        + " | "
+        + "Speed-up"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for dtype in dtypes:
+        for shape in shapes:
+            for gs in group_sizes:
+                if dtype == "fp8":
+                    for col_major in (False, True):
+                        for ue8m0 in (False, True):
+                            _run_single(
+                                shape,
+                                gs,
+                                dtype,
+                                column_major=col_major,
+                                scale_ue8m0=ue8m0,
+                                warmup_iters=warmup_iters,
+                                bench_iters=bench_iters,
+                            )
+                else:  # INT8 has no col-major / ue8m0 switches
+                    _run_single(
+                        shape,
+                        gs,
+                        dtype,
+                        warmup_iters=warmup_iters,
+                        bench_iters=bench_iters,
+                    )

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from vllm.model_executor.layers.quantization.utils import fp8_utils
+from vllm.model_executor.layers.quantization.utils import fp8_utils, int8_utils
 
 
 @pytest.mark.parametrize("shape", [(32, 128), (64, 256), (16, 512)])
@@ -38,6 +38,35 @@ def test_per_token_group_quant_fp8(shape, column_major: bool,
             group_size,
             column_major_scales=column_major,
             use_ue8m0=scale_ue8m0,
+        )
+
+    assert torch.allclose(out_q.float(), ref_q.float(), atol=0.15, rtol=0.15)
+    assert torch.allclose(scale, ref_s, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.parametrize("shape", [(32, 128), (64, 256), (16, 512)])
+@pytest.mark.parametrize("group_size", [64, 128])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_per_token_group_quant_int8(shape, group_size: int):
+    device = "cuda"
+
+    torch.manual_seed(42)
+    num_tokens, hidden_dim = shape
+
+    x = (torch.randn(
+        (num_tokens, hidden_dim), device=device, dtype=torch.bfloat16) * 8)
+
+    # cuda path
+    out_q, scale = int8_utils.per_token_group_quant_int8(
+        x,
+        group_size,
+    )
+
+    # triton ref
+    with patch("vllm.platforms.current_platform.is_cuda", return_value=False):
+        ref_q, ref_s = int8_utils.per_token_group_quant_int8(
+            x,
+            group_size,
         )
 
     assert torch.allclose(out_q.float(), ref_q.float(), atol=0.15, rtol=0.15)


### PR DESCRIPTION
## Purpose

This should be merged with https://github.com/vllm-project/vllm/pull/21476

It is my mistake that I didn't push to the branch, sorry for that.

## Test


Unit test:

```bash
(wentao) wentao@H100-GPU17:~/vllm/tests/kernels/quantization$ pytest test_per_token_group_quant.py
================================================================= test session starts =================================================================
platform linux -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/wentao/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 30 items                                                                                                                                    

test_per_token_group_quant.py ..............................                                                                                    [100%]

================================================================= 30 passed in 6.38s ==================================================================
```

Benchmark: **15x faster compared with triton**

```bash
(wentao) wentao@H100-GPU17:~/vllm/benchmarks/kernels$ python benchmark_per_token_group_quant.py 
Configuration                                           |  CUDA (ms)   |  Triton (ms)  | Speed-up
-------------------------------------------------------------------------------------------------
shape=(32, 128)  gs=64   col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.169 ms  | speed-up ×15.73
shape=(32, 128)  gs=64   col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.011 ms  | Triton   0.159 ms  | speed-up ×14.99
shape=(32, 128)  gs=64   col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.83
shape=(32, 128)  gs=64   col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.86
shape=(32, 128)  gs=128  col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.159 ms  | speed-up ×15.13
shape=(32, 128)  gs=128  col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.22
shape=(32, 128)  gs=128  col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.169 ms  | speed-up ×13.84
shape=(32, 128)  gs=128  col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.94
shape=(64, 256)  gs=64   col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×14.97
shape=(64, 256)  gs=64   col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×14.88
shape=(64, 256)  gs=64   col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.59
shape=(64, 256)  gs=64   col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.63
shape=(64, 256)  gs=128  col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.158 ms  | speed-up ×14.90
shape=(64, 256)  gs=128  col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.10
shape=(64, 256)  gs=128  col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.79
shape=(64, 256)  gs=128  col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.87
shape=(16, 512)  gs=64   col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.011 ms  | Triton   0.157 ms  | speed-up ×14.77
shape=(16, 512)  gs=64   col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.011 ms  | Triton   0.157 ms  | speed-up ×14.86
shape=(16, 512)  gs=64   col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.82
shape=(16, 512)  gs=64   col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.84
shape=(16, 512)  gs=128  col_major=0      ue8m0=0      dtype=fp8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.06
shape=(16, 512)  gs=128  col_major=0      ue8m0=1      dtype=fp8 | CUDA   0.011 ms  | Triton   0.158 ms  | speed-up ×14.97
shape=(16, 512)  gs=128  col_major=1      ue8m0=0      dtype=fp8 | CUDA   0.012 ms  | Triton   0.168 ms  | speed-up ×13.80
shape=(16, 512)  gs=128  col_major=1      ue8m0=1      dtype=fp8 | CUDA   0.012 ms  | Triton   0.167 ms  | speed-up ×13.71
```

Int8

```bash
shape=(32, 128)  gs=64   col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×15.47
shape=(32, 128)  gs=128  col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.158 ms  | speed-up ×15.87
shape=(64, 256)  gs=64   col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.155 ms  | speed-up ×15.33
shape=(64, 256)  gs=128  col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.155 ms  | speed-up ×15.53
shape=(16, 512)  gs=64   col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×15.57
shape=(16, 512)  gs=128  col_major=0      ue8m0=0      dtype=int8 | CUDA   0.010 ms  | Triton   0.156 ms  | speed-up ×15.42
```