### PR TITLE
[Bugfix] Mask OOV tokens IDs from the Rejection Sampler

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -425,6 +425,9 @@ def sample_recovered_tokens(
         triton.next_power_of_2(vocab_size),
         NO_DRAFT_PROBS=draft_probs is None,
     )
+    # mask any out-of-vocabulary values in recovered_token_ids
+    recovered_token_ids = recovered_token_ids * (recovered_token_ids
+                                                 < vocab_size)
     return recovered_token_ids
 
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
The `sample_recovered_tokens_kernel` in the V1 Rejection Sampler currently returns out-of-vocabulary tokens when the input `target_probs` contains `nan` values. This sampling of OOV token ids causes the engine to crash as described in #20531

This seems to be because the kernel pads the vocabulary size with `-inf` and Triton's argmax function selects the index of the first `-inf` when the previous elements in the tensor are `nan` (i.e. `tl.argmax([nan, nan, -inf, ...]) --> 2`).

This PR masks out any OOV token ids so that any output token which is outside the vocabulary will be set to 0. 

The approach taken here is admittedly a band-aid, as it merely aligns the Rejection Sampler's behavior with that of the base target model sampler (i.e. by sampling token id `0` when the logits are full of `nan` values). This spitting out of `0` tokens when the logits have `nan`s, however, seems to be more of an accident, as opposed to an intended behavior; so I am curious to hear if there are any other thoughts on how to better handle this scenario.

## Test Plan

Added a new test case, `test_nan_logits`, which illustrates the behavior described above. 

## Test Result

This test fails without the change applied in this PR, and now passes.

## (Optional) Documentation Update

N/A

