### PR TITLE
[gpt-oss] Add openai-harmony as default dependency

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -49,3 +49,4 @@ ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects
 setproctitle # Used to set process names for better debugging and monitoring
+openai-harmony  # Required for gpt-oss

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -49,4 +49,4 @@ ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects
 setproctitle # Used to set process names for better debugging and monitoring
-openai-harmony  # Required for gpt-oss
+openai-harmony >= 0.0.3  # Required for gpt-oss


### PR DESCRIPTION
We believe openai-harmony is lightweight enough to be a default dependency. Also, we'd like to smoothen the user experience in deploying gpt-oss with vLLM.