### PR TITLE
Update `flashinfer-python==0.2.10`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -392,7 +392,7 @@ RUN --mount=type=bind,from=build,src=/workspace/dist,target=/vllm-workspace/dist
 ARG FLASHINFER_GIT_REPO="https://github.com/flashinfer-ai/flashinfer.git"
 # Keep this in sync with https://github.com/vllm-project/vllm/blob/main/requirements/cuda.txt
 # We use `--force-reinstall --no-deps` to avoid issues with the existing FlashInfer wheel.
-ARG FLASHINFER_GIT_REF="v0.2.9"
+ARG FLASHINFER_GIT_REF="v0.2.10"
 RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
   . /etc/environment
     git clone --depth 1 --recursive --shallow-submodules \

--- a/setup.py
+++ b/setup.py
@@ -665,7 +665,7 @@ setup(
                   "mistral_common[audio]"],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility
         # FlashInfer should be updated together with the Dockerfile
-        "flashinfer": ["flashinfer-python==0.2.9"],
+        "flashinfer": ["flashinfer-python==0.2.10"],
     },
     cmdclass=cmdclass,
     package_data=package_data,


### PR DESCRIPTION
Needed for GPT-OSS Support: Add Blackwell MoE mxfp4 implementation from TRTLLM and Attention Sink in https://github.com/flashinfer-ai/flashinfer/pull/1389