### PR TITLE
Remove index_put from MM embeddings merging

### DIFF
--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -393,7 +393,7 @@ def merge_multimodal_embeddings_from_map(
         inputs_embeds: torch.Tensor, multimodal_embeddings: NestedTensors,
         placeholder_map: MultiModalPlaceholderMap.IndexMap) -> torch.Tensor:
     """
-    Merge ``multimodal_embeddings`` into ``inputs_embeds`` using the provided 
+    Merge ``multimodal_embeddings`` into ``inputs_embeds`` using the provided
     placeholder map .
 
     Note:
@@ -418,17 +418,23 @@ def _merge_multimodal_embeddings(
     Note:
         This updates ``inputs_embeds`` in place.
     """
-    num_expected_tokens = is_multimodal.sum().item()
-    assert isinstance(num_expected_tokens, int)
-
     flattened = _flatten_embeddings(multimodal_embeddings)
-    if flattened.shape[0] != num_expected_tokens:
-        expr = _embedding_count_expression(multimodal_embeddings)
-        raise ValueError(
-            f"Attempted to assign {expr} = {flattened.shape[0]} "
-            f"multimodal tokens to {num_expected_tokens} placeholders")
+    try:
+        # This is equivalent to: inputs_embeds[is_multimodal] = flattened.
+        inputs_embeds.masked_scatter_(is_multimodal.unsqueeze(-1), flattened)
+    except RuntimeError as e:
+        num_expected_tokens = is_multimodal.sum().item()
+        assert isinstance(num_expected_tokens, int)
 
-    inputs_embeds[is_multimodal] = flattened
+        if flattened.shape[0] != num_expected_tokens:
+            expr = _embedding_count_expression(multimodal_embeddings)
+            raise ValueError(
+                f"Attempted to assign {expr} = {flattened.shape[0]} "
+                f"multimodal tokens to {num_expected_tokens} placeholders"
+            ) from e
+        else:
+            raise ValueError("Error during masked scatter operation") from e
+
     return inputs_embeds
 
 
@@ -478,11 +484,11 @@ def merge_multimodal_embeddings(
     Merge ``multimodal_embeddings`` into ``inputs_embeds`` by overwriting the
     positions in ``inputs_embeds`` corresponding to placeholder tokens in
     ``input_ids``.
-    
-    ``placeholder_token_id`` can be a list of token ids (e.g, token ids 
-    of img_start, img_break, and img_end tokens) when needed: This means 
-    the order of these tokens in the ``input_ids`` MUST MATCH the order of 
-    their embeddings in ``multimodal_embeddings`` since we need to 
+
+    ``placeholder_token_id`` can be a list of token ids (e.g, token ids
+    of img_start, img_break, and img_end tokens) when needed: This means
+    the order of these tokens in the ``input_ids`` MUST MATCH the order of
+    their embeddings in ``multimodal_embeddings`` since we need to
     slice-merge instead of individually scattering.
 
     For example, if input_ids is "TTTTTSIIIBIIIBIIIETTT", where
@@ -491,9 +497,9 @@ def merge_multimodal_embeddings(
     - I is image embedding token
     - B is image break token
     - E is image end token.
-    
-    Then the image embeddings (that correspond to I's) from vision encoder 
-    must be padded with embeddings of S, B, and E in the same order of 
+
+    Then the image embeddings (that correspond to I's) from vision encoder
+    must be padded with embeddings of S, B, and E in the same order of
     input_ids for a correct embedding merge.
 
     Note:


### PR DESCRIPTION
Summary:
Previously, _merge_multimodal_embeddings used `inputs_embeds[is_multimodal]=flattened` to merge the MM embeddings. This index_put operations calls non_zero in pytorch, which forces an additional D2H shape check sync point.
This diff uses masked_scatter_ to bypass the D2H point. The latency changes from 35ms to 0.08ms.

Test Plan:
E2E Results:
Before:
```
QPS:                 0.91
Avg latency:         8.542s
Avg TTFT (client):   4186.02ms
P50 TTFT (client):   4589.01ms
P99 TTFT (client):   6897.92ms
Avg TTIT (client):   21.78ms
P50 TTIT (client):   19.99ms
P99 TTIT (client):   41.25ms
Avg TTFT (server):   5657.19ms
Avg TTIT (server):   130.71ms
Avg prefill len:     22284.20 tokens
P50 prefill len:     22284.00 tokens
P99 prefill len:     22291.00 tokens
Avg decode len:      200.00 tokens
P50 decode len:      200.00 tokens
P99 decode len:      200.00 tokens
```
After:
```
QPS:                 0.94
Avg latency:         8.456s
Avg TTFT (client):   4089.09ms
P50 TTFT (client):   4510.47ms
P99 TTFT (client):   6902.79ms
Avg TTIT (client):   21.83ms
P50 TTIT (client):   19.89ms
P99 TTIT (client):   41.02ms
Avg TTFT (server):   3808.06ms
Avg TTIT (server):   79.76ms
Avg prefill len:     22284.26 tokens
P50 prefill len:     22284.00 tokens
P99 prefill len:     22291.00 tokens
Avg decode len:      200.00 tokens
P50 decode len:      200.00 tokens
P99 decode len:      200.00 tokens
```

Rollback Plan:

Differential Revision: D79405697
