### PR TITLE
Remove CPU -> GPU copy in GPUModelRunner._calc_spec_decode_metadata

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1106,15 +1106,18 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # [0, 1, 2, 5, 6, 9]
         target_logits_indices += arange
 
-        # TODO: Optimize the CPU -> GPU copy.
-        cu_num_draft_tokens = torch.from_numpy(cu_num_draft_tokens).to(
-            self.device, non_blocking=True)
-        logits_indices = torch.from_numpy(logits_indices).to(self.device,
-                                                             non_blocking=True)
-        target_logits_indices = torch.from_numpy(target_logits_indices).to(
-            self.device, non_blocking=True)
-        bonus_logits_indices = torch.from_numpy(bonus_logits_indices).to(
-            self.device, non_blocking=True)
+        cu_num_draft_tokens = torch.tensor(cu_num_draft_tokens,
+                                           dtype=torch.int32,
+                                           device=self.device)
+        logits_indices = torch.tensor(logits_indices,
+                                      dtype=torch.int32,
+                                      device=self.device)
+        target_logits_indices = torch.tensor(target_logits_indices,
+                                             dtype=torch.int32,
+                                             device=self.device)
+        bonus_logits_indices = torch.tensor(bonus_logits_indices,
+                                            dtype=torch.int32,
+                                            device=self.device)
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]


### PR DESCRIPTION
## Purpose
This PR simplifies how CPU-generated NumPy arrays are converted into GPU tensors in `GPUModelRunner._calc_spec_decode_metadata`.

Specifically, it replaces calls to `torch.from_numpy(…).to(device)` with `torch.tensor(…, dtype=…, device=…)`, which avoids intermediate CPU tensor creation and memory transfers.

## Test Plan
* Relying on CI to validate correctness. Key coverage expected in `tests/v1/worker/test_gpu_model_runner.py`
* Manually benchmark `torch.from_numpy(…).to(device)` with `torch.tensor(…, dtype=…, device=…)`

## Test Result
```
(vllm-env) (base) bbeckca@instance-20250803-153508:~$ python benchmark_tensor_copy.py
torch.tensor:         676.706 ms
from_numpy().to():    671.152 ms
(vllm-env) (base) bbeckca@instance-20250803-153508:~$ python benchmark_tensor_copy.py
torch.tensor:         659.648 ms
from_numpy().to():    655.030 ms
(vllm-env) (base) bbeckca@instance-20250803-153508:~$ python benchmark_tensor_copy.py
torch.tensor:         666.793 ms
from_numpy().to():    671.833 ms
(vllm-env) (base) bbeckca@instance-20250803-153508:~$ python benchmark_tensor_copy.py
torch.tensor:         668.503 ms
from_numpy().to():    668.353 ms
(vllm-env) (base) bbeckca@instance-20250803-153508:~$ python benchmark_tensor_copy.py
torch.tensor:         663.323 ms
from_numpy().to():    657.133 ms
```