### PR TITLE
[Bugfix] Remove faulty test for oot attention backend

### DIFF
--- a/tests/plugins_tests/test_platform_plugins.py
+++ b/tests/plugins_tests/test_platform_plugins.py
@@ -4,9 +4,7 @@
 import pytest
 import torch
 
-from vllm.attention.selector import get_attn_backend
 from vllm.plugins import load_general_plugins
-from vllm.utils import STR_BACKEND_ENV_VAR, STR_INVALID_VAL
 
 
 def test_platform_plugins():
@@ -25,14 +23,6 @@ def test_platform_plugins():
         f"Expected DummyDevice, got {current_platform.device_name}, "
         "possibly because current_platform is imported before the plugin"
         f" is loaded. The first import:\n{_init_trace}")
-
-
-def test_oot_attention_backend(monkeypatch: pytest.MonkeyPatch):
-    # ignore the backend env variable if it is set
-    with monkeypatch.context() as m:
-        m.setenv(STR_BACKEND_ENV_VAR, STR_INVALID_VAL)
-        backend = get_attn_backend(16, torch.float16, "auto", 16, False)
-        assert backend.get_name() == "Dummy_Backend"
 
 
 def test_oot_custom_op(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/22285

This test isn't valid anymore since we changed the attention selection behavior to error with invalid backends