### PR TITLE
[Feat] Allow custom `comm_group` in ParallelLinear layers

### DIFF
--- a/vllm/lora/layers.py
+++ b/vllm/lora/layers.py
@@ -932,12 +932,13 @@ class RowParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
         else:
             # TODO: simplify code below
             splitted_input = split_tensor_along_last_dim(
-                input_, num_partitions=self.base_layer.tp_size)
+                input_, num_partitions=self.base_layer.comm_group_size)
             input_parallel = splitted_input[self.tp_rank].contiguous()
 
         # Matrix multiply.
         output_parallel = self.apply(input_parallel)
-        if self.base_layer.reduce_results and self.base_layer.tp_size > 1:
+        if self.base_layer.reduce_results and \
+            self.base_layer.comm_group_size > 1:
             output_ = tensor_model_parallel_all_reduce(output_parallel)
         else:
             output_ = output_parallel

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -644,9 +644,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         return_bias: bool = True,
     ):
         self.output_sizes = output_sizes
-        self.comm_group = comm_group or get_tp_group()
-        self.comm_group_size = self.comm_group.world_size
-        self.comm_group_rank = self.comm_group.rank_in_group
 
         assert all(output_size % self.comm_group_size == 0
                    for output_size in output_sizes)
@@ -657,6 +654,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                          skip_bias_add=skip_bias_add,
                          params_dtype=params_dtype,
                          quant_config=quant_config,
+                         comm_group=comm_group,
                          prefix=prefix,
                          return_bias=return_bias)
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -11,10 +11,8 @@ from torch.nn.parameter import Parameter, UninitializedParameter
 
 from vllm import envs
 from vllm.distributed import (GroupCoordinator, divide,
-                              get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size,
-                              get_tp_group, split_tensor_along_last_dim,
-                              tensor_model_parallel_all_gather)
+                              get_tp_group, split_tensor_along_last_dim)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
@@ -590,7 +588,7 @@ class ColumnParallelLinear(LinearBase):
         output_parallel = self.quant_method.apply(self, input_, bias)
         if self.gather_output:
             # All-gather across the partitions.
-            output = tensor_model_parallel_all_gather(output_parallel)
+            output = self.comm_group.all_gather(output_parallel)
         else:
             output = output_parallel
         output_bias = self.bias if self.skip_bias_add else None

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -644,9 +644,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         return_bias: bool = True,
     ):
         self.output_sizes = output_sizes
-
-        assert all(output_size % self.comm_group_size == 0
-                   for output_size in output_sizes)
         super().__init__(input_size=input_size,
                          output_size=sum(output_sizes),
                          bias=bias,


### PR DESCRIPTION
Introduce an optional `comm_group` parameter to ColumnParallelLinear, MergedColumnParallelLinear and RowParallelLinear.  This makes it easier to implement layer-level heterogeneous tensor-parallel placement without touching the global TP group, e.g., running LM-head with TP=4 while the rest of the model uses TP=1 in DeepSeek-R1 decode phase.

- Replace global TP size/rank queries with `comm_group.world_size` and `comm_group.rank_in_group`.
- Default to the original global TP group, ensuring backward compatibility.
- Update weight loaders and repr strings accordingly.