### PR TITLE
[Bugfix] EPLB load statistics problem

### DIFF
--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -466,9 +466,7 @@ class EplbState:
                                             group_src=0)
 
             # Perform all-reduce to get the expert load across all ranks
-            ep_size = ep_group.size()
-            global_expert_load_window = (
-                logical_expert_load_window.sum(dim=0) // ep_size)
+            global_expert_load_window = logical_expert_load_window.sum(dim=0)
             all_reduce(global_expert_load_window, group=ep_group)
 
             if not execute_shuffle:

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1411,22 +1411,9 @@ class FusedMoE(torch.nn.Module):
             # to the modular kernel, we can move this logic there
             # to achieve better efficiency.
 
-            # `expert_load_view`: (num_logical_experts,)
+            # `expert_load_view`: (num_physical_experts,)
 
-            # Mask out non-local experts
-            if expert_map is not None:
-                topk_ids_local = expert_map[topk_ids]
-                topk_ids_flatten = topk_ids_local.flatten()
-            else:
-                topk_ids_flatten = topk_ids.flatten()
-
-            # Should be equivalent to:
-            # ```
-            # topk_ids_masked = topk_ids_local[topk_ids_local >= 0]
-            # expert_load_view += topk_ids_masked.bincount(
-            #     minlength=expert_load_view.shape[0])
-            # ```
-            # We use `scatter_add_` since `bincount` cannot be compiled
+            topk_ids_flatten = topk_ids.flatten()
 
             # Performance optimization:
             # `masked_fill` is significantly faster than `masked_select`


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fix the bug of [#21883](https://github.com/vllm-project/vllm/issues/21883).

When using naive dispatch, there will be no problem with the statistics of expert workload. However, when using the pplx-kernel or DeepEP, which follow a different code path, the dispatch might not have been executed yet at that point. **The load of experts routed to other nodes is not counted.**

Previously, the logic for calculating expert load was to only count the load of activated experts by the current rank and aggregate the global load in `eplc_state.py`. **The logic for modifying expert statistics in this PR is to directly count the load of all physical experts activated by each token.**

After this modification, the time point of dispatch is no longer important, and load statistics can work normally when activating the pplx-kernel or DeepEP. When using naive dispatch, due to the modification of logic, each token's activated expert will be counted multiple times. However, since the load between experts is still proportional, this modification will not affect the results of the EPLB algorithm.

## Test Plan

Output the sum of expert load in the function `rearrange()` in `eplb_state.py` after expert load calculation:
```python
if not is_profile:
    print(f"The sum of global_expert_load is: {global_expert_load_window.sum().item()}")
```

Test with/wo pplx:
```bash
VLLM_ALL2ALL_BACKEND=pplx CUDA_VISIBLE_DEVICES=0,1 python examples/offline_inference/data_parallel.py \
    --model="/workspace/models/DeepSeek-V2-Lite" \
    --trust-remote-code \
    --dp-size=2 \
    --tp-size=1
```

```bash
CUDA_VISIBLE_DEVICES=0,1 python examples/offline_inference/data_parallel.py \
    --model="/workspace/models/DeepSeek-V2-Lite" \
    --trust-remote-code \
    --dp-size=2 \
    --tp-size=1
```

## Test Result

with pplx:
```
The sum of global_expert_load is: 3618264
```

wo pplx, twice as much as using pplx when `dp=2` and `tp=1` (because each token's activated expert count twice) , which is expected:
```
The sum of global_expert_load is: 7236528
```


## (Optional) Documentation Update

