### PR TITLE
[V1] [Hybrid] Enable Full CUDA graph by default for hybrid models in V1

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import vllm.envs as envs
+from vllm.config.compilation import CUDAGraphMode
 from vllm.logger import init_logger
 from vllm.model_executor.models import ModelRegistry
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, cdiv
@@ -275,6 +276,42 @@ class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
                     "%d for performance.", 1024)
 
 
+class MambaModelConfig(VerifyAndUpdateConfig):
+
+    @classmethod
+    def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        """
+        Enable FULL_AND_PIECEWISE cuda graph mode by default (required
+        to get good performance for mamba layers in V1).
+
+        Args:
+            vllm_config: vLLM Config
+        """
+
+        if not envs.VLLM_USE_V1:
+            return
+
+        model_config = vllm_config.model_config
+        compilation_config = vllm_config.compilation_config
+
+        model_cls, _ = ModelRegistry.resolve_model_cls(
+            model_config.architecture,
+            model_config=model_config,
+        )
+
+        # TODO(tdoublep): remove as full cuda graph support is added
+        FCG_NOT_SUPPORTED_MODELS = [
+            "Lfm2ForCausalLM", "MiniMaxText01ForCausalLM"
+        ]
+
+        if (model_config.architecture not in FCG_NOT_SUPPORTED_MODELS
+                and compilation_config.cudagraph_mode is None):
+            logger.info(
+                "Hybrid or mamba-based model detected: setting cudagraph mode "
+                "to FULL_AND_PIECEWISE in order to optimize performance.")
+            compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
+
+
 class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
 
     @classmethod
@@ -292,6 +329,9 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
 
         if not envs.VLLM_USE_V1:
             return
+
+        # Enable FULL_AND_PIECEWISE by default
+        MambaModelConfig.verify_and_update_config(vllm_config)
 
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
@@ -374,4 +414,6 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "JambaForSequenceClassification": JambaForSequenceClassificationConfig,
     "GraniteMoeHybridForCausalLM": GraniteMoeHybridModelConfig,
     "GptOssForCausalLM": GptOssForCausalLMConfig,
+    "MambaForCausalLM": MambaModelConfig,
+    "Mamba2ForCausalLM": MambaModelConfig,
 }


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

The mamba2 layer has a lot of CPU overhead which mean its performance is really poor for small batches unless CUDA graphs are used. This means that the default V1 performance is still significantly worse than the default V0 performance (see below).

We recently merged #21401 which solves this problem by enabling full CUDA graphs for decode-only batches. This PR proposes to enable this by default for models with mamba2. Without this change, users will continue to experience poor performance when switching from V0 to V1, unless they really know what they are doing. 

In my view, this PR and #21549 would be the last steps required to enable V1 by default for these models and to start stripping out the V0 code. 

cc @heheda12345 @tlrmchlsmth 

## Test Plan
- default V0 performance (main)
- default V1 performance (main)
- default V1 performance (this PR)

## Test Result

Default V0 performance (main):
```
python benchmark_latency.py \
	--model ibm-granite/granite-4.0-tiny-preview \
	--input-len 31500 \
	--output-len 512 \
	--batch-size 1	\
	--num-iters-warmup 3 \
	--num-iters 3 

Avg latency: 3.505638455351194 seconds
10% percentile latency: 3.501975697884336 seconds
25% percentile latency: 3.5030823255656287 seconds
50% percentile latency: 3.5049267050344497 seconds
75% percentile latency: 3.5078387099783868 seconds
90% percentile latency: 3.509585912944749 seconds
99% percentile latency: 3.5106342347245665 seconds
```

Default V1 performance (main):
```
VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER python benchmark_latency.py \
	--model ibm-granite/granite-4.0-tiny-preview \
	--input-len 31500 \
	--output-len 512 \
	--batch-size 1	\
	--num-iters-warmup 3 \
	--num-iters 3 

Avg latency: 8.384082738310099 seconds
10% percentile latency: 8.35280047832057 seconds
25% percentile latency: 8.372324891504832 seconds
50% percentile latency: 8.40486558014527 seconds
75% percentile latency: 8.406232006032951 seconds
90% percentile latency: 8.40705186156556 seconds
99% percentile latency: 8.407543774885125 seconds
```

Default V1 performance (this PR):
```
VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER python benchmark_latency.py \
	--model ibm-granite/granite-4.0-tiny-preview \
	--input-len 31500 \
	--output-len 512 \
	--batch-size 1	\
	--num-iters-warmup 3 \
	--num-iters 3 

Avg latency: 3.398241866302366 seconds
10% percentile latency: 3.3959803130012007 seconds
25% percentile latency: 3.397328175487928 seconds
50% percentile latency: 3.3995746129658073 seconds
75% percentile latency: 3.3998219304485247 seconds
90% percentile latency: 3.399970320938155 seconds
99% percentile latency: 3.4000593552319334 seconds
```

## (Optional) Documentation Update

