### PR TITLE
[UX] Fail if an invalid attention backend is specified

### DIFF
--- a/vllm/attention/selector.py
+++ b/vllm/attention/selector.py
@@ -193,6 +193,10 @@ def _cached_get_attn_backend(
         backend_by_env_var: Optional[str] = envs.VLLM_ATTENTION_BACKEND
         if backend_by_env_var is not None:
             selected_backend = backend_name_to_enum(backend_by_env_var)
+            if selected_backend is None:
+                raise ValueError(
+                    f"Invalid attention backend: '{backend_by_env_var}'. "
+                    f"Valid backends are: {list(_Backend.__members__.keys())}")
 
     # get device-specific attn_backend
     attention_cls = current_platform.get_attn_backend_cls(


### PR DESCRIPTION
## Purpose

As the title states, I think if an invalid attention backend is manually specified like VLLM_ATTENTION_BACKEND=INVALID it should fail rather than fallback to some default

Rob found that this PR https://github.com/vllm-project/vllm/pull/21966 causes fallback to V0 if that env variable is set incorrectly
```
WARNING 08-04 15:00:03 [arg_utils.py:1771] VLLM_ATTENTION_BACKEND=CUTLASS_MLA_VLLM_V1 is not supported by the V1 Engine. Falling back to V0. We recommend to remove VLLM_ATTENTION_BACKEND=CUTLASS_MLA_VLLM_V1 from your config in favor of the V1 Engine.
```

## Test Plan

CI

## Test Result
