### PR TITLE
[UX] Move FlashInfer workspace cache inside of vLLM's cache (`~/.cache/vllm`)

### DIFF
--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -39,3 +39,10 @@ os.environ['PYTORCH_NVML_BASED_CUDA_CHECK'] = '1'
 os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
 # see https://github.com/vllm-project/vllm/issues/10619
 torch._inductor.config.compile_threads = 1
+
+# Set FlashInfer workspace directory to be inside vLLM's cache directory
+# This ensures FlashInfer kernels are stored alongside other vLLM cache files
+if 'FLASHINFER_WORKSPACE_BASE' not in os.environ:
+    import vllm.envs as envs
+
+    os.environ['FLASHINFER_WORKSPACE_BASE'] = envs.VLLM_CACHE_ROOT


### PR DESCRIPTION
## Purpose 

Idea from @tlrmchlsmth to make it easy for users who already copy `~/.cache/vllm` between devices in order to preserve warm-start artifacts like torch.compile cache and p2p check. This should help preserve flashinfer kernels that are jitted with usage.