### PR TITLE
Migrate Llama4ImagePatchInputs to TensorSchema

### DIFF
--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -84,8 +84,7 @@ class Llama4ImagePatchInputs(TensorSchema):
     flattened just like `flat_data`.
     """
 
-    aspect_ratios: Annotated[Union[torch.Tensor, list[torch.Tensor]],
-                             TensorShape("batch_size", 2)]
+    aspect_ratios: Annotated[torch.Tensor, TensorShape("batch_size", 2)]
     """
     A list of aspect ratios corresponding to the number of tiles
     in each dimension that each image in the batch corresponds to.
@@ -631,7 +630,7 @@ class Mllama4MultiModalProcessor(BaseMultiModalProcessor[Mllama4ProcessingInfo]
                 for (r_h, r_w) in aspect_ratios
             ]
 
-            processed_outputs["aspect_ratios"] = aspect_ratios
+            processed_outputs["aspect_ratios"] = torch.tensor(aspect_ratios)
             processed_outputs["patches_per_image"] = torch.tensor(
                 patches_per_image)
 
@@ -778,12 +777,7 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         # TODO: confirm handling for variable lengths
         flat_pixel_values = flatten_bn(pixel_values, concat=True)
         patches_per_image = flatten_bn(kwargs.pop("patches_per_image"))
-
-        aspect_ratios = kwargs.pop("aspect_ratios", None)
-        if aspect_ratios is not None and not isinstance(
-                aspect_ratios, torch.Tensor):
-            aspect_ratios = torch.tensor(aspect_ratios,
-                                         device=flat_pixel_values.device)
+        aspect_ratios = kwargs.pop("aspect_ratios")
 
         return Llama4ImagePatchInputs(
             type="pixel_values",

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -68,7 +68,6 @@ class Llama4ImagePatchInputs(TensorSchema):
         - total_num_chunks: Batch size * number of chunks
         - num_channels: Number of channels
         - image_size: Size of each image
-        - ratio: Aspect ratio pair (where each pair is (ratio_h, ratio_w))
     """
 
     type: Literal["pixel_values"] = "pixel_values"
@@ -86,10 +85,11 @@ class Llama4ImagePatchInputs(TensorSchema):
     """
 
     aspect_ratios: Annotated[Union[torch.Tensor, list[torch.Tensor]],
-                             TensorShape("batch_size", "ratio")]
+                             TensorShape("batch_size", 2)]
     """
     A list of aspect ratios corresponding to the number of tiles
     in each dimension that each image in the batch corresponds to.
+    Each aspect ratio is a pair (ratio_h, ratio_w).
     """
 
 

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -77,7 +77,7 @@ class Llama4ImagePatchInputs(TensorSchema):
                          TensorShape("total_num_chunks", "num_channels",
                                      "image_size", "image_size")]
 
-    patches_per_image: Annotated[torch.Tensor]
+    patches_per_image: Annotated[torch.Tensor, TensorShape("batch_size")]
     """
     The number of total patches for each image in the batch.
     
@@ -780,6 +780,10 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         patches_per_image = flatten_bn(kwargs.pop("patches_per_image"))
 
         aspect_ratios = kwargs.pop("aspect_ratios", None)
+        if aspect_ratios is not None and not isinstance(
+                aspect_ratios, torch.Tensor):
+            aspect_ratios = torch.tensor(aspect_ratios,
+                                         device=flat_pixel_values.device)
 
         return Llama4ImagePatchInputs(
             type="pixel_values",

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -778,6 +778,8 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         flat_pixel_values = flatten_bn(pixel_values, concat=True)
         patches_per_image = flatten_bn(kwargs.pop("patches_per_image"))
         aspect_ratios = kwargs.pop("aspect_ratios")
+        if aspect_ratios.ndim == 3:
+            aspect_ratios = aspect_ratios.squeeze(1)
 
         return Llama4ImagePatchInputs(
             type="pixel_values",


### PR DESCRIPTION
## Purpose
This PR migrates Llama4ImagePatchInputs from a TypedDict-based definition to a structured TensorSchema model with runtime shape validation. This brings it in line with recent changes to Phi3VImagePixelInputs, and is part of a broader effort to improve input contract enforcement and debug-ability across multi-modal models.

## Test Plan

Confirm validation works via standalone tests in tests/standalone_test/test_tensor_schema.py and rely on CI to check integration.

## Test Result

```
(venv) benjibeck@Benjis-MacBook-Pro vllm % python3 -m pytest tests/utils_/test_tensor_schema.py -v --log-cli-level=DEBUG
========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.9.6, pytest-8.4.1, pluggy-1.6.0 -- /Users/benjibeck/Projects/vllm/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/benjibeck/Projects/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 19 items                                                                                                                                                      

tests/utils_/test_tensor_schema.py::test_tensor_schema_valid_tensor PASSED                                                                                        [  5%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_optional_fields PASSED                                                                                     [ 10%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_constant_dim_failure PASSED                                                                                [ 15%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_invalid_types_in_list PASSED                                                                               [ 21%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_rank_mismatch PASSED                                                                                       [ 26%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_missing_required_field PASSED                                                                              [ 31%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_symbolic_dim_mismatch PASSED                                                                               [ 36%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_list_tensor_valid PASSED                                                                                   [ 42%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_variable_patch_counts_valid PASSED                                                                         [ 47%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_tuple_tensor_valid PASSED                                                                                  [ 52%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_inconsistent_shapes_in_list PASSED                                                                         [ 57%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_empty_list PASSED                                                                                          [ 63%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_validation_disabled_skips_shape_check PASSED                                                               [ 68%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_with_valid_resolve_binding_dims PASSED                                                                     [ 73%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_with_invalid_resolve_binding_dims PASSED                                                                   [ 78%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_with_list_of_symbolic_dim PASSED                                                                           [ 84%]
tests/utils_/test_tensor_schema.py::test_tensor_schema_with_list_of_symbolic_dim_mismatch_in_length PASSED                                                        [ 89%]
tests/utils_/test_tensor_schema.py::test_valid_tensor_schema_with_static_last_dim PASSED                                                                          [ 94%]
tests/utils_/test_tensor_schema.py::test_invalid_tensor_schema_with_static_last_dim PASSED                                                                        [100%]
```