### PR TITLE
Fix pre-commit failure for SECURTIY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-## Reporting security issues:
+## Reporting security issues
 
 Please report security issues privately using [the vulnerability submission form](https://github.com/vllm-project/vllm/security/advisories/new).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,15 +19,19 @@ Please see [PyTorch's Security Policy](https://github.com/pytorch/pytorch/blob/m
 We will determine the risk of each issue, taking into account our experience dealing with past issues, versions affected, common defaults, and use cases. We use the following severity categories:
 
 ### CRITICAL Severity
+
 Vulnerabilities that allow remote attackers to execute arbitrary code, take full control of the system, or significantly compromise confidentiality, integrity, or availability without any interaction or privileges needed, examples include remote code execution via network, deserialization issues that allow exploit chains. Generally those issues which are rated as CVSS  ≥ 9.0.
 
 ### HIGH Severity
+
 Serious security flaws that allow elevated impact—like RCE in specific, limited contexts or significant data loss—but require advanced conditions or some trust, examples include RCE in advanced deployment modes (e.g. multi-node), or high impact issues where some sort of privileged network access is required. These issues typically have CVSS scores between 7.0 and 8.9
 
 ### MODERATE Severity
+
 Vulnerabilities that cause denial of service or partial disruption, but do not allow arbitrary code execution or data breach and have limited impact. These issues have a CVSS rating between 4.0 and 6.9
 
 ### LOW Severity
+
 Minor issues such as informational disclosures, logging errors, non-exploitable flaws, or weaknesses that require local or high-privilege access and offer negligible impact. Examples include side channel attacks or hash collisions. These issues often have CVSS scores less than 4.0
 
 ## Prenotification policy


### PR DESCRIPTION
Fixes pre-commit broken on main since https://github.com/vllm-project/vllm/pull/21119 landed

Failure is
```
markdownlint........................................................................................Failed
- hook id: markdownlint
- exit code: 1

Error: SECURITY.md:3:29 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
Error: SECURITY.md:21 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "### CRITICAL Severity"]
Error: SECURITY.md:24 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "### HIGH Severity"]
Error: SECURITY.md:27 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "### MODERATE Severity"]
Error: SECURITY.md:30 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "### LOW Severity"]
```