### PR TITLE
[V1] Enhanced Exception Handling for KV Cache Loading from Remote Store

### DIFF
--- a/tests/v1/kv_connector/unit/test_output_aggreagator.py
+++ b/tests/v1/kv_connector/unit/test_output_aggreagator.py
@@ -11,46 +11,56 @@ class DummyModelRunnerOutput(ModelRunnerOutput):
 
     def __init__(self,
                  finished_sending: Optional[set[str]] = None,
-                 finished_recving: Optional[set[str]] = None):
+                 finished_recving: Optional[set[str]] = None,
+                 finished_loading_dict: Optional[dict[str, int]] = None):
         self.finished_sending = finished_sending
         self.finished_recving = finished_recving
+        self.finished_loading_dict = finished_loading_dict
 
 
 def test_aggregate_workers_output():
     aggregator = KVOutputAggregator(world_size=2)
 
     output1 = DummyModelRunnerOutput(finished_sending={'req1'},
-                                     finished_recving={'req2'})
+                                     finished_recving={'req2'},
+                                     finished_loading_dict={'req2': 256})
     output2 = DummyModelRunnerOutput(finished_sending=None,
-                                     finished_recving=None)
+                                     finished_recving=None,
+                                     finished_loading_dict=None)
 
     aggregated = aggregator.aggregate([output1, output2])
 
     assert aggregated is output1
     assert aggregated.finished_sending is None
     assert aggregated.finished_recving is None
+    assert aggregated.finished_loading_dict is None
 
     output1 = DummyModelRunnerOutput(finished_sending=None,
-                                     finished_recving=None)
+                                     finished_recving=None,
+                                     finished_loading_dict=None)
     output2 = DummyModelRunnerOutput(finished_sending={'req1'},
-                                     finished_recving=None)
+                                     finished_recving=None,
+                                     finished_loading_dict=None)
 
     aggregated = aggregator.aggregate([output1, output2])
 
     assert aggregated is output1
     assert aggregated.finished_sending == {'req1'}
     assert aggregated.finished_recving is None
+    assert aggregated.finished_loading_dict is None
 
     output1 = DummyModelRunnerOutput(finished_sending=None,
                                      finished_recving=None)
     output2 = DummyModelRunnerOutput(finished_sending={'req1'},
-                                     finished_recving={'req2'})
+                                     finished_recving={'req2'},
+                                     finished_loading_dict={'req2': 128})
 
     aggregated = aggregator.aggregate([output1, output2])
 
     assert aggregated is output1
     assert aggregated.finished_sending is None
     assert aggregated.finished_recving == {'req2'}
+    assert aggregated.finished_loading_dict == {'req2': 128}
 
 
 def test_async_aggregate_workers_output():
@@ -61,9 +71,11 @@ def test_async_aggregate_workers_output():
     result_future = aggregator.async_aggregate([future1, future2])
 
     output1 = DummyModelRunnerOutput(finished_sending={'req1'},
-                                     finished_recving={'req2'})
+                                     finished_recving={'req2'},
+                                     finished_loading_dict={'req2': 256})
     output2 = DummyModelRunnerOutput(finished_sending=None,
-                                     finished_recving=None)
+                                     finished_recving=None,
+                                     finished_loading_dict=None)
     future1.set_result(output1)
     future2.set_result(output2)
 
@@ -72,15 +84,18 @@ def test_async_aggregate_workers_output():
     assert aggregated is output1
     assert aggregated.finished_sending is None
     assert aggregated.finished_recving is None
+    assert aggregated.finished_loading_dict is None
 
     future1 = Future()
     future2 = Future()
     result_future = aggregator.async_aggregate([future1, future2])
 
     output1 = DummyModelRunnerOutput(finished_sending=None,
-                                     finished_recving=None)
+                                     finished_recving=None,
+                                     finished_loading_dict=None)
     output2 = DummyModelRunnerOutput(finished_sending={'req1'},
-                                     finished_recving=None)
+                                     finished_recving=None,
+                                     finished_loading_dict=None)
     future1.set_result(output1)
     future2.set_result(output2)
 
@@ -89,15 +104,18 @@ def test_async_aggregate_workers_output():
     assert aggregated is output1
     assert aggregated.finished_sending == {'req1'}
     assert aggregated.finished_recving is None
+    assert aggregated.finished_loading_dict is None
 
     future1 = Future()
     future2 = Future()
     result_future = aggregator.async_aggregate([future1, future2])
 
     output1 = DummyModelRunnerOutput(finished_sending=None,
-                                     finished_recving=None)
+                                     finished_recving=None,
+                                     finished_loading_dict=None)
     output2 = DummyModelRunnerOutput(finished_sending={'req1'},
-                                     finished_recving={'req2'})
+                                     finished_recving={'req2'},
+                                     finished_loading_dict={'req2': 128})
     future1.set_result(output1)
     future2.set_result(output2)
 
@@ -106,3 +124,4 @@ def test_async_aggregate_workers_output():
     assert aggregated is output1
     assert aggregated.finished_sending is None
     assert aggregated.finished_recving == {'req2'}
+    assert aggregated.finished_loading_dict == {'req2': 128}

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -167,6 +167,7 @@ def create_model_runner_output(
     reqs: list[Request],
     finished_sending: Optional[list[str]] = None,
     finished_recving: Optional[list[str]] = None,
+    finished_loading_dict: Optional[dict[str, int]] = None,
     use_eos: bool = False,
 ) -> ModelRunnerOutput:
     """Make dummy model runner output for testing."""
@@ -180,17 +181,16 @@ def create_model_runner_output(
     sampled_token_ids = [[sampled_token] for _ in req_ids]
 
     # Make output data structure.
-    return ModelRunnerOutput(
-        req_ids=req_ids,
-        req_id_to_index=req_id_to_index,
-        sampled_token_ids=sampled_token_ids,
-        spec_token_ids=None,
-        logprobs=None,
-        prompt_logprobs_dict={},
-        pooler_output=None,
-        finished_sending=finished_sending,
-        finished_recving=finished_recving,
-    )
+    return ModelRunnerOutput(req_ids=req_ids,
+                             req_id_to_index=req_id_to_index,
+                             sampled_token_ids=sampled_token_ids,
+                             spec_token_ids=None,
+                             logprobs=None,
+                             prompt_logprobs_dict={},
+                             pooler_output=None,
+                             finished_sending=finished_sending,
+                             finished_recving=finished_recving,
+                             finished_loading_dict=finished_loading_dict)
 
 
 class TestSharedStorageConnector(SharedStorageConnector):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -28,6 +28,9 @@ The class provides the following primitives:
 
         get_finished() - called with ids of finished requests, returns
             ids of requests that have completed async sending/recving.
+        get_finished_loading() - called with scheduler outputs, returns
+            a dictionary that the keys are request IDs and the values are
+            the actual number of tokens loaded from the remote KV cache
 """
 
 import enum
@@ -218,6 +221,23 @@ class KVConnectorBase_V1(ABC):
             call to this method (this call or a prior one).
         """
         return None, None
+
+    def get_finished_loading(
+            self, scheduler_output: "SchedulerOutput") -> dict[str, int]:
+        """
+        Retrieves the actual number of tokens loaded for requests that have
+        completed the asynchronous loading process from the remote KV cache.
+
+        This function is used by the scheduler process (via the Executors)
+        to track the progress of requests and determine which requests have
+        successfully finished loading their KV cache data.
+
+        Returns:
+            A dictionary where the keys are request IDs and the values are the
+            corresponding number of tokens that have been successfully loaded
+            for each request.
+        """
+        return {}
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -132,6 +132,15 @@ class MultiConnector(KVConnectorBase_V1):
 
         return finished_sending or None, finished_recving or None
 
+    def get_finished_loading(
+            self, scheduler_output: "SchedulerOutput") -> dict[str, int]:
+        finished_loading_dict: dict[str, int] = {}
+        for c in self._connectors:
+            loading_dict = c.get_finished_loading(scheduler_output)
+            # Each request will only be assigned to one connector.
+            finished_loading_dict.update(loading_dict or {})
+        return finished_loading_dict
+
     # ==============================
     # Scheduler-side methods
     # ==============================

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -1167,6 +1167,8 @@ class IntermediateTensors:
     # [req_ids]
     finished_sending: Optional[set[str]] = None
     finished_recving: Optional[set[str]] = None
+    #req_id -> num_actual_load_tokens
+    finished_loading_dict: Optional[dict[str, int]] = None
 
     def __init__(self, tensors):
         # manually define this function, so that

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -118,6 +118,12 @@ class Scheduler(SchedulerInterface):
 
         # KV Connector: requests in process of async KV loading or recving
         self.finished_recving_kv_req_ids: set[str] = set()
+        # The keys are request IDs, and the values are corresponding token
+        # count that have been successfully loaded from the remote KV store
+        self.finished_loading_dict: dict[str, int] = {}
+        # Requests that have completed loading from remote storage but failed
+        # (e.g., due to network timeout) will revert to re-inference.
+        self.failure_loading_request: set[str] = set()
 
         # Encoder-related.
         # Calculate encoder cache size if applicable
@@ -374,7 +380,9 @@ class Scheduler(SchedulerInterface):
                 load_kv_async = False
 
                 # Get already-cached tokens.
-                if request.num_computed_tokens == 0:
+                if request.num_computed_tokens == 0 and (
+                        request.request_id
+                        not in self.failure_loading_request):
                     # Get locally-cached tokens.
                     new_computed_blocks, num_new_local_computed_tokens = \
                         self.kv_cache_manager.get_computed_blocks(
@@ -392,6 +400,7 @@ class Scheduler(SchedulerInterface):
                 # KVTransfer: WAITING reqs have num_computed_tokens > 0
                 # after async KV recvs are completed.
                 else:
+                    self.failure_loading_request.discard(request.request_id)
                     new_computed_blocks = (
                         self.kv_cache_manager.create_empty_block_list())
                     num_new_local_computed_tokens = 0
@@ -1094,6 +1103,22 @@ class Scheduler(SchedulerInterface):
         (block_ids, ) = self.kv_cache_manager.get_block_ids(request.request_id)
         return self.connector.request_finished(request, block_ids)
 
+    def _update_actual_load_token_num_from_remote_kv(self,
+                                                     request: Request) -> bool:
+        num_actual_load_tokens = self.finished_loading_dict.pop(
+            request.request_id)
+        if num_actual_load_tokens <= 0:
+            self.failure_loading_request.add(request.request_id)
+            return True
+
+        num_computed_tokens = num_actual_load_tokens - (
+            1 if num_actual_load_tokens == request.num_tokens else 0)
+        self.kv_cache_manager.cache_blocks(request, num_computed_tokens)
+
+        # Update the request state for scheduling.
+        request.num_computed_tokens = num_computed_tokens
+        return True
+
     def _update_waiting_for_remote_kv(self, request: Request) -> bool:
         """
         KV Connector: check if the request_id is finished_recving.
@@ -1107,6 +1132,10 @@ class Scheduler(SchedulerInterface):
         WAITING_FOR_REMOTE_KV.
         """
         assert self.connector is not None
+        if request.request_id in self.finished_loading_dict:
+            self.finished_recving_kv_req_ids.discard(request.request_id)
+            return self._update_actual_load_token_num_from_remote_kv(request)
+
         if request.request_id not in self.finished_recving_kv_req_ids:
             return False
 
@@ -1145,3 +1174,6 @@ class Scheduler(SchedulerInterface):
         for req_id in (model_runner_output.finished_sending or ()):
             logger.debug("Finished sending KV transfer for request %s", req_id)
             self._free_blocks(self.requests[req_id])
+        if model_runner_output.finished_loading_dict:
+            self.finished_loading_dict.update(
+                model_runner_output.finished_loading_dict)

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -107,6 +107,8 @@ class ModelRunnerOutput:
     # [req_ids]
     finished_sending: Optional[set[str]] = None
     finished_recving: Optional[set[str]] = None
+    # req_id -> actual_load_token from connector
+    finished_loading_dict: Optional[dict[str, int]] = None
 
     # req_id -> num_nans_in_logits
     num_nans_in_logits: Optional[dict[str, int]] = None
@@ -121,4 +123,5 @@ EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[],
                                               pooler_output=[],
                                               finished_sending=None,
                                               finished_recving=None,
+                                              finished_loading_dict=None,
                                               num_nans_in_logits=None)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1431,6 +1431,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_scheduled_tokens_np: np.ndarray,
         finished_sending: Optional[set[str]],
         finished_recving: Optional[set[str]],
+        finished_loading_dict: Optional[dict[str, int]],
     ) -> ModelRunnerOutput:
         assert self.input_batch.num_reqs ==\
             len(self.input_batch.pooling_params), \
@@ -1467,6 +1468,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             pooler_output=pooler_output,
             finished_sending=finished_sending,
             finished_recving=finished_recving,
+            finished_loading_dict=finished_loading_dict,
         )
 
     @torch.inference_mode()
@@ -1587,6 +1589,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.maybe_wait_for_kv_save()
             finished_sending, finished_recving = (
                 self.get_finished_kv_transfers(scheduler_output))
+            finished_loading_dict = self.get_finished_loading(scheduler_output)
 
         if self.use_aux_hidden_state_outputs:
             hidden_states, aux_hidden_states = model_output
@@ -1604,9 +1607,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if not get_pp_group().is_last_rank:
             # For mid-pipeline stages, return the hidden states.
             if not broadcast_pp_output:
-                if finished_sending or finished_recving:
+                if (finished_sending or finished_recving
+                        or finished_loading_dict):
                     hidden_states.finished_sending = finished_sending
                     hidden_states.finished_recving = finished_recving
+                    hidden_states.finished_loading_dict = finished_loading_dict
                 return hidden_states
             assert isinstance(hidden_states, IntermediateTensors)
             get_pp_group().send_tensor_dict(hidden_states.tensors,
@@ -1616,7 +1621,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.input_batch.pooling_params:
                 return self._pool(hidden_states, num_scheduled_tokens,
                                   num_scheduled_tokens_np, finished_sending,
-                                  finished_recving)
+                                  finished_recving, finished_loading_dict)
 
             sample_hidden_states = hidden_states[logits_indices]
             logits = self.model.compute_logits(sample_hidden_states, None)
@@ -1768,6 +1773,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             pooler_output=[],
             finished_sending=finished_sending,
             finished_recving=finished_recving,
+            finished_loading_dict=finished_loading_dict,
             num_nans_in_logits=num_nans_in_logits,
         )
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -370,10 +370,12 @@ class Worker(WorkerBase):
             # In case of PP with kv transfer, we need to pass through the
             # finished_sending and finished_recving buffers.
             new_output = EMPTY_MODEL_RUNNER_OUTPUT
-            if output.finished_sending or output.finished_recving:
+            if (output.finished_sending or output.finished_recving
+                    or output.finished_loading_dict):
                 new_output = copy.copy(new_output)
                 new_output.finished_sending = output.finished_sending
                 new_output.finished_recving = output.finished_recving
+                new_output.finished_loading_dict = output.finished_loading_dict
             output = new_output
 
         assert isinstance(output, ModelRunnerOutput)

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -53,6 +53,14 @@ class KVConnectorModelRunnerMixin:
                 scheduler_output.finished_req_ids)
         return None, None
 
+    @staticmethod
+    def get_finished_loading(
+        scheduler_output: "SchedulerOutput", ) -> dict[str, int]:
+        if has_kv_transfer_group():
+            return get_kv_transfer_group().get_finished_loading(
+                scheduler_output)
+        return {}
+
     def kv_connector_no_forward(self, scheduler_output: "SchedulerOutput",
                                 vllm_config: VllmConfig) -> ModelRunnerOutput:
         # KV send/recv even if no work to do.
@@ -60,11 +68,14 @@ class KVConnectorModelRunnerMixin:
             self.maybe_setup_kv_connector(scheduler_output)
             finished_sending, finished_recving = (
                 self.get_finished_kv_transfers(scheduler_output))
+            finished_loading_dict = self.get_finished_loading(scheduler_output)
 
-        if not finished_sending and not finished_recving:
+        if (not finished_sending and not finished_recving
+                and not finished_loading_dict):
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
         output.finished_sending = finished_sending
         output.finished_recving = finished_recving
+        output.finished_loading_dict = finished_loading_dict
         return output


### PR DESCRIPTION
# [V1] Enhanced Exception Handling for KV Cache Loading from Remote Store
### Proposed Alternative Solution for Loading Error
We noticed that the community already has a PR #19330 addressing the loading error issue by rescheduling and returning an invalid_block_list. However, for the following two reasons, we are proposing a new solution:

- In practice, KV loading failures are rare, and the scenario where a middle block fails to load while subsequent blocks succeed is even rarer (given that eviction policies like LRU are typically used). Therefore, it’s worth considering whether such fine-grained control is necessary for such edge cases. 
- More importantly, neither vLLM’s current scheduling nor its attention_metadata construction can effectively utilize non-contiguous blocks.

Given the current state of vLLM, we propose a simpler solution that reuses the process and some interfaces of the Nixl connector. This solution is applicable to both KV Cache Offloading and Disaggregated Prefilling scenarios.

## Purpose
This PR is an improvement to https://github.com/vllm-project/vllm/pull/21534

> This PR implements an exception handling mechanism for cases where loading the KV cache from remote storage fails.

> The key point of this scheme is that the kv cache blocks are allocated in advance to load the remote kv store, wait for the load to complete, and then schedule the request to execute according to the actual number of loaded tokens.

> We reused the process and some interfaces of the Nixl connector to minimize additional modifications to vLLM. Naturally, this mechanism is also applicable to the Nixl Connector, requiring only minimal adaptation.

Mainly fixed the following points: 
1. Fix the logic for consolidating the finished_loading_dict results from multiple workers.
2. Add support for multi_connector
3. Addressed the case where loading kv cache is completed but the actual number of loaded tokens is 0 (e.g., due to network timeouts during KV transfer or file storage system failures). Added `failure_loading_request` in the scheduler to prevent reattempting to load the KV cache from the KV connector.

## Test Plan
Currently relying on CI unit tests.

In #21534, we introduced a mock `RandomDropConnector` that simulates the scenario where the actual number of KV tokens loaded is less than the prompt length. It can verify whether the failed loading requests are completed but cannot validate the correctness of the output.
Therefore, we are constructing a `RandomDropStorageConnector` that supports asynchronous loading of the KV cache and randomly drops a portion of the tokens during the loading process.

## Test Result
`python3 tests/v1/kv_connector/unit/test_output_aggreagator.py`
`python3 tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py`

Tagging @youkaichao @KuntaiDu @ApostaC @njhill @robertgshaw2-redhat @NickLucche @orozery @sdavidbd for visibility. I’m glad to receive your thoughts and suggestions.