### PR TITLE
[Bugfix] Fix: distributed_executor_backend class preventing V1 usage

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -41,7 +41,6 @@ from vllm.test_utils import MODEL_WEIGHTS_S3_BUCKET, MODELS_ON_S3
 from vllm.transformers_utils.utils import check_gguf_file
 from vllm.utils import (STR_DUAL_CHUNK_FLASH_ATTN_VAL, FlexibleArgumentParser,
                         GiB_bytes, get_ip, is_in_ray_actor)
-from vllm.v1.executor.abstract import Executor as ExecutorV1
 
 # yapf: enable
 
@@ -1446,6 +1445,7 @@ class EngineArgs:
                 and _warn_or_fallback("Engine in background thread")):
             return False
 
+        from vllm.v1.executor.abstract import Executor as ExecutorV1
         if (self.pipeline_parallel_size > 1
                 and self.distributed_executor_backend
                 not in (ParallelConfig.distributed_executor_backend, "ray",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1450,7 +1450,7 @@ class EngineArgs:
                 and self.distributed_executor_backend
                 not in (ParallelConfig.distributed_executor_backend, "ray",
                         "mp", "external_launcher")
-                and not issubclass(self.distributed_executor_backend, ExecutorV1)):
+                and not (isinstance(self.distributed_executor_backend, type) and issubclass(self.distributed_executor_backend, ExecutorV1))):
             name = "Pipeline Parallelism without Ray distributed executor " \
                     "or multiprocessing executor or external launcher"
             _raise_or_fallback(feature_name=name, recommend_to_remove=False)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -41,6 +41,7 @@ from vllm.test_utils import MODEL_WEIGHTS_S3_BUCKET, MODELS_ON_S3
 from vllm.transformers_utils.utils import check_gguf_file
 from vllm.utils import (STR_DUAL_CHUNK_FLASH_ATTN_VAL, FlexibleArgumentParser,
                         GiB_bytes, get_ip, is_in_ray_actor)
+from vllm.v1.executor.abstract import Executor as ExecutorV1
 
 # yapf: enable
 
@@ -1448,7 +1449,8 @@ class EngineArgs:
         if (self.pipeline_parallel_size > 1
                 and self.distributed_executor_backend
                 not in (ParallelConfig.distributed_executor_backend, "ray",
-                        "mp", "external_launcher")):
+                        "mp", "external_launcher")
+                and not issubclass(self.distributed_executor_backend, ExecutorV1)):
             name = "Pipeline Parallelism without Ray distributed executor " \
                     "or multiprocessing executor or external launcher"
             _raise_or_fallback(feature_name=name, recommend_to_remove=False)


### PR DESCRIPTION
[Bugfix] Fix: distributed_executor_backend may be a V1 Executor class and should not prevent usage of V1 usage.

# Essential Elements of an Effective PR Description Checklist

- [X ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

distributed_executor_backend may be a string from the command line like, mp, ray, uni, etc. However, it may also be a class when vllm is used programatically. If that class inherits from the V1 executor, it should not prevent V1 engine usage.

## Test Plan

## Test Result

## (Optional) Documentation Update

