### PR TITLE
[Bugfix] Fix 3D input passed into cutlass_scaled_mm

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -748,15 +748,15 @@ def cutlass_scaled_mm_azp(a: torch.Tensor,
     assert (out_dtype is torch.bfloat16 or out_dtype is torch.float16)
     assert bias is None or bias.numel(
     ) == b.shape[1] and bias.dtype == out_dtype
-    assert azp is None or azp.numel() == a.shape[0]
 
     # Massage the input to be 2D
     target_shape = (*a.shape[:-1], b.shape[1])
     a = a.view(-1, a.shape[-1])
-    m = a.shape[0]
-    n = b.shape[1]
-    out = torch.empty((m, n), dtype=out_dtype, device=a.device)
+    assert azp is None or azp.numel() == a.shape[0]
 
+    out = torch.empty((a.shape[0], b.shape[1]),
+                      dtype=out_dtype,
+                      device=a.device)
     torch.ops._C.cutlass_scaled_mm_azp(out, a, b, scale_a, scale_b, azp_adj,
                                        azp, bias)
     return out.view(*target_shape)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -710,23 +710,25 @@ def cutlass_scaled_mm(a: torch.Tensor,
         scale_b.shape * [128, 128] == b.shape
     """
     assert (out_dtype is torch.bfloat16 or out_dtype is torch.float16)
-    assert bias is None or bias.shape[0] == b.shape[
-        1] and bias.dtype == out_dtype
+    assert bias is None or bias.numel(
+    ) == b.shape[1] and bias.dtype == out_dtype
 
-    m = a.shape[0]
-    n = b.shape[1]
+    # Massage the input to be 2D
+    target_shape = (*a.shape[:-1], b.shape[1])
+    a = a.view(-1, a.shape[-1])
 
     cutlass_compatible_b = (b.shape[0] % 16 == 0 and b.shape[1] % 16 == 0)
     if current_platform.is_rocm() or not cutlass_compatible_b:
         from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa
             triton_scaled_mm)
-        return triton_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
+        out = triton_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
+    else:
+        out = torch.empty((a.shape[0], b.shape[1]),
+                          dtype=out_dtype,
+                          device=a.device)
+        torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, bias)
 
-    out = torch.empty((m, n), dtype=out_dtype, device=a.device)
-
-    torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, bias)
-
-    return out
+    return out.view(*target_shape)
 
 
 def cutlass_scaled_mm_azp(a: torch.Tensor,
@@ -748,13 +750,16 @@ def cutlass_scaled_mm_azp(a: torch.Tensor,
     ) == b.shape[1] and bias.dtype == out_dtype
     assert azp is None or azp.numel() == a.shape[0]
 
+    # Massage the input to be 2D
+    target_shape = (*a.shape[:-1], b.shape[1])
+    a = a.view(-1, a.shape[-1])
     m = a.shape[0]
     n = b.shape[1]
     out = torch.empty((m, n), dtype=out_dtype, device=a.device)
 
     torch.ops._C.cutlass_scaled_mm_azp(out, a, b, scale_a, scale_b, azp_adj,
                                        azp, bias)
-    return out
+    return out.view(*target_shape)
 
 
 def cutlass_sparse_scaled_mm_supported(cuda_device_capability: int) -> bool:


### PR DESCRIPTION
## Purpose

FIX to resolve CI failure https://buildkite.com/vllm/ci/builds/25994/steps/canvas?sid=01987864-0149-4914-b388-f5792751d1dd

```

[2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py", line 111, in apply_weights
--
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]     return self.kernel.apply_weights(layer, x, bias)
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/kernels/scaled_mm/cutlass.py", line 132, in apply_weights
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]     return ops.cutlass_scaled_mm(x_q,
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]   File "/usr/local/lib/python3.12/dist-packages/vllm/_custom_ops.py", line 723, in cutlass_scaled_mm
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]     return triton_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py", line 136, in triton_scaled_mm
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]     M, K = input.shape
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683]     ^^^^
  | [2025-08-05T05:47:14Z] (EngineCore_0 pid=14726) ERROR 08-04 22:47:14 [core.py:683] ValueError: too many values to unpack (expected 2)
```

## Test Plan

## Test Result