### PR TITLE
 Implemented a token bucket rate limiter to prevent PD service overload conditions, with parallel enhancements to request processing logging for improved observability.

### DIFF
--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -20,7 +20,7 @@ REQUEST_QUEUE_SIZE = 50  # Maximum number of requests in the queue
 RATE_LIMIT = 5  # Maximum requests per second (rate limiting)
 PRE_SERVICE_URL = "http://localhost:8100/v1/completions"  # Prefill service endpoint
 DECODE_SERVICE_URL = "http://localhost:8200/v1/completions"  # Decode service endpoint
-
+#run this need pip install quart
 app = Quart(__name__)
 
 
@@ -54,7 +54,6 @@ class RateLimiter:
             self.last_refill = time.monotonic()
             self.tokens = self.rate_limit - 1
             return True
-
 
 # Request queue manager with concurrency control
 class RequestQueue:

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -188,5 +188,5 @@ async def handle_request():
 
 
 if __name__ == "__main__":
-    # Start the Quart server with host 0.0.0.0
+    # Start the Quart server with host 0.0.0.0 port 8000
     app.run(port=8000, host="0.0.0.0")

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -188,5 +188,5 @@ async def handle_request():
 
 
 if __name__ == "__main__":
-    # Start the Quart server with host 0.0.0.0 port: 8000
+    # Start the Quart server with host: 0.0.0.0 port: 8000
     app.run(port=8000, host="0.0.0.0")

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -188,5 +188,5 @@ async def handle_request():
 
 
 if __name__ == "__main__":
-    # Start the Quart server with host 0.0.0.0 port 8000
+    # Start the Quart server with host 0.0.0.0 port: 8000
     app.run(port=8000, host="0.0.0.0")

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -3,222 +3,187 @@
 
 import os
 import asyncio
-import time
-from collections import deque
-from quart import Quart, make_response, request, jsonify, g
 import aiohttp
+from quart import Quart, make_response, request, Response
+from collections import deque
+import time
+import logging
 
-# Configuration parameters
-MAX_CONCURRENT_REQUESTS = 10  # Maximum concurrent requests allowed
-REQUEST_RATE_LIMIT = 100  # Token bucket capacity (max burst requests)
-REQUEST_RATE_REFILL = 5  # Token refill rate per second
-CONCURRENCY_TIMEOUT = 5.0  # Timeout for acquiring concurrency slot (seconds)
-AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=1 * 60 * 60)  # Backend request timeout  (unit:hour)
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Global configuration parameters
+AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=60)  # Timeout for backend service requests (seconds)
+MAX_CONCURRENT_REQUESTS = 10  # Maximum concurrent requests to backend services
+REQUEST_QUEUE_SIZE = 50  # Maximum number of requests in the queue
+RATE_LIMIT = 5  # Maximum requests per second (rate limiting)
+PRE_SERVICE_URL = "http://localhost:8100/v1/completions"  # Prefill service endpoint
+DECODE_SERVICE_URL = "http://localhost:8200/v1/completions"  # Decode service endpoint
 
 app = Quart(__name__)
 
 
-# Rate limiter implementation using token bucket algorithm
+# Token bucket rate limiter implementation
 class RateLimiter:
-    def __init__(self, rate_limit, refill_rate):
-        self.rate_limit = rate_limit  # Maximum tokens (requests) in bucket
-        self.refill_rate = refill_rate  # Tokens added per second
-        self.tokens = rate_limit  # Current token count
-        self.last_refill = time.monotonic()  # Last refill timestamp
-        self.lock = asyncio.Lock()  # Thread-safe lock
+    def __init__(self, rate_limit):
+        self.rate_limit = rate_limit  # Requests per second
+        self.tokens = rate_limit  # Available tokens
+        self.last_refill = time.monotonic()  # Last token refill time
+        self.lock = asyncio.Lock()  # Synchronization lock
 
     async def acquire(self):
-        """Acquire a token from the bucket if available."""
+        """Acquire a token from the rate limiter"""
         async with self.lock:
-            # Refill tokens based on time elapsed
-            now = time.monotonic()
-            elapsed = now - self.last_refill
-            if elapsed > 0:
-                # Calculate tokens to add and cap at bucket capacity
-                self.tokens = min(
-                    self.rate_limit,
-                    self.tokens + elapsed * self.refill_rate
-                )
-                self.last_refill = now
+            current_time = time.monotonic()
+            elapsed = current_time - self.last_refill
 
-            # Check if token is available
-            if self.tokens >= 1:
+            # Refill tokens if more than 1 second has passed
+            if elapsed > 1.0:
+                self.tokens = self.rate_limit
+                self.last_refill = current_time
+
+            # Check if tokens are available
+            if self.tokens > 0:
                 self.tokens -= 1
                 return True
-            return False
 
-
-# Concurrency limiter using semaphore
-class ConcurrencyLimiter:
-    def __init__(self, max_concurrent):
-        self.semaphore = asyncio.Semaphore(max_concurrent)  # Semaphore for concurrency control
-
-    async def acquire(self):
-        """Acquire a concurrency slot with timeout."""
-        try:
-            # Try to acquire slot with timeout
-            await asyncio.wait_for(self.semaphore.acquire(), timeout=CONCURRENCY_TIMEOUT)
+            # Calculate wait time if no tokens available
+            wait_time = 1.0 - elapsed
+            await asyncio.sleep(wait_time)
+            self.last_refill = time.monotonic()
+            self.tokens = self.rate_limit - 1
             return True
-        except asyncio.TimeoutError:
+
+
+# Request queue manager with concurrency control
+class RequestQueue:
+    def __init__(self, max_concurrent, max_queue_size):
+        self.max_concurrent = max_concurrent  # Maximum concurrent requests
+        self.max_queue_size = max_queue_size  # Maximum queue size
+        self.semaphore = asyncio.Semaphore(max_concurrent)  # Concurrency control
+        self.queue = deque()  # Request queue
+        self.queue_size = 0  # Current queue size
+
+    async def enqueue(self, task):
+        """Add a request task to the queue"""
+        if self.queue_size >= self.max_queue_size:
+            logger.warning("Request queue full, rejecting request")
             return False
 
-    def release(self):
-        """Release a concurrency slot."""
-        self.semaphore.release()
+        self.queue.append(task)
+        self.queue_size += 1
+        return True
+
+    async def process(self):
+        """Process queued requests using semaphore for concurrency control"""
+        while True:
+            if self.queue:
+                async with self.semaphore:
+                    task = self.queue.popleft()
+                    self.queue_size -= 1
+                    await task
+            await asyncio.sleep(0.01)  # Yield control to event loop
 
 
-# Initialize limiters
-rate_limiter = RateLimiter(REQUEST_RATE_LIMIT, REQUEST_RATE_REFILL)
-concurrency_limiter = ConcurrencyLimiter(MAX_CONCURRENT_REQUESTS)
-
-# Backend service endpoints with load balancing
-SERVICE_ENDPOINTS = {
-    "prefill": [
-        "http://localhost:8100/v1/completions",
-        # Add more instances for horizontal scaling:
-        # "http://prefill-instance2:8100/v1/completions",
-    ],
-    "decode": [
-        "http://localhost:8200/v1/completions",
-        # Add more instances for horizontal scaling:
-        # "http://decode-instance2:8200/v1/completions",
-    ]
-}
-
-# Initialize round-robin state
-endpoint_pointers = {service: 0 for service in SERVICE_ENDPOINTS}
-endpoint_locks = {service: asyncio.Lock() for service in SERVICE_ENDPOINTS}
+# Initialize rate limiter and request queue
+rate_limiter = RateLimiter(RATE_LIMIT)
+request_queue = RequestQueue(MAX_CONCURRENT_REQUESTS, REQUEST_QUEUE_SIZE)
 
 
-def get_next_endpoint(service_type):
-    """
-    Get next endpoint using round-robin load balancing.
-
-    Args:
-        service_type: 'prefill' or 'decode'
-
-    Returns:
-        str: Endpoint URL
-    """
-
-    async def _get_next():
-        async with endpoint_locks[service_type]:
-            endpoints = SERVICE_ENDPOINTS[service_type]
-            if not endpoints:
-                raise ValueError(f"No endpoints available for {service_type}")
-
-            # Round-robin selection
-            idx = endpoint_pointers[service_type]
-            endpoint = endpoints[idx]
-            endpoint_pointers[service_type] = (idx + 1) % len(endpoints)
-            return endpoint
-
-    return asyncio.run(_get_next())
+# Start queue processing on app startup
+@app.before_serving
+async def startup():
+    """Start request processing task when app starts serving"""
+    asyncio.create_task(request_queue.process())
 
 
 async def forward_request(url, data):
-    """
-    Forward request to backend service with streaming response.
+    """Forward request to backend service with rate limiting and error handling"""
+    # Apply rate limiting before making request
+    await rate_limiter.acquire()
 
-    Args:
-        url: Backend service URL
-        data: Request payload
-
-    Yields:
-        bytes: Response chunks
-    """
+    headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
-        headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
-        async with session.post(url=url, json=data, headers=headers) as response:
-            if response.status == 200:
-                # Stream response in 1KB chunks
-                async for chunk_bytes in response.content.iter_chunked(1024):
-                    yield chunk_bytes
+        try:
+            async with session.post(url=url, json=data, headers=headers) as response:
+                if response.status == 200:
+                    # Stream response chunks
+                    async for chunk_bytes in response.content.iter_chunked(1024):
+                        yield chunk_bytes
+                else:
+                    # Handle backend service errors
+                    error_text = await response.text()
+                    logger.error(f"Backend service error: {response.status} - {error_text}")
+                    yield b'{"error": "Backend service error"}'
+        except aiohttp.ClientError as e:
+            # Handle connection errors
+            logger.error(f"Connection error to {url}: {str(e)}")
+            yield b'{"error": "Service unavailable"}'
+        except asyncio.TimeoutError:
+            # Handle timeout errors
+            logger.error(f"Timeout connecting to {url}")
+            yield b'{"error": "Service timeout"}'
 
 
-@app.before_request
-async def before_request_handler():
-    """
-    Pre-request handler for rate limiting and concurrency control.
+async def process_request():
+    """Process a single request through prefill and decode stages"""
+    try:
+        original_request_data = await request.get_json()
 
-    Returns:
-        Response: Error response if limits are exceeded
-    """
-    # Initialize concurrency tracking
-    g.concurrency_acquired = False
+        # Create prefill request (max_tokens=1)
+        prefill_request = original_request_data.copy()
+        prefill_request["max_tokens"] = 1
 
-    # Rate limiting check
-    if not await rate_limiter.acquire():
-        app.logger.warning("Rate limit exceeded")
-        return jsonify({"error": "Too many requests"}), 429
+        # Execute prefill stage
+        async for _ in forward_request(PRE_SERVICE_URL, prefill_request):
+            continue
 
-    # Concurrency limiting check
-    if not await concurrency_limiter.acquire():
-        app.logger.warning("Concurrency limit reached")
-        return jsonify({"error": "Service busy, please try again later"}), 503
+        # Execute decode stage and stream response
+        generator = forward_request(DECODE_SERVICE_URL, original_request_data)
+        response = await make_response(generator)
+        response.timeout = None  # Disable timeout for streaming response
+        return response
 
-    # Mark concurrency slot as acquired
-    g.concurrency_acquired = True
-
-
-@app.teardown_request
-async def teardown_request(exc):
-    """
-    Post-request handler to release concurrency slot.
-
-    Args:
-        exc: Exception if any occurred during handling
-    """
-    if getattr(g, 'concurrency_acquired', False):
-        concurrency_limiter.release()
+    except Exception as e:
+        # Handle internal server errors
+        import traceback
+        logger.error(f"Error processing request: {str(e)}")
+        logger.error(traceback.format_exc())
+        return Response(
+            response=b'{"error": "Internal server error"}',
+            status=500,
+            content_type="application/json"
+        )
 
 
 @app.route("/v1/completions", methods=["POST"])
 async def handle_request():
-    """
-    Main request handler for completion requests.
+    """Handle incoming API requests with concurrency and rate limiting"""
+    # Create task for request processing
+    task = asyncio.create_task(process_request())
 
-    Returns:
-        Response: Streaming response or error
-    """
+    # Enqueue request or reject if queue is full
+    if not await request_queue.enqueue(task):
+        return Response(
+            response=b'{"error": "Server busy, try again later"}',
+            status=503,
+            content_type="application/json"
+        )
+
     try:
-        # Parse incoming request
-        original_request_data = await request.get_json()
-
-        # Phase 1: Prefill request
-        prefill_request = original_request_data.copy()
-        prefill_request["max_tokens"] = 1  # Force prefill-only
-        prefill_url = get_next_endpoint("prefill")
-
-        # Execute prefill (no streaming needed)
-        async for _ in forward_request(prefill_url, prefill_request):
-            continue  # Drain prefill response
-
-        # Phase 2: Decode request
-        decode_url = get_next_endpoint("decode")
-        generator = forward_request(decode_url, original_request_data)
-
-        # Create and return streaming response
-        response = await make_response(generator)
-        response.timeout = None  # Disable Quart timeout for streaming
-        return response
-
-    except Exception as e:
-        # Error handling and logging
-        import sys
-        import traceback
-
-        exc_info = sys.exc_info()
-        app.logger.error("Error in proxy server")
-        app.logger.error(f"Exception: {str(e)}")
-        app.logger.error("Traceback:\n" + "".join(traceback.format_exception(*exc_info)))
-
-        return jsonify({
-            "error": "Internal server error",
-            "message": str(e)
-        }), 500
+        # Return the response from the processing task
+        return await task
+    except asyncio.CancelledError:
+        # Handle task cancellation (timeout or queue full)
+        logger.warning("Request cancelled due to timeout or queue full")
+        return Response(
+            response=b'{"error": "Request cancelled"}',
+            status=503,
+            content_type="application/json"
+        )
 
 
 if __name__ == "__main__":
-    # Start server on all interfaces
+    # Start the Quart server
     app.run(port=8000, host="0.0.0.0")

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Global configuration parameters
-AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=60)  # Timeout for backend service requests (seconds)
+AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=300)  # Timeout for backend service requests (seconds)
 MAX_CONCURRENT_REQUESTS = 10  # Maximum concurrent requests to backend services
 REQUEST_QUEUE_SIZE = 50  # Maximum number of requests in the queue
 RATE_LIMIT = 5  # Maximum requests per second (rate limiting)

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -188,5 +188,5 @@ async def handle_request():
 
 
 if __name__ == "__main__":
-    # Start the Quart server
+    # Start the Quart server with host 0.0.0.0
     app.run(port=8000, host="0.0.0.0")

--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -2,62 +2,223 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
-
+import asyncio
+import time
+from collections import deque
+from quart import Quart, make_response, request, jsonify, g
 import aiohttp
-from quart import Quart, make_response, request
 
-AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
+# Configuration parameters
+MAX_CONCURRENT_REQUESTS = 10  # Maximum concurrent requests allowed
+REQUEST_RATE_LIMIT = 100  # Token bucket capacity (max burst requests)
+REQUEST_RATE_REFILL = 5  # Token refill rate per second
+CONCURRENCY_TIMEOUT = 5.0  # Timeout for acquiring concurrency slot (seconds)
+AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=1 * 60 * 60)  # Backend request timeout  (unit:hour)
 
 app = Quart(__name__)
 
 
+# Rate limiter implementation using token bucket algorithm
+class RateLimiter:
+    def __init__(self, rate_limit, refill_rate):
+        self.rate_limit = rate_limit  # Maximum tokens (requests) in bucket
+        self.refill_rate = refill_rate  # Tokens added per second
+        self.tokens = rate_limit  # Current token count
+        self.last_refill = time.monotonic()  # Last refill timestamp
+        self.lock = asyncio.Lock()  # Thread-safe lock
+
+    async def acquire(self):
+        """Acquire a token from the bucket if available."""
+        async with self.lock:
+            # Refill tokens based on time elapsed
+            now = time.monotonic()
+            elapsed = now - self.last_refill
+            if elapsed > 0:
+                # Calculate tokens to add and cap at bucket capacity
+                self.tokens = min(
+                    self.rate_limit,
+                    self.tokens + elapsed * self.refill_rate
+                )
+                self.last_refill = now
+
+            # Check if token is available
+            if self.tokens >= 1:
+                self.tokens -= 1
+                return True
+            return False
+
+
+# Concurrency limiter using semaphore
+class ConcurrencyLimiter:
+    def __init__(self, max_concurrent):
+        self.semaphore = asyncio.Semaphore(max_concurrent)  # Semaphore for concurrency control
+
+    async def acquire(self):
+        """Acquire a concurrency slot with timeout."""
+        try:
+            # Try to acquire slot with timeout
+            await asyncio.wait_for(self.semaphore.acquire(), timeout=CONCURRENCY_TIMEOUT)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    def release(self):
+        """Release a concurrency slot."""
+        self.semaphore.release()
+
+
+# Initialize limiters
+rate_limiter = RateLimiter(REQUEST_RATE_LIMIT, REQUEST_RATE_REFILL)
+concurrency_limiter = ConcurrencyLimiter(MAX_CONCURRENT_REQUESTS)
+
+# Backend service endpoints with load balancing
+SERVICE_ENDPOINTS = {
+    "prefill": [
+        "http://localhost:8100/v1/completions",
+        # Add more instances for horizontal scaling:
+        # "http://prefill-instance2:8100/v1/completions",
+    ],
+    "decode": [
+        "http://localhost:8200/v1/completions",
+        # Add more instances for horizontal scaling:
+        # "http://decode-instance2:8200/v1/completions",
+    ]
+}
+
+# Initialize round-robin state
+endpoint_pointers = {service: 0 for service in SERVICE_ENDPOINTS}
+endpoint_locks = {service: asyncio.Lock() for service in SERVICE_ENDPOINTS}
+
+
+def get_next_endpoint(service_type):
+    """
+    Get next endpoint using round-robin load balancing.
+
+    Args:
+        service_type: 'prefill' or 'decode'
+
+    Returns:
+        str: Endpoint URL
+    """
+
+    async def _get_next():
+        async with endpoint_locks[service_type]:
+            endpoints = SERVICE_ENDPOINTS[service_type]
+            if not endpoints:
+                raise ValueError(f"No endpoints available for {service_type}")
+
+            # Round-robin selection
+            idx = endpoint_pointers[service_type]
+            endpoint = endpoints[idx]
+            endpoint_pointers[service_type] = (idx + 1) % len(endpoints)
+            return endpoint
+
+    return asyncio.run(_get_next())
+
+
 async def forward_request(url, data):
+    """
+    Forward request to backend service with streaming response.
+
+    Args:
+        url: Backend service URL
+        data: Request payload
+
+    Yields:
+        bytes: Response chunks
+    """
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
         async with session.post(url=url, json=data, headers=headers) as response:
             if response.status == 200:
-                # if response.headers.get('Transfer-Encoding') == 'chunked':
-                if True:
-                    async for chunk_bytes in response.content.iter_chunked(1024):
-                        yield chunk_bytes
-                else:
-                    content = await response.read()
-                    yield content
+                # Stream response in 1KB chunks
+                async for chunk_bytes in response.content.iter_chunked(1024):
+                    yield chunk_bytes
+
+
+@app.before_request
+async def before_request_handler():
+    """
+    Pre-request handler for rate limiting and concurrency control.
+
+    Returns:
+        Response: Error response if limits are exceeded
+    """
+    # Initialize concurrency tracking
+    g.concurrency_acquired = False
+
+    # Rate limiting check
+    if not await rate_limiter.acquire():
+        app.logger.warning("Rate limit exceeded")
+        return jsonify({"error": "Too many requests"}), 429
+
+    # Concurrency limiting check
+    if not await concurrency_limiter.acquire():
+        app.logger.warning("Concurrency limit reached")
+        return jsonify({"error": "Service busy, please try again later"}), 503
+
+    # Mark concurrency slot as acquired
+    g.concurrency_acquired = True
+
+
+@app.teardown_request
+async def teardown_request(exc):
+    """
+    Post-request handler to release concurrency slot.
+
+    Args:
+        exc: Exception if any occurred during handling
+    """
+    if getattr(g, 'concurrency_acquired', False):
+        concurrency_limiter.release()
 
 
 @app.route("/v1/completions", methods=["POST"])
 async def handle_request():
+    """
+    Main request handler for completion requests.
+
+    Returns:
+        Response: Streaming response or error
+    """
     try:
+        # Parse incoming request
         original_request_data = await request.get_json()
 
+        # Phase 1: Prefill request
         prefill_request = original_request_data.copy()
-        # change max_tokens = 1 to let it only do prefill
-        prefill_request["max_tokens"] = 1
+        prefill_request["max_tokens"] = 1  # Force prefill-only
+        prefill_url = get_next_endpoint("prefill")
 
-        # finish prefill
-        async for _ in forward_request(
-            "http://localhost:8100/v1/completions", prefill_request
-        ):
-            continue
+        # Execute prefill (no streaming needed)
+        async for _ in forward_request(prefill_url, prefill_request):
+            continue  # Drain prefill response
 
-        # return decode
-        generator = forward_request(
-            "http://localhost:8200/v1/completions", original_request_data
-        )
+        # Phase 2: Decode request
+        decode_url = get_next_endpoint("decode")
+        generator = forward_request(decode_url, original_request_data)
+
+        # Create and return streaming response
         response = await make_response(generator)
-        response.timeout = None
-
+        response.timeout = None  # Disable Quart timeout for streaming
         return response
 
     except Exception as e:
+        # Error handling and logging
         import sys
         import traceback
 
         exc_info = sys.exc_info()
-        print("Error occurred in disagg prefill proxy server")
-        print(e)
-        print("".join(traceback.format_exception(*exc_info)))
+        app.logger.error("Error in proxy server")
+        app.logger.error(f"Exception: {str(e)}")
+        app.logger.error("Traceback:\n" + "".join(traceback.format_exception(*exc_info)))
+
+        return jsonify({
+            "error": "Internal server error",
+            "message": str(e)
+        }), 500
 
 
 if __name__ == "__main__":
-    app.run(port=8000)
+    # Start server on all interfaces
+    app.run(port=8000, host="0.0.0.0")


### PR DESCRIPTION
I found that when using 1P1D with proxy server, the prefiil instance or decode instance would take up error because of high concurrency and the process would be killed.So I add a rate limiter to proxy server to prevent PD service overload and it‘s effective.
What's more, you can contact me via email if you have any questions. My email address is: yongshengwang686@gmail.com
