### PR TITLE
[Misc] Support routing logic simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,5 +203,3 @@ shellcheck*/
 
 # Ignore moe/marlin_moe gen code
 csrc/moe/marlin_moe_wna16/kernel_*
-
-nixl_installer/

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,5 @@ shellcheck*/
 
 # Ignore moe/marlin_moe gen code
 csrc/moe/marlin_moe_wna16/kernel_*
+
+nixl_installer/

--- a/tests/test_routing_simulator.py
+++ b/tests/test_routing_simulator.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Test script for the token-to-expert routing simulator.
+
+This script demonstrates how to use the routing simulator to test
+different routing strategies and analyze their performance, including
+integration tests with FusedMoE layer.
+"""
+
+import os
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.routing_simulator import (
+    RoutingSimulator)
+
+
+@pytest.fixture
+def device():
+    """Fixture to provide the appropriate device for testing."""
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@pytest.fixture
+def test_data(device):
+    """Fixture to provide common test data."""
+    num_tokens = 100
+    hidden_size = 64
+    num_experts = 4
+    top_k = 2
+
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device)
+    router_logits = torch.randn(num_tokens, num_experts, device=device)
+
+    return {
+        "num_tokens": num_tokens,
+        "hidden_size": hidden_size,
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "hidden_states": hidden_states,
+        "router_logits": router_logits,
+    }
+
+
+def test_basic_functionality(test_data):
+    """Test basic functionality of the routing simulator."""
+    # Test each routing strategy
+    strategies = ["uniform_random", "softmax", "weighted_random"]
+
+    for strategy in strategies:
+        # Simulate routing
+        topk_weights, topk_ids = RoutingSimulator.simulate_routing(
+            hidden_states=test_data["hidden_states"],
+            router_logits=test_data["router_logits"],
+            strategy_name=strategy,
+            top_k=test_data["top_k"],
+        )
+
+        # Check output shapes
+        assert topk_weights.shape == (
+            test_data["num_tokens"],
+            test_data["top_k"],
+        ), f"Wrong weights shape for {strategy}"
+        assert topk_ids.shape == (
+            test_data["num_tokens"],
+            test_data["top_k"],
+        ), f"Wrong ids shape for {strategy}"
+
+        # Check that expert IDs are valid
+        assert (topk_ids.min()
+                >= 0), f"Invalid expert ID (negative) for {strategy}"
+        assert (topk_ids.max() < test_data["num_experts"]
+                ), f"Invalid expert ID (too large) for {strategy}"
+
+
+def test_routing_strategy_integration(device):
+    """Test that the routing strategy environment variable works with
+    FusedMoE."""
+    pytest.importorskip("vllm.model_executor.layers.fused_moe.layer")
+
+    import vllm.envs as envs
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+    # Test parameters
+    num_tokens = 32
+    hidden_size = 16
+    num_experts = 4
+    top_k = 2
+
+    # Create test data
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device)
+    router_logits = torch.randn(num_tokens, num_experts, device=device)
+
+    # Test different routing strategies
+    strategies = ["softmax", "uniform_random", "weighted_random"]
+    original_env_value = os.environ.get("VLLM_MOE_ROUTING_STRATEGY", "softmax")
+
+    try:
+        for strategy in strategies:
+            # Set environment variable
+            os.environ["VLLM_MOE_ROUTING_STRATEGY"] = strategy
+
+            # Force reload of environment variable
+            envs.environment_variables[
+                "VLLM_MOE_ROUTING_STRATEGY"] = lambda s=strategy: s
+
+            # Test the select_experts method
+            topk_weights, topk_ids = FusedMoE.select_experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                top_k=top_k,
+                use_grouped_topk=False,
+                renormalize=True,
+                indices_type=torch.long)
+
+            # Verify output shapes
+            assert topk_weights.shape == (
+                num_tokens, top_k), f"Wrong weights shape for {strategy}"
+            assert topk_ids.shape == (num_tokens,
+                                      top_k), f"Wrong ids shape for {strategy}"
+
+            # Verify expert IDs are valid
+            assert topk_ids.min(
+            ) >= 0, f"Invalid expert ID (negative) for {strategy}"
+            assert topk_ids.max(
+            ) < num_experts, f"Invalid expert ID (too large) for {strategy}"
+
+    finally:
+        # Reset environment variable
+        os.environ["VLLM_MOE_ROUTING_STRATEGY"] = original_env_value
+
+
+def test_direct_routing_simulator_methods(device):
+    """Test the new routing methods directly."""
+    pytest.importorskip("vllm.model_executor.layers.fused_moe.layer")
+
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+    # Test parameters
+    num_tokens = 24
+    hidden_size = 12
+    num_experts = 4
+    top_k = 2
+
+    # Create test data
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device)
+    router_logits = torch.randn(num_tokens, num_experts, device=device)
+
+    # Test the new select_experts_with_simulated_strategy method
+    strategies = ["softmax", "uniform_random", "weighted_random"]
+
+    for strategy in strategies:
+        topk_weights, topk_ids = \
+            FusedMoE.select_experts_with_simulated_strategy(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                top_k=top_k,
+                strategy=strategy,
+                indices_type=torch.long)
+
+        # Verify output shapes
+        assert topk_weights.shape == (
+            num_tokens, top_k), f"Wrong weights shape for {strategy}"
+        assert topk_ids.shape == (num_tokens,
+                                  top_k), f"Wrong ids shape for {strategy}"
+
+
+def test_static_methods():
+    """Test that static methods work without instantiation."""
+    # Test that we can register strategies without creating an instance
+    from vllm.model_executor.layers.fused_moe.routing_simulator import (
+        SoftmaxRouting)
+
+    # Register a custom strategy
+    custom_strategy = SoftmaxRouting(renormalize=False)
+    RoutingSimulator.register_strategy("custom_softmax", custom_strategy)
+
+    # Verify it was registered
+    available_strategies = RoutingSimulator.get_available_strategies()
+    assert "custom_softmax" in available_strategies
+
+    # Test that we can use the static simulate_routing method
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    hidden_states = torch.randn(10, 8, device=device)
+    router_logits = torch.randn(10, 4, device=device)
+
+    topk_weights, topk_ids = RoutingSimulator.simulate_routing(
+        hidden_states=hidden_states,
+        router_logits=router_logits,
+        strategy_name="custom_softmax",
+        top_k=2)
+
+    assert topk_weights.shape == (10, 2)
+    assert topk_ids.shape == (10, 2)
+
+
+def test_instance_compatibility():
+    """Test that static methods work correctly."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Test static method directly
+    hidden_states = torch.randn(10, 8, device=device)
+    router_logits = torch.randn(10, 4, device=device)
+
+    topk_weights, topk_ids = RoutingSimulator.simulate_routing(
+        hidden_states=hidden_states,
+        router_logits=router_logits,
+        strategy_name="softmax",
+        top_k=2)
+
+    assert topk_weights.shape == (10, 2)
+    assert topk_ids.shape == (10, 2)

--- a/tests/test_routing_simulator.py
+++ b/tests/test_routing_simulator.py
@@ -89,11 +89,11 @@ def test_routing_strategy_integration(monkeypatch, device):
 
     for strategy in strategies:
         # Set environment variable
-        monkeypatch.setenv("VLLM_MOE_ROUTING_STRATEGY", strategy)
+        env_name = "VLLM_MOE_ROUTING_SIMULATION_STRATEGY"
+        monkeypatch.setenv(env_name, strategy)
 
         # Force reload of environment variable
-        envs.environment_variables[
-            "VLLM_MOE_ROUTING_STRATEGY"] = lambda s=strategy: s
+        envs.environment_variables[env_name] = lambda s=strategy: s
 
         # Test the select_experts method
         topk_weights, topk_ids = FusedMoE.select_experts(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -964,9 +964,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE":
     lambda: int(os.getenv("VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE", "163840")),
 
-    # MoE routing strategy selector. Available strategies:
-    # - "uniform_random": Uniform random routing for perfect load balancing
-    # - "weighted_random": Weighted random routing with temperature scaling
+    # MoE routing strategy selector.
+    # See `RoutingSimulator.get_available_strategies()` # for available
+    # strategies.
+    # Cutstom routing strategies can be registered by
+    # RoutingSimulator.register_strategy()
     # Note: custom strategies may not produce correct model outputs
     "VLLM_MOE_ROUTING_STRATEGY":
     lambda: os.environ.get("VLLM_MOE_ROUTING_STRATEGY", "").lower(),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -970,8 +970,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Cutstom routing strategies can be registered by
     # RoutingSimulator.register_strategy()
     # Note: custom strategies may not produce correct model outputs
-    "VLLM_MOE_ROUTING_STRATEGY":
-    lambda: os.environ.get("VLLM_MOE_ROUTING_STRATEGY", "").lower(),
+    "VLLM_MOE_ROUTING_SIMULATION_STRATEGY":
+    lambda: os.environ.get("VLLM_MOE_ROUTING_SIMULATION_STRATEGY", "").lower(),
 
     # Regex timeout for use by the vLLM tool parsing plugins.
     "VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS":

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -964,6 +964,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE":
     lambda: int(os.getenv("VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE", "163840")),
 
+    # MoE routing strategy selector. Available strategies:
+    # - "softmax": Standard softmax-based routing
+    # - "uniform_random": Uniform random routing for perfect load balancing
+    # - "weighted_random": Weighted random routing with temperature scaling
+    # Note: custom strategies may not produce correct model outputs
+    "VLLM_MOE_ROUTING_STRATEGY":
+    lambda: os.environ.get("VLLM_MOE_ROUTING_STRATEGY", "").lower(),
+
     # Regex timeout for use by the vLLM tool parsing plugins.
     "VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS":
     lambda: int(os.getenv("VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS", "1")),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -965,7 +965,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: int(os.getenv("VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE", "163840")),
 
     # MoE routing strategy selector. Available strategies:
-    # - "softmax": Standard softmax-based routing
     # - "uniform_random": Uniform random routing for perfect load balancing
     # - "weighted_random": Weighted random routing with temperature scaling
     # Note: custom strategies may not produce correct model outputs

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1278,7 +1278,7 @@ class FusedMoE(torch.nn.Module):
         from vllm.model_executor.layers.fused_moe.fused_moe import fused_topk
 
         # Check if we should use a routing simulation strategy
-        routing_strategy = envs.VLLM_MOE_ROUTING_STRATEGY
+        routing_strategy = envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY
         if routing_strategy != "":
             return RoutingSimulator.simulate_routing(
                 hidden_states=hidden_states,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1249,7 +1249,7 @@ class FusedMoE(torch.nn.Module):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         top_k: int,
-        strategy: str = "softmax",
+        strategy: str,
         indices_type: Optional[torch.dtype] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1245,33 +1245,6 @@ class FusedMoE(torch.nn.Module):
         self.logical_replica_count = logical_replica_count[moe_layer_idx]
 
     @staticmethod
-    def select_experts_with_simulated_strategy(
-        hidden_states: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        strategy: str,
-        indices_type: Optional[torch.dtype] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Select experts using the specified routing strategy.
-
-        Args:
-            hidden_states: Input hidden states [num_tokens, hidden_size]
-            router_logits: Router logits [num_tokens, num_experts]
-            top_k: Number of experts to select per token
-            strategy: Routing strategy name
-            indices_type: Data type for expert indices
-
-        Returns:
-            Tuple of (topk_weights, topk_ids)
-        """
-        return RoutingSimulator.simulate_routing(hidden_states=hidden_states,
-                                                 router_logits=router_logits,
-                                                 strategy_name=strategy,
-                                                 top_k=top_k,
-                                                 indices_type=indices_type)
-
-    @staticmethod
     def select_experts(
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
@@ -1307,11 +1280,11 @@ class FusedMoE(torch.nn.Module):
         # Check if we should use a routing simulation strategy
         routing_strategy = envs.VLLM_MOE_ROUTING_STRATEGY
         if routing_strategy != "":
-            return FusedMoE.select_experts_with_simulated_strategy(
+            return RoutingSimulator.simulate_routing(
                 hidden_states=hidden_states,
                 router_logits=router_logits,
+                strategy_name=routing_strategy,
                 top_k=top_k,
-                strategy=routing_strategy,
                 indices_type=indices_type)
 
         # DeepSeekv2 uses grouped_top_k

--- a/vllm/model_executor/layers/fused_moe/routing_simulator.py
+++ b/vllm/model_executor/layers/fused_moe/routing_simulator.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Token-to-Expert Routing Simulator
+
+This module provides a framework for simulating and testing different
+token-to-expert routing strategies for Mixture of Experts (MoE) models.
+It supports routing logic customization and includes example implementations
+like uniform random routing.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+
+class RoutingStrategy(ABC):
+    """Base class for token-to-expert routing strategies."""
+
+    @abstractmethod
+    def route_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        indices_type: Optional[torch.dtype] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Route tokens to experts.
+
+        Args:
+            hidden_states: Input hidden states [num_tokens, hidden_size]
+            router_logits: Router logits [num_tokens, num_experts]
+            top_k: Number of experts to select per token
+            indices_type: Data type for expert indices
+
+        Returns:
+            tuple of (topk_weights, topk_ids)
+        """
+        pass
+
+
+class UniformRandomRouting(RoutingStrategy):
+    """
+    Uniform random routing strategy for perfect load balancing in expectation.
+
+    This routing strategy randomly selects experts for each token, providing
+    perfect load balancing in expectation. It's useful for performance analysis
+    when using dummy weights, but will not produce correct model outputs.
+    """
+
+    def route_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        indices_type: Optional[torch.dtype] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Randomly select experts for each token.
+
+        Args:
+            hidden_states: Input hidden states [num_tokens, hidden_size]
+            router_logits: Router logits [num_tokens, num_experts]
+            top_k: Number of experts to select per token
+            indices_type: Data type for expert indices
+
+        Returns:
+            tuple of (topk_weights, topk_ids) where:
+            - topk_weights: All-ones weights [num_tokens, top_k]
+            - topk_ids: Random expert indices [num_tokens, top_k]
+        """
+        num_tokens = hidden_states.shape[0]
+        global_num_experts = router_logits.shape[-1]
+
+        if indices_type is None:
+            indices_type = torch.long
+
+        # Random expert IDs, uniform in [0, global_num_experts)
+        topk_ids = torch.randint(
+            low=0,
+            high=global_num_experts,
+            size=(num_tokens, top_k),
+            dtype=indices_type,
+            device=hidden_states.device,
+        )
+
+        # All-ones weights
+        topk_weights = torch.ones(
+            (num_tokens, top_k),
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+
+        return topk_weights, topk_ids
+
+
+class SoftmaxRouting(RoutingStrategy):
+    """
+    Standard softmax-based routing strategy.
+
+    This is the default routing strategy that uses softmax on router logits
+    to select the top-k experts for each token.
+    """
+
+    def __init__(self, renormalize: bool = True):
+        """
+        Initialize softmax routing.
+
+        Args:
+            renormalize: Whether to renormalize the selected expert weights
+        """
+        self.renormalize = renormalize
+
+    def route_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        indices_type: Optional[torch.dtype] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Select top-k experts using softmax routing.
+
+        Args:
+            hidden_states: Input hidden states [num_tokens, hidden_size]
+            router_logits: Router logits [num_tokens, num_experts]
+            top_k: Number of experts to select per token
+            indices_type: Data type for expert indices
+
+        Returns:
+            tuple of (topk_weights, topk_ids)
+        """
+        # Apply softmax to get probabilities
+        routing_weights = F.softmax(router_logits, dim=-1)
+
+        # Select top-k experts
+        topk_weights, topk_ids = torch.topk(routing_weights, top_k, dim=-1)
+
+        # Renormalize weights if requested
+        if self.renormalize:
+            topk_weights = topk_weights / topk_weights.sum(dim=-1,
+                                                           keepdim=True)
+
+        # Convert indices to requested type
+        if indices_type is not None:
+            topk_ids = topk_ids.to(dtype=indices_type)
+
+        return topk_weights, topk_ids
+
+
+class WeightedRandomRouting(RoutingStrategy):
+    """
+    Weighted random routing strategy.
+
+    This strategy samples experts randomly based on the router logits
+    probabilities, providing a stochastic routing approach that still respects
+    the learned routing preferences while introducing randomness for load
+    balancing.
+    """
+
+    def __init__(self, temperature: float = 1.0):
+        """
+        Initialize weighted random routing.
+
+        Args:
+            temperature: Temperature for softmax sampling (lower = more
+            deterministic)
+        """
+        self.temperature = temperature
+
+    def route_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        indices_type: Optional[torch.dtype] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Sample top-k experts using weighted random selection.
+
+        Args:
+            hidden_states: Input hidden states [num_tokens, hidden_size]
+            router_logits: Router logits [num_tokens, num_experts]
+            top_k: Number of experts to select per token
+            indices_type: Data type for expert indices
+
+        Returns:
+            tuple of (topk_weights, topk_ids)
+        """
+        num_tokens, num_experts = router_logits.shape
+
+        # Apply temperature scaling and softmax
+        scaled_logits = router_logits / self.temperature
+        routing_probs = F.softmax(scaled_logits, dim=-1)
+
+        # Sample experts without replacement
+        topk_ids = torch.multinomial(routing_probs, top_k, replacement=False)
+
+        # Get corresponding weights
+        topk_weights = routing_probs.gather(dim=-1, index=topk_ids)
+
+        # Renormalize weights
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+        # Convert indices to requested type
+        if indices_type is not None:
+            topk_ids = topk_ids.to(dtype=indices_type)
+
+        return topk_weights, topk_ids
+
+
+class RoutingSimulator:
+    """
+    Token-to-Expert Routing Simulator.
+
+    This class provides a framework for testing and comparing different
+    routing strategies for MoE models. It can simulate routing behavior
+    and collect statistics for analysis.
+    """
+
+    # Class-level registry of routing strategies
+    _routing_strategies = {
+        "uniform_random": UniformRandomRouting(),
+        "softmax": SoftmaxRouting(),
+        "weighted_random": WeightedRandomRouting(),
+    }
+
+    @classmethod
+    def register_strategy(cls, name: str, strategy: RoutingStrategy):
+        """
+        Register a custom routing strategy.
+
+        Args:
+            name: Name of the strategy
+            strategy: RoutingStrategy instance
+        """
+        cls._routing_strategies[name] = strategy
+
+    @classmethod
+    def get_available_strategies(cls):
+        """
+        Get list of available routing strategy names.
+
+        Returns:
+            List of available strategy names
+        """
+        return list(cls._routing_strategies.keys())
+
+    @staticmethod
+    def simulate_routing(
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        strategy_name: str,
+        top_k: int,
+        indices_type: Optional[torch.dtype] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Simulate token-to-expert routing using the specified strategy.
+
+        Args:
+            hidden_states: Input hidden states [num_tokens, hidden_size]
+            router_logits: Router logits [num_tokens, num_experts]
+            strategy_name: Name of the routing strategy to use
+            top_k: Number of experts to select per token
+            indices_type: Data type for expert indices
+
+        Returns:
+            tuple of (topk_weights, topk_ids)
+        """
+        if strategy_name not in RoutingSimulator._routing_strategies:
+            raise ValueError(
+                f"Unknown routing strategy: {strategy_name}. "
+                f"Available strategies: "
+                f"{list(RoutingSimulator._routing_strategies.keys())}")
+
+        strategy = RoutingSimulator._routing_strategies[strategy_name]
+        return strategy.route_tokens(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            top_k=top_k,
+            indices_type=indices_type,
+        )

--- a/vllm/model_executor/layers/fused_moe/routing_simulator.py
+++ b/vllm/model_executor/layers/fused_moe/routing_simulator.py
@@ -13,7 +13,6 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 import torch
-import torch.nn.functional as F
 
 
 class RoutingStrategy(ABC):
@@ -42,14 +41,46 @@ class RoutingStrategy(ABC):
         pass
 
 
-class UniformRandomRouting(RoutingStrategy):
+class DistributionBasedRouting(RoutingStrategy):
     """
-    Uniform random routing strategy for perfect load balancing in expectation.
+    Distribution-based random routing strategy with configurable distributions.
 
-    This routing strategy randomly selects experts for each token, providing
-    perfect load balancing in expectation. It's useful for performance analysis
-    when using dummy weights, but will not produce correct model outputs.
+    This routing strategy randomly selects experts for each token based on
+    different probability distributions. Currently supports uniform and normal
+    distributions for testing different routing patterns.
     """
+
+    def __init__(self, distribution: str = "uniform", **distribution_params):
+        """
+        Initialize distribution-based routing.
+
+        Args:
+            distribution: Type of distribution to use for sampling
+                - "uniform": Uniform distribution (default)
+                - "normal": Normal/Gaussian distribution
+            **distribution_params: Parameters specific to the
+                chosen distribution
+                For "uniform": No additional parameters needed
+                For "normal": mean (default: 0.0), std (default: 1.0)
+        """
+        self.distribution = distribution.lower()
+        self.distribution_params = distribution_params
+
+        # Validate distribution and parameters
+        self._validate_distribution_params()
+
+    def _validate_distribution_params(self):
+        """Validate distribution type and parameters."""
+        valid_distributions = ["uniform", "normal"]
+
+        if self.distribution not in valid_distributions:
+            raise ValueError(f"Unsupported distribution: {self.distribution}. "
+                             f"Supported distributions: {valid_distributions}")
+
+        # Set default parameters if not provided
+        if self.distribution == "normal":
+            self.distribution_params.setdefault("mean", 0.0)
+            self.distribution_params.setdefault("std", 1.0)
 
     def route_tokens(
         self,
@@ -59,7 +90,7 @@ class UniformRandomRouting(RoutingStrategy):
         indices_type: Optional[torch.dtype] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
-        Randomly select experts for each token.
+        Randomly select experts for each token using the specified distribution.
 
         Args:
             hidden_states: Input hidden states [num_tokens, hidden_size]
@@ -69,97 +100,118 @@ class UniformRandomRouting(RoutingStrategy):
 
         Returns:
             tuple of (topk_weights, topk_ids) where:
-            - topk_weights: All-ones weights [num_tokens, top_k]
-            - topk_ids: Random expert indices [num_tokens, top_k]
+            - topk_weights: Weights based on distribution sampling
+            - topk_ids: Expert indices sampled from the distribution
         """
         num_tokens = hidden_states.shape[0]
-        global_num_experts = router_logits.shape[-1]
+        num_experts = router_logits.shape[-1]
 
         if indices_type is None:
             indices_type = torch.long
 
-        # Random expert IDs, uniform in [0, global_num_experts)
-        topk_ids = torch.randint(
-            low=0,
-            high=global_num_experts,
-            size=(num_tokens, top_k),
-            dtype=indices_type,
-            device=hidden_states.device,
-        )
+        # Generate expert IDs based on the specified distribution
+        topk_ids = self._sample_expert_ids(num_tokens, num_experts, top_k,
+                                           hidden_states.device, indices_type)
 
-        # All-ones weights
-        topk_weights = torch.ones(
-            (num_tokens, top_k),
-            dtype=torch.float32,
-            device=hidden_states.device,
-        )
+        # Generate weights based on the distribution
+        topk_weights = self._generate_weights(num_tokens, top_k,
+                                              hidden_states.device)
 
         return topk_weights, topk_ids
 
-
-class WeightedRandomRouting(RoutingStrategy):
-    """
-    Weighted random routing strategy.
-
-    This strategy samples experts randomly based on the router logits
-    probabilities, providing a stochastic routing approach that still respects
-    the learned routing preferences while introducing randomness for load
-    balancing.
-    """
-
-    def __init__(self, temperature: float = 1.0):
-        """
-        Initialize weighted random routing.
-
-        Args:
-            temperature: Temperature for softmax sampling (lower = more
-            deterministic)
-            * Controls the "sharpness" of the probability distribution
-            * `temperature = 1.0`: Normal softmax probabilities
-            * `temperature < 1.0`: More deterministic (sharper distribution)
-            * `temperature > 1.0`: More random (flatter distribution)
-        """
-        self.temperature = temperature
-
-    def route_tokens(
+    def _sample_expert_ids(
         self,
-        hidden_states: torch.Tensor,
-        router_logits: torch.Tensor,
+        num_tokens: int,
+        num_experts: int,
         top_k: int,
-        indices_type: Optional[torch.dtype] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Sample top-k experts using weighted random selection.
+        device: torch.device,
+        indices_type: torch.dtype,
+    ) -> torch.Tensor:
+        """Sample expert IDs based on the specified distribution."""
 
-        Args:
-            hidden_states: Input hidden states [num_tokens, hidden_size]
-            router_logits: Router logits [num_tokens, num_experts]
-            top_k: Number of experts to select per token
-            indices_type: Data type for expert indices
+        if self.distribution == "uniform":
+            # Uniform random sampling
+            return torch.randint(
+                low=0,
+                high=num_experts,
+                size=(num_tokens, top_k),
+                dtype=indices_type,
+                device=device,
+            )
 
-        Returns:
-            tuple of (topk_weights, topk_ids)
-        """
-        num_tokens, num_experts = router_logits.shape
+        elif self.distribution == "normal":
+            # For normal distribution, sample continuous values and map to
+            # expert IDs
+            continuous_samples = self._sample_continuous_distribution(
+                num_tokens, top_k, device)
 
-        # Apply temperature scaling and softmax
-        scaled_logits = router_logits / self.temperature
-        routing_probs = F.softmax(scaled_logits, dim=-1)
+            # Map continuous samples to expert indices
+            # Normalize to [0, 1] range and scale to [0, num_experts)
+            normalized_samples = self._normalize_samples(continuous_samples)
+            expert_ids = (normalized_samples * num_experts).long()
+            expert_ids = torch.clamp(expert_ids, 0, num_experts - 1)
 
-        # Sample experts without replacement
-        topk_ids = torch.multinomial(routing_probs, top_k, replacement=False)
+            return expert_ids.to(dtype=indices_type)
 
-        # Get corresponding weights
-        topk_weights = routing_probs.gather(dim=-1, index=topk_ids)
+        else:
+            raise ValueError(f"Unsupported distribution: {self.distribution}")
 
-        # Renormalize weights
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    def _sample_continuous_distribution(self, num_tokens: int, top_k: int,
+                                        device: torch.device) -> torch.Tensor:
+        """Sample from continuous distributions."""
+        shape = (num_tokens, top_k)
 
-        # Convert indices to requested type
-        if indices_type is not None:
-            topk_ids = topk_ids.to(dtype=indices_type)
+        if self.distribution == "normal":
+            mean = self.distribution_params["mean"]
+            std = self.distribution_params["std"]
+            return torch.normal(mean, std, size=shape, device=device)
 
-        return topk_weights, topk_ids
+        else:
+            raise ValueError(
+                f"Unsupported continuous distribution: {self.distribution}")
+
+    def _normalize_samples(self, samples: torch.Tensor) -> torch.Tensor:
+        """Normalize samples to [0, 1] range."""
+        if self.distribution == "normal":
+            # Use sigmoid to map normal distribution to [0, 1]
+            return torch.sigmoid(samples)
+
+        else:
+            raise ValueError(f"Unsupported distribution for normalization: "
+                             f"{self.distribution}")
+
+    def _generate_weights(self, num_tokens: int, top_k: int,
+                          device: torch.device) -> torch.Tensor:
+        """Generate weights based on the distribution."""
+        if self.distribution == "uniform":
+            # All-ones weights for uniform distribution
+            return torch.ones(
+                (num_tokens, top_k),
+                dtype=torch.float32,
+                device=device,
+            )
+
+        elif self.distribution == "normal":
+            # For normal distribution, generate weights from the same
+            # distribution
+            continuous_weights = self._sample_continuous_distribution(
+                num_tokens, top_k, device)
+            # Normalize to positive values and sum to 1
+            weights = torch.abs(continuous_weights)
+            weights = weights / weights.sum(dim=-1, keepdim=True)
+            return weights
+
+        else:
+            raise ValueError(
+                f"Unsupported distribution for weight generation: "
+                f"{self.distribution}")
+
+    def get_distribution_info(self) -> dict:
+        """Get information about the current distribution configuration."""
+        return {
+            "distribution": self.distribution,
+            "parameters": self.distribution_params.copy()
+        }
 
 
 class RoutingSimulator:
@@ -172,9 +224,12 @@ class RoutingSimulator:
     """
 
     # Class-level registry of routing strategies
-    _routing_strategies = {
-        "uniform_random": UniformRandomRouting(),
-        "weighted_random": WeightedRandomRouting(),
+    _routing_strategies: dict[str, RoutingStrategy] = {
+        # Basic routing strategies
+        "uniform_random":
+        DistributionBasedRouting(distribution="uniform", mean=0.0, std=1.0),
+        "normal_routing":
+        DistributionBasedRouting(distribution="normal", mean=0.0, std=1.0),
     }
 
     @classmethod


### PR DESCRIPTION
## Purpose

This is to support token-to-expert routing logic customization. We need this to work around imbalanced token-to-expert selection and support balanced selection for benchmark purpose.

Customization can be implemented by extending RoutingStrategy and implement route_tokens, being registered with RoutingSimulator, and selected by VLLM_MOE_ROUTING_STRATEGY envvar.

Thanks @tlrmchlsmth for initial implementation and handover!

Next PR:
* Add metrics to confirm effectiveness of customized routing
* Potentially extend RoutingSimulator into a general Router class and modularize FusedMoE.select_experts implementation.

## Test Plan

pytest tests/test_routing_simulator.py

## Test Result

passed

## (Optional) Documentation Update

