### PR TITLE
[Hardware][AMD] support KV cache block size > 1 in aiter mla

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -202,13 +202,12 @@ class RocmPlatform(Platform):
                         f"does not support block size {block_size}.")
             elif selected_backend == _Backend.ROCM_AITER_MLA \
                 or selected_backend == _Backend.ROCM_AITER_MLA_VLLM_V1:
-                if block_size == 1:
-                    if use_v1:
-                        logger.info("Using AITER MLA backend on V1 engine.")
-                        return "vllm.v1.attention.backends.mla.rocm_aiter_mla.AiterMLABackend"  # noqa: E501
-                    else:
-                        logger.info("Using AITER MLA backend")
-                        return "vllm.attention.backends.rocm_aiter_mla.AiterMLABackend"  # noqa: E501
+                if use_v1:
+                    logger.info("Using AITER MLA backend on V1 engine.")
+                    return "vllm.v1.attention.backends.mla.rocm_aiter_mla.AiterMLABackend"  # noqa: E501
+                elif block_size == 1:
+                    logger.info("Using AITER MLA backend")
+                    return "vllm.attention.backends.rocm_aiter_mla.AiterMLABackend"  # noqa: E501
                 else:
                     raise ValueError(
                         f" The selected backend, {selected_backend.name},"

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -125,18 +125,18 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             block_offsets = torch.arange(page_size,
                                          device=device,
                                          dtype=torch.int32)
-            expanded_block_table = block_table.unsqueeze(
+            expanded_block_table = block_table_tensor.unsqueeze(
                 -1) * page_size + block_offsets
             flat_block_table = expanded_block_table.view(
-                block_table.size(0), -1)
+                block_table_tensor.size(0), -1)
 
             max_model_len = flat_block_table.size(1)
             mask = torch.arange(
                 max_model_len,
                 device=device).unsqueeze(0) < seq_lens.unsqueeze(1)
 
-            # e.g. block_table = [[1, 2, 4], [3, 5, 0]], seq_lens = [5, 3] and page_size = 2,
-            # then paged_kv_indices = [1, 2, 4, 5, 8, 3, 4, 10]
+            # e.g. block_table = [[1, 2, 4], [3, 5, 0]], seq_lens = [5, 3] and
+            # page_size = 2, then paged_kv_indices = [1, 2, 4, 5, 8, 3, 4, 10]
             paged_kv_indices = flat_block_table[mask]
             paged_kv_indptr = torch.cat([
                 torch.zeros(1, dtype=seq_lens.dtype, device=device),


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- When using the aiter MLA kernel, KV cache block size must be set to 1.
  - When performing disaggregated prefill, there is a kv cache transfer process between the prefill worker and the decode worker, and the minimum unit of kv cache transfer is a block.
  - If the block size is 1, kv cache transfers occur frequently, which may result in significant communication overhead.
- I modified this to allow the use of aiter MLA even when the KV cache block size is greater than 1. 
  - When performing aiter MLA with block size > 1, the block table is expanded as if the block size were 1, so that the relevant tensors for aiter MLA can be correctly generated.
  - For example, if the block table is [0, 2, 4], the block size is 4, and the sequence length is 10, the restructured block table becomes [0, 1, 2, 3, 8, 9, 10, 11, 16, 17].

## Test Plan
The DeepSeek-R1 model was deployed with block size 64 on an MI300 node, and the following curl command was executed.
```
curl http://localhost:12000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "deepseek-ai/DeepSeek-R1",
    "messages": [
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "Who won the world series in 2020?"}
    ],
    "max_tokens": 2000
}'
```
## Test Result
The response came through without issues.
```
Okay, so the user is asking who won the World Series in 2020. Let me think. First, I need to recall the MLB World Series for that year. The World Series is usually held in October, but I remember that 2020 was the year of the COVID-19 pandemic. That might have affected the season. Wait, right, the 2020 season was shortened, and they played in neutral sites instead of the teams' home stadiums. I think the Los Angeles Dodgers were involved. They had a strong team around that time. Let me confirm. The Dodgers won the World Series in 2020, right? They beat the Tampa Bay Rays. The series went to six games. The clinching game was Game 6, where the Dodgers won. Corey Seager was the MVP. Yeah, that's right. I should make sure there's no confusion with other years. The Dodgers also won in 2020, which was their first title since 1988. So the answer is the Los Angeles Dodgers. Let me check if there's any other possible team that could be confused here. No, Tampa Bay Rays were the American League champions that year, but they lost to the Dodgers. So the answer should be the Los Angeles Dodgers.\n</think>\n\nThe Los Angeles Dodgers won the 2020 World Series, defeating the Tampa Bay Rays in six games. This was the Dodgers' first championship since 1988, and Corey Seager was named the World Series MVP. The series was notable for being held at a neutral site (Globe Life Field in Arlington, Texas) due to the COVID-19 pandemic.
```