### PR TITLE
[V1] reduce block size for tree attention correctness test to fix 'ou…

### DIFF
--- a/tests/v1/spec_decode/test_tree_attention.py
+++ b/tests/v1/spec_decode/test_tree_attention.py
@@ -155,7 +155,7 @@ def test_tree_attn_correctness() -> None:
 
     dim_per_head = 128
     num_kv_heads = 2
-    block_size = 128
+    block_size = 32
     max_sequence_length = 8192
     randomize_blocks = True
     for batch_size in [1, 16, 32]:


### PR DESCRIPTION
## Purpose
Fix the following "out of resource" error that occurs during execution of the `kernel_unified_attention_2d` kernel. Here's the error:

```
[2025-08-04T06:55:28Z] v1/spec_decode/test_tree_attention.py:110: in forward_attention
--
  | [2025-08-04T06:55:28Z]     return instance.forward(
  | [2025-08-04T06:55:28Z] /usr/local/lib/python3.12/dist-packages/vllm/v1/attention/backends/tree_attn.py:432: in forward
  | [2025-08-04T06:55:28Z]     unified_attention(
  | [2025-08-04T06:55:28Z] /usr/local/lib/python3.12/dist-packages/vllm/attention/ops/triton_unified_attention.py:664: in unified_attention
  | [2025-08-04T06:55:28Z]     kernel_unified_attention_2d[(
  | [2025-08-04T06:55:28Z] /usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py:347: in <lambda>
  | [2025-08-04T06:55:28Z]     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
  | [2025-08-04T06:55:28Z] /usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py:591: in run
  | [2025-08-04T06:55:28Z]     kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata,
  | [2025-08-04T06:55:28Z] /usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py:413: in __getattribute__
  | [2025-08-04T06:55:28Z]     self._init_handles()
  | [2025-08-04T06:55:28Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | [2025-08-04T06:55:28Z]
  | [2025-08-04T06:55:28Z] self = <triton.compiler.compiler.CompiledKernel object at 0x7f4cedee5df0>
  | [2025-08-04T06:55:28Z]
  | [2025-08-04T06:55:28Z]     def _init_handles(self):
  | [2025-08-04T06:55:28Z]         if self.module is not None:
  | [2025-08-04T06:55:28Z]             return
  | [2025-08-04T06:55:28Z]         device = driver.active.get_current_device()
  | [2025-08-04T06:55:28Z]         # create launcher
  | [2025-08-04T06:55:28Z]         self.run = driver.active.launcher_cls(self.src, self.metadata)
  | [2025-08-04T06:55:28Z]         # not enough shared memory to run the kernel
  | [2025-08-04T06:55:28Z]         max_shared = driver.active.utils.get_device_properties(device)["max_shared_mem"]
  | [2025-08-04T06:55:28Z]         if self.metadata.shared > max_shared:
  | [2025-08-04T06:55:28Z] >           raise OutOfResources(self.metadata.shared, max_shared, "shared memory")
  | [2025-08-04T06:55:28Z] E           triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 155648, Hardware limit: 101376. Reducing block sizes or `num_stages` may help.
  | [2025-08-04T06:55:28Z]
  | [2025-08-04T06:55:28Z] /usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py:401: OutOfResources
  | [2025-08-04T06:55:28Z] =============================== warnings summary ===============================
  | [2025-08-04T06:55:28Z] ../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
  | [2025-08-04T06:55:28Z]   /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
  | [2025-08-04T06:55:28Z]     ref_error: type[Exception] = jsonschema.RefResolutionError,
  | [2025-08-04T06:55:28Z]
  | [2025-08-04T06:55:28Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
  | [2025-08-04T06:55:28Z] =========================== short test summary info ============================
  | [2025-08-04T06:55:28Z] FAILED v1/spec_decode/test_tree_attention.py::test_tree_attn_correctness - triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 155648, Hardware limit: 101376. Reducing block sizes or `num_stages` may help.
  | [2025-08-04T06:55:28Z] ============= 1 failed, 24 passed, 1 warning in 233.80s (0:03:53) ==============
  | [2025-08-04T06:55:31Z] 🚨 Error: The command exited with status 1
```

It is currently triggered by the `test_tree_attention` test, and is a result of using a large block size (128). I have reduced the block size to 32, reducing the per-block shared memory usage to ~38K, which is supported by the majority of modern hardware.


## Test Plan
(py312conda) bash-5.1$ pytest tests/v1/spec_decode/test_tree_attention.py -k test_tree_attn_correctness
============================================================================================================================================ test session starts ============================================================================================================================================
platform linux -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /data/users/gdelfin/gitrepos/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0, asyncio-1.1.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                                                                                                                            

tests/v1/spec_decode/test_tree_attention.py .                                                                                                                                                                                                                                                         [100%]

============================================================================================================================================ 1 passed in 34.33s =============================================================================================================================================
