### PR TITLE
[BugFix] Fix interleaved sliding window not set for Gemma3n

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -723,11 +723,12 @@ class ModelConfig:
         )
 
         # Workaround for Gemma 2 which uses interleaved sliding window
-        # attention, but it's not specified in its config. TODO: remove this
-        # when Gemma 2 is fixed in Transformers.
+        # attention, but it's not specified in its config.
+        # TODO: remove this when Gemma 2 config updated in HuggingFace.
         if self.hf_text_config.model_type == "gemma2":
             self.hf_text_config.sliding_window_pattern = 2
 
+        # TODO: remove this when Gemma 3n config updated in HuggingFace.
         if self.hf_text_config.model_type == "gemma3n_text":
             # 4 sliding window attention followed by 1 full attention
             self.hf_text_config.sliding_window_pattern = "LLLLG"

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -728,6 +728,10 @@ class ModelConfig:
         if self.hf_text_config.model_type == "gemma2":
             self.hf_text_config.sliding_window_pattern = 2
 
+        if self.hf_text_config.model_type == "gemma3n_text":
+            # 4 sliding window attention followed by 1 full attention
+            self.hf_text_config.sliding_window_pattern = "LLLLG"
+
         sliding_window = getattr(self.hf_text_config, "sliding_window", None)
         sliding_window_pattern = getattr(self.hf_text_config,
                                          "sliding_window_pattern", None)

--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -297,8 +297,13 @@ class Gemma3nAttention(nn.Module):
                               has_weight=False)
 
         layer_idx = extract_layer_index(prefix)
-        if config.layer_types[layer_idx] == "sliding_attention":
-            self.sliding_window = config.sliding_window
+
+        is_sliding_window = (
+            getattr(config, "interleaved_sliding_window", None) is not None
+            and config.layer_types[layer_idx] == "sliding_attention")
+
+        if is_sliding_window:
+            self.sliding_window = config.interleaved_sliding_window
             rope_theta = config.rope_local_base_freq
             rope_scaling = {"rope_type": "default"}
         else:


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
Currently Gemma3n model has sliding window enabled for all layers, when it should actually be interleaved (pattern `LLLG`). This is because vLLM requires HF config to have `sliding_window_pattern` set.

Otherwise, even for layers where `per_layer_sliding_window` is set to `None` in Attention layer, vLLM will fall back to using cache_config's sliding_window attr (https://github.com/vllm-project/vllm/blob/main/vllm/attention/layer.py#L93-L95). IMO this is not intuitive and we should fix it so we can prevent bugs like this in the future.

## Test Plan
```
vllm serve google/gemma-3n-E2B-it --disable-log-requests
```

run eval
```
MODEL=google/gemma-3n-E2B-it
PORT=8000
lm_eval --model local-completions --tasks gsm8k \
    --model_args model=$MODEL,base_url=http://127.0.0.1:$PORT/v1/completions,num_concurrent=200,max_retries=3,tokenized_requests=False \
    --limit 1000
```

## Test Result
KV cache spec after this PR:
```
> [layer.self_attn.attn.sliding_window for layer in self.model.model.language_model.layers]

[512, 512, 512, 512, None, 512, 512, 512, 512, None, 512, 512, 512, 512, None, 512, 512, 512, 512, None, 512, 512, 512, 512, None, 512, 512, 512, 512, None]
```

Before:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.622|±  |0.0153|
|     |       |strict-match    |     5|exact_match|↑  |0.601|±  |0.0155|
```

This PR (gsm8k improved)
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.645|±  |0.0151|
|     |       |strict-match    |     5|exact_match|↑  |0.644|±  |0.0151|
```

