### PR TITLE
[CI Bugfix] Fix CI OOM for `test_shared_storage_connector_hashes`

### DIFF
--- a/tests/v1/kv_connector/unit/test_shared_storage_connector.py
+++ b/tests/v1/kv_connector/unit/test_shared_storage_connector.py
@@ -10,7 +10,7 @@ from vllm.assets.image import ImageAsset
 from vllm.config import KVTransferConfig
 from vllm.multimodal.utils import encode_image_base64
 
-MODEL_NAME = "Qwen/Qwen2.5-VL-3B-Instruct"
+MODEL_NAME = "RedHatAI/Qwen2.5-VL-3B-Instruct-quantized.w4a16"
 
 SAMPLING_PARAMS = SamplingParams(temperature=0.0, top_k=1, max_tokens=128)
 

--- a/tests/v1/kv_connector/unit/test_shared_storage_connector.py
+++ b/tests/v1/kv_connector/unit/test_shared_storage_connector.py
@@ -130,6 +130,8 @@ def test_shared_storage_connector_hashes(tmp_path):
         model=MODEL_NAME,
         max_model_len=8192,
         max_num_seqs=1,
+        gpu_memory_utilization=0.4,
+        enforce_eager=True,
         kv_transfer_config=kv_transfer_config,
         limit_mm_per_prompt={"image": 2},
     )


### PR DESCRIPTION
## Purpose

This test has been consistently failing since its addition in https://github.com/vllm-project/vllm/pull/21611
https://buildkite.com/vllm/ci/builds/25475/steps/canvas?sid=01985c5a-a224-435b-ab54-41cb1837705a#01985c5a-a380-4372-bf58-7de2780ad329/7-13621

History https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests/7b01abb7-8064-8f64-9362-7eceb5b9280e?period=7days
<img width="1346" height="719" alt="Screenshot 2025-07-30 at 5 46 55 PM" src="https://github.com/user-attachments/assets/61fc85ca-6148-4898-b159-cdbcc26795bc" />


## Test Plan

Green CI

## Test Result

