### PR TITLE
Optimize configuration access with LRU cache in custom ops

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import (MISSING, Field, asdict, field, fields, is_dataclass,
                          replace)
-from functools import cached_property
+from functools import cached_property, lru_cache
 from importlib.util import find_spec
 from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Literal, Optional,
                     Protocol, TypeVar, Union, cast, get_args)
@@ -5100,6 +5100,14 @@ def set_current_vllm_config(vllm_config: VllmConfig,
     finally:
         _current_vllm_config = old_vllm_config
         _current_prefix = old_prefix
+        # Clear the compilation config cache when context changes
+        get_cached_compilation_config.cache_clear()
+
+
+@lru_cache(maxsize=1)
+def get_cached_compilation_config():
+    """Cache config to avoid repeated calls to get_current_vllm_config()"""
+    return get_current_vllm_config().compilation_config
 
 
 def get_current_vllm_config() -> VllmConfig:

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -15,7 +15,7 @@ logger = init_logger(__name__)
 
 @lru_cache(maxsize=1)
 def get_cached_compilation_config():
-    """Cache compilation config to avoid repeated calls to get_current_vllm_config()"""
+    """Cache config to avoid repeated calls to get_current_vllm_config()"""
     return get_current_vllm_config().compilation_config
 
 

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -1,22 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from functools import lru_cache
 from typing import Optional
 
 import torch.nn as nn
 
-from vllm.config import get_current_vllm_config
+from vllm.config import get_cached_compilation_config
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
-
-
-@lru_cache(maxsize=1)
-def get_cached_compilation_config():
-    """Cache config to avoid repeated calls to get_current_vllm_config()"""
-    return get_current_vllm_config().compilation_config
 
 
 class CustomOp(nn.Module):


### PR DESCRIPTION
 Changes

  - Added get_cached_compilation_config() function with
  @lru_cache(maxsize=1) to cache compilation config access
  - Added cache invalidation in set_current_vllm_config() context
  manager to ensure cache freshness
  - Fixed code style (line length) issues

  Benefits

  - Reduces repeated configuration lookups in custom operations
  - Improves performance for frequently accessed compilation config
  - Maintains correctness with proper cache invalidation

  Files Modified

  - vllm/config.py: Added caching function and invalidation logic
  - vllm/model_executor/custom_op.py: Updated to use cached config access