### PR TITLE
feat(compilation): add VLLM_COMPILE_DEPYF env var to control depyf de…

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -794,6 +794,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
+    # Controls whether to perform depyf decompilation during compilation
+    # 0 (default): Write placeholder file with comment
+    # 1: Perform actual depyf decompilation
+    "VLLM_COMPILE_DEPYF":
+    lambda: bool(int(os.getenv("VLLM_COMPILE_DEPYF", "0"))),
 
     # If set, vllm will run in development mode, which will enable
     # some additional endpoints for developing and debugging,


### PR DESCRIPTION
…compilation

introduce VLLM_COMPILE_DEPYF environment variable to allow users to toggle actual depyf decompilation during compilation. by default, a placeholder file is written unless VLLM_COMPILE_DEPYF=1 is set. this change also ensures that cudagraph error checking always performs decompilation regardless of the flag.

fixes issue where decompilation was always attempted, causing unnecessary overhead in production environments.

# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

