### PR TITLE
[CI Bugfix] Fix wNa16 kernel not found for test_shared_storage_connector_hashes

### DIFF
--- a/tests/v1/kv_connector/unit/test_shared_storage_connector.py
+++ b/tests/v1/kv_connector/unit/test_shared_storage_connector.py
@@ -10,7 +10,7 @@ from vllm.assets.image import ImageAsset
 from vllm.config import KVTransferConfig
 from vllm.multimodal.utils import encode_image_base64
 
-MODEL_NAME = "RedHatAI/Qwen2.5-VL-3B-Instruct-quantized.w4a16"
+MODEL_NAME = "RedHatAI/Qwen2.5-VL-3B-Instruct-quantized.w8a8"
 
 SAMPLING_PARAMS = SamplingParams(temperature=0.0, top_k=1, max_tokens=128)
 


### PR DESCRIPTION
## Purpose

Test is currently failing with:
```
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683] ValueError: Failed to find a kernel that can implement the WNA16 linear layer. Reasons:
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683] MacheteLinearKernel requires capability 90, current compute  capability is 89
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683]  AllSparkLinearKernel cannot implement due to: For Ampere GPU, AllSpark does not support group_size = 128. Only group_size = -1 are supported.
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683]  MarlinLinearKernel cannot implement due to: Weight output_size_per_partition = 6840 is not divisible by  min_thread_n = 64. Consider reducing tensor_parallel_size or running with --quantization gptq.
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683]  Dynamic4bitLinearKernel cannot implement due to: Only CPU is supported
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683]  BitBLASLinearKernel cannot implement due to: bitblas is not installed. Please install bitblas by running `pip install bitblas>=0.1.0`
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683]  ConchLinearKernel cannot implement due to: conch-triton-kernels is not installed, please install it via `pip install conch-triton-kernels` and try again!
[2025-08-03T23:44:26Z] (EngineCore_0 pid=14405) ERROR 08-03 16:44:26 [core.py:683]  ExllamaLinearKernel cannot implement due to: Exllama only supports float16 activations
```

This PR switches the model for one with that should be more generally well supported.

Test history is here: https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests/7b01abb7-8064-8f64-9362-7eceb5b9280e?period=7days

## Test Plan

## Test Result

## (Optional) Documentation Update

