### PR TITLE
[CI/Build] Update flashinfer to 0.2.9

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -384,7 +384,7 @@ RUN --mount=type=bind,from=build,src=/workspace/dist,target=/vllm-workspace/dist
 ARG FLASHINFER_GIT_REPO="https://github.com/flashinfer-ai/flashinfer.git"
 # Keep this in sync with https://github.com/vllm-project/vllm/blob/main/requirements/cuda.txt
 # We use `--force-reinstall --no-deps` to avoid issues with the existing FlashInfer wheel.
-ARG FLASHINFER_GIT_REF="v0.2.9rc2"
+ARG FLASHINFER_GIT_REF="v0.2.9"
 RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
   . /etc/environment
     git clone --depth 1 --recursive --shallow-submodules \

--- a/setup.py
+++ b/setup.py
@@ -665,7 +665,7 @@ setup(
                   "mistral_common[audio]"],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility
         # FlashInfer should be updated together with the Dockerfile
-        "flashinfer": ["flashinfer-python==0.2.9rc2"],
+        "flashinfer": ["flashinfer-python==0.2.9"],
     },
     cmdclass=cmdclass,
     package_data=package_data,


### PR DESCRIPTION
Critical to make the docker build on CPU actually build the AOT kernels https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.2.9