### PR TITLE
[Bugfix] Add num_special_tokens_to_add to MistralTokenizer, fixes #22013

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -519,3 +519,13 @@ class MistralTokenizer(TokenizerBase):
             tokens = [self.tokenizer.id_to_byte_piece(id) for id in ids]
 
         return tokens
+
+    def num_special_tokens_to_add(self) -> int:
+        # MistralTokenizer always adds [INST] and [/INST]
+        num_tokens = 2
+
+        # MistralTokenizer does not appear to add an eos token
+        if hasattr(self, "bos_token_id") and self.bos_token_id is not None:
+            num_tokens += 1
+
+        return num_tokens


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Fixes #22013

## Test Plan
Manually testing the serve benchmark without the changes and with the changes in place.
```bash
uv run vllm/entrypoints/openai/api_server.py --model /models/ministral-8b-instruct-2410 --gpu-memory-utilization 0.8 --max-model-len 256 --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --quantization bitsandbytes --kv-cache-dtype fp8 --max-num-seqs 1 --max-num-batched-tokens 512 --served-model-name ministral-8b-instruct-2410 --enable-auto-tool-choice --disable-log-requests
```

```bash
uv run benchmarks/benchmark_serving.py --backend openai-chat --model /models/ministral-8b-instruct-2410 --served-model-name ministral-8b-instruct-2410 --endpoint /v1/chat/completions --dataset-name random --num-prompts 1 --tokenizer_mode mistral --base-url "http://0.0.0.0:8000" --random-input-len 64 --random-output-len 64
```

## Test Result
Manually testing without the changes produces an error:
```bash
Traceback (most recent call last):
  File "/home/user/llm/benchmarks/benchmark_serving.py", line 1299, in <module>
    main(args)
  File "/home/user/vllm/.venv/lib/python3.12/site-packages/typing_extensions.py", line 2956, in wrapper
    return arg(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/user/vllm/benchmarks/benchmark_serving.py", line 774, in main
    input_requests = dataset_mapping[args.dataset_name]()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/vllm/benchmarks/benchmark_serving.py", line 763, in <lambda>
    "random": lambda: RandomDataset(dataset_path=args.dataset_path).sample(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/vllm/benchmarks/benchmark_dataset.py", line 314, in sample
    num_special_tokens = tokenizer.num_special_tokens_to_add()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MistralTokenizer' object has no attribute 'num_special_tokens_to_add'. Did you mean: 'all_special_tokens_extended'
```

Manually testing with the changes produces the desired result, i.e. a full run of the benchmark:
```bash
============ Serving Benchmark Result ============
Successful requests:                     1         
Benchmark duration (s):                  2.63      
Total input tokens:                      61        
Total generated tokens:                  64        
Request throughput (req/s):              0.38      
Output token throughput (tok/s):         24.32     
Total Token throughput (tok/s):          47.51     
---------------Time to First Token----------------
Mean TTFT (ms):                          369.13    
Median TTFT (ms):                        369.13    
P99 TTFT (ms):                           369.13    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.90     
Median TPOT (ms):                        35.90     
P99 TPOT (ms):                           35.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.34     
Median ITL (ms):                         35.86     
P99 ITL (ms):                            36.38     
==================================================
```

## (Optional) Documentation Update

