### PR TITLE
[Misc] Remove upper bound in openai package version

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -13,7 +13,7 @@ tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
-openai >= 1.87.0, <= 1.90.0 # Ensure modern openai package (ensure ResponsePrompt exists in type.responses and max_completion_tokens field support)
+openai >= 1.87.0 # Ensure modern openai package (ensure ResponsePrompt exists in type.responses and max_completion_tokens field support)
 pydantic >= 2.10
 prometheus_client >= 0.18.0
 pillow  # Required for image processing


### PR DESCRIPTION
Context from @DarkLight1337 
> It was changed in https://github.com/vllm-project/vllm/pull/20363
It is to avoid flakiness in the transcription test. But we recently found that it's actually just due to the client having a different timeout than what we're used to
so feel free to remove the version limit