### PR TITLE
[Misc] DeepEPLLPrepareAndFinalize - Cleanup

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -127,14 +127,8 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             f"{self.SUPPORTED_HIDDEN_SIZES}")
 
         if self.use_fp8_dispatch:
-            assert hidden_size % 128 == 0, \
+            assert quant_config.is_block_quantized and hidden_size % 128 == 0, \
             "DeepEP kernels quantize the inputs in blocks of shape 128"
-
-        has_per_token_scales = a1_scale.numel(
-        ) != 1 if a1_scale is not None else (
-            a2_scale.numel() != 1 if a2_scale is not None else False)
-        assert not has_per_token_scales, (
-            "low_latency kernels doesn't support dispatching per-token scales")
 
         if apply_router_weight_on_input:
             topk = topk_ids.size(1)

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -127,8 +127,10 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             f"{self.SUPPORTED_HIDDEN_SIZES}")
 
         if self.use_fp8_dispatch:
-            assert quant_config.is_block_quantized and hidden_size % 128 == 0, \
-            "DeepEP kernels quantize the inputs in blocks of shape 128"
+            assert ((quant_config.is_block_quantized)
+                    and (hidden_size % DEEPEP_QUANT_BLOCK_SIZE == 0)), (
+                        "DeepEP kernels quantize the inputs in blocks of size "
+                        f"{DEEPEP_QUANT_BLOCK_SIZE}")
 
         if apply_router_weight_on_input:
             topk = topk_ids.size(1)


### PR DESCRIPTION
## Purpose
Cleanup - Remove the confusing and incorrect `has_per_token_scales` assert. 

## Test Plan

TODO
- lm_eval
- test_deepep_deepgemm
- test_deepep_moe
- test_modular_kernel_combinations

## Test Result
