### PR TITLE
[V1][P/D]Bug fix: handle edge case where KVConnectorOutput is None

### DIFF
--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -125,3 +125,14 @@ EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[],
                                               prompt_logprobs_dict={},
                                               pooler_output=[],
                                               num_nans_in_logits=None)
+
+EMPTY_MODEL_RUNNER_WITH_KVC_OUTPUT = ModelRunnerOutput(
+    req_ids=[],
+    req_id_to_index={},
+    sampled_token_ids=[],
+    spec_token_ids=None,
+    logprobs=None,
+    prompt_logprobs_dict={},
+    pooler_output=[],
+    num_nans_in_logits=None,
+    kv_connector_output=KVConnectorOutput())

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -27,7 +27,8 @@ from vllm.tasks import SupportedTask
 from vllm.utils import GiB_bytes, MemorySnapshot, memory_profiling
 from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
-from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
+from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_WITH_KVC_OUTPUT,
+                             ModelRunnerOutput)
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.worker_base import WorkerBase
@@ -377,9 +378,9 @@ class Worker(WorkerBase):
             # kv_connector_output
             if (not kv_connector_output.finished_sending
                     and not kv_connector_output.finished_recving):
-                return EMPTY_MODEL_RUNNER_OUTPUT
+                return EMPTY_MODEL_RUNNER_WITH_KVC_OUTPUT
 
-            output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
+            output = copy.copy(EMPTY_MODEL_RUNNER_WITH_KVC_OUTPUT)
             output.kv_connector_output = kv_connector_output
             return output
 

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -14,8 +14,8 @@ from vllm.distributed.kv_transfer import (get_kv_transfer_group,
 from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.logger import init_logger
-from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, KVConnectorOutput,
-                             ModelRunnerOutput)
+from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_WITH_KVC_OUTPUT,
+                             KVConnectorOutput, ModelRunnerOutput)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -68,9 +68,9 @@ class KVConnectorModelRunnerMixin:
 
         if (not kv_connector_output.finished_sending
                 and not kv_connector_output.finished_recving):
-            return EMPTY_MODEL_RUNNER_OUTPUT
+            return EMPTY_MODEL_RUNNER_WITH_KVC_OUTPUT
 
-        output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
+        output = copy.copy(EMPTY_MODEL_RUNNER_WITH_KVC_OUTPUT)
         output.kv_connector_output = kv_connector_output
         return output
 


### PR DESCRIPTION
## Purpose
From #21980, we refactor the KV connector path but we miss an edge case where KV connector loads kv cache async, and for some model iteration, there is no kv connector output at all. 

https://github.com/vllm-project/vllm/blob/7e3a8dc90670fd312ce1e0d4eba9bf11c571e3ad/vllm/v1/worker/kv_connector_model_runner_mixin.py#L69-L71

https://github.com/vllm-project/vllm/blob/7e3a8dc90670fd312ce1e0d4eba9bf11c571e3ad/vllm/v1/outputs.py#L120-L127

## Test
Before
```
(EngineCore_0 pid=2913251) Traceback (most recent call last):
(EngineCore_0 pid=2913251)   File "/usr/local/fbcode/platform010/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_0 pid=2913251)     self.run()
(EngineCore_0 pid=2913251)   File "/usr/local/fbcode/platform010/lib/python3.10/multiprocessing/process.py", line 108, in run
(EngineCore_0 pid=2913251)     self._target(*self._args, **self._kwargs)
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/engine/core.py", line 687, in run_engine_core
(EngineCore_0 pid=2913251)     raise e
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/engine/core.py", line 676, in run_engine_core
(EngineCore_0 pid=2913251)     engine_core.run_busy_loop()
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/engine/core.py", line 703, in run_busy_loop
(EngineCore_0 pid=2913251)     self._process_engine_step()
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/engine/core.py", line 728, in _process_engine_step
(EngineCore_0 pid=2913251)     outputs, model_executed = self.step_fn()
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/engine/core.py", line 273, in step
(EngineCore_0 pid=2913251)     model_output = self.execute_model_with_error_logging(
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/engine/core.py", line 259, in execute_model_with_error_logging
(EngineCore_0 pid=2913251)     raise err
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/engine/core.py", line 250, in execute_model_with_error_logging
(EngineCore_0 pid=2913251)     return model_fn(scheduler_output)
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/v1/executor/multiproc_executor.py", line 192, in execute_model
(EngineCore_0 pid=2913251)     return self.kv_output_aggregator.aggregate(outputs, self.output_rank)
(EngineCore_0 pid=2913251)   File "/data/users/zijingliu/fbsource/buck-out/v2/gen/fbcode/603862b2f935f1b2/smart/inference_platform_sp/llm_predictor_gpu/__service__/service#link-tree/vllm/distributed/kv_transfer/kv_connector/utils.py", line 146, in aggregate
(EngineCore_0 pid=2913251)     update_finished_set(output.finished_sending,
(EngineCore_0 pid=2913251) AttributeError: 'NoneType' object has no attribute 'finished_sending'
```

After
P/D disagg could run properly

Eval
```
[2025-08-07 14:50:41,290] [rank 0] [INFO] Per prompt detailed info dumped to /tmp/eval_dump.gsm8k.8_shot.1_gen.20250807_145041.json
[2025-08-07 14:50:41,290] [rank 0] [INFO] Evaluation results on task gsm8k.8_shot.1_gen: em: 0.948000 | f1: 0.948000 | em_maj1@1: 0.948000 | f1_maj1@1: 0.948000
[2025-08-07 14:50:41,290] [rank 0] [INFO] Task gsm8k.8_shot.1_gen took 189.51 seconds
```

cc @sdavidbd @njhill @houseroad 