### PR TITLE
Skip Qwen 1 in CI because remote code is no longer compatible with Transformers

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -278,6 +278,8 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
                                          transformers_version_reason="vLLM impl inherits PreTrainedModel and clashes with get_input_embeddings",  # noqa: E501
                                         trust_remote_code=True),
     "QWenLMHeadModel": _HfExamplesInfo("Qwen/Qwen-7B-Chat",
+                                       max_transformers_version="4.53",
+                                       transformers_version_reason="HF model uses remote code that is not compatible with latest Transformers",  # noqa: E501
                                        trust_remote_code=True),
     "Qwen2ForCausalLM": _HfExamplesInfo("Qwen/Qwen2-0.5B-Instruct",
                                         extras={"2.5": "Qwen/Qwen2.5-0.5B-Instruct"}), # noqa: E501


### PR DESCRIPTION
Tests using this model are failing on main because the remote code used for the HF reference is incompatible with Transformers v4.55.0.

Since it's a very old model we can just skip the test instead of trying to fix https://huggingface.co/Qwen/Qwen-7B-Chat.