### PR TITLE
`NixlConnector` Support HTTP/S metadata exchange instead of zmq

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
+++ b/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
@@ -27,30 +27,28 @@ async def lifespan(app: FastAPI):
 
     # Create prefill clients
     for i, (host, port) in enumerate(global_args.prefiller_instances):
+
         prefiller_base_url = f'http://{host}:{port}/v1'
+
+        client = httpx.AsyncClient(timeout=None, base_url=prefiller_base_url)
+
         app.state.prefill_clients.append({
-            'client':
-            httpx.AsyncClient(timeout=None, base_url=prefiller_base_url),
-            'host':
-            host,
-            'port':
-            port,
-            'id':
-            i
+            'client': client,
+            'host': host,
+            'port': port,
+            'id': i
         })
 
     # Create decode clients
     for i, (host, port) in enumerate(global_args.decoder_instances):
         decoder_base_url = f'http://{host}:{port}/v1'
+
+        client = httpx.AsyncClient(timeout=None, base_url=decoder_base_url)
         app.state.decode_clients.append({
-            'client':
-            httpx.AsyncClient(timeout=None, base_url=decoder_base_url),
-            'host':
-            host,
-            'port':
-            port,
-            'id':
-            i
+            'client': client,
+            'host': host,
+            'port': port,
+            'id': i
         })
 
     # Initialize round-robin iterators

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -959,7 +959,9 @@ def get_current_model_prefix() -> str:
         "Current model prefix is not set. "
     return _current_prefix
 
+
 T = TypeVar("T")
+
 
 def get_layers_from_vllm_config(
         vllm_config: VllmConfig,

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -666,8 +666,8 @@ class VllmConfig:
                 # Hybrid KV cache manager is not compatible with KV transfer.
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True
                 if self.kv_transfer_config.is_kv_transfer_instance:
-                    self.parallel_config.xfer_handshake_metadata = defaultdict(
-                        dict)
+                    self.parallel_config.kv_conn_endpoint_metadata = (
+                        defaultdict(dict))
             if self.kv_events_config is not None:
                 # Hybrid KV cache manager is not compatible with KV events.
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -663,6 +663,11 @@ class VllmConfig:
             if self.kv_transfer_config is not None:
                 # Hybrid KV cache manager is not compatible with KV transfer.
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True
+            if (self.kv_transfer_config is not None
+                    and self.kv_transfer_config.is_kv_transfer_instance):
+                from collections import defaultdict
+                self.parallel_config.xfer_handshake_metadata = defaultdict(
+                    dict)
             if self.kv_events_config is not None:
                 # Hybrid KV cache manager is not compatible with KV events.
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -9,6 +9,8 @@ import inspect
 import json
 import os
 import textwrap
+import warnings
+from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import field, fields, is_dataclass, replace
 from functools import cached_property, lru_cache
@@ -665,7 +667,6 @@ class VllmConfig:
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True
             if (self.kv_transfer_config is not None
                     and self.kv_transfer_config.is_kv_transfer_instance):
-                from collections import defaultdict
                 self.parallel_config.xfer_handshake_metadata = defaultdict(
                     dict)
             if self.kv_events_config is not None:
@@ -959,9 +960,7 @@ def get_current_model_prefix() -> str:
         "Current model prefix is not set. "
     return _current_prefix
 
-
 T = TypeVar("T")
-
 
 def get_layers_from_vllm_config(
         vllm_config: VllmConfig,

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -665,10 +665,9 @@ class VllmConfig:
             if self.kv_transfer_config is not None:
                 # Hybrid KV cache manager is not compatible with KV transfer.
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True
-            if (self.kv_transfer_config is not None
-                    and self.kv_transfer_config.is_kv_transfer_instance):
-                self.parallel_config.xfer_handshake_metadata = defaultdict(
-                    dict)
+                if self.kv_transfer_config.is_kv_transfer_instance:
+                    self.parallel_config.xfer_handshake_metadata = defaultdict(
+                        dict)
             if self.kv_events_config is not None:
                 # Hybrid KV cache manager is not compatible with KV events.
                 self.scheduler_config.disable_hybrid_kv_cache_manager = True

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -215,6 +215,11 @@ class ParallelConfig:
         should only be set by API server scale-out.
     """
 
+    xfer_handshake_metadata: Optional[dict[int, dict[
+        int, KVConnectorHandshakeMetadata]]] = None
+    """ Metadata for KV transfer handshake between prefill and decode engine
+    processes."""
+
     @property
     def world_size_across_dp(self) -> int:
         """world_size_across_dp is TPxPPxDP, it is the size of the world

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
 else:
     RuntimeEnv = Any
     PlacementGroup = Any
-    ExecutorBase = Any
     KVConnectorHandshakeMetadata = Any
+    ExecutorBase = Any
 
 logger = init_logger(__name__)
 
@@ -215,7 +215,7 @@ class ParallelConfig:
         should only be set by API server scale-out.
     """
 
-    xfer_handshake_metadata: Optional[dict[int, dict[
+    kv_conn_endpoint_metadata: Optional[dict[int, dict[
         int, KVConnectorHandshakeMetadata]]] = None
     """ Metadata for KV transfer handshake between prefill and decode engine
     processes."""

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -21,11 +21,14 @@ if TYPE_CHECKING:
     from ray.runtime_env import RuntimeEnv
     from ray.util.placement_group import PlacementGroup
 
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorHandshakeMetadata)
     from vllm.executor.executor_base import ExecutorBase
 else:
     RuntimeEnv = Any
     PlacementGroup = Any
     ExecutorBase = Any
+    KVConnectorHandshakeMetadata = Any
 
 logger = init_logger(__name__)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -263,7 +263,6 @@ class KVConnectorBase_V1(ABC):
         """
         return None
 
-
     # ==============================
     # Scheduler-side methods
     # ==============================

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -39,9 +39,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
-import msgspec
 import torch
-from pydantic_core import core_schema
 
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -74,37 +72,12 @@ class KVConnectorRole(enum.Enum):
     WORKER = 1
 
 
-class KVConnectorHandshakeMetadata(
-        msgspec.Struct,
-        omit_defaults=True,  # type: ignore[call-arg]
-        # required for @cached_property.
-        dict=True):
+class KVConnectorHandshakeMetadata(ABC):  # noqa: B024
     """
-    Metadata optionally used for out of band connector handshake between
-    P/D workers.
+    Metadata used for out of band connector handshakeandshake between
+    P/D workers. This needs to serializeable.
     """
-    connector_type: str = "base"
-
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Callable[[Any],
-                                                   core_schema.CoreSchema]
-    ) -> core_schema.CoreSchema:
-        """bridge msgspec.Struct with pydantic for schema generation"""
-        return core_schema.no_info_after_validator_function(
-            cls, core_schema.dict_schema())
-
-
-class KVConnectorTransferMetadata(
-        msgspec.Struct,
-        omit_defaults=True,  # type: ignore[call-arg]
-        dict=True):
-    """
-    Wrapper for transfer handshake metadata sent between engine and utils.
-    """
-    tensor_parallel_rank: int
-    data_parallel_rank: int
-    content: Optional[dict]
+    pass
 
 
 class KVConnectorMetadata(ABC):  # noqa: B024
@@ -124,10 +97,6 @@ class KVConnectorBase_V1(ABC):
         self._connector_metadata: Optional[KVConnectorMetadata] = None
         self._vllm_config = vllm_config
         self._role = role
-        # Optional handshake metadata used for connector init between
-        # workers. This is not used by default, just used for connections
-        # that need to be initialized out of band.
-        self._handshake_metadata: Optional[KVConnectorHandshakeMetadata] = None
 
     @property
     def role(self) -> KVConnectorRole:
@@ -281,6 +250,19 @@ class KVConnectorBase_V1(ABC):
         Get the KV connector stats collected during the last interval.
         """
         return None
+
+    def get_handshake_metadata(self) -> Optional[KVConnectorHandshakeMetadata]:
+        """
+        Get the KVConnector handshake metadata for this connector.
+        This metadata is used for out-of-band connector handshake
+        between P/D workers.
+
+        Returns:
+            KVConnectorHandshakeMetadata: the handshake metadata.
+            None if no handshake metadata is available.
+        """
+        return None
+
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/__init__.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import contextlib
 import copy
 import logging
 import math
@@ -1277,25 +1276,6 @@ class NixlConnectorWorker:
         if not self.xfer_stats.is_empty():
             return self.xfer_stats.clone_and_reset()
         return None
-
-
-@contextlib.contextmanager
-def zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:
-    """Context manager for a ZMQ socket"""
-
-    if socket_type not in (zmq.ROUTER, zmq.REQ):
-        raise ValueError(f"Unexpected socket type: {socket_type}")
-
-    ctx: Optional[zmq.Context] = None
-    try:
-        ctx = zmq.Context()  # type: ignore[attr-defined]
-        yield make_zmq_socket(ctx=ctx,
-                              path=addr,
-                              socket_type=socket_type,
-                              bind=socket_type == zmq.ROUTER)
-    finally:
-        if ctx is not None:
-            ctx.destroy(linger=0)
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/_nixl_import.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/_nixl_import.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Centralized lazy import for NIXL wrapper to avoid circular dependencies."""
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Lazy import nixl_wrapper to avoid loading nixl_bindings if nixl is not used
+try:
+    from nixl._api import nixl_agent as NixlWrapper
+    logger.info("NIXL is available")
+except ImportError:
+    logger.warning("NIXL is not available")
+    NixlWrapper = None
+
+__all__ = ["NixlWrapper"]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/handshake.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/handshake.py
@@ -7,7 +7,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from dataclasses import field
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 import msgspec
@@ -27,15 +27,15 @@ logger = init_logger(__name__)
 GET_META_MSG = b"get_meta_msg"
 
 
+@dataclass
 class NixlAgentMetadata(KVConnectorHandshakeMetadata):
-    engine_id: str = field()
-    agent_metadata: bytes = field()
-    kv_caches_base_addr: list[int] = field()
-    num_blocks: int = field()
-    block_len: int = field()
-    attn_backend_name: str = field()
-    kv_cache_layout: str = field()
-    connector_type: str = "nixl"
+    engine_id: str
+    agent_metadata: bytes
+    kv_caches_base_addr: list[int]
+    num_blocks: int
+    block_len: int
+    attn_backend_name: str
+    kv_cache_layout: str
 
 
 class HandshakeStrategy(ABC):
@@ -45,7 +45,7 @@ class HandshakeStrategy(ABC):
     communication protocols.
     """
 
-    def __init__(self, nixl_wrapper, tp_rank: int, tp_size: int,
+    def __init__(self, nixl_wrapper: NixlWrapper, tp_rank: int, tp_size: int,
                  side_channel_port: int, engine_id: str):
         self.nixl_wrapper = nixl_wrapper
         self.tp_rank = tp_rank

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/handshake.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector/handshake.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import base64
+import contextlib
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import field
+from typing import Any, Optional
+
+import msgspec
+import zmq
+
+from vllm import envs
+from vllm.connections import HTTPConnection
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata)
+from vllm.logger import init_logger
+from vllm.utils import build_uri, make_zmq_path, make_zmq_socket
+
+logger = init_logger(__name__)
+
+GET_META_MSG = b"get_meta_msg"
+
+
+class NixlAgentMetadata(KVConnectorHandshakeMetadata):
+    engine_id: str = field()
+    agent_metadata: bytes = field()
+    kv_caches_base_addr: list[int] = field()
+    num_blocks: int = field()
+    block_len: int = field()
+    attn_backend_name: str = field()
+    kv_cache_layout: str = field()
+    connector_type: str = "nixl"
+
+
+class HandshakeStrategy(ABC):
+    """
+    Abstract base class for handshake strategies.
+    This class is used to abstract the handshake process for different
+    communication protocols.
+    """
+
+    def __init__(self, nixl_wrapper, tp_rank: int, tp_size: int,
+                 side_channel_port: int, engine_id: str):
+        self.nixl_wrapper = nixl_wrapper
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.side_channel_port = side_channel_port
+        self.engine_id = engine_id
+
+    @abstractmethod
+    def initiate_handshake(self, host: str, port: int, remote_tp_size: int,
+                           expected_engine_id: str) -> dict[int, str]:
+        pass
+
+    @abstractmethod
+    def setup_listener(self, metadata: NixlAgentMetadata) -> None:
+        pass
+
+    @abstractmethod
+    def cleanup(self) -> None:
+        pass
+
+
+class ZmqHandshakeStrategy(HandshakeStrategy):
+    """
+    Handshake strategy that uses a ZMQ socket at port defined by
+    VLLM_NIXL_SIDE_CHANNEL_PORT + tp_rank for communication.
+    This is the default handshake strategy for NIXL, and is P2P.
+    """
+
+    def __init__(self, nixl_wrapper, tp_rank: int, tp_size: int,
+                 side_channel_port: int, engine_id: str,
+                 add_remote_agent_func):
+        super().__init__(nixl_wrapper, tp_rank, tp_size, side_channel_port,
+                         engine_id)
+        self.add_remote_agent_func = add_remote_agent_func
+        self._listener_thread: Optional[threading.Thread] = None
+        self._tp_size: dict[str, int] = {engine_id: tp_size}
+
+    def initiate_handshake(self, host: str, port: int, remote_tp_size: int,
+                           expected_engine_id: str) -> dict[int, str]:
+        start_time = time.perf_counter()
+
+        def handshake(path: str, rank: int) -> tuple[NixlAgentMetadata, str]:
+            with self._zmq_ctx(zmq.REQ, path) as sock:
+                sock.send(GET_META_MSG)
+                metadata_bytes = sock.recv()
+                decoder = msgspec.msgpack.Decoder(NixlAgentMetadata)
+                metadata = decoder.decode(metadata_bytes)
+                got_metadata_time = time.perf_counter()
+                logger.debug("NIXL handshake: get metadata took: %s",
+                             got_metadata_time - start_time)
+
+                if metadata.engine_id != expected_engine_id:
+                    raise RuntimeError(
+                        f"Remote NIXL agent engine ID mismatch. "
+                        f"Expected {expected_engine_id},"
+                        f"received {metadata.engine_id}.")
+                # Register Remote agent
+                agent_name = self.add_remote_agent_func(
+                    metadata, rank, remote_tp_size)
+                setup_agent_time = time.perf_counter()
+
+                logger.debug("NIXL handshake: add agent took: %s",
+                             setup_agent_time - got_metadata_time)
+                return metadata, agent_name
+
+        # Handshake with remote agent-rank0 first to get the tp_size of remote
+        path = make_zmq_path("tcp", host, port)
+        logger.debug("Querying master rank metadata on path: %s", path)
+        metadata, agent_name_0 = handshake(path, 0)
+
+        agents = {0: agent_name_0}
+
+        # Handshake only with the other TP remote the current local rank will
+        # pull from. With homogeneous TP it happens to be the same rank_i.
+        tp_ratio = self._tp_size[self.engine_id] // remote_tp_size
+        p_remote_rank = self.tp_rank // tp_ratio
+        if p_remote_rank > 0:
+            path = make_zmq_path("tcp", host, port + p_remote_rank)
+            logger.debug("Querying metadata on path: %s at remote rank %s",
+                         path, p_remote_rank)
+            _, agent_name = handshake(path, p_remote_rank)
+            agents[p_remote_rank] = agent_name
+
+        return agents
+
+    def setup_listener(self, metadata: NixlAgentMetadata) -> None:
+        ready_event = threading.Event()
+        self._listener_thread = threading.Thread(
+            target=self._nixl_handshake_listener,
+            args=(metadata, ready_event, self.side_channel_port, self.tp_rank),
+            daemon=True,
+            name="nixl_handshake_listener")
+        self._listener_thread.start()
+        ready_event.wait()
+
+    def cleanup(self) -> None:
+        if self._listener_thread:
+            self._listener_thread.join(timeout=0)
+
+    @staticmethod
+    def _nixl_handshake_listener(metadata: NixlAgentMetadata,
+                                 ready_event: threading.Event, base_port: int,
+                                 tp_rank: int):
+        encoder = msgspec.msgpack.Encoder()
+        encoded_data = encoder.encode(metadata)
+        size_in_bytes = len(encoded_data)
+        logger.debug("Size of encoded NixlAgentMetadata: %s bytes",
+                     size_in_bytes)
+
+        # Listen for new requests for metadata
+        host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
+        path = make_zmq_path("tcp", host, base_port + tp_rank)
+        logger.debug("Starting listening on path: %s", path)
+        with ZmqHandshakeStrategy._zmq_ctx(zmq.ROUTER, path) as sock:
+            ready_event.set()
+            while True:
+                identity, _, msg = sock.recv_multipart()
+                if msg != GET_META_MSG:
+                    logger.warning(
+                        "Connection listener got unexpected message %s", msg)
+                sock.send_multipart((identity, b"", encoded_data))
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:
+        if socket_type not in (zmq.ROUTER, zmq.REQ):
+            raise ValueError(f"Unexpected socket type: {socket_type}")
+
+        ctx: Optional[zmq.Context] = None
+        try:
+            ctx = zmq.Context()
+            yield make_zmq_socket(ctx=ctx,
+                                  path=addr,
+                                  socket_type=socket_type,
+                                  bind=socket_type == zmq.ROUTER)
+        finally:
+            if ctx is not None:
+                ctx.destroy(linger=0)
+
+
+class HttpHandshakeStrategy(HandshakeStrategy):
+    """
+    Handshake strategy that uses HTTP requests to fetch metadata from a
+    remote server. This is done through the front-end, and is
+    North-South, not P2P.
+    """
+
+    def __init__(self, nixl_wrapper, tp_rank: int, tp_size: int,
+                 side_channel_port: int, engine_id: str,
+                 add_remote_agent_func):
+        super().__init__(nixl_wrapper, tp_rank, tp_size, side_channel_port,
+                         engine_id)
+        self.add_remote_agent_func = add_remote_agent_func
+        self._tp_size: dict[str, int] = {engine_id: tp_size}
+
+    def initiate_handshake(self, host: str, port: int, remote_tp_size: int,
+                           expected_engine_id: str) -> dict[int, str]:
+        start_time = time.perf_counter()
+        logger.debug("Starting NIXL handshake with %s:%s", host, port)
+
+        url = build_uri("http", host, port, path="get_kv_connector_metadata")
+
+        try:
+            http_client = HTTPConnection()
+            response = http_client.get_response(
+                url, timeout=envs.VLLM_NIXL_HANDSHAKE_TIMEOUT)
+            response.raise_for_status()
+            res = response.json()
+        except Exception as e:
+            logger.error("Failed to fetch metadata from %s: %s", url, e)
+            raise
+
+        if res is None:
+            logger.warning(
+                "Remote server returned None metadata, skipping handshake")
+            raise RuntimeError("Remote server returned None metadata")
+
+        # Get dp_rank 0 data (standard for disaggregated prefill-decode)
+        dp_data = res.get("0", {})
+        if not dp_data:
+            raise RuntimeError("No metadata found for dp_rank 0")
+
+        remote_tp_size = len(dp_data.keys())
+
+        # Handshake only with the remote TP rank that current local rank will
+        # pull from. With homogeneous TP it happens to be the same rank_i.
+        tp_ratio = self._tp_size[self.engine_id] // remote_tp_size
+        p_remote_rank = self.tp_rank // tp_ratio
+
+        # Get data for the specific rank we need to connect to
+        rank_data = dp_data.get(str(p_remote_rank), {})
+        if not rank_data:
+            raise RuntimeError(
+                f"No metadata found for remote rank {p_remote_rank}")
+
+        metadata_bytes = rank_data.get("agent_metadata", None)
+        if metadata_bytes is None:
+            raise RuntimeError(
+                f"No agent metadata found for remote rank {p_remote_rank}")
+
+        rank_data_copy = rank_data.copy()
+        rank_data_copy.pop("agent_metadata", None)
+        metadata = NixlAgentMetadata(
+            agent_metadata=base64.b64decode(metadata_bytes), **rank_data_copy)
+
+        if metadata.engine_id != expected_engine_id:
+            raise RuntimeError(f"Remote NIXL agent engine ID mismatch. "
+                               f"Expected {expected_engine_id}, "
+                               f"received {metadata.engine_id}.")
+
+        pre_register = time.perf_counter()
+        # Register Remote agent
+        remote_agent_name = self.add_remote_agent_func(metadata, p_remote_rank,
+                                                       remote_tp_size)
+        agent_time = time.perf_counter()
+
+        logger.debug("Finished registering remote agent for engine %s",
+                     metadata.engine_id)
+        logger.debug("NIXL handshake: get metadata took: %s",
+                     pre_register - start_time)
+        logger.debug("NIXL handshake: add agent took: %s",
+                     agent_time - pre_register)
+
+        logger.debug("NIXL handshake method completed for %s:%s", host, port)
+
+        # Return remote rank -> agent name mapping
+        return {p_remote_rank: remote_agent_name}
+
+    def setup_listener(self, metadata: NixlAgentMetadata) -> None:
+        pass
+
+    def cleanup(self) -> None:
+        pass

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -171,7 +171,8 @@ def run_multi_api_server(args: argparse.Namespace):
 
     with launch_core_engines(vllm_config, executor_class, log_stats,
                              num_api_servers) as (local_engine_manager,
-                                                  coordinator, addresses):
+                                                  coordinator, addresses,
+                                                  kv_metadata):
 
         # Construct common args for the APIServerProcessManager up-front.
         api_server_manager_kwargs = dict(
@@ -183,7 +184,8 @@ def run_multi_api_server(args: argparse.Namespace):
             input_addresses=addresses.inputs,
             output_addresses=addresses.outputs,
             stats_update_address=coordinator.get_stats_publish_address()
-            if coordinator else None)
+            if coordinator else None,
+            kv_handshake_metadata=kv_metadata)
 
         # For dp ranks > 0 in external/hybrid DP LB modes, we must delay the
         # start of the API servers until the local engine is started

--- a/vllm/entrypoints/kv_handshake.py
+++ b/vllm/entrypoints/kv_handshake.py
@@ -14,15 +14,20 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
-class NixlSideChannelServer:
+class KVConnHandshakeServer:
 
     def __init__(self, vllm_config: VllmConfig, host: str, port: int):
         self.vllm_config = vllm_config
         self.host = host
         self.port = port
-        self.app = FastAPI(title="vLLM NIXL Side Channel Server")
+        self.app = FastAPI(title="vLLM KVConnector Handshake Server")
         self.server: Optional[uvicorn.Server] = None
         self._setup_routes()
+
+    def _get_connector_name(self) -> str:
+        if self.vllm_config.kv_transfer_config is None:
+            return "Unknown"
+        return self.vllm_config.kv_transfer_config.kv_connector or "Unknown"
 
     def _setup_routes(self):
 
@@ -37,22 +42,22 @@ class NixlSideChannelServer:
                 raise HTTPException(
                     status_code=404,
                     detail="KV connector handshake metadata is not available")
-            if dp_rank is not None and not (dp_data := kv_meta.get(dp_rank)):
+            if dp_rank is None:
+                return kv_meta
+
+            if not (dp_data := kv_meta.get(dp_rank)):
                 raise HTTPException(
                     status_code=404,
                     detail=f"Data parallel rank {dp_rank} not found")
-            if tp_rank is not None and dp_data is not None and not (
-                    tp_data := dp_data.get(tp_rank)):
+
+            if tp_rank is None:
+                return {dp_rank: dp_data}
+
+            if not (tp_data := dp_data.get(tp_rank)):
                 raise HTTPException(
                     status_code=404,
                     detail=f"Tensor parallel rank {tp_rank} not found for data \
                         parallel rank {dp_rank}")
-
-            if dp_rank is None:
-                return kv_meta
-
-            if tp_rank is None:
-                return {dp_rank: dp_data}
 
             return {dp_rank: {tp_rank: tp_data}}
 
@@ -62,7 +67,8 @@ class NixlSideChannelServer:
             return
 
         listen_address = f"http://{self.host}:{self.port}"
-        logger.info("Starting NIXL side channel server on %s", listen_address)
+        logger.info("Starting %s handshake server on %s",
+                    self._get_connector_name(), listen_address)
 
         # prepare uvicorn configuration
         config_kwargs: dict[str, Any] = {
@@ -80,11 +86,13 @@ class NixlSideChannelServer:
         # start the server in a background task
         if self.server is not None:
             asyncio.create_task(self.server.serve())
-        logger.info("NIXL side channel server started successfully")
+        logger.info("%s handshake server started successfully",
+                    self._get_connector_name())
 
     async def stop_async(self):
         if self.server is not None:
-            logger.info("Stopping NIXL side channel server")
+            logger.info("Stopping %s handshake server",
+                        self._get_connector_name())
             try:
                 self.server.should_exit = True
                 await asyncio.sleep(1)  # give it time to shutdown
@@ -92,32 +100,58 @@ class NixlSideChannelServer:
                 logger.warning("Error during side channel server shutdown: %s",
                                e)
             self.server = None
-            logger.info("NIXL side channel server stopped")
+            logger.info("%s handshake server stopped",
+                        self._get_connector_name())
 
 
-def should_start_nixl_side_channel_server(vllm_config: VllmConfig) -> bool:
+def should_start_kv_handshake_server(vllm_config: VllmConfig) -> bool:
     if vllm_config.kv_transfer_config is None:
         return False
 
-    if vllm_config.kv_transfer_config.kv_connector != "NixlConnector":
+    connector_name = vllm_config.kv_transfer_config.kv_connector
+    if connector_name is None:
         return False
 
-    handshake_method = envs.VLLM_NIXL_HANDSHAKE_METHOD.lower()
-    return handshake_method == "http"
+    # check connector-specific handshake method
+    if connector_name == "NixlConnector":
+        handshake_method = envs.VLLM_NIXL_HANDSHAKE_METHOD.lower()
+        return handshake_method == "http"
+
+    # other connectors can be added here with their own logic
+    # for now, only nixl supports http handshake
+    return False
 
 
-async def set_up_nixl_side_channel_server(
-        vllm_config: VllmConfig) -> Optional[NixlSideChannelServer]:
-    if not should_start_nixl_side_channel_server(vllm_config):
+def _get_handshake_server_config(vllm_config: VllmConfig) -> tuple[str, int]:
+    """get host and port for the handshake server based on connector type."""
+    if vllm_config.kv_transfer_config is None:
+        raise RuntimeError(
+            "KV transfer config is None but tried to start handshake server")
+    connector_name = vllm_config.kv_transfer_config.kv_connector
+
+    if connector_name == "NixlConnector":
+        return (envs.VLLM_NIXL_SIDE_CHANNEL_HOST,
+                envs.VLLM_NIXL_SIDE_CHANNEL_PORT)
+
+    # default fallback values
+    return "localhost", 5557
+
+
+async def set_up_kv_handshake_server(
+        vllm_config: VllmConfig) -> Optional[KVConnHandshakeServer]:
+    if not should_start_kv_handshake_server(vllm_config):
         return None
 
-    side_channel_host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
-    side_channel_port = envs.VLLM_NIXL_SIDE_CHANNEL_PORT
+    side_channel_host, side_channel_port = _get_handshake_server_config(
+        vllm_config)
 
-    logger.info("Starting NIXL side channel metadata server on %s:%d",
+    assert vllm_config.kv_transfer_config is not None
+    connector_name = vllm_config.kv_transfer_config.kv_connector
+
+    logger.info("Starting %s handshake server on %s:%d", connector_name,
                 side_channel_host, side_channel_port)
 
-    server = NixlSideChannelServer(vllm_config, side_channel_host,
+    server = KVConnHandshakeServer(vllm_config, side_channel_host,
                                    side_channel_port)
     await server.start_async()
     return server

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -15,6 +15,8 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.constants import (H11_MAX_HEADER_COUNT_DEFAULT,
                                         H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT)
 from vllm.entrypoints.ssl import SSLCertRefresher
+from vllm.entrypoints.ssl import SSLConfig
+from vllm.entrypoints.ssl import SSLCertRefresher
 from vllm.logger import init_logger
 from vllm.utils import find_process_using_port
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
@@ -51,6 +53,11 @@ async def serve_http(app: FastAPI,
         h11_max_incomplete_event_size = H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT
     if h11_max_header_count is None:
         h11_max_header_count = H11_MAX_HEADER_COUNT_DEFAULT
+
+    # add SSL configuration to uvicorn kwargs
+    if ssl_config:
+        uvicorn_kwargs.update(ssl_config.to_uvicorn_kwargs())
+
 
     config = uvicorn.Config(app, **uvicorn_kwargs)
     # Set header limits

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -15,8 +15,6 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.constants import (H11_MAX_HEADER_COUNT_DEFAULT,
                                         H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT)
 from vllm.entrypoints.ssl import SSLCertRefresher
-from vllm.entrypoints.ssl import SSLConfig
-from vllm.entrypoints.ssl import SSLCertRefresher
 from vllm.logger import init_logger
 from vllm.utils import find_process_using_port
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
@@ -53,11 +51,6 @@ async def serve_http(app: FastAPI,
         h11_max_incomplete_event_size = H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT
     if h11_max_header_count is None:
         h11_max_header_count = H11_MAX_HEADER_COUNT_DEFAULT
-
-    # add SSL configuration to uvicorn kwargs
-    if ssl_config:
-        uvicorn_kwargs.update(ssl_config.to_uvicorn_kwargs())
-
 
     config = uvicorn.Config(app, **uvicorn_kwargs)
     # Set header limits

--- a/vllm/entrypoints/nixl_side_channel_server.py
+++ b/vllm/entrypoints/nixl_side_channel_server.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+from typing import Any, Optional
+
+import uvicorn
+from fastapi import FastAPI
+
+from vllm import envs
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class NixlSideChannelServer:
+
+    def __init__(self, vllm_config: VllmConfig, host: str, port: int):
+        self.vllm_config = vllm_config
+        self.host = host
+        self.port = port
+        self.app = FastAPI(title="vLLM NIXL Side Channel Server")
+        self.server: Optional[uvicorn.Server] = None
+        self._setup_routes()
+
+    def _setup_routes(self):
+
+        @self.app.get("/get_kv_connector_metadata")
+        @self.app.get("/get_kv_connector_metadata/{dp_rank}")
+        @self.app.get("/get_kv_connector_metadata/{dp_rank}/{tp_rank}")
+        async def get_kv_connector_metadata(dp_rank: Optional[int] = None,
+                                            tp_rank: Optional[int] = None):
+            kv_meta = self.vllm_config.parallel_config.xfer_handshake_metadata
+
+            if kv_meta is None:
+                return {}
+
+            if dp_rank is None:
+                return kv_meta
+
+            if not (dp_data := kv_meta.get(dp_rank)):
+                return {}
+
+            if tp_rank is None:
+                return {dp_rank: dp_data}
+
+            if not (tp_data := dp_data.get(tp_rank)):
+                return {}
+
+            return {dp_rank: {tp_rank: tp_data}}
+
+    async def start_async(self):
+        if self.server is not None:
+            logger.warning("Side channel server is already running")
+            return
+
+        listen_address = f"http://{self.host}:{self.port}"
+        logger.info("Starting NIXL side channel server on %s", listen_address)
+
+        # prepare uvicorn configuration
+        config_kwargs: dict[str, Any] = {
+            "app": self.app,
+            "host": self.host,
+            "port": self.port,
+            "log_level": "info",
+            "access_log": True,
+        }
+
+        config = uvicorn.Config(**config_kwargs)
+        config.load()  # need to load config to get SSL context
+        self.server = uvicorn.Server(config)
+
+        # start the server in a background task
+        if self.server is not None:
+            asyncio.create_task(self.server.serve())
+        logger.info("NIXL side channel server started successfully")
+
+    async def stop_async(self):
+        if self.server is not None:
+            logger.info("Stopping NIXL side channel server")
+            try:
+                self.server.should_exit = True
+                await asyncio.sleep(1)  # give it time to shutdown
+            except Exception as e:
+                logger.warning("Error during side channel server shutdown: %s",
+                               e)
+            self.server = None
+            logger.info("NIXL side channel server stopped")
+
+
+def should_start_nixl_side_channel_server(vllm_config: VllmConfig) -> bool:
+    if vllm_config.kv_transfer_config is None:
+        return False
+
+    if vllm_config.kv_transfer_config.kv_connector != "NixlConnector":
+        return False
+
+    handshake_method = envs.VLLM_NIXL_HANDSHAKE_METHOD.lower()
+    return handshake_method == "http"
+
+
+async def set_up_nixl_side_channel_server(
+        vllm_config: VllmConfig) -> Optional[NixlSideChannelServer]:
+    if not should_start_nixl_side_channel_server(vllm_config):
+        return None
+
+    side_channel_host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
+    side_channel_port = envs.VLLM_NIXL_SIDE_CHANNEL_PORT
+
+    logger.info("Starting NIXL side channel metadata server on %s:%d",
+                side_channel_host, side_channel_port)
+
+    server = NixlSideChannelServer(vllm_config, side_channel_host,
+                                   side_channel_port)
+    await server.start_async()
+    return server

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1893,7 +1893,7 @@ async def run_server_worker(listen_address,
         vllm_config = await engine_client.get_vllm_config()
 
         await init_app_state(engine_client, vllm_config, app.state, args)
-    
+
         logger.info("Starting vLLM API server %d on %s",
                     vllm_config.parallel_config._api_process_rank,
                     listen_address)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -148,13 +148,15 @@ if TYPE_CHECKING:
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
-    VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
-    VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
     VLLM_ALL2ALL_BACKEND: Literal["naive", "pplx",
                                   "deepep_high_throughput",
                                   "deepep_low_latency",
                                   "allgather_reducescatter"] = \
                                   "allgather_reducescatter"
+    VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
+    VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
+    VLLM_NIXL_HANDSHAKE_TIMEOUT: float = 2.0
+    VLLM_NIXL_HANDSHAKE_METHOD: str = "zmq"
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_SLEEP_WHEN_IDLE: bool = False
@@ -1121,6 +1123,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_PORT":
     lambda: int(os.getenv("VLLM_NIXL_SIDE_CHANNEL_PORT", "5557")),
+
+    # Timeout in seconds for NIXL HTTP handshake requests.
+    # Default is 2 seconds
+    "VLLM_NIXL_HANDSHAKE_TIMEOUT":
+    lambda: float(os.getenv("VLLM_NIXL_HANDSHAKE_TIMEOUT", "2.0")),
+
+    # NIXL handshake method ("zmq" or "http")
+    "VLLM_NIXL_HANDSHAKE_METHOD":
+    lambda: os.getenv("VLLM_NIXL_HANDSHAKE_METHOD", "zmq"),
 
     # all2all backend for vllm's expert parallel communication
     # Available options:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1131,7 +1131,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
 
     # NIXL handshake method ("zmq" or "http")
     "VLLM_NIXL_HANDSHAKE_METHOD":
-    lambda: os.getenv("VLLM_NIXL_HANDSHAKE_METHOD", "zmq"),
+    lambda: os.getenv("VLLM_NIXL_HANDSHAKE_METHOD", "zmq").lower(),
 
     # all2all backend for vllm's expert parallel communication
     # Available options:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -155,7 +155,7 @@ if TYPE_CHECKING:
                                   "allgather_reducescatter"
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
-    VLLM_NIXL_HANDSHAKE_TIMEOUT: float = 2.0
+    VLLM_NIXL_HANDSHAKE_TIMEOUT: float = 10.0
     VLLM_NIXL_HANDSHAKE_METHOD: str = "zmq"
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
@@ -1127,7 +1127,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout in seconds for NIXL HTTP handshake requests.
     # Default is 2 seconds
     "VLLM_NIXL_HANDSHAKE_TIMEOUT":
-    lambda: float(os.getenv("VLLM_NIXL_HANDSHAKE_TIMEOUT", "2.0")),
+    lambda: float(os.getenv("VLLM_NIXL_HANDSHAKE_TIMEOUT", "10.0")),
 
     # NIXL handshake method ("zmq" or "http")
     "VLLM_NIXL_HANDSHAKE_METHOD":

--- a/vllm/executor/uniproc_executor.py
+++ b/vllm/executor/uniproc_executor.py
@@ -95,6 +95,10 @@ class UniProcExecutor(ExecutorBase):
             future.set_exception(e)
         return [future]
 
+    def get_kv_connector_handshake_metadata(self) -> List[Optional[Dict]]:
+        """Get KV connector handshake metadata from all workers."""
+        return self.collective_rpc("get_kv_connector_handshake_metadata")
+
     def check_health(self) -> None:
         # UniProcExecutor will always be healthy as long as
         # it's running.

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3440,8 +3440,8 @@ def build_uri(scheme: str,
 
     # Ensure IPv6 addresses are bracketed
     if (is_valid_ipv6_address(host)
-            and not (host.startswith('[') and host.endswith(']'))):
-        host = f'[{host}]'
+            and not (host.startswith("[") and host.endswith("]"))):
+        host = f"[{host}]"
 
     netloc = f"{host}:{port}" if port else host
     return urlunparse((scheme, netloc, path, params, query, fragment))

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -48,7 +48,7 @@ from functools import cache, lru_cache, partial, wraps
 from types import MappingProxyType
 from typing import (TYPE_CHECKING, Any, Callable, Generic, Literal, NamedTuple,
                     Optional, TextIO, TypeVar, Union, cast, overload)
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 import cachetools
@@ -3413,3 +3413,35 @@ def length_from_prompt_token_ids_or_embeds(
                 f" prompt_token_ids={prompt_token_len}"
                 f" prompt_embeds={prompt_embeds_len}")
         return prompt_token_len
+
+
+def build_uri(scheme: str,
+              host: str,
+              port: Optional[int] = None,
+              path: str = "",
+              params: str = "",
+              query: str = "",
+              fragment: str = "") -> str:
+    """
+    Robustly build a URI that properly handles IPv6 addresses.
+    
+    Args:
+        scheme: URI scheme (e.g., 'http', 'https')
+        host: hostname or IP address
+        port: port number (optional)
+        path: path component
+        params: parameters component
+        query: query string
+        fragment: fragment identifier
+    
+    Returns:
+        Complete URI string
+    """
+
+    # Ensure IPv6 addresses are bracketed
+    if (is_valid_ipv6_address(host)
+            and not (host.startswith('[') and host.endswith(']'))):
+        host = f'[{host}]'
+
+    netloc = f"{host}:{port}" if port else host
+    return urlunparse((scheme, netloc, path, params, query, fragment))

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -598,6 +598,10 @@ class AsyncLLM(EngineClient):
 
         return self.tokenizer
 
+    async def get_kv_handshake_metadata(self) -> Optional[dict]:
+        """Get KV connector handshake metadata if available."""
+        return self.engine_core.get_kv_handshake_metadata()
+
     async def is_tracing_enabled(self) -> bool:
         return self.observability_config.otlp_traces_endpoint is not None
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -214,7 +214,7 @@ class EngineCore:
         elapsed = time.time() - start
         logger.info(("init engine (profile, create kv cache, "
                      "warmup model) took %.2f seconds"), elapsed)
-        return (num_gpu_blocks, num_cpu_blocks, scheduler_kv_cache_config)
+        return num_gpu_blocks, num_cpu_blocks, scheduler_kv_cache_config
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.model_executor.supported_tasks
@@ -629,8 +629,7 @@ class EngineCoreProc(EngineCore):
                 "dp_stats_address": dp_stats_address,
             }
 
-            if (self.xfer_handshake_metadata is not None
-                    and len(self.xfer_handshake_metadata) > 0):
+            if self.xfer_handshake_metadata:
                 # self.xfer_handshake_metadata is list of dicts from workers
                 # Each dict already has structure {dp_rank: {tp_rank: metadata}}
                 # Merge all worker dicts into a single dict

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -629,9 +629,8 @@ class EngineCoreProc(EngineCore):
                 "dp_stats_address": dp_stats_address,
             }
 
-            # Include KV connector metadata if available
-            if hasattr(self, 'xfer_handshake_metadata'
-                       ) and self.xfer_handshake_metadata:
+            if (self.xfer_handshake_metadata is not None
+                    and len(self.xfer_handshake_metadata) > 0):
                 # self.xfer_handshake_metadata is list of dicts from workers
                 # Each dict already has structure {dp_rank: {tp_rank: metadata}}
                 # Merge all worker dicts into a single dict

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -97,8 +97,7 @@ class Executor(ExecutorBase):
 
     def get_kv_connector_handshake_metadata(
             self) -> list[dict[int, dict[int, dict]]]:
-        output = self.collective_rpc("get_kv_connector_handshake_metadata")
-        return output
+        return self.collective_rpc("get_kv_connector_handshake_metadata")
 
     def execute_model(
         self,

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -96,7 +96,7 @@ class Executor(ExecutorBase):
         raise NotImplementedError
 
     def get_kv_connector_handshake_metadata(
-            self) -> list[Optional[dict[int, dict[int, dict]]]]:
+            self) -> list[dict[int, dict[int, dict]]]:
         output = self.collective_rpc("get_kv_connector_handshake_metadata")
         return output
 

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -95,6 +95,11 @@ class Executor(ExecutorBase):
                        non_block: bool = False) -> list[Any]:
         raise NotImplementedError
 
+    def get_kv_connector_handshake_metadata(
+            self) -> list[Optional[dict[int, dict[int, dict]]]]:
+        output = self.collective_rpc("get_kv_connector_handshake_metadata")
+        return output
+
     def execute_model(
         self,
         scheduler_output: SchedulerOutput,

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -174,6 +174,7 @@ class APIServerProcessManager:
         input_addresses: list[str],
         output_addresses: list[str],
         stats_update_address: Optional[str] = None,
+        kv_handshake_metadata: Optional[dict] = None,
     ):
         """Initialize and start API server worker processes.
 
@@ -186,6 +187,7 @@ class APIServerProcessManager:
             input_addresses: Input addresses for each API server
             output_addresses: Output addresses for each API server
             stats_update_address: Optional stats update address
+            kv_handshake_metadata: Optional KV connector handshake metadata
         """
         self.listen_address = listen_address
         self.sock = sock
@@ -205,6 +207,8 @@ class APIServerProcessManager:
             }
             if stats_update_address is not None:
                 client_config["stats_update_address"] = stats_update_address
+            if kv_handshake_metadata is not None:
+                client_config["kv_handshake_metadata"] = kv_handshake_metadata
 
             proc = spawn_context.Process(target=target_server_fn,
                                          name=f"ApiServer_{i}",

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -7,6 +7,7 @@ import os
 from contextlib import AbstractContextManager, nullcontext
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+import msgspec
 import torch
 import torch.distributed
 import torch.nn as nn
@@ -16,7 +17,10 @@ from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment,
                               set_custom_all_reduce)
-from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized
+from vllm.distributed.kv_transfer import (ensure_kv_transfer_initialized,
+                                          get_kv_transfer_group,
+                                          has_kv_transfer_group,
+                                          is_v1_kv_transfer_group)
 from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -301,6 +305,30 @@ class Worker(WorkerBase):
         gc.collect()
 
         return int(self.available_kv_cache_memory_bytes)
+
+    def get_kv_connector_handshake_metadata(self) -> Optional[dict]:
+        """Get KV connector metadata from this worker if available."""
+
+        if not has_kv_transfer_group():
+            return None
+
+        connector = get_kv_transfer_group()
+        if not is_v1_kv_transfer_group(connector):
+            logger.warning("The KV connector is not a v1 connector. "
+                           "This method is only supported for v1 connectors.")
+            return None
+
+        metadata = connector.get_handshake_metadata()
+        if metadata is None:
+            logger.warning(
+                "KV connector metadata is not available. "
+                "This may happen if the KV connector is not initialized "
+                "or the worker is not part of a disaggregated KV cache setup.")
+            return None
+
+        tp_rank = get_tp_group().rank_in_group
+        dp_rank = self.vllm_config.parallel_config.data_parallel_rank_local
+        return {dp_rank: {tp_rank: msgspec.to_builtins(metadata)}}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -19,8 +19,7 @@ from vllm.distributed import (ensure_model_parallel_initialized,
                               set_custom_all_reduce)
 from vllm.distributed.kv_transfer import (ensure_kv_transfer_initialized,
                                           get_kv_transfer_group,
-                                          has_kv_transfer_group,
-                                          is_v1_kv_transfer_group)
+                                          has_kv_transfer_group)
 from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -313,11 +312,6 @@ class Worker(WorkerBase):
             return None
 
         connector = get_kv_transfer_group()
-        if not is_v1_kv_transfer_group(connector):
-            logger.warning("The KV connector is not a v1 connector. "
-                           "This method is only supported for v1 connectors.")
-            return None
-
         metadata = connector.get_handshake_metadata()
         if metadata is None:
             logger.warning(


### PR DESCRIPTION
## Purpose

Adds support for HTTP based metadata interchange between prefill and decode instances of vllm in a "north to south" fashion, using a dedicated API server endpoint as the side channel (completely new entrypoint). This new entrypoint is spawned dynamically based on KVConnector configuration and the value of the new  `VLLM_NIXL_HANDSHAKE_METHOD` method env var.

This PR is a manual rebase of work originally started in #19447. The amount of changes and merge commits made it difficult to rebase incrementally, so I've reimplemented the PR. 

During initial review of #19447, it was rightly pointed out by @russellb that this new side-channel route needs additional protections, and should not be part of the existing user facing API server. It has been factored out into the new entrypoint setp.

New features:

- Adds two new environment variables to envs.py:
  - `VLLM_NIXL_HANDSHAKE_METHOD`: "zmq" or "http", defaults to "zmq" to preserve legacy behaviour
  -  `VLLM_NIXL_HANDSHAKE_TIMEOUT`: an `http` timeout to apply so the handshake doesn't cause blocking indefinitely. The handshake runs in a background thread, but we don't want to wait forever for it to complete.


**Moved to another PR:** 
- Support for TLS configuration of the sidechannel. Uses the same TLS config as the server itself, supporting a pod level ssl termination setup like what would be desirable in k8s.

## Test Plan

Using the pd_examples justfile here: https://github.com/wseaton/pd_examples/blob/dp-experiments/Justfile#L41-L126, install vllm in a venv with `nixl==0.5.1`. 

Spin up 4 different tmux panes w/ various decode TP sizes:
- `just prefill` 
- `just decode`
- `just proxy`
- `just send_request`
