### PR TITLE
[TPU][Misc] Fix TPU.device_name

### DIFF
--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -27,7 +27,7 @@ logger = init_logger(__name__)
 
 class TpuPlatform(Platform):
     _enum = PlatformEnum.TPU
-    device_name: str = "tpu"
+    device_name: str = "xla"
     device_type: str = "tpu"
     dispatch_key: str = "XLA"
     ray_device_key: str = "TPU"


### PR DESCRIPTION
TPU `device_name` is wrong as in it does not reflect its common usage across the torch community and beyond.
I would also like to change the `device_type` too, but I wanted to understand first whether we wanted to have "tpu" has an enforced internal nomeclature (I would move both to xla tbh).

```
>>> import torch_xla
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
>>> import torch
>>> torch.randn(10).to("xla").device
device(type='xla', index=0)
>>> torch.randn(10).to("tpu")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, fpga, maia, xla, lazy, vulkan, mps, meta, hpu, mtia, privateuseone device type at start of device string: tpu
```
