### PR TITLE
[ROCm][Bugfix] Compilation passes fix

### DIFF
--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -9,8 +9,10 @@ from vllm.platforms import current_platform
 
 if current_platform.is_cuda_alike():
     from .fusion import FusionPass
-    from .collective_fusion import AllReduceFusionPass, AsyncTPPass
     from .fusion_attn import AttnFusionPass
+
+if current_platform.is_cuda():
+    from .collective_fusion import AllReduceFusionPass, AsyncTPPass
 
 from .activation_quant_fusion import ActivationQuantFusionPass
 from .fix_functionalization import FixFunctionalizationPass

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -7,7 +7,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
-if current_platform.is_cuda():
+if current_platform.is_cuda_alike():
     from .fusion import FusionPass
     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
     from .fusion_attn import AttnFusionPass


### PR DESCRIPTION
This is to expand on the partial fix from #22083
The original bug was introduced in #21069 by importing NVFP4 ops on cuda_alike platforms, when it only applies to cuda
Per @ilmarkov the collective_fusion.py in its current state is not applicable to ROCm due to its dependency on Flashinfer. So it is safe to exclude it from the import.
Fusion and AttentionFusion however are essential for ROCm