### PR TITLE
[Bugfix] Add Dense module support for sentence-transformers models

### DIFF
--- a/vllm/model_executor/layers/dense.py
+++ b/vllm/model_executor/layers/dense.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import torch.nn as nn
+from typing import Optional
+
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.utils import set_weight_attrs
+
+
+class Dense(nn.Module):
+    """
+    Dense layer for sentence-transformers models.
+    
+    This layer transforms embeddings from one dimension to another,
+    typically used in sentence-transformers models like TencentBAC/Conan-embedding-v1.
+    """
+    
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        params_dtype: Optional[torch.dtype] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        
+        self.in_features = in_features
+        self.out_features = out_features
+        
+        # Use ReplicatedLinear for the dense transformation
+        self.linear = ReplicatedLinear(
+            input_size=in_features,
+            output_size=out_features,
+            bias=bias,
+            params_dtype=params_dtype or torch.float32,
+            prefix=prefix,
+        )
+        
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass of the dense layer.
+        
+        Args:
+            x: Input tensor of shape (batch_size, in_features)
+            
+        Returns:
+            Output tensor of shape (batch_size, out_features)
+        """
+        return self.linear(x)
+    
+    def load_weights(self, weights):
+        """
+        Load weights for the dense layer.
+        
+        Args:
+            weights: Iterable of (name, tensor) pairs containing the weights
+        """
+        loaded_params = set()
+        
+        for name, weight in weights:
+            if name == "dense.weight":
+                self.linear.weight.data.copy_(weight)
+                loaded_params.add("dense.weight")
+            elif name == "dense.bias" and self.linear.bias is not None:
+                self.linear.bias.data.copy_(weight)
+                loaded_params.add("dense.bias")
+                
+        return loaded_params 

--- a/vllm/model_executor/layers/dense.py
+++ b/vllm/model_executor/layers/dense.py
@@ -38,6 +38,7 @@ class Dense(nn.Module):
             bias=bias,
             params_dtype=params_dtype or torch.float32,
             prefix=prefix,
+            return_bias=False,
         )
         
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
**Key Fix:** The Dense layer now correctly handles the tuple return from `ReplicatedLinear` and returns only the output tensor, preventing the `AttributeError`.

FIX #15509
FIX #16898

## Documentation Update

### Files Modified
1. **`vllm/model_executor/layers/dense.py`** - New Dense layer with tuple handling fix
2. **`vllm/model_executor/layers/pooler.py`** - Integration with pooling system  
3. **`vllm/model_executor/models/adapters.py`** - Auto-detection logic

### Usage-1
```python
from vllm import LLM

# Automatic detection and loading
llm = LLM(model="TencentBAC/Conan-embedding-v1")
# Output embeddings will have correct dimension (1792)
```

### Usage-2
```python
import torch
from vllm.model_executor.layers.dense import Dense

dense = Dense(in_features=1024, out_features=1792, bias=True)
x = torch.randn(2, 1024)

try:
    y = dense(x)
    assert isinstance(y, torch.Tensor), "Output is not a tensor"
    assert y.shape == (2, 1792), f"Wrong shape: {y.shape}"
    print("Dense layer test passed.")
except Exception as e:
    print(f"Test failed: {e}")
```