### PR TITLE
[Misc] `VLLM_TARGET_DEVICE.lower()`

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -212,7 +212,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Target device of vLLM, supporting [cuda (by default),
     # rocm, neuron, cpu]
     "VLLM_TARGET_DEVICE":
-    lambda: os.getenv("VLLM_TARGET_DEVICE", "cuda"),
+    lambda: os.getenv("VLLM_TARGET_DEVICE", "cuda").lower(),
 
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs


### PR DESCRIPTION
I think the `VLLM_TARGET_DEVICE` env var should not be case-sensitive as each target platform name is unique.
This would make these two equivalent 

```
VLLM_TARGET_DEVICE="tpu" python -m pip install -e .
VLLM_TARGET_DEVICE="TPU" python -m pip install -e .
```
