### PR TITLE
[Misc] Use comma-separated string for --kernels to avoid greedy consumption of the subparser command

### DIFF
--- a/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
+++ b/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
@@ -329,7 +329,7 @@ Benchmark Cutlass GEMM.
     )
     parser.add_argument(
         "--kernels",
-        type=lambda s: s.split(','),
+        type=lambda s: [k.strip() for k in s.split(',') if k.strip()],
         default=None,
         help="Comma-separated list of the kernels to benchmark. If not set, runs all kernels.",
     )

--- a/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
+++ b/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
@@ -329,10 +329,9 @@ Benchmark Cutlass GEMM.
     )
     parser.add_argument(
         "--kernels",
-        nargs="+",
-        type=str,
+        type=lambda s: s.split(','),
         default=None,
-        help="Exact names of the kernels to benchmark. If not set, runs all kernels.",
+        help="Comma-separated list of the kernels to benchmark. If not set, runs all kernels.",
     )
 
     subparsers = parser.add_subparsers(dest="cmd")

--- a/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
+++ b/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
@@ -329,9 +329,10 @@ Benchmark Cutlass GEMM.
     )
     parser.add_argument(
         "--kernels",
-        type=lambda s: [k.strip() for k in s.split(',') if k.strip()],
+        type=lambda s: [k.strip() for k in s.split(",") if k.strip()],
         default=None,
-        help="Comma-separated list of the kernels to benchmark. If not set, runs all kernels.",
+        help="Comma-separated list of the kernels to benchmark."
+        + " If not set, runs all kernels.",
     )
 
     subparsers = parser.add_subparsers(dest="cmd")


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Use comma-separated string for --kernels to avoid greedy consumption of the subparser command. Without this, it is impossible to specify the kernels before the subparser command the since it will greedily consume the command as a kernel name.

## Test Plan
python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype fp8 --kernels cutlass_fp8_fp8_fp16_scaled_mm_blockwise,triton_fp8_fp8_fp16_scaled_mm_blockwise model_bench --models meta-llama/Llama-2-7b-hf

## Test Result
Before: 
```
# python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype fp8 --kernels cutlass_fp8_fp8_fp16_scaled_mm_blockwise triton_fp8_fp8_fp16_scaled_mm_blockwise model_bench --models meta-llama/Llama-2-7b-hf
INFO 08-05 07:42:00 [__init__.py:241] Automatically detected platform cuda.
usage: w8a8_benchmarks.py [-h] --dtype DTYPE [--kernels KERNELS [KERNELS ...]] {square_bench,range_bench,model_bench} ...
w8a8_benchmarks.py: error: argument cmd: invalid choice: 'meta-llama/Llama-2-7b-hf' (choose from square_bench, range_bench, model_bench)
```
After:
```
# python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype fp8 --kernels cutlass_fp8_fp8_fp16_scaled_mm_blockwise,triton_fp8_fp8_fp16_scaled_mm_blockwise model_bench --models meta-llama/Llama-2-7b-hf
INFO 08-05 07:46:19 [__init__.py:241] Automatically detected platform cuda.
Benchmarking models:
[0]  meta-llama/Llama-2-7b-hf
...
```

## (Optional) Documentation Update

