### PR TITLE
[PERF] Use pybase64 to more quickly decode prompt embeddings

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
-import base64
 import io
 import json
 import sys
@@ -12,6 +11,7 @@ from http import HTTPStatus
 from typing import (Annotated, Any, Callable, ClassVar, Generic, Optional,
                     TypeVar, Union, cast, overload)
 
+import pybase64
 import torch
 from fastapi import Request
 from pydantic import BaseModel, ConfigDict, Field
@@ -1008,7 +1008,8 @@ class OpenAIServing:
     ) -> list[EmbedsPrompt]:
 
         def _load_and_validate_embed(embed: bytes) -> EmbedsPrompt:
-            tensor = torch.load(io.BytesIO(base64.b64decode(embed)),
+            tensor = torch.load(io.BytesIO(
+                pybase64.b64decode(embed, validate=True)),
                                 weights_only=True)
             assert isinstance(tensor, torch.Tensor) and tensor.dtype in (
                 torch.float32,


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Prompt embeddings can be quite large compared to string or prompt token id inputs of the same token length. The builtin base64 module, while correct, is slow. Since `pybase64` is already being used elsewhere ([in the image multimodal handling](https://github.com/vllm-project/vllm/blob/0e25721cacd81ef59fbda3c65666906da6507ff4/vllm/multimodal/image.py#L8)), and has significant speed-ups for decoding base64 strings, it makes sense to use this faster implementation for decoding prompt_embeds in the OpenAI compatible API, as well.

## Test Plan

No tests should need to be updated. This change is a drop-in replacement. If CI passes, then this should be good to merge.

I ran this prompt_embeds test file from the docs, using this change, and it worked. https://github.com/vllm-project/vllm/blob/main/examples/online_serving/prompt_embed_inference_with_openai_client.py

## Test Result

_Pending CI results_

The test file from the docs runs fine.

## (Optional) Documentation Update

