### PR TITLE
Vectorize RMSNorm CUDA kernel

### DIFF
--- a/benchmarks/kernels/benchmark_layernorm.py
+++ b/benchmarks/kernels/benchmark_layernorm.py
@@ -11,7 +11,7 @@ from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, FlexibleArgumentParser
 
 
 @torch.inference_mode()
-def run_benchmark(
+def main(
     num_tokens: int,
     hidden_size: int,
     add_residual: bool,
@@ -59,8 +59,7 @@ def run_benchmark(
     print(f"Kernel running time: {latency * 1000000:.3f} us")
 
 
-def main():
-    """Main function for Buck compatibility."""
+if __name__ == "__main__":
     parser = FlexibleArgumentParser(description="Benchmark the layernorm kernel.")
     parser.add_argument("--num-tokens", type=int, default=4096)
     parser.add_argument("--hidden-size", type=int, default=8192)
@@ -82,7 +81,7 @@ def main():
     args = parser.parse_args()
     print(args)
 
-    run_benchmark(
+    main(
         num_tokens=args.num_tokens,
         hidden_size=args.hidden_size,
         add_residual=args.add_residual,
@@ -92,7 +91,3 @@ def main():
         num_warmup_iters=args.num_warmup_iters,
         num_iters=args.num_iters,
     )
-
-
-if __name__ == "__main__":
-    main()

--- a/benchmarks/kernels/benchmark_layernorm.py
+++ b/benchmarks/kernels/benchmark_layernorm.py
@@ -11,7 +11,7 @@ from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, FlexibleArgumentParser
 
 
 @torch.inference_mode()
-def main(
+def run_benchmark(
     num_tokens: int,
     hidden_size: int,
     add_residual: bool,
@@ -59,7 +59,8 @@ def main(
     print(f"Kernel running time: {latency * 1000000:.3f} us")
 
 
-if __name__ == "__main__":
+def main():
+    """Main function for Buck compatibility."""
     parser = FlexibleArgumentParser(description="Benchmark the layernorm kernel.")
     parser.add_argument("--num-tokens", type=int, default=4096)
     parser.add_argument("--hidden-size", type=int, default=8192)
@@ -81,7 +82,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     print(args)
 
-    main(
+    run_benchmark(
         num_tokens=args.num_tokens,
         hidden_size=args.hidden_size,
         add_residual=args.add_residual,
@@ -91,3 +92,7 @@ if __name__ == "__main__":
         num_warmup_iters=args.num_warmup_iters,
         num_iters=args.num_iters,
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary:
•	Vectorize writes when in/out phases align; scalar reads for weight when needed
•	Use an optional fp16 shared-mem cache (avoids second read)
•	Preserve numerics on odd/strided shapes by keeping scalar fallback
•	Match unfused launch/reduction order

## Test Result

**Accuracy **
```

lm_eval   --model vllm   --model_args "pretrained=Qwen/Qwen3-30B-A3B-FP8,max_model_len=32768,enforce_eager=True"   --trust_remote_code   --tasks gsm8k   --num_fewshot 5   --batch_size auto

# Before
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8279|±  |0.0104|
|     |       |strict-match    |     5|exact_match|↑  |0.8878|±  |0.0087|

# After
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8218|±  |0.0105|
|     |       |strict-match    |     5|exact_match|↑  |0.8939|±  |0.0085|

```

```
(vllm-env) bbeckca@computeinstance-e00z6c2em7n8zqhbdr:~/vllm$ pytest tests/kernels/core/test_layernorm.py
======================= test session starts =======================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/bbeckca/vllm
configfile: pyproject.toml
plugins: anyio-4.10.0
collected 1584 items                                              

tests/kernels/core/test_layernorm.py ...................... [  1%]
........................................................... [  5%]
........................................................... [  8%]
........................................................... [ 12%]
........................................................... [ 16%]
........................................................... [ 20%]
........................................................... [ 23%]
........................................................... [ 27%]
........................................................... [ 31%]
........................................................... [ 34%]
........................................................... [ 38%]
........................................................... [ 42%]
........................................................... [ 46%]
........................................................... [ 49%]
........................................................... [ 53%]
........................................................... [ 57%]
........................................................... [ 60%]
........................................................... [ 64%]
........................................................... [ 68%]
........................................................... [ 72%]
........................................................... [ 75%]
........................................................... [ 79%]
........................................................... [ 83%]
........................................................... [ 87%]
........................................................... [ 90%]
........................................................... [ 94%]
........................................................... [ 98%]
............................                                [100%]

================ 1584 passed in 375.51s (0:06:15) =================
```

**Performance**

```
python benchmark_layernorm.py

| Tokens | Hidden | Dtype    | Old (µs) | New (µs) | Change (%) |
|-------:|-------:|:---------|---------:|---------:|-----------:|
|      2 |   1024 | bfloat16 |   13.544 |   13.444 |      -0.7% |
|      2 |   1024 | half     |   13.628 |   13.567 |      -0.4% |
|      2 |   8192 | bfloat16 |   13.673 |   13.801 |      +0.9% |
|      2 |   8192 | half     |   13.779 |   13.741 |      -0.3% |
|      4 |   1024 | bfloat16 |   13.732 |   13.662 |      -0.5% |
|      4 |   1024 | half     |   13.692 |   13.399 |      -2.1% |
|      4 |   8192 | bfloat16 |   13.646 |   14.323 |      +5.0% |
|      4 |   8192 | half     |   14.483 |   13.464 |      -7.0% |
|      8 |   1024 | bfloat16 |   13.664 |   13.595 |      -0.5% |
|      8 |   1024 | half     |   13.687 |   13.914 |      +1.7% |
|      8 |   8192 | bfloat16 |   13.472 |   13.629 |      +1.2% |
|      8 |   8192 | half     |   13.235 |   13.314 |      +0.6% |
|     16 |   1024 | bfloat16 |   13.451 |   13.264 |      -1.4% |
|     16 |   1024 | half     |   13.718 |   13.357 |      -2.6% |
|     16 |   8192 | bfloat16 |   13.207 |   13.332 |      +0.9% |
|     16 |   8192 | half     |   13.690 |   13.673 |      -0.1% |
|     32 |   1024 | bfloat16 |   13.998 |   13.560 |      -3.1% |
|     32 |   1024 | half     |   13.687 |   13.359 |      -2.4% |
|     32 |   8192 | bfloat16 |   13.671 |   13.661 |      -0.1% |
|     32 |   8192 | half     |   13.401 |   13.362 |      -0.3% |
|     64 |   1024 | bfloat16 |   13.587 |   13.600 |      +0.1% |
|     64 |   1024 | half     |   13.691 |   13.453 |      -1.7% |
|     64 |   8192 | bfloat16 |   13.571 |   13.648 |      +0.6% |
|     64 |   8192 | half     |   13.851 |   13.505 |      -2.5% |
|    128 |   1024 | bfloat16 |   13.882 |   13.577 |      -2.2% |
|    128 |   1024 | half     |   13.325 |   13.681 |      +2.7% |
|    128 |   8192 | bfloat16 |   13.960 |   13.663 |      -2.1% |
|    128 |   8192 | half     |   13.844 |   13.897 |      +0.4% |
|    256 |   1024 | bfloat16 |   13.469 |   13.655 |      +1.4% |
|    256 |   1024 | half     |   14.165 |   13.392 |      -5.5% |
|    256 |   8192 | bfloat16 |   13.734 |   13.834 |      +0.7% |
|    256 |   8192 | half     |   13.432 |   13.725 |      +2.2% |
|    512 |   1024 | bfloat16 |   13.612 |   13.556 |      -0.4% |
|    512 |   1024 | half     |   13.954 |   13.409 |      -3.9% |
|    512 |   8192 | bfloat16 |   13.658 |   13.703 |      +0.3% |
|    512 |   8192 | half     |   13.554 |   13.532 |      -0.2% |
|   1024 |   1024 | bfloat16 |   13.760 |   13.615 |      -1.1% |
|   1024 |   1024 | half     |   13.868 |   13.805 |      -0.5% |
|   1024 |   8192 | bfloat16 |   24.042 |   16.055 |     -33.2% |
|   1024 |   8192 | half     |   24.103 |   15.766 |     -34.6% |
|   2048 |   1024 | bfloat16 |   13.683 |   13.656 |      -0.2% |
|   2048 |   1024 | half     |   13.445 |   13.720 |      +2.0% |
|   2048 |   8192 | bfloat16 |   60.042 |   43.753 |     -27.1% |
|   2048 |   8192 | half     |   59.763 |   43.622 |     -27.0% |
|   4096 |   1024 | bfloat16 |   23.686 |   13.645 |     -42.4% |
|   4096 |   1024 | half     |   23.456 |   13.514 |     -42.4% |
|   4096 |   8192 | bfloat16 |  114.548 |   81.739 |     -28.6% |
|   4096 |   8192 | half     |  114.347 |   81.835 |     -28.4% |
|   8192 |   1024 | bfloat16 |   46.955 |   20.395 |     -56.6% |
|   8192 |   1024 | half     |   46.964 |   19.760 |     -57.9% |
|   8192 |   8192 | bfloat16 |  220.422 |  156.080 |     -29.2% |
|   8192 |   8192 | half     |  220.369 |  156.161 |     -29.1% |
|  16384 |   1024 | bfloat16 |  100.117 |   51.102 |     -49.0% |
|  16384 |   1024 | half     |  100.163 |   41.369 |     -58.7% |
|  16384 |   8192 | bfloat16 |  433.641 |  303.721 |     -30.0% |
|  16384 |   8192 | half     |  432.265 |  303.430 |     -29.8% |
```

Differential Revision: D79969610


