### PR TITLE
[Bugfix] Ignore the stop str while in reasoning stage

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -375,7 +375,7 @@ class LLMEngine:
         if self.decoding_config.reasoning_backend is not None:
             reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                 self.decoding_config.reasoning_backend)
-            self.reasoner = reasoner_cls(self.tokenizer.get_lora_tokenizer())
+            self.reasoner = reasoner_cls(tokenizer=self.tokenizer)
 
         # Create sequence output processor, e.g. for beam search or
         # speculative decoding.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -373,9 +373,14 @@ class LLMEngine:
         # Initialize reasoning parser if reasoning backend is set.
         self.reasoner: Optional[ReasoningParser] = None
         if self.decoding_config.reasoning_backend:
+            if self.tokenizer is None:
+                raise ValueError(
+                    "Reasoning backend requires a tokenizer so it can't be used with 'skip_tokenizer_init'"  # noqa: E501
+                )
             reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                 self.decoding_config.reasoning_backend)
-            self.reasoner = reasoner_cls(tokenizer=self.tokenizer)
+            self.reasoner = reasoner_cls(
+                tokenizer=self.tokenizer.get_lora_tokenizer())
 
         # Create sequence output processor, e.g. for beam search or
         # speculative decoding.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -371,12 +371,11 @@ class LLMEngine:
                 self.observability_config.otlp_traces_endpoint)
 
         # Initialize reasoning parser if reasoning backend is set.
-        self.reasoner = None
+        self.reasoner: Optional[ReasoningParser] = None
         if self.decoding_config.reasoning_backend is not None:
             reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                 self.decoding_config.reasoning_backend)
-            self.reasoner: ReasoningParser = reasoner_cls(
-                self.tokenizer.get_lora_tokenizer())
+            self.reasoner = reasoner_cls(self.tokenizer.get_lora_tokenizer())
 
         # Create sequence output processor, e.g. for beam search or
         # speculative decoding.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -372,7 +372,7 @@ class LLMEngine:
 
         # Initialize reasoning parser if reasoning backend is set.
         self.reasoner: Optional[ReasoningParser] = None
-        if self.decoding_config.reasoning_backend is not None:
+        if self.decoding_config.reasoning_backend:
             reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                 self.decoding_config.reasoning_backend)
             self.reasoner = reasoner_cls(tokenizer=self.tokenizer)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -40,6 +40,7 @@ from vllm.multimodal.processing import EncDecMultiModalProcessor
 from vllm.outputs import (PoolingRequestOutput, RequestOutput,
                           RequestOutputFactory)
 from vllm.pooling_params import PoolingParams
+from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.sequence import (ExecuteModelRequest, ParallelSampleSequenceGroup,
                            PoolingSequenceGroupOutput, Sequence, SequenceGroup,
@@ -368,6 +369,14 @@ class LLMEngine:
             self.tracer = init_tracer(
                 "vllm.llm_engine",
                 self.observability_config.otlp_traces_endpoint)
+
+        # Initialize reasoning parser if reasoning backend is set.
+        self.reasoner = None
+        if self.decoding_config.reasoning_backend is not None:
+            reasoner_cls = ReasoningParserManager.get_reasoning_parser(
+                self.decoding_config.reasoning_backend)
+            self.reasoner: ReasoningParser = reasoner_cls(
+                self.tokenizer.get_lora_tokenizer())
 
         # Create sequence output processor, e.g. for beam search or
         # speculative decoding.

--- a/vllm/engine/output_processor/stop_checker.py
+++ b/vllm/engine/output_processor/stop_checker.py
@@ -4,6 +4,7 @@
 from typing import Callable, List, Optional, Tuple
 
 from vllm.lora.request import LoRARequest
+from vllm.reasoning import ReasoningParser
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import Sequence, SequenceStatus
 from vllm.transformers_utils.tokenizer import AnyTokenizer
@@ -16,11 +17,16 @@ class StopChecker:
     emitted, or if we have exceeded the max model len.
     """
 
-    def __init__(self, max_model_len: int,
-                 get_tokenizer_for_seq: Callable[[Sequence], AnyTokenizer]):
+    def __init__(
+        self,
+        max_model_len: int,
+        get_tokenizer_for_seq: Callable[[Sequence], AnyTokenizer],
+        reasoner: Optional[ReasoningParser] = None,
+    ):
         # Do not use it directly, but use `self._get_max_model_len`.
         self._max_model_len = max_model_len
         self.get_tokenizer_for_seq = get_tokenizer_for_seq
+        self.reasoner = reasoner
 
     def _get_max_model_len(self, lora_req: Optional[LoRARequest]):
         if lora_req and lora_req.long_lora_max_len:
@@ -44,6 +50,10 @@ class StopChecker:
         # Check if the minimum number of tokens has been generated yet;
         # skip the stop string/token checks if not
         if seq.get_output_len() < sampling_params.min_tokens:
+            return
+
+        if self.reasoner is not None and \
+            not self.reasoner.is_reasoning_end(seq.get_token_ids()):
             return
 
         # Check if the sequence has generated the EOS token.

--- a/vllm/engine/output_processor/stop_checker.py
+++ b/vllm/engine/output_processor/stop_checker.py
@@ -73,7 +73,7 @@ class StopChecker:
             seq.status = SequenceStatus.FINISHED_LENGTH_CAPPED
             return
 
-        # ignore stop tokens or stop strings if still in a reasoning stage
+        # Ignore stop tokens or stop strings if still in a reasoning stage
         if self.reasoner is not None and \
             not self.reasoner.is_reasoning_end(seq.get_token_ids()):
             return

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -48,8 +48,8 @@ class ReasoningParser:
         """
         Check if the reasoning content ends in the input_ids.
 
-        It is used in structured engines like `xgrammar` to check if the
-        reasoning content ends in the model output.
+        It is used in structured engines like `xgrammar` or stop checks 
+        to check if the reasoning content ends in the model output.
 
         Parameters:
         input_ids: list[int]

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 from vllm.logger import init_logger
+from vllm.reasoning import ReasoningParser
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.request import Request, RequestStatus
@@ -30,10 +33,11 @@ class AsyncScheduler(Scheduler):
         self,
         request: Request,
         new_token_ids: list[int],
+        reasoner: Optional[ReasoningParser] = None,
     ) -> tuple[list[int], bool]:
         status_before_update = request.status
         new_token_ids, stopped = super()._update_request_with_output(
-            request, new_token_ids)
+            request, new_token_ids, reasoner)
 
         # Update the number of output placeholders.
         request.num_output_placeholders -= len(new_token_ids)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -60,14 +60,14 @@ class Scheduler(SchedulerInterface):
         self.parallel_config = vllm_config.parallel_config
         self.log_stats = log_stats
         self.structured_output_manager = structured_output_manager
-        self.tokenizer = init_tokenizer_from_configs(
-            model_config=self.vllm_config.model_config,
-            scheduler_config=self.vllm_config.scheduler_config,
-            lora_config=self.vllm_config.lora_config,
-        ).get_lora_tokenizer(None)
         self.reasoner: Optional[ReasoningParser] = None
         reasoning_backend = vllm_config.decoding_config.reasoning_backend
         if reasoning_backend:
+            self.tokenizer = init_tokenizer_from_configs(
+                model_config=self.vllm_config.model_config,
+                scheduler_config=self.vllm_config.scheduler_config,
+                lora_config=self.vllm_config.lora_config,
+            ).get_lora_tokenizer()
             reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                 reasoning_backend)
             self.reasoner = reasoner_cls(tokenizer=self.tokenizer)

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -35,7 +35,7 @@ def check_stop(request: Request,
     if last_token_id in (sampling_params.stop_token_ids or ()):
         if reasoner is not None and not reasoner.is_reasoning_end(
                 request.all_token_ids):
-            # Reasoning it not ended yet, not to stop
+            # Reasoning is not ended yet, not to stop
             return False
 
         request.status = RequestStatus.FINISHED_STOPPED

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -109,9 +109,15 @@ class AsyncLLM(EngineClient):
         self.reasoner: Optional[ReasoningParser] = None
         reasoning_backend = vllm_config.decoding_config.reasoning_backend
         if reasoning_backend:
+            if self.tokenizer is None:
+                raise ValueError(
+                    "Reasoning backend requires a tokenizer so it can't be used with 'skip_tokenizer_init'"  # noqa: E501
+                )
             reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                 reasoning_backend)
-            self.reasoner = reasoner_cls(tokenizer=self.tokenizer)
+
+            self.reasoner = reasoner_cls(
+                tokenizer=self.tokenizer.get_lora_tokenizer())
 
         # Processor (converts Inputs --> EngineCoreRequests).
         self.processor = Processor(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -20,6 +20,7 @@ from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
+from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
 from vllm.transformers_utils.config import (
@@ -105,6 +106,13 @@ class AsyncLLM(EngineClient):
                 scheduler_config=vllm_config.scheduler_config,
                 lora_config=vllm_config.lora_config)
 
+        self.reasoner: Optional[ReasoningParser] = None
+        reasoning_backend = vllm_config.decoding_config.reasoning_backend
+        if reasoning_backend:
+            reasoner_cls = ReasoningParserManager.get_reasoning_parser(
+                reasoning_backend)
+            self.reasoner = reasoner_cls(tokenizer=self.tokenizer)
+
         # Processor (converts Inputs --> EngineCoreRequests).
         self.processor = Processor(
             vllm_config=vllm_config,
@@ -114,7 +122,8 @@ class AsyncLLM(EngineClient):
 
         # OutputProcessor (converts EngineCoreOutputs --> RequestOutput).
         self.output_processor = OutputProcessor(self.tokenizer,
-                                                log_stats=self.log_stats)
+                                                log_stats=self.log_stats,
+                                                reasoner=self.reasoner)
 
         # EngineCore (starts the engine in background process).
         self.engine_core = EngineCoreClient.make_async_mp_client(

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -95,9 +95,14 @@ class LLMEngine:
         self.reasoner: Optional[ReasoningParser] = None
         reasoning_backend = vllm_config.decoding_config.reasoning_backend
         if reasoning_backend:
+            if self.tokenizer is None:
+                raise ValueError(
+                    "Reasoning backend requires a tokenizer so it can't be used with 'skip_tokenizer_init'"  # noqa: E501
+                )
             reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                 reasoning_backend)
-            self.reasoner = reasoner_cls(tokenizer=self.tokenizer)
+            self.reasoner = reasoner_cls(
+                tokenizer=self.tokenizer.get_lora_tokenizer())
 
         # Processor (convert Inputs --> EngineCoreRequests)
         self.processor = Processor(vllm_config=vllm_config,


### PR DESCRIPTION
When evaluating reasoning models, we found that it would stop with stop strings during a reasoning stage, which is unexpected.

Thus,  in this PR, ignore the stop strings while in a reasoning stage.

