### PR TITLE
[Bugfix] Mamba2 remove bugged initial state condition in chunk scan

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/ssd_chunk_scan.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_chunk_scan.py
@@ -476,15 +476,8 @@ def _chunk_scan_fwd(
             # with initial states, we need to take care of how
             # seq_idx crosses the boundaries
             assert batch == 1, "chunk scan only supports initial states with batch 1"
-
-            if initial_states.shape[0] == 1:
-                # no in this case no point to use initial states
-                initial_states = None
-            else:
-                assert chunk_indices is not None and chunk_offsets is not None, \
-                    (
-                        "chunk_indices and chunk_offsets should have been set"
-                    )
+            assert chunk_indices is not None and chunk_offsets is not None, \
+                "chunk_indices and chunk_offsets should have been set"
         else:
             chunk_indices, chunk_offsets = None, None
     else:


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
This PR removes the condition that erroneously ignores `initial_states` tensor when batch size is 1.

```
            if initial_states.shape[0] == 1:
                # no in this case no point to use initial states
                initial_states = None
```

 Keeping it causes problem in batch size=1 prefill. For example, if the input batch contains only 1 long prefill request, when chunked prefilled is turned on, the prefill request will be processed in multiple `forward` iterations, which results in chunks 1, 2, ... to have valid initial_states. Ignore them leads to incorrect results.

## Test Plan

- Testing with lm_eval and show no loss of accuracy
- Pass unit tests in CI/CD

## Test Result

Test Command
```
VLLM_ATTENTION_BACKEND=FLASHINFER VLLM_USE_V1=1 lm_eval --model vllm  --model_args pretrained=ibm-granite/granite-4.0-tiny-preview,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.95,enable_prefix_caching=False --batch_size auto --trust_remote_code  --cache_requests true --tasks gsm8k
```

Before (207b750)
```
vllm (pretrained=ibm-granite/granite-4.0-tiny-preview,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.95,enable_prefix_caching=False,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6058|±  |0.0135|
|     |       |strict-match    |     5|exact_match|↑  |0.5838|±  |0.0136|
```

This PR
```
vllm (pretrained=ibm-granite/granite-4.0-tiny-preview,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.95,enable_prefix_caching=False,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6050|±  |0.0135|
|     |       |strict-match    |     5|exact_match|↑  |0.5838|±  |0.0136|
```

## (Optional) Documentation Update

