### PR TITLE
remove duplicate code within cleanup_dist_env_and_memory

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1238,8 +1238,6 @@ def destroy_distributed_environment():
 def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
     destroy_model_parallel()
     destroy_distributed_environment()
-    with contextlib.suppress(AssertionError):
-        torch.distributed.destroy_process_group()
     if shutdown_ray:
         import ray  # Lazy import Ray
         ray.shutdown()


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
The code is duplicated with `destroy_model_parallel` in  https://github.com/vllm-project/vllm/blob/6d98843b31fb6d12fa682fecf584a5b7a4e98491/vllm/distributed/parallel_state.py#L1234-L1235. 

`cleanup_dist_env_and_memory` will first call `destroy_model_parallel` and `destroy_model_parallel` will call `torch.distributed.destroy_process_group`. So, i think the code is duplicated and should be cleaned.

/cc @comaniac
## Test Plan
NA
## Test Result
NA
## (Optional) Documentation Update
NA
