### PR TITLE
[Metrics] Expose num_requests_waiting_by_priority metric

### DIFF
--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -129,8 +130,9 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_request_counts(self) -> tuple[int, int]:
-        """Returns (num_running_reqs, num_waiting_reqs)."""
+    def get_request_counts(self) -> tuple[int, int, Counter[int]]:
+        """Returns (num_running_reqs, num_waiting_reqs, 
+        num_waiting_reqs_by_priority)."""
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -5,7 +5,7 @@ import queue
 import signal
 import threading
 import time
-from collections import deque
+from collections import Counter, deque
 from collections.abc import Generator
 from concurrent.futures import Future
 from contextlib import ExitStack, contextmanager
@@ -930,7 +930,7 @@ class DPEngineCoreProc(EngineCoreProc):
         # finished with DP peers every N steps.
         self.step_counter = 0
         self.current_wave = 0
-        self.last_counts = (0, 0)
+        self.last_counts: tuple[int, int, Counter] = (0, 0, Counter())
 
         # Initialize the engine.
         dp_rank = vllm_config.parallel_config.data_parallel_rank

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -29,9 +29,9 @@ class PrefixCacheStats:
 @dataclass
 class SchedulerStats:
     """Stats associated with the scheduler."""
-
     num_running_reqs: int = 0
     num_waiting_reqs: int = 0
+    num_waiting_reqs_by_priority: dict[int, int] = field(default_factory=dict)
 
     # These are used for internal DP load-balancing.
     step_counter: int = 0


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Currently, there is no direct way to observe the number of waiting requests broken down by priority. This information is valuable for upstream services (e.g., API gateways, load balancers) that need to implement intelligent load shedding or routing logic based on the server's state.

For example, if the queue for high-priority requests is growing, an upstream service might decide to temporarily reject new, low-priority requests to ensure the high-priority ones are processed promptly.

## Test Plan
1. Launch the vLLM server with priority scheduling enabled. 
```
# python -m vllm.entrypoints.openai.api_server   --disable-log-requests    --gpu-memory-utilization=0.8    --seed=0   --tensor-parallel-size=1       --model=meta-llama/Llama-3.2-1B-Instruct   --trust-remote-code --scheduling-policy priority
```
2. Configure a load generation tool capable of sending chat completion requests with a priority field in the request.
3. Scrape the /metrics endpoint of the vLLM server and verify the num_requests_waiting_by_priority metric is exposed as expected
```
curl http://localhost:8000/metrics 
```


## Test Result
Verified the num_requests_waiting_by_priority is exposed as below
```
vllm:num_requests_waiting{engine="0",model_name="meta-llama/Llama-3.2-1B-Instruct"} 114.0
# HELP vllm:num_requests_waiting_by_priority Number of requests waiting to be processed, by priority.
# TYPE vllm:num_requests_waiting_by_priority gauge
vllm:num_requests_waiting_by_priority{engine="0",model_name="meta-llama/Llama-3.2-1B-Instruct",priority="0"} 1.0
vllm:num_requests_waiting_by_priority{engine="0",model_name="meta-llama/Llama-3.2-1B-Instruct",priority="1"} 32.0
vllm:num_requests_waiting_by_priority{engine="0",model_name="meta-llama/Llama-3.2-1B-Instruct",priority="2"} 82.0
```

## (Optional) Documentation Update

