### PR TITLE
[Model]Force use triton compressed_tensor_moe instead of cutlass

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -484,7 +484,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, vllm will force use Triton compressed tensor MOE kernel;
     # otherwise it will use the cutlass based one.
     "VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL":
-    lambda: bool(int(os.getenv("VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL", "0"))),
+    lambda: os.getenv("VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL", "0").lower() in ("1", "true"),
 
     # If set, vllm will force flashinfer to use tensor cores;
     # otherwise will use heuristic based on model architecture.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -481,6 +481,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"]))
     if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ else None,
 
+    # If set, vllm will force use Triton compressed tensor MOE kernel;
+    # otherwise it will use the cutlass based one.
+    "VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL":
+    lambda: bool(int(os.getenv("VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL", "0"))),
+
+    # If set, vllm will force flashinfer to use tensor cores;
+    # otherwise will use heuristic based on model architecture.
+    "VLLM_FLASHINFER_FORCE_TENSOR_CORES":
+    lambda: bool(int(os.getenv("VLLM_FLASHINFER_FORCE_TENSOR_CORES", "0"))),
+
     # Pipeline stage partition strategy
     "VLLM_PP_LAYER_PARTITION":
     lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -484,7 +484,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, vllm will force use Triton compressed tensor MOE kernel;
     # otherwise it will use the cutlass based one.
     "VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL":
-    lambda: os.getenv("VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL", "0").lower() in ("1", "true"),
+    lambda: bool(
+        int(os.getenv("VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL", "0"))),
 
     # If set, vllm will force flashinfer to use tensor cores;
     # otherwise will use heuristic based on model architecture.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -523,8 +523,10 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         # cutlass path
         self.is_fp8_w8a8_sm100 = quant_config._is_fp8_w8a8_sm100(
             self.weight_quant, self.input_quant)
-        self.use_cutlass = (quant_config._is_fp8_w8a8_sm90(
+        self.use_cutlass = ((quant_config._is_fp8_w8a8_sm90(
             self.weight_quant, self.input_quant) or self.is_fp8_w8a8_sm100)
+            and not envs.VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL)
+        self.fused_experts = None  # type: ignore[assignment]
         self.disable_expert_map = False
 
     def create_weights(self, layer: torch.nn.Module, num_experts: int,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -524,8 +524,8 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         self.is_fp8_w8a8_sm100 = quant_config._is_fp8_w8a8_sm100(
             self.weight_quant, self.input_quant)
         self.use_cutlass = ((quant_config._is_fp8_w8a8_sm90(
-            self.weight_quant, self.input_quant) or self.is_fp8_w8a8_sm100)
-            and not envs.VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL)
+            self.weight_quant, self.input_quant) or self.is_fp8_w8a8_sm100) and
+                            not envs.VLLM_TRITON_COMPRESSED_TENSORS_MOE_KERNEL)
         self.fused_experts = None  # type: ignore[assignment]
         self.disable_expert_map = False
 


### PR DESCRIPTION
…  this improves performance for llama4

# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
This PR is to improve performance of LLama 4 by force use triton based compressed tensor MOE kernel with the help of a flagh. Changed the following files:

    envs.py: added environment varaibles
    compressed_tensors_moe.py: logic to force override triton kernel 


## Test Plan
an with a uploaded scout based eagle to test E2E
Example cmd

CUDA_VISIBLE_DEVICES=4,5,6,7 VLLM_USE_V1=1 python examples/offline_inference/spec_decode.py  --num_spec_tokens 7 --num_prompts 1 --method eagle --model_dir /home/$USER/local/models/scout_base_HF_20250605_201140 --eagle_dir /home/$USER/local/models/scout_draft_HF_20250605_202942 --tp 4

unit test: python -m pytest tests/v1/e2e/test_spec_decode.py

vllm serve + benchmarking
EAGLE server cmd

#!/bin/bash
# Configuration of environment variables
export CUDA_VISIBLE_DEVICES=4,5,6,7
export VLLM_USE_V1=1
# Command to run the vllm server
spec_dec_config='{"method": "eagle", "model": "/home/$USER/local/models/scout_draft_HF_20250605_202942", "prefill_token_shift": false, "num_speculative_tokens": 3, "draft_tensor_parallel_size": 4, "max_model_len": 32768}'
vllm serve /home/$USER/local/models/scout_base_HF_20250605_201140 --disable-log-requests \
    -tp 4 \
    --max-num-seqs 128 \
    --max_num_batched_tokens=80000 \
    --max-model-len=32768 \
    --no-enable-prefix-caching \
    --trust-remote-code \
    --speculative-config="$spec_dec_config" \
    --num-lookahead-slots=3 \
    2>&1 | tee /data/users/$USER/logs/server/vllm_17b16e_vllm_serving$(date +%Y%m%d_%H%M%S).log

base cmd = eagle server cmd, removing --speculative-config="$spec_dec_config" \

benchmarking

python benchmarks/benchmark_serving.py --backend vllm --model /home/$USER/local/models/scout_base_HF_20250605_201140 --dataset-name hf --dataset-path philschmid/mt-bench --seed 0 --max-concurrency 16 2>&1 | tee /data/users/$USER/tmp/vllm_17b16e_vllm_loadgen$(date +%Y%m%d_%H%M%S).log\n


## Test Result
[WIP]

## (Optional) Documentation Update

