### PR TITLE
[Misc] Add comprehensive error message for non-integer CUDA_VISIBLE_DEVICES variables

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -182,7 +182,16 @@ class Platform:
                 cls.device_control_env_var] != "":
             device_ids = os.environ[cls.device_control_env_var].split(",")
             physical_device_id = device_ids[device_id]
-            return int(physical_device_id)
+            try:
+                return int(physical_device_id)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid device ID '{physical_device_id}' in "
+                    f"{cls.device_control_env_var} environment variable. "
+                    "Expected a comma-separated list of integers, "
+                    "which is the only supported format for this variable. "
+                    "See also https://github.com/vllm-project/vllm/issues/6551#issuecomment-2239800023"
+                ) from None
         else:
             return device_id
 


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

Replace ValueError message around processing of `CUDA_VISIBLE_DEVICES`.

## Purpose

According to https://github.com/vllm-project/vllm/issues/6551#issuecomment-2239703378 , vLLM seems not to support device IDs other than integers. The current error message only describes the direct reason (parse error), which is not informative for users who is running into the problem. This PR adds a verbose message instead.

## Test Plan

NA

## Test Result

NA

## (Optional) Documentation Update

NA

