### PR TITLE
Add EXAONE 4.0 reasoning parser

### DIFF
--- a/tests/reasoning/test_exaone4_reasoning_parser.py
+++ b/tests/reasoning/test_exaone4_reasoning_parser.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from transformers import AutoTokenizer
+
+from vllm.entrypoints.openai.protocol import ChatCompletionRequest, DeltaMessage
+from vllm.reasoning import (
+    DeepSeekR1ReasoningParser,
+    Exaone4ReasoningParser,
+    IdentityReasoningParser,
+)
+
+REASONING_MODEL_NAME = "LGAI-EXAONE/EXAONE-4.0-1.2B"
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    return AutoTokenizer.from_pretrained(REASONING_MODEL_NAME)
+
+
+@pytest.mark.parametrize(
+    "enable_thinking,expected_parser_type",
+    [
+        (True, DeepSeekR1ReasoningParser),
+        (False, IdentityReasoningParser),
+    ],
+)
+def test_parser_selection(tokenizer, enable_thinking, expected_parser_type):
+    parser = Exaone4ReasoningParser(
+        tokenizer, chat_template_kwargs={"enable_thinking": enable_thinking}
+    )
+
+    assert isinstance(parser._parser, expected_parser_type)
+
+
+def test_identity_reasoning_parser_basic(tokenizer):
+    parser = IdentityReasoningParser(tokenizer)
+
+    # Test is_reasoning_end always returns True
+    input_text = "This is some output"
+    input_tokens = tokenizer.tokenize(input_text)
+    input_ids = tokenizer.convert_tokens_to_ids(input_tokens)
+    assert parser.is_reasoning_end(input_ids) is True
+
+    # Test extract_content_ids returns all input_ids
+    assert parser.extract_content_ids(input_ids) == input_ids
+
+    # Test extract_reasoning_content returns (None, model_output)
+    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
+    reasoning, content = parser.extract_reasoning_content(input_text, request)
+    assert reasoning is None
+    assert content == input_text
+
+    # Test extract_reasoning_content_streaming returns DeltaMessage or None
+    result = parser.extract_reasoning_content_streaming(
+        previous_text="",
+        current_text="Hello world",
+        delta_text="Hello world",
+        previous_token_ids=[],
+        current_token_ids=input_ids,
+        delta_token_ids=input_ids,
+    )
+    assert isinstance(result, DeltaMessage)
+    assert result.content == "Hello world"
+
+    # If delta_text is empty, should return None
+    result_none = parser.extract_reasoning_content_streaming(
+        previous_text="Hello world",
+        current_text="Hello world",
+        delta_text="",
+        previous_token_ids=input_ids,
+        current_token_ids=input_ids,
+        delta_token_ids=[],
+    )
+    assert result_none is None

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -6,6 +6,7 @@ from .basic_parsers import BaseThinkingReasoningParser
 from .deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
 from .deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
 from .ernie45_reasoning_parser import Ernie45ReasoningParser
+from .exaone4_reasoning_parser import Exaone4ReasoningParser
 from .glm4_moe_reasoning_parser import Glm4MoeModelReasoningParser
 from .gptoss_reasoning_parser import GptOssReasoningParser
 from .granite_reasoning_parser import GraniteReasoningParser
@@ -26,6 +27,7 @@ __all__ = [
     "IdentityReasoningParser",
     "DeepSeekV3ReasoningParser",
     "Ernie45ReasoningParser",
+    "Exaone4ReasoningParser",
     "GraniteReasoningParser",
     "HunyuanA13BReasoningParser",
     "Qwen3ReasoningParser",

--- a/vllm/reasoning/exaone4_reasoning_parser.py
+++ b/vllm/reasoning/exaone4_reasoning_parser.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+from transformers import PreTrainedTokenizerBase
+
+from vllm.logger import init_logger
+from vllm.reasoning import (
+    DeepSeekR1ReasoningParser,
+    DeepSeekV3ReasoningParser,
+    ReasoningParserManager,
+)
+
+from .identity_reasoning_parser import IdentityReasoningParser
+
+logger = init_logger(__name__)
+
+
+@ReasoningParserManager.register_module("exaone4")
+class Exaone4ReasoningParser(DeepSeekV3ReasoningParser):
+    """
+    Reasoning parser for EXAONE 4.0 model.
+
+    The EXAONE 4.0 model uses <think>...</think> tokens to denote reasoning
+    text. This parser extracts the reasoning content from the model output.
+    """
+
+    def __init__(self, tokenizer: PreTrainedTokenizerBase, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+        print("Exaone4ReasoningParser init")
+
+        chat_kwargs = kwargs.pop("chat_template_kwargs", {}) or {}
+        enable_thinking = bool(chat_kwargs.pop("enable_thinking", False))
+
+        if enable_thinking:
+            self._parser = DeepSeekR1ReasoningParser(tokenizer, *args, **kwargs)
+        else:
+            self._parser = IdentityReasoningParser(tokenizer, *args, **kwargs)


### PR DESCRIPTION
- Add EXAONE 4.0 reasoning parser
- Add `request` parameter for `ReasoningParser.extract_reasoning_content_streaming()`

# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

EXAONE 4.0 currently uses `reasoning_parser=deepseek_r1` (Please refer https://github.com/vllm-project/vllm/issues/21718).
However, it incorrectly treats all output as reasoning content instead of normal content when no `<think>` or `</think>` tags are found and `enable_thinking=False`.

While this was easily fixed by modifying the output of `extract_reasoning_content()`, the issue persists in streaming mode.
By adding a `request` parameter to `extract_reasoning_content_streaming()`, we can figure out whether the streamed token is reasoning content or normal content.

## Test Plan
You can change the `"stream"` option for testing.

- Run server
```bash
vllm serve LGAI-EXAONE/EXAONE-4.0.1-32B --tool-call-parser hermes --reasoning-parser exaone4
```
1. Test normal request (all outputs should be `content`)
```bash
curl -X POST http://localhost:8850/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "LGAI-EXAONE/EXAONE-4.0.1-32B",
        "messages": [
            {"role": "user", "content": "Which is bigger, 3.7 or 3.11?"}
        ],
        "max_tokens": 1024,
        "stream": false
    }'
```

2. Test reasoning request (should starts with `reasoning_content`)
```bash
curl -X POST http://localhost:8850/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "LGAI-EXAONE/EXAONE-4.0.1-32B",
        "messages": [
            {"role": "user", "content": "Which is bigger, 3.7 or 3.11?"}
        ],
        "chat_template_kwargs": {"enable_thinking": true},
        "max_tokens": 4096,
        "stream": false
    }'
```

## Test Result
1. 
```bash
{"id":"chatcmpl-717caf53062e4b06ba51ad9e71c9512b","object":"chat.completion","created":1754885297,"model":"LGAI-EXAONE/EXAONE-4.0.1-32B","choices":[{"index":0,"message":{"role":"assistant","content":"To determine which number is bigger between **3.7** and **3.11**, follow these steps:\n\n1. **Compare the Whole Number Parts:**\n   - Both numbers have the same whole number part: **3**.\n\n2. **Compare the Decimal Parts:**\n   - **3.7** can be written as **3.70** to make the comparison easier.\n   - Now, compare **0.70** and **0.11**:\n     - **70** (from 0.70) is greater than **11** (from 0.11).\n\n3. **Conclusion:**\n   - Since **0.70 > 0.11**, it follows that **3.7 > 3.11**.\n\n\\[\n\\boxed{3.7}\n\\]","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":27,"total_tokens":219,"completion_tokens":192,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null}
```

2. 
```bash
{"id":"chatcmpl-fbaf462004774a73a947f9ff99d1cfb3","object":"chat.completion","created":1754885833,"model":"LGAI-EXAONE/EXAONE-4.0.1-32B","choices":[{"index":0,"message":{"role":"assistant","content":"\n\nTo determine which is bigger between 3.7 and 3.11, compare the decimal values digit by digit, starting from the left.\n\n- Both numbers have the same whole number part (3).\n- In the tenths place, 3.7 has a 7, while 3.11 has a 1. Since 7 is greater than 1, 3.7 is larger at this point.\n- Even without further digits, the tenths place comparison is sufficient to conclude that 3.7 is bigger than 3.11.\n\nTo verify:\n- Rewrite 3.7 as 3.70 for easier comparison: 3.70 vs. 3.11.\n- Compare place values:\n  - Units: 3 = 3\n  - Tenths: 7 > 1\n  - Since the tenths differ, no need to check hundredths.\n- Alternatively, convert to fractions:\n  - 3.7 = 37/10 = 370/100\n  - 3.11 = 311/100\n  - Since 370/100 > 311/100, 3.7 is larger.\n\nSubtraction also confirms:  \n3.70 - 3.11 = 0.59, which is positive, so 3.7 is bigger.\n\nThus, **3.7 is bigger than 3.11**.","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":"I need to determine which is bigger between 3.7 and 3.11. Both are decimals, so I should compare them digit by digit.\n\nFirst, look at the whole number part. Both have 3, so they're equal up to the units place. Now, I need to look at the tenths place.\n\nFor 3.7, the tenths digit is 7. For 3.11, the tenths digit is 1. Since 7 is greater than 1, 3.7 should be larger than 3.11.\n\nBut let me write them with the same number of decimal places to make it easier. 3.7 can be written as 3.70, and 3.11 is already 3.11. So, comparing 3.70 and 3.11:\n\n- Units: both 3\n\n- Tenths: 7 vs 1 → 7 > 1\n\nSince the tenths digit is higher for 3.7, it doesn't matter what comes after; 3.70 is greater than 3.11.\n\nI could also think in terms of fractions. 3.7 is 37/10, which is 370/100. And 3.11 is 311/100. Comparing 370/100 and 311/100, clearly 370 > 311, so 370/100 > 311/100, meaning 3.7 > 3.11.\n\n370/100 is 3.70, and 311/100 is 3.11, yes. So, 3.70 is indeed greater than 3.11.\n\nAnother way: 3.11 is three and eleven hundredths, while 3.7 is three and seven tenths. Seven tenths is seventy hundredths, and seventy hundredths is greater than eleven hundredths, so 3.7 > 3.11.\n\nI think I'm overcomplicating it. The simple comparison shows that since the tenths place is higher in 3.7, it's bigger.\n\nBut just to be thorough, let's consider if there's any trick here. Sometimes people might misread 3.7 as 3.07 or something, but no, 3.7 is clearly three point seven, which is 3.70.\n\nIn some contexts, decimals might be written differently, but standardly, 3.7 means 3.70.\n\nPerhaps the question is about numerical values only, so no tricks.\n\nSo, I think 3.7 is bigger than 3.11.\n\nBut let me confirm with subtraction: 3.7 - 3.11 = ? 3.7 minus 3.11.\n\nTo subtract, align decimals:\n\n  3.70\n\n- 3.11\n\n______\n\nStart from right: 0 - 1, can't do, borrow. 10 - 1 = 9, but since we borrowed, the 7 becomes 6 (because 70 becomes 69? Let's think carefully.\n\nActually, 3.70 minus 3.11:\n\nHundredths place: 0 < 1, so need to borrow from tenths. But tenths place has 7, which is 70 hundredths. So, take one from tenths, so tenths become 6, and hundredths become 10. Then 10 - 1 = 9.\n\nNow tenths place: 6 (after borrowing) minus 1 = 5.\n\nUnits place: 3 - 3 = 0.\n\nSo, 0.59, which is positive, meaning 3.70 > 3.11.\n\nYes, difference is 0.59, so 3.7 is bigger.\n\nIf I think on a number line, 3.11 is to the left of 3.7, so smaller.\n\nTherefore, 3.7 is bigger.\n\nThe question is \"which is bigger, 3.7 or 3.11?\" So, answer should be 3.7.\n\nBut just to be complete, is there any context where 3.11 could be larger? I don't think so. Unless it's a different base or something, but it's standard decimal.\n\nPerhaps someone might confuse it with fractions, but 3.7 is 37/10 = 3.7, 3.11 is 311/100 = 3.11, and 37/10 = 370/100 > 311/100.\n\n370/100 vs 311/100, yes.\n\nOr as mixed numbers: 3 7/10 vs 3 11/100. 7/10 = 70/100 > 11/100, so 3 70/100 > 3 11/100.\n\nAll ways confirm.\n\nSo, I think it's clear.\n"},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":23,"total_tokens":1572,"completion_tokens":1549,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null}
```

## (Optional) Documentation Update

