### PR TITLE
[BugFix] [P/D] Handle lookahead token count edge-case with Eagle Spec Decoding and P/D

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -437,14 +437,21 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
+                # Handles an edge case when P/D Disaggregation is used with Spec Decoding
+                # where an extra block gets allocated which creates a mismatch between the
+                # number of local and remote blocks.
+                effective_lookahead_tokens = (0 if request.num_computed_tokens == 0 
+                                             else self.num_lookahead_tokens)
+                
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     num_new_tokens + num_external_computed_tokens,
                     num_new_local_computed_tokens,
                     new_computed_blocks,
-                    num_lookahead_tokens=self.num_lookahead_tokens,
+                    num_lookahead_tokens=effective_lookahead_tokens,
                     delay_cache_blocks=load_kv_async,
                 )
+
                 if new_blocks is None:
                     # The request cannot be scheduled.
                     break

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -459,7 +459,6 @@ class Scheduler(SchedulerInterface):
                     # The request cannot be scheduled.
                     break
 
-
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that
                 # This information is used to determine if a load is

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -437,11 +437,11 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                # Handles an edge case when P/D Disaggregation is used with Spec Decoding
-                # where an extra block gets allocated which creates a mismatch between the
-                # number of local and remote blocks.
-                effective_lookahead_tokens = (0 if request.num_computed_tokens == 0 
-                                             else self.num_lookahead_tokens)
+                # Handles an edge case when P/D Disaggregation is used with 
+                # Spec Decoding where an extra block gets allocated which creates 
+                # a mismatch between the number of local and remote blocks.
+                effective_lookahead_tokens = (0 if request.num_computed_tokens == 0
+                                              else self.num_lookahead_tokens)
                 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
@@ -451,6 +451,8 @@ class Scheduler(SchedulerInterface):
                     num_lookahead_tokens=effective_lookahead_tokens,
                     delay_cache_blocks=load_kv_async,
                 )
+
+
 
                 if new_blocks is None:
                     # The request cannot be scheduled.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -437,15 +437,15 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                # Handles an edge case when P/D Disaggregation 
-                # is used with Spec Decoding where an 
-                # extra block gets allocated which 
+                # Handles an edge case when P/D Disaggregation
+                # is used with Spec Decoding where an
+                # extra block gets allocated which
                 # creates a mismatch between the number
                 # of local and remote blocks.
-                effective_lookahead_tokens = (0 
-                                             if request.num_computed_tokens == 0
-                                             else self.num_lookahead_tokens)
-                
+                effective_lookahead_tokens = (0 if request.num_computed_tokens
+                                              == 0 else
+                                              self.num_lookahead_tokens)
+
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     num_new_tokens + num_external_computed_tokens,
@@ -455,11 +455,10 @@ class Scheduler(SchedulerInterface):
                     delay_cache_blocks=load_kv_async,
                 )
 
-
-
                 if new_blocks is None:
                     # The request cannot be scheduled.
                     break
+
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -438,8 +438,9 @@ class Scheduler(SchedulerInterface):
                             break
 
                 # Handles an edge case when P/D Disaggregation is used with 
-                # Spec Decoding where an extra block gets allocated which creates 
-                # a mismatch between the number of local and remote blocks.
+                # Spec Decoding where an extra block gets allocated which 
+                # creates a mismatch between the number
+                # of local and remote blocks.
                 effective_lookahead_tokens = (0 if request.num_computed_tokens == 0
                                               else self.num_lookahead_tokens)
                 
@@ -451,7 +452,6 @@ class Scheduler(SchedulerInterface):
                     num_lookahead_tokens=effective_lookahead_tokens,
                     delay_cache_blocks=load_kv_async,
                 )
-
 
 
                 if new_blocks is None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -437,12 +437,14 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                # Handles an edge case when P/D Disaggregation is used with 
-                # Spec Decoding where an extra block gets allocated which 
+                # Handles an edge case when P/D Disaggregation 
+                # is used with Spec Decoding where an 
+                # extra block gets allocated which 
                 # creates a mismatch between the number
                 # of local and remote blocks.
-                effective_lookahead_tokens = (0 if request.num_computed_tokens == 0
-                                              else self.num_lookahead_tokens)
+                effective_lookahead_tokens = (0 
+                                             if request.num_computed_tokens == 0
+                                             else self.num_lookahead_tokens)
                 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
@@ -452,6 +454,7 @@ class Scheduler(SchedulerInterface):
                     num_lookahead_tokens=effective_lookahead_tokens,
                     delay_cache_blocks=load_kv_async,
                 )
+
 
 
                 if new_blocks is None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -442,9 +442,8 @@ class Scheduler(SchedulerInterface):
                 # extra block gets allocated which
                 # creates a mismatch between the number
                 # of local and remote blocks.
-                effective_lookahead_tokens = (0 if request.num_computed_tokens
-                                              == 0 else
-                                              self.num_lookahead_tokens)
+              effective_lookahead_tokens = self.num_lookahead_tokens if request.num_computed_tokens else 0
+
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -442,8 +442,9 @@ class Scheduler(SchedulerInterface):
                 # extra block gets allocated which
                 # creates a mismatch between the number
                 # of local and remote blocks.
-              effective_lookahead_tokens = self.num_lookahead_tokens if request.num_computed_tokens else 0
-
+                effective_lookahead_tokens = (0 if request.num_computed_tokens
+                                              == 0 else
+                                              self.num_lookahead_tokens)
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,


### PR DESCRIPTION
## Purpose

When P/D Disaggregation with the NIXL connector is used with EAGLE spec decoding, the scheduler ends up allocating an extra block in the D instance which causes this assertion to fail

`assert len(local_block_descs_ids) == len(remote_block_descs_ids)` 

This fix handles that case by setting the num_lookahead_tokens to 0 if num_computed_tokens is 0.

## Test Plan
Previously, this error would surface:
```
 File "/tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 1530, in maybe_setup_kv_connector
    kv_connector.start_load_kv(get_forward_context())
  File "/tmp/vllm/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 153, in start_load_kv
    self.connector_worker.start_load_kv(self._connector_metadata)
  File "/tmp/vllm/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 706, in start_load_kv
    self._read_blocks(
  File "/tmp/vllm/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 791, in _read_blocks
    assert len(local_block_descs_ids) == len(remote_block_descs_ids)
```
## Test Result
Request is successful and EAGLE spec decoding works with P/D

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
