### PR TITLE
Move flashinfer-python to optional extra `vllm[flashinfer]`

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -12,5 +12,3 @@ torchaudio==2.7.1
 torchvision==0.22.1 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # https://github.com/facebookresearch/xformers/releases/tag/v0.0.31
 xformers==0.0.31; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7
-# FlashInfer should be updated together with the Dockerfile
-flashinfer_python==0.2.9rc2

--- a/setup.py
+++ b/setup.py
@@ -691,7 +691,9 @@ setup(
         ["runai-model-streamer >= 0.13.3", "runai-model-streamer-s3", "boto3"],
         "audio": ["librosa", "soundfile",
                   "mistral_common[audio]"],  # Required for audio processing
-        "video": []  # Kept for backwards compatibility
+        "video": [],  # Kept for backwards compatibility
+        # FlashInfer should be updated together with the Dockerfile
+        "flashinfer": ["flashinfer-python==0.2.9rc2"],
     },
     cmdclass=cmdclass,
     package_data=package_data,


### PR DESCRIPTION
Adding flashinfer-python by default to the CUDA requirements introduced a new hard requirement for vLLM to have `nvcc` installed, which we don't want to enforce for all users. See issue https://github.com/vllm-project/vllm/issues/21960

For now we will move the dependency as an extras i.e. `uv pip install vllm[flashinfer]`