### PR TITLE
Qwen FP8 ModelOPT support

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1066,8 +1066,9 @@ class ModelConfig:
             # Set quant_method for ModelOpt models.
             producer_name = quant_cfg.get("producer", {}).get("name")
             if producer_name == "modelopt":
-                quant_algo = quant_cfg.get("quantization",
-                                           {}).get("quant_algo")
+                quant_algo = (quant_cfg.get("quantization",
+                                            {}).get("quant_algo")
+                              or quant_cfg.get("quant_algo"))
                 if quant_algo == "FP8":
                     quant_cfg["quant_method"] = "modelopt"
                 elif quant_algo == "NVFP4":

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -455,6 +455,12 @@ class Qwen3MoeModel(nn.Module):
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:
                     continue
+                if name.endswith("scale"):
+                    remapped_name = maybe_remap_kv_scale_name(
+                        name, params_dict)
+                    if remapped_name is None:
+                        continue
+                    name = remapped_name
                 # We have mlp.experts[0].gate_proj in the checkpoint.
                 # Since we handle the experts below in expert_params_mapping,
                 # we need to skip here BEFORE we update the name, otherwise
@@ -475,8 +481,11 @@ class Qwen3MoeModel(nn.Module):
                 if name.endswith("scale"):
                     # Remapping the name of FP8 kv-scale.
                     name = maybe_remap_kv_scale_name(name, params_dict)
-                    if name is None:
+                    remapped_name = maybe_remap_kv_scale_name(
+                        name, params_dict)
+                    if remapped_name is None:
                         continue
+                    name = remapped_name
                 if name not in params_dict:
                     continue
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Add the QwQ-32B/Qwen2.5/Qwen3/Qwen3-MoE FP8 support from ModelOPT.
The FP8 ckpt can be generated using ModelOPT's example: https://github.com/NVIDIA/TensorRT-Model-Optimizer/tree/main/examples/llm_ptq.

Tested on QwQ-32B/Qwen2.5-14B/Qwen3-1.7B/Qwen3-30B-A3B

## Test Plan

Using this script to test it:

```python
from vllm import LLM, SamplingParams

def main():
    # model_id = "QwQ-32B"
    # model_id = "Qwen2.5-14B"
    # model_id = "Qwen3-1.7B"
    model_id = "Qwen3-30B-A3B"
    sampling_params = SamplingParams(temperature=0.8, top_p=0.9)

    prompts = [
        "Hello, my name is",
        "The president of the United States is",
        "The capital of France is",
        "The future of AI is",
    ]

    llm = LLM(model=model_id, quantization="modelopt")
    outputs = llm.generate(prompts, sampling_params)

    for output in outputs:
        print(f"Prompt: {output.prompt!r}, Generated text: {output.outputs[0].text!r}")

if __name__ == "__main__":
    main()
```

## Test Result

```
Prompt: 'Hello, my name is', Generated text: ' Chris. I need to make a form with a custom submit button. The problem'
Prompt: 'The president of the United States is', Generated text: ' not allowed to be a foreign national. The president must be a natural-born citizen'
Prompt: 'The capital of France is', Generated text: ' Paris. The capital of the United States is Washington, D.C. What is'
Prompt: 'The future of AI is', Generated text: ' about the emergence of super-intelligence, but the problem is that humans are not'
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
