### PR TITLE
[BUG] [ROCm] Fix import bug on ROCm

### DIFF
--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -7,7 +7,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
-if current_platform.is_cuda_alike():
+if current_platform.is_cuda():
     from .fusion import FusionPass
     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
     from .fusion_attn import AttnFusionPass


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fix the bug introduce by PR https://github.com/vllm-project/vllm/pull/21069
following the bugfix PR https://github.com/vllm-project/vllm/pull/21036

Bug Log

```
1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/executor/executor_base.py", line 53, in __init__
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     self._init_executor()
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/executor/uniproc_executor.py", line 49, in _init_executor
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     self.collective_rpc("load_model")
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     answer = run_method(self.driver_worker, method, args, kwargs)
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/utils/__init__.py", line 2948, in run_method
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     return func(*args, **kwargs)
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/v1/worker/gpu_worker.py", line 212, in load_model
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     self.model_runner.load_model(eep_scale_up=eep_scale_up)
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/v1/worker/gpu_model_runner.py", line 1972, in load_model
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     self.drafter.load_model(self.model)
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/v1/spec_decode/eagle.py", line 389, in load_model
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     from vllm.compilation.backends import set_model_tag
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/compilation/backends.py", line 27, in <module>
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     from .pass_manager import PostGradPassManager
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/compilation/pass_manager.py", line 12, in <module>
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/app/fix-specdec-rocm/vllm/compilation/collective_fusion.py", line 41, in <module>
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.default
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]   File "/usr/local/lib/python3.10/dist-packages/torch/_ops.py", line 1267, in __getattr__
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667]     raise AttributeError(
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m ERROR 08-01 09:45:20 [core.py:667] AttributeError: '_OpNamespace' '_C' object has no attribute 'scaled_fp4_quant'
^[[1;36m(EngineCore_0 pid=162345)^[[0;0m Process EngineCore_0:
```

## Test Plan

## Test Result

## (Optional) Documentation Update

