### PR TITLE
[V0] Correct CUDA Graph capture for encoder-decoder models

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1165,15 +1165,18 @@ class ModelConfig:
                     "non-quantized models.", self.quantization)
 
     def _verify_cuda_graph(self) -> None:
-        # The `max_seq_len_to_capture` was incorrectly based on the encoder's input length (448) 
+        # The `max_seq_len_to_capture` was incorrectly
+        # based on the encoder's input length (448) 
         # but not the decoder's larger input length (1500). 
         # This change ensures the CUDA Graph captures the correct,
         # larger sequence length, allowing it to work as intended.
         effective_max_seq_len = self.max_model_len
         if self.is_encoder_decoder:
             effective_max_seq_len = max(
-                effective_max_seq_len, getattr(self.hf_config, "max_source_positions", 0))
-        self.max_seq_len_to_capture = min(self.max_seq_len_to_capture, effective_max_seq_len)
+                effective_max_seq_len, 
+              getattr(self.hf_config, "max_source_positions", 0))
+        self.max_seq_len_to_capture = min(self.max_seq_len_to_capture,
+                                          effective_max_seq_len)
         # CUDAGraph capture not supported for enc-dec models and mllama on ROCm
         ROCM_UNSUPPORTED_MODELS = ['mllama']
         unsupported_rocm = (self.hf_config.model_type

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1165,8 +1165,9 @@ class ModelConfig:
                     "non-quantized models.", self.quantization)
 
     def _verify_cuda_graph(self) -> None:
-        self.max_seq_len_to_capture = min(self.max_seq_len_to_capture,
-                                          self.max_model_len)
+        if not self.is_encoder_decoder:
+            self.max_seq_len_to_capture = min(self.max_seq_len_to_capture,
+                                              self.max_model_len)
         # CUDAGraph capture not supported for enc-dec models and mllama on ROCm
         ROCM_UNSUPPORTED_MODELS = ['mllama']
         unsupported_rocm = (self.hf_config.model_type

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1166,15 +1166,15 @@ class ModelConfig:
 
     def _verify_cuda_graph(self) -> None:
         # The `max_seq_len_to_capture` was incorrectly
-        # based on the encoder's input length (448) 
-        # but not the decoder's larger input length (1500). 
+        # based on the encoder's input length (448)
+        # but not the decoder's larger input length (1500).
         # This change ensures the CUDA Graph captures the correct,
         # larger sequence length, allowing it to work as intended.
         effective_max_seq_len = self.max_model_len
         if self.is_encoder_decoder:
             effective_max_seq_len = max(
-                effective_max_seq_len, 
-              getattr(self.hf_config, "max_source_positions", 0))
+                effective_max_seq_len,
+                getattr(self.hf_config, "max_source_positions", 0))
         self.max_seq_len_to_capture = min(self.max_seq_len_to_capture,
                                           effective_max_seq_len)
         # CUDAGraph capture not supported for enc-dec models and mllama on ROCm


### PR DESCRIPTION
This commit addresses a bug where CUDA Graph failed to provide performance benefits for Whisper-style encoder-decoder models. ﻿
The previous implementation of CUDA Graph capture incorrectly set the `max_seq_len_to_capture` based solely on the encoder's max sequence length (448). For models like Whisper, the decoder's max sequence length (1500) is significantly larger. This mismatch caused the captured graph to be too small for the decoder's operations, leading to a failure to properly leverage the feature. ﻿
The fix updates the capture logic to correctly determine the max sequence length by considering both the encoder and decoder. By ensuring the captured graph is large enough to handle both components, we can now successfully utilize CUDA Graph for these models, resulting in improved inference performance.

# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

