### PR TITLE
preload heavy modules when mp method is forkserver

### DIFF
--- a/vllm/benchmarks/latency.py
+++ b/vllm/benchmarks/latency.py
@@ -13,7 +13,6 @@ import numpy as np
 from tqdm import tqdm
 
 import vllm.envs as envs
-from vllm import LLM, SamplingParams
 from vllm.benchmarks.lib.utils import (convert_to_pytorch_benchmark_format,
                                        write_to_json)
 from vllm.engine.arg_utils import EngineArgs
@@ -84,6 +83,9 @@ def main(args: argparse.Namespace):
             "The environment variable 'VLLM_TORCH_PROFILER_DIR' is not set. "
             "Please set it to a valid path to use torch profiler.")
     engine_args = EngineArgs.from_cli_args(args)
+
+    # Lazy import to avoid importing LLM when the bench command is not selected.
+    from vllm import LLM, SamplingParams
 
     # NOTE(woosuk): If the request cannot be processed in a single batch,
     # the engine will automatically process the request in multiple batches.

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -8,6 +8,7 @@ import importlib
 import inspect
 import json
 import multiprocessing
+import multiprocessing.forkserver as forkserver
 import os
 import signal
 import socket
@@ -153,6 +154,15 @@ async def build_async_engine_client(
     disable_frontend_multiprocessing: Optional[bool] = None,
     client_config: Optional[dict[str, Any]] = None,
 ) -> AsyncIterator[EngineClient]:
+
+    if os.getenv("VLLM_WORKER_MULTIPROC_METHOD") == "forkserver":
+        # The executor is expected to be mp.
+        # Pre-import heavy modules in the forkserver process
+        logger.debug("Setup forkserver with pre-imports")
+        multiprocessing.set_start_method('forkserver')
+        multiprocessing.set_forkserver_preload(["vllm.entrypoints.llm"])
+        forkserver.ensure_running()
+        logger.debug("Forkserver setup complete!")
 
     # Context manager to handle engine_client lifecycle
     # Ensures everything is shutdown and cleaned up on error/exit

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -160,7 +160,7 @@ async def build_async_engine_client(
         # Pre-import heavy modules in the forkserver process
         logger.debug("Setup forkserver with pre-imports")
         multiprocessing.set_start_method('forkserver')
-        multiprocessing.set_forkserver_preload(["vllm.entrypoints.llm"])
+        multiprocessing.set_forkserver_preload(["vllm.v1.engine.async_llm"])
         forkserver.ensure_running()
         logger.debug("Forkserver setup complete!")
 


### PR DESCRIPTION
Summary
---
- Speed up workers initialization by preloading heavy modules when the multiprocessing method is set to 'forkserver' (as `fork` is [unsafe](https://docs.python.org/3/library/os.html#os.fork)). 
- Import llm.py only when needed 


The speedup is about 4s.

/label startup-ux
