### PR TITLE
Fix error with skip_tokenizer_init = True

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -283,8 +283,11 @@ class Processor:
                     len(decoder_inputs["prompt_token_ids"]))
             sampling_params.update_from_generation_config(
                 self.generation_config_fields, eos_token_id)
-            sampling_params.update_from_tokenizer(
-                self.tokenizer.get_lora_tokenizer(lora_request))
+            if lora_request is not None:
+                if self.model_config.skip_tokenizer_init:
+                    raise ValueError("skip_tokenizer_init is not supported with lora_request")
+                sampling_params.update_from_tokenizer(
+                    self.tokenizer.get_lora_tokenizer(lora_request))
         else:
             pooling_params = params.clone()
 


### PR DESCRIPTION
## Purpose

New behavior prohibits the use of `skip_tokenizer_init`, as the engine processor attempts to utilize the tokenizer to obtain lora params, even in the case where `lora_request=None`. This should fix: #21846. 

## Test Plan

Run a test using this branch, setting skip_tokenizer_init=True.

## Test Result

TODO

## (Optional) Documentation Update

