### PR TITLE
Add option to disable weakref conversion for last piecewise cudagraph in a module

### DIFF
--- a/tests/compile/fullgraph/test_multiple_graphs.py
+++ b/tests/compile/fullgraph/test_multiple_graphs.py
@@ -80,7 +80,7 @@ class Attention(nn.Module):
         return x
 
 
-@support_torch_compile
+@support_torch_compile(no_weak_ref_output=True)
 class CompiledAttention(nn.Module):
     def __init__(
         self,
@@ -144,8 +144,10 @@ class SimpleModelWithTwoGraphs(ParentModel):
         self.hidden_states[:bsz].copy_(x)
         x = self.attn_one(self.hidden_states[:bsz])
         self.hidden_states[:bsz].copy_(x)
-        x = self.attn_two(self.hidden_states[:bsz])
-        return x
+        y = self.attn_two(self.hidden_states[:bsz])
+        # Use value x in the final output to test that value of x
+        # is not overwritten by call to self.attn_two when using cudagraph
+        return x + y
 
 
 @torch.inference_mode

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -470,8 +470,9 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
                 # non-last submodule should not be converted to a weakref as it
                 # may result in memory being overwritten by subsequent graph
                 # replays. In these cases, no_weak_ref_output can be set to True
-                weak_ref_output = (piecewise_backend.is_last_graph
-                                   and not self.no_weak_ref_output)
+                weak_ref_output = (
+                    piecewise_backend.is_last_graph and not self.no_weak_ref_output
+                )
 
                 # Always assign PIECEWISE runtime mode to the
                 # CUDAGraphWrapper for piecewise_backend, to distinguish
@@ -756,11 +757,11 @@ class VllmBackend:
         # propagate the split graph to the piecewise backend,
         # compile submodules with symbolic shapes
         PiecewiseCompileInterpreter(
-            self.split_gm, 
+            self.split_gm,
             submod_names_to_compile,
-            self.vllm_config, 
+            self.vllm_config,
             self.no_weak_ref_output,
-            self
+            self,
         ).run(*example_inputs)
 
         graph_path = os.path.join(local_cache_dir, "computation_graph.py")

--- a/vllm/compilation/counter.py
+++ b/vllm/compilation/counter.py
@@ -29,6 +29,8 @@ class CompilationCounter:
     num_compiled_artifacts_saved: int = 0
     # Number of times a model was loaded with CompilationMode.STOCK_TORCH_COMPILE
     stock_torch_compile_count: int = 0
+    # Number of piecewise graphs that will return a weakref output
+    num_weakref_output_graphs: int = 0
 
     def clone(self) -> "CompilationCounter":
         return copy.deepcopy(self)

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -181,6 +181,8 @@ class CUDAGraphWrapper:
                         # any other cuda graph.
                         output = weak_ref_tensors(output)
 
+                        compilation_counter.num_weakref_output_graphs += 1
+
             # here we always use weak ref for the output
             # to save memory
             entry.output = weak_ref_tensors(output)

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -495,7 +495,9 @@ def _support_torch_compile(
                 InliningInstructionTranslator, "inline_call_", patched_inline_call
             ),
             torch._dynamo.config.patch(**dynamo_config_patches),
-            maybe_use_cudagraph_partition_wrapper(self.vllm_config),
+            maybe_use_cudagraph_partition_wrapper(
+                self.vllm_config, self.no_weak_ref_output
+            ),
             _torch27_patch_tensor_subclasses(),
         ):
             if envs.VLLM_USE_AOT_COMPILE:

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -51,8 +51,7 @@ class PiecewiseBackend:
         self.vllm_backend = vllm_backend
 
         self.is_first_graph = piecewise_compile_index == 0
-        self.is_last_graph = (
-            piecewise_compile_index == total_piecewise_compiles - 1)
+        self.is_last_graph = piecewise_compile_index == total_piecewise_compiles - 1
 
         self.is_full_graph = total_piecewise_compiles == 1
 

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -51,7 +51,8 @@ class PiecewiseBackend:
         self.vllm_backend = vllm_backend
 
         self.is_first_graph = piecewise_compile_index == 0
-        self.is_last_graph = piecewise_compile_index == total_piecewise_compiles - 1
+        self.is_last_graph = (
+            piecewise_compile_index == total_piecewise_compiles - 1)
 
         self.is_full_graph = total_piecewise_compiles == 1
 

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -124,7 +124,7 @@ class TorchCompileWithNoGuardsWrapper:
 
         if envs.VLLM_USE_BYTECODE_HOOK and mode != CompilationMode.STOCK_TORCH_COMPILE:
             torch._dynamo.convert_frame.register_bytecode_hook(self.bytecode_hook)
-            self._compiled_bytecode = None
+            self._compiled_bytecode: CodeType | None = None
 
     def aot_compile(self, *args, **kwargs):
         if not hasattr(self._compiled_callable, "aot_compile"):

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -85,16 +85,18 @@ class TorchCompileWithNoGuardsWrapper:
     since we drop all guards.
     """
 
-    def __init__(self):
+    def __init__(self, no_weak_ref_output: bool = False):
         self.compiled = False
-
         vllm_config = get_current_vllm_config()
         self.vllm_config = vllm_config
         mode = vllm_config.compilation_config.mode
         if mode is None:
             raise RuntimeError("Compilation mode cannot be NO_COMPILATION")
 
-        backend = vllm_config.compilation_config.init_backend(vllm_config)
+        backend = vllm_config.compilation_config.init_backend(
+            vllm_config,
+            no_weak_ref_output
+        )
         options = {}
 
         if isinstance(backend, str) and backend == "inductor":

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -94,8 +94,7 @@ class TorchCompileWithNoGuardsWrapper:
             raise RuntimeError("Compilation mode cannot be NO_COMPILATION")
 
         backend = vllm_config.compilation_config.init_backend(
-            vllm_config,
-            no_weak_ref_output
+            vllm_config, no_weak_ref_output
         )
         options = {}
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -710,7 +710,11 @@ class CompilationConfig:
         if self.backend == "":
             self.backend = current_platform.simple_compile_backend
 
-    def init_backend(self, vllm_config: "VllmConfig") -> str | Callable:
+    def init_backend(
+        self,
+        vllm_config: "VllmConfig",
+        no_weak_ref_output: bool = False,
+    ) -> str | Callable:
         """
         Initialize the backend for the compilation config from a vllm config.
         Arguments:
@@ -748,7 +752,7 @@ class CompilationConfig:
 
         # TODO[@lucaskabela]: See if we can forward prefix
         # https://github.com/vllm-project/vllm/issues/27045
-        return VllmBackend(vllm_config)
+        return VllmBackend(vllm_config, no_weak_ref_output)
 
     def post_init_cudagraph_sizes(self) -> None:
         """To complete the initialization after cudagraph related


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
https://github.com/vllm-project/vllm/pull/21044 shows an example where multiple submodules in a model are compiled instead of the top-level model being compiled.

This has a subtle bug currently. For example, if we have 2 submodules compiled in a model: module A followed by module B, then call to module B will overwrite the outputs returned by module A.

This is because:
- Each compilation unit (module A and module B) will independently set `self.is_last_graph=True` for the last graph in its local compiled submodules
- vLLM's piecewise cudagraph backend will convert the output to weakref if `self.is_last_graph=True`  [here](https://github.com/vllm-project/vllm/blob/23c939fd30b845d06568304a0e9d168a48cc8cb4/vllm/compilation/cuda_piecewise_backend.py#L49-L50) as it assumes that for the last graph, its output will not be used another other cuda graph. So it converts final output of module A to a weakref.
- Once converted to weakref, the output will be immediately released to save memory.
- vLLM uses a single [global graph pool](https://github.com/vllm-project/vllm/blob/23c939fd30b845d06568304a0e9d168a48cc8cb4/vllm/compilation/backends.py#L436) amongst all its cuda graphs, so it will try to reuse free memory where it can
- Subsequent cuda graph replays for module B will reuse memory freed from weakref output of module A.
- Value of module A output is overwritten

This PR adds a new argument to the `@support_torch_compile` decorator, `no_weak_ref_output`, which can be set to `True` to disable the weakref conversion for non-last submodules in a model.

## Test Plan

Correctness test:
```
pytest tests/compile/fullgraph/test_multiple_graphs.py
```

Decorator check that child/parent override works as expected:
```
pytest tests/compile/test_decorator.py::test_no_weak_ref_output_decorator
``` 

## Test Result
Before this PR, the test fails due to:
- piecewise compile + cudagraph not `allclose` with eager 
- piecewise compile + cudagraph not bitwise equal to piecewise compile

After this PR, test passes.

Decorator test passes

