### PR TITLE
[Docs] Reduce noise in docs and `--help` from the JSON tip

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -16,6 +16,16 @@ Available Commands:
 vllm {chat,complete,serve,bench,collect-env,run-batch}
 ```
 
+When passing JSON CLI arguments, the following sets of arguments are equivalent:
+
+   - `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
+   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`
+
+Additionally, list elements can be passed individually using `+`:
+
+   - `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
+   - `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
+
 ## serve
 
 Start the vLLM OpenAI Compatible API server.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -18,13 +18,13 @@ vllm {chat,complete,serve,bench,collect-env,run-batch}
 
 When passing JSON CLI arguments, the following sets of arguments are equivalent:
 
-   - `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
-   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`
+- `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
+- `--json-arg.key1 value1 --json-arg.key2.key3 value2`
 
 Additionally, list elements can be passed individually using `+`:
 
-   - `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
-   - `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
+- `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
+- `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
 
 ## serve
 

--- a/docs/configuration/engine_args.md
+++ b/docs/configuration/engine_args.md
@@ -11,6 +11,16 @@ Engine arguments control the behavior of the vLLM engine.
 
 The engine argument classes, [EngineArgs][vllm.engine.arg_utils.EngineArgs] and [AsyncEngineArgs][vllm.engine.arg_utils.AsyncEngineArgs], are a combination of the configuration classes defined in [vllm.config][]. Therefore, if you are interested in developer documentation, we recommend looking at these configuration classes as they are the source of truth for types, defaults and docstrings.
 
+When passing JSON CLI arguments, the following sets of arguments are equivalent:
+
+   - `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
+   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`
+
+Additionally, list elements can be passed individually using `+`:
+
+   - `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
+   - `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
+
 ## `EngineArgs`
 
 --8<-- "docs/argparse/engine_args.md"

--- a/docs/configuration/engine_args.md
+++ b/docs/configuration/engine_args.md
@@ -13,13 +13,13 @@ The engine argument classes, [EngineArgs][vllm.engine.arg_utils.EngineArgs] and 
 
 When passing JSON CLI arguments, the following sets of arguments are equivalent:
 
-   - `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
-   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`
+- `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
+- `--json-arg.key1 value1 --json-arg.key2.key3 value2`
 
 Additionally, list elements can be passed individually using `+`:
 
-   - `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
-   - `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
+- `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
+- `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
 
 ## `EngineArgs`
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -178,17 +178,8 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, Any]:
         kwargs[name] = {"default": default, "help": help}
 
         # Set other kwargs based on the type hints
-        json_tip = """Should either be a valid JSON string or JSON keys
-passed individually. For example, the following sets of arguments are
-equivalent:
-
-- `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`\n
-- `--json-arg.key1 value1 --json-arg.key2.key3 value2`
-
-Additionally, list elements can be passed individually using `+`:
-
-- `--json-arg '{"key4": ["value3", "value4", "value5"]}'`\n
-- `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`"""
+        json_tip = ("Should either be a valid JSON string or JSON keys passed "
+                    "individually.")
         if dataclass_cls is not None:
 
             def parse_dataclass(val: str, cls=dataclass_cls) -> Any:
@@ -1831,13 +1822,3 @@ def human_readable_int(value):
 
     # Regular plain number.
     return int(value)
-
-
-# These functions are used by sphinx to build the documentation
-def _engine_args_parser():
-    return EngineArgs.add_cli_args(FlexibleArgumentParser())
-
-
-def _async_engine_args_parser():
-    return AsyncEngineArgs.add_cli_args(FlexibleArgumentParser(),
-                                        async_args_only=True)

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -29,6 +29,19 @@ from vllm.v1.utils import (APIServerProcessManager,
 
 logger = init_logger(__name__)
 
+VLLM_SERVE_EPILOG = """
+When passing JSON CLI arguments, the following sets of arguments are equivalent:
+
+   - `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
+   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`
+
+Additionally, list elements can be passed individually using `+`:
+
+   - `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
+   - `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
+
+"""
+
 
 class ServeSubcommand(CLISubcommand):
     """The `serve` subcommand for the vLLM CLI. """
@@ -63,7 +76,7 @@ class ServeSubcommand(CLISubcommand):
 
         serve_parser = make_arg_parser(serve_parser)
         show_filtered_argument_or_group_from_help(serve_parser, ["serve"])
-        serve_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG
+        serve_parser.epilog = VLLM_SERVE_EPILOG + VLLM_SUBCMD_PARSER_EPILOG
         return serve_parser
 
 

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -29,19 +29,6 @@ from vllm.v1.utils import (APIServerProcessManager,
 
 logger = init_logger(__name__)
 
-VLLM_SERVE_EPILOG = """
-When passing JSON CLI arguments, the following sets of arguments are equivalent:
-
-   - `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
-   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`
-
-Additionally, list elements can be passed individually using `+`:
-
-   - `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
-   - `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`
-
-"""
-
 
 class ServeSubcommand(CLISubcommand):
     """The `serve` subcommand for the vLLM CLI. """
@@ -76,7 +63,7 @@ class ServeSubcommand(CLISubcommand):
 
         serve_parser = make_arg_parser(serve_parser)
         show_filtered_argument_or_group_from_help(serve_parser, ["serve"])
-        serve_parser.epilog = VLLM_SERVE_EPILOG + VLLM_SUBCMD_PARSER_EPILOG
+        serve_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG
         return serve_parser
 
 

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1669,11 +1669,20 @@ class FlexibleArgumentParser(ArgumentParser):
     """ArgumentParser that allows both underscore and dash in names."""
 
     _deprecated: set[Action] = set()
+    _json_tip: str = (
+        "When passing JSON CLI arguments, the following sets of arguments "
+        "are equivalent:\n"
+        '   - `--json-arg \'{"key1": "value1", "key2": {"key3": "value2"}}\'`\n'
+        "   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`\n\n"
+        "Additionally, list elements can be passed individually using `+`:\n"
+        '   - `--json-arg \'{"key4": ["value3", "value4", "value5"]}\'`\n'
+        "   - `--json-arg.key4+ value3 --json-arg.key4+=\'value4,value5\'`\n\n"
+    )
 
     def __init__(self, *args, **kwargs):
-        # Set the default 'formatter_class' to SortedHelpFormatter
-        if 'formatter_class' not in kwargs:
-            kwargs['formatter_class'] = SortedHelpFormatter
+        # Set the default "formatter_class" to SortedHelpFormatter
+        if "formatter_class" not in kwargs:
+            kwargs["formatter_class"] = SortedHelpFormatter
         super().__init__(*args, **kwargs)
 
     if sys.version_info < (3, 13):
@@ -1714,6 +1723,12 @@ class FlexibleArgumentParser(ArgumentParser):
             group = self._FlexibleArgumentGroup(self, *args, **kwargs)
             self._action_groups.append(group)
             return group
+
+    def format_help(self) -> str:
+        # Add tip about JSON arguments to the epilog
+        if not self.epilog.startswith(FlexibleArgumentParser._json_tip):
+            self.epilog = FlexibleArgumentParser._json_tip + self.epilog
+        return super().format_help()
 
     def parse_args(  # type: ignore[override]
         self,

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1672,12 +1672,11 @@ class FlexibleArgumentParser(ArgumentParser):
     _json_tip: str = (
         "When passing JSON CLI arguments, the following sets of arguments "
         "are equivalent:\n"
-        '   - `--json-arg \'{"key1": "value1", "key2": {"key3": "value2"}}\'`\n'
-        "   - `--json-arg.key1 value1 --json-arg.key2.key3 value2`\n\n"
-        "Additionally, list elements can be passed individually using `+`:\n"
-        '   - `--json-arg \'{"key4": ["value3", "value4", "value5"]}\'`\n'
-        "   - `--json-arg.key4+ value3 --json-arg.key4+=\'value4,value5\'`\n\n"
-    )
+        '   --json-arg \'{"key1": "value1", "key2": {"key3": "value2"}}\'\n'
+        "   --json-arg.key1 value1 --json-arg.key2.key3 value2\n\n"
+        "Additionally, list elements can be passed individually using +:\n"
+        '   --json-arg \'{"key4": ["value3", "value4", "value5"]}\'\n'
+        "   --json-arg.key4+ value3 --json-arg.key4+=\'value4,value5\'\n\n")
 
     def __init__(self, *args, **kwargs):
         # Set the default "formatter_class" to SortedHelpFormatter
@@ -1726,8 +1725,9 @@ class FlexibleArgumentParser(ArgumentParser):
 
     def format_help(self) -> str:
         # Add tip about JSON arguments to the epilog
-        if not self.epilog.startswith(FlexibleArgumentParser._json_tip):
-            self.epilog = FlexibleArgumentParser._json_tip + self.epilog
+        epilog = self.epilog or ""
+        if not epilog.startswith(FlexibleArgumentParser._json_tip):
+            self.epilog = FlexibleArgumentParser._json_tip + epilog
         return super().format_help()
 
     def parse_args(  # type: ignore[override]


### PR DESCRIPTION
- Explicitly adds the JSON tip to the top of the CLI reference and the Engine Args docs
- Remove verbose explanation of JSON arg parsing from the JSON tip that's added to every JSON arg's help string
- Add the JSON tip to the epilog of the `FlexibleArgumentParser`
- Remove old helper functions added for Sphinx

---

```console
$ vllm serve --help
...
  --kv-transfer-config KV_TRANSFER_CONFIG
                        The configurations for distributed KV cache transfer.
                        Should either be a valid JSON string or JSON keys passed individually. (default: None)
  --speculative-config SPECULATIVE_CONFIG
                        Speculative decoding configuration.
                        Should either be a valid JSON string or JSON keys passed individually. (default: None)

When passing JSON CLI arguments, the following sets of arguments are equivalent:
   --json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'
   --json-arg.key1 value1 --json-arg.key2.key3 value2

Additionally, list elements can be passed individually using +:
   --json-arg '{"key4": ["value3", "value4", "value5"]}'
   --json-arg.key4+ value3 --json-arg.key4+='value4,value5'

Tip: Use `vllm [serve|run-batch|bench <bench_type>] --help=<keyword>` to explore arguments from help.
   - To view a argument group:     --help=ModelConfig
   - To view a single argument:    --help=max-num-seqs
   - To search by keyword:         --help=max
   - To list all groups:           --help=listgroup
   - To view help with pager:      --help=page
```

<img width="1345" height="1266" alt="image" src="https://github.com/user-attachments/assets/8dfc9011-12d0-4d90-a1ea-c48b06500c60" />
