### PR TITLE
Update scheduler.py to handle lookahead tokens in P/D with SD 

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -437,17 +437,21 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
+                # Handles an edge case when P/D Disaggregation is used with Spec Decoding
+                # where an extra block gets allocated which creates a mismatch between the
+                # number of local and remote blocks.
+                effective_lookahead_tokens = (0 if request.num_computed_tokens == 0 
+                                             else self.num_lookahead_tokens)
+                
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     num_new_tokens + num_external_computed_tokens,
                     num_new_local_computed_tokens,
                     new_computed_blocks,
-                    num_lookahead_tokens=self.num_lookahead_tokens,
+                    num_lookahead_tokens=effective_lookahead_tokens,
                     delay_cache_blocks=load_kv_async,
                 )
-                if new_blocks is None:
-                    # The request cannot be scheduled.
-                    break
+
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that


### PR DESCRIPTION
Signed-off-by: Pradyun Ramadorai <pradyunco.8592@gmail.com>

## Purpose

When P/D Disaggregation with the NIXL connector is used with EAGLE spec decoding, the scheduler ends up allocating an extra block in the D instance which causes this assertion to fail

`assert len(local_block_descs_ids) == len(remote_block_descs_ids)` 

This fix handles that case by setting the num_lookahead_tokens to 0 if num_computed_tokens is 0.

## Test Plan
Previously, this error would surface:
```
 File "/tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 1530, in maybe_setup_kv_connector
    kv_connector.start_load_kv(get_forward_context())
  File "/tmp/vllm/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 153, in start_load_kv
    self.connector_worker.start_load_kv(self._connector_metadata)
  File "/tmp/vllm/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 706, in start_load_kv
    self._read_blocks(
  File "/tmp/vllm/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 791, in _read_blocks
    assert len(local_block_descs_ids) == len(remote_block_descs_ids)
```
## Test Result
Request is successful and EAGLE spec decoding works with P/D

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
