### PR TITLE
Add support for model signature verification

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -49,3 +49,4 @@ pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects
 setproctitle # Used to set process names for better debugging and monitoring
 openai-harmony >= 0.0.3  # Required for gpt-oss
+model-signing >= 1.0.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -50,3 +50,5 @@ cbor2 # Required for cross-language serialization of hashable objects
 setproctitle # Used to set process names for better debugging and monitoring
 openai-harmony >= 0.0.3  # Required for gpt-oss
 model-signing >= 1.0.1
+betterproto == 2.0.0b6  #
+sigstore == 3.6.2

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -41,6 +41,7 @@ from vllm.config.multimodal import (MMCacheType, MMEncoderTPMode,
 from vllm.config.parallel import (DistributedExecutorBackend, EPLBConfig,
                                   ParallelConfig)
 from vllm.config.scheduler import SchedulerConfig, SchedulerPolicy
+from vllm.config.signature_verification import SignatureVerificationConfig
 from vllm.config.speculative import SpeculativeConfig
 from vllm.config.utils import ConfigType, config
 from vllm.logger import init_logger
@@ -446,6 +447,9 @@ class ModelConfig:
     definitions"""
     io_processor_plugin: Optional[str] = None
     """IOProcessor plugin name to load at model startup"""
+    signature_verification_config: \
+        Optional[SignatureVerificationConfig] = None
+    """The model's signature verification configuration."""
 
     # Multimodal config and init vars
     multimodal_config: Optional[MultiModalConfig] = None

--- a/vllm/config/signature_verification.py
+++ b/vllm/config/signature_verification.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
 import os
 from collections.abc import Iterable
 from dataclasses import field
@@ -103,6 +104,8 @@ class SignatureVerificationConfig:
         log_fingerprints: bool,
     ) -> None:
         """Verify using a certificate chain"""
+        if log_fingerprints:
+            logging.getLogger("model_signing").setLevel(logging.INFO)
         try:
             model_signing.verifying.Config().use_certificate_verifier(
                 certificate_chain=certificate_chain,
@@ -117,6 +120,8 @@ class SignatureVerificationConfig:
             raise ValueError(
                 "Signature verification with certificate failed "
                 "on %s", model_path) from err
+        finally:
+            logging.getLogger("model_signing").setLevel(logging.WARNING)
 
     def _verify_private_key(
         self,

--- a/vllm/config/signature_verification.py
+++ b/vllm/config/signature_verification.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+from collections.abc import Iterable
+from dataclasses import field
+from pathlib import Path
+from typing import Literal, Optional
+
+import model_signing
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+
+from vllm.config.utils import config
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+VerificationMethod = Literal["sigstore", "certificate", "key"]
+
+# yapf: enable
+
+
+@config
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+class SignatureVerificationConfig:
+    """Signature verification configuration."""
+
+    verification_method: Optional[VerificationMethod] = None
+    """The signature verification method to use."""
+    signature: str = "model.sig"
+    """Path to the signature file. If only a filename is given, then a file
+    with this name is expected to hold the signature in the model's
+    directory."""
+    ignore_paths: list[str] = field(default_factory=list)
+    """File paths to ignore when verifying. Absolute file paths will be used
+    as-is, others will be made absolute by prepending the model's
+    directory."""
+    ignore_git_paths: bool = True
+    """Ignore git-related files when verifying."""
+    identity: str = ""
+    """The email identity that signed with the 'sigstore' method."""
+    identity_provider: str = ""
+    """The email identity provider that was used when signing with the
+    'sigstore' method."""
+    use_staging: bool = False
+    """Use the Sigstore staging server."""
+    certificate_chain: list[str] = field(default_factory=list)
+    """A PEM file containing the certificate chain needed for verifying with
+    method 'certificate'."""
+    log_fingerprints: bool = False
+    """Whether to log certificate fingerprints when using the 'certificate'
+    method."""
+    public_key: Optional[str] = None
+    """A PEM file containing the public key required for signature
+    verification when using the 'key' method."""
+    _verification_done: bool = False
+    """Set to True once signature verification was done."""
+
+    def signature_verification_requested(self) -> bool:
+        """Check whether signature verification was requested."""
+        return self.verification_method is not None
+
+    def signature_verification_needed(self) -> bool:
+        """Check whether signature verification is requested but has
+        not been done yet."""
+        return self.signature_verification_requested() and \
+               not self._verification_done
+
+    def _verify_sigstore(
+        self,
+        model_path: Path,
+        signature: Path,
+        ignore_paths: Iterable[Path],
+        ignore_git_paths: bool,
+        identity: str,
+        identity_provider: str,
+        use_staging: bool,
+    ) -> None:
+        """Verify using Sigstore"""
+        try:
+            model_signing.verifying.Config().use_sigstore_verifier(
+                identity=identity,
+                oidc_issuer=identity_provider,
+                use_staging=use_staging,
+            ).set_hashing_config(
+                model_signing.hashing.Config().set_ignored_paths(
+                    paths=list(ignore_paths) + [signature],
+                    ignore_git_paths=ignore_git_paths,
+                )).verify(model_path, signature)
+        except Exception as err:
+            logger.error("Verification failed with error: %s", err)
+            raise ValueError("Sigstore verification failed on %s",
+                             model_path) from err
+
+    def _verify_certificate(
+        self,
+        model_path: Path,
+        signature: Path,
+        ignore_paths: Iterable[Path],
+        ignore_git_paths: bool,
+        certificate_chain: Iterable[Path],
+        log_fingerprints: bool,
+    ) -> None:
+        """Verify using a certificate chain"""
+        try:
+            model_signing.verifying.Config().use_certificate_verifier(
+                certificate_chain=certificate_chain,
+                log_fingerprints=log_fingerprints,
+            ).set_hashing_config(
+                model_signing.hashing.Config().set_ignored_paths(
+                    paths=list(ignore_paths) + [signature],
+                    ignore_git_paths=ignore_git_paths,
+                )).verify(model_path, signature)
+        except Exception as err:
+            logger.error("Verification failed with error: %s", err)
+            raise ValueError(
+                "Signature verification with certificate failed "
+                "on %s", model_path) from err
+
+    def _verify_private_key(
+        self,
+        model_path: Path,
+        signature: Path,
+        ignore_paths: Iterable[Path],
+        ignore_git_paths: bool,
+        public_key: Path,
+    ) -> None:
+        """Verify using a public key (paired with a private one)."""
+        try:
+            model_signing.verifying.Config().use_elliptic_key_verifier(
+                public_key=public_key, ).set_hashing_config(
+                    model_signing.hashing.Config().set_ignored_paths(
+                        paths=list(ignore_paths) + [signature],
+                        ignore_git_paths=ignore_git_paths,
+                    )).verify(model_path, signature)
+        except Exception as err:
+            logger.error("Verification failed with error: %s", err)
+            raise ValueError(
+                "Signature verification with public key failed "
+                "on %s", model_path) from err
+
+    def verify_signature(self, model: str) -> None:
+        """Verify the signature of a model."""
+        model_path = Path(model)
+
+        def make_abs(model_path: Path, file: str) -> Path:
+            if os.path.isabs(file):
+                return Path(file)
+            return model_path / file
+
+        ignore_paths = [make_abs(model_path, f) for f in self.ignore_paths]
+        signature = make_abs(model_path, self.signature)
+
+        if self.verification_method == "sigstore":
+            self._verify_sigstore(model_path, signature, ignore_paths,
+                                  self.ignore_git_paths, self.identity,
+                                  self.identity_provider, self.use_staging)
+        elif self.verification_method == "certificate":
+            cert_chain_paths = [
+                make_abs(model_path, f) for f in self.certificate_chain
+            ]
+
+            self._verify_certificate(model_path, signature, ignore_paths,
+                                     self.ignore_git_paths, cert_chain_paths,
+                                     self.log_fingerprints)
+        elif self.verification_method == "key":
+            if not self.public_key:
+                raise ValueError("Missing public key")
+
+            self._verify_private_key(model_path, signature, ignore_paths,
+                                     self.ignore_git_paths,
+                                     make_abs(model_path, self.public_key))
+        else:
+            raise NotImplementedError(
+                "Unsupported signature verification method "
+                f"'{self.verification_method}'")
+        logger.info("Signature verification succeeded on %s", model)
+        self._verification_done = True

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -226,6 +226,12 @@ class LLMEngine:
             use_cached_outputs,
         )
 
+        svc = self.model_config.signature_verification_config
+        if svc.signature_verification_needed():
+            raise Exception("Signature verification was requested but was not "
+                            "done since a code path was taken that is not yet "
+                            "instrumented for signature verification.")
+
         self.log_stats = log_stats
         self.use_cached_outputs = use_cached_outputs
 

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -48,6 +48,11 @@ DEFAULT_LOGGING_CONFIG = {
             "level": "DEBUG",
             "propagate": False,
         },
+        "model_signing": {
+            "handlers": ["vllm"],
+            "level": "WARNING",
+            "propagate": False,
+        }
     },
     "version": 1,
     "disable_existing_loggers": False

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -75,6 +75,12 @@ class LLMEngine:
         if self.log_stats:
             self.stat_logger = PrometheusStatLogger(vllm_config)
 
+        svc = self.model_config.signature_verification_config
+        if svc.signature_verification_needed():
+            raise Exception("Signature verification was requested but was not "
+                            "done since a code path was taken that is not yet "
+                            "instrumented for signature verification.")
+
         # important: init dp group before init the engine_core
         # In the decoupled engine case this is handled in EngineCoreProc.
         parallel_config = vllm_config.parallel_config


### PR DESCRIPTION

# Essential Elements of an Effective PR Description Checklist

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Add support for model signature verification on local models. To do this, replicate many of the command line options from the model signing library's model_signing tool into vllm so that many use cases (different types of signatures) are addressed.

For the local model signature verification check early on whether a directory with the given name is available and if signature verification is requested by the user by passing the --verification-method option.

Signature verification for models downloaded from the Huggingface hub is not addressed in this patch. For this I am currently waiting for another release of the model_signing library where the necessary symlink support is provided.

## Test Plan

To verify this patch you may want to try the following signed model:

git clone https://huggingface.co/ibm-granite/granite-4.0-tiny-preview

Verify and run it with the following command line:

vllm serve \
	--verification-method sigstore \
	--identity Granite.Preview@ibm.com \
	--identity-provider https://sigstore.verify.ibm.com/oauth2 \
	~/models/granite-4.0-tiny-preview/

## Test Result

The following line must appear in the `vllm serve`:
```
(APIServer pid=4545) INFO 07-30 16:49:48 [config.py:431] Signature verification succeeded
```

## (Optional) Documentation Update

