### PR TITLE
[EPLB] Optimize EPLB for Async Rearrange Experts 

### DIFF
--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -1,13 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
 import random
 
 import pytest
 import torch
 import torch.distributed
 
-from vllm.distributed.eplb.rebalance_execute import rearrange_expert_weights_inplace
+from vllm.distributed.eplb.rebalance_execute import (
+    move_from_buffer,
+    rearrange_expert_weights_inplace,
+    transfer_layer,
+)
 from vllm.distributed.parallel_state import (
     ensure_model_parallel_initialized,
     get_tp_group,
@@ -397,6 +402,114 @@ def _test_rearrange_expert_weights_no_change(env, world_size) -> None:
                 msg=f"""Layer {layer}, weight {weight_idx}
  should remain unchanged""",
             )
+
+@pytest.mark.parametrize(
+    "world_size,num_layers,num_local_experts,num_logical_experts",
+    [
+        (2, 2, 2, 3),
+    ],
+)
+def test_async_transfer_layer_without_mtp(
+    world_size: int,
+    num_layers: int,
+    num_local_experts: int,
+    num_logical_experts: int,
+):
+    """Exercise async EPLB transfer path without MTP/spec decode."""
+
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"Need at least {world_size} GPUs to run the test")
+
+    @worker_fn_wrapper
+    def worker_fn():
+        ensure_model_parallel_initialized(
+            tensor_model_parallel_size=world_size, pipeline_model_parallel_size=1
+        )
+
+        tp_group = get_tp_group()
+        ep_group = tp_group.device_group
+        ep_rank = torch.distributed.get_rank()
+        device = torch.device(f"cuda:{ep_rank}")
+
+        total_physical_experts = world_size * num_local_experts
+        hidden_sizes = [16, 32]
+
+        redundancy_config = create_redundancy_config(
+            num_logical_experts,
+            total_physical_experts,
+        )
+        old_indices = create_expert_indices_with_redundancy(
+            num_layers,
+            num_logical_experts,
+            total_physical_experts,
+            redundancy_config,
+        )
+
+        new_redundancy_config = create_redundancy_config(
+            num_logical_experts,
+            total_physical_experts,
+        )
+        new_indices = create_expert_indices_with_redundancy(
+            num_layers,
+            num_logical_experts,
+            total_physical_experts,
+            new_redundancy_config,
+        )
+
+        expert_weights = create_expert_weights(
+            num_layers,
+            num_local_experts,
+            hidden_sizes,
+            ep_rank,
+            device,
+            old_indices,
+        )
+
+        expert_buffer = [torch.empty_like(w) for w in expert_weights[0]]
+        cuda_stream = torch.cuda.Stream(device=device)
+
+        for layer_idx in range(num_layers):
+            (
+                is_unchanged,
+                is_received_locally,
+                experts_recv_loc,
+            ) = asyncio.run(
+                transfer_layer(
+                    old_global_expert_indices=old_indices,
+                    new_global_expert_indices=new_indices,
+                    expert_weights=expert_weights,
+                    expert_weights_buffer=expert_buffer,
+                    ep_group=ep_group,
+                    layer=layer_idx,
+                    cuda_stream=cuda_stream,
+                )
+            )
+
+            cuda_stream.synchronize()
+            move_from_buffer(
+                expert_weights=expert_weights[layer_idx],
+                expert_weights_buffer=expert_buffer,
+                is_unchanged=is_unchanged,
+                is_received_locally=is_received_locally,
+                experts_recv_loc=experts_recv_loc,
+                new_indices=new_indices[layer_idx].tolist(),
+                ep_group=ep_group,
+            )
+
+        verify_expert_weights_after_shuffle(
+            expert_weights,
+            new_indices,
+            hidden_sizes,
+            ep_rank,
+            num_local_experts,
+        )
+        verify_redundant_experts_have_same_weights(
+            expert_weights,
+            new_indices,
+            hidden_sizes,
+            world_size,
+            num_local_experts,
+        )
 
 
 @pytest.mark.parametrize("world_size", [2, 4])

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -497,6 +497,7 @@ def _test_rearrange_expert_weights_no_change(env, world_size) -> None:
  should remain unchanged""",
             )
 
+
 @pytest.mark.parametrize(
     "world_size,num_layers,num_local_experts,num_logical_experts",
     [

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -236,6 +236,100 @@ def verify_redundant_experts_have_same_weights(
                     )
 
 
+def _test_async_transfer_layer_without_mtp_worker(
+    env,
+    world_size: int,
+    num_layers: int,
+    num_local_experts: int,
+    num_logical_experts: int,
+) -> None:
+    set_env_vars_and_device(env)
+    ensure_model_parallel_initialized(
+        tensor_model_parallel_size=world_size, pipeline_model_parallel_size=1
+    )
+
+    tp_group = get_tp_group()
+    ep_group = tp_group.device_group
+    ep_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{ep_rank}")
+
+    total_physical_experts = world_size * num_local_experts
+    hidden_sizes = [16, 32]
+
+    redundancy_config = create_redundancy_config(
+        num_logical_experts,
+        total_physical_experts,
+    )
+    old_indices = create_expert_indices_with_redundancy(
+        num_layers,
+        num_logical_experts,
+        total_physical_experts,
+        redundancy_config,
+    )
+
+    new_redundancy_config = create_redundancy_config(
+        num_logical_experts,
+        total_physical_experts,
+    )
+    new_indices = create_expert_indices_with_redundancy(
+        num_layers,
+        num_logical_experts,
+        total_physical_experts,
+        new_redundancy_config,
+    )
+
+    expert_weights = create_expert_weights(
+        num_layers,
+        num_local_experts,
+        hidden_sizes,
+        ep_rank,
+        device,
+        old_indices,
+    )
+
+    expert_buffer = [torch.empty_like(w) for w in expert_weights[0]]
+    cuda_stream = torch.cuda.Stream(device=device)
+
+    for layer_idx in range(num_layers):
+        is_unchanged, is_received_locally, experts_recv_loc = asyncio.run(
+            transfer_layer(
+                old_global_expert_indices=old_indices,
+                new_global_expert_indices=new_indices,
+                expert_weights=expert_weights,
+                expert_weights_buffer=expert_buffer,
+                ep_group=ep_group,
+                layer=layer_idx,
+                cuda_stream=cuda_stream,
+            )
+        )
+
+        cuda_stream.synchronize()
+        move_from_buffer(
+            expert_weights=expert_weights[layer_idx],
+            expert_weights_buffer=expert_buffer,
+            is_unchanged=is_unchanged,
+            is_received_locally=is_received_locally,
+            experts_recv_loc=experts_recv_loc,
+            new_indices=new_indices[layer_idx].tolist(),
+            ep_group=ep_group,
+        )
+
+    verify_expert_weights_after_shuffle(
+        expert_weights,
+        new_indices,
+        hidden_sizes,
+        ep_rank,
+        num_local_experts,
+    )
+    verify_redundant_experts_have_same_weights(
+        expert_weights,
+        new_indices,
+        hidden_sizes,
+        world_size,
+        num_local_experts,
+    )
+
+
 def _test_rearrange_expert_weights_with_redundancy(
     env, world_size, num_layers, num_local_experts, num_logical_experts
 ) -> None:
@@ -420,96 +514,13 @@ def test_async_transfer_layer_without_mtp(
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need at least {world_size} GPUs to run the test")
 
-    @worker_fn_wrapper
-    def worker_fn():
-        ensure_model_parallel_initialized(
-            tensor_model_parallel_size=world_size, pipeline_model_parallel_size=1
-        )
-
-        tp_group = get_tp_group()
-        ep_group = tp_group.device_group
-        ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"cuda:{ep_rank}")
-
-        total_physical_experts = world_size * num_local_experts
-        hidden_sizes = [16, 32]
-
-        redundancy_config = create_redundancy_config(
-            num_logical_experts,
-            total_physical_experts,
-        )
-        old_indices = create_expert_indices_with_redundancy(
-            num_layers,
-            num_logical_experts,
-            total_physical_experts,
-            redundancy_config,
-        )
-
-        new_redundancy_config = create_redundancy_config(
-            num_logical_experts,
-            total_physical_experts,
-        )
-        new_indices = create_expert_indices_with_redundancy(
-            num_layers,
-            num_logical_experts,
-            total_physical_experts,
-            new_redundancy_config,
-        )
-
-        expert_weights = create_expert_weights(
-            num_layers,
-            num_local_experts,
-            hidden_sizes,
-            ep_rank,
-            device,
-            old_indices,
-        )
-
-        expert_buffer = [torch.empty_like(w) for w in expert_weights[0]]
-        cuda_stream = torch.cuda.Stream(device=device)
-
-        for layer_idx in range(num_layers):
-            (
-                is_unchanged,
-                is_received_locally,
-                experts_recv_loc,
-            ) = asyncio.run(
-                transfer_layer(
-                    old_global_expert_indices=old_indices,
-                    new_global_expert_indices=new_indices,
-                    expert_weights=expert_weights,
-                    expert_weights_buffer=expert_buffer,
-                    ep_group=ep_group,
-                    layer=layer_idx,
-                    cuda_stream=cuda_stream,
-                )
-            )
-
-            cuda_stream.synchronize()
-            move_from_buffer(
-                expert_weights=expert_weights[layer_idx],
-                expert_weights_buffer=expert_buffer,
-                is_unchanged=is_unchanged,
-                is_received_locally=is_received_locally,
-                experts_recv_loc=experts_recv_loc,
-                new_indices=new_indices[layer_idx].tolist(),
-                ep_group=ep_group,
-            )
-
-        verify_expert_weights_after_shuffle(
-            expert_weights,
-            new_indices,
-            hidden_sizes,
-            ep_rank,
-            num_local_experts,
-        )
-        verify_redundant_experts_have_same_weights(
-            expert_weights,
-            new_indices,
-            hidden_sizes,
-            world_size,
-            num_local_experts,
-        )
+    distributed_run(
+        _test_async_transfer_layer_without_mtp_worker,
+        world_size,
+        num_layers,
+        num_local_experts,
+        num_logical_experts,
+    )
 
 
 @pytest.mark.parametrize("world_size", [2, 4])

--- a/tests/distributed/test_eplb_spec_decode.py
+++ b/tests/distributed/test_eplb_spec_decode.py
@@ -14,6 +14,7 @@ def get_model_args(
     spec_method: str,
     tp_size: int,
     model_max_len: int,
+    use_async: bool = False,
 ) -> dict:
     speculative_config = {
         "method": spec_method,
@@ -37,6 +38,8 @@ def get_model_args(
         "enable_eplb": True,
         "max_model_len": model_max_len,
     }
+    if use_async:
+        model_args["eplb_config"] = {"use_async": True}
     return model_args
 
 
@@ -80,6 +83,40 @@ def test_eplb_spec_decode(
         spec_method=method,
         tp_size=tp_size,
         model_max_len=4096,
+    )
+
+    results = lm_eval.simple_evaluate(
+        model="vllm",
+        model_args=model_args,
+        tasks=TASK,
+        batch_size=64,
+        num_fewshot=8,
+    )
+    measured_value = results["results"][TASK][FILTER]
+    assert (
+        measured_value - RTOL < expected_gsm8k_value
+        and measured_value + RTOL > expected_gsm8k_value
+    ), f"Expected: {expected_gsm8k_value} |  Measured: {measured_value}"
+
+
+@large_gpu_mark(min_gb=80)
+def test_eplb_spec_decode_qwen3_next_mtp_async() -> None:
+    """
+    Ensure async EPLB works with MTP speculative decoding for Qwen3-Next.
+    """
+
+    TASK = "gsm8k"
+    FILTER = "exact_match,strict-match"
+    RTOL = 0.03
+    expected_gsm8k_value = 0.86
+
+    model_args = get_model_args(
+        model_name="Qwen/Qwen3-Next-80B-A3B-Instruct",
+        spec_model_name=None,
+        spec_method="mtp",
+        tp_size=4,
+        model_max_len=4096,
+        use_async=True,
     )
 
     results = lm_eval.simple_evaluate(

--- a/tests/distributed/test_eplb_spec_decode.py
+++ b/tests/distributed/test_eplb_spec_decode.py
@@ -10,7 +10,7 @@ from tests.utils import large_gpu_mark
 
 def get_model_args(
     model_name: str,
-    spec_model_name: str,
+    spec_model_name: str | None,
     spec_method: str,
     tp_size: int,
     model_max_len: int,

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -60,6 +60,10 @@ class EPLBConfig:
     Log the balancedness each step of expert parallelism.
     This is turned off by default since it will cause communication overhead.
     """
+    use_async: bool = False
+    """
+    Whether to use non-blocking EPLB.
+    """
 
 
 @config

--- a/vllm/distributed/eplb/async_worker.py
+++ b/vllm/distributed/eplb/async_worker.py
@@ -66,11 +66,12 @@ async def transfer_run_periodically(
 ) -> None:
     while True:
         await asyncio.to_thread(state.rearrange_event.wait)
+        logger.info("async worker woke up for EPLB transfer")
 
         for model_state in state.model_states.values():
             if not model_state.is_async_enabled:
                 continue
-
+            logger.info("async worker model_state.model.num_moe_layers %d", model_state.model.num_moe_layers)
             current_num_layers = model_state.model.num_moe_layers
             while model_state.layer_to_transfer < current_num_layers:
                 if (
@@ -108,4 +109,5 @@ async def transfer_run_periodically(
                 else:
                     await asyncio.sleep(0.001)
 
+        logger.info("async worker completed current EPLB pass, clearing event")
         state.rearrange_event.clear()

--- a/vllm/distributed/eplb/async_worker.py
+++ b/vllm/distributed/eplb/async_worker.py
@@ -71,7 +71,6 @@ async def transfer_run_periodically(
         for model_state in state.model_states.values():
             if not model_state.is_async_enabled:
                 continue
-            logger.info("async worker model_state.model_name: %s, model_state.model.num_moe_layers %d", model_state.model_name, model_state.model.num_moe_layers)
             current_num_layers = model_state.model.num_moe_layers
             while (
                 model_state.rebalanced
@@ -102,7 +101,6 @@ async def transfer_run_periodically(
                             cuda_stream=cuda_stream,
                             rank_mapping=rank_mapping,
                         )
-                        logger.info("async model_state.model_name: %s, transfer_layer layer: %d", model_state.model_name, model_state.layer_to_transfer)
                         event = torch.cuda.Event(blocking=False)
                         cuda_stream.record_event(event)
                         model_state.buffer_ready_event = event
@@ -114,5 +112,4 @@ async def transfer_run_periodically(
                         break
                     await asyncio.sleep(0.001)
 
-        logger.info("async worker completed current EPLB pass, clearing event")
         state.rearrange_event.clear()

--- a/vllm/distributed/eplb/async_worker.py
+++ b/vllm/distributed/eplb/async_worker.py
@@ -98,6 +98,7 @@ async def transfer_run_periodically(
                             cuda_stream=cuda_stream,
                             rank_mapping=rank_mapping,
                         )
+                        logger.info("async transfer_layer layer: %d", model_state.layer_to_transfer)
                         event = torch.cuda.Event(blocking=False)
                         cuda_stream.record_event(event)
                         model_state.buffer_ready_event = event

--- a/vllm/distributed/eplb/async_worker.py
+++ b/vllm/distributed/eplb/async_worker.py
@@ -73,7 +73,10 @@ async def transfer_run_periodically(
                 continue
             logger.info("async worker model_state.model_name: %s, model_state.model.num_moe_layers %d", model_state.model_name, model_state.model.num_moe_layers)
             current_num_layers = model_state.model.num_moe_layers
-            while model_state.layer_to_transfer < current_num_layers:
+            while (
+                model_state.rebalanced
+                and model_state.layer_to_transfer < current_num_layers
+            ):
                 if (
                     not model_state.ep_buffer_ready
                     and model_state.rebalanced
@@ -107,6 +110,8 @@ async def transfer_run_periodically(
                     finally:
                         model_state.buffer_lock.release()
                 else:
+                    if not model_state.rebalanced:
+                        break
                     await asyncio.sleep(0.001)
 
         logger.info("async worker completed current EPLB pass, clearing event")

--- a/vllm/distributed/eplb/async_worker.py
+++ b/vllm/distributed/eplb/async_worker.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+The async worker that transfers experts in the background.
+"""
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING
+
+import torch
+from torch.distributed import ProcessGroup
+
+from vllm.distributed.parallel_state import get_ep_group
+from vllm.logger import init_logger
+
+from .rebalance_execute import transfer_layer
+
+if TYPE_CHECKING:
+    from .eplb_state import EplbState
+
+logger = init_logger(__name__)
+
+
+def start_async_worker(
+    state: "EplbState",
+    model,
+    rank_mapping: dict[int, int] | None = None,
+    is_profile: bool = False,
+) -> threading.Thread:
+    ep_group = get_ep_group().device_group
+    rank = ep_group.rank()
+    device_index = state.cuda_device_index
+
+    def thread_target() -> None:
+        assert device_index is not None
+        torch.cuda.set_device(device_index)
+        cuda_stream = torch.cuda.Stream(device=device_index)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(
+                transfer_run_periodically(
+                    state=state,
+                    model=model,
+                    ep_group=ep_group,
+                    is_profile=is_profile,
+                    rank_mapping=rank_mapping,
+                    cuda_stream=cuda_stream,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - diagnostic path
+            logger.exception("async loop error (Rank %d): %s", rank, str(exc))
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=thread_target, daemon=True)
+    thread.start()
+    return thread
+
+
+async def transfer_run_periodically(
+    state: "EplbState",
+    model,
+    ep_group: ProcessGroup,
+    is_profile: bool = False,
+    rank_mapping: dict[int, int] | None = None,
+    cuda_stream: torch.cuda.Stream = None,
+) -> None:
+    while True:
+        await asyncio.to_thread(state.rearrange_event.wait)
+
+        current_num_layers = model.num_moe_layers
+        while state.layer_to_transfer < current_num_layers:
+            if not state.ep_buffer_ready and state.rebalanced:
+                assert state.new_physical_to_logical_map is not None
+                await asyncio.to_thread(state.buffer_lock.acquire)
+                try:
+                    if state.layer_to_transfer >= current_num_layers:
+                        break
+
+                    (
+                        state.is_unchanged,
+                        state.is_received_locally,
+                        state.experts_recv_loc,
+                    ) = await transfer_layer(
+                        old_global_expert_indices=state.physical_to_logical_map,
+                        new_global_expert_indices=state.new_physical_to_logical_map,
+                        expert_weights=model.expert_weights,
+                        expert_weights_buffer=state.expert_buffer,
+                        ep_group=ep_group,
+                        is_profile=is_profile,
+                        layer=state.layer_to_transfer,
+                        cuda_stream=cuda_stream,
+                        rank_mapping=rank_mapping,
+                    )
+                    event = torch.cuda.Event(blocking=False)
+                    cuda_stream.record_event(event)
+                    state.buffer_ready_event = event
+                    state.ep_buffer_ready = 1
+                finally:
+                    state.buffer_lock.release()
+            else:
+                await asyncio.sleep(0.001)
+
+        state.rearrange_event.clear()

--- a/vllm/distributed/eplb/async_worker.py
+++ b/vllm/distributed/eplb/async_worker.py
@@ -71,7 +71,7 @@ async def transfer_run_periodically(
         for model_state in state.model_states.values():
             if not model_state.is_async_enabled:
                 continue
-            logger.info("async worker model_state.model.num_moe_layers %d", model_state.model.num_moe_layers)
+            logger.info("async worker model_state.model_name: %s, model_state.model.num_moe_layers %d", model_state.model_name, model_state.model.num_moe_layers)
             current_num_layers = model_state.model.num_moe_layers
             while model_state.layer_to_transfer < current_num_layers:
                 if (
@@ -99,7 +99,7 @@ async def transfer_run_periodically(
                             cuda_stream=cuda_stream,
                             rank_mapping=rank_mapping,
                         )
-                        logger.info("async transfer_layer layer: %d", model_state.layer_to_transfer)
+                        logger.info("async model_state.model_name: %s, transfer_layer layer: %d", model_state.model_name, model_state.layer_to_transfer)
                         event = torch.cuda.Event(blocking=False)
                         cuda_stream.record_event(event)
                         model_state.buffer_ready_event = event

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -613,7 +613,11 @@ class EplbState:
                     all_ranks_buffer_ready = self._all_ranks_buffer_ready(
                         eplb_model_state
                     )
-                if eplb_model_state.is_async_enabled and eplb_model_state.ep_buffer_ready and all_ranks_buffer_ready:
+                if (
+                    eplb_model_state.is_async_enabled
+                    and eplb_model_state.ep_buffer_ready
+                    and all_ranks_buffer_ready
+                ):
                     self.move_to_workspace(
                         model_state=eplb_model_state,
                         ep_group=ep_group,
@@ -623,16 +627,16 @@ class EplbState:
                         eplb_model_state.layer_to_transfer
                         >= eplb_model_state.model.num_moe_layers
                     ):
-                            self.post_eplb(eplb_model_state, is_profile)
-                            eplb_model_state.rebalanced = False
-                            eplb_model_state.layer_to_transfer = 0
-                            eplb_model_state.pending_global_ready_check = False
-                            logger.info(
-                                "finish async transfer for model %s rank %d layer %d",
-                                eplb_model_state.model_name,
-                                ep_group.rank(),
-                                eplb_model_state.model.num_moe_layers,
-                            )
+                        self.post_eplb(eplb_model_state, is_profile)
+                        eplb_model_state.rebalanced = False
+                        eplb_model_state.layer_to_transfer = 0
+                        eplb_model_state.pending_global_ready_check = False
+                        logger.info(
+                            "finish async transfer for model %s rank %d layer %d",
+                            eplb_model_state.model_name,
+                            ep_group.rank(),
+                            eplb_model_state.model.num_moe_layers,
+                        )
 
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:
             if any(

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -26,9 +26,10 @@ MoE layer. If we have 32 EP ranks, then each GPU will hold 288 / 32 = 9 local
 physical experts.
 """
 
+import threading
 import time
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 from torch.distributed import ProcessGroup, all_reduce
@@ -43,8 +44,9 @@ from vllm.distributed.utils import StatelessProcessGroup
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MixtureOfExperts
 
+from .async_worker import start_async_worker
 from .rebalance_algo import rebalance_experts
-from .rebalance_execute import rearrange_expert_weights_inplace
+from .rebalance_execute import move_from_buffer, rearrange_expert_weights_inplace
 
 logger = init_logger(__name__)
 
@@ -164,12 +166,68 @@ class EplbState:
         Otherwise, the rearrangement will hang at collective
         communication calls.
         """
-        self.expert_rearrangement_step: int = 0
+        self.expert_rearrangement_step_interval: int = 0
         """
         Interval for expert rearrangement steps.
         This is a constant and is taken from the config.
         """
-        self.expert_rearrangement_step_interval: int = 0
+        self.layer_to_transfer: int = 0
+        """
+        The layer index to transfer in async mode.
+        """
+        self.ep_buffer_ready: int = 0
+        """
+        The flag indicates whether the expert buffer is ready for transfer.
+        0 or 1.
+        """
+        self.rearrange_event: threading.Event = field(default_factory=threading.Event)
+        """
+        Event to signal when a new rearrangement is needed for the async thread.
+        """
+        self.buffer_lock: threading.Lock = field(default_factory=threading.Lock)
+        """
+        The lock to protect the expert buffer.
+        """
+        self.expert_buffer: list[torch.Tensor] = field(default_factory=list)
+        """
+        The buffer to store the expert weights during transfer.
+        """
+        self.buffer_ready_event: torch.cuda.Event | None = None
+        """
+        CUDA event recorded when the async worker finishes filling the buffer.
+        The main thread waits on this before consuming the buffer.
+        """
+        self.rebalanced: bool = False
+        """
+        The flag indicates whether the experts rebalance have been computed.
+        """
+        self.is_unchanged: list[bool] = field(default_factory=list)
+        """
+        intermediate variable between `move_to_buffer` and `move_to_workspace`.
+        The size is same as the num of physical experts in the current layer.
+        """
+        self.is_received_locally: list[bool] = field(default_factory=list)
+        """
+        intermediate variable between `move_to_buffer` and `move_to_workspace`.
+        The size is same as the num of physical experts in the current layer.
+        """
+        self.experts_recv_loc: dict[int, int] = field(default_factory=dict)
+        """
+        intermediate variable between `move_to_buffer` and `move_to_workspace`.
+        The size is same as the num of physical experts in the current layer.
+        """
+        self.is_async: bool = False
+        """
+        The flag indicates whether the EPLB is running in async mode.
+        """
+        self.cuda_device_index: int | None = None
+        """
+        CUDA device index for the async EPLB worker thread.
+        """
+        self.pending_global_ready_check: bool = False
+        """
+        Whether the async EPLB needs to poll peers for buffer readiness.
+        """
 
     @staticmethod
     def build_initial_global_physical_to_logical_map(
@@ -239,6 +297,8 @@ class EplbState:
         Build the initial EPLB state.
         """
         self.validate_ep_configuration(model)
+        is_async = model_config.parallel_config.eplb_config.use_async
+
         physical_to_logical_map_list = (
             EplbState.build_initial_global_physical_to_logical_map(
                 model.num_routed_experts,
@@ -368,7 +428,12 @@ class EplbState:
             physical_to_logical_map = new_physical_to_logical_map.to(self.device)
             logical_to_physical_map.copy_(new_logical_to_physical_map)
             logical_replica_count.copy_(new_logical_replica_count)
+        else:
+            new_physical_to_logical_map = None
 
+            new_logical_to_physical_map = None
+
+            new_logical_replica_count = None
         model.set_eplb_state(
             expert_load_pass,
             logical_to_physical_map,
@@ -385,6 +450,13 @@ class EplbState:
             )
             self.expert_rearrangement_step = 0
 
+        device_index: int | None = None
+        if self.device.type == "cuda":
+            device_index = self.device.index
+            if device_index is None and torch.cuda.is_available():
+                device_index = torch.cuda.current_device()
+        expert_buffer = [torch.empty_like(w) for w in model.expert_weights[0]]
+
         self.model_states[model_config.compute_hash()] = EplbModelState(
             physical_to_logical_map,
             logical_to_physical_map,
@@ -393,6 +465,9 @@ class EplbState:
             expert_load_window,
             model_config.model,
             model,
+            expert_buffer=expert_buffer,
+            is_async=is_async,
+            cuda_device_index=device_index,
         )
 
     def step(
@@ -420,7 +495,7 @@ class EplbState:
             - `max_tokens`: The maximum load across ranks.
             - `balancedness`: The ratio of average load to maximum load.
         """
-
+        ep_group = get_ep_group().device_group
         if is_profile:
             self.rearrange(is_profile=True)
             return
@@ -488,7 +563,28 @@ class EplbState:
         # rearrangement step and perform rearrangement to ensure all ranks are
         # performing collective communication.
         self.expert_rearrangement_step += 1
+
+        all_ranks_buffer_ready = False
+        if self.is_async and self.pending_global_ready_check:
+            all_ranks_buffer_ready = self._all_ranks_buffer_ready()
+
+        if self.is_async and self.ep_buffer_ready and all_ranks_buffer_ready:
+            self.move_to_workspace(
+                model=model, ep_group=ep_group, is_profile=is_profile
+            )
+
+            # Check if all layers have been processed
+            if self.layer_to_transfer >= model.num_moe_layers:
+                self.post_eplb(model, is_profile)
+                # Reset for next rearrangement cycle
+                self.rebalanced = False
+                self.layer_to_transfer = 0
+                self.pending_global_ready_check = False
+
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:
+            if self.is_async and self.rebalanced:
+                # Still performing asynchronous rearrangement
+                return
             self.expert_rearrangement_step = 0
             self.rearrange()
 
@@ -524,7 +620,11 @@ class EplbState:
         if is_main_rank:
             torch.cuda.synchronize()
             time_start = time.perf_counter()
-            logger.info("Rearranging experts %s...", "(profile)" if is_profile else "")
+            logger.info(
+                "Rearranging experts %s %s...",
+                "(async mode)" if self.is_async else "sync mode",
+                "(profile)" if is_profile else "",
+            )
 
         if global_expert_loads is None:
             # Map the physical expert load to global logical experts
@@ -593,6 +693,7 @@ class EplbState:
         model = eplb_model_state.model
         num_replicas = model.num_physical_experts
         num_groups = model.num_expert_groups
+
         if rank_mapping is not None and len(rank_mapping) == ep_group.size():
             # NOTE(yongji): scale down, we need to rebalance the experts on
             # remaining GPUs, transfer the experts while we haven't shutdown
@@ -608,7 +709,7 @@ class EplbState:
             num_gpus = ep_group.size()
 
         if num_gpus % num_nodes != 0:
-            self.num_nodes = 1
+            num_nodes = 1
             logger.warning_once(
                 f"num_gpus % num_nodes != 0, "
                 "not using hierarchical rearrangement algorithm.\n"
@@ -631,48 +732,49 @@ class EplbState:
                 num_gpus,
             )
 
-            # Update expert weights
-            rearrange_expert_weights_inplace(
-                eplb_model_state.physical_to_logical_map,
-                new_physical_to_logical_map,
-                eplb_model_state.model.expert_weights,
-                ep_group,
-                is_profile,
-                rank_mapping,
-            )
+            if not self.is_async or is_profile:
+                # Update expert weights
+                rearrange_expert_weights_inplace(
+                    eplb_model_state.physical_to_logical_map,
+                    new_physical_to_logical_map,
+                    eplb_model_state.model.expert_weights,
+                    ep_group,
+                    is_profile,
+                    rank_mapping,
+                )
 
-            if not is_profile:
-                if (
-                    eplb_model_state.physical_to_logical_map.shape[1]
-                    != new_physical_to_logical_map.shape[1]
-                ):
-                    eplb_model_state.physical_to_logical_map = (
-                        new_physical_to_logical_map.to(
-                            eplb_model_state.physical_to_logical_map.device
+                if not is_profile:
+                    if (
+                        eplb_model_state.physical_to_logical_map.shape[1]
+                        != new_physical_to_logical_map.shape[1]
+                    ):
+                        eplb_model_state.physical_to_logical_map = (
+                            new_physical_to_logical_map.to(
+                                eplb_model_state.physical_to_logical_map.device
+                            )
                         )
+                    else:
+                        eplb_model_state.physical_to_logical_map.copy_(
+                            new_physical_to_logical_map
+                        )
+                    max_physical_slots = new_logical_to_physical_map.shape[-1]
+                    assert (
+                        max_physical_slots
+                        <= eplb_model_state.logical_to_physical_map.shape[-1]
                     )
-                else:
-                    eplb_model_state.physical_to_logical_map.copy_(
-                        new_physical_to_logical_map
+                    new_logical_to_physical_map = torch.nn.functional.pad(
+                        new_logical_to_physical_map,
+                        (
+                            0,
+                            eplb_model_state.logical_to_physical_map.shape[-1]
+                            - max_physical_slots,
+                        ),
+                        value=-1,
                     )
-                max_physical_slots = new_logical_to_physical_map.shape[-1]
-                assert (
-                    max_physical_slots
-                    <= eplb_model_state.logical_to_physical_map.shape[-1]
-                )
-                new_logical_to_physical_map = torch.nn.functional.pad(
-                    new_logical_to_physical_map,
-                    (
-                        0,
-                        eplb_model_state.logical_to_physical_map.shape[-1]
-                        - max_physical_slots,
-                    ),
-                    value=-1,
-                )
-                eplb_model_state.logical_to_physical_map.copy_(
-                    new_logical_to_physical_map
-                )
-                eplb_model_state.logical_replica_count.copy_(new_logical_replica_count)
+                    eplb_model_state.logical_to_physical_map.copy_(
+                        new_logical_to_physical_map
+                    )
+                    eplb_model_state.logical_replica_count.copy_(new_logical_replica_count)
 
         if is_main_rank:
             assert time_start is not None
@@ -683,7 +785,122 @@ class EplbState:
                 " (profile) " if is_profile else " ",
                 time_end - time_start,
             )
+
+        # Signal async thread to start transferring layers
+        if self.is_async and (not is_profile):
+            self.rebalanced = True
+            self.layer_to_transfer = 0  # Reset for new rearrangement
+            self.pending_global_ready_check = True
+            self.rearrange_event.set()
         return None
+
+    def start_async_loop(
+        self,
+        model,
+        rank_mapping: dict[int, int] | None = None,
+        is_profile: bool = False,
+    ):
+        start_async_worker(
+            self, model, rank_mapping=rank_mapping, is_profile=is_profile
+        )
+
+    def _update_layer_mapping_from_new(self, layer: int) -> None:
+        if (
+            self.new_physical_to_logical_map is None
+            or self.new_logical_to_physical_map is None
+            or self.new_logical_replica_count is None
+        ):
+            return
+
+        target_device = self.physical_to_logical_map.device
+        new_physical = self.new_physical_to_logical_map
+        if self.physical_to_logical_map.shape[1] != new_physical.shape[1]:
+            self.physical_to_logical_map = new_physical.to(target_device)
+        else:
+            self.physical_to_logical_map[layer].copy_(
+                new_physical[layer].to(target_device)
+            )
+
+        logical_device = self.logical_to_physical_map.device
+        new_logical = self.new_logical_to_physical_map[layer].to(logical_device)
+        max_slots = self.logical_to_physical_map.shape[-1]
+        slot_delta = max_slots - new_logical.shape[-1]
+        if slot_delta > 0:
+            new_logical = torch.nn.functional.pad(
+                new_logical, (0, slot_delta), value=-1
+            )
+        self.logical_to_physical_map[layer].copy_(new_logical)
+
+        replica_device = self.logical_replica_count.device
+        self.logical_replica_count[layer].copy_(
+            self.new_logical_replica_count[layer].to(replica_device)
+        )
+
+    def _all_ranks_buffer_ready(self) -> bool:
+        parallel_state = get_ep_group()
+        cpu_group = getattr(parallel_state, "cpu_group", None)
+        if cpu_group is not None and cpu_group.size() > 1:
+            flag = torch.tensor(
+                (int(self.ep_buffer_ready),), dtype=torch.int32, device="cpu"
+            )
+            all_reduce(flag, group=cpu_group)
+            return int(flag.item()) == cpu_group.size()
+
+        device_group = parallel_state.device_group
+        if device_group.size() <= 1:
+            return bool(self.ep_buffer_ready)
+
+        device = getattr(parallel_state, "device", self.physical_to_logical_map.device)
+        flag = torch.tensor(
+            (int(self.ep_buffer_ready),), dtype=torch.int32, device=device
+        )
+        all_reduce(flag, group=device_group)
+        return int(flag.item()) == device_group.size()
+
+    def move_to_workspace(
+        self, model: MixtureOfExperts, ep_group: ProcessGroup, is_profile: bool = False
+    ):
+        if not self.buffer_lock.acquire(blocking=False):
+            return
+        try:
+            assert self.new_physical_to_logical_map is not None
+            if self.buffer_ready_event is not None:
+                stream = torch.cuda.current_stream(device=self.cuda_device_index)
+                stream.wait_event(self.buffer_ready_event)
+                self.buffer_ready_event = None
+            move_from_buffer(
+                expert_weights=model.expert_weights[self.layer_to_transfer],
+                expert_weights_buffer=self.expert_buffer,
+                is_unchanged=self.is_unchanged,
+                is_received_locally=self.is_received_locally,
+                experts_recv_loc=self.experts_recv_loc,
+                new_indices=self.new_physical_to_logical_map[
+                    self.layer_to_transfer
+                ].tolist(),
+                ep_group=ep_group,
+            )
+            transferred_layer = self.layer_to_transfer
+            self._update_layer_mapping_from_new(transferred_layer)
+            # After the main thread consumes, advance layer_to_transfer
+            self.layer_to_transfer += 1
+            self.ep_buffer_ready = 0
+        finally:
+            try:
+                self.buffer_lock.release()
+            except Exception as e:
+                logger.error(
+                    "Rank %d: buffer_lock release failed in move_to_workspace: %s",
+                    ep_group.rank(),
+                    str(e),
+                )
+
+    def post_eplb(self, model: MixtureOfExperts, is_profile: bool = False) -> None:
+        assert self.new_physical_to_logical_map is not None
+        assert self.new_logical_to_physical_map is not None
+        assert self.new_logical_replica_count is not None
+        if not is_profile:
+            for layer_idx in range(self.physical_to_logical_map.shape[0]):
+                self._update_layer_mapping_from_new(layer_idx)
 
     @staticmethod
     def recv_state() -> tuple[list[torch.Tensor], list[torch.Tensor]]:

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -505,8 +505,7 @@ class EplbState:
             cuda_device_index=self.cuda_device_index,
             new_physical_to_logical_map=new_physical_to_logical_map,
             new_logical_to_physical_map=new_logical_to_physical_map,
-            new_logical_replica_count=new_logical_replica_count
-
+            new_logical_replica_count=new_logical_replica_count,
         )
         self.model_states[model_config.compute_hash()] = model_state
 

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -629,11 +629,11 @@ class EplbState:
                             eplb_model_state.rebalanced = False
                             eplb_model_state.layer_to_transfer = 0
                             eplb_model_state.pending_global_ready_check = False
-                            logger.info(
-                                "finish async transfer for model %s rank %d",
-                                eplb_model_state.model_name,
-                                ep_group.rank(),
-                            )
+                logger.info(
+                    "finish async transfer for model %s rank %d",
+                    eplb_model_state.model_name,
+                    ep_group.rank(),
+                )
 
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:
             if any(
@@ -866,7 +866,7 @@ class EplbState:
 
         # Signal async thread to start transferring layers
         if self.is_async and (not is_profile):
-            logger.info("EPLB async rearrange triggered")
+            logger.info("EPLB async rearrange triggered for model %s", eplb_model_state.model_name)
             self.rearrange_event.set()
         return None
 
@@ -974,7 +974,11 @@ class EplbState:
             # After the main thread consumes, advance layer_to_transfer
             model_state.layer_to_transfer += 1
             model_state.ep_buffer_ready = 0
-            logger.info("successfully move_to_workspace transferred_layer: %d", transferred_layer)
+            logger.info(
+                "model %s successfully move_to_workspace layer %d",
+                model_state.model_name,
+                transferred_layer,
+            )
         finally:
             try:
                 model_state.buffer_lock.release()

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -613,14 +613,12 @@ class EplbState:
                     all_ranks_buffer_ready = self._all_ranks_buffer_ready(
                         eplb_model_state
                     )
-                logger.info("ep_buffer_ready: %d", eplb_model_state.ep_buffer_ready)
                 if eplb_model_state.is_async_enabled and eplb_model_state.ep_buffer_ready and all_ranks_buffer_ready:
                     self.move_to_workspace(
                         model_state=eplb_model_state,
                         ep_group=ep_group,
                         is_profile=is_profile,
                     )
-                    logger.info("eplb_state eplb_model_state.layer_to_transfer: %d, eplb_model_state.model.num_moe_layers: %d", eplb_model_state.layer_to_transfer, eplb_model_state.model.num_moe_layers)
                     if (
                         eplb_model_state.layer_to_transfer
                         >= eplb_model_state.model.num_moe_layers
@@ -629,12 +627,12 @@ class EplbState:
                             eplb_model_state.rebalanced = False
                             eplb_model_state.layer_to_transfer = 0
                             eplb_model_state.pending_global_ready_check = False
-                logger.info(
-                    "finish async transfer for model %s rank %d layer %d",
-                    eplb_model_state.model_name,
-                    ep_group.rank(),
-                    eplb_model_state.layer_to_transfer,
-                )
+                            logger.info(
+                                "finish async transfer for model %s rank %d layer %d",
+                                eplb_model_state.model_name,
+                                ep_group.rank(),
+                                eplb_model_state.model.num_moe_layers,
+                            )
 
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:
             if any(
@@ -867,7 +865,6 @@ class EplbState:
 
         # Signal async thread to start transferring layers
         if self.is_async and (not is_profile):
-            logger.info("EPLB async rearrange triggered for model %s", eplb_model_state.model_name)
             self.rearrange_event.set()
         return None
 

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -275,7 +275,7 @@ class EplbState:
         Build the initial EPLB state.
         """
         self.validate_ep_configuration(model)
-        self.is_async = model_config.parallel_config.eplb_config.use_async
+        self.is_async = self.parallel_config.eplb_config.use_async
 
         physical_to_logical_map_list = (
             EplbState.build_initial_global_physical_to_logical_map(

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -569,14 +569,16 @@ class EplbState:
             all_ranks_buffer_ready = self._all_ranks_buffer_ready()
 
         if self.is_async and self.ep_buffer_ready and all_ranks_buffer_ready:
-            self.move_to_workspace(
-                model=model, ep_group=ep_group, is_profile=is_profile
-            )
+            for eplb_model_state in self.model_states.values():
+                self.move_to_workspace(
+                    model=eplb_model_state.model, ep_group=ep_group, is_profile=is_profile
+                )
 
-            # Check if all layers have been processed
-            if self.layer_to_transfer >= model.num_moe_layers:
-                self.post_eplb(model, is_profile)
-                # Reset for next rearrangement cycle
+                # Check if all layers have been processed
+                if self.layer_to_transfer >= eplb_model_state.model.num_moe_layers:
+                    self.post_eplb(eplb_model_state.model, is_profile)
+            # Reset for next rearrangement cycle
+            if self.layer_to_transfer >= eplb_model_state.model.num_moe_layers:
                 self.rebalanced = False
                 self.layer_to_transfer = 0
                 self.pending_global_ready_check = False

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -630,9 +630,10 @@ class EplbState:
                             eplb_model_state.layer_to_transfer = 0
                             eplb_model_state.pending_global_ready_check = False
                 logger.info(
-                    "finish async transfer for model %s rank %d",
+                    "finish async transfer for model %s rank %d layer %d",
                     eplb_model_state.model_name,
                     ep_group.rank(),
+                    eplb_model_state.layer_to_transfer,
                 )
 
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:

--- a/vllm/distributed/eplb/rebalance_execute.py
+++ b/vllm/distributed/eplb/rebalance_execute.py
@@ -419,7 +419,6 @@ def rearrange_expert_weights_inplace(
     # If you figure out the reason, please let me know -- thank you!
     torch.cuda.synchronize()
 
-
     for layer in range(num_moe_layers):
         is_unchanged, is_received_locally, experts_recv_loc = move_to_buffer(
             num_local_experts=num_local_physical_experts,

--- a/vllm/distributed/eplb/rebalance_execute.py
+++ b/vllm/distributed/eplb/rebalance_execute.py
@@ -100,18 +100,19 @@ def get_ep_ranks_with_expert(
     return ranks_to_send, ranks_to_recv_actual
 
 
-def shuffle_layer(
+def move_to_buffer(
     num_local_experts: int,
-    ep_rank: int,
     old_indices: Sequence[int],
     new_indices: Sequence[int],
     expert_weights: Iterable[torch.Tensor],
     expert_weights_buffer: Sequence[torch.Tensor],
+    cuda_stream: torch.cuda.Stream | None,
     ep_group: ProcessGroup,
-) -> None:
+) -> tuple[list[bool], list[bool], dict[int, int]]:
     """
     Perform expert weights rearrangement of one layer.
     """
+    ep_rank = ep_group.rank()
     local2global = partial(
         idx_local_to_global,
         local_cnt=num_local_experts,
@@ -137,7 +138,8 @@ def shuffle_layer(
             if old_indices[src_global] == new_indices[dst_global]:
                 is_received_locally[dst] = True
                 for weight, buffer in zip(expert_weights, expert_weights_buffer):
-                    buffer[dst].copy_(weight[src])
+                    with torch.cuda.stream(cuda_stream):
+                        buffer[dst].copy_(weight[src], non_blocking=True)
 
     p2p_ops: list[P2POp] = []
 
@@ -225,25 +227,115 @@ def shuffle_layer(
         ]
 
     # 4. Execute the P2P operations. The real communication happens here.
-    if p2p_ops:
+    if p2p_ops and cuda_stream is not None:
+        with torch.cuda.stream(cuda_stream):
+            reqs = batch_isend_irecv(p2p_ops)
+            for req in reqs:
+                req.wait()
+    elif p2p_ops:
         reqs = batch_isend_irecv(p2p_ops)
         for req in reqs:
             req.wait()
+    # wait for the communication to finish
+    return is_unchanged, is_received_locally, experts_recv_loc
 
-    # 5. Copy the weights from the buffer back to the original weights.
+
+def move_from_buffer(
+    expert_weights: Iterable[torch.Tensor],
+    expert_weights_buffer: list[torch.Tensor],
+    is_unchanged: list[bool],
+    is_received_locally: list[bool],
+    experts_recv_loc: dict[int, int],
+    new_indices: Sequence[int],
+    ep_group: ProcessGroup,
+) -> None:
+    ep_rank = ep_group.rank()
+    num_local_experts = len(is_unchanged)
+
+    local2global = partial(
+        idx_local_to_global, local_cnt=num_local_experts, ep_rank=ep_rank
+    )
+
     for dst in range(num_local_experts):
         if is_unchanged[dst]:
             continue
         if is_received_locally[dst]:
             for weight, buffer in zip(expert_weights, expert_weights_buffer):
-                weight[dst].copy_(buffer[dst])
+                weight[dst].copy_(buffer[dst], non_blocking=True)
         else:
             expert = new_indices[local2global(dst)]
             if expert == -1:
                 continue
             src = experts_recv_loc[expert]
             for weight, buffer in zip(expert_weights, expert_weights_buffer):
-                weight[dst].copy_(buffer[src])
+                weight[dst].copy_(buffer[src], non_blocking=True)
+
+
+async def transfer_layer(
+    old_global_expert_indices: torch.Tensor,
+    new_global_expert_indices: torch.Tensor,
+    expert_weights: Sequence[Iterable[torch.Tensor]],
+    expert_weights_buffer: Sequence[torch.Tensor],
+    ep_group: ProcessGroup,
+    is_profile: bool = False,
+    layer: int = 0,
+    cuda_stream: torch.cuda.Stream | None = None,
+    rank_mapping: dict[int, int] | None = None,
+) -> tuple[list[bool], list[bool], dict[int, int]]:
+    """
+    Rearranges the expert weights in place according to the new expert indices.
+
+    The value of the indices arguments are logical indices of the experts,
+    while keys are physical.
+
+    Args:
+        old_global_expert_indices: Shape (num_moe_layers, num_physical_experts).
+        new_global_expert_indices: Shape (num_moe_layers, num_physical_experts).
+        expert_weights: A sequence of shape (num_moe_layers)(weight_count)
+            of tensors of shape (num_local_physical_experts, hidden_size_i).
+            For example, a linear layer may have up and down projection,
+            so weight_count = 2. Each weight's hidden size can be different.
+        ep_group: The device process group for expert parallelism.
+        is_profile (bool): If `True`, do not perform any actual weight copy.
+            This is used during profile run, where we only perform dummy
+            communications to reserve enough memory for the buffers.
+    """
+    ep_size = ep_group.size()
+    if rank_mapping is not None:
+        if len(rank_mapping) == ep_group.size():
+            # scale down
+            new_global_expert_indices = _map_new_expert_indices_with_rank_mapping(
+                new_global_expert_indices,
+                rank_mapping,
+            )
+        else:
+            # scale up
+            old_global_expert_indices = _map_old_expert_indices_with_rank_mapping(
+                old_global_expert_indices,
+                rank_mapping,
+                ep_group.size(),
+            )
+
+    assert old_global_expert_indices.shape[1] == new_global_expert_indices.shape[1]
+    num_moe_layers, num_physical_experts = old_global_expert_indices.shape
+    assert len(expert_weights) == num_moe_layers
+    num_local_physical_experts = next(iter(expert_weights[0])).shape[0]
+    assert new_global_expert_indices.shape == (num_moe_layers, num_physical_experts)
+    assert num_physical_experts == ep_size * num_local_physical_experts
+    # A buffer to hold the expert weights in one layer during the exchange.
+    # NOTE: Currently we assume the same weights across different layers
+    # have the same shape.
+
+    is_unchanged, is_received_locally, experts_recv_loc = move_to_buffer(
+        num_local_experts=num_local_physical_experts,
+        old_indices=old_global_expert_indices[layer].tolist(),
+        new_indices=new_global_expert_indices[layer].tolist(),
+        expert_weights=expert_weights[layer],
+        expert_weights_buffer=expert_weights_buffer,
+        cuda_stream=cuda_stream,
+        ep_group=ep_group,
+    )
+    return is_unchanged, is_received_locally, experts_recv_loc
 
 
 def rearrange_expert_weights_inplace(
@@ -296,7 +388,6 @@ def rearrange_expert_weights_inplace(
     num_local_physical_experts = next(iter(expert_weights[0])).shape[0]
     assert new_global_expert_indices.shape == (num_moe_layers, num_physical_experts)
 
-    ep_rank = ep_group.rank()
     ep_size = ep_group.size()
     assert num_physical_experts == ep_size * num_local_physical_experts
 
@@ -328,15 +419,26 @@ def rearrange_expert_weights_inplace(
     # If you figure out the reason, please let me know -- thank you!
     torch.cuda.synchronize()
 
+
     for layer in range(num_moe_layers):
-        shuffle_layer(
-            num_local_physical_experts,
-            ep_rank,
-            old_global_expert_indices_cpu[layer].tolist(),
-            new_global_expert_indices_cpu[layer].tolist(),
-            expert_weights[layer],
-            expert_weights_buffer,
-            ep_group,
+        is_unchanged, is_received_locally, experts_recv_loc = move_to_buffer(
+            num_local_experts=num_local_physical_experts,
+            old_indices=old_global_expert_indices_cpu[layer].tolist(),
+            new_indices=new_global_expert_indices_cpu[layer].tolist(),
+            expert_weights=expert_weights[layer],
+            expert_weights_buffer=expert_weights_buffer,
+            cuda_stream=None,
+            ep_group=ep_group,
+        )
+
+        move_from_buffer(
+            expert_weights=expert_weights[layer],
+            expert_weights_buffer=expert_weights_buffer,
+            is_unchanged=is_unchanged,
+            is_received_locally=is_received_locally,
+            experts_recv_loc=experts_recv_loc,
+            new_indices=new_global_expert_indices[layer].tolist(),
+            ep_group=ep_group,
         )
 
 
@@ -428,4 +530,4 @@ def _map_new_expert_indices_with_rank_mapping(
     return mapped_expert_indices
 
 
-__all__ = ["rearrange_expert_weights_inplace"]
+__all__ = ["transfer_layer", "move_from_buffer"]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3371,7 +3371,7 @@ class GPUModelRunner(
                 rank_mapping,
             )
             if self.eplb_state.is_async:
-                self.eplb_state.start_async_loop(model=self.model)
+                self.eplb_state.start_async_loop(rank_mapping=rank_mapping)
 
         if (
             self.vllm_config.compilation_config.mode

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3370,6 +3370,8 @@ class GPUModelRunner(
                 old_global_expert_indices,
                 rank_mapping,
             )
+            if self.eplb_state.is_async:
+                self.eplb_state.start_async_loop(model=self.model)
 
         if (
             self.vllm_config.compilation_config.mode


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
issue #20805 #24116 
pr #18343    
EPLB Execution
- [ ] Parallelize the rearrangement algorithm (calculating new expert mapping, not the communication)
- [x] Shuffle one layer at once and use multiple steps, to lower the impact on inter-token latency
- [x] Investigate should we pre-allocate expert weight buffer used for transferring
- [ ] Take locality into consideration in expert weight transmission, e.g. prioritize transferring to GPUs on the same node
- [x] Use cuda.Stream() asynchronously moves the weight to the buffer

They jointly provided the initial code
5 Key Pitfalls in EPLB Asynchronous Core Implementation

1. CUDA Stream must be bound to Device:
After creating an asynchronous thread, the initialized torch.cuda.Stream must be explicitly bound to the target GPU device. Otherwise, mismatched devices will cause asynchronous task execution to fail.

2. Separate “move_to_buffer” and “move_to_workspace”:
move_to_buffer: should be executed in asynchronous threads to hide data transfer latency. move_to_workspace: involves copying cached weights into the working area. Since this is an on-device operation (only ~300–400 µs), it must be executed synchronously. However, the performance impact is minimal.

3. Layer-level synchronization: wait for P2P completion:
After each layer executes move to buffer, all GPUs must wait until their P2P (point-to-point) send/receive operations finish. This ensures that subsequent steps won’t fail due to missing or incomplete data.

4. All Reduce must be coupled with Rank synchronization to avoid deadlocks:
While waiting for P2P operations, an All Reduce is required to ensure all Ranks (GPUs) reach the same condition. This All Reduce must be executed at every rank interaction, otherwise desynchronized progress across GPUs may cause deadlocks. To reduce overhead, All Reduce should only be performed during the Rearrange phase, not in other stages.

5. Update expert weights after each layer’s move_from_buffer:
After move_from_buffer at each layer, expert weights must be updated. Otherwise, computations may use stale weights, causing mapping inconsistencies and leading to accuracy issues.

## Test Plan
```
pytest tests/distributed/test_eplb_execute.py
pytest tests/distributed/test_eplb_spec_decode.py
```
## Test Result
Benchmark TP=8,EP=8, 8XH800 80G dataset: MMLU-pro, 
Due to resource limitations, we only measured up to EP8. A larger EP size with no-blocking EPLB would yield greater benefits:
benchmark test without eplb:

```
vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
     --gpu-memory-utilization 0.8 \
     --trust-remote-code

vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
     --enable-eplb \
     --eplb-config '{"window_size":1000,"step_interval":3000}' \
     --gpu-memory-utilization 0.8 \
     --trust-remote-code

vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
     --enable-eplb \
     --eplb-config '{"window_size":1000,"step_interval":3000,"use_async":"true"}' \
     --gpu-memory-utilization 0.8 \
     --trust-remote-code
```
accuracy:
```
python tests/evals/gsm8k/gsm8k_eval.py --port 8000
```

```
w/o EPLB:
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:07<00:00, 19.67it/s]
Results:
Accuracy: 0.901
Invalid responses: 0.000    
Total latency: 67.070 s     
Questions per second: 19.666

w/ EPLB, main:
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:22<00:00, 16.00it/s]
Results:
Accuracy: 0.902
Invalid responses: 0.000    
Total latency: 82.434 s     
Questions per second: 16.001

w/ EPLB, this PR:
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:20<00:00, 16.46it/s]
Results:
Accuracy: 0.908
Invalid responses: 0.000    
Total latency: 80.133 s     
Questions per second: 16.460


```

```
async EPLB + MTP:
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct --max-model-len 2048  --trust-remote-code --port 8000 -dp 1 -tp 4 --enable-expert-parallel --gpu-memory-utilization 0.86 --enable-eplb  --eplb-config '{"window_size":200,"step_interval":600,"use_async":"true"}' --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":1}' 2>&1 | tee ../prof/test_async_mtp.log

Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|████████████████████████████████████████████████████████████████| 1319/1319 [01:34<00:00, 14.00it/s]

Results:
Accuracy: 0.864
Invalid responses: 0.000
Total latency: 94.256 s
Questions per second: 13.994

```

benchmark:
```
vllm bench serve  \
--backend vllm   \
--model Qwen/Qwen3-235B-A22B-Instruct-2507-FP8   \
--endpoint /v1/completions   \
--dataset-name custom   \
--dataset-path /root/.cache/cwq/datasets/mmlu_pro_test.jsonl   \
--max-concurrency 64 --num-prompt 1000
```

```
w/o EPLB:
============ Serving Benchmark Result ============
Successful requests:                     1000
Maximum request concurrency:             64
Benchmark duration (s):                  109.47
Total input tokens:                      69309
Total generated tokens:                  231400
Request throughput (req/s):              9.13
Output token throughput (tok/s):         2113.74
Peak output token throughput (tok/s):    2367.00
Peak concurrent requests:                112.00
Total Token throughput (tok/s):          2746.85
---------------Time to First Token----------------
Mean TTFT (ms):                          93.20
Median TTFT (ms):                        61.91
P99 TTFT (ms):                           310.75
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.11
Median TPOT (ms):                        29.18
P99 TPOT (ms):                           29.96
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.10
Median ITL (ms):                         28.52
P99 ITL (ms):                            38.27
==================================================

w/ EPLB, main:
============ Serving Benchmark Result ============
Successful requests:                     1000
Maximum request concurrency:             64
Benchmark duration (s):                  131.87
Total input tokens:                      69309
Total generated tokens:                  231534
Request throughput (req/s):              7.58
Output token throughput (tok/s):         1755.72
Peak output token throughput (tok/s):    2068.00
Peak concurrent requests:                113.00
Total Token throughput (tok/s):          2281.29
---------------Time to First Token----------------
Mean TTFT (ms):                          97.56
Median TTFT (ms):                        69.89
P99 TTFT (ms):                           348.90
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.04
Median TPOT (ms):                        33.06
P99 TPOT (ms):                           63.84
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.07
Median ITL (ms):                         32.17
P99 ITL (ms):                            45.01
==================================================

w/ EPLB, this PR:
============ Serving Benchmark Result ============
Successful requests:                     1000
Maximum request concurrency:             64
Benchmark duration (s):                  129.85
Total input tokens:                      69309
Total generated tokens:                  230828
Request throughput (req/s):              7.70
Output token throughput (tok/s):         1777.61
Peak output token throughput (tok/s):    2047.00
Peak concurrent requests:                114.00
Total Token throughput (tok/s):          2311.35
---------------Time to First Token----------------
Mean TTFT (ms):                          100.83
Median TTFT (ms):                        71.17
P99 TTFT (ms):                           350.46
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          34.47
Median TPOT (ms):                        33.27
P99 TPOT (ms):                           46.01
---------------Inter-token Latency----------------
Mean ITL (ms):                           34.51
Median ITL (ms):                         32.28
P99 ITL (ms):                            45.79
==================================================

```

profile:
non-blocking EPLB:
<img width="1682" height="790" alt="image" src="https://github.com/user-attachments/assets/c2029559-807d-4a97-b725-ff2f83a64d15" />


## (Optional) Documentation Update

Co-authored-by: jiangkuaixue123 <jiangxiaozhou111@163.com>
Co-authored-by: SunChenxiang123 <1291824390@qq.com>