### PR TITLE
Enable `Union` types to be parsed when processing CLI args

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -17,6 +17,21 @@ from vllm.engine.arg_utils import (EngineArgs, contains_type, get_kwargs,
 from vllm.utils import FlexibleArgumentParser
 
 
+class TestClass:
+    """Dummy class for testing Union type parsing"""
+
+    def __init__(self, int_as_str: str):
+        """Consume a string, must be possible to cast to int"""
+        # Cast and store int
+        self.arg = int(int_as_str)
+
+    def __eq__(self, other):
+        """Compare class instances based on stored int values"""
+        if not isinstance(other, TestClass):
+            return NotImplemented
+        return self.arg == other.arg
+
+
 @pytest.mark.parametrize(("type", "value", "expected"), [
     (int, "42", 42),
     (float, "3.14", 3.14),
@@ -28,6 +43,8 @@ from vllm.utils import FlexibleArgumentParser
     (Union[int, str], "42", 42),
     (Union[int, str], "apple", "apple"),
     (Union[int, str], 42, 42),
+    (Union[TestClass, str], "apple", "apple"),
+    (Union[TestClass, str], "42", TestClass("42")),
 ])
 def test_parse_type(type, value, expected):
     parse_type_func = parse_type(type)

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -25,22 +25,13 @@ from vllm.utils import FlexibleArgumentParser
         "foo": 1,
         "bar": 2
     }),
+    (Union[int, str], "42", 42),
+    (Union[int, str], "apple", "apple"),
+    (Union[int, str], 42, 42),
 ])
 def test_parse_type(type, value, expected):
     parse_type_func = parse_type(type)
     assert parse_type_func(value) == expected
-
-
-@pytest.mark.parametrize(("type", "value", "expected"), [
-    (Union[int, str], "42", (42, "42")),
-])
-def test_parse_union_type(type, value, expected):
-    """Parse a `Union` type yielding an instance of either type option
-    (int or str)
-    """
-    parse_type_func = parse_type(type)
-    out = parse_type_func(value)
-    assert out in expected
 
 
 def test_optional_type():

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -17,13 +17,6 @@ from vllm.engine.arg_utils import (EngineArgs, contains_type, get_kwargs,
 from vllm.utils import FlexibleArgumentParser
 
 
-class TestClass:
-    """Dummy class for testing Union type parsing"""
-
-    def __init__(self, val: str):
-        self.val = val
-
-
 @pytest.mark.parametrize(("type", "value", "expected"), [
     (int, "42", 42),
     (float, "3.14", 3.14),
@@ -32,7 +25,6 @@ class TestClass:
         "foo": 1,
         "bar": 2
     }),
-    (Union[int, str], "42", "42"),
 ])
 def test_parse_type(type, value, expected):
     parse_type_func = parse_type(type)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -72,7 +72,7 @@ def parse_type(return_type: Callable[[str], T]) -> Callable[[str], T]:
                 try:
                     # Instantiate first type option compatible with the string
                     return tp(val)
-                except ValueError:
+                except Exception:
                     pass
 
             # Union type is incompatible with string

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -72,7 +72,7 @@ def parse_type(return_type: Callable[[str], T]) -> Callable[[str], T]:
                 try:
                     # Instantiate first type option compatible with the string
                     return tp(val)
-                except Exception:
+                except ValueError:
                     pass
 
             # Union type is incompatible with string

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -66,11 +66,28 @@ TypeHintT = Union[type[T], object]
 def parse_type(return_type: Callable[[str], T]) -> Callable[[str], T]:
 
     def _parse_type(val: str) -> T:
-        try:
-            return return_type(val)
-        except ValueError as e:
+        if getattr(return_type, '__origin__', None) is Union:
+            # Instantiate Union type from string
+            for tp in get_args(return_type):
+                try:
+                    # Instantiate first type option compatible with the string
+                    return tp(val)
+                except ValueError:
+                    pass
+
+            # Union type is incompatible with string
             raise argparse.ArgumentTypeError(
-                f"Value {val} cannot be converted to {return_type}.") from e
+                f"Value {val} cannot be converted to {return_type}.")
+        else:
+            # Not a Union type
+            try:
+                # Instantiate type from string
+                return return_type(val)
+            except ValueError as e:
+                # Type is incompatible with string
+                raise argparse.ArgumentTypeError(
+                    f"Value {val} cannot be converted to {return_type}."
+                ) from e
 
     return _parse_type
 


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x] The test plan, such as providing test command.
- [ x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

In `vllm/engine/arg_utils.py` the `parse_type(return_type: Callable[[str], T])` function should be able to parse a `Union` type, but cannot. When `return_type` is a `Union` type, the ideal behavior of `return_type(val)` would be to find the union type option compatible with `val` and instantiate that type, passing `val` as a constructor argument. This PR makes that possible.

## Test Plan

Adding `Union` test cases to `tests/engine/test_arg_utils.py`

## Test Result

Success

FIXES #22009

