### PR TITLE
[Quant] Refactor CompressedTensorsConfig

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -477,15 +477,14 @@ class CompressedTensorsConfig(QuantizationConfig):
                                     sparsity_scheme=sparsity_scheme):
             # Have a valid sparsity scheme
             # Validate layer is supported by Cutlass 2:4 Kernel
-            model_compression_config = (None if sparsity_scheme is None
-                                        or sparsity_scheme.format == "dense"
-                                        else self.config)
+            config = (None if sparsity_scheme is None
+                      or sparsity_scheme.format == "dense" else self)
 
             scheme = CompressedTensors24(
                 quantized=weight_quant is not None or input_quant is not None,
                 weight_quant=weight_quant,
                 input_quant=input_quant,
-                model_compression_config=model_compression_config,
+                config=config,
             )
 
         # TODO (@ksayers): Move this check into `_get_scheme_from_parts`

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -80,7 +80,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         return "compressed-tensors"
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
-        # quantization (no kv)
+        # quantization
         for config_group in self.quant_config.config_groups.values():
             config_group.targets = hf_to_vllm_mapper.apply_list(
                 config_group.targets)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1,17 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+from compressed_tensors import (KV_CACHE_SCHEME_NAME, SPARSITY_CONFIG_NAME,
+                                TRANSFORM_CONFIG_NAME)
 from compressed_tensors.config import (CompressionFormat,
                                        SparsityCompressionConfig,
                                        SparsityStructure)
-from compressed_tensors.quantization import (QuantizationArgs,
-                                             QuantizationStrategy,
+from compressed_tensors.quantization import QuantizationArgs
+from compressed_tensors.quantization import QuantizationConfig as CTQuantConfig
+from compressed_tensors.quantization import (QuantizationStrategy,
                                              QuantizationType)
-from pydantic import BaseModel
+from compressed_tensors.transform import (TransformArgs, TransformConfig,
+                                          TransformLocation, TransformScheme)
+from compressed_tensors.utils import is_match
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -31,8 +35,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsW8A8Int8, CompressedTensorsW8A16Fp8,
     CompressedTensorsWNA16)
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
-    find_matched_target, is_activation_quantization_format,
-    should_ignore_layer)
+    is_activation_quantization_format)
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     cutlass_fp4_supported)
@@ -45,31 +48,23 @@ logger = init_logger(__name__)
 
 __all__ = ["CompressedTensorsLinearMethod"]
 
-SPARSITY_CONFIG_NAME: Literal["sparsity_config"] = "sparsity_config"
-QUANTIZATION_SCHEME_MAP_TYPE = dict[str, Optional[dict[str, QuantizationArgs]]]
-
 
 class CompressedTensorsConfig(QuantizationConfig):
 
-    def __init__(
-        self,
-        target_scheme_map: dict[str, Any],
-        ignore: list[str],
-        quant_format: str,
-        sparsity_scheme_map: dict[str, SparsityCompressionConfig],
-        sparsity_ignore_list: list[str],
-        kv_cache_scheme: Optional[dict[str, Any]] = None,
-        config: Optional[dict[str, Any]] = None,
-    ):
+    def __init__(self, config: dict[str, Any]):
         super().__init__()
-        self.ignore = ignore
-        self.quant_format = quant_format
-        # Map from [target -> scheme]
-        self.target_scheme_map = target_scheme_map
-        self.kv_cache_scheme = kv_cache_scheme
-        self.sparsity_scheme_map = sparsity_scheme_map
-        self.sparsity_ignore_list = sparsity_ignore_list
-        self.config = config
+        q_config = config.copy()
+        s_config = q_config.pop(SPARSITY_CONFIG_NAME, None)
+        t_config = q_config.pop(TRANSFORM_CONFIG_NAME, None)
+        kv_scheme = q_config.pop(KV_CACHE_SCHEME_NAME, None)
+
+        self.quant_config = CTQuantConfig.model_validate(q_config)
+        self.sparsity_config = SparsityCompressionConfig.model_validate(
+            s_config) if s_config else None
+        self.transform_config = TransformConfig.model_validate(
+            t_config) if t_config else None
+        self.kv_cache_scheme = QuantizationArgs.model_validate(
+            kv_scheme) if kv_scheme else None
 
     def get_linear_method(self) -> "CompressedTensorsLinearMethod":
         return CompressedTensorsLinearMethod(self)
@@ -85,16 +80,26 @@ class CompressedTensorsConfig(QuantizationConfig):
         return "compressed-tensors"
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
-        self.target_scheme_map = hf_to_vllm_mapper.apply_dict(
-            self.target_scheme_map)
-        self.ignore = hf_to_vllm_mapper.apply_list(self.ignore)
-        self.sparsity_scheme_map = hf_to_vllm_mapper.apply_dict(
-            self.sparsity_scheme_map)
-        self.sparsity_ignore_list = hf_to_vllm_mapper.apply_list(
-            self.sparsity_ignore_list)
-        if self.kv_cache_scheme is not None:
-            self.kv_cache_scheme = hf_to_vllm_mapper.apply_dict(
-                self.kv_cache_scheme)
+        # quantization (no kv)
+        for config_group in self.quant_config.config_groups.values():
+            config_group.targets = hf_to_vllm_mapper.apply_list(
+                config_group.targets)
+        self.quant_config.ignore = hf_to_vllm_mapper.apply_list(
+            self.quant_config.ignore)
+
+        # sparsity
+        if self.sparsity_config is not None:
+            self.sparsity_config.targets = hf_to_vllm_mapper.apply_list(
+                self.sparsity_config.targets)
+            self.sparsity_config.ignore = hf_to_vllm_mapper.apply_list(
+                self.sparsity_config.ignore)
+
+        # transform
+        if self.transform_config is not None:
+            for scheme in self.transform_config.config_groups.values():
+                for arg in scheme.apply:
+                    arg.targets = hf_to_vllm_mapper.apply_list(arg.targets)
+                    arg.ignore = hf_to_vllm_mapper.apply_list(arg.ignore)
 
     def get_quant_method(
         self,
@@ -103,13 +108,10 @@ class CompressedTensorsConfig(QuantizationConfig):
     ) -> Optional["QuantizeMethodBase"]:
         from vllm.attention.layer import Attention  # Avoid circular import
 
-        # Check if the layer is skipped for quantization.
-        # TODO (@robertgshaw2): support module names
-        if should_ignore_layer(prefix,
-                               ignore=self.ignore,
-                               fused_mapping=self.packed_modules_mapping):
-            return UnquantizedLinearMethod()
         if isinstance(layer, LinearBase):
+            # TODO (@ksayers): maybe refactor this to live on the
+            # LinearMethod, similar to MoEMethod. This makes clear
+            # the separation of schemes by module type
             scheme = self.get_scheme(layer=layer, layer_name=prefix)
             if scheme is None:
                 return UnquantizedLinearMethod()
@@ -118,94 +120,14 @@ class CompressedTensorsConfig(QuantizationConfig):
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
         if isinstance(layer, FusedMoE):
-            return CompressedTensorsMoEMethod.get_moe_method(self, layer)
+            return CompressedTensorsMoEMethod.get_moe_method(self,
+                                                             layer=layer,
+                                                             layer_name=prefix)
         return None
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "CompressedTensorsConfig":
-        ignore: list[str] = cast(list[str], config.get("ignore", []))
-        quant_format = cast(str, config.get("format"))
-        target_scheme_map = cls._quantization_scheme_map_from_config(
-            config=config)
-        sparsity_scheme_map, sparsity_ignore_list = cls._parse_sparsity_config(
-            config=config)
-
-        return cls(
-            target_scheme_map=target_scheme_map,
-            ignore=ignore,
-            quant_format=quant_format,
-            sparsity_scheme_map=sparsity_scheme_map,
-            sparsity_ignore_list=sparsity_ignore_list,
-            config=config,
-        )
-
-    @classmethod
-    def _parse_sparsity_config(
-        cls, config: dict[str, Any]
-    ) -> tuple[dict[str, SparsityCompressionConfig], list[str]]:
-        """
-        :param config: The `quantization_config` dictionary from config.json
-        :return: A tuple with two elements
-            1. A dictionary mapping target layer names to their corresponding
-                sparsity_config
-            2. A list of layer names to ignore for sparsity
-        """
-        if not (sparsity_config := config.get(SPARSITY_CONFIG_NAME)):
-            return dict(), []
-
-        sparsity_config = SparsityCompressionConfig.model_validate(
-            sparsity_config)
-        sparse_scheme_map: dict[str, SparsityCompressionConfig] = {
-            target: sparsity_config
-            for target in sparsity_config.targets or list()
-        }
-        sparsity_ignore_list = sparsity_config.ignore or list()
-        return sparse_scheme_map, sparsity_ignore_list
-
-    @classmethod
-    def _quantization_scheme_map_from_config(
-            cls, config: dict[str, Any]) -> QUANTIZATION_SCHEME_MAP_TYPE:
-        """
-        :param config: The `quantization_config` dictionary from config.json
-        :return: A dictionary mapping target layer names to their corresponding
-            quantization_args for weights and input activations
-        """
-        target_scheme_map: dict[str, Any] = dict()
-        quant_format = cast(str, config.get("format"))
-
-        # The quant_config has multiple config_groups, each containing
-        # an input_activations key with details about how the activations are
-        # quantized, a weights key indicating how the weights are quantized,
-        # and a list of targets under the `targets` key, dictating which
-        # layers are impacted by the quantization details. The quantization
-        # details follow the structure defined by the QuantizationArgs
-        # pydantic model, which is used to verify the structure of the
-        # quant_config and also store the details for later use.
-
-        config_groups = config.get("config_groups", dict())
-        for _, quant_config in config_groups.items():
-            targets = quant_config.get("targets")
-            for target in targets:
-                target_scheme_map[target] = {}
-                target_scheme_map[target][
-                    "weights"] = QuantizationArgs.model_validate(
-                        quant_config.get("weights"))
-
-                target_scheme_map[target]["input_activations"] = None
-                if is_activation_quantization_format(quant_format):
-                    input_activations = quant_config.get("input_activations")
-                    # The only case where we have activation quant supported
-                    # but no input_activations provided in the config
-                    # should be w8a16fp8 w8a16fp8 can also run for cases where
-                    # there is an input_quant but it is ignored
-                    if not input_activations:
-                        assert target_scheme_map[target][
-                            "weights"].type == QuantizationType.FLOAT
-                    else:
-                        target_scheme_map[target][
-                            "input_activations"] = QuantizationArgs.model_validate(  # noqa: E501
-                                quant_config.get("input_activations"))
-        return target_scheme_map
+        return cls(config)
 
     @classmethod
     def get_config_filenames(cls) -> list[str]:
@@ -237,7 +159,8 @@ class CompressedTensorsConfig(QuantizationConfig):
         else:
             return False
 
-    def _is_fp4a4_nvfp4(self, weight_quant: BaseModel, input_quant: BaseModel):
+    def _is_fp4a4_nvfp4(self, weight_quant: Optional[QuantizationArgs],
+                        input_quant: Optional[QuantizationArgs]):
 
         if weight_quant is None or input_quant is None:
             return False
@@ -257,8 +180,8 @@ class CompressedTensorsConfig(QuantizationConfig):
         return (is_tensor_group_quant and is_float_type and is_4_bits
                 and is_group_size_16 and is_symmetric)
 
-    def _is_fp4a16_nvfp4(self, weight_quant: BaseModel,
-                         input_quant: BaseModel):
+    def _is_fp4a16_nvfp4(self, weight_quant: Optional[QuantizationArgs],
+                         input_quant: Optional[QuantizationArgs]):
 
         is_weight_only = weight_quant is not None and input_quant is None
         is_tensor_group_quant = (
@@ -272,8 +195,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         return (is_weight_only and is_tensor_group_quant and is_float_type
                 and is_4_bits and is_group_size_16 and is_symmetric)
 
-    def _is_static_tensor_w8a8(self, weight_quant: BaseModel,
-                               input_quant: BaseModel) -> bool:
+    def _is_static_tensor_w8a8(
+            self, weight_quant: Optional[QuantizationArgs],
+            input_quant: Optional[QuantizationArgs]) -> bool:
         is_8_bits = weight_quant.num_bits == input_quant.num_bits == 8
         weight_strategy = (
             weight_quant.strategy == QuantizationStrategy.TENSOR.value
@@ -286,8 +210,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         # Only symmetric weight quantization supported.
         return is_8_bits and is_tensor and weight_quant.symmetric and is_static
 
-    def _is_dynamic_token_w8a8(self, weight_quant: BaseModel,
-                               input_quant: BaseModel) -> bool:
+    def _is_dynamic_token_w8a8(
+            self, weight_quant: Optional[QuantizationArgs],
+            input_quant: Optional[QuantizationArgs]) -> bool:
         is_8_bits = weight_quant.num_bits == input_quant.num_bits == 8
         weight_strategy = (
             weight_quant.strategy == QuantizationStrategy.TENSOR.value
@@ -300,8 +225,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         # Only symmetric weight quantization supported.
         return is_8_bits and is_token and weight_quant.symmetric and is_dynamic
 
-    def _is_dynamic_token_w4a8_int(self, weight_quant: BaseModel,
-                                   input_quant: BaseModel) -> bool:
+    def _is_dynamic_token_w4a8_int(
+            self, weight_quant: Optional[QuantizationArgs],
+            input_quant: Optional[QuantizationArgs]) -> bool:
         is_weight_4_bits = weight_quant.num_bits == 4
         is_activation_8_bits = input_quant.num_bits == 8
         weight_strategy = (
@@ -316,8 +242,8 @@ class CompressedTensorsConfig(QuantizationConfig):
         return (is_weight_4_bits and is_activation_8_bits and is_token
                 and weight_quant.symmetric and is_dynamic)
 
-    def _is_fp8_w8a8(self, weight_quant: BaseModel,
-                     input_quant: BaseModel) -> bool:
+    def _is_fp8_w8a8(self, weight_quant: Optional[QuantizationArgs],
+                     input_quant: Optional[QuantizationArgs]) -> bool:
         # Confirm weights and activations quantized.
         if weight_quant is None or input_quant is None:
             return False
@@ -344,19 +270,19 @@ class CompressedTensorsConfig(QuantizationConfig):
             input_quant.strategy == QuantizationStrategy.TENSOR)
         return is_symmetric_activation and is_per_tensor_activation
 
-    def _is_fp8_w8a8_sm90(self, weight_quant: BaseModel,
-                          input_quant: BaseModel) -> bool:
+    def _is_fp8_w8a8_sm90(self, weight_quant: Optional[QuantizationArgs],
+                          input_quant: Optional[QuantizationArgs]) -> bool:
         return (self._check_scheme_supported(90, error=False, match_exact=True)
                 and self._is_fp8_w8a8(weight_quant, input_quant))
 
-    def _is_fp8_w8a8_sm100(self, weight_quant: BaseModel,
-                           input_quant: BaseModel) -> bool:
+    def _is_fp8_w8a8_sm100(self, weight_quant: Optional[QuantizationArgs],
+                           input_quant: Optional[QuantizationArgs]) -> bool:
         return (self._check_scheme_supported(
             100, error=False, match_exact=True)
                 and self._is_fp8_w8a8(weight_quant, input_quant))
 
-    def _is_fp8_w8a16(self, weight_quant: BaseModel,
-                      input_quant: BaseModel) -> bool:
+    def _is_fp8_w8a16(self, weight_quant: Optional[QuantizationArgs],
+                      input_quant: Optional[QuantizationArgs]) -> bool:
         # Confirm weights quantized.
         if weight_quant is None:
             return False
@@ -378,8 +304,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         # All conditions satisfied.
         return True
 
-    def _is_wNa16_group_channel(self, weight_quant: BaseModel,
-                                input_quant: BaseModel) -> bool:
+    def _is_wNa16_group_channel(
+            self, weight_quant: Optional[QuantizationArgs],
+            input_quant: Optional[QuantizationArgs]) -> bool:
         input_quant_none = input_quant is None
         is_channel_group = (
             weight_quant.strategy == QuantizationStrategy.CHANNEL.value
@@ -389,21 +316,24 @@ class CompressedTensorsConfig(QuantizationConfig):
         return (is_channel_group and input_quant_none and is_static)
 
     def _get_scheme_from_parts(
-            self, weight_quant: BaseModel,
-            input_quant: BaseModel) -> "CompressedTensorsScheme":
+        self, weight_quant: Optional[QuantizationArgs],
+        input_quant: Optional[QuantizationArgs], quant_format: str,
+        input_tfm: Optional[tuple[TransformScheme, TransformArgs]],
+        output_tfm: Optional[tuple[TransformScheme, TransformArgs]]
+    ) -> "CompressedTensorsScheme":
         # Detect If Mixed Precision
         if self._is_fp4a16_nvfp4(weight_quant, input_quant):
             return CompressedTensorsW4A16Fp4()
 
         if self._is_wNa16_group_channel(weight_quant, input_quant):
-            if (self.quant_format == CompressionFormat.marlin_24.value
+            if (quant_format == CompressionFormat.marlin_24.value
                     and weight_quant.num_bits in W4A16SPARSE24_SUPPORTED_BITS):
                 assert weight_quant.symmetric
                 return CompressedTensorsW4A16Sparse24(
                     strategy=weight_quant.strategy,
                     num_bits=weight_quant.num_bits,
                     group_size=weight_quant.group_size)
-            if (self.quant_format == CompressionFormat.pack_quantized.value
+            if (quant_format == CompressionFormat.pack_quantized.value
                     and weight_quant.num_bits in WNA16_SUPPORTED_BITS):
                 return CompressedTensorsWNA16(
                     num_bits=weight_quant.num_bits,
@@ -412,7 +342,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                     group_size=weight_quant.group_size,
                     actorder=weight_quant.actorder)
 
-        if is_activation_quantization_format(self.quant_format):
+        if is_activation_quantization_format(quant_format):
             if self._is_fp4a4_nvfp4(weight_quant, input_quant):
                 if cutlass_fp4_supported(
                 ) or envs.VLLM_USE_NVFP4_CT_EMULATIONS:
@@ -488,39 +418,61 @@ class CompressedTensorsConfig(QuantizationConfig):
         use the quantization scheme corresponding to the matched target
         to select the CompressedTensorsScheme used for inference.
         """
-
-        # Find the "target" in the compressed-tensors config
-        # that our layer conforms to.
-        # TODO (@robertgshaw): add compressed-tensors as dep
-        # so we do not have to re-write these functions
-        # need to make accelerate optional in ct to do this
-
-        # Will be empty for models with only sparsity
-        weight_quant = input_quant = None
-        if self.target_scheme_map:
-            matched_target = find_matched_target(
-                layer_name=layer_name,
-                module=layer,
-                targets=self.target_scheme_map.keys(),
-                fused_mapping=self.packed_modules_mapping)
-
-            scheme_dict = self.target_scheme_map[matched_target]
-            weight_quant = scheme_dict.get("weights")
-            input_quant = scheme_dict.get("input_activations")
-
-        # Find the sparsity scheme of the layer
-        # assume that fused layers inerhit first component's sparsity scheme
-        sparsity_targets = (self.sparsity_scheme_map.keys() -
-                            set(self.sparsity_ignore_list))
+        # Find quantization, sparsity, and transform args for this layer.
+        # Because the config does not see the entire model structure,
+        # we must match from layer to schemes (rather than schemes to layers)
+        input_quant: Optional[QuantizationArgs] = None
+        weight_quant: Optional[QuantizationArgs] = None
+        quant_format: str = self.quant_config.format  # TODO (@bdellabetta)
         sparsity_scheme: Optional[SparsityCompressionConfig] = None
-        with suppress(ValueError):
-            matched_target = find_matched_target(
-                layer_name=layer_name,
-                module=layer,
-                targets=sparsity_targets,
-                fused_mapping=self.packed_modules_mapping)
-            sparsity_scheme = self.sparsity_scheme_map[matched_target]
+        input_tfm: Optional[tuple[TransformScheme, TransformArgs]] = None
+        output_tfm = Optional[tuple[TransformScheme, TransformArgs]] = None
 
+        # throw an error if schemes overlap
+        def replace_with_check(original, new):
+            if new and original:
+                raise ValueError(
+                    "The provided compressed tensors config has overlapping "
+                    f"config groups for the layer {layer_name}")
+            return new or original
+
+        # match quantization args
+        for scheme in self.quant_config.config_groups.values():
+            if is_match(layer_name,
+                        layer,
+                        scheme.targets,
+                        self.quant_config.ignore,
+                        fused=self.packed_modules_mapping):
+                input_quant = replace_with_check(input_quant,
+                                                 scheme.input_activations)
+                weight_quant = replace_with_check(weight_quant, scheme.weights)
+
+        # match sparsity args
+        if self.sparsity_config and is_match(
+                layer_name,
+                layer,
+                self.sparsity_config.targets,
+                self.sparsity_config.ignore,
+                fused=self.packed_modules_mapping):
+            sparsity_scheme = self.sparsity_config
+
+        # match transform args
+        if self.transform_config is not None:
+            for scheme in self.transform_config.config_groups.values():
+                for args in scheme.apply:
+                    if is_match(layer_name,
+                                layer,
+                                args.targets,
+                                args.ignore,
+                                fused=self.packed_modules_mapping):
+                        if args.location == TransformLocation.INPUT:
+                            input_tfm = replace_with_check(
+                                input_tfm, (scheme, args))
+                        if args.location == TransformLocation.OUTPUT:
+                            output_tfm = replace_with_check(
+                                output_tfm, (scheme, args))
+
+        # TODO (@ksayers): Move this check into `_get_scheme_from_parts`
         if self.supports_cutlass_24(weight_quant=weight_quant,
                                     input_quant=input_quant,
                                     sparsity_scheme=sparsity_scheme):
@@ -536,6 +488,8 @@ class CompressedTensorsConfig(QuantizationConfig):
                 input_quant=input_quant,
                 model_compression_config=model_compression_config,
             )
+
+        # TODO (@ksayers): Move this check into `_get_scheme_from_parts`
         elif weight_quant is None:
             logger.warning_once("Acceleration for non-quantized schemes is "
                                 "not supported by Compressed Tensors. "
@@ -544,10 +498,11 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         else:
             # Find the quant_scheme
-            scheme = self._get_scheme_from_parts(  # type: ignore
-                weight_quant=weight_quant,
-                input_quant=input_quant,
-            )
+            scheme = self._get_scheme_from_parts(weight_quant=weight_quant,
+                                                 input_quant=input_quant,
+                                                 quant_format=quant_format,
+                                                 input_tfm=input_tfm,
+                                                 output_tfm=output_tfm)
 
         # Raise error if device does not support the scheme
         # (e.g. fp8 needs ada lovelace)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -4,41 +4,24 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
-from compressed_tensors import (KV_CACHE_SCHEME_NAME, SPARSITY_CONFIG_NAME,
-                                TRANSFORM_CONFIG_NAME)
-from compressed_tensors.config import (CompressionFormat,
-                                       SparsityCompressionConfig,
-                                       SparsityStructure)
+from compressed_tensors import KV_CACHE_SCHEME_NAME, SPARSITY_CONFIG_NAME
+from compressed_tensors.config import SparsityCompressionConfig
 from compressed_tensors.quantization import QuantizationArgs
 from compressed_tensors.quantization import QuantizationConfig as CTQuantConfig
-from compressed_tensors.quantization import (QuantizationStrategy,
-                                             QuantizationType)
-from compressed_tensors.transform import (TransformArgs, TransformConfig,
-                                          TransformLocation, TransformScheme)
+from compressed_tensors.transform import TransformConfig
 
-import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoE
-from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
-                                               UnquantizedLinearMethod)
+from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (  # noqa: E501
     QuantizationConfig, QuantizeMethodBase)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_kv import (  # noqa: E501
+    CompressedTensorsKVCacheMethod)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_linear import (  # noqa: E501
+    CompressedTensorsLinearMethod)
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
     CompressedTensorsMoEMethod)
-from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
-    W4A16SPARSE24_SUPPORTED_BITS, WNA16_SUPPORTED_BITS, CompressedTensors24,
-    CompressedTensorsScheme, CompressedTensorsW4A4Fp4,
-    CompressedTensorsW4A8Int, CompressedTensorsW4A16Fp4,
-    CompressedTensorsW4A16Sparse24, CompressedTensorsW8A8Fp8,
-    CompressedTensorsW8A8Int8, CompressedTensorsW8A16Fp8,
-    CompressedTensorsWNA16)
-from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
-    is_activation_quantization_format, is_match)
-from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
-from vllm.model_executor.layers.quantization.utils.quant_utils import (
-    cutlass_fp4_supported)
-from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -49,12 +32,16 @@ __all__ = ["CompressedTensorsLinearMethod"]
 
 
 class CompressedTensorsConfig(QuantizationConfig):
+    quant_config: CTQuantConfig
+    sparsity_config: Optional[SparsityCompressionConfig]
+    transform_config: Optional[TransformConfig]
+    kv_cache_scheme: Optional[QuantizationArgs]
 
     def __init__(self, config: dict[str, Any]):
         super().__init__()
         q_config = config.copy()
         s_config = q_config.pop(SPARSITY_CONFIG_NAME, None)
-        t_config = q_config.pop(TRANSFORM_CONFIG_NAME, None)
+        t_config = None  #q_config.pop(TRANSFORM_CONFIG_NAME, None)
         kv_scheme = q_config.pop(KV_CACHE_SCHEME_NAME, None)
 
         self.quant_config = CTQuantConfig.model_validate(q_config)
@@ -65,8 +52,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.kv_cache_scheme = QuantizationArgs.model_validate(
             kv_scheme) if kv_scheme else None
 
-    def get_linear_method(self) -> "CompressedTensorsLinearMethod":
-        return CompressedTensorsLinearMethod(self)
+    # NOTE: `QuantizationConfig.get_linear_method` doesn't
+    # seem to be used and doesn't really seem to make sense.
+    # Leave as undefined (as many qconfigs do)
 
     def get_supported_act_dtypes(cls) -> list[torch.dtype]:
         return [torch.float32, torch.float16, torch.bfloat16]
@@ -108,14 +96,8 @@ class CompressedTensorsConfig(QuantizationConfig):
         from vllm.attention.layer import Attention  # Avoid circular import
 
         if isinstance(layer, LinearBase):
-            # TODO (@ksayers): maybe refactor this to live on the
-            # LinearMethod, similar to MoEMethod. This makes clear
-            # the separation of schemes by module type
-            scheme = self.get_scheme(layer=layer, layer_name=prefix)
-            if scheme is None:
-                return UnquantizedLinearMethod()
-            layer.scheme = scheme
-            return CompressedTensorsLinearMethod(self)
+            return CompressedTensorsLinearMethod.get_linear_method(
+                self, layer=layer, layer_name=prefix)
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
         if isinstance(layer, FusedMoE):
@@ -132,381 +114,7 @@ class CompressedTensorsConfig(QuantizationConfig):
     def get_config_filenames(cls) -> list[str]:
         return []
 
-    def _check_scheme_supported(self,
-                                min_capability: int,
-                                error: bool = True,
-                                match_exact: bool = False) -> bool:
-        capability_tuple = current_platform.get_device_capability()
-
-        if capability_tuple is not None:
-            capability = capability_tuple.to_int()
-            if match_exact:
-                supported = capability == min_capability
-                if error and not supported:
-                    raise RuntimeError(
-                        "Quantization scheme is not supported for ",
-                        "the current GPU. Required capability: ",
-                        f"{min_capability}. Current capability: {capability}.")
-            else:
-                supported = capability >= min_capability
-                if error and not supported:
-                    raise RuntimeError(
-                        "Quantization scheme is not supported for ",
-                        f"the current GPU. Min capability: {min_capability}. ",
-                        f"Current capability: {capability}.")
-            return supported
-        else:
-            return False
-
-    def _is_fp4a4_nvfp4(self, weight_quant: QuantizationArgs,
-                        input_quant: Optional[QuantizationArgs]):
-
-        if weight_quant is None or input_quant is None:
-            return False
-
-        is_tensor_group_quant = (weight_quant.strategy
-                                 == QuantizationStrategy.TENSOR_GROUP.value
-                                 and input_quant.strategy
-                                 == QuantizationStrategy.TENSOR_GROUP.value)
-        is_symmetric = weight_quant.symmetric and input_quant.symmetric
-
-        is_group_size_16 = (weight_quant.group_size == 16
-                            and input_quant.group_size == 16)
-        is_float_type = (weight_quant.type == QuantizationType.FLOAT
-                         and input_quant.type == QuantizationType.FLOAT.value)
-        is_4_bits = weight_quant.num_bits == 4 and input_quant.num_bits == 4
-
-        return (is_tensor_group_quant and is_float_type and is_4_bits
-                and is_group_size_16 and is_symmetric)
-
-    def _is_fp4a16_nvfp4(self, weight_quant: QuantizationArgs,
-                         input_quant: Optional[QuantizationArgs]):
-
-        is_weight_only = weight_quant is not None and input_quant is None
-        is_tensor_group_quant = (
-            weight_quant.strategy == QuantizationStrategy.TENSOR_GROUP.value)
-        is_symmetric = weight_quant.symmetric
-
-        is_group_size_16 = weight_quant.group_size == 16
-        is_float_type = weight_quant.type == QuantizationType.FLOAT
-        is_4_bits = weight_quant.num_bits == 4
-
-        return (is_weight_only and is_tensor_group_quant and is_float_type
-                and is_4_bits and is_group_size_16 and is_symmetric)
-
-    def _is_static_tensor_w8a8(
-            self, weight_quant: QuantizationArgs,
-            input_quant: Optional[QuantizationArgs]) -> bool:
-        is_8_bits = weight_quant.num_bits == input_quant.num_bits == 8
-        weight_strategy = (
-            weight_quant.strategy == QuantizationStrategy.TENSOR.value
-            or weight_quant.strategy == QuantizationStrategy.CHANNEL.value)
-        is_tensor = (weight_strategy and input_quant.strategy
-                     == QuantizationStrategy.TENSOR.value)
-        is_static = not weight_quant.dynamic and not input_quant.dynamic
-
-        # Both symmetric and asymmetric input quantization supported.
-        # Only symmetric weight quantization supported.
-        return is_8_bits and is_tensor and weight_quant.symmetric and is_static
-
-    def _is_dynamic_token_w8a8(
-            self, weight_quant: QuantizationArgs,
-            input_quant: Optional[QuantizationArgs]) -> bool:
-        is_8_bits = weight_quant.num_bits == input_quant.num_bits == 8
-        weight_strategy = (
-            weight_quant.strategy == QuantizationStrategy.TENSOR.value
-            or weight_quant.strategy == QuantizationStrategy.CHANNEL.value)
-        is_token = (weight_strategy and input_quant.strategy
-                    == QuantizationStrategy.TOKEN.value)
-        is_dynamic = not weight_quant.dynamic and input_quant.dynamic
-
-        # Both symmetric and asymmetric input quantization supported.
-        # Only symmetric weight quantization supported.
-        return is_8_bits and is_token and weight_quant.symmetric and is_dynamic
-
-    def _is_dynamic_token_w4a8_int(
-            self, weight_quant: QuantizationArgs,
-            input_quant: Optional[QuantizationArgs]) -> bool:
-        is_weight_4_bits = weight_quant.num_bits == 4
-        is_activation_8_bits = input_quant.num_bits == 8
-        weight_strategy = (
-            weight_quant.strategy == QuantizationStrategy.GROUP.value
-            or weight_quant.strategy == QuantizationStrategy.CHANNEL.value)
-        is_token = (weight_strategy and input_quant.strategy
-                    == QuantizationStrategy.TOKEN.value)
-        is_dynamic = not weight_quant.dynamic and input_quant.dynamic
-
-        # Both symmetric and asymmetric input quantization supported.
-        # Only symmetric weight quantization supported.
-        return (is_weight_4_bits and is_activation_8_bits and is_token
-                and weight_quant.symmetric and is_dynamic)
-
-    def _is_fp8_w8a8(self, weight_quant: QuantizationArgs,
-                     input_quant: Optional[QuantizationArgs]) -> bool:
-        # Confirm weights and activations quantized.
-        if weight_quant is None or input_quant is None:
-            return False
-
-        # Confirm weight scheme is supported.
-        is_floating_point = (weight_quant.type == QuantizationType.FLOAT
-                             and input_quant.type == QuantizationType.FLOAT)
-        is_symmetric_weight = weight_quant.symmetric
-        is_static_weight = not weight_quant.dynamic
-        is_per_tensor_or_channel_weight = (weight_quant.strategy in [
-            QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL
-        ])
-        if not (is_floating_point and is_symmetric_weight and is_static_weight
-                and is_per_tensor_or_channel_weight):
-            return False
-
-        # Dynamic quantization is always supported if weights supported.
-        if input_quant.dynamic:
-            return True
-
-        # Confirm activation scheme is supported.
-        is_symmetric_activation = input_quant.symmetric
-        is_per_tensor_activation = (
-            input_quant.strategy == QuantizationStrategy.TENSOR)
-        return is_symmetric_activation and is_per_tensor_activation
-
-    def _is_fp8_w8a8_sm90(self, weight_quant: QuantizationArgs,
-                          input_quant: Optional[QuantizationArgs]) -> bool:
-        return (self._check_scheme_supported(90, error=False, match_exact=True)
-                and self._is_fp8_w8a8(weight_quant, input_quant))
-
-    def _is_fp8_w8a8_sm100(self, weight_quant: QuantizationArgs,
-                           input_quant: Optional[QuantizationArgs]) -> bool:
-        return (self._check_scheme_supported(
-            100, error=False, match_exact=True)
-                and self._is_fp8_w8a8(weight_quant, input_quant))
-
-    def _is_fp8_w8a16(self, weight_quant: QuantizationArgs,
-                      input_quant: Optional[QuantizationArgs]) -> bool:
-        # Confirm weights quantized.
-        if weight_quant is None:
-            return False
-
-        # Confirm we have floating points.
-        if weight_quant.type != QuantizationType.FLOAT:
-            return False
-
-        # Confirm weight scheme is supported.
-        is_symmetric_weight = weight_quant.symmetric
-        is_static_weight = not weight_quant.dynamic
-        is_per_tensor_or_channel_weight = (weight_quant.strategy in [
-            QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL
-        ])
-        if not (is_symmetric_weight and is_static_weight  # noqa: SIM103
-                and is_per_tensor_or_channel_weight):
-            return False
-
-        # All conditions satisfied.
-        return True
-
-    def _is_wNa16_group_channel(
-            self, weight_quant: QuantizationArgs,
-            input_quant: Optional[QuantizationArgs]) -> bool:
-        input_quant_none = input_quant is None
-        is_channel_group = (
-            weight_quant.strategy == QuantizationStrategy.CHANNEL.value
-            or weight_quant.strategy == QuantizationStrategy.GROUP.value)
-        is_static = not weight_quant.dynamic
-
-        return (is_channel_group and input_quant_none and is_static)
-
-    def _get_scheme_from_parts(
-        self, weight_quant: QuantizationArgs,
-        input_quant: Optional[QuantizationArgs], quant_format: str,
-        input_tfm: Optional[tuple[TransformScheme, TransformArgs]],
-        output_tfm: Optional[tuple[TransformScheme, TransformArgs]]
-    ) -> "CompressedTensorsScheme":
-        # Detect If Mixed Precision
-        if self._is_fp4a16_nvfp4(weight_quant, input_quant):
-            return CompressedTensorsW4A16Fp4()
-
-        if self._is_wNa16_group_channel(weight_quant, input_quant):
-            if (quant_format == CompressionFormat.marlin_24.value
-                    and weight_quant.num_bits in W4A16SPARSE24_SUPPORTED_BITS):
-                assert weight_quant.symmetric
-                return CompressedTensorsW4A16Sparse24(
-                    strategy=weight_quant.strategy,
-                    num_bits=weight_quant.num_bits,
-                    group_size=weight_quant.group_size)
-            if (quant_format == CompressionFormat.pack_quantized.value
-                    and weight_quant.num_bits in WNA16_SUPPORTED_BITS):
-                return CompressedTensorsWNA16(
-                    num_bits=weight_quant.num_bits,
-                    strategy=weight_quant.strategy,
-                    symmetric=weight_quant.symmetric,
-                    group_size=weight_quant.group_size,
-                    actorder=weight_quant.actorder)
-
-        if is_activation_quantization_format(quant_format):
-            if self._is_fp4a4_nvfp4(weight_quant, input_quant):
-                if cutlass_fp4_supported(
-                ) or envs.VLLM_USE_NVFP4_CT_EMULATIONS:
-                    return CompressedTensorsW4A4Fp4()
-                else:
-                    logger.warning_once(
-                        "Current platform does not support cutlass NVFP4."
-                        " Running CompressedTensorsW4A16Fp4.")
-                    return CompressedTensorsW4A16Fp4(
-                        has_input_global_scale=True)
-
-            if self._is_fp8_w8a8(weight_quant, input_quant):
-                is_fp8_w8a8_supported = self._check_scheme_supported(
-                    CompressedTensorsW8A8Fp8.get_min_capability(), error=False)
-                if is_fp8_w8a8_supported:
-                    return CompressedTensorsW8A8Fp8(
-                        strategy=weight_quant.strategy,
-                        is_static_input_scheme=bool(
-                            input_quant and not input_quant.dynamic))
-                else:
-                    # note: input_quant will be present for converted models;
-                    # will be ignored during inference post loading
-                    return CompressedTensorsW8A16Fp8(
-                        strategy=weight_quant.strategy,
-                        is_static_input_scheme=bool(not input_quant.dynamic))
-
-            # note: input_quant can be None
-            if self._is_fp8_w8a16(weight_quant, input_quant):
-                is_static_input_scheme = bool(input_quant
-                                              and not input_quant.dynamic)
-                return CompressedTensorsW8A16Fp8(
-                    strategy=weight_quant.strategy,
-                    is_static_input_scheme=is_static_input_scheme)
-
-            if self._is_static_tensor_w8a8(weight_quant, input_quant):
-                return CompressedTensorsW8A8Int8(
-                    strategy=weight_quant.strategy,
-                    is_static_input_scheme=True,
-                    input_symmetric=input_quant.symmetric)
-
-            if self._is_dynamic_token_w8a8(weight_quant, input_quant):
-                return CompressedTensorsW8A8Int8(
-                    strategy=weight_quant.strategy,
-                    is_static_input_scheme=False,
-                    input_symmetric=input_quant.symmetric)
-
-            if self._is_dynamic_token_w4a8_int(weight_quant, input_quant):
-                is_static_input_scheme = bool(input_quant
-                                              and not input_quant.dynamic)
-                return CompressedTensorsW4A8Int(
-                    num_bits=weight_quant.num_bits,
-                    strategy=weight_quant.strategy,
-                    group_size=weight_quant.group_size,
-                    is_static_input_scheme=is_static_input_scheme,
-                    input_symmetric=input_quant.symmetric)
-
-        raise NotImplementedError(
-            "No compressed-tensors compatible scheme was found.")
-
-    def get_scheme(self, layer: torch.nn.Module,
-                   layer_name: str) -> Optional["CompressedTensorsScheme"]:
-        """
-        compressed-tensors supports non uniform in the following way:
-
-        targets of config_groups: There can be N config_groups which each
-            have a quantization scheme. Each config_group has a list of targets
-            which can be a full layer_name, a regex for a layer_name, or
-            an nn.Module name.
-
-        Detect whether a layer_name is found in any target and
-        use the quantization scheme corresponding to the matched target
-        to select the CompressedTensorsScheme used for inference.
-        """
-        # Find quantization, sparsity, and transform args for this layer.
-        # Because the config does not see the entire model structure,
-        # we must match from layer to schemes (rather than schemes to layers)
-        input_quant: Optional[QuantizationArgs] = None
-        weight_quant: QuantizationArgs = None
-        quant_format: str = self.quant_config.format  # TODO (@bdellabetta)
-        sparsity_scheme: Optional[SparsityCompressionConfig] = None
-        input_tfm: Optional[tuple[TransformScheme, TransformArgs]] = None
-        output_tfm = Optional[tuple[TransformScheme, TransformArgs]] = None
-
-        # throw an error if schemes overlap
-        def replace_with_check(original, new):
-            if new and original:
-                raise ValueError(
-                    "The provided compressed tensors config has overlapping "
-                    f"config groups for the layer {layer_name}")
-            return new or original
-
-        # match quantization args
-        for scheme in self.quant_config.config_groups.values():
-            if is_match(layer_name,
-                        layer,
-                        scheme.targets,
-                        self.quant_config.ignore,
-                        fused=self.packed_modules_mapping):
-                input_quant = replace_with_check(input_quant,
-                                                 scheme.input_activations)
-                weight_quant = replace_with_check(weight_quant, scheme.weights)
-
-        # match sparsity args
-        if self.sparsity_config and is_match(
-                layer_name,
-                layer,
-                self.sparsity_config.targets,
-                self.sparsity_config.ignore,
-                fused=self.packed_modules_mapping):
-            sparsity_scheme = self.sparsity_config
-
-        # match transform args
-        if self.transform_config is not None:
-            for scheme in self.transform_config.config_groups.values():
-                for args in scheme.apply:
-                    if is_match(layer_name,
-                                layer,
-                                args.targets,
-                                args.ignore,
-                                fused=self.packed_modules_mapping):
-                        if args.location == TransformLocation.INPUT:
-                            input_tfm = replace_with_check(
-                                input_tfm, (scheme, args))
-                        if args.location == TransformLocation.OUTPUT:
-                            output_tfm = replace_with_check(
-                                output_tfm, (scheme, args))
-
-        # TODO (@ksayers): Move this check into `_get_scheme_from_parts`
-        if self.supports_cutlass_24(weight_quant=weight_quant,
-                                    input_quant=input_quant,
-                                    sparsity_scheme=sparsity_scheme):
-            # Have a valid sparsity scheme
-            # Validate layer is supported by Cutlass 2:4 Kernel
-            config = (None if sparsity_scheme is None
-                      or sparsity_scheme.format == "dense" else self)
-
-            scheme = CompressedTensors24(
-                quantized=weight_quant is not None or input_quant is not None,
-                weight_quant=weight_quant,
-                input_quant=input_quant,
-                config=config,
-            )
-
-        # TODO (@ksayers): Move this check into `_get_scheme_from_parts`
-        elif weight_quant is None:
-            logger.warning_once("Acceleration for non-quantized schemes is "
-                                "not supported by Compressed Tensors. "
-                                "Falling back to UnquantizedLinearMethod")
-            return None
-
-        else:
-            # Find the quant_scheme
-            scheme = self._get_scheme_from_parts(weight_quant=weight_quant,
-                                                 input_quant=input_quant,
-                                                 quant_format=quant_format,
-                                                 input_tfm=input_tfm,
-                                                 output_tfm=output_tfm)
-
-        # Raise error if device does not support the scheme
-        # (e.g. fp8 needs ada lovelace)
-        self._check_scheme_supported(scheme.get_min_capability())
-        logger.debug("Using scheme: %s for %s", scheme.__class__.__name__,
-                     layer_name)
-        return scheme
-
+    # base QuantizationConfig, needs to stay here
     def get_cache_scale(self, name: str) -> Optional[str]:
         """
         Check whether the param name matches the format for k/v cache scales
@@ -522,156 +130,3 @@ class CompressedTensorsConfig(QuantizationConfig):
             return name.replace(".v_proj.output_scale", ".attn.v_scale")
         # If no matches, return None
         return None
-
-    @staticmethod
-    def supports_cutlass_24(
-            weight_quant: QuantizationArgs,
-            input_quant: Optional[QuantizationArgs],
-            sparsity_scheme: Optional[SparsityCompressionConfig] = None
-    ) -> bool:
-        """
-        Check if the layer is supported by the Cutlass 2:4 Kernel
-        Conditions:
-            - Overarching condition: Sparsity Structure is 2:4
-            - Unquantized cases are supported
-            - Weight only quantization is not-supported
-            - Supported weight quantization strategies are TENSOR and CHANNEL
-            - Supported input quantization strategies are TENSOR and TOKEN
-            - Only 8 bit quantization is supported 
-
-        :return: True if the layer is supported by the Cutlass 2:4 Kernel
-            False otherwise
-        """
-        if sparsity_scheme is None:
-            return False
-
-        is_valid_sparsity_structure: bool = (
-            sparsity_scheme.sparsity_structure ==
-            SparsityStructure.TWO_FOUR.value)
-
-        valid_compressors = {
-            CompressionFormat.dense.value,
-            CompressionFormat.sparse_24_bitmask.value
-        }
-
-        is_valid_sparsity = (is_valid_sparsity_structure
-                             and sparsity_scheme.format in valid_compressors)
-
-        if not is_valid_sparsity:
-            return False
-
-        # Unquantized cases are supported
-        if weight_quant is None and input_quant is None:
-            return True
-
-        # Weight only quantization is not-supported
-        if weight_quant is not None and input_quant is None:
-            return False
-
-        supported_weight_quant_strategies = [
-            QuantizationStrategy.TENSOR.value,
-            QuantizationStrategy.CHANNEL.value
-        ]
-
-        assert weight_quant is not None
-        assert input_quant is not None
-        if weight_quant.strategy not in supported_weight_quant_strategies:
-            return False
-
-        supported_input_quant_strategies = [
-            QuantizationStrategy.TENSOR.value, QuantizationStrategy.TOKEN.value
-        ]
-
-        if input_quant.strategy not in supported_input_quant_strategies:
-            return False
-
-        return weight_quant.num_bits == input_quant.num_bits == 8
-
-
-class CompressedTensorsLinearMethod(LinearMethodBase):
-
-    def __init__(self, quantization_config: CompressedTensorsConfig):
-        self.quantization_config = quantization_config
-
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        layer.scheme.process_weights_after_loading(layer)
-
-    def create_weights(self, layer: torch.nn.Module,
-                       input_size_per_partition: int,
-                       output_partition_sizes: list[int], input_size: int,
-                       output_size: int, params_dtype: torch.dtype,
-                       **extra_weight_attrs):
-        """
-        Use the CompressedTensorsScheme associated with each layer to create
-        the necessary parameters for the layer. See LinearMethodBase for param
-        details
-        """
-        weight_loader = extra_weight_attrs.get("weight_loader")
-        layer.scheme.create_weights(
-            layer=layer,
-            input_size=input_size,
-            input_size_per_partition=input_size_per_partition,
-            output_partition_sizes=output_partition_sizes,
-            output_size=output_size,
-            params_dtype=params_dtype,
-            weight_loader=weight_loader)
-
-    def apply(self,
-              layer: torch.nn.Module,
-              x: torch.Tensor,
-              bias: Optional[torch.Tensor] = None):
-        """
-        Use the output of create_weights and the CompressedTensorsScheme
-        associated with the layer to apply the forward pass with the
-        layer input.  See LinearMethodBase for param details
-
-        """
-
-        scheme = layer.scheme
-        if scheme is None:
-            raise ValueError("A scheme must be defined for each layer")
-        return scheme.apply_weights(layer, x, bias=bias)
-
-
-class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
-    """
-    Supports loading kv-cache scaling factors from compressed-tensors
-    checkpoints.
-    """
-
-    def __init__(self, quant_config: CompressedTensorsConfig):
-        self.validate_kv_cache_scheme(quant_config.kv_cache_scheme)
-        super().__init__(quant_config)
-
-    @staticmethod
-    def validate_kv_cache_scheme(kv_cache_scheme: Optional[dict[str, Any]]):
-        """
-        Validator for the kv cache scheme. Useful for controlling the
-        kv cache quantization schemes, that are being supported in vLLM
-        :param kv_cache_scheme: the compressed-tensors kv cache scheme
-        """
-        if kv_cache_scheme is None:
-            return
-
-        type_ = kv_cache_scheme.get("type")
-        num_bits = kv_cache_scheme.get("num_bits")
-
-        if type_ != "float" and num_bits != 8:
-            raise NotImplementedError(
-                "Currently supported kv cache quantization is "
-                "num_bits=8, type=float, however "
-                f"received num_bits={num_bits}, type={type_}")
-
-        strategy = kv_cache_scheme.get("strategy")
-        if strategy != "tensor":
-            raise NotImplementedError(
-                "Only support per-tensor scaling factor "
-                "for compressed-tensors KV cache. "
-                f"Expected strategy: tensor, found strategy: {strategy}")
-
-        is_symmetric = kv_cache_scheme.get("symmetric")
-        if not is_symmetric:
-            raise NotImplementedError(
-                "Only support symmetric scaling factor "
-                "for compressed-tensors KV cache. "
-                f"However found symmetric: {is_symmetric}")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -15,7 +15,6 @@ from compressed_tensors.quantization import (QuantizationStrategy,
                                              QuantizationType)
 from compressed_tensors.transform import (TransformArgs, TransformConfig,
                                           TransformLocation, TransformScheme)
-from compressed_tensors.utils import is_match
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -35,7 +34,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsW8A8Int8, CompressedTensorsW8A16Fp8,
     CompressedTensorsWNA16)
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
-    is_activation_quantization_format)
+    is_activation_quantization_format, is_match)
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     cutlass_fp4_supported)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_kv.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_kv.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any, Optional
+
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+    CompressedTensorsConfig)
+from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
+
+
+class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
+    """
+    Supports loading kv-cache scaling factors from compressed-tensors
+    checkpoints.
+    """
+
+    def __init__(self, quant_config: CompressedTensorsConfig):
+        self.validate_kv_cache_scheme(quant_config.kv_cache_scheme)
+        super().__init__(quant_config)
+
+    @staticmethod
+    def validate_kv_cache_scheme(kv_cache_scheme: Optional[dict[str, Any]]):
+        """
+        Validator for the kv cache scheme. Useful for controlling the
+        kv cache quantization schemes, that are being supported in vLLM
+        :param kv_cache_scheme: the compressed-tensors kv cache scheme
+        """
+        if kv_cache_scheme is None:
+            return
+
+        type_ = kv_cache_scheme.get("type")
+        num_bits = kv_cache_scheme.get("num_bits")
+
+        if type_ != "float" and num_bits != 8:
+            raise NotImplementedError(
+                "Currently supported kv cache quantization is "
+                "num_bits=8, type=float, however "
+                f"received num_bits={num_bits}, type={type_}")
+
+        strategy = kv_cache_scheme.get("strategy")
+        if strategy != "tensor":
+            raise NotImplementedError(
+                "Only support per-tensor scaling factor "
+                "for compressed-tensors KV cache. "
+                f"Expected strategy: tensor, found strategy: {strategy}")
+
+        is_symmetric = kv_cache_scheme.get("symmetric")
+        if not is_symmetric:
+            raise NotImplementedError(
+                "Only support symmetric scaling factor "
+                "for compressed-tensors KV cache. "
+                f"However found symmetric: {is_symmetric}")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_linear.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_linear.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Optional
+
+import torch
+from compressed_tensors import CompressionFormat, SparsityCompressionConfig
+from compressed_tensors.quantization import (QuantizationArgs,
+                                             QuantizationConfig)
+from compressed_tensors.transform import (TransformArgs, TransformLocation,
+                                          TransformScheme)
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               UnquantizedLinearMethod)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+    CompressedTensorsConfig)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (  # noqa: E501
+    CompressedTensorsScheme)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_24 import (  # noqa: E501
+    CompressedTensors24, supports_cutlass_24)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import (  # noqa: E501
+    CompressedTensorsW4A4Fp4, is_fp4a4_nvfp4)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a8_int import (  # noqa: E501
+    CompressedTensorsW4A8Int, is_dynamic_token_w4a8_int)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a16_24 import (  # noqa: E501
+    W4A16SPARSE24_SUPPORTED_BITS, CompressedTensorsW4A16Sparse24)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a16_nvfp4 import (  # noqa: E501
+    CompressedTensorsW4A16Fp4, is_fp4a16_nvfp4)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import (  # noqa: E501
+    CompressedTensorsW8A8Fp8, is_fp8_w8a8)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_int8 import (  # noqa: E501
+    CompressedTensorsW8A8Int8, is_dynamic_token_w8a8, is_static_tensor_w8a8)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a16_fp8 import (  # noqa: E501
+    CompressedTensorsW8A16Fp8, is_fp8_w8a16)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa: E501
+    WNA16_SUPPORTED_BITS, CompressedTensorsWNA16, is_wNa16_group_channel)
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    is_activation_quantization_format, is_match)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    cutlass_fp4_supported)
+
+logger = init_logger(__name__)
+
+
+class CompressedTensorsLinearMethod(LinearMethodBase):
+    """
+    TODO: write a better docstring. This is essentially just a
+    thin wrapper around the scheme. In the future, maybe each
+    scheme could provide a linear method
+    """
+
+    @staticmethod
+    def get_linear_method(
+        cls, layer: torch.nn.Module, layer_name: str,
+        config: CompressedTensorsConfig
+    ) -> "CompressedTensorsLinearMethod" | "UnquantizedLinearMethod":
+        scheme = get_scheme(layer_name, layer, config)
+        if scheme is None:
+            return UnquantizedLinearMethod()
+
+        return cls()
+
+    def __init__(self, scheme: CompressedTensorsScheme):
+        self.scheme = scheme
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.scheme.process_weights_after_loading(layer)
+
+    def create_weights(self, layer: torch.nn.Module,
+                       input_size_per_partition: int,
+                       output_partition_sizes: list[int], input_size: int,
+                       output_size: int, params_dtype: torch.dtype,
+                       **extra_weight_attrs):
+        """
+        Use the CompressedTensorsScheme associated with each layer to create
+        the necessary parameters for the layer. See LinearMethodBase for param
+        details
+        """
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        self.scheme.create_weights(
+            layer=layer,
+            input_size=input_size,
+            input_size_per_partition=input_size_per_partition,
+            output_partition_sizes=output_partition_sizes,
+            output_size=output_size,
+            params_dtype=params_dtype,
+            weight_loader=weight_loader)
+
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None):
+        """
+        Use the output of create_weights and the CompressedTensorsScheme
+        associated with the layer to apply the forward pass with the
+        layer input.  See LinearMethodBase for param details
+
+        """
+        return self.scheme.apply_weights(layer, x, bias=bias)
+
+
+def get_scheme(config: CompressedTensorsConfig, layer: torch.nn.Module,
+               layer_name: str) -> Optional["CompressedTensorsScheme"]:
+    """
+    compressed-tensors supports non uniform in the following way:
+
+    targets of config_groups: There can be N config_groups which each
+        have a quantization scheme. Each config_group has a list of targets
+        which can be a full layer_name, a regex for a layer_name, or
+        an nn.Module name.
+
+    Detect whether a layer_name is found in any target and
+    use the quantization scheme corresponding to the matched target
+    to select the CompressedTensorsScheme used for inference.
+    """
+    # Find quantization, sparsity, and transform args for this layer.
+    # Because the config does not see the entire model structure,
+    # we must match from layer to schemes (rather than schemes to layers)
+    input_quant: Optional[QuantizationArgs] = None
+    weight_quant: QuantizationArgs = None
+    quant_format: str = config.quant_config.format  # TODO (@bdellabetta)
+    sparsity_scheme: Optional[SparsityCompressionConfig] = None
+    input_tfm: Optional[tuple[TransformScheme, TransformArgs]] = None
+    output_tfm = Optional[tuple[TransformScheme, TransformArgs]] = None
+
+    # throw an error if schemes overlap
+    def replace_with_check(original, new):
+        if new and original:
+            raise ValueError(
+                "The provided compressed tensors config has overlapping "
+                f"config groups for the layer {layer_name}")
+        return new or original
+
+    # match quantization args
+    for scheme in config.quant_config.config_groups.values():
+        if is_match(layer_name,
+                    layer,
+                    scheme.targets,
+                    config.quant_config.ignore,
+                    fused=config.packed_modules_mapping):
+            input_quant = replace_with_check(input_quant,
+                                             scheme.input_activations)
+            weight_quant = replace_with_check(weight_quant, scheme.weights)
+
+    # match sparsity args
+    if config.sparsity_config and is_match(
+            layer_name,
+            layer,
+            config.sparsity_config.targets,
+            config.sparsity_config.ignore,
+            fused=config.packed_modules_mapping):
+        sparsity_scheme = config.sparsity_config
+
+    # match transform args
+    if config.transform_config is not None:
+        for scheme in config.transform_config.config_groups.values():
+            for args in scheme.apply:
+                if is_match(layer_name,
+                            layer,
+                            args.targets,
+                            args.ignore,
+                            fused=config.packed_modules_mapping):
+                    if args.location == TransformLocation.INPUT:
+                        input_tfm = replace_with_check(input_tfm,
+                                                       (scheme, args))
+                    if args.location == TransformLocation.OUTPUT:
+                        output_tfm = replace_with_check(
+                            output_tfm, (scheme, args))
+
+    # Find the scheme which determines LinearMethod behavior
+    scheme: Optional[CompressedTensorsScheme] = get_scheme_from_parts(
+        weight_quant=weight_quant,
+        input_quant=input_quant,
+        quant_format=quant_format,
+        sparisty_scheme=sparsity_scheme,
+        input_tfm=input_tfm,
+        output_tfm=output_tfm,
+        quant_config=config.quant_config)
+
+    if scheme is not None:
+        # Raise error if device does not support the scheme
+        # (e.g. fp8 needs ada lovelace)
+        scheme.check_scheme_supported(scheme.get_min_capability())
+        logger.debug("Using scheme: %s for %s", scheme.__class__.__name__,
+                     layer_name)
+    return scheme
+
+
+def get_scheme_from_parts(
+        weight_quant: Optional[QuantizationArgs],
+        input_quant: Optional[QuantizationArgs],
+        quant_format: str,
+        sparsity_scheme: Optional[SparsityCompressionConfig],
+        input_tfm: Optional[tuple[TransformScheme, TransformArgs]],
+        output_tfm: Optional[tuple[TransformScheme, TransformArgs]],
+        quant_config: QuantizationConfig,  # used for cutlass_24
+) -> Optional[CompressedTensorsScheme]:
+    if weight_quant is None:
+        logger.warning_once("Acceleration for non-quantized schemes is "
+                            "not supported by Compressed Tensors. "
+                            "Falling back to UnquantizedLinearMethod")
+        return None
+
+    if supports_cutlass_24(weight_quant=weight_quant,
+                           input_quant=input_quant,
+                           sparsity_scheme=sparsity_scheme):
+        # Have a valid sparsity scheme
+        # Validate layer is supported by Cutlass 2:4 Kernel
+        config = (None if sparsity_scheme is None
+                  or sparsity_scheme.format == "dense" else quant_config)
+
+        return CompressedTensors24(
+            quantized=weight_quant is not None or input_quant is not None,
+            weight_quant=weight_quant,
+            input_quant=input_quant,
+            config=config,
+        )
+
+    # Detect If Mixed Precision
+    if is_fp4a16_nvfp4(weight_quant, input_quant):
+        return CompressedTensorsW4A16Fp4()
+
+    if is_wNa16_group_channel(weight_quant, input_quant):
+        if (quant_format == CompressionFormat.marlin_24.value
+                and weight_quant.num_bits in W4A16SPARSE24_SUPPORTED_BITS):
+            assert weight_quant.symmetric
+            return CompressedTensorsW4A16Sparse24(
+                strategy=weight_quant.strategy,
+                num_bits=weight_quant.num_bits,
+                group_size=weight_quant.group_size)
+        if (quant_format == CompressionFormat.pack_quantized.value
+                and weight_quant.num_bits in WNA16_SUPPORTED_BITS):
+            return CompressedTensorsWNA16(num_bits=weight_quant.num_bits,
+                                          strategy=weight_quant.strategy,
+                                          symmetric=weight_quant.symmetric,
+                                          group_size=weight_quant.group_size,
+                                          actorder=weight_quant.actorder)
+
+    if is_activation_quantization_format(quant_format):
+        if is_fp4a4_nvfp4(weight_quant, input_quant):
+            if cutlass_fp4_supported() or envs.VLLM_USE_NVFP4_CT_EMULATIONS:
+                return CompressedTensorsW4A4Fp4()
+            else:
+                logger.warning_once(
+                    "Current platform does not support cutlass NVFP4."
+                    " Running CompressedTensorsW4A16Fp4.")
+                return CompressedTensorsW4A16Fp4(has_input_global_scale=True)
+
+        if is_fp8_w8a8(weight_quant, input_quant):
+            is_fp8_w8a8_supported = CompressedTensorsScheme.check_scheme_supported(  # noqa: E501
+                CompressedTensorsW8A8Fp8.get_min_capability(),
+                error=False)
+            if is_fp8_w8a8_supported:
+                return CompressedTensorsW8A8Fp8(
+                    strategy=weight_quant.strategy,
+                    is_static_input_scheme=bool(input_quant
+                                                and not input_quant.dynamic))
+            else:
+                # note: input_quant will be present for converted models;
+                # will be ignored during inference post loading
+                return CompressedTensorsW8A16Fp8(
+                    strategy=weight_quant.strategy,
+                    is_static_input_scheme=bool(not input_quant.dynamic))
+
+        # note: input_quant can be None
+        if is_fp8_w8a16(weight_quant, input_quant):
+            is_static_input_scheme = bool(input_quant
+                                          and not input_quant.dynamic)
+            return CompressedTensorsW8A16Fp8(
+                strategy=weight_quant.strategy,
+                is_static_input_scheme=is_static_input_scheme)
+
+        if is_static_tensor_w8a8(weight_quant, input_quant):
+            return CompressedTensorsW8A8Int8(
+                strategy=weight_quant.strategy,
+                is_static_input_scheme=True,
+                input_symmetric=input_quant.symmetric)
+
+        if is_dynamic_token_w8a8(weight_quant, input_quant):
+            return CompressedTensorsW8A8Int8(
+                strategy=weight_quant.strategy,
+                is_static_input_scheme=False,
+                input_symmetric=input_quant.symmetric)
+
+        if is_dynamic_token_w4a8_int(weight_quant, input_quant):
+            is_static_input_scheme = bool(input_quant
+                                          and not input_quant.dynamic)
+            return CompressedTensorsW4A8Int(
+                num_bits=weight_quant.num_bits,
+                strategy=weight_quant.strategy,
+                group_size=weight_quant.group_size,
+                is_static_input_scheme=is_static_input_scheme,
+                input_symmetric=input_quant.symmetric)
+
+    raise NotImplementedError(
+        "No compressed-tensors compatible scheme was found.")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -3,7 +3,7 @@
 
 import enum
 from enum import Enum
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 from compressed_tensors import CompressionFormat
@@ -41,6 +41,10 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+        CompressedTensorsConfig)
 
 logger = init_logger(__name__)
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -656,14 +656,18 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
                 max_num_tokens=max_num_tokens_per_rank,
                 num_dispatchers=prepare_finalize.num_dispatchers(),
                 use_fp8_w8a8=True,
-                block_shape=self.quant_config.weight_block_size,
+                # TODO (@ksayers): `self.weight_quant.block_structure`
+                block_shape=self.quant_config.
+                weight_block_size,  # type: ignore # noqa E501
                 per_act_token_quant=(
                     self.input_quant.strategy == QuantizationStrategy.TOKEN),
             )
         else:
             return TritonExperts(
                 use_fp8_w8a8=True,
-                block_shape=self.quant_config.weight_block_size,
+                # TODO (@ksayers): `self.weight_quant.block_structure`
+                block_shape=self.quant_config.
+                weight_block_size,  # type: ignore # noqa E501
                 per_act_token_quant=(
                     self.input_quant.strategy == QuantizationStrategy.TOKEN),
             )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -656,18 +656,14 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
                 max_num_tokens=max_num_tokens_per_rank,
                 num_dispatchers=prepare_finalize.num_dispatchers(),
                 use_fp8_w8a8=True,
-                # TODO (@ksayers): `self.weight_quant.block_structure`
-                block_shape=self.quant_config.
-                weight_block_size,  # type: ignore # noqa E501
+                block_shape=self.weight_quant.block_structure,
                 per_act_token_quant=(
                     self.input_quant.strategy == QuantizationStrategy.TOKEN),
             )
         else:
             return TritonExperts(
                 use_fp8_w8a8=True,
-                # TODO (@ksayers): `self.weight_quant.block_structure`
-                block_shape=self.quant_config.
-                weight_block_size,  # type: ignore # noqa E501
+                block_shape=self.weight_quant.block_structure,
                 per_act_token_quant=(
                     self.input_quant.strategy == QuantizationStrategy.TOKEN),
             )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_24.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_24.py
@@ -4,7 +4,8 @@
 from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
-from compressed_tensors import CompressionFormat, ModelCompressor
+from compressed_tensors import (CompressionFormat, ModelCompressor,
+                                SparsityCompressionConfig, SparsityStructure)
 from compressed_tensors.quantization import (QuantizationArgs,
                                              QuantizationStrategy,
                                              QuantizationType)
@@ -32,6 +33,67 @@ if TYPE_CHECKING:
 __all__ = ["CompressedTensors24"]
 
 from vllm.platforms import current_platform
+
+
+def supports_cutlass_24(
+        weight_quant: QuantizationArgs,
+        input_quant: Optional[QuantizationArgs],
+        sparsity_scheme: Optional[SparsityCompressionConfig] = None) -> bool:
+    """
+    Check if the layer is supported by the Cutlass 2:4 Kernel
+    Conditions:
+        - Overarching condition: Sparsity Structure is 2:4
+        - Unquantized cases are supported
+        - Weight only quantization is not-supported
+        - Supported weight quantization strategies are TENSOR and CHANNEL
+        - Supported input quantization strategies are TENSOR and TOKEN
+        - Only 8 bit quantization is supported 
+
+    :return: True if the layer is supported by the Cutlass 2:4 Kernel
+        False otherwise
+    """
+    if sparsity_scheme is None:
+        return False
+
+    is_valid_sparsity_structure: bool = (
+        sparsity_scheme.sparsity_structure == SparsityStructure.TWO_FOUR.value)
+
+    valid_compressors = {
+        CompressionFormat.dense.value,
+        CompressionFormat.sparse_24_bitmask.value
+    }
+
+    is_valid_sparsity = (is_valid_sparsity_structure
+                         and sparsity_scheme.format in valid_compressors)
+
+    if not is_valid_sparsity:
+        return False
+
+    # Unquantized cases are supported
+    if weight_quant is None and input_quant is None:
+        return True
+
+    # Weight only quantization is not-supported
+    if weight_quant is not None and input_quant is None:
+        return False
+
+    supported_weight_quant_strategies = [
+        QuantizationStrategy.TENSOR.value, QuantizationStrategy.CHANNEL.value
+    ]
+
+    assert weight_quant is not None
+    assert input_quant is not None
+    if weight_quant.strategy not in supported_weight_quant_strategies:
+        return False
+
+    supported_input_quant_strategies = [
+        QuantizationStrategy.TENSOR.value, QuantizationStrategy.TOKEN.value
+    ]
+
+    if input_quant.strategy not in supported_input_quant_strategies:
+        return False
+
+    return weight_quant.num_bits == input_quant.num_bits == 8
 
 
 class CompressedTensors24(CompressedTensorsScheme):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -3,6 +3,9 @@
 from typing import Callable, Optional
 
 import torch
+from compressed_tensors.quantization import (QuantizationArgs,
+                                             QuantizationStrategy,
+                                             QuantizationType)
 from torch.nn.parameter import Parameter
 
 import vllm.envs as envs
@@ -18,7 +21,27 @@ from vllm.model_executor.parameter import (GroupQuantScaleParameter,
 
 logger = init_logger(__name__)
 
-__all__ = ["CompressedTensorsW4A4Fp4"]
+__all__ = ["is_fp4a4_nvfp4", "CompressedTensorsW4A4Fp4"]
+
+
+def is_fp4a4_nvfp4(weight_quant: QuantizationArgs,
+                   input_quant: Optional[QuantizationArgs]):
+    if input_quant is None:
+        return False
+
+    is_tensor_group_quant = (
+        weight_quant.strategy == QuantizationStrategy.TENSOR_GROUP.value
+        and input_quant.strategy == QuantizationStrategy.TENSOR_GROUP.value)
+    is_symmetric = weight_quant.symmetric and input_quant.symmetric
+
+    is_group_size_16 = (weight_quant.group_size == 16
+                        and input_quant.group_size == 16)
+    is_float_type = (weight_quant.type == QuantizationType.FLOAT
+                     and input_quant.type == QuantizationType.FLOAT.value)
+    is_4_bits = weight_quant.num_bits == 4 and input_quant.num_bits == 4
+
+    return (is_tensor_group_quant and is_float_type and is_4_bits
+            and is_group_size_16 and is_symmetric)
 
 
 class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_int.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_int.py
@@ -4,6 +4,8 @@
 from typing import Callable, Optional
 
 import torch
+from compressed_tensors.quantization import (QuantizationArgs,
+                                             QuantizationStrategy)
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
@@ -17,11 +19,28 @@ from vllm.scalar_type import scalar_types
 
 logger = init_logger(__name__)
 
-__all__ = ["CompressedTensorsW4A8Int"]
+__all__ = ["is_dynamic_token_w4a8_int", "CompressedTensorsW4A8Int"]
 W4A8_SUPPORTED_TYPES_MAP = {
     4: scalar_types.int4,
 }
 W4A8_SUPPORTED_BITS = list(W4A8_SUPPORTED_TYPES_MAP.keys())
+
+
+def is_dynamic_token_w4a8_int(weight_quant: QuantizationArgs,
+                              input_quant: Optional[QuantizationArgs]) -> bool:
+    is_weight_4_bits = weight_quant.num_bits == 4
+    is_activation_8_bits = input_quant.num_bits == 8
+    weight_strategy = (
+        weight_quant.strategy == QuantizationStrategy.GROUP.value
+        or weight_quant.strategy == QuantizationStrategy.CHANNEL.value)
+    is_token = (weight_strategy
+                and input_quant.strategy == QuantizationStrategy.TOKEN.value)
+    is_dynamic = not weight_quant.dynamic and input_quant.dynamic
+
+    # Both symmetric and asymmetric input quantization supported.
+    # Only symmetric weight quantization supported.
+    return (is_weight_4_bits and is_activation_8_bits and is_token
+            and weight_quant.symmetric and is_dynamic)
 
 
 class CompressedTensorsW4A8Int(CompressedTensorsScheme):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable, Mapping
-from types import MappingProxyType
-from typing import Optional
+from typing import TYPE_CHECKING
 
-import regex as re
 from compressed_tensors import CompressionFormat
-from torch.nn import Module
+from compressed_tensors.quantization import QuantizationArgs
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import (  # noqa: E501
+        QuantizationConfig)
+
+__all__ = ["is_activation_quantization_format", "get_linear_quantization"]
 
 
 def is_activation_quantization_format(format: str) -> bool:
@@ -20,197 +23,12 @@ def is_activation_quantization_format(format: str) -> bool:
     return format in _ACTIVATION_QUANTIZATION_FORMATS
 
 
-def should_ignore_layer(
-    layer_name: Optional[str],
-    ignore: Iterable[str] = tuple(),
-    fused_mapping: Mapping[str, list[str]] = MappingProxyType({})
-) -> bool:
-    if layer_name is None:
-        return False
+def get_linear_quantization(
+        config: "QuantizationConfig"
+) -> tuple[QuantizationArgs, QuantizationArgs]:
+    for scheme in config.quantization_config.config_groups:
+        if scheme.targets == "Linear":
+            return (scheme.input_activations, scheme.weights)
 
-    # layer_name = model.layers.0.self_attn.qkv_proj
-    # proj_name = qkv_proj
-    proj_name = layer_name.split(".")[-1]
-
-    # Fused layers like gate_up_proj or qkv_proj will not be fused
-    # in the safetensors checkpoint. So, we convert the name
-    # from the fused version to unfused + check to make sure that
-    # each shard of the fused layer has the same scheme.
-    if proj_name in fused_mapping and layer_name not in ignore:
-        shard_proj_names = fused_mapping[proj_name]
-
-        # Convert fused_name --> [shard_names]
-        shard_names = [
-            layer_name.replace(proj_name, shard_proj_name)
-            for shard_proj_name in shard_proj_names
-        ]
-
-        # Layer should be ignored if shards are ignored.
-        should_ignore_layer = None
-        for shard_name in shard_names:
-            should_ignore_shard = check_equal_or_regex_match(
-                layer_name=shard_name, targets=ignore)
-
-            # If shard_idx=0, set layer ignore to match shard.
-            if should_ignore_layer is None:
-                should_ignore_layer = should_ignore_shard
-
-            # If shard_idx=1+ confirm scheme matches prior shards.
-            elif should_ignore_shard != should_ignore_layer:
-                raise ValueError(f"Found a different quantization schemes for "
-                                 f"{shard_proj_names} in {layer_name}. vLLM "
-                                 "requires all to use the same scheme.")
-
-    # Unfused layers like down_proj and o_proj will match
-    # the safetensors checkpoint already.
-    else:
-        should_ignore_layer = check_equal_or_regex_match(layer_name=layer_name,
-                                                         targets=ignore)
-
-    assert should_ignore_layer is not None
-    return should_ignore_layer
-
-
-def check_equal_or_regex_match(layer_name: str,
-                               targets: Iterable[str]) -> bool:
-    """
-    Checks whether a layer_name is exactly equal or a regex match for
-    if target starts with 're:' to any target in list.
-    """
-    for target in targets:
-        if _is_equal_or_regex_match(layer_name, target):
-            return True
-    return False
-
-
-def find_matched_target(
-    layer_name: Optional[str],
-    module: Module,
-    targets: Iterable[str],
-    fused_mapping: Mapping[str, list[str]] = MappingProxyType({})
-) -> str:
-    """
-    Helper function to look up which "target" in the compressed-tensors
-    config that a layer corresponds to.
-
-    Recall that a compressed-tensors configs has a concept of
-    config_groups, where each layer can be quantized with with a different
-    scheme.
-
-    targets in each config_group will be a list of either layer names
-    (or regexes corresponding to layer names) or names of torch Modules.
-
-    First, we try to match the layer_name with a target
-    Second, we try to match the module's name with a target
-    Third, we try to map the layer_name to a list of fused module names.
-        *All* component module names must match in order for a match to be
-        successful. A successful match returns the first component target
-
-    :param layer_name: layer name
-    :param module: torch.nn.Module
-    :param targets: list of targets to match the layer against
-    :param fused_mapping: map from fused layer names to its components
-    :param fused_strategy: either "all" or "any". If using "all", fused
-        layers match if "all" of its components match
-    """
-
-    if layer_name is None:
-        layer_name = ""
-
-    matched_target = (
-        _find_first_match(layer_name, targets)
-        or _find_first_match(module.__class__.__name__, targets, True)
-        or _match_fused_layer(layer_name, targets, fused_mapping))
-
-    if matched_target is None:
-        raise ValueError(
-            f"Unable to find matching target for {layer_name} in the "
-            "compressed-tensors config.")
-
-    return matched_target
-
-
-def _find_first_match(value: str,
-                      targets: Iterable[str],
-                      check_contains: bool = False) -> Optional[str]:
-    """
-    Returns first element of target that matches value either
-    exactly or as a regex after 're:'. If check_contains is set to True,
-    additionally checks if the target string is contained within the value.
-
-    :param value: string to compare the list of targets against
-    :param targets: list of targets to match the layer against
-    :param check_contains: whether or not to do a substring match
-    """
-
-    for target in targets:
-        if _is_equal_or_regex_match(value,
-                                    target,
-                                    check_contains=check_contains):
-            return target
-    return None
-
-
-def _is_equal_or_regex_match(value: str,
-                             target: str,
-                             check_contains: bool = False) -> bool:
-    """
-    Checks whether a value is exactly equal or a regex match for target
-    if target starts with 're:'. If check_contains is set to True,
-    additionally checks if the target string is contained within the value.
-    """
-
-    if target.startswith("re:"):
-        pattern = target[3:]
-        if re.match(pattern, value):
-            return True
-    elif check_contains:
-        if target.lower() in value.lower():
-            return True
-    elif target == value:
-        return True
-    return False
-
-
-def _match_fused_layer(
-        layer_name: str, target_layers: Iterable[str],
-        fused_mapping: Mapping[str, list[str]]) -> Optional[str]:
-    """
-    Match a fused layer name to its corresponding individual layer in 
-    target_layers. Returns first value in fused_mapping which matches targets
-
-    Implements an "all" matching strategy where a fused layer matches iff
-    "all" of its components match
-
-    :param layer_name: layer name
-    :param target_layers: list of targets to match the layer against
-    :param fused_mapping: map from fused layer names to its components
-
-    Examples:
-        layer_name = "model.layers.0.self_attn.qkv_proj"
-        target_layers = ["model.layers.0.self_attn.q_proj",
-                        "model.layers.0.self_attn.k_proj",
-                        "model.layers.0.self_attn.v_proj"]
-    """
-    # find layer_name in mapping
-    fused = next((key for key in fused_mapping if layer_name.endswith(key)),
-                 None)
-    if fused is None:
-        return None
-
-    # expand path of unfused components
-    unfused_paths = [
-        layer_name.replace(fused, unfused) for unfused in fused_mapping[fused]
-    ]
-
-    # for each unfused component, find a match in targets
-    unfused_matches: list[Optional[str]] = []
-    for unfused in unfused_paths:
-        for target in target_layers:
-            if _is_equal_or_regex_match(unfused, target):
-                unfused_matches.append(target)
-                break
-        else:
-            unfused_matches.append(None)
-
-    return unfused_matches[0] if all(unfused_matches) else None
+    raise ValueError(
+        "Could not find a quantization scheme applied to all linears")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -7,8 +7,8 @@ from compressed_tensors import CompressionFormat
 from compressed_tensors.quantization import QuantizationArgs
 
 if TYPE_CHECKING:
-    from vllm.model_executor.layers.quantization.base_config import (  # noqa: E501
-        QuantizationConfig)
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+        CompressedTensorsConfig)
 
 __all__ = ["is_activation_quantization_format", "get_linear_quantization"]
 
@@ -24,9 +24,9 @@ def is_activation_quantization_format(format: str) -> bool:
 
 
 def get_linear_quantization(
-        config: "QuantizationConfig"
+    config: "CompressedTensorsConfig"
 ) -> tuple[QuantizationArgs, QuantizationArgs]:
-    for scheme in config.quantization_config.config_groups:
+    for scheme in config.quant_config.config_groups.values():
         if scheme.targets == "Linear":
             return (scheme.input_activations, scheme.weights)
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -26,6 +26,15 @@ def is_activation_quantization_format(format: str) -> bool:
 def get_linear_quantization(
     config: "CompressedTensorsConfig"
 ) -> tuple[QuantizationArgs, QuantizationArgs]:
+    """
+    Returns the quantization which is used for all `Linear` layers of a model,
+    if it exists. This is a gross generalization to assist with selecting
+    MoE kernels and should be removed in the future.
+
+    :param config: Compressed Tensors config
+    :return: input and weight quantization of Linear layers if it exists,
+        otherwise raise a ValueError
+    """
     for scheme in config.quant_config.config_groups.values():
         if scheme.targets == "Linear":
             return (scheme.input_activations, scheme.weights)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -14,7 +14,9 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
         CompressedTensorsConfig)
 
-__all__ = ["is_activation_quantization_format", "get_linear_quantization", "is_match"]
+__all__ = [
+    "is_activation_quantization_format", "get_linear_quantization", "is_match"
+]
 
 
 def is_activation_quantization_format(format: str) -> bool:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -3,20 +3,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import regex as re
 import torch
 from compressed_tensors import CompressionFormat
-from compressed_tensors.quantization import QuantizationArgs
 
-if TYPE_CHECKING:
-    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
-        CompressedTensorsConfig)
-
-__all__ = [
-    "is_activation_quantization_format", "get_linear_quantization", "is_match"
-]
+__all__ = ["is_activation_quantization_format", "is_match"]
 
 
 def is_activation_quantization_format(format: str) -> bool:
@@ -27,26 +20,6 @@ def is_activation_quantization_format(format: str) -> bool:
         CompressionFormat.nvfp4_pack_quantized.value
     ]
     return format in _ACTIVATION_QUANTIZATION_FORMATS
-
-
-def get_linear_quantization(
-    config: "CompressedTensorsConfig"
-) -> tuple[QuantizationArgs, QuantizationArgs]:
-    """
-    Returns the quantization which is used for all `Linear` layers of a model,
-    if it exists. This is a gross generalization to assist with selecting
-    MoE kernels and should be removed in the future.
-
-    :param config: Compressed Tensors config
-    :return: input and weight quantization of Linear layers if it exists,
-        otherwise raise a ValueError
-    """
-    for scheme in config.quant_config.config_groups.values():
-        if scheme.targets == "Linear":
-            return (scheme.input_activations, scheme.weights)
-
-    raise ValueError(
-        "Could not find a quantization scheme applied to all linears")
 
 
 # The code below is copied from `compressed_tensors/utils/match.py`

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -1,8 +1,12 @@
+# flake8: noqa
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import TYPE_CHECKING
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Optional
 
+import regex as re
+import torch
 from compressed_tensors import CompressionFormat
 from compressed_tensors.quantization import QuantizationArgs
 
@@ -10,7 +14,7 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
         CompressedTensorsConfig)
 
-__all__ = ["is_activation_quantization_format", "get_linear_quantization"]
+__all__ = ["is_activation_quantization_format", "get_linear_quantization", "is_match"]
 
 
 def is_activation_quantization_format(format: str) -> bool:
@@ -41,3 +45,79 @@ def get_linear_quantization(
 
     raise ValueError(
         "Could not find a quantization scheme applied to all linears")
+
+
+# The code below is copied from `compressed_tensors/utils/match.py`
+# and will be substituted after the release of `compressed-tensors>=0.11`
+
+FusedMappping = Mapping[str, Iterable[str]]
+
+
+def is_match(
+    name: str,
+    module: torch.nn.Module,
+    target: str,
+    fused: Optional[FusedMappping] = None,
+) -> bool:
+    """
+    Returns true if either module name or module parent classes match against target
+    and the module is not an internal module. The name and module may refer to a fused
+    module defined by vLLM. In these cases, a `fused` mapping must be provided.
+
+    For example, in `vllm/model_executor/models/llama.py`:
+    ```python
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"]
+    }
+    ```
+
+    :param name: name of module
+    :param module: module to match
+    :param target: target which matches name or module, potentially contains regex
+    :fused: optional mapping from suffixes of fused modules to the suffixes of their
+        corresponding shards
+    """
+    return (_match_name(name, target, fused) or _match_class(module, target))
+
+
+def _match_name(name: str,
+                target: str,
+                fused: Optional[FusedMappping] = None) -> bool:
+    """
+    Returns true if target string begins with "re:" and regex matches or if target
+    string exactly matches name. If the name refers to a fused module defined by vLLM,
+    a `fused` mapping must be provided.
+
+    :param name: name of module
+    :param target: target name, potentially contains regex
+    :fused: optional mapping from suffixes of fused modules to the suffixes of their
+        corresponding shards
+    """
+    if fused is not None:
+        for fused_suffix in fused:
+            if name.endswith(fused_suffix):
+                name_stripped = name.removesuffix(fused_suffix)
+                return any(
+                    _match_name(name_stripped + shard_suffix, target)
+                    for shard_suffix in fused[fused_suffix])
+
+    if target.startswith("re:"):
+        return re.match(target.removeprefix("re:"), name) is not None
+    else:
+        return target == name
+
+
+def _match_class(module: torch.nn.Module, target: str) -> bool:
+    """
+    Returns true if any torch parent class names match the target string exactly.
+    A special exception is made for vllm's `LinearBase` class which matches `Linear`
+
+    :param module: module to match
+    :param target: target which matches name or module
+    """
+    # will never match against a regex pattern since `:` is not allowed in class names
+    return any(
+        (issubclass(cls, torch.nn.Module) and (cls.__name__ == target or (
+            cls.__name__ == "LinearBase" and target == "Linear")))
+        for cls in module.__class__.__mro__)


### PR DESCRIPTION
## Purpose ##
* Enable ingestion of transforms configs by Compressed Tensors
* Make compressed tensors matching logic clearer
  * Use matching utils provided by compressed-tensors in order to make sure matching is consistent
  * Throw errors if config groups overlap
  * Use proper type hints, rather than skipping type checking

## Changes ##
* Refactor logic
  * Replace the `target_scheme_map[find_matching_targets(layer)]` pattern with a simple for loop over schemes and check which ones match the target
  * Replace explicit `target`, `map`, `config`, and `ignore-list` attributes (7 total) with 4 attributes corresponding to the 4 config types, `quant_config`, `sparsity_config`, `transform_config`, and `kv_cache_scheme`
  * Add proper type hints (use optional types for quant args)
  * Use matching utils provided by compressed-tensors
    * This are copied into the source code for now, but will be removed and imported once `compressed-tensors>=0.11` is released
* Support matching transform schemes to modules
  * These will be mapped to kernels in a follow-up PR