### PR TITLE
[Perf] Optimize `reshape_and_cache_flash` CUDA Kernel

### DIFF
--- a/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
+++ b/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
@@ -53,7 +53,6 @@ def run_benchmark(
     slot_mapping_lst = random.sample(range(num_slots), num_tokens)
     slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
 
-    # create the KV-cache tensors.
     key_caches, value_caches = create_kv_caches_with_random_flash(
         num_blocks,
         block_size,

--- a/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
+++ b/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import random
+import time
+
+import torch
+from tabulate import tabulate
+
+from vllm import _custom_ops as ops
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils import (
+    STR_DTYPE_TO_TORCH_DTYPE,
+    FlexibleArgumentParser,
+    create_kv_caches_with_random_flash,
+)
+
+logger = init_logger(__name__)
+
+
+@torch.inference_mode()
+def run_benchmark(
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+    kv_cache_dtype: str,
+    kv_cache_layout: str,
+    num_iters: int,
+    device: str = "cuda",
+) -> float:
+    """Return latency (seconds) for given num_tokens."""
+
+    if kv_cache_dtype == "fp8" and head_size % 16:
+        raise ValueError("fp8 kv-cache requires head_size to be a multiple of 16.")
+
+    current_platform.seed_everything(42)
+    torch.set_default_device(device)
+
+    # create random key / value tensors [T, H, D].
+    key = torch.randn(num_tokens, num_heads, head_size, dtype=dtype, device=device)
+    value = torch.randn_like(key)
+
+    # prepare the slot mapping.
+    # each token is assigned a unique slot in the KV-cache.
+    num_slots = block_size * num_blocks
+    if num_tokens > num_slots:
+        raise ValueError("num_tokens cannot exceed the total number of cache slots")
+    slot_mapping_lst = random.sample(range(num_slots), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+
+    # create the KV-cache tensors.
+    key_caches, value_caches = create_kv_caches_with_random_flash(
+        num_blocks,
+        block_size,
+        1,  # num_layers
+        num_heads,
+        head_size,
+        kv_cache_dtype,
+        dtype,
+        device=device,
+        cache_layout=kv_cache_layout,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+
+    # compute per-kernel scaling factors for fp8 conversion (if used).
+    k_scale = (key.amax() / 64.0).to(torch.float32)
+    v_scale = (value.amax() / 64.0).to(torch.float32)
+
+    def run_cuda_benchmark(n_iters: int) -> float:
+        nonlocal key, value, key_cache, value_cache, slot_mapping
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        for _ in range(n_iters):
+            ops.reshape_and_cache_flash(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                slot_mapping,
+                kv_cache_dtype,
+                k_scale,
+                v_scale,
+            )
+        torch.cuda.synchronize()
+        end = time.perf_counter()
+        return (end - start) / n_iters
+
+    # warm-up
+    run_cuda_benchmark(3)
+
+    lat = run_cuda_benchmark(num_iters)
+
+    # free tensors to mitigate OOM when sweeping
+    del key, value, key_cache, value_cache, slot_mapping
+    torch.cuda.empty_cache()
+
+    return lat
+
+
+def main(args):
+    rows = []
+    for exp in range(1, 17):
+        n_tok = 2**exp
+        lat = run_benchmark(
+            num_tokens=n_tok,
+            num_heads=args.num_heads,
+            head_size=args.head_size,
+            block_size=args.block_size,
+            num_blocks=args.num_blocks,
+            dtype=STR_DTYPE_TO_TORCH_DTYPE[args.dtype],
+            kv_cache_dtype=args.kv_cache_dtype,
+            kv_cache_layout=args.kv_cache_layout,
+            num_iters=args.iters,
+            device="cuda",
+        )
+        rows.append([n_tok, f"{lat * 1e6:.3f}"])
+
+    print(tabulate(rows, headers=["num_tokens", "latency (µs)"]))
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser()
+
+    parser.add_argument("--num-heads", type=int, default=128)
+    parser.add_argument(
+        "--head-size",
+        type=int,
+        choices=[64, 80, 96, 112, 120, 128, 192, 256],
+        default=128,
+    )
+    parser.add_argument("--block-size", type=int, choices=[16, 32], default=16)
+    parser.add_argument("--num-blocks", type=int, default=128 * 512)
+
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        choices=["half", "bfloat16", "float"],
+        default="bfloat16",
+    )
+
+    parser.add_argument(
+        "--kv-cache-dtype",
+        type=str,
+        choices=["auto", "fp8"],
+        default="auto",
+    )
+
+    parser.add_argument(
+        "--kv-cache-layout",
+        type=str,
+        choices=["NHD", "HND"],
+        default="NHD",
+        help="Memory layout of the packed KV-cache tensor.",
+    )
+
+    parser.add_argument("--iters", type=int, default=100)
+    args = parser.parse_args()
+
+    main(args)

--- a/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
+++ b/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
@@ -104,23 +104,24 @@ def run_benchmark(
 
 def main(args):
     rows = []
-    for exp in range(1, 17):
-        n_tok = 2**exp
-        lat = run_benchmark(
-            num_tokens=n_tok,
-            num_heads=args.num_heads,
-            head_size=args.head_size,
-            block_size=args.block_size,
-            num_blocks=args.num_blocks,
-            dtype=STR_DTYPE_TO_TORCH_DTYPE[args.dtype],
-            kv_cache_dtype=args.kv_cache_dtype,
-            kv_cache_layout=args.kv_cache_layout,
-            num_iters=args.iters,
-            device="cuda",
-        )
-        rows.append([n_tok, f"{lat * 1e6:.3f}"])
+    for layout in ["NHD", "HND"]:
+        for exp in range(1, 17):
+            n_tok = 2**exp
+            lat = run_benchmark(
+                num_tokens=n_tok,
+                num_heads=args.num_heads,
+                head_size=args.head_size,
+                block_size=args.block_size,
+                num_blocks=args.num_blocks,
+                dtype=STR_DTYPE_TO_TORCH_DTYPE[args.dtype],
+                kv_cache_dtype=args.kv_cache_dtype,
+                kv_cache_layout=layout,
+                num_iters=args.iters,
+                device="cuda",
+            )
+            rows.append([n_tok, layout, f"{lat * 1e6:.3f}"])
 
-    print(tabulate(rows, headers=["num_tokens", "latency (µs)"]))
+    print(tabulate(rows, headers=["num_tokens", "layout", "latency (µs)"]))
 
 
 if __name__ == "__main__":
@@ -148,14 +149,6 @@ if __name__ == "__main__":
         type=str,
         choices=["auto", "fp8"],
         default="auto",
-    )
-
-    parser.add_argument(
-        "--kv-cache-layout",
-        type=str,
-        choices=["NHD", "HND"],
-        default="NHD",
-        help="Memory layout of the packed KV-cache tensor.",
     )
 
     parser.add_argument("--iters", type=int, default=100)

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -5,6 +5,7 @@
 #include "cuda_utils.h"
 #include "cuda_compat.h"
 #include "dispatch_utils.h"
+#include "quantization/vectorization_utils.cuh"
 
 #ifdef USE_ROCM
   #include "quantization/fp8/amd/quant_utils.cuh"
@@ -261,6 +262,20 @@ __global__ void reshape_and_cache_kernel(
   }
 }
 
+// Used by vectorization_utils to copy/convert one element
+template <typename OutT, typename InT, Fp8KVCacheDataType kv_dt>
+struct CopyWithScaleOp {
+  float scale;
+
+  __device__ __forceinline__ void operator()(OutT& dst, const InT src) const {
+    if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
+      dst = static_cast<OutT>(src);
+    } else {
+      dst = fp8::scaled_convert<OutT, InT, kv_dt>(src, scale);
+    }
+  }
+};
+
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
 __global__ void reshape_and_cache_flash_kernel(
     const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size]
@@ -282,27 +297,33 @@ __global__ void reshape_and_cache_flash_kernel(
   }
   const int64_t block_idx = slot_idx / block_size;
   const int64_t block_offset = slot_idx % block_size;
-  const int n = num_heads * head_size;
-  for (int i = threadIdx.x; i < n; i += blockDim.x) {
-    const int64_t src_key_idx = token_idx * key_stride + i;
-    const int64_t src_value_idx = token_idx * value_stride + i;
-    const int head_idx = i / head_size;
-    const int head_offset = i % head_size;
-    const int64_t tgt_key_value_idx = block_idx * block_stride +
-                                      block_offset * page_stride +
-                                      head_idx * head_stride + head_offset;
-    scalar_t tgt_key = key[src_key_idx];
-    scalar_t tgt_value = value[src_value_idx];
-    if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
-      key_cache[tgt_key_value_idx] = tgt_key;
-      value_cache[tgt_key_value_idx] = tgt_value;
-    } else {
-      key_cache[tgt_key_value_idx] =
-          fp8::scaled_convert<cache_t, scalar_t, kv_dt>(tgt_key, *k_scale);
-      value_cache[tgt_key_value_idx] =
-          fp8::scaled_convert<cache_t, scalar_t, kv_dt>(tgt_value, *v_scale);
-    }
-  }
+  const int n_elems = num_heads * head_size;
+
+  // pointers to the beginning of the source row for this token.
+  const scalar_t* __restrict__ key_src = key + token_idx * key_stride;
+  const scalar_t* __restrict__ value_src = value + token_idx * value_stride;
+
+  // find the start position inside the kv-cache for this token.
+  cache_t* __restrict__ key_dst =
+      key_cache + block_idx * block_stride + block_offset * page_stride;
+  cache_t* __restrict__ value_dst =
+      value_cache + block_idx * block_stride + block_offset * page_stride;
+
+  // prefer 16-byte transactions when possible.
+  constexpr int VEC_SIZE = (sizeof(scalar_t) == 2) ? 8 : 4;
+
+  // prepare per-element copy functors
+  float k_scale_val = (kv_dt == Fp8KVCacheDataType::kAuto) ? 0.f : *k_scale;
+  float v_scale_val = (kv_dt == Fp8KVCacheDataType::kAuto) ? 0.f : *v_scale;
+
+  CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
+  CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
+
+  vectorize_with_alignment<VEC_SIZE>(key_src, key_dst, n_elems, threadIdx.x,
+                                     blockDim.x, k_op);
+
+  vectorize_with_alignment<VEC_SIZE>(value_src, value_dst, n_elems, threadIdx.x,
+                                     blockDim.x, v_op);
 }
 
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>


### PR DESCRIPTION
## Purpose

Using vectorization utils to  `reshape_and_cache_flash` and get performance improvement

## Test

### Acc

```bash
lm_eval   --model vllm   --model_args "pretrained=Qwen/Qwen3-30B-A3B-FP8,max_model_len=32768,enforce_eager=True"   --trust_remote_code   --tasks gsm8k   --num_fewshot 5   --batch_size auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8173|±  |0.0106|
|     |       |strict-match    |     5|exact_match|↑  |0.8870|±  |0.0087|
# main
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8173|±  |0.0106|
|     |       |strict-match    |     5|exact_match|↑  |0.8870|±  |0.0087|
```

```bash
pytest test_cache.py -x
==================== test session starts ====================
platform linux -- Python 3.12.3, pytest-8.4.0, pluggy-1.6.0
rootdir: /home/wentao/vllm-source
configfile: pyproject.toml
plugins: asyncio-1.0.0, anyio-4.9.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1102 items                                        

test_cache.py ....................................... [  3%]
...................................s...s...s...s...s. [  8%]
..s...s...s...s...s...s...s...s...s...s...s...s...s.. [ 13%]
..................................................... [ 17%]
....................s...s...s...s...s...s...s...s...s [ 22%]
...s...s...s...s...s...s...s...s...s................. [ 27%]
..................................................... [ 32%]
..................................................... [ 37%]
..................................................... [ 42%]
..................................................... [ 46%]
..................................................... [ 51%]
..................................................... [ 56%]
..................................................... [ 61%]
..................................................... [ 66%]
..................................................... [ 70%]
...........s.ss.sssss.ss.ss.sssss.ss.ss.sssss.ss.ss.s [ 75%]
ssss.ss.ss.sssss.ss.ss.sssss.ss.ss.sssss.ss.ss.sssss. [ 80%]
ss.ss.sssss.ss.ss.sssss.ss.ss.sssss.ss.ss.sssss.ss.ss [ 85%]
.sssss.ss.ss.sssss.ss.ss.sssss.ss.ss.sssss.ss.ss.ssss [ 90%]
s.ss.ss.sssss.s...................................... [ 94%]
..................................................... [ 99%]
sss                                                   [100%]

======= 901 passed, 201 skipped in 349.21s (0:05:49) ========
```

### Performance

`python benchmark_reshape_and_cache_flash.py`

num_tokens | layout | Old Run (µs) | New Run (µs) | Change (%)
-- | -- | -- | -- | --
2 | HND | 10.326 | 8.323 | -19.4% 🚀
4 | HND | 10.440 | 8.355 | -20.0% 🚀
8 | HND | 10.356 | 8.344 | -19.4% 🚀
16 | HND | 10.330 | 8.372 | -19.0% 🚀
32 | HND | 10.345 | 8.348 | -19.3% 🚀
64 | HND | 10.454 | 8.354 | -20.1% 🚀
128 | HND | 10.397 | 8.370 | -19.5% 🚀
256 | HND | 14.431 | 10.375 | -28.1% 🚀
512 | HND | 24.809 | 20.137 | -18.8% 🚀
1024 | HND | 51.389 | 45.196 | -12.1% 🚀
2048 | HND | 96.466 | 77.908 | -19.2% 🚀
4096 | HND | 175.695 | 147.068 | -16.3% 🚀
8192 | HND | 336.814 | 279.106 | -17.1% 🚀
16384 | HND | 668.001 | 547.169 | -18.1% 🚀
32768 | HND | 1320.570 | 1082.070 | -18.1% 🚀
65536 | HND | 2605.930 | 2149.950 | -17.5% 🚀
2 | NHD | 10.371 | 6.649 | -35.9% 🚀
4 | NHD | 10.337 | 6.407 | -38.0% 🚀
8 | NHD | 10.346 | 6.338 | -38.7% 🚀
16 | NHD | 10.352 | 6.394 | -38.2% 🚀
32 | NHD | 10.350 | 7.416 | -28.3% 🚀
64 | NHD | 10.341 | 7.305 | -29.4% 🚀
128 | NHD | 10.349 | 7.614 | -26.4% 🚀
256 | NHD | 14.401 | 10.363 | -28.0% 🚀
512 | NHD | 25.955 | 15.084 | -41.9% 🚀
1024 | NHD | 49.264 | 30.690 | -37.7% 🚀
2048 | NHD | 93.674 | 53.726 | -42.6% 🚀
4096 | NHD | 172.364 | 101.030 | -41.4% 🚀
8192 | NHD | 333.329 | 195.911 | -41.2% 🚀
16384 | NHD | 665.351 | 385.012 | -42.1% 🚀
32768 | NHD | 1308.720 | 762.607 | -41.7% 🚀
65536 | NHD | 2587.800 | 1519.310 | -41.3% 🚀
