### PR TITLE
[bugfix] Fix Llama3/4 issues caused by FlashInfer 0.2.10

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -6,14 +6,22 @@ import torch
 
 
 def calculate_tile_tokens_dim(num_tokens, top_k, num_experts):
-    from flashinfer import next_positive_power_of_2
 
-    # Guess tokens per expert assuming perfect expert distribution first.
-    num_tokens_per_expert = (num_tokens * top_k) // num_experts
-    # And pad the number to the next power of 2.
-    tile_tokens_dim = next_positive_power_of_2(num_tokens_per_expert)
-    # Cap to 8-64 tokens per CTA tile as it's the range supported by the kernel.
-    tile_tokens_dim = min(max(tile_tokens_dim, 8), 64)
+    # FlashInfer 0.2.10 has issues with larger tile sizes. Set to 8 for now.
+    # TODO: Revert this to dynamic calculation once a new version of FlashInfer
+    # with the necessary kernels is released.
+    tile_tokens_dim = 8
+
+    # from flashinfer import next_positive_power_of_2
+
+    # # Guess tokens per expert assuming perfect expert distribution first.
+    # num_tokens_per_expert = (num_tokens * top_k) // num_experts
+    # # And pad the number to the next power of 2.
+    # tile_tokens_dim = next_positive_power_of_2(num_tokens_per_expert)
+    # # Cap to 8-64 tokens per CTA tile as it's the range supported by the
+    # # kernel.
+    # tile_tokens_dim = min(max(tile_tokens_dim, 8), 64)
+
     return tile_tokens_dim
 
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -524,7 +524,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         head_dim = self.kv_cache_spec.head_size
 
         # currently prefill trtllm attention does not support fp8 kv cache
-        prefill_use_trtllm = use_trtllm_attention(
+        prefill_use_trtllm = not cache_dtype.startswith("fp8") \
+                                and use_trtllm_attention(
                                 num_prefill_tokens, max_seq_len, cache_dtype,
                                 num_qo_heads, num_kv_heads, head_dim)
         decode_use_trtllm = use_trtllm_attention(


### PR DESCRIPTION
Changes:

1. Set FlashInfer trtllm MoE tile size back to 8 since kernels with larger tile sizes are missing in FlashInfer 0.2.10.
2. Disable FlashInfer trtllm prefill attn backend when kv-cache dtype if FP8 because here is no BF16-Q FP8-KV prefill kernels in FlashInfer 0.2.10.

# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fix Llama3/4 issues caused by FlashInfer 0.2.10

## Test Plan

Llama4 Scout FP8 on B200

```
export VLLM_ATTENTION_BACKEND=FLASHINFER
export VLLM_USE_TRTLLM_ATTENTION=1
export VLLM_USE_FLASHINFER_MOE_FP8=1

vllm serve nvidia/Llama-4-Scout-17B-16E-Instruct-FP8 \
  --host 0.0.0.0 \
  --port 8080 \
  --tokenizer nvidia/Llama-4-Scout-17B-16E-Instruct-FP8 \
  --kv-cache-dtype fp8 \
  --trust-remote-code \
  --gpu-memory-utilization 0.9 \
  --compilation-config '{"pass_config":{"enable_fi_allreduce_fusion":true},"level":3,"custom_ops":["+quant_fp8","+rms_norm"],"full_cuda_graph":true}' \
  --async-scheduling \
  --enable-chunked-prefill \
  --no-enable-prefix-caching \
  --pipeline-parallel-size 1 \
  --tensor-parallel-size 1 \
  --max-num-seqs 512 \
  --max-num-batched-tokens 8192 \
  --max-model-len 9216 &

lm_eval \
  --model local-completions \
  --tasks gsm8k \
  --model_args \
base_url=http://0.0.0.0:8080/v1/completions,\
model=nvidia/HF_model_hub/Llama-4-Scout-17B-16E-Instruct-FP8,\
tokenized_requests=False,tokenizer_backend=None,\
num_concurrent=128,timeout=120,max_retries=5

```

## Test Result

```
local-completions (base_url=http://0.0.0.0:8080/v1/completions,model=nvidia/Llama-4-Scout-17B-16E-Instruct-FP8,tokenized_requests=False,tokenizer_backend=None,num_concurrent=128,timeout=120,max_retries=5), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9128|±  |0.0078|
|     |       |strict-match    |     5|exact_match|↑  |0.8923|±  |0.0085|
```

## (Optional) Documentation Update

