### PR TITLE
[Misc] DeepGemmExperts : Avoid JIT generation in the hot-path

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -120,6 +120,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_TPU_MOST_MODEL_LEN: Optional[int] = None
     VLLM_USE_DEEP_GEMM: bool = False
+    VLLM_DISABLE_DEEP_GEMM_WARMUP: bool = False
     VLLM_USE_FLASHINFER_MOE_FP8: bool = False
     VLLM_USE_FLASHINFER_MOE_FP4: bool = False
     VLLM_XGRAMMAR_CACHE_MB: int = 0
@@ -865,6 +866,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM":
     lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "0"))),
+
+    # DeepGemm JITs the kernels on-demand. The warmup attempts to make DeepGemm
+    # JIT all the required kernels before model execution so there is no
+    # JIT'ing in the hot-path. However, this warmup increases the engine
+    # startup time by a couple of minutes.
+    # Set `VLLM_DISABLE_DEEP_GEMM_WARMUP` to disable the warmup.
+    "VLLM_DISABLE_DEEP_GEMM_WARMUP":
+    lambda: bool(int(os.getenv("VLLM_DISABLE_DEEP_GEMM_WARMUP", "0"))),
 
     # Allow use of FlashInfer MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP8":

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -120,7 +120,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_TPU_MOST_MODEL_LEN: Optional[int] = None
     VLLM_USE_DEEP_GEMM: bool = False
-    VLLM_DISABLE_DEEP_GEMM_WARMUP: bool = False
+    VLLM_SKIP_DEEP_GEMM_WARMUP: bool = False
     VLLM_USE_FLASHINFER_MOE_FP8: bool = False
     VLLM_USE_FLASHINFER_MOE_FP4: bool = False
     VLLM_XGRAMMAR_CACHE_MB: int = 0
@@ -871,9 +871,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # JIT all the required kernels before model execution so there is no
     # JIT'ing in the hot-path. However, this warmup increases the engine
     # startup time by a couple of minutes.
-    # Set `VLLM_DISABLE_DEEP_GEMM_WARMUP` to disable the warmup.
-    "VLLM_DISABLE_DEEP_GEMM_WARMUP":
-    lambda: bool(int(os.getenv("VLLM_DISABLE_DEEP_GEMM_WARMUP", "0"))),
+    # Set `VLLM_SKIP_DEEP_GEMM_WARMUP` to disable the warmup.
+    "VLLM_SKIP_DEEP_GEMM_WARMUP":
+    lambda: bool(int(os.getenv("VLLM_SKIP_DEEP_GEMM_WARMUP", "0"))),
 
     # Allow use of FlashInfer MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP8":

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -125,7 +125,7 @@ def warmup_deepgemm_gg_contiguous_kernels(w1: torch.Tensor, w2: torch.Tensor,
         out = torch.empty((MAX_M, n), device=device, dtype=torch.bfloat16)
 
         pbar = tqdm(total=MAX_M // block_m,
-                    desc=f"DeepGemm warmup (MAX_M={MAX_M})")
+                    desc=f"DeepGemmExperts GEMM warmup (MAX_M={MAX_M})")
         num_tokens = MAX_M
         while num_tokens > 0:
             m_grouped_fp8_gemm_nt_contiguous(

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -220,7 +220,7 @@ class DeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         assert w1_scale is not None
         assert w2_scale is not None
 
-        if not env.VLLM_DISABLE_DEEP_GEMM_WARMUP:
+        if not env.VLLM_SKIP_DEEP_GEMM_WARMUP:
             # DeepGemm JITs the grouped-gemm kernels. We don't want the JIT'ing
             # to happen during actual model-inference. The
             # `warmup_deepgemm_kernels` function is a `run_once` decorated

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -83,9 +83,10 @@ def _valid_deep_gemm(hidden_states: torch.Tensor, w1: torch.Tensor,
 
 
 @run_once
-def warmup_deepgemm_kernels(w1: torch.Tensor, w2: torch.Tensor,
-                            w1_scale: torch.Tensor, w2_scale: torch.Tensor,
-                            num_topk: int):
+def warmup_deepgemm_gg_contiguous_kernels(w1: torch.Tensor, w2: torch.Tensor,
+                                          w1_scale: torch.Tensor,
+                                          w2_scale: torch.Tensor,
+                                          num_topk: int):
     """
     DeepGemm JITs the grouped-gemm kernels. The JIT'ing happens based on the
     input tensor shapes. In this function, we construct all possible input
@@ -219,11 +220,11 @@ class DeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         # function is a `run_once` decorated that executes during the model
         # profile run. This warmup is should create all the required JITs for
         # this model.
-        warmup_deepgemm_kernels(w1,
-                                w2,
-                                w1_scale,
-                                w2_scale,
-                                num_topk=topk_ids.size(1))
+        warmup_deepgemm_gg_contiguous_kernels(w1,
+                                              w2,
+                                              w1_scale,
+                                              w2_scale,
+                                              num_topk=topk_ids.size(1))
 
         a1q = hidden_states
         _, N, K = w1.size()

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -110,7 +110,7 @@ def warmup_deepgemm_kernels(w1: torch.Tensor, w2: torch.Tensor,
     MAX_M = compute_aligned_M(env.VLLM_FUSED_MOE_CHUNK_SIZE,
                               num_topk,
                               num_experts,
-                              deep_gemm_block_shape()[0],
+                              block_m,
                               expert_tokens_meta=None)
     expert_ids = torch.zeros((MAX_M, ), device=device, dtype=torch.int32)
 
@@ -118,7 +118,7 @@ def warmup_deepgemm_kernels(w1: torch.Tensor, w2: torch.Tensor,
 
         _, n, k = w.size()
         a1q = torch.empty((MAX_M, k), device=device).to(torch.float8_e4m3fn)
-        a1q_scales = torch.empty((MAX_M, k // 128),
+        a1q_scales = torch.empty((MAX_M, k // block_m),
                                  device=device,
                                  dtype=torch.float32)
         out = torch.empty((MAX_M, n), device=device, dtype=torch.bfloat16)

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -4,7 +4,9 @@ import functools
 from typing import Any, Optional
 
 import torch
+from tqdm import tqdm
 
+import vllm.envs as env
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
@@ -94,10 +96,6 @@ def warmup_deepgemm_gg_contiguous_kernels(w1: torch.Tensor, w2: torch.Tensor,
     Note that this warmup is expected to happen during the model profile
     call and not during actual model inference.
     """
-
-    from tqdm import tqdm
-
-    import vllm.envs as env
 
     assert w1.size(0) == w2.size(0), (
         "w1 and w2 must have the same number of experts")

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_moe.py
@@ -220,16 +220,17 @@ class DeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         assert w1_scale is not None
         assert w2_scale is not None
 
-        # DeepGemm JITs the grouped-gemm kernels. We don't want the JIT'ing
-        # to happen during actual model-inference. The `warmup_deepgemm_kernels`
-        # function is a `run_once` decorated that executes during the model
-        # profile run. This warmup is should create all the required JITs for
-        # this model.
-        warmup_deepgemm_gg_contiguous_kernels(w1,
-                                              w2,
-                                              w1_scale,
-                                              w2_scale,
-                                              num_topk=topk_ids.size(1))
+        if not env.VLLM_DISABLE_DEEP_GEMM_WARMUP:
+            # DeepGemm JITs the grouped-gemm kernels. We don't want the JIT'ing
+            # to happen during actual model-inference. The
+            # `warmup_deepgemm_kernels` function is a `run_once` decorated
+            # function that executes during the model profile run. This warmup
+            # should create all the required JITs for the current model.
+            warmup_deepgemm_gg_contiguous_kernels(w1,
+                                                  w2,
+                                                  w1_scale,
+                                                  w2_scale,
+                                                  num_topk=topk_ids.size(1))
 
         a1q = hidden_states
         _, N, K = w1.size()

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -71,8 +71,10 @@ def _lazy_init() -> None:
         return
 
     # Set up deep_gemm cache path
-    os.environ['DG_JIT_CACHE_DIR'] = os.path.join(envs.VLLM_CACHE_ROOT,
-                                                  "deep_gemm")
+    DEEP_GEMM_JIT_CACHE_ENV_NAME = 'DG_JIT_CACHE_DIR'
+    if not os.environ.get(DEEP_GEMM_JIT_CACHE_ENV_NAME, None):
+        os.environ[DEEP_GEMM_JIT_CACHE_ENV_NAME] = os.path.join(
+            envs.VLLM_CACHE_ROOT, "deep_gemm")
 
     _dg = importlib.import_module("deep_gemm")
 

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -71,8 +71,8 @@ def _lazy_init() -> None:
         return
 
     # Set up deep_gemm cache path
-    os.environ['DG_JIT_CACHE_DIR'] = os.path.join(
-        envs.get_default_cache_root(), "deep_gemm")
+    os.environ['DG_JIT_CACHE_DIR'] = os.path.join(envs.VLLM_CACHE_ROOT,
+                                                  "deep_gemm")
 
     _dg = importlib.import_module("deep_gemm")
 

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import importlib
+import os
 from typing import Any, Callable, NoReturn
 
 import torch
@@ -68,6 +69,10 @@ def _lazy_init() -> None:
 
     if not has_deep_gemm():
         return
+
+    # Set up deep_gemm cache path
+    os.environ['DG_JIT_CACHE_DIR'] = os.path.join(
+        envs.get_default_cache_root(), "deep_gemm")
 
     _dg = importlib.import_module("deep_gemm")
 


### PR DESCRIPTION
## Purpose
DeepGemm JITs the grouped-gemm kernels. This JIT generation depends on the Gemm input tensor shapes. We want to avoid generating JITs during actual model inference. To this effect, during model profile run, we invoke the DeepGemm grouped_gemm function with all possible input shapes for the model so all JIT generation is complete.

## Test Plan

vllm_serve-command : `VLLM_ALL2ALL_BACKEND="deepep_high_throughput" VLLM_USE_DEEP_GEMM=1   canhazgpu run -g2 -- vllm serve Qwen/Qwen3-30B-A3B-FP8  --trust-remote-code --enable-expert-parallel --data-parallel-size 2 --port 9010 --no-enable-prefix-caching`
lm_eval-command : `lm_eval --model local-completions --tasks gsm8k --model_args model=Qwen/Qwen3-30B-A3B-FP8,base_url=http://127.0.0.1:9010/v1/completions,num_concurrent=30,max_retries=3 --limit 100 `

## Test Result
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.85|±  |0.0359|
|     |       |strict-match    |     5|exact_match|↑  | 0.94|±  |0.0239|
```

## Test JIT Generation
DeepGemm stores the JITs at `~/.deep_gemm/cache`.
- Clear `~/.deep_gemm/cache`
- Execute `vllm_serve-command`
- After engine startup, I verified that the JITs are populated at `~/.deep_gemm/cache`
- Execute `lm_eval-command`.
- After the `lm_eval` run command finished I verified that there were no new JITs created. 