### PR TITLE
[fix] fix correct assertion syntax error in attention utils.

### DIFF
--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -97,7 +97,9 @@ def _make_metadata_with_slice(
 
     query_start_loc = slice_query_start_locs(attn_metadata.query_start_loc,
                                              request_slice)
-    assert len(query_start_loc) >= 2, f"query_start_loc must have at least 2 elements, got {len(query_start_loc)}"
+    assert len(query_start_loc) >= 2, (
+        f"query_start_loc must have at least 2 elements, "
+        f"got {len(query_start_loc)}")
     query_start_loc_cpu = slice_query_start_locs(
         attn_metadata.query_start_loc_cpu, request_slice)
 

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -97,7 +97,7 @@ def _make_metadata_with_slice(
 
     query_start_loc = slice_query_start_locs(attn_metadata.query_start_loc,
                                              request_slice)
-    assert len(query_start_loc >= 2)
+    assert len(query_start_loc) >= 2, f"query_start_loc must have at least 2 elements, got {len(query_start_loc)}"
     query_start_loc_cpu = slice_query_start_locs(
         attn_metadata.query_start_loc_cpu, request_slice)
 


### PR DESCRIPTION
 ## Purpose

  Fix syntax error in assertion statement in vllm/v1/attention/backends/utils.py where
  parentheses were incorrectly placed. The assertion len(query_start_loc >= 2) should be
   len(query_start_loc) >= 2 to properly validate that query_start_loc has at least 2
  elements.

  ## Test Plan

  - Run existing unit tests to ensure no regressions
  - Verify the assertion now correctly validates tensor length
  - Test with malformed input to confirm descriptive error message is shown

 ##  Test Result

  - Syntax error is resolved
  - Assertion now properly validates tensor dimensions
  - Improved error message provides better debugging information
