### PR TITLE
Fix test_kv_sharing_fast_prefill flakiness

### DIFF
--- a/tests/v1/e2e/test_kv_sharing_fast_prefill.py
+++ b/tests/v1/e2e/test_kv_sharing_fast_prefill.py
@@ -117,12 +117,10 @@ def cleanup(llm: LLM, compilation_config: CompilationConfig):
 
 @fork_new_process_for_each_test
 @pytest.mark.parametrize("enforce_eager", [True])
-@pytest.mark.parametrize("execute_number", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 def test_kv_sharing_fast_prefill(
     monkeypatch: pytest.MonkeyPatch,
     enforce_eager: bool,
     test_prompts: list[str],
-    execute_number: int,
 ):
     ModelRegistry.register_model("Gemma3nForConditionalGeneration",
                                  TestGemma3nForConditionalGeneration)


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
Fixes https://github.com/vllm-project/vllm/issues/22104

This unit test, added in #21590, checks for exact outputs from two `LLM` instances. However, due to inherent randomness in vLLM (e.g. scheduling), sometimes the test fails, making it flaky. Following vLLM's [reproducibility guide](https://docs.vllm.ai/en/v0.8.5.post1/getting_started/examples/reproduciblity.html), make this less flaky.

The key was to turn off multiprocessing to make scheduling deterministic with `VLLM_ENABLE_V1_MULTIPROCESSING=0`. However, this requires further changes to release GPU memory for second `LLM` instance (as unlike with multiprocessing, there is no separate worker process that gets killed to free memory). 

Follow up required: had to disable `enforce_eager=False` test case as `del`eting model and KV caches ref doesn't seem to remove all references, so memory doesn't get freed.

## Test Plan
Ran `pytest tests/v1/e2e/test_kv_sharing_fast_prefill.py::test_kv_sharing_fast_prefill` 10 times

## Test Result
Before PR, some runs would fail. After PR, all 10 runs pass.

