### PR TITLE
Remove redundant row_indices unsqueeze operation in MiniCPMO

### DIFF
--- a/vllm/model_executor/models/minicpmo.py
+++ b/vllm/model_executor/models/minicpmo.py
@@ -605,7 +605,6 @@ class MiniCPMO(MiniCPMV2_6):
                                   max=size)
         # Create column indices for broadcasting
         col_indices = torch.arange(size, device=device).unsqueeze(0)
-        row_indices = row_indices.unsqueeze(1)
         start_indices = start_indices.unsqueeze(1)
         end_indices = end_indices.unsqueeze(1)
         # Vectorized mask creation


### PR DESCRIPTION
  ### Summary

  Remove redundant row_indices unsqueeze operation in MiniCPMO model

  This PR removes an unnecessary row_indices.unsqueeze(1) operation in the vectorized mask creation logic within the MiniCPMO class. The operation was redundant and its removal simplifies the code without affecting functionality.

  ### Changes

  - File: vllm/model_executor/models/minicpmo.py
  - Change: Removed row_indices = row_indices.unsqueeze(1) line (line 608)

  ### Impact

  - Type: Code cleanup/optimization
  - Risk: Low - removes redundant operation only
  - Performance: Minimal positive impact by removing unnecessary tensor operation

  ### Testing

  - Existing tests should continue to pass
  - No functional changes expected in model behavior

 ### Context

This change was identified during code review of the MiniCPMO model implementation. The row_indices.unsqueeze(1) operation was not being used in the subsequent vectorized mask creation logic, making it safe to remove.