### PR TITLE
[Bugfix][CI/Build][ROCm] Make sure to use the headers from the build folder on ROCm

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -467,6 +467,12 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   if (GPU_LANGUAGE STREQUAL "HIP")
     # Make this target dependent on the hipify preprocessor step.
     add_dependencies(${GPU_MOD_NAME} hipify${GPU_MOD_NAME})
+    # Make sure we include the hipified versions of the headers, and avoid conflicts with the ones in the original source folder
+    target_include_directories(${GPU_MOD_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/csrc
+      ${GPU_INCLUDE_DIRECTORIES})
+  else()
+    target_include_directories(${GPU_MOD_NAME} PRIVATE csrc
+      ${GPU_INCLUDE_DIRECTORIES})
   endif()
 
   if (GPU_ARCHITECTURES)
@@ -482,8 +488,6 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   target_compile_definitions(${GPU_MOD_NAME} PRIVATE
     "-DTORCH_EXTENSION_NAME=${GPU_MOD_NAME}")
 
-  target_include_directories(${GPU_MOD_NAME} PRIVATE csrc
-    ${GPU_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${GPU_LIBRARIES})
 


### PR DESCRIPTION
Fix for the ROCm build being broken by #21961
When using #include with a path that is not explicitly relative, a header file from the csrc in the source folder is being picked up
On ROCm [some of] the headers undergo hipify, and a copy in the build folder may differ, so it is important to pick the same file from each include site to avoid declaration conflicts.
This PR changes the target_include_directories on ROCm to point the -I to the build folder rather than the original source folder.