### PR TITLE
[BugFix] Update AttnFusionPass cache key

### DIFF
--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -164,3 +164,6 @@ class AttnFusionPass(VllmInductorPass):
         logger.debug("Fused quantization onto %s attention nodes", count)
         self.dump_graph(graph, "after_attn_fusion")
         self.end_and_log()
+
+    def uuid(self):
+        return VllmInductorPass.hash_source(self, AttentionStaticQuantPattern)

--- a/vllm/compilation/inductor_pass.py
+++ b/vllm/compilation/inductor_pass.py
@@ -76,9 +76,10 @@ class InductorPass(CustomGraphPass):
         for src in srcs:
             if isinstance(src, str):
                 src_str = src
-            elif isinstance(src, types.FunctionType):
+            elif isinstance(src, (types.FunctionType, type)):
                 src_str = inspect.getsource(src)
             else:
+                # object instance
                 src_str = inspect.getsource(src.__class__)
             hasher.update(src_str.encode("utf-8"))
         return hasher.hexdigest()


### PR DESCRIPTION
## Purpose

Previously, if you update AttentionStaticQuantPattern without updating AttnFusionPass, this does not change the cache key for AttnFusionPass. This PR fixes that.

## Test Plan and Test Result

Tested Locally: run `pytest -s tests/models/quantization/test_modelopt.py -vv`, updated AttnFusionPass, re-ran `pytest -s tests/models/quantization/test_modelopt.py -vv`, and confirmed that we got a cache miss.

Writing a test that can be checked into the codebase for this is hard so I didn't do it.
