### PR TITLE
Use float32 for test_completion.py

### DIFF
--- a/tests/v1/entrypoints/openai/test_completion.py
+++ b/tests/v1/entrypoints/openai/test_completion.py
@@ -22,7 +22,7 @@ def default_server_args():
     return [
         # use half precision for speed and memory savings in CI environment
         "--dtype",
-        "bfloat16",
+        "float32",
         "--max-model-len",
         "2048",
         "--max-num-seqs",

--- a/tests/v1/entrypoints/openai/test_completion.py
+++ b/tests/v1/entrypoints/openai/test_completion.py
@@ -20,7 +20,6 @@ MODEL_NAME = "facebook/opt-125m"
 @pytest.fixture(scope="module")
 def default_server_args():
     return [
-        # use half precision for speed and memory savings in CI environment
         "--dtype",
         "float32",
         "--max-model-len",


### PR DESCRIPTION
Try to fix this flaky test https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests/e0037ea8-753f-8000-938f-d772ab07343e?branch=main&period=1day

<img width="902" height="717" alt="Screenshot 2025-08-06 at 12 05 15 PM" src="https://github.com/user-attachments/assets/e31ae723-c34f-478a-a727-507d5c37f8c9" />
