### PR TITLE
[bugfix] fix blackwell deepep installation

### DIFF
--- a/tools/ep_kernels/README.md
+++ b/tools/ep_kernels/README.md
@@ -13,16 +13,16 @@ All scripts accept a positional argument as workspace path for staging the build
 
 ## Usage
 
-### Single-node
-
 ```bash
-bash install_python_libraries.sh
+# for hopper
+TORCH_CUDA_ARCH_LIST="9.0" bash install_python_libraries.sh
+# for blackwell
+TORCH_CUDA_ARCH_LIST="10.0" bash install_python_libraries.sh
 ```
 
-### Multi-node
+Additional step for multi-node deployment:
 
 ```bash
-bash install_python_libraries.sh
 sudo bash configure_system_drivers.sh
 sudo reboot # Reboot is required to load the new driver
 ```

--- a/tools/ep_kernels/install_python_libraries.sh
+++ b/tools/ep_kernels/install_python_libraries.sh
@@ -29,6 +29,12 @@ if [ -z "$CUDA_HOME" ]; then
     exit 1
 fi
 
+# assume TORCH_CUDA_ARCH_LIST is set correctly
+if [ -z "$TORCH_CUDA_ARCH_LIST" ]; then
+    echo "TORCH_CUDA_ARCH_LIST is not set, please set it to your desired architecture."
+    exit 1
+fi
+
 # disable all features except IBGDA
 export NVSHMEM_IBGDA_SUPPORT=1
 
@@ -95,7 +101,7 @@ clone_repo "https://github.com/ppl-ai/pplx-kernels" "pplx-kernels" "setup.py"
 cd pplx-kernels
 # see https://github.com/pypa/pip/issues/9955#issuecomment-838065925
 # PIP_NO_BUILD_ISOLATION=0 disables build isolation
-PIP_NO_BUILD_ISOLATION=0 TORCH_CUDA_ARCH_LIST="9.0 10.0" pip install -vvv -e  .
+PIP_NO_BUILD_ISOLATION=0 pip install -vvv -e  .
 popd
 
 # build and install deepep, require pytorch installed
@@ -103,6 +109,5 @@ pushd $WORKSPACE
 clone_repo "https://github.com/deepseek-ai/DeepEP" "DeepEP" "setup.py"
 cd DeepEP
 export NVSHMEM_DIR=$WORKSPACE/nvshmem_install
-export TORCH_CUDA_ARCH_LIST="9.0 10.0"
 PIP_NO_BUILD_ISOLATION=0 pip install -vvv -e  .
 popd

--- a/tools/ep_kernels/install_python_libraries.sh
+++ b/tools/ep_kernels/install_python_libraries.sh
@@ -95,7 +95,7 @@ clone_repo "https://github.com/ppl-ai/pplx-kernels" "pplx-kernels" "setup.py"
 cd pplx-kernels
 # see https://github.com/pypa/pip/issues/9955#issuecomment-838065925
 # PIP_NO_BUILD_ISOLATION=0 disables build isolation
-PIP_NO_BUILD_ISOLATION=0 TORCH_CUDA_ARCH_LIST=9.0a+PTX pip install -vvv -e  .
+PIP_NO_BUILD_ISOLATION=0 TORCH_CUDA_ARCH_LIST="9.0 10.0" pip install -vvv -e  .
 popd
 
 # build and install deepep, require pytorch installed
@@ -103,5 +103,6 @@ pushd $WORKSPACE
 clone_repo "https://github.com/deepseek-ai/DeepEP" "DeepEP" "setup.py"
 cd DeepEP
 export NVSHMEM_DIR=$WORKSPACE/nvshmem_install
+export TORCH_CUDA_ARCH_LIST="9.0 10.0"
 PIP_NO_BUILD_ISOLATION=0 pip install -vvv -e  .
 popd


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

running `bash tools/ep_kernels/install_python_libraries.sh` and then run deepep kernels with hit 

```text
RuntimeError: Failed: CUDA error /data/youkaichao/vllm/ep_kernels_workspace/DeepEP/csrc/kernels/layout.cu:128 'named symbol not found'
```

It is because deepep compiles for hopper by default. we need to add blackwell support.

## Test Plan

change the flag and then run deepep tests

## Test Result

test passes.

## (Optional) Documentation Update

