### PR TITLE
Removing redundant installation of torch for CPU build

### DIFF
--- a/requirements/cpu-build.txt
+++ b/requirements/cpu-build.txt
@@ -6,7 +6,6 @@ packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0+cpu
 wheel
 jinja2>=3.1.6
 regex

--- a/requirements/cpu-build.txt
+++ b/requirements/cpu-build.txt
@@ -6,6 +6,9 @@ packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 --extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.6.0+cpu; platform_machine == "x86_64" # torch>2.6.0+cpu has performance regression on x86 platform, see https://github.com/pytorch/pytorch/pull/151218
+torch==2.6.0; platform_machine == "aarch64" # for arm64 CPUs, torch 2.7.0 has a issue: https://github.com/vllm-project/vllm/issues/17960
+
 wheel
 jinja2>=3.1.6
 regex

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -8,10 +8,8 @@ numba == 0.61.2; python_version > '3.9'
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0+cpu; platform_machine == "x86_64" # torch>2.6.0+cpu has performance regression on x86 platform, see https://github.com/pytorch/pytorch/pull/151218
 torch==2.7.0; platform_system == "Darwin"
 torch==2.7.0; platform_machine == "ppc64le"
-torch==2.6.0; platform_machine == "aarch64" # for arm64 CPUs, torch 2.7.0 has a issue: https://github.com/vllm-project/vllm/issues/17960
 
 # required for the image processor of minicpm-o-2_6, this must be updated alongside torch
 torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"


### PR DESCRIPTION
## Purpose
The torch installation is duplicate for CPU build See [1](https://github.com/vllm-project/vllm/blob/dd16bdc7981349edc44900c1c614e09b2faa712e/docker/Dockerfile.cpu#L96) and [2](https://github.com/vllm-project/vllm/blob/dd16bdc7981349edc44900c1c614e09b2faa712e/docker/Dockerfile.cpu#L57)  
Issue [22183](https://github.com/vllm-project/vllm/issues/22183)

## Test Plan

## Test Result

## (Optional) Documentation Update

