### PR TITLE
[Bugfix] Fix PyNcclCommunicator device assertion for un-indexed CUDA devices

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -92,6 +92,11 @@ class PyNcclCommunicator:
             device = torch.device(device)
         # now `device` is a `torch.device` object
         assert isinstance(device, torch.device)
+
+        # Check if device has specific index, if not, resolve to current device
+        if getattr(device, "index", None) is None:
+            device = torch.device(torch.cuda.current_device())
+
         self.device = device
         # nccl communicator and stream will use this device
         # `torch.cuda.device` is a context manager that changes the
@@ -299,12 +304,6 @@ class PyNcclCommunicator:
               as the communicator.
         '''
 
-        # Check if device has specific index, if not, resolve to current device
-        if getattr(self.device, "index", None) is None:
-            device = torch.device(torch.cuda.current_device())
-        else:
-            device = self.device
-
-        assert tensor.device == device, (
-            f"this nccl communicator is created to work on {device}, "
+        assert tensor.device == self.device, (
+            f"this nccl communicator is created to work on {self.device}, "
             f"but the input tensor is on {tensor.device}")


### PR DESCRIPTION
### **Problem**
The PyNcclCommunicator device assertions were failing when comparing tensors on indexed CUDA devices (e.g., `cuda:0`) with communicators initialized with un-indexed CUDA devices (e.g., `cuda`). This occurred because:

```python
torch.device('cuda') == torch.device('cuda:0')  # False (even when both refer to the same physical device)
```

### **Example**

You can reproduce the error with the following example:
```python
# test_nccl_broadcast.py
import os
import torch
import torch.distributed as dist
from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator

def main():
    # Initialize the default process group
    dist.init_process_group(backend="gloo")

    rank = dist.get_rank()
    world_size = dist.get_world_size()

    device = torch.device("cuda")

    with torch.cuda.device(device):
        
        # Create PyNcclCommunicator instance
        comm = PyNcclCommunicator(group=dist.group.WORLD, device=device)

        # Tensor to broadcast
        if rank == 0:
            tensor = torch.tensor([42], dtype=torch.int32, device=device)
        else:
            tensor = torch.zeros(1, dtype=torch.int32, device=device)

        print(f"[Before {str(torch.cuda.get_device_properties(device).uuid)}] Rank {rank}: tensor = {tensor.item()}")
        
        # Perform broadcast from rank 0
        comm.broadcast(tensor, src=0)

        print(f"[After {str(torch.cuda.get_device_properties(device).uuid)}] Rank {rank}: tensor = {tensor.item()}")

    dist.destroy_process_group()

if __name__ == "__main__":
    main()
```

Run with:
```sh
CUDA_VISIBLE_DEVICES=0 MASTER_ADDR=127.0.0.1 MASTER_PORT=29500 \
WORLD_SIZE=2 RANK=0 LOCAL_RANK=0 \
python test_nccl_broadcast.py > log_rank_0.log 2>&1 &

CUDA_VISIBLE_DEVICES=1 MASTER_ADDR=127.0.0.1 MASTER_PORT=29500 \
WORLD_SIZE=2 RANK=1 LOCAL_RANK=1 \
python test_nccl_broadcast.py > log_rank_1.log 2>&1 &
```

Even though the communicator were created with the same device, the following assertion error is raised:
```
INFO 07-29 20:05:42 [__init__.py:235] Automatically detected platform cuda.
INFO 07-29 20:05:42 [__init__.py:1376] Found nccl from library libnccl.so.2
INFO 07-29 20:05:42 [pynccl.py:70] vLLM is using nccl==2.26.2
[rank0]: Traceback (most recent call last):
[rank0]:   File "/workspace/mytest/test_nccl_broadcast.py", line 36, in <module>
[rank0]:     main()
[rank0]:   File "/workspace/mytest/test_nccl_broadcast.py", line 18, in main
[rank0]:     comm = PyNcclCommunicator(group=dist.group.WORLD, device=device)
[rank0]:   File "/workspace/vllm/vllm/distributed/device_communicators/pynccl.py", line 106, in __init__
[rank0]:     self.all_reduce(data)
[rank0]:   File "/workspace/vllm/vllm/distributed/device_communicators/pynccl.py", line 119, in all_reduce
[rank0]:     assert in_tensor.device == self.device, (
[rank0]: AssertionError: this nccl communicator is created to work on cuda, but the input tensor is on cuda:0
```

### **Solution**
Implemented a centralized device comparison method that resolves un-indexed devices dynamically:

1. **Refactored all device assertions** to use a new `_assert_tensor_on_device()` method
2. **Dynamic device resolution**: When the communicator device lacks a specific index (un-indexed device), resolve it to the current active device using `torch.cuda.current_device()` (which is the same thing pytorch does when it needs to create a tensor in an un-indexed device)
3. **Consistent behavior**: All NCCL operations now use the same device validation logic

### **Key Changes**
- Replaced inline device assertions across all methods (`all_reduce`, `all_gather`, `broadcast`, `send`, `recv`, etc.)
- Added `_assert_tensor_on_device()` method with proper un-indexed device handling
- Maintains the same error messages and behavior for indexed device mismatches

### **Before**
```python
assert tensor.device == self.device  # Fails with un-indexed devices
```

### **After**
```python
def _assert_tensor_on_device(self, tensor: torch.Tensor):
    # Resolve un-indexed devices to current device
    if getattr(self.device, "index", None) is None:
        device = torch.device(torch.cuda.current_device())
    else:
        device = self.device
    
    assert tensor.device == device, (...)
```

### **Impact**
- Fixes device assertion failures in scenarios where group is initialized with un-indexed devices, but created tensor is in the correct device
- Maintains backward compatibility
- No performance impact (device resolution is lightweight)

This fix ensures PyNcclCommunicator works correctly regardless of whether devices are specified implicitly (`cuda`) or explicitly (`cuda:0`). One example where the current implementation raises the assertion error when it shouldn't (i.e. when the tensor and group were created in the same device) is when the group is initialized with Hugging Face's `Accelerator.device` attribute (see [trl-PR#3774](https://github.com/huggingface/trl/pull/3774) ), so it is an important correction to make the integration more robust.