### PR TITLE
[Docs] Add missing dependency for docs build

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -19,6 +19,7 @@ cloudpickle
 fastapi
 msgspec
 openai
+openai-harmony
 partial-json-parser
 pillow
 psutil


### PR DESCRIPTION
Should fix failing docs builds