### PR TITLE
[docs] Add FlashInfer installation guidance with torch 2.7 + cuda 12.8 

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -214,4 +214,4 @@ If desired, you can also manually set the backend of your choice by configuring 
 
 !!! warning
     There are no pre-built vllm wheels containing Flash Infer, so you must install it in your environment first. Refer to the [Flash Infer official docs](https://docs.flashinfer.ai/) or see <gh-file:docker/Dockerfile> for instructions on how to install it. For environments using PyTorch 2.7.1 + CUDA 12.8, install the matching wheel with `pip install --no-index --find-links=https://download.pytorch.org/whl/flashinfer-python flashinfer-python`.
-
+    

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -213,4 +213,5 @@ Currently, vLLM supports multiple backends for efficient Attention computation a
 If desired, you can also manually set the backend of your choice by configuring the environment variable `VLLM_ATTENTION_BACKEND` to one of the following options: `FLASH_ATTN`, `FLASHINFER` or `XFORMERS`.
 
 !!! warning
-    There are no pre-built vllm wheels containing Flash Infer, so you must install it in your environment first. Refer to the [Flash Infer official docs](https://docs.flashinfer.ai/) or see <gh-file:docker/Dockerfile> for instructions on how to install it.
+    There are no pre-built vllm wheels containing Flash Infer, so you must install it in your environment first. Refer to the [Flash Infer official docs](https://docs.flashinfer.ai/) or see <gh-file:docker/Dockerfile> for instructions on how to install it. For environments using PyTorch 2.7.1 + CUDA 12.8, install the matching wheel with `pip install --no-index --find-links=https://download.pytorch.org/whl/flashinfer-python flashinfer-python`.
+


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Add explicit installation guidance for FlashInfer in environments using PyTorch 2.7.1 + CUDA 12.8, which is currently not covered by FlashInfer's official documentation.

Specifically, this PR updates the Quickstart doc to include:  

```bash
pip install --no-index \
            --find-links=https://download.pytorch.org/whl/flashinfer-python/ \
            flashinfer-python
```

## Test Plan

Verified that FlashInfer was properly enabled by running:

```bash
vllm bench throughput \
  --model models/Qwen2.5-7B-Instruct \
  --input-len 512 \
  --output-len 8
```

## Test Result

```
...
INFO [topk_topp_sampler.py:49] Using FlashInfer for top-p & top-k sampling.
INFO [gpu_model_runner.py:1866] Starting to load model models/Qwen2.5-7B-Instruct...
INFO [cuda.py:305] Using Flash Attention backend on V1 engine.
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:02<00:00,  1.64it/s]
...
Throughput: 21.08 requests/s, 10934.08 total tokens/s, 168.64 output tokens/s
Total num prompt tokens:  510688
Total num output tokens:  8000
```

## (Optional) Documentation Update

Updated:

- docs/getting_started/quickstart.md — added installation instructions under a !!! warning block

