### PR TITLE
[Bugfix] Fix port conflict by obtaining a list of open ports upfront

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -89,7 +89,7 @@ class ParallelConfig:
     """Port for data parallel messaging."""
     data_parallel_master_port: int = 29500
     """Port of the data parallel master."""
-    data_parallel_master_port_list: list[int] = field(default_factory=list)
+    _data_parallel_master_port_list: list[int] = field(default_factory=list)
     """List of port for data parallel messaging"""
     data_parallel_backend: str = "mp"
     """Backend to use for data parallel, either "mp" or "ray"."""
@@ -179,6 +179,11 @@ class ParallelConfig:
         including data parallelism."""
         return self.world_size * self.data_parallel_size
 
+    @property
+    def data_parallel_master_port_list(self) -> list[int]:
+        """provide a getter for this port list that is generated during init"""
+        return self._data_parallel_master_port_list
+
     def get_next_dp_init_port(self) -> int:
         """
         We might need to initialize process groups in multiple
@@ -188,8 +193,8 @@ class ParallelConfig:
         pop a new port from the prepared port list each time we need to
         initialize a new process group related to data parallelism.
         """
-        if len(self.data_parallel_master_port_list) > 0:
-            answer = self.data_parallel_master_port_list.pop()
+        if len(self._data_parallel_master_port_list) > 0:
+            answer = self._data_parallel_master_port_list.pop()
         else:
             answer = self.data_parallel_master_port
 
@@ -319,10 +324,10 @@ class ParallelConfig:
 
         if self.data_parallel_size > 1 or self.data_parallel_size_local == 0:
             # Data parallel was specified in the engine args.
-            self.data_parallel_master_port_list = get_open_ports_list(5)
-            assert len(self.data_parallel_master_port_list) > 0
+            self._data_parallel_master_port_list = get_open_ports_list(5)
+            assert len(self._data_parallel_master_port_list) > 0
             self.data_parallel_master_port = \
-                self.data_parallel_master_port_list.pop()
+                self._data_parallel_master_port_list.pop()
 
             if not (0 <= self.data_parallel_rank < self.data_parallel_size):
                 raise ValueError(

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -15,8 +15,7 @@ import vllm.envs as envs
 from vllm.config.utils import config
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.utils import (cuda_device_count_stateless, get_open_port,
-                        get_open_ports_list)
+from vllm.utils import cuda_device_count_stateless, get_open_ports_list
 
 if TYPE_CHECKING:
     from ray.runtime_env import RuntimeEnv

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -171,7 +171,7 @@ class ParallelConfig:
     rank: int = 0
     """Global rank in distributed setup."""
 
-    _data_parallel_master_port_list: Optional[list[int]] = None
+    _data_parallel_master_port_list: list[int] = field(default_factory=list)
     """List of open port auto-queried for data parallel messaging.
     Set to be private as it's not intended to be configured by users.
     """

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -942,10 +942,10 @@ def get_open_port() -> int:
 
 def get_open_ports_list(count: int = 5) -> list[int]:
     """Get a list of open ports."""
-    ports = []
-    for _ in range(count):
-        ports.append(get_open_port())
-    return ports
+    ports = set()
+    while len(ports) < count:
+        ports.add(get_open_port())
+    return list(ports)
 
 
 def _get_open_port() -> int:

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -516,8 +516,8 @@ def random_uuid() -> str:
 class AsyncMicrobatchTokenizer:
     """Asynchronous tokenizer with micro-batching.
 
-    Pulls pending encode/decode requests from a queue and batches them 
-    up to reduce overhead. A single-thread ThreadPoolExecutor is used 
+    Pulls pending encode/decode requests from a queue and batches them
+    up to reduce overhead. A single-thread ThreadPoolExecutor is used
     so the event loop stays responsive.
     """
 
@@ -664,18 +664,18 @@ class AsyncMicrobatchTokenizer:
     def _queue_key(self, op: str, kwargs: dict) -> tuple:
         """
         Return a normalized key describing operation + kwargs.
-        
+
         - `add_special_tokens`: {True/False}
         - `truncation`: {True/False}
-          - If `truncation` is False (`max_length` is None), 
+          - If `truncation` is False (`max_length` is None),
             returns a key for a can_batch queue.
           - If `truncation` is True and `max_length` is None or equals
             `tokenizer.model_max_length`, returns a key for a can_batch queue.
           - Otherwise, returns a key for a cannot_batch queue.
-        
+
         Examples:
           - Decode: ("decode",)
-          - Encode typical: 
+          - Encode typical:
             ("encode", add_special_tokens, bool_truncation, max_length_label)
           - Fallback: ("encode", "other")
         """
@@ -938,6 +938,14 @@ def get_open_port() -> int:
             if candidate_port not in reserved_port_range:
                 return candidate_port
     return _get_open_port()
+
+
+def get_open_ports_list(count: int = 5) -> list[int]:
+    """Get a list of open ports."""
+    ports = []
+    for _ in range(count):
+        ports.append(get_open_port())
+    return ports
 
 
 def _get_open_port() -> int:

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -798,7 +798,7 @@ def wait_for_engine_startup(
                         parallel_config.data_parallel_master_ip,
                         "data_parallel_master_port":
                         parallel_config.data_parallel_master_port,
-                        "data_parallel_master_port_list":
+                        "_data_parallel_master_port_list":
                         parallel_config.data_parallel_master_port_list,
                         "data_parallel_size":
                         parallel_config.data_parallel_size,

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -799,7 +799,7 @@ def wait_for_engine_startup(
                         "data_parallel_master_port":
                         parallel_config.data_parallel_master_port,
                         "_data_parallel_master_port_list":
-                        parallel_config.data_parallel_master_port_list,
+                        parallel_config._data_parallel_master_port_list,
                         "data_parallel_size":
                         parallel_config.data_parallel_size,
                     }))

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -71,7 +71,7 @@ class EngineHandshakeMetadata:
     connect to.
     """
     addresses: EngineZmqAddresses
-    parallel_config: dict[str, Union[int, str]]
+    parallel_config: dict[str, Union[int, str, list[int]]]
 
 
 class CoreEngineProcManager:
@@ -798,6 +798,8 @@ def wait_for_engine_startup(
                         parallel_config.data_parallel_master_ip,
                         "data_parallel_master_port":
                         parallel_config.data_parallel_master_port,
+                        "data_parallel_master_port_list":
+                        parallel_config.data_parallel_master_port_list,
                         "data_parallel_size":
                         parallel_config.data_parallel_size,
                     }))


### PR DESCRIPTION
## Purpose

Mitigate #21638 by querying a list of open ports in the main process.

Race condition still persists, but much less likely, in the case where an open port is used by other processes after it is queried.  In comparison, before this PR, it is betting on the `master_port + 1` to be open.

Ideal solution would be locking this list of open ports for torch.distributed. It would require sophisticated changes, including changes to torch.distributed.

## Test Plan

Verify and lm_eval dp+tp+ep serving with:

```
VLLM_USE_V1=1 VLLM_LOGGING_LEVEL=DEBUG VLLM_ALL2ALL_BACKEND=pplx VLLM_USE_DEEP_GEMM=1 vllm serve  meta-llama/Llama-4-Scout-17B-16E  --max_model_len 8192 --kv_cache_dtype fp8 --enable-expert-parallel --tensor-parallel-size 2 --data-parallel-size 4 --trust-remote-code --gpu-memory-utilization 0.9 --disable-log-requests --compilation-config '{"full_cuda_graph":true}' 2>&1 | tee ~/log/ep_`date +%Y%m%d_%H%M%S`.log
```

## Test Result

local-chat-completions (model=meta-llama/Llama-4-Scout-17B-16E,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=32), gen_kwargs: (None), limit: 200.0, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.78|±  |0.0294|
|     |       |strict-match    |     5|exact_match|↑  | 0.83|±  |0.0266|

## (Optional) Documentation Update

