### PR TITLE
Update sampling_metadata.py

### DIFF
--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -539,37 +539,37 @@ class SamplingTensors:
         temperatures_t = torch.tensor(
             temperatures,
             device="cpu",
-            dtype=dtype,
+            dtype=torch.float32,
             pin_memory=pin_memory,
         )
         top_ps_t = torch.tensor(
             top_ps,
             device="cpu",
-            dtype=dtype,
+            dtype=torch.float32,
             pin_memory=pin_memory,
         )
         min_ps_t = torch.tensor(
             min_ps,
             device="cpu",
-            dtype=dtype,
+            dtype=torch.float32,
             pin_memory=pin_memory,
         )
         presence_penalties_t = torch.tensor(
             presence_penalties,
             device="cpu",
-            dtype=dtype,
+            dtype=torch.float32,
             pin_memory=pin_memory,
         )
         frequency_penalties_t = torch.tensor(
             frequency_penalties,
             device="cpu",
-            dtype=dtype,
+            dtype=torch.float32,
             pin_memory=pin_memory,
         )
         repetition_penalties_t = torch.tensor(
             repetition_penalties,
             device="cpu",
-            dtype=dtype,
+            dtype=torch.float32,
             pin_memory=pin_memory,
         )
         top_ks_t = torch.tensor(


### PR DESCRIPTION
Purpose
This PR fixes a crash in the non-GPU sampler caused by a change in the logits tensor dtype. Specifically, when logits are in float16, the temperature and top_p tensors—if not explicitly set to float32—can lead to computation errors or incompatibilities. This PR addresses [#21936](https://github.com/vllm-project/vllm/issues/21936) by hardcoding float32 dtype for temperature and top_p in the SamplingTensors structure to ensure consistent behavior across both GPU and CPU execution paths.

Test Plan
Run vllm using models that output float16 logits.

Set temperature and top_p to arbitrary values (e.g., temperature=0.7, top_p=0.9).

Verify that these values are correctly cast to float32 and propagated through the sampling logic.

Confirm no crashes occur on CPU (non-GPU) inference mode.
