### PR TITLE
[Speculators][Speculative Decoding] Add Eagle3 support for Qwen2

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -475,6 +475,13 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
+    
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int]:
+        num_layers = len(self.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -475,13 +475,13 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
-    
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int]) -> None:
+        self.model.aux_hidden_state_layers = layers
+
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int]:
         num_layers = len(self.model.layers)
         return (2, num_layers // 2, num_layers - 3)
-
-    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR enables support for **Eagle-style speculative decoding** on the **Qwen2 model architecture**.

The change is a straightforward addition of the `get_eagle3_aux_hidden_state_layers` method to the `Qwen2ForCausalLM` class. This implementation is minimal and directly follows the established pattern used for other models with Eagle support, such as Llama and Qwen3, ensuring consistency across the framework.

## Test Plan

Since a public Qwen2 model with Eagle heads is not currently available for full end-to-end testing, I have focused on ensuring that this change does not negatively impact the existing Qwen2 functionality.

The standard regression test for the `Qwen/Qwen2.5-0.5B-Instruct` model was executed to verify this.

## Test Result

The regression test was executed using the following command:
```bash
pytest tests/models/language/generation/test_common.py -k "Qwen2"
```

The test **passed successfully**, confirming that the standard Qwen2 model functionality remains unaffected by this change.

> **Final Test Summary:**
> ```
> =================== 1 passed, 17 deselected, 8 warnings in 89.19s (0:01:29) ====================
> ```

Given the simplicity of the change and its consistency with existing model implementations, I believe it is safe to merge. I would appreciate it if a maintainer with access to the necessary models could perform a final validation.

## (Optional) Documentation Update

No documentation changes are included in this PR. 

