### PR TITLE
[V1] Test cases for parallel sampling with all output_kind options

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -107,10 +107,8 @@ async def test_streaming_with_parallel_sampling(
         NUM_REQUESTS = 10
         N = 5
         NUM_TOKENS = 20
-        prompt = (
-            f"<|im_start|>user\nTell me the long history "
-            f"of the Earth is<|im_end|>\n<|im_start|>assistant\n<think>"
-        )
+        prompt = ("<|im_start|>user\nTell me the long history "
+                  "of the Earth is<|im_end|>\n<|im_start|>assistant\n<think>")
         request_ids = [f"request-{i}" for i in range(NUM_REQUESTS)]
 
         async def run_generate(engine, request_id, prompt, output_kind,
@@ -127,7 +125,7 @@ async def test_streaming_with_parallel_sampling(
             total_indices = 0
             from collections import defaultdict
             prev_token_counts = defaultdict(int)
-            token_all = defaultdict(int)
+            ttoken_all: defaultdict[str, int] = defaultdict(int)
 
             async for output_group in engine.generate(
                     request_id=request_id,

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -93,16 +93,16 @@ async def generate(
 @pytest.mark.asyncio
 async def test_streaming_with_parallel_sampling(monkeypatch: pytest.MonkeyPatch, output_kind: RequestOutputKind):
     """test parallel sampling along with ouput_kind""" 
-    engine_args = AsyncEngineArgs(model="Qwen/Qwen3-0.6B", gpu_memory_utilization=0.5)
+    engine_args = AsyncEngineArgs(model="Qwen/Qwen3-0.6B", gpu_memory_utilization=0.8)
     with monkeypatch.context() as m, ExitStack() as after:
         m.setenv("VLLM_USE_V1", "1")
         with set_default_torch_num_threads(1):
             engine = AsyncLLM.from_engine_args(engine_args)
         after.callback(engine.shutdown)
 
-        NUM_REQUESTS = 100
-        N = 500
-        NUM_TOKENS = 50
+        NUM_REQUESTS = 10
+        N = 5
+        NUM_TOKENS = 20
         prompt = "<|im_start|>user\nTell me the long history of the Earth is<|im_end|>\n<|im_start|>assistant\n<think>"
 
         request_ids = [f"request-{i}" for i in range(NUM_REQUESTS)]

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -204,7 +204,7 @@ async def test_streaming_with_parallel_sampling(
                 #assert total_indices == N*NUM_TOKENS # fail due to coalesing
                 assert len(set(token_all.values())) == 1
                 assert list(
-                    token_all.values())[0] == NUM_TOKENS * (NUM_TOKENS + 1) / 2
+                    token_all.values())[0] == NUM_TOKENS * (NUM_TOKENS + 1) // 2
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -25,7 +25,7 @@ if not current_platform.is_cuda():
                 allow_module_level=True)
 
 TEXT_ENGINE_ARGS = AsyncEngineArgs(
-    model="meta-llama/Llama-3.2-1B-Instruct",
+    model="facebook/opt-125m",
     enforce_eager=True,
 )
 
@@ -96,17 +96,18 @@ async def generate(
 async def test_streaming_with_parallel_sampling(
         monkeypatch: pytest.MonkeyPatch, output_kind: RequestOutputKind):
     """test parallel sampling along with ouput_kind"""
-    engine_args = AsyncEngineArgs(model="Qwen/Qwen3-0.6B",
-                                  gpu_memory_utilization=0.8)
+    engine_args = AsyncEngineArgs(model="facebook/opt-125m",
+                                  gpu_memory_utilization=0.8,
+                                  enforce_eager=True)
     with monkeypatch.context() as m, ExitStack() as after:
         m.setenv("VLLM_USE_V1", "1")
         with set_default_torch_num_threads(1):
             engine = AsyncLLM.from_engine_args(engine_args)
         after.callback(engine.shutdown)
 
-        NUM_REQUESTS = 10
+        NUM_REQUESTS = 3
         N = 5
-        NUM_TOKENS = 20
+        NUM_TOKENS = 10
         prompt = ("<|im_start|>user\nTell me the long history "
                   "of the Earth is<|im_end|>\n<|im_start|>assistant\n<think>")
         request_ids = [f"request-{i}" for i in range(NUM_REQUESTS)]

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -125,7 +125,7 @@ async def test_streaming_with_parallel_sampling(
             total_indices = 0
             from collections import defaultdict
             prev_token_counts = defaultdict(int)
-            ttoken_all: defaultdict[str, int] = defaultdict(int)
+            token_all: defaultdict[str, int] = defaultdict(int)
 
             async for output_group in engine.generate(
                     request_id=request_id,

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -107,8 +107,10 @@ async def test_streaming_with_parallel_sampling(
         NUM_REQUESTS = 10
         N = 5
         NUM_TOKENS = 20
-        prompt = "<|im_start|>user\nTell me the long history of the Earth is<|im_end|>\n<|im_start|>assistant\n<think>"
-
+        prompt = (
+            f"<|im_start|>user\nTell me the long history "
+            f"of the Earth is<|im_end|>\n<|im_start|>assistant\n<think>"
+        )
         request_ids = [f"request-{i}" for i in range(NUM_REQUESTS)]
 
         async def run_generate(engine, request_id, prompt, output_kind,
@@ -135,26 +137,30 @@ async def test_streaming_with_parallel_sampling(
                 indices = [comp.index
                            for comp in completions]  # index = parallel samples
                 total_indices += len(indices)
-                texts = [comp.text for comp in completions]
+                #texts = [comp.text for comp in completions]
 
                 for comp in completions:
                     current_len = len(comp.token_ids)
-                    prev_len = prev_token_counts[comp.index]
+                    #prev_len = prev_token_counts[comp.index]
                     token_all[comp.index] += current_len
 
                     if output_kind == RequestOutputKind.DELTA:
-                        # Each chunk doesn't always deliver only 1 token due to coalescing
+                        # Each chunk doesn't always deliver only 1 token
+                        # due to coalescing
                         # assert current_len == 1, (
-                        #     f"{request_id} - DELTA: Expected 1 token, got {current_len} "
+                        #     f"{request_id} - DELTA: Expected 1 token, "
+                        #     f"got {current_len} "
                         #     f"for index {comp.index}"
                         # )
                         pass
 
                     elif output_kind == RequestOutputKind.CUMULATIVE:
-                        # Token count doesn's always increase by 1 due to coalescing
+                        # Token count doesn's always increase by 1
+                        # due to coalescing
                         # expected = prev_len + 1
                         # assert current_len == expected, (
-                        #     f"{request_id} - CUMULATIVE: Expected {expected} tokens, got {current_len} "
+                        #     f"{request_id} - CUMULATIVE: Expected {expected} "
+                        #     f"tokens, got {current_len} "
                         #     f"for index {comp.index}"
                         # )
                         pass
@@ -170,8 +176,8 @@ async def test_streaming_with_parallel_sampling(
 
                 total_validated += 1
 
-            assert total_validated > 0, f"{request_id} produced no output groups"
-
+            assert total_validated > 0, (
+                f"{request_id} produced no output groups")
             return total_indices, token_all, total_validated
 
         tasks = [
@@ -190,21 +196,23 @@ async def test_streaming_with_parallel_sampling(
             if output_kind == RequestOutputKind.FINAL_ONLY:
                 # FINAL_ONLY must return only one output group
                 assert total_validated == 1, (
-                    f"{request_id} - FINAL_ONLY: Expected 1 output group, got {total_validated}"
-                )
+                    f"{request_id} - FINAL_ONLY: Expected 1 output group, "
+                    f"got {total_validated}")
 
             if output_kind == RequestOutputKind.DELTA:
                 #assert total_indices == N*NUM_TOKENS # fail due to coalesing
                 for idx, total in token_all.items():
                     assert total == NUM_TOKENS, (
-                        f"{request_id} - DELTA: Total tokens aggregated for index {idx} = {total}, "
+                        f"{request_id} - DELTA: Total tokens aggregated "
+                        f"for index {idx} = {total}, "
                         f"but expected {NUM_TOKENS}")
 
             if output_kind == RequestOutputKind.CUMULATIVE:
                 #assert total_indices == N*NUM_TOKENS # fail due to coalesing
                 assert len(set(token_all.values())) == 1
                 assert list(
-                    token_all.values())[0] == NUM_TOKENS * (NUM_TOKENS + 1) // 2
+                    token_all.values())[0] == NUM_TOKENS * (NUM_TOKENS +
+                                                            1) // 2
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -89,6 +89,118 @@ async def generate(
 
 
 @pytest.mark.parametrize(
+    "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.CUMULATIVE, RequestOutputKind.FINAL_ONLY])
+@pytest.mark.asyncio
+async def test_streaming_with_parallel_sampling(monkeypatch: pytest.MonkeyPatch, output_kind: RequestOutputKind):
+    """test parallel sampling along with ouput_kind""" 
+    engine_args = AsyncEngineArgs(model="Qwen/Qwen3-0.6B", gpu_memory_utilization=0.5)
+    with monkeypatch.context() as m, ExitStack() as after:
+        m.setenv("VLLM_USE_V1", "1")
+        with set_default_torch_num_threads(1):
+            engine = AsyncLLM.from_engine_args(engine_args)
+        after.callback(engine.shutdown)
+
+        NUM_REQUESTS = 100
+        N = 500
+        NUM_TOKENS = 50
+        prompt = "<|im_start|>user\nTell me the long history of the Earth is<|im_end|>\n<|im_start|>assistant\n<think>"
+
+        request_ids = [f"request-{i}" for i in range(NUM_REQUESTS)]
+
+        async def run_generate(engine, request_id, prompt, output_kind, num_tokens, num_index):
+            sampling_params = SamplingParams(
+                max_tokens=num_tokens,
+                min_tokens=num_tokens,
+                n=num_index,
+                output_kind=output_kind,
+                temperature=0.9,
+            )
+
+            total_validated = 0
+            total_indices = 0
+            from collections import defaultdict
+            prev_token_counts = defaultdict(int)
+            token_all = defaultdict(int)
+
+            async for output_group in engine.generate(
+                request_id=request_id,
+                prompt=prompt,
+                sampling_params=sampling_params
+            ):
+                completions = output_group.outputs
+                indices = [comp.index for comp in completions] # index = parallel samples
+                total_indices += len(indices)
+                texts = [comp.text for comp in completions]
+
+                for comp in completions:
+                    current_len = len(comp.token_ids)
+                    prev_len = prev_token_counts[comp.index]
+                    token_all[comp.index] += current_len
+                    
+                    if output_kind == RequestOutputKind.DELTA:
+                        # Each chunk doesn't always deliver only 1 token due to coalescing
+                        # assert current_len == 1, (
+                        #     f"{request_id} - DELTA: Expected 1 token, got {current_len} "
+                        #     f"for index {comp.index}"
+                        # )                        
+                        pass
+                        
+                    elif output_kind == RequestOutputKind.CUMULATIVE:
+                        # Token count doesn's always increase by 1 due to coalescing
+                        # expected = prev_len + 1
+                        # assert current_len == expected, (
+                        #     f"{request_id} - CUMULATIVE: Expected {expected} tokens, got {current_len} "
+                        #     f"for index {comp.index}"
+                        # )                        
+                        pass
+
+                    elif output_kind == RequestOutputKind.FINAL_ONLY:
+                        assert len(indices) == num_index
+
+                    else:
+                        raise ValueError(f"Unsupported output kind: {output_kind}")
+
+                    prev_token_counts[comp.index] = current_len
+
+                total_validated += 1
+
+            assert total_validated > 0, f"{request_id} produced no output groups"
+            
+            return total_indices, token_all, total_validated
+                
+        tasks = [
+            asyncio.create_task(
+                run_generate(engine, request_id, prompt, output_kind, NUM_TOKENS, N)
+            )
+            for request_id in request_ids]
+
+        results = await asyncio.gather(*tasks)
+        assert not engine.output_processor.has_unfinished_requests()
+  
+        for i, (total_indices, token_all, total_validated) in enumerate(results):
+            request_id = request_ids[i]  # Get corresponding request_id
+            
+            if output_kind == RequestOutputKind.FINAL_ONLY:
+                # FINAL_ONLY must return only one output group
+                assert total_validated == 1, (
+                    f"{request_id} - FINAL_ONLY: Expected 1 output group, got {total_validated}"
+                )
+
+            if output_kind == RequestOutputKind.DELTA:
+                #assert total_indices == N*NUM_TOKENS # fail due to coalesing
+                for idx, total in token_all.items():
+                    assert total == NUM_TOKENS, (
+                        f"{request_id} - DELTA: Total tokens aggregated for index {idx} = {total}, "
+                        f"but expected {NUM_TOKENS}"
+                    )
+                    
+            if output_kind == RequestOutputKind.CUMULATIVE:
+                #assert total_indices == N*NUM_TOKENS # fail due to coalesing
+                assert len(set(token_all.values())) == 1
+                assert list(token_all.values())[0] == NUM_TOKENS*(NUM_TOKENS+1)/2
+
+
+@pytest.mark.parametrize(
     "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
 @pytest.mark.parametrize(
     "engine_args,prompt",

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Optional
 
 import pytest
 
-from vllm import LLM, EngineArgs, LLMEngine
+from vllm import LLM, EngineArgs
+from vllm.v1.engine.llm_engine import LLMEngine
 from vllm.sampling_params import (GuidedDecodingParams, RequestOutputKind,
                                   SamplingParams)
 from vllm.v1.metrics.reader import Counter, Gauge, Histogram, Metric, Vector

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -184,8 +184,10 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
     prompts = ["The history of the Earth is" for i in range(NUM_REQUESTS)]
     request_ids = []
     from collections import defaultdict
-    partial_tokens = defaultdict(lambda: defaultdict(list))
-    finished_requests = set()
+    partial_tokens: defaultdict[
+        str, defaultdict[int, list[int]]
+    ] = defaultdict(lambda: defaultdict(list))
+    finished_requests: set[int] = set()
 
     for i, prompt in enumerate(prompts):
         request_id = f"req-{i}"

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -187,7 +187,7 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
     partial_tokens: defaultdict[
         str, defaultdict[int, list[int]]
     ] = defaultdict(lambda: defaultdict(list))
-    finished_requests: set[int] = set()
+    finished_requests: set[str] = set()
 
     for i, prompt in enumerate(prompts):
         request_id = f"req-{i}"

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -179,9 +179,8 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
     )
 
     if output_kind is None:
-        assert (
-            sampling_params.output_kind == RequestOutputKind.CUMULATIVE
-        ), "default is CUMULATIVE"         
+        assert (sampling_params.output_kind == RequestOutputKind.CUMULATIVE
+                ), "default is CUMULATIVE"
 
     prompts = ["The history of the Earth is" for i in range(NUM_REQUESTS)]
     request_ids = []
@@ -230,14 +229,12 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
                     assert len(partial_tokens[request_id]) == num_index
                     assert len(
                         set(token_all)) == 1 and token_all[0] == NUM_TOKENS
-                elif (
-                    sampling_params.output_kind == RequestOutputKind.FINAL_ONLY
-                ):
-                    assert (
-                        index_count == num_index and
-                        token_count == NUM_TOKENS
-                    )
-                    assert index_count == num_index and token_count == NUM_TOKENS
+                elif (sampling_params.output_kind ==
+                      RequestOutputKind.FINAL_ONLY):
+                    assert (index_count == num_index
+                            and token_count == NUM_TOKENS)
+                    assert (index_count == num_index
+                            and token_count == NUM_TOKENS)
                     assert len(partial_tokens[request_id]) == num_index
                     assert len(
                         set(token_all)) == 1 and token_all[0] == NUM_TOKENS

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -178,8 +178,10 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
         temperature=0.9,
     )
 
-    if output_kind == None:
-        assert sampling_params.output_kind == RequestOutputKind.CUMULATIVE, "default is CUMULATIVE"
+    if output_kind is None:
+        assert (
+            sampling_params.output_kind == RequestOutputKind.CUMULATIVE
+        ), "default is CUMULATIVE"         
 
     prompts = ["The history of the Earth is" for i in range(NUM_REQUESTS)]
     request_ids = []
@@ -215,7 +217,8 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
 
                 # 1st assert: checks the last output
                 # 2nd assert: checks the number of parallel sampling number
-                # 3rd assert: verifies each index generated the same number of tokens in sum
+                # 3rd assert: verifies each index generated the same number
+                # of tokens in sum
                 if sampling_params.output_kind == RequestOutputKind.CUMULATIVE:
                     assert index_count == 1 and token_count == NUM_TOKENS
                     assert len(partial_tokens[request_id]) == num_index
@@ -227,7 +230,13 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
                     assert len(partial_tokens[request_id]) == num_index
                     assert len(
                         set(token_all)) == 1 and token_all[0] == NUM_TOKENS
-                elif sampling_params.output_kind == RequestOutputKind.FINAL_ONLY:
+                elif (
+                    sampling_params.output_kind == RequestOutputKind.FINAL_ONLY
+                ):
+                    assert (
+                        index_count == num_index and
+                        token_count == NUM_TOKENS
+                    )
                     assert index_count == num_index and token_count == NUM_TOKENS
                     assert len(partial_tokens[request_id]) == num_index
                     assert len(

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -184,9 +184,8 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
     prompts = ["The history of the Earth is" for i in range(NUM_REQUESTS)]
     request_ids = []
     from collections import defaultdict
-    partial_tokens: defaultdict[
-        str, defaultdict[int, list[int]]
-    ] = defaultdict(lambda: defaultdict(list))
+    partial_tokens: defaultdict[str, defaultdict[
+        int, list[int]]] = defaultdict(lambda: defaultdict(list))
     finished_requests: set[str] = set()
 
     for i, prompt in enumerate(prompts):
@@ -234,7 +233,7 @@ def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
                     assert len(
                         set(token_all)) == 1 and token_all[0] == NUM_TOKENS
                 else:
-                    assert False, "output_kind is missing"
+                    raise AssertionError("output_kind is missing")
 
 
 @pytest.mark.parametrize("num_index", [2, 5])

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Optional
 import pytest
 
 from vllm import LLM, EngineArgs, LLMEngine
-from vllm.sampling_params import GuidedDecodingParams, SamplingParams, RequestOutputKind
+from vllm.sampling_params import (GuidedDecodingParams, RequestOutputKind,
+                                  SamplingParams)
 from vllm.v1.metrics.reader import Counter, Gauge, Histogram, Metric, Vector
 
 if TYPE_CHECKING:
@@ -153,107 +154,126 @@ def test_parallel_sampling(vllm_model, example_prompts) -> None:
 
 @pytest.mark.parametrize("model", ["Qwen/Qwen3-0.6B"])
 @pytest.mark.parametrize("num_index", [2, 5])
-@pytest.mark.parametrize(
-    "output_kind", [None, RequestOutputKind.CUMULATIVE, RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
-def test_llmengine_streaming_with_parallel_sampling(model, output_kind, num_index) -> None:
+@pytest.mark.parametrize("output_kind", [
+    None, RequestOutputKind.CUMULATIVE, RequestOutputKind.DELTA,
+    RequestOutputKind.FINAL_ONLY
+])
+def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
+                                                    num_index) -> None:
     """Test output_kind in LLMEngine when parallel sampling (index) `n>1`.
-    """   
+    """
     engine_args = EngineArgs(model=model, gpu_memory_utilization=0.5)
     engine = LLMEngine.from_engine_args(engine_args)
-    
+
     NUM_REQUESTS = 10
     NUM_TOKENS = 20
-      
+
     sampling_params = SamplingParams(
         max_tokens=NUM_TOKENS,
         min_tokens=NUM_TOKENS,
         n=num_index,
-        **({"output_kind": output_kind} if output_kind is not None else {}),
+        **({
+            "output_kind": output_kind
+        } if output_kind is not None else {}),
         temperature=0.9,
     )
 
     if output_kind == None:
         assert sampling_params.output_kind == RequestOutputKind.CUMULATIVE, "default is CUMULATIVE"
-    
-    prompts = [f"The history of the Earth is" for i in range(NUM_REQUESTS)]
+
+    prompts = ["The history of the Earth is" for i in range(NUM_REQUESTS)]
     request_ids = []
     from collections import defaultdict
     partial_tokens = defaultdict(lambda: defaultdict(list))
     finished_requests = set()
-    
+
     for i, prompt in enumerate(prompts):
         request_id = f"req-{i}"
         request_ids.append(request_id)
         engine.add_request(request_id, prompt, sampling_params)
-    
+
     while len(finished_requests) < len(request_ids):
         for request_output in engine.step():
             request_id = request_output.request_id
-           
+
             # Accumulate outputs by using the `index` field
             for output in request_output.outputs:
-                partial_tokens[request_id][output.index].extend(output.token_ids)
+                partial_tokens[request_id][output.index].extend(
+                    output.token_ids)
 
             if request_output.finished:
                 finished_requests.add(request_id)
-                index_count = len(set(comp.index for comp in request_output.outputs))
+                index_count = len(
+                    set(comp.index for comp in request_output.outputs))
                 token_count = len(request_output.outputs[0].token_ids)
                 # total generated token counts per index
-                token_all = [len(partial_tokens[request_id][i]) for i in partial_tokens[request_id]]
- 
+                token_all = [
+                    len(partial_tokens[request_id][i])
+                    for i in partial_tokens[request_id]
+                ]
+
                 # 1st assert: checks the last output
                 # 2nd assert: checks the number of parallel sampling number
                 # 3rd assert: verifies each index generated the same number of tokens in sum
                 if sampling_params.output_kind == RequestOutputKind.CUMULATIVE:
                     assert index_count == 1 and token_count == NUM_TOKENS
                     assert len(partial_tokens[request_id]) == num_index
-                    assert len(set(token_all)) == 1 and token_all[0] == NUM_TOKENS*(NUM_TOKENS+1)/2
+                    assert (len(set(token_all)) == 1
+                            and token_all[0] == NUM_TOKENS *
+                            (NUM_TOKENS + 1) // 2)
                 elif sampling_params.output_kind == RequestOutputKind.DELTA:
                     assert index_count == 1 and token_count == 1
                     assert len(partial_tokens[request_id]) == num_index
-                    assert len(set(token_all)) == 1 and token_all[0] == NUM_TOKENS    
+                    assert len(
+                        set(token_all)) == 1 and token_all[0] == NUM_TOKENS
                 elif sampling_params.output_kind == RequestOutputKind.FINAL_ONLY:
                     assert index_count == num_index and token_count == NUM_TOKENS
                     assert len(partial_tokens[request_id]) == num_index
-                    assert len(set(token_all)) == 1 and token_all[0] == NUM_TOKENS                   
+                    assert len(
+                        set(token_all)) == 1 and token_all[0] == NUM_TOKENS
                 else:
-                    assert False, "output_kind is missing"        
+                    assert False, "output_kind is missing"
 
 
 @pytest.mark.parametrize("num_index", [2, 5])
-@pytest.mark.parametrize(
-    "output_kind", [None, RequestOutputKind.CUMULATIVE, RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
-def test_llm_streaming_with_parallel_sampling(vllm_model, num_index, output_kind) -> None:
+@pytest.mark.parametrize("output_kind", [
+    None, RequestOutputKind.CUMULATIVE, RequestOutputKind.DELTA,
+    RequestOutputKind.FINAL_ONLY
+])
+def test_llm_streaming_with_parallel_sampling(vllm_model, num_index,
+                                              output_kind) -> None:
     """Test output_kind in LLM class when parallel sampling (index) `n>1`.
     """
     NUM_REQUESTS = 10
     NUM_TOKENS = 20
-    prompts = [f"The history of the Earth is" for i in range(NUM_REQUESTS)]
-    
+    prompts = ["The history of the Earth is" for i in range(NUM_REQUESTS)]
+
     sampling_params = SamplingParams(
         max_tokens=NUM_TOKENS,
         min_tokens=NUM_TOKENS,
         n=num_index,
-        **({"output_kind": output_kind} if output_kind is not None else {}),
+        **({
+            "output_kind": output_kind
+        } if output_kind is not None else {}),
         temperature=0.9,
     )
 
     llm = vllm_model.llm
     outputs = llm.generate(prompts, sampling_params)
-    
+
     # ATM output_kind is overwritten to FINAL_ONLY
-    assert sampling_params.output_kind == RequestOutputKind.FINAL_ONLY,(
+    assert sampling_params.output_kind == RequestOutputKind.FINAL_ONLY, (
         f"output_kind={output_kind} overwritten to FINAL_ONLY,"
         f"got {sampling_params.output_kind} instead")
-       
+
     for output in outputs:
         index_count = len(set(comp.index for comp in output.outputs))
         token_ids = output.outputs[0].token_ids
-        
+
         assert index_count == num_index
-        
+
         if index_count == 1:
-            if len(token_ids) == 1: 
+            if len(token_ids) == 1:
                 raise AssertionError("works like streaming DELTA")
             else:
                 raise AssertionError("works like streaming CUMULATIVE")

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -152,10 +152,18 @@ def test_parallel_sampling(vllm_model, example_prompts) -> None:
                 f"{len(completion_counts)} unique completions; expected"
                 f" {n}. Repeats: {repeats}")
 
+
 sampling_params_sets = [
-    {"logprobs": 2, "min_p": 0.5},
-    {"logprobs": 3, "min_p": 0.7},
+    {
+        "logprobs": 2,
+        "min_p": 0.5
+    },
+    {
+        "logprobs": 3,
+        "min_p": 0.7
+    },
 ]
+
 
 @pytest.mark.parametrize("model", ["Qwen/Qwen3-0.6B"])
 @pytest.mark.parametrize("num_index", [2, 5])
@@ -164,9 +172,8 @@ sampling_params_sets = [
     RequestOutputKind.FINAL_ONLY
 ])
 @pytest.mark.parametrize("params", sampling_params_sets)
-def test_llmengine_streaming_with_parallel_sampling(
-    model, output_kind, num_index, params
-) -> None:
+def test_llmengine_streaming_with_parallel_sampling(model, output_kind,
+                                                    num_index, params) -> None:
     """Test output_kind in LLMEngine when parallel sampling (index) `n>1`.
     """
     engine_args = EngineArgs(model=model, gpu_memory_utilization=0.5)
@@ -175,16 +182,14 @@ def test_llmengine_streaming_with_parallel_sampling(
     NUM_REQUESTS = 10
     NUM_TOKENS = 20
 
-    sampling_params = SamplingParams(
-        max_tokens=NUM_TOKENS,
-        min_tokens=NUM_TOKENS,
-        n=num_index,
-        **({
-            "output_kind": output_kind
-        } if output_kind is not None else {}),
-        temperature=0.9,
-        **params
-    )
+    sampling_params = SamplingParams(max_tokens=NUM_TOKENS,
+                                     min_tokens=NUM_TOKENS,
+                                     n=num_index,
+                                     **({
+                                         "output_kind": output_kind
+                                     } if output_kind is not None else {}),
+                                     temperature=0.9,
+                                     **params)
 
     if output_kind is None:
         assert (sampling_params.output_kind == RequestOutputKind.CUMULATIVE


### PR DESCRIPTION
## Purpose

The current test cases in  `tests` validates parallel sampling but misses the full coverage for the `output_kind` parameters which are options for streaming modes (`DELTA`, `CUMULATIVE`) and the unary `FINAL_ONLY` mode.

This PR fills  this gap by adding comprehensive test cases for all combinations of these parameters over multiple requests. The new tests cover the `LLM`, `LLMEngine`, and `AsyncLLM` classes for all the combinations in `test_llm_engine.py` and `test_async_llm.py`, addressing the issue #21948

* `test_llm_engine.py`
	 - `LLM`: test_llm_streaming_with_parallel_sampling
	 - `LLMEngine`: test_llmengine_streaming_with_parallel_sampling`
* `test_async_llm.py`
	* `AsyncLLM`: test_streaming_with_parallel_sampling

Each call is tested with `num_index` × `[RequestOutputKind.DELTA, RequestOutputKind.CUMULATIVE, RequestOutputKind.FINAL_ONLY]` combos.


## Test Plan

Directly run in `test_llm_engine.py` and `test_async_llm.py` 
`pytest -s -v vllm/tests/v1/engine/test_llm_engine.py`
`pytest -s -v vllm/tests/v1/engine/test_async_llm.py` 

## Test Results

The test cases in `test_llm_engine.py` run successfully with various values for the parallel sampling parameters `n` and `output_kind`, including stress tests. To reproduce the bug reported in #21413, several other scenarios were tested for  `LLMEngine` with  `CUMULATIVE` , but the issue hasn’t been reproduced so far.

Stress tests with the `AsyncLLM` engine show sporadic failures in stress tests, which is normal due to coalescing and possibly asynch nature . I'm willing to add more test scenarios if needed.



Fix #21948
