### PR TITLE
[Frontend] Added parallel_tool_calls option on the openai API with Guided Decoding

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -763,7 +763,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     "anyOf": [get_tool_schema(tool) for tool in self.tools]
                 }
             }
-            if not self.parallel_tool_calls:
+            if self.parallel_tool_calls is False:
                 json_schema["maxItems"] = 1
             json_schema_defs = get_tool_schema_defs(self.tools)
             if json_schema_defs:

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -763,7 +763,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     "anyOf": [get_tool_schema(tool) for tool in self.tools]
                 }
             }
-            if not self.parse_tool_calls:
+            if not self.parallel_tool_calls:
                 json_schema["maxItems"] = 1
             json_schema_defs = get_tool_schema_defs(self.tools)
             if json_schema_defs:

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -763,6 +763,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     "anyOf": [get_tool_schema(tool) for tool in self.tools]
                 }
             }
+            if not self.parse_tool_calls:
+                json_schema["maxItems"] = 1
             json_schema_defs = get_tool_schema_defs(self.tools)
             if json_schema_defs:
                 json_schema["$defs"] = json_schema_defs

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -81,11 +81,6 @@ class OpenAIServingChat(OpenAIServing):
 
         # set up tool use
         self.enable_auto_tools: bool = enable_auto_tools
-        if self.enable_auto_tools:
-            logger.info(
-                "\"auto\" tool choice has been enabled please note that while"
-                " the parallel_tool_calls client option is preset for "
-                "compatibility reasons, it will be ignored.")
 
         self.reasoning_parser: Optional[Callable[[AnyTokenizer],
                                                  ReasoningParser]] = None


### PR DESCRIPTION
Now we can set parallel_tool_calls to False and actually get a single tool_call from models that support multi tool calls.