### PR TITLE
[Doc] Fix API doc link in side navigation

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,5 +1,5 @@
 nav:
-  - Home: 
+  - Home:
     - vLLM: README.md
     - Getting Started:
       - getting_started/quickstart.md
@@ -11,7 +11,7 @@ nav:
     - Quick Links:
       - User Guide: usage/README.md
       - Developer Guide: contributing/README.md
-      - API Reference: api/README.md
+      - API Reference: api/summary.md
       - CLI Reference: cli/README.md
     - Timeline:
       - Roadmap: https://roadmap.vllm.ai
@@ -49,7 +49,7 @@ nav:
     - General:
       - glob: contributing/*
         flatten_single_child_sections: true
-    - Model Implementation: 
+    - Model Implementation:
       - contributing/model/README.md
       - contributing/model/basic.md
       - contributing/model/registration.md


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Currently in https://docs.vllm.ai/en/latest/index.html, [API Reference](https://docs.vllm.ai/en/latest/api/README.md) on the left side nav bar link will give you 404.
Noticed this while looking for some place to add new docs.

## Test Plan
[API Reference](https://docs.vllm.ai/en/latest/api/summary.html)

## Test Result
passed

## (Optional) Documentation Update

