### PR TITLE
[Disagg][Perf] Add env var to allow gpu model work runs in non-default CUDA stream, improving disagg TTIT/TTFT

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -158,6 +158,7 @@ if TYPE_CHECKING:
     VLLM_USE_TRTLLM_ATTENTION: Optional[str] = None
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_BF16: bool = False
+    VLLM_USE_DEFAULT_STREAM: bool = True
 
 
 def get_default_cache_root():
@@ -1120,6 +1121,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #    never removed from memory until the server terminates.
     "VLLM_ENABLE_RESPONSES_API_STORE":
     lambda: bool(int(os.getenv("VLLM_ENABLE_RESPONSES_API_STORE", "0"))),
+
+    # Environment variable to control the use of the default stream.
+    # If set to 1, the default stream is used for model forward. Otherwise,
+    # a separate stream is used for model forward.
+    "VLLM_USE_DEFAULT_STREAM":
+    lambda: bool(int(os.getenv("VLLM_USE_DEFAULT_STREAM", "1"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -164,6 +164,9 @@ class Worker(WorkerBase):
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
             self.device = torch.device(f"cuda:{self.local_rank}")
+            if not envs.VLLM_USE_DEFAULT_STREAM:
+                self.cuda_stream = torch.cuda.Stream(device=self.device)
+                torch.cuda.set_stream(self.cuda_stream)
             current_platform.set_device(self.device)
 
             _check_if_gpu_supports_dtype(self.model_config.dtype)


### PR DESCRIPTION
## Current Issue
Mitigation to avoid blocking copy operations across different CUDA streams. Details could be found in: https://github.com/vllm-project/vllm/issues/22754

## Change
Add a new env var "VLLM_USE_DEFAULT_STREAM" to allow users to specify whether Let GPU model runner runs in its own CUDA stream, other than the default CUDA stream.

## Test for Non Disagg
Bring up vLLM server
```
VLLM_USE_V1=1  vllm serve $llama4 --disable-log-requests -tp 8 --max-num-seqs 64 --no-enable-prefix-caching --max_num_batched_tokens=8000
```

Load test for non-disagg setup and observe no perf difference:

Before
```
Maximum request concurrency: 64
============ Serving Benchmark Result ============
Successful requests:                     5120      
Maximum request concurrency:             64        
Benchmark duration (s):                  395.63    
Total input tokens:                      10232471  
Total generated tokens:                  755215    
Request throughput (req/s):              12.94     
Output token throughput (tok/s):         1908.90   
Total Token throughput (tok/s):          27772.69  
---------------Time to First Token----------------
Mean TTFT (ms):                          201.37    
Median TTFT (ms):                        158.35    
P99 TTFT (ms):                           667.29    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          32.29     
Median TPOT (ms):                        32.60     
P99 TPOT (ms):                           34.40     
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.29     
Median ITL (ms):                         16.29     
P99 ITL (ms):                            152.78    
==================================================
``` 

After
```
Maximum request concurrency: 64
============ Serving Benchmark Result ============
Successful requests:                     5120      
Maximum request concurrency:             64        
Benchmark duration (s):                  399.79    
Total input tokens:                      10232471  
Total generated tokens:                  754340    
Request throughput (req/s):              12.81     
Output token throughput (tok/s):         1886.82   
Total Token throughput (tok/s):          27481.20  
---------------Time to First Token----------------
Mean TTFT (ms):                          206.31    
Median TTFT (ms):                        160.45    
P99 TTFT (ms):                           619.50    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          32.64     
Median TPOT (ms):                        33.01     
P99 TPOT (ms):                           34.96     
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.64     
Median ITL (ms):                         16.46     
P99 ITL (ms):                            154.56    
==================================================
```


## Test for Disagg
Runs with a vendor internal disagg implementation (kv connector interface based), and observe TTIT wins.

Before
```
Ran 1029/1029 requests in 133.00s
Success rate:        100.00%
QPS:                 7.74
Avg latency:         4.841s
Avg TTFT (client):   137.37ms
P50 TTFT (client):   130.12ms
P99 TTFT (client):   364.42ms
Avg TTIT (client):   31.35ms
P50 TTIT (client):   31.12ms
P99 TTIT (client):   38.27ms
Avg TTFT (server):   134.39ms
Avg TTIT (server):   31.29ms
Avg prefill len:     2199.72 tokens
P50 prefill len:     2199.00 tokens
P99 prefill len:     2231.00 tokens
Avg decode len:      150.00 tokens
P50 decode len:      150.00 tokens
P99 decode len:      150.00 tokens
```
After
```
Ran 1026/1026 requests in 132.34s
Success rate:        100.00%
QPS:                 7.75
Avg latency:         4.550s
Avg TTFT (client):   128.50ms
P50 TTFT (client):   125.91ms
P99 TTFT (client):   205.68ms
Avg TTIT (client):   29.47ms
P50 TTIT (client):   29.59ms
P99 TTIT (client):   30.00ms
Avg TTFT (server):   124.88ms
Avg TTIT (server):   28.88ms
Avg prefill len:     2199.10 tokens
P50 prefill len:     2199.00 tokens
P99 prefill len:     2233.00 tokens
Avg decode len:      150.00 tokens
P50 decode len:      150.00 tokens
P99 decode len:      150.00 tokens
```

Also confirmed from GPU trace that there is no blocking behavior between vLLM model forward CUDA stream with other CUDA streams.
<img width="2335" height="881" alt="Screenshot 2025-07-30 at 10 19 28 PM" src="https://github.com/user-attachments/assets/e25ac78a-87bd-44a5-aca7-38dc839b6711" />
<img width="2337" height="1190" alt="Screenshot 2025-07-30 at 10 20 23 PM" src="https://github.com/user-attachments/assets/5b9a61c2-2c4e-4348-88c1-d78fc9f0fca6" />

## Accuracy
gsm8K 8shot (disagg)
```
[2025-07-30 23:06:36,254] [rank 0] [INFO] Per prompt detailed info dumped to /tmp/eval_dump.gsm8k.8_shot.1_gen.20250730_230636.json
[2025-07-30 23:06:36,254] [rank 0] [INFO] Evaluation results on task gsm8k.8_shot.1_gen: em: 0.970000 | f1: 0.970000 | em_maj1@1: 0.970000 | f1_maj1@1: 0.970000
[2025-07-30 23:06:36,254] [rank 0] [INFO] Task gsm8k.8_shot.1_gen took 54.20 seconds
```

mmlu_pro (non-disagg)
```
vllm (pretrained=/data/users/zijingliu/cp/Llama-4-Maverick-17B-128E-Instruct-FP8,dtype=auto,max_model_len=8196,tensor_parallel_size=8,gpu_memory_utilization=0.9,max_gen_toks=2048,seed=0), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|      |exact_match|↑  |0.7976|±  |0.0036|
| - biology         |    2.1|custom-extract|     5|exact_match|↑  |0.8982|±  |0.0113|
| - business        |    2.1|custom-extract|     5|exact_match|↑  |0.8276|±  |0.0135|
| - chemistry       |    2.1|custom-extract|     5|exact_match|↑  |0.8445|±  |0.0108|
| - computer_science|    2.1|custom-extract|     5|exact_match|↑  |0.8220|±  |0.0189|
| - economics       |    2.1|custom-extract|     5|exact_match|↑  |0.8578|±  |0.0120|
| - engineering     |    2.1|custom-extract|     5|exact_match|↑  |0.7131|±  |0.0145|
| - health          |    2.1|custom-extract|     5|exact_match|↑  |0.7763|±  |0.0146|
| - history         |    2.1|custom-extract|     5|exact_match|↑  |0.6929|±  |0.0237|
| - law             |    2.1|custom-extract|     5|exact_match|↑  |0.5967|±  |0.0148|
| - math            |    2.1|custom-extract|     5|exact_match|↑  |0.8949|±  |0.0083|
| - other           |    2.1|custom-extract|     5|exact_match|↑  |0.7662|±  |0.0139|
| - philosophy      |    2.1|custom-extract|     5|exact_match|↑  |0.7355|±  |0.0198|
| - physics         |    2.1|custom-extract|     5|exact_match|↑  |0.8514|±  |0.0099|
| - psychology      |    2.1|custom-extract|     5|exact_match|↑  |0.8095|±  |0.0139|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|------|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.7976|±  |0.0036|
```



cc @KuntaiDu @simon-mo @WoosukKwon @houseroad @KingsleyZhang123

