### PR TITLE
Revert "[compile][startup] Disable C++ compilation of symbolic shapes"

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -267,15 +267,8 @@ def _support_torch_compile(
                     code.co_filename)
                 return inline_call(parent, func, args, kwargs)
 
-            # Disable the C++ compilation of symbolic shape guards. C++-fication
-            # of symbolic shape guards can improve guard overhead. But, since
-            # vllm skip guards anyways, setting this flag to False can improve
-            # compile time.
-            with torch._dynamo.config.patch("enable_cpp_symbolic_shape_guards",
-                                            False), patch.object(
-                                                InliningInstructionTranslator,
-                                                'inline_call',
-                                                patched_inline_call):
+            with patch.object(InliningInstructionTranslator, 'inline_call',
+                              patched_inline_call):
                 output = self.compiled_callable(*args, **kwargs)
             return output
 


### PR DESCRIPTION
Reverts vllm-project/vllm#20836

due to the issue in https://github.com/vllm-project/vllm/pull/20836#issuecomment-3146045109
and https://github.com/vllm-project/vllm/pull/20836#issuecomment-3146260394