### PR TITLE
[Fix] apply_temperature() casuing `inf` logits

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -303,7 +303,7 @@ class InputBatch:
                 self.spec_decode_unsupported_reqs.add(req_id)
             if sampling_params.sampling_type == SamplingType.GREEDY:
                 # Avoid later division by zero.
-                self.temperature_cpu[req_index] = -1.0
+                self.temperature_cpu[req_index] = 1.0
                 self.greedy_reqs.add(req_id)
             else:
                 self.temperature_cpu[req_index] = sampling_params.temperature


### PR DESCRIPTION
Spotted by courage17340@ in #22180.

When there are both greedy sampling and sampling params causing "-inf" (bad words, structured output) mixed in a single batch, `apply_temperature()` can flip `-inf` into `inf` in logits and causing `nan` when sampler does softmax. The `nan` values will cause `flashinfer` to crash.

It also fixes #19483 in our tests.

Fix it by setting greedy sampling entries' temperature to 1.0 instead of -1.0.

Fixes #22180, #19483.

# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

