### PR TITLE
Ability to use custom-all-reduce on systems with more than 2 PCIe GPUs via env var

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -137,8 +137,9 @@ class CustomAllreduce:
             logger.warning(
                 "Custom allreduce is disabled because it's not supported on"
                 " more than two PCIe-only GPUs. To silence this warning, "
-                "specify disable_custom_all_reduce=True explicitly. To bypass"
-                "check set env variable VLLM_SKIP_NVLINK_CHECK=1.")
+                "specify disable_custom_all_reduce=True explicitly. To bypass "
+                "this check, set the environment variable "
+                "VLLM_SKIP_INTERCONNECT_CHECK=1.")
             return
         # test P2P capability, this checks software/cudaruntime support
         # this is expensive to compute at the first time

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -137,7 +137,8 @@ class CustomAllreduce:
             logger.warning(
                 "Custom allreduce is disabled because it's not supported on"
                 " more than two PCIe-only GPUs. To silence this warning, "
-                "specify disable_custom_all_reduce=True explicitly.")
+                "specify disable_custom_all_reduce=True explicitly. To bypass"
+                "check set env variable VLLM_SKIP_NVLINK_CHECK=1.")
             return
         # test P2P capability, this checks software/cudaruntime support
         # this is expensive to compute at the first time

--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -153,8 +153,9 @@ class QuickAllReduce:
         if self.world_size > 2 and not self.fully_connected:
             logger.debug(
                 "Custom quick allreduce is disabled because it's not supported "
-                "on more than two PCIe-only GPUs. To bypass"
-                "check set env variable VLLM_SKIP_NVLINK_CHECK=1.")
+                "on more than two PCIe-only GPUs. To bypass "
+                "this check, set the environment variable "
+                "VLLM_SKIP_INTERCONNECT_CHECK=1.")
             return
 
         self.init_quick_all_reduce()

--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -153,7 +153,8 @@ class QuickAllReduce:
         if self.world_size > 2 and not self.fully_connected:
             logger.debug(
                 "Custom quick allreduce is disabled because it's not supported "
-                "on more than two PCIe-only GPUs. ")
+                "on more than two PCIe-only GPUs. To bypass"
+                "check set env variable VLLM_SKIP_NVLINK_CHECK=1.")
             return
 
         self.init_quick_all_reduce()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_SKIP_P2P_CHECK: bool = False
+    VLLM_SKIP_NVLINK_CHECK: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
     VLLM_USE_V1: bool = True
     VLLM_ROCM_USE_AITER: bool = False
@@ -686,6 +687,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # See https://github.com/vllm-project/vllm/blob/a9b15c606fea67a072416ea0ea115261a2756058/vllm/distributed/device_communicators/custom_all_reduce_utils.py#L101-L108 for details. # noqa
     "VLLM_SKIP_P2P_CHECK":
     lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "1") == "1",
+
+    # Allow custom all-reduce optimizations for systems without full NVLink
+    # support with more than 2 GPUs
+    "VLLM_SKIP_NVLINK_CHECK":
+    lambda: os.getenv("VLLM_SKIP_NVLINK_CHECK", "0") == "1",
 
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -87,7 +87,7 @@ if TYPE_CHECKING:
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_SKIP_P2P_CHECK: bool = False
-    VLLM_SKIP_NVLINK_CHECK: bool = False
+    VLLM_SKIP_INTERCONNECT_CHECK: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
     VLLM_USE_V1: bool = True
     VLLM_ROCM_USE_AITER: bool = False
@@ -688,10 +688,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SKIP_P2P_CHECK":
     lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "1") == "1",
 
-    # Allow custom all-reduce optimizations for systems without full NVLink
-    # support with more than 2 GPUs
-    "VLLM_SKIP_NVLINK_CHECK":
-    lambda: os.getenv("VLLM_SKIP_NVLINK_CHECK", "0") == "1",
+    # Allow custom all-reduce optimizations for systems without full high-speed
+    # interconnect support (e.g. NVLink, XGMI) with more than 2 GPUs
+    "VLLM_SKIP_INTERCONNECT_CHECK":
+    lambda: os.getenv("VLLM_SKIP_INTERCONNECT_CHECK", "0") == "1",
 
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -565,6 +565,9 @@ class NvmlCudaPlatform(CudaPlatformBase):
         """
         query if the set of gpus are fully connected by nvlink (1 hop)
         """
+        if envs.VLLM_SKIP_NVLINK_CHECK:
+            logger.info("Skipping NVLink check.")
+            return True
         handles = [
             pynvml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_ids
         ]

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -565,8 +565,8 @@ class NvmlCudaPlatform(CudaPlatformBase):
         """
         query if the set of gpus are fully connected by nvlink (1 hop)
         """
-        if envs.VLLM_SKIP_NVLINK_CHECK:
-            logger.info("Skipping NVLink check.")
+        if envs.VLLM_SKIP_INTERCONNECT_CHECK:
+            logger.info("Skipping interconnect check.")
             return True
         handles = [
             pynvml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_ids

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -275,8 +275,8 @@ class RocmPlatform(Platform):
         """
         Query if the set of gpus are fully connected by xgmi (1 hop)
         """
-        if envs.VLLM_SKIP_NVLINK_CHECK:
-            logger.info("Skipping NVLink check.")
+        if envs.VLLM_SKIP_INTERCONNECT_CHECK:
+            logger.info("Skipping interconnect check.")
             return True
         handles = [
             amdsmi_get_processor_handles()[i] for i in physical_device_ids

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -275,6 +275,9 @@ class RocmPlatform(Platform):
         """
         Query if the set of gpus are fully connected by xgmi (1 hop)
         """
+        if envs.VLLM_SKIP_NVLINK_CHECK:
+            logger.info("Skipping NVLink check.")
+            return True
         handles = [
             amdsmi_get_processor_handles()[i] for i in physical_device_ids
         ]


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
Allow custom all-reduce optimizations for systems without full NVLink support with more than 2 GPUs via using env variable `VLLM_SKIP_INTERCONNECT_CHECK =1`.

## Test Plan
Compare perf with `QuantTrio/GLM-4.5-Air-GPTQ-Int4-Int8Mix` on 4 x 3090 with env var set and unset with https://github.com/chigkim/prompt-test

Command to start server:
```
export VLLM_SLEEP_WHEN_IDLE=1
export VLLM_SKIP_INTERCONNECT_CHECK =1
export CUDA_VISIBLE_DEVICES=0,1,2,3

vllm serve /home/ubuntu/models/GLM-4.5-Air-GPTQ-Int4-Int8Mix-QuantTrio \
    -tp 4 \
    --port 8000 \
    --host 0.0.0.0 \
    --uvicorn-log-level info \
    --trust-remote-code \
    --disable-sliding-window \
    --gpu-memory-utilization 0.9 \
    --max-model-len 123000 \
    --max-seq-len-to-capture 123000 \
    --max-num-seqs 1 \
    --enable-expert-parallel \
    --trust-remote-code \
    --dtype=float16 \
    --tool-call-parser glm45 \
    --reasoning-parser glm45 \
    --enable-auto-tool-choice \
    --seed 1234
```

## Test Result
Without var set - performance for single batch size is 70 TG/s, with var set is 80 TG/s on my system for 1000 tokens prompt length.

## (Optional) Documentation Update

