### PR TITLE
[Bugfix] load bias from config for Eagle

### DIFF
--- a/vllm/model_executor/models/llama_eagle.py
+++ b/vllm/model_executor/models/llama_eagle.py
@@ -71,7 +71,7 @@ class LlamaModel(nn.Module):
         ])
         self.fc = torch.nn.Linear(self.config.hidden_size * 2,
                                   self.config.hidden_size,
-                                  bias=False)
+                                  bias=getattr(self.config, "bias", False))
 
     def forward(
         self,


### PR DESCRIPTION
Models trained using the EAGLE approach have `fc.bias` set to true by default https://github.com/SafeAILab/EAGLE/blob/main/eagle/model/cnets1.py#L473 (contrary to EAGLE3 where `fc.bias` is `false` https://github.com/SafeAILab/EAGLE/blob/main/eagle/model/cnets.py#L532). While this bug was fixed previously in the PR https://github.com/vllm-project/vllm/pull/8790, but it has crept in again. 

Added the loading `bias` value from the config file. 


