### PR TITLE
[feature] add all_reduce registry for custom backends

### DIFF
--- a/examples/offline_inference/all_reduce_registry_example.py
+++ b/examples/offline_inference/all_reduce_registry_example.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Simple example showing how to use the all_reduce registry with custom backends.
+
+Usage:
+    # With custom backend (sets VLLM_ALLREDUCE_BACKEND)
+    python examples/offline_inference/all_reduce_registry_example.py \
+        --backend=my_custom_backend
+
+    # Without setting environment variable (uses system default)
+    python examples/offline_inference/all_reduce_registry_example.py --no-env-backend
+"""
+
+import torch
+from torch.distributed import ProcessGroup
+
+from vllm import LLM, SamplingParams
+from vllm.distributed.device_communicators.all_reduce_registry import (
+    get_allreduce_info,
+    register_allreduce_backend,
+)
+
+
+def my_custom_all_reduce(tensor: torch.Tensor, group: ProcessGroup) -> torch.Tensor:
+    """
+    Example custom all_reduce backend.
+
+    This shows how to write your own all_reduce function.
+    For safety, it uses torch.distributed.all_reduce internally.
+    """
+    print(f"Using my custom all_reduce! Tensor shape: {tensor.shape}")
+
+    # Your custom logic here (preprocessing, logging, etc.)
+    result = tensor.clone()
+    torch.distributed.all_reduce(result, group=group)
+
+    print("Custom all_reduce completed!")
+    return result
+
+
+def main():
+    # Parse simple arguments
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model", default="meta-llama/Llama-3.2-3B-Instruct", help="Model to use"
+    )
+    parser.add_argument("--tp-size", type=int, default=2, help="Tensor parallel size")
+    parser.add_argument(
+        "--backend", default="torch_distributed", help="All-reduce backend"
+    )
+    parser.add_argument(
+        "--no-env-backend",
+        action="store_true",
+        help="Don't set VLLM_ALLREDUCE_BACKEND environment variable",
+    )
+    args = parser.parse_args()
+
+    print("=== All-Reduce Registry Example ===")
+
+    # Step 1: Register your custom backend
+    print("1. Registering custom all_reduce backend...")
+    register_allreduce_backend(name="my_custom_backend", backend=my_custom_all_reduce)
+
+    # Step 2: Show what backends are available
+    print("2. Available backends:")
+    info = get_allreduce_info()
+    print(f"   Backends: {info['backends']}")
+    print(f"   Default: {info['default']}")
+
+    # Step 3: Set which backend to use
+    import os
+
+    if args.no_env_backend:
+        print("3. Skipping VLLM_ALLREDUCE_BACKEND (using system default)")
+    else:
+        print(f"3. Setting VLLM_ALLREDUCE_BACKEND to: {args.backend}")
+        os.environ["VLLM_ALLREDUCE_BACKEND"] = args.backend
+
+    # Step 4: Create LLM and run inference
+    print("4. Creating LLM...")
+    llm = LLM(
+        model=args.model,
+        tensor_parallel_size=args.tp_size,
+    )
+
+    print("5. Running inference...")
+    prompts = ["Hello, my name is", "The capital of France is"]
+    sampling_params = SamplingParams(temperature=0, max_tokens=20, top_k=1)
+    outputs = llm.generate(prompts, sampling_params)
+
+    # Step 5: Show results
+    print("6. Results:")
+    for output in outputs:
+        print(f"   Prompt: {output.prompt}")
+        print(f"   Output: {output.outputs[0].text}")
+        print()
+
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/distributed/device_communicators/all_reduce_registry.py
+++ b/vllm/distributed/device_communicators/all_reduce_registry.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Registry for all_reduce backends.
+
+This module provides a plugin system for all_reduce backends, allowing
+users to register their own custom all_reduce kernels.
+"""
+
+import threading
+from typing import Any, Optional, Protocol
+
+import torch
+from torch.distributed import ProcessGroup
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class AllReduceBackend(Protocol):
+    """Protocol for all_reduce backends."""
+
+    def __call__(self, tensor: torch.Tensor,
+                 group: ProcessGroup) -> torch.Tensor:
+        """Perform all_reduce operation on the given tensor."""
+        ...
+
+
+class AllReduceRegistry:
+    """Registry for all_reduce backends with thread-safe operations."""
+
+    def __init__(self):
+        self._backends: dict[str, AllReduceBackend] = {}
+        self._default_backend: Optional[str] = None
+        self._lock = threading.RLock()
+
+    def register(self,
+                 name: str,
+                 backend: AllReduceBackend,
+                 is_default: bool = False) -> None:
+        """Register an all_reduce backend."""
+        if not callable(backend):
+            raise ValueError("Backend must be callable")
+
+        with self._lock:
+            self._backends[name] = backend
+            if is_default or self._default_backend is None:
+                self._default_backend = name
+
+    def get(self, name: Optional[str] = None) -> Optional[AllReduceBackend]:
+        """Get an all_reduce backend by name or return default."""
+        with self._lock:
+            backend_name = name or self._default_backend
+            return self._backends.get(backend_name) if backend_name else None
+
+    def list_backends(self) -> dict[str, AllReduceBackend]:
+        """List all registered backends."""
+        with self._lock:
+            return self._backends.copy()
+
+
+# Global registry instance
+_registry = AllReduceRegistry()
+
+
+def register_allreduce_backend(name: str,
+                               backend: AllReduceBackend,
+                               is_default: bool = False) -> None:
+    """Register an all_reduce backend globally."""
+    _registry.register(name, backend, is_default)
+
+
+def get_allreduce_backend(
+        name: Optional[str] = None) -> Optional[AllReduceBackend]:
+    """Get an all_reduce backend by name."""
+    return _registry.get(name)
+
+
+def list_allreduce_backends() -> dict[str, AllReduceBackend]:
+    """List all registered all_reduce backends."""
+    return _registry.list_backends()
+
+
+def get_allreduce_info() -> dict[str, Any]:
+    """Get detailed information about all registered backends."""
+    with _registry._lock:
+        return {
+            "backends": list(_registry._backends.keys()),
+            "default": _registry._default_backend,
+            "count": len(_registry._backends)
+        }
+
+
+def torch_all_reduce(tensor: torch.Tensor,
+                     group: ProcessGroup) -> torch.Tensor:
+    """Default torch.distributed.all_reduce backend."""
+    output = tensor.clone()
+    torch.distributed.all_reduce(output, group=group)
+    return output
+
+
+# Register the default backend
+register_allreduce_backend("torch_distributed",
+                           torch_all_reduce,
+                           is_default=True)

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -10,6 +10,7 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
+from .all_reduce_registry import get_allreduce_backend, list_allreduce_backends
 from .base_device_communicator import DeviceCommunicatorBase
 
 logger = init_logger(__name__)
@@ -36,6 +37,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
 
         self.use_pynccl = use_pynccl
         self.use_custom_allreduce = use_custom_allreduce
+
+        # Setup plugin allreduce backend if specified
+        self._setup_plugin_allreduce_backend()
 
         # lazy import to avoid documentation build error
         from vllm.distributed.device_communicators.custom_all_reduce import (
@@ -90,7 +94,31 @@ class CudaCommunicator(DeviceCommunicatorBase):
             else:
                 raise ValueError(f"Unknown all2all backend: {all2all_backend}")
 
+    def _setup_plugin_allreduce_backend(self):
+        """Setup plugin all_reduce backend if specified."""
+        # Initialize the plugin backend to None
+        self._plugin_allreduce_backend = None
+
+        backend_name = envs.VLLM_ALLREDUCE_BACKEND
+        if backend_name is not None:
+            backend = get_allreduce_backend(backend_name)
+            if backend is not None:
+                self._plugin_allreduce_backend = backend
+                logger.info("Using plugin all_reduce backend: %s",
+                            backend_name)
+            else:
+                available = list(list_allreduce_backends().keys())
+                logger.warning(
+                    "Requested all_reduce backend '%s' not found. "
+                    "Available backends: %s. "
+                    "Falling back to default behavior.", backend_name,
+                    available)
+
     def all_reduce(self, input_):
+        # Check plugin backend first
+        if self._plugin_allreduce_backend is not None:
+            return self._plugin_allreduce_backend(input_, self.device_group)
+
         # always try quick reduce first, then custom allreduce,
         # and then pynccl. (quick reduce just for ROCM MI3*)
         qr_comm = self.qr_comm

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,6 +156,7 @@ if TYPE_CHECKING:
     VLLM_USE_TRTLLM_DECODE_ATTENTION: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_BF16: bool = False
+    VLLM_ALLREDUCE_BACKEND: Optional[str] = None
 
 
 def get_default_cache_root():
@@ -1089,6 +1090,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #    never removed from memory until the server terminates.
     "VLLM_ENABLE_RESPONSES_API_STORE":
     lambda: bool(int(os.getenv("VLLM_ENABLE_RESPONSES_API_STORE", "0"))),
+
+    # Specify which all_reduce backend to use. If not set, uses the
+    # default behavior (try quick reduce, custom allreduce, pynccl, then torch).
+    "VLLM_ALLREDUCE_BACKEND": lambda: os.getenv("VLLM_ALLREDUCE_BACKEND", None),
 }
 
 # --8<-- [end:env-vars-definition]


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

I am trying to use all reduce implementation might not suitable for all the models and hardwares. 

So implement this to add all_reduce registry for custom backends. 

## Test Plan & Test Result

### Functional

- functional works

```
# run with VLLM_ALLREDUCE_BACKEND=my_custom_backend
python examples/offline_inference/all_reduce_registry_example.py --backend=my_custom_backend

# logs
(EngineCore_0 pid=2904808) (VllmWorker TP0 pid=2904816) Using my custom all_reduce! Tensor shape: torch.Size([1024, 3072])
(EngineCore_0 pid=2904808) (VllmWorker TP0 pid=2904816) Custom all_reduce completed!

# output
   Prompt: Hello, my name is
   Output:  [Your Name] and I am a [Your Profession/Student/Enthusiast] with

   Prompt: The capital of France is
   Output:  Paris. The capital of Italy is Rome. The capital of Spain is Madrid. The capital of Germany

# run without (default behavior)
python examples/offline_inference/all_reduce_registry_example.py --no-env-backend

# output 
   Prompt: Hello, my name is
   Output:  [Your Name] and I am a [Your Profession/Student/Enthusiast] with

   Prompt: The capital of France is
   Output:  Paris. The capital of Italy is Rome. The capital of Spain is Madrid. The capital of Germany
```

### Performance
- No performance regression observed

Test with
```
VLLM_USE_V1=1 vllm serve meta-llama/Llama-3.2-3B-Instruct --disable-log-requests --no-enable-prefix-caching -tp 8 --dtype auto

python3 benchmarks/benchmark_serving.py --model meta-llama/Llama-3.2-3B-Instruct --dataset-name sonnet --dataset-path benchmarks/sonnet.txt --num-prompts 500 --request-rate 10
```

Before PR
```
============ Serving Benchmark Result ============
Successful requests:                     500       
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  50.46     
Total input tokens:                      254452    
Total generated tokens:                  75000     
Request throughput (req/s):              9.91      
Output token throughput (tok/s):         1486.33   
Total Token throughput (tok/s):          6528.99   
---------------Time to First Token----------------
Mean TTFT (ms):                          17.61     
Median TTFT (ms):                        18.18     
P99 TTFT (ms):                           28.34     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.24      
Median TPOT (ms):                        3.21      
P99 TPOT (ms):                           3.75      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.24      
Median ITL (ms):                         2.99      
P99 ITL (ms):                            11.30     
==================================================
```
After PR
```
============ Serving Benchmark Result ============
Successful requests:                     500       
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  50.46     
Total input tokens:                      254452    
Total generated tokens:                  75000     
Request throughput (req/s):              9.91      
Output token throughput (tok/s):         1486.35   
Total Token throughput (tok/s):          6529.08   
---------------Time to First Token----------------
Mean TTFT (ms):                          17.20     
Median TTFT (ms):                        18.11     
P99 TTFT (ms):                           25.29     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.23      
Median TPOT (ms):                        3.21      
P99 TPOT (ms):                           3.69      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.23      
Median ITL (ms):                         2.98      
P99 ITL (ms):                            11.26     
==================================================
```