### PR TITLE
[Misc] Remove pass_config from CompilationConfig dump_json excluded

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1585,7 +1585,7 @@ class ModelConfig:
         """
         This method attempts to retrieve the non-default values of the
         generation config for this model.
-        
+
         The generation config can contain information about special tokens, as
         well as sampling parameters. Which is why this method exists separately
         to `get_diff_sampling_param`.
@@ -2066,7 +2066,7 @@ class ParallelConfig:
     and when data_parallel_size > 0. Enables running an AsyncLLM
     and API server on a "per-node" basis where vLLM load balances
     between local data parallel ranks, but an external LB balances
-    between vLLM nodes/replicas. Set explicitly in conjunction with 
+    between vLLM nodes/replicas. Set explicitly in conjunction with
     --data-parallel-start-rank."""
     enable_expert_parallel: bool = False
     """Use expert parallelism instead of tensor parallelism for MoE layers."""
@@ -4358,12 +4358,20 @@ class CompilationConfig:
             "disabled_custom_ops": True,
             "compilation_time": True,
             "bs_to_padded_graph_size": True,
-            "pass_config": True,
             "traced_files": True,
             "inductor_compile_config": {
                 "post_grad_custom_post_pass": True,
             },
         }
+
+        # exclude default attr in pass_config
+        pass_config_exclude = {}
+        for attr, default_val in vars(PassConfig()).items():
+            if getattr(self.pass_config, attr) == default_val:
+                pass_config_exclude[attr] = True
+        if pass_config_exclude:
+            exclude["pass_config"] = pass_config_exclude
+
         # The cast to string is necessary because Pydantic is mocked in docs
         # builds and sphinx-argparse doesn't know the return type of decode()
         return str(


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
The motivation is we cannot find the `compilation_config.pass_config` option from `non-default args`, that's confusing whether our config is working or not.

before
```
INFO 07-30 04:45:26 [utils.py:326] non-default args: {'model_tag': 'nvidia/Llama-4-Scout-17B-16E-Instruct-FP8', ..., 'compilation_config': {"level":3, ...,"full_cuda_graph":false,"max_capture_size":null,"local_cache_dir":null}, 'disable_log_requests': True}
```

after
```
INFO 07-30 05:57:17 [utils.py:326] non-default args: {'model_tag': 'nvidia/Llama-4-Scout-17B-16E-Instruct-FP8', ..., 'compilation_config': {"level":3, ...,"full_cuda_graph":false,"pass_config":{"enable_fusion":false,"enable_attn_fusion":false,"enable_noop":false,"enable_sequence_parallelism":false,"enable_async_tp":false,"enable_fi_allreduce_fusion":true,"fi_allreduce_fusion_max_token_num":1024},"max_capture_size":null,"local_cache_dir":null}, 'disable_log_requests': True}
```

## Test Plan

## Test Result

## (Optional) Documentation Update

