### PR TITLE
[Bugfix] Enable killing of orphaned EngineCores

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2091,6 +2091,10 @@ class ParallelConfig:
     """ Use data parallelism instead of tensor parallelism for vision encoder.
     Only support LLama4 for now"""
 
+    engine_core_orphaned_check_interval: int = 20
+    """The interval at which to check whether EngineCore processes have been
+    orphaned or not."""
+
     @property
     def world_size_across_dp(self) -> int:
         """world_size_across_dp is TPxPPxDP, it is the size of the world

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -317,6 +317,8 @@ class EngineArgs:
     eplb_log_balancedness: bool = ParallelConfig.eplb_log_balancedness
     max_parallel_loading_workers: Optional[
         int] = ParallelConfig.max_parallel_loading_workers
+    engine_core_orphaned_check_interval: int = \
+        ParallelConfig.engine_core_orphaned_check_interval
     block_size: Optional[BlockSize] = CacheConfig.block_size
     enable_prefix_caching: Optional[bool] = CacheConfig.enable_prefix_caching
     prefix_caching_hash_algo: PrefixCachingHashAlgo = \
@@ -674,6 +676,9 @@ class EngineArgs:
         parallel_group.add_argument(
             "--enable-multimodal-encoder-data-parallel",
             **parallel_kwargs["enable_multimodal_encoder_data_parallel"])
+        parallel_group.add_argument(
+            "--engine_core_orphaned_check_interval",
+            **parallel_kwargs["engine_core_orphaned_check_interval"])
 
         # KV cache arguments
         cache_kwargs = get_kwargs(CacheConfig)
@@ -1189,6 +1194,8 @@ class EngineArgs:
             worker_extension_cls=self.worker_extension_cls,
             enable_multimodal_encoder_data_parallel=self.
             enable_multimodal_encoder_data_parallel,
+            engine_core_orphaned_check_interval=self.
+            engine_core_orphaned_check_interval,
         )
 
         speculative_config = self.create_speculative_config(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -668,6 +668,7 @@ class AsyncLLM(EngineClient):
 
     @property
     def errored(self) -> bool:
+        # If any subprocess is dead, check_health will raise an EngineDeadError
         return self.engine_core.resources.engine_dead or not self.is_running
 
     @property

--- a/vllm/v1/engine/engine_proc_observer.py
+++ b/vllm/v1/engine/engine_proc_observer.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+import time
+
+import psutil
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class EngineProcObserver:
+    """For tracking EngineCore orphaned status in background process."""
+
+    @staticmethod
+    def track_processes(pids_with_create_time: list[tuple[int, float]],
+                        parent_pid: int, alive_check_interval: int):
+        """
+        Check every alive_check_interval seconds
+        whether any EngineCore has been orphaned.
+        """
+
+        while True:
+            if not psutil.pid_exists(parent_pid):
+                logger.info(
+                    "EngineCores have been orphaned... Proceeding to terminate."
+                )
+
+                for pid, create_time in pids_with_create_time:
+                    try:
+                        if psutil.Process(pid).create_time() == create_time:
+                            os.kill(pid, 9)
+                    except psutil.NoSuchProcess:
+                        # Process already terminated, which is fine.
+                        pass
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to kill orphaned process %d: %s", pid, e)
+
+                return
+
+            time.sleep(alive_check_interval)


### PR DESCRIPTION



# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

The purpose of this PR is to fix the second bug listed in #19849 :
In the V1 AsyncLLM, if the parent process itself restarts (for example, due to an orchestrator reboot or code reload), the EngineCore process sometimes remains alive, continues to hold GPU memory, and blocks any subsequent vLLM restart because the memory cannot be reclaimed.

## After this PR

If the main process exits and EngineCores are left orphaned, an observer process will kill the orphaned EngineCores and free memory. There are other alternative methods to be considered as well, such as running observer loops within the EngineCore subprocesses, but for now this fixes the issue. The observation interval is added as a new ParallelConfig variable called engine_core_orphaned_check_interval and CoreEngineProcManager.alive_check_interval takes on this value. The default interval is set to be 20 seconds.

We add relevant tests for these scenarios as well.


## Test Plan
The test script is in tests/v1/engine/test_async_llm.py

We add a new test test_engine_core_orphaned() for the scenario of orphaned EngineCores.
We also made additions to the existing test_check_health() test by including the scenario of the EngineCore crashing. While it failed originally, recent changes to the vLLM repo correctly lead to an EngineDeadError.

1. pytest test_async_llm.py -k test_check_health
2. pytest test_async_llm.py -k test_engine_core_orphaned

## Test Result