### PR TITLE
[FEAT][ROCm] Enable running Flash Attention as ViT attn backend for Qwen-VL models on ROCm platform.

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -308,7 +308,7 @@ class Qwen2_5_VisionAttention(nn.Module):
         if self.flash_attn_backend:
             # from vllm_flash_attn.flash_attn_interface import (
             #   flash_attn_varlen_func)
-            if self.flash_attn_backend == _Backend.ROCM_AITER_FA:
+            if self.attn_backend == _Backend.ROCM_AITER_FA:
                 from aiter import flash_attn_varlen_func
             else:
                 from flash_attn import flash_attn_varlen_func

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -310,8 +310,10 @@ class Qwen2_5_VisionAttention(nn.Module):
             #   flash_attn_varlen_func)
             if self.attn_backend == _Backend.ROCM_AITER_FA:
                 from aiter import flash_attn_varlen_func
+                dropout_p = float(0)
             else:
                 from flash_attn import flash_attn_varlen_func
+                dropout_p = 0
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -322,7 +324,7 @@ class Qwen2_5_VisionAttention(nn.Module):
                                             cu_seqlens_k=cu_seqlens,
                                             max_seqlen_q=max_seqlen,
                                             max_seqlen_k=max_seqlen,
-                                            dropout_p=0,
+                                            dropout_p=dropout_p,
                                             causal=False)
 
             context_layer = rearrange(output,

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -646,7 +646,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
         cu_seqlens: torch.Tensor,
     ) -> tuple[Optional[int], Optional[list[int]]]:
         max_seqlen, seqlens = None, None
-        if self.attn_backend in {_Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA}:
+        if (self.attn_backend == _Backend.FLASH_ATTN
+                or self.attn_backend == _Backend.ROCM_AITER_FA):
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
         elif self.attn_backend == _Backend.XFORMERS:
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -250,11 +250,15 @@ class Qwen2_5_VisionAttention(nn.Module):
         # Detect attention implementation.
         self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
         if self.attn_backend not in {
-                _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS
+                _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
+                _Backend.ROCM_AITER_FA
         }:
             raise RuntimeError(
                 f"Qwen2.5-VL does not support {self.attn_backend} backend now."
             )
+        self.flash_attn_backend = self.attn_backend in {
+            _Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA
+        }
 
     def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
         # [s, b, 3 * head * head_dim]
@@ -301,10 +305,13 @@ class Qwen2_5_VisionAttention(nn.Module):
             q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
             k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
 
-        if self.attn_backend == _Backend.FLASH_ATTN:
+        if self.flash_attn_backend:
             # from vllm_flash_attn.flash_attn_interface import (
             #   flash_attn_varlen_func)
-            from flash_attn import flash_attn_varlen_func
+            if self.flash_attn_backend == _Backend.ROCM_AITER_FA:
+                from aiter import flash_attn_varlen_func
+            else:
+                from flash_attn import flash_attn_varlen_func
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -639,7 +646,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
         cu_seqlens: torch.Tensor,
     ) -> tuple[Optional[int], Optional[list[int]]]:
         max_seqlen, seqlens = None, None
-        if self.attn_backend == _Backend.FLASH_ATTN:
+        if self.attn_backend in {_Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA}:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
         elif self.attn_backend == _Backend.XFORMERS:
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -333,7 +333,7 @@ class Qwen2VisionAttention(nn.Module):
         if self.flash_attn_backend:
             # from vllm_flash_attn.flash_attn_interface import (
             #   flash_attn_varlen_func)
-            if self.flash_attn_backend == _Backend.ROCM_AITER_FA:
+            if self.attn_backend == _Backend.ROCM_AITER_FA:
                 from aiter import flash_attn_varlen_func
             else:
                 from flash_attn import flash_attn_varlen_func

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -276,10 +276,14 @@ class Qwen2VisionAttention(nn.Module):
         # Detect attention implementation.
         self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
         if self.attn_backend not in {
-                _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS
+                _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
+                _Backend.ROCM_AITER_FA
         }:
             raise RuntimeError(
                 f"Qwen2-VL does not support {self.attn_backend} backend now.")
+        self.flash_attn_backend = self.attn_backend in {
+            _Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA
+        }
 
     def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
         # [s, b, 3 * head * head_dim]
@@ -326,10 +330,13 @@ class Qwen2VisionAttention(nn.Module):
             q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
             k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
 
-        if self.attn_backend == _Backend.FLASH_ATTN:
+        if self.flash_attn_backend:
             # from vllm_flash_attn.flash_attn_interface import (
             #   flash_attn_varlen_func)
-            from flash_attn import flash_attn_varlen_func
+            if self.flash_attn_backend == _Backend.ROCM_AITER_FA:
+                from aiter import flash_attn_varlen_func
+            else:
+                from flash_attn import flash_attn_varlen_func
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -622,7 +629,7 @@ class Qwen2VisionTransformer(nn.Module):
             self, cu_seqlens: torch.Tensor
     ) -> tuple[Optional[int], Optional[list[int]]]:
         max_seqlen, seqlens = None, None
-        if self.attn_backend == _Backend.FLASH_ATTN:
+        if self.attn_backend in {_Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA}:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
         elif self.attn_backend == _Backend.XFORMERS:
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -335,8 +335,10 @@ class Qwen2VisionAttention(nn.Module):
             #   flash_attn_varlen_func)
             if self.attn_backend == _Backend.ROCM_AITER_FA:
                 from aiter import flash_attn_varlen_func
+                dropout_p = float(0)
             else:
                 from flash_attn import flash_attn_varlen_func
+                dropout_p = 0
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -347,7 +349,7 @@ class Qwen2VisionAttention(nn.Module):
                                             cu_seqlens_k=cu_seqlens,
                                             max_seqlen_q=max_seqlen,
                                             max_seqlen_k=max_seqlen,
-                                            dropout_p=0,
+                                            dropout_p=dropout_p,
                                             causal=False)
 
             context_layer = rearrange(output,

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -627,7 +627,8 @@ class Qwen2VisionTransformer(nn.Module):
             self, cu_seqlens: torch.Tensor
     ) -> tuple[Optional[int], Optional[list[int]]]:
         max_seqlen, seqlens = None, None
-        if self.attn_backend in {_Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA}:
+        if (self.attn_backend == _Backend.FLASH_ATTN
+                or self.attn_backend == _Backend.ROCM_AITER_FA):
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
         elif self.attn_backend == _Backend.XFORMERS:
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -279,7 +279,7 @@ class Qwen2VisionAttention(nn.Module):
         }:
             raise RuntimeError(
                 f"Qwen2-VL does not support {self.attn_backend} backend now.")
-        self.flash_attn_backend = self.attn_backend in {
+        self.is_flash_attn_backend = self.attn_backend in {
             _Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA
         }
 
@@ -328,15 +328,13 @@ class Qwen2VisionAttention(nn.Module):
             q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
             k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
 
-        if self.flash_attn_backend:
+        if self.is_flash_attn_backend:
             # from vllm_flash_attn.flash_attn_interface import (
             #   flash_attn_varlen_func)
             if self.attn_backend == _Backend.ROCM_AITER_FA:
                 from aiter import flash_attn_varlen_func
-                dropout_p = float(0)
             else:
                 from flash_attn import flash_attn_varlen_func
-                dropout_p = 0
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -347,7 +345,7 @@ class Qwen2VisionAttention(nn.Module):
                                             cu_seqlens_k=cu_seqlens,
                                             max_seqlen_q=max_seqlen,
                                             max_seqlen_k=max_seqlen,
-                                            dropout_p=dropout_p,
+                                            dropout_p=0.0,
                                             causal=False)
 
             context_layer = rearrange(output,

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -97,6 +97,8 @@ def get_vit_attn_backend(support_fa: bool = False) -> _Backend:
             else:
                 # For Volta and Turing GPUs, use xformers instead.
                 selected_backend = _Backend.XFORMERS
+        elif current_platform.is_rocm():
+            selected_backend = _Backend.FLASH_ATTN
         else:
             # Default to torch SDPA for other non-GPU platforms.
             selected_backend = _Backend.TORCH_SDPA

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -207,7 +207,7 @@ class CudaPlatformBase(Platform):
         return torch.cuda.max_memory_allocated(device)
 
     @classmethod
-    def get_vit_attn_backend(cls, support_fa: bool = False) -> str:
+    def get_vit_attn_backend(cls, support_fa: bool = False) -> _Backend:
         if cls.has_device_capability(80) and support_fa:
             from transformers.utils import is_flash_attn_2_available
             if is_flash_attn_2_available():

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -207,6 +207,20 @@ class CudaPlatformBase(Platform):
         return torch.cuda.max_memory_allocated(device)
 
     @classmethod
+    def get_vit_attn_backend(cls, support_fa: bool = False) -> str:
+        if cls.has_device_capability(80) and support_fa:
+            from transformers.utils import is_flash_attn_2_available
+            if is_flash_attn_2_available():
+                return _Backend.FLASH_ATTN
+            logger.warning_once(
+                "Current `vllm-flash-attn` has a bug inside vision "
+                "module, so we use xformers backend instead. You can "
+                "run `pip install flash-attn` to use flash-attention "
+                "backend.")
+        # Fallback for Volta/Turing GPUs or FA not supported
+        return _Backend.XFORMERS
+
+    @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,
                              kv_cache_dtype, block_size, use_v1,
                              use_mla) -> str:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -188,6 +188,10 @@ class Platform:
             return device_id
 
     @classmethod
+    def get_vit_attn_backend(cls, support_fa: bool = False) -> str:
+        return _Backend.TORCH_SDPA
+
+    @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
                              block_size: int, use_v1: bool,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -188,7 +188,7 @@ class Platform:
             return device_id
 
     @classmethod
-    def get_vit_attn_backend(cls, support_fa: bool = False) -> str:
+    def get_vit_attn_backend(cls, support_fa: bool = False) -> _Backend:
         return _Backend.TORCH_SDPA
 
     @classmethod

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -46,6 +46,7 @@ class _Backend(enum.Enum):
     ROCM_FLASH = enum.auto()
     ROCM_AITER_MLA = enum.auto()  # Supported by V1
     ROCM_AITER_MLA_VLLM_V1 = enum.auto()
+    ROCM_AITER_FA = enum.auto()  # used for ViT attn backend
     TORCH_SDPA = enum.auto()
     FLASHINFER = enum.auto()
     FLASHINFER_VLLM_V1 = enum.auto()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -174,10 +174,12 @@ class RocmPlatform(Platform):
     ]
 
     @classmethod
-    def get_vit_attn_backend(cls, support_fa: bool = False) -> str:
+    def get_vit_attn_backend(cls, support_fa: bool = False) -> _Backend:
         if support_fa:
             if (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA
                     and on_gfx9()):
+                # Note: AITER FA is only supported for Qwen-VL models.
+                # TODO: Add support for other VL models in their model class.
                 return _Backend.ROCM_AITER_FA
             elif on_mi3xx():
                 return _Backend.FLASH_ATTN

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -181,7 +181,7 @@ class RocmPlatform(Platform):
                 # Note: AITER FA is only supported for Qwen-VL models.
                 # TODO: Add support for other VL models in their model class.
                 return _Backend.ROCM_AITER_FA
-            elif on_mi3xx():
+            if on_gfx9():
                 return _Backend.FLASH_ATTN
         return _Backend.TORCH_SDPA
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -174,6 +174,16 @@ class RocmPlatform(Platform):
     ]
 
     @classmethod
+    def get_vit_attn_backend(cls, support_fa: bool = False) -> str:
+        if support_fa:
+            if (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA
+                    and on_gfx9()):
+                return _Backend.ROCM_AITER_FA
+            elif on_mi3xx():
+                return _Backend.FLASH_ATTN
+        return _Backend.TORCH_SDPA
+
+    @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,
                              kv_cache_dtype, block_size, use_v1,
                              use_mla) -> str:


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose 
This PR enables the ViT backend selection in the Qwen2 and Qwen2.5 vision language models to support the `FLASH_ATTN` backend on the ROCm platform. It uses the flash_attn_varlen_func from vLLM and additionally provides support for the AITER flash attention implementation (flash_attn_varlen_func from AITER).

## Test Plan and Results

Use [mistral-evals](https://github.com/mistralai/mistral-evals/tree/main) repo for accuracy evaluation.

eval result of `Qwen/Qwen2.5-VL-7B-Instruct` model  on  on `chartqa` dataset

Result of using `vllm flash attention` for ViT backend 
{
    "explicit_prompt_relaxed_correctness": 0.8632,
    "anywhere_in_answer_relaxed_correctness": 0.8632
}

Result of using `aiter flash attention` for ViT backend
{
    "explicit_prompt_relaxed_correctness": 0.8644,
    "anywhere_in_answer_relaxed_correctness": 0.8648
}

eval result of `Qwen/Qwen2-VL-7B-Instruct` model on `chartqa` dataset

Result of using `vllm flash attention` for ViT backend 
{
    "explicit_prompt_relaxed_correctness": 0.4596,
    "anywhere_in_answer_relaxed_correctness": 0.6988
}
Result of using `aiter flash attention` for ViT backend
{
    "explicit_prompt_relaxed_correctness": 0.4576,
    "anywhere_in_answer_relaxed_correctness": 0.6964
}

## Benchmark

Benchmark results on `Qwen/Qwen2.5-VL-7B-Instruct`

| Metric                              | Base           | Flash Attention | Aiter Flash Attention (updated) |
|--------------------------------------|:--------------:|:---------------:|:-------------------------------:|
| **Successful requests**              | 1000           | 1000            | 1000                            |
| **Benchmark duration (s)**           | 669.11         | 438.96          | 443.07                          |
| **Total input tokens**               | 94,327         | 94,327          | 94,327                          |
| **Total generated tokens**           | 114,147        | 114,130         | 114,004                         |
| **Request throughput (req/s)**       | 1.49           | 2.28            | 2.26                            |
| **Output token throughput (tok/s)**  | 170.60         | 260.00          | 257.30                          |
| **Total token throughput (tok/s)**   | 311.57         | 474.89          | 470.20                          |
| **Mean TTFT (ms)**                   | 304,688.19     | 195,171.21      | 197,359.33                      |
| **Median TTFT (ms)**                 | 285,449.09     | 169,784.12      | 169,383.98                      |
| **P99 TTFT (ms)**                    | 653,794.14     | 426,574.61      | 431,132.11                      |
| **Mean TPOT (ms)**                   | 3,273.63       | 2,178.81        | 2,196.19                        |
| **Median TPOT (ms)**                 | 3,336.22       | 2,287.00        | 2,305.96                        |
| **P99 TPOT (ms)**                    | 7,618.51       | 4,620.32        | 4,617.08                        |
| **Mean ITL (ms)**                    | 2,996.72       | 1,999.78        | 2,018.82                        |
| **Median ITL (ms)**                  | 72.78          | 64.97           | 69.10                           |
| **P99 ITL (ms)**                     | 8,251.64       | 8,252.79        | 5,775.12                        |


