### PR TITLE
Remove `from_dict` from `SpeculativeConfig`

### DIFF
--- a/tests/v1/spec_decode/test_ngram.py
+++ b/tests/v1/spec_decode/test_ngram.py
@@ -47,13 +47,12 @@ def test_ngram_proposer():
         model_config = ModelConfig(model="facebook/opt-125m")
         return NgramProposer(
             vllm_config=VllmConfig(model_config=model_config,
-                                   speculative_config=SpeculativeConfig.
-                                   from_dict({
-                                       "prompt_lookup_min": min_n,
-                                       "prompt_lookup_max": max_n,
-                                       "num_speculative_tokens": k,
-                                       "method": "ngram",
-                                   })))
+                                   speculative_config=SpeculativeConfig(
+                                       prompt_lookup_min=min_n,
+                                       prompt_lookup_max=max_n,
+                                       num_speculative_tokens=k,
+                                       method="ngram",
+                                   )))
 
     # No match.
     result = ngram_proposer(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2880,11 +2880,6 @@ class SpeculativeConfig:
                                usedforsecurity=False).hexdigest()
         return hash_str
 
-    @classmethod
-    def from_dict(cls, dict_value: dict) -> "SpeculativeConfig":
-        """Parse the CLI value for the speculative config."""
-        return cls(**dict_value)
-
     @staticmethod
     def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
         if hf_config.model_type == "deepseek_v3":

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1003,10 +1003,7 @@ class EngineArgs:
             "enable_chunked_prefill": enable_chunked_prefill,
             "disable_log_stats": disable_log_stats,
         })
-        speculative_config = SpeculativeConfig.from_dict(
-            self.speculative_config)
-
-        return speculative_config
+        return SpeculativeConfig(**self.speculative_config)
 
     def create_engine_config(
         self,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -401,8 +401,7 @@ class EngineArgs:
     logits_processor_pattern: Optional[
         str] = ModelConfig.logits_processor_pattern
 
-    speculative_config: Optional[
-        SpeculativeConfig] = VllmConfig.speculative_config
+    speculative_config: Optional[Dict[str, Any]] = None
 
     show_hidden_metrics_for_version: Optional[str] = \
         ObservabilityConfig.show_hidden_metrics_for_version
@@ -957,19 +956,20 @@ class EngineArgs:
             pt_load_map_location=self.pt_load_map_location,
         )
 
-    def maybe_update_speculative_config(
+    def create_speculative_config(
         self,
         target_model_config: ModelConfig,
         target_parallel_config: ParallelConfig,
         enable_chunked_prefill: bool,
         disable_log_stats: bool,
-    ):
-        """
-        Auto-loads SpeculativeConfig from the model config if not set and HF
-        config is a SpeculatorsConfig.
+    ) -> Optional["SpeculativeConfig"]:
+        """Initializes and returns a SpeculativeConfig object based on
+        `speculative_config`.
 
-        If a speculative config is required, updates the necessary fields with
-        the parameters from other configs.
+        This function utilizes `speculative_config` to create a
+        SpeculativeConfig object. The `speculative_config` can either be
+        provided as a JSON string input via CLI arguments or directly as a
+        dictionary from the engine.
         """
 
         from vllm.transformers_utils.config import get_config
@@ -986,21 +986,27 @@ class EngineArgs:
             # no user input required / expected
             if isinstance(hf_config, SpeculatorsConfig):
                 # We create one since we dont create one
-                self.speculative_config = SpeculativeConfig(
-                    num_speculative_tokens=hf_config.num_lookahead_tokens,
-                    model=self.model,
-                    method=hf_config.method,
-                )
+                self.speculative_config = {}
+                self.speculative_config[
+                    "num_speculative_tokens"] = hf_config.num_lookahead_tokens
+                self.speculative_config["model"] = self.model
+                self.speculative_config["method"] = hf_config.method
             else:
                 return None
 
         # Note(Shangming): These parameters are not obtained from the cli arg
         # '--speculative-config' and must be passed in when creating the engine
         # config.
-        self.speculative_config.target_model_config = target_model_config
-        self.speculative_config.target_parallel_config = target_parallel_config
-        self.speculative_config.enable_chunked_prefill = enable_chunked_prefill
-        self.speculative_config.disable_log_stats = disable_log_stats
+        self.speculative_config.update({
+            "target_model_config": target_model_config,
+            "target_parallel_config": target_parallel_config,
+            "enable_chunked_prefill": enable_chunked_prefill,
+            "disable_log_stats": disable_log_stats,
+        })
+        speculative_config = SpeculativeConfig.from_dict(
+            self.speculative_config)
+
+        return speculative_config
 
     def create_engine_config(
         self,
@@ -1226,7 +1232,7 @@ class EngineArgs:
                     "between API and engine core processes.")
                 model_config.set_disable_mm_preprocessor_cache(True)
 
-        self.maybe_update_speculative_config(
+        speculative_config = self.create_speculative_config(
             target_model_config=model_config,
             target_parallel_config=parallel_config,
             enable_chunked_prefill=self.enable_chunked_prefill,
@@ -1236,7 +1242,7 @@ class EngineArgs:
         # Reminder: Please update docs/features/compatibility_matrix.md
         # If the feature combo become valid
         if self.num_scheduler_steps > 1:
-            if self.speculative_config is not None:
+            if speculative_config is not None:
                 raise ValueError("Speculative decoding is not supported with "
                                  "multi-step (--num-scheduler-steps > 1)")
             if self.enable_chunked_prefill and self.pipeline_parallel_size > 1:
@@ -1253,8 +1259,8 @@ class EngineArgs:
         num_lookahead_slots = max(self.num_lookahead_slots,
                                   self.num_scheduler_steps - 1)
         num_lookahead_slots = num_lookahead_slots \
-            if self.speculative_config is None \
-            else self.speculative_config.num_lookahead_slots
+            if speculative_config is None \
+            else speculative_config.num_lookahead_slots
 
         scheduler_config = SchedulerConfig(
             runner_type=model_config.runner_type,
@@ -1327,7 +1333,7 @@ class EngineArgs:
             scheduler_config=scheduler_config,
             device_config=device_config,
             lora_config=lora_config,
-            speculative_config=self.speculative_config,
+            speculative_config=speculative_config,
             load_config=load_config,
             decoding_config=decoding_config,
             observability_config=observability_config,


### PR DESCRIPTION
Remove `from_dict` from `SpeculativeConfig` because it's not necessary for `dataclass`es
