### PR TITLE
[ez] Remove a trailing space from compilation/decorators.py

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -108,7 +108,7 @@ def support_torch_compile(
     During runtime, when we actually mark dimensions of tensors,
      it depends on the value of arguments:
 
-    - if it is a single integer (can be negative), the corresponding dimension 
+    - if it is a single integer (can be negative), the corresponding dimension
         of the argument will be marked as dynamic.
     - if it is `None`, ignored.
     - if it is `IntermediateTensors`, all the tensors in the intermediate


### PR DESCRIPTION
My local IDE keeps complaining about this trailing space so I guess it doesn't hurt to remove it directly.

# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Local code quality improvement by removing a trailing space.
## Test Plan
CI
## Test Result
should pass
## (Optional) Documentation Update

