### PR TITLE
[Fix] Fix python path resolving in cpu cmake

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -3,7 +3,17 @@
 # `EXECUTABLE` and is one of the `SUPPORTED_VERSIONS`.
 #
 macro (find_python_from_executable EXECUTABLE SUPPORTED_VERSIONS)
-  file(REAL_PATH ${EXECUTABLE} EXECUTABLE)
+  if(NOT EXISTS "${EXECUTABLE}" OR IS_DIRECTORY "${EXECUTABLE}")
+    message(FATAL_ERROR "EXECUTABLE does not exist or is a directory: ${EXECUTABLE}")
+  endif()
+  execute_process(
+    COMMAND "${EXECUTABLE}" --version
+    RESULT_VARIABLE _PYTHON_EXEC_RESULT
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  if(NOT _PYTHON_EXEC_RESULT EQUAL 0)
+    message(FATAL_ERROR "EXECUTABLE is not a valid python executable: ${EXECUTABLE}")
+  endif()
   set(Python_EXECUTABLE ${EXECUTABLE})
   find_package(Python COMPONENTS Interpreter Development.Module Development.SABIModule)
   if (NOT Python_FOUND)


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Removed the python path resolving in cpu cmake file.
Also added input validation.

Issue was discovered during failed deployment to cpu only environment, link resolving is not working and unnecessary:
<img width="437" height="39" alt="image" src="https://github.com/user-attachments/assets/3f3ba8d5-5b76-41f5-84e7-1e51ce704a18" />


## Test Plan
`VLLM_TARGET_DEVICE=cpu python setup.py develop` or `VLLM_TARGET_DEVICE=cpu python setup.py install`

## Test Result
https://gist.github.com/xiszishu/d0375720534b4344759a6e2b8c2ed6c4

## (Optional) Documentation Update

