### PR TITLE
Update `hf_xet` pin to resolve hangs

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,6 @@ tqdm
 blake3
 py-cpuinfo
 transformers >= 4.55.0
-huggingface-hub[hf_xet] >= 0.33.0  # Required for Xet downloads.
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -31,7 +31,6 @@ lm-eval[api]==0.4.8 # required for model evaluation test
 mteb>=1.38.11, <2 # required for mteb test
 transformers==4.52.4
 tokenizers==0.21.1
-huggingface-hub[hf_xet]>=0.30.0  # Required for Xet downloads.
 schemathesis>=3.39.15 # Required for openai schema test.
 # quantization
 bitsandbytes>=0.46.1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -37,7 +37,6 @@ lm-eval[api]==0.4.8 # required for model evaluation test
 mteb[bm25s]>=1.38.11, <2 # required for mteb test
 transformers==4.55.0
 tokenizers==0.21.1
-huggingface-hub[hf_xet]>=0.33.0  # Required for Xet downloads.
 schemathesis>=3.39.15 # Required for openai schema test.
 # quantization
 bitsandbytes==0.46.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -276,7 +276,7 @@ h5py==3.13.0
     # via terratorch
 harfile==0.3.0
     # via schemathesis
-hf-xet==1.1.3
+hf-xet==1.1.7
     # via huggingface-hub
 hiredis==3.0.0
     # via tensorizer

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -288,7 +288,6 @@ httpx==0.27.2
     #   schemathesis
 huggingface-hub==0.34.3
     # via
-    #   -r requirements/test.in
     #   accelerate
     #   datasets
     #   evaluate


### PR DESCRIPTION
Should resolve issue reported in https://vllm-dev.slack.com/archives/C07R5PAL2L9/p1753374336027519.

Note that `hf_xet` has been a hard requirement of `huggingface_hub` since `0.31.0`, so we no longer need to explicitly require `huggingface_hub[hf_xet]`.