### PR TITLE
[BUGFIX] KeyError 'layers.14.mlp.gate.g_idx' for Qwen3-MoE with GPTQ on ROCm

### DIFF
--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -122,7 +122,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         self.gate = ReplicatedLinear(config.hidden_size,
                                      config.num_experts,
                                      bias=False,
-                                     quant_config=None,
+                                     quant_config=quant_config,
                                      prefix=f"{prefix}.gate")
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Description:
This PR fixes a KeyError for 'layers.14.mlp.gate.g_idx' that was popping up when loading GPTQ-quantized Qwen3-MoE models, particularly in ROCm setups.

The problem surfaced during the weight loading of the Mixture-of-Experts (MoE) gate layer, deep inside Qwen3MoeSparseMoeBlock. Essentially, the model was looking for a g_idx parameter – a key piece of metadata for GPTQ-quantized weights – but couldn't find it.