### PR TITLE
[Bugfix] Fix NemotronH d_inner calculation to prevent incorrect num_heads derivation

### DIFF
--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -48,22 +48,21 @@ class Mamba2DecoderLayer(nn.Module):
                  prefix: str = "") -> None:
         super().__init__()
         self.config = config
-        self.mixer = MambaMixer2(
-            hidden_size=config.hidden_size,
-            ssm_state_size=config.state_size,
-            conv_kernel_size=config.conv_kernel,
-            intermediate_size=getattr(
-                config, "intermediate_size",
-                config.mamba_num_heads * config.mamba_head_dim),
-            use_conv_bias=config.use_conv_bias,
-            use_bias=config.use_bias,
-            n_groups=config.n_groups,
-            num_heads=config.num_heads,
-            head_dim=config.head_dim,
-            rms_norm_eps=config.layer_norm_epsilon,
-            activation=config.hidden_act,
-            quant_config=quant_config,
-            prefix=f"{prefix}.mixer")
+        self.mixer = MambaMixer2(hidden_size=config.hidden_size,
+                                 ssm_state_size=config.state_size,
+                                 conv_kernel_size=config.conv_kernel,
+                                 intermediate_size=getattr(
+                                     config, "intermediate_size",
+                                     config.expand * config.hidden_size),
+                                 use_conv_bias=config.use_conv_bias,
+                                 use_bias=config.use_bias,
+                                 n_groups=config.n_groups,
+                                 num_heads=config.num_heads,
+                                 head_dim=config.head_dim,
+                                 rms_norm_eps=config.layer_norm_epsilon,
+                                 activation=config.hidden_act,
+                                 quant_config=quant_config,
+                                 prefix=f"{prefix}.mixer")
 
         self.norm = RMSNorm(config.hidden_size, eps=config.layer_norm_epsilon)
 
@@ -219,7 +218,7 @@ class Mamba2ForCausalLM(nn.Module, HasInnerState, IsAttentionFree):
         """
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_config
-        intermediate_size = hf_config.mamba_num_heads * hf_config.mamba_head_dim
+        intermediate_size = hf_config.expand * hf_config.hidden_size
 
         return get_mamba_state_shape(
             intermediate_size=intermediate_size,

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -53,7 +53,7 @@ class Mamba2DecoderLayer(nn.Module):
                                  conv_kernel_size=config.conv_kernel,
                                  intermediate_size=getattr(
                                      config, "intermediate_size",
-                                     config.expand * config.hidden_size),
+                                     config.mamba_num_heads * config.mamba_head_dim),
                                  use_conv_bias=config.use_conv_bias,
                                  use_bias=config.use_bias,
                                  n_groups=config.n_groups,
@@ -218,7 +218,7 @@ class Mamba2ForCausalLM(nn.Module, HasInnerState, IsAttentionFree):
         """
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_config
-        intermediate_size = hf_config.expand * hf_config.hidden_size
+        intermediate_size = hf_config.mamba_num_heads * hf_config.mamba_head_dim
 
         return get_mamba_state_shape(
             intermediate_size=intermediate_size,

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -48,21 +48,22 @@ class Mamba2DecoderLayer(nn.Module):
                  prefix: str = "") -> None:
         super().__init__()
         self.config = config
-        self.mixer = MambaMixer2(hidden_size=config.hidden_size,
-                                 ssm_state_size=config.state_size,
-                                 conv_kernel_size=config.conv_kernel,
-                                 intermediate_size=getattr(
-                                     config, "intermediate_size",
-                                     config.mamba_num_heads * config.mamba_head_dim),
-                                 use_conv_bias=config.use_conv_bias,
-                                 use_bias=config.use_bias,
-                                 n_groups=config.n_groups,
-                                 num_heads=config.num_heads,
-                                 head_dim=config.head_dim,
-                                 rms_norm_eps=config.layer_norm_epsilon,
-                                 activation=config.hidden_act,
-                                 quant_config=quant_config,
-                                 prefix=f"{prefix}.mixer")
+        self.mixer = MambaMixer2(
+            hidden_size=config.hidden_size,
+            ssm_state_size=config.state_size,
+            conv_kernel_size=config.conv_kernel,
+            intermediate_size=getattr(
+                config, "intermediate_size",
+                config.mamba_num_heads * config.mamba_head_dim),
+            use_conv_bias=config.use_conv_bias,
+            use_bias=config.use_bias,
+            n_groups=config.n_groups,
+            num_heads=config.num_heads,
+            head_dim=config.head_dim,
+            rms_norm_eps=config.layer_norm_epsilon,
+            activation=config.hidden_act,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mixer")
 
         self.norm = RMSNorm(config.hidden_size, eps=config.layer_norm_epsilon)
 

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -145,7 +145,7 @@ class NemotronHMambaDecoderLayer(nn.Module):
             hidden_size=config.hidden_size,
             ssm_state_size=config.ssm_state_size,
             conv_kernel_size=config.conv_kernel,
-            intermediate_size=config.expand * config.hidden_size,
+            intermediate_size=config.mamba_num_heads * config.mamba_head_dim,
             use_conv_bias=config.use_conv_bias,
             use_bias=config.use_bias,
             n_groups=config.n_groups,
@@ -480,7 +480,7 @@ class NemotronHForCausalLM(nn.Module, HasInnerState, SupportsLoRA, SupportsPP,
         """
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_config
-        intermediate_size = hf_config.expand * hf_config.hidden_size
+        intermediate_size = hf_config.mamba_num_heads * hf_config.mamba_head_dim
 
         return get_mamba_state_shape(
             intermediate_size=intermediate_size,


### PR DESCRIPTION
Previously, Mamba models calculated `d_inner` as:
```python
d_inner = expand * d_hidden_size
```

When `num_heads` is derived from `d_inner`, this can lead to incorrect values if `expand` is not evenly divisible by `mamba_head_dim`. This mismatch can cause dimension errors and incorrect model behavior.

## Solution
Changed the calculation to follow the same as transformer pattern:
```python
d_inner = num_heads * head_dim
```
