### PR TITLE
[Bugfix]fix deepseek_r1_reasoning bugs when <think> </think> in contents.

### DIFF
--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+
 from collections.abc import Sequence
 from typing import Optional, Union
 
@@ -28,6 +29,13 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
 
     start_token: str = "<think>"
     end_token: str = "</think>"
+    # why not we use end_token directly?
+    # because end_token may appear in output lonely.
+    special_end_id: int = 201  # Special end token ID for DeepSeek R1
+    
+    # State management for pending end token confirmation
+    _pending_end_token: bool = False
+    _pending_end_content: str = ""
 
     def __init__(self, tokenizer: PreTrainedTokenizerBase):
         super().__init__(tokenizer)
@@ -43,9 +51,26 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
             raise RuntimeError(
                 "DeepSeek R1 reasoning parser could not locate think start/end "
                 "tokens in the tokenizer!")
+        
+        # Initialize state management
+        self._pending_end_token = False
+        self._pending_end_content = ""
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        return self.end_token_id in input_ids
+        """
+        Check if reasoning has ended by looking for </think> followed by special_end_id (201).
+        Only confirms reasoning end when </think> is immediately followed by 201.
+        """
+        if self.end_token_id not in input_ids:
+            return False
+        
+        # Find all occurrences of end_token_id
+        for i, token_id in enumerate(input_ids):
+            if token_id == self.end_token_id:
+                if i + 1 < len(input_ids) and input_ids[i + 1] == self.special_end_id:
+                    return True
+        
+        return False
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         """
@@ -72,6 +97,9 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         For text <think>abc</think>xyz:
         - 'abc' goes to reasoning_content
         - 'xyz' goes to content
+        
+        Enhanced logic to handle delayed confirmation of </think> tokens.
+        Only confirms reasoning end when </think> is followed by special_end_id (201).
         """
         # Skip single special tokens
         if len(delta_token_ids) == 1 and (delta_token_ids[0] in [
@@ -79,62 +107,157 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         ]):
             return None
 
+        # Handle pending end token confirmation first
+        if self._pending_end_token:
+            if len(delta_token_ids) > 0 and delta_token_ids[0] == self.special_end_id:
+                # Confirmed: previous </think> was real end of reasoning
+                self._pending_end_token = False
+                pending_content = self._pending_end_content
+                self._pending_end_content = ""
+                
+                # Extract remaining content after special_end_id
+                remaining_content = ""
+                if len(delta_token_ids) > 1:
+                    # Decode remaining tokens after special_end_id
+                    remaining_tokens = delta_token_ids[1:]
+                    remaining_content = self.model_tokenizer.decode(remaining_tokens, skip_special_tokens=False)
+                
+                return DeltaMessage(
+                    reasoning_content=pending_content,
+                    content=remaining_content if remaining_content else None,
+                )
+            else:
+                # Not confirmed: previous </think> was model output during reasoning,
+                # treat as reasoning_content since reasoning hasn't ended yet
+                self._pending_end_token = False
+                combined_reasoning = self._pending_end_content + self.end_token + delta_text
+                self._pending_end_content = ""
+                return DeltaMessage(reasoning_content=combined_reasoning)
+
         # Check if <think> is present in previous or delta.
+        # if <think> is in previous, it means reasoning content is opened.
         # Keep compatibility with models that don't generate <think> tokens.
         if self.start_token_id in previous_token_ids:
-            if self.end_token_id in delta_token_ids:
+            if self.end_token_id in delta_token_ids and \
+                    self.end_token_id not in previous_token_ids:
                 # <think> in previous, </think> in delta,
-                # extract reasoning content
+                # Need to check if this is real end or model output
                 end_index = delta_text.find(self.end_token)
-                reasoning_content = delta_text[:end_index]
-                content = delta_text[end_index + len(self.end_token):]
-                return DeltaMessage(
-                    reasoning_content=reasoning_content,
-                    content=content if content else None,
-                )
+                end_token_index = delta_token_ids.index(self.end_token_id)
+                
+                # If there are more tokens after </think>, judge if it's real end of think.
+                if end_token_index + 1 < len(delta_token_ids):
+                    if delta_token_ids[end_token_index + 1] == self.special_end_id:
+                        # Confirmed end of reasoning
+                        reasoning_content = delta_text[:end_index]
+                        content = delta_text[end_index + len(self.end_token):]
+                        return DeltaMessage(
+                            reasoning_content=reasoning_content,
+                            content=content if content else None,
+                        )
+                    else:
+                        # Not confirmed, treat </think> as reasoning content
+                        return DeltaMessage(reasoning_content=delta_text)
+                else:
+                    # </think> is at the end, need to wait for next token to confirm
+                    reasoning_content = delta_text[:end_index]
+                    self._pending_end_token = True
+                    self._pending_end_content = reasoning_content
+                    return None  # Temporarily not handle. Wait for next token
+                    
             elif self.end_token_id in previous_token_ids:
                 # <think> in previous, </think> in previous,
-                # reasoning content continues
-                return DeltaMessage(content=delta_text)
+                # Need to check if reasoning has actually ended by confirming </think> + 201
+                if self.is_reasoning_end(list(previous_token_ids)):
+                    # Reasoning has truly ended, this is normal content
+                    return DeltaMessage(content=delta_text)
+                else:
+                    # </think> was in previous but not confirmed as end, still reasoning
+                    return DeltaMessage(reasoning_content=delta_text)
             else:
                 # <think> in previous, no </think> in previous or delta,
                 # reasoning content continues
                 return DeltaMessage(reasoning_content=delta_text)
+                
         elif self.start_token_id in delta_token_ids:
             if self.end_token_id in delta_token_ids:
-                # <think> in delta, </think> in delta, extract reasoning content
+                # <think> in delta, </think> in delta, need to check for 201 confirmation
                 start_index = delta_text.find(self.start_token)
                 end_index = delta_text.find(self.end_token)
-                reasoning_content = delta_text[start_index +
-                                               len(self.start_token):end_index]
-                content = delta_text[end_index + len(self.end_token):]
-                return DeltaMessage(
-                    reasoning_content=reasoning_content,
-                    content=content if content else None,
-                )
+                end_token_index = delta_token_ids.index(self.end_token_id)
+                
+                # Check if special_end_id follows immediately after </think>
+                if end_token_index + 1 < len(delta_token_ids):
+                    if delta_token_ids[end_token_index + 1] == self.special_end_id:
+                        # Confirmed end of reasoning
+                        reasoning_content = delta_text[start_index + len(self.start_token):end_index]
+                        content = delta_text[end_index + len(self.end_token):]
+                        return DeltaMessage(
+                            reasoning_content=reasoning_content,
+                            content=content if content else None,
+                        )
+                    else:
+                        # Not confirmed, treat </think> as part of reasoning content
+                        reasoning_content = delta_text[start_index + len(self.start_token):]
+                        return DeltaMessage(reasoning_content=reasoning_content)
+                else:
+                    # </think> is at the end, need to wait for confirmation
+                    reasoning_content = delta_text[start_index + len(self.start_token):end_index]
+                    self._pending_end_token = True
+                    self._pending_end_content = reasoning_content
+                    return None  # Wait for next token
             else:
                 # <think> in delta, no </think> in delta,
                 # reasoning content continues
-                return DeltaMessage(reasoning_content=delta_text)
+                if delta_token_ids == current_token_ids:
+                    processed_text = delta_text.replace(self.start_token, "")
+                    return DeltaMessage(reasoning_content=processed_text)
+                else:
+                    return DeltaMessage(content=delta_text)
         else:
             # No <think> in previous or delta, also need to check for </think>.
             # Because the model may have generated </think> without <think>
             # Ref https://huggingface.co/deepseek-ai/DeepSeek-R1/commit/8a58a132790c9935686eb97f042afa8013451c9f
             if self.end_token_id in delta_token_ids:
-                # </think> in delta with more tokens,
-                # extract reasoning content and content
+                # </think> in delta, need delayed confirmation
                 end_index = delta_text.find(self.end_token)
-                reasoning_content = delta_text[:end_index]
-                content = delta_text[end_index + len(self.end_token):]
-                return DeltaMessage(
-                    reasoning_content=reasoning_content,
-                    content=content if content else None,
-                )
+                end_token_index = delta_token_ids.index(self.end_token_id)
+                
+                # Check if special_end_id follows immediately
+                if end_token_index + 1 < len(delta_token_ids):
+                    if delta_token_ids[end_token_index + 1] == self.special_end_id:
+                        # Confirmed end of reasoning
+                        reasoning_content = delta_text[:end_index]
+                        content = delta_text[end_index + len(self.end_token):]
+                        return DeltaMessage(
+                            reasoning_content=reasoning_content,
+                            content=content if content else None,
+                        )
+                    else:
+                        # Not confirmed, since we're in a context where no </think>
+                        # has been confirmed in previous tokens, we're likely still
+                        # in reasoning mode, so treat as reasoning_content
+                        return DeltaMessage(reasoning_content=delta_text)
+                else:
+                    # </think> is at the end, need to wait for confirmation
+                    reasoning_content = delta_text[:end_index]
+                    self._pending_end_token = True
+                    self._pending_end_content = reasoning_content
+                    return None  # Wait for next token
+                    
             elif self.end_token_id in previous_token_ids:
-                # </think> in previous, thinking content ends
-                return DeltaMessage(content=delta_text)
+                # </think> in previous, need to check if reasoning truly ended
+                if self.is_reasoning_end(list(previous_token_ids)):
+                    # Reasoning has truly ended, this is normal content
+                    return DeltaMessage(content=delta_text)
+                else:
+                    # </think> was in previous but not confirmed as end, still reasoning
+                    return DeltaMessage(reasoning_content=delta_text)
             else:
                 # no </think> in previous or delta, reasoning content continues
+                # it means in delta_text, there is no <think> or </think>
+                # meanwhile, in previous_text, there is no <think> or </think>
+                # Since no confirmed end of reasoning has occurred, treat as reasoning_content
                 return DeltaMessage(reasoning_content=delta_text)
 
     def extract_reasoning_content(
@@ -147,27 +270,43 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         - 'abc' goes to reasoning_content
         - 'xyz' goes to content
 
+        Enhanced to check for <think>\n and </think>\n patterns to ensure
+        proper detection of reasoning tokens followed by newline (token 201).
+
         Returns:
             tuple[Optional[str], Optional[str]]: reasoning content and content
         """
+        # Check if both start and end tokens are absent and response_format is not None
+        # In this case, treat the entire output as content
+        start_token_with_newline = self.start_token + "\n"
+        end_token_with_newline = self.end_token + "\n"
+        
+        if (self.start_token not in model_output and \
+                self.end_token not in model_output and \
+                request.response_format is not None):
+            return None, model_output
 
-        # Check if the start token is present in the model output, remove it
-        # if it is present.
-        model_output_parts = model_output.partition(self.start_token)
-        model_output = model_output_parts[2] if model_output_parts[
-            1] else model_output_parts[0]
+        # Check if the start token with newline is present, prioritize it
+        # If not found, fall back to start token without newline for compatibility
+        if start_token_with_newline in model_output:
+            model_output_parts = model_output.partition(start_token_with_newline)
+            model_output = model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
+        else:
+            model_output_parts = model_output.partition(self.start_token)
+            model_output = model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
 
         # DeepSeek R1 doesn't generate <think> now.
         # Thus we assume the reasoning content is always at the start.
         # Ref https://huggingface.co/deepseek-ai/DeepSeek-R1/commit/8a58a132790c9935686eb97f042afa8013451c9f
-        if self.end_token not in model_output:
-            return model_output, None
-        else:
-            reasoning_content, _, content = model_output.partition(
-                self.end_token)
-            # If the end token is not found, return the model output as is.
-            # It should not happen since we already checked for the presence
-            # of the end token.
-            # If generation stops right after end-of-think, return null content
+        
+        # Check for end token with newline first, then fall back to end token without newline
+        if end_token_with_newline in model_output:
+            reasoning_content, _, content = model_output.partition(end_token_with_newline)
             final_content = content or None
             return reasoning_content, final_content
+        elif self.end_token in model_output:
+            reasoning_content, _, content = model_output.partition(self.end_token)
+            final_content = content or None
+            return reasoning_content, final_content
+        else:
+            return model_output, None

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -58,17 +58,20 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         """
-        Check if reasoning has ended by looking for </think> followed by special_end_id (201).
-        Only confirms reasoning end when </think> is immediately followed by 201.
+        Check if reasoning has ended by looking for </think> 
+        followed by special_end_id (201).
+        Only confirms reasoning end when </think> is immediately 
+        followed by 201.
         """
         if self.end_token_id not in input_ids:
             return False
         
         # Find all occurrences of end_token_id
         for i, token_id in enumerate(input_ids):
-            if token_id == self.end_token_id:
-                if i + 1 < len(input_ids) and input_ids[i + 1] == self.special_end_id:
-                    return True
+            if token_id == self.end_token_id and \
+               i + 1 < len(input_ids) and input_ids[
+                i + 1] == self.special_end_id:
+                return True
         
         return False
 
@@ -99,7 +102,8 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         - 'xyz' goes to content
         
         Enhanced logic to handle delayed confirmation of </think> tokens.
-        Only confirms reasoning end when </think> is followed by special_end_id (201).
+        Only confirms reasoning end when </think> is followed 
+        by special_end_id (201).
         """
         # Skip single special tokens
         if len(delta_token_ids) == 1 and (delta_token_ids[0] in [
@@ -109,7 +113,8 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
 
         # Handle pending end token confirmation first
         if self._pending_end_token:
-            if len(delta_token_ids) > 0 and delta_token_ids[0] == self.special_end_id:
+            if len(delta_token_ids
+                    ) > 0 and delta_token_ids[0] == self.special_end_id:
                 # Confirmed: previous </think> was real end of reasoning
                 self._pending_end_token = False
                 pending_content = self._pending_end_content
@@ -120,17 +125,20 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
                 if len(delta_token_ids) > 1:
                     # Decode remaining tokens after special_end_id
                     remaining_tokens = delta_token_ids[1:]
-                    remaining_content = self.model_tokenizer.decode(remaining_tokens, skip_special_tokens=False)
-                
+                    remaining_content = self.model_tokenizer.decode(
+                        remaining_tokens, skip_special_tokens=False)
+
                 return DeltaMessage(
                     reasoning_content=pending_content,
                     content=remaining_content if remaining_content else None,
                 )
             else:
-                # Not confirmed: previous </think> was model output during reasoning,
+                # Not confirmed: previous </think> was model output,
                 # treat as reasoning_content since reasoning hasn't ended yet
                 self._pending_end_token = False
-                combined_reasoning = self._pending_end_content + self.end_token + delta_text
+                combined_reasoning = (
+                    self._pending_end_content + self.end_token + delta_text
+                )
                 self._pending_end_content = ""
                 return DeltaMessage(reasoning_content=combined_reasoning)
 
@@ -147,7 +155,8 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
                 
                 # If there are more tokens after </think>, judge if it's real end of think.
                 if end_token_index + 1 < len(delta_token_ids):
-                    if delta_token_ids[end_token_index + 1] == self.special_end_id:
+                    if delta_token_ids[end_token_index + 
+                                        1] == self.special_end_id:
                         # Confirmed end of reasoning
                         reasoning_content = delta_text[:end_index]
                         content = delta_text[end_index + len(self.end_token):]
@@ -167,12 +176,12 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
                     
             elif self.end_token_id in previous_token_ids:
                 # <think> in previous, </think> in previous,
-                # Need to check if reasoning has actually ended by confirming </think> + 201
+                # Need to check if reasoning has actually ended
                 if self.is_reasoning_end(list(previous_token_ids)):
                     # Reasoning has truly ended, this is normal content
                     return DeltaMessage(content=delta_text)
                 else:
-                    # </think> was in previous but not confirmed as end, still reasoning
+                    # </think> was in previous but not confirmed as end
                     return DeltaMessage(reasoning_content=delta_text)
             else:
                 # <think> in previous, no </think> in previous or delta,
@@ -181,16 +190,19 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
                 
         elif self.start_token_id in delta_token_ids:
             if self.end_token_id in delta_token_ids:
-                # <think> in delta, </think> in delta, need to check for 201 confirmation
+                # <think> in delta, </think> in delta, need to check
                 start_index = delta_text.find(self.start_token)
                 end_index = delta_text.find(self.end_token)
                 end_token_index = delta_token_ids.index(self.end_token_id)
                 
                 # Check if special_end_id follows immediately after </think>
                 if end_token_index + 1 < len(delta_token_ids):
-                    if delta_token_ids[end_token_index + 1] == self.special_end_id:
+                    if delta_token_ids[end_token_index + 
+                                        1] == self.special_end_id:
                         # Confirmed end of reasoning
-                        reasoning_content = delta_text[start_index + len(self.start_token):end_index]
+                        reasoning_content = delta_text[
+                            start_index + len(self.start_token):end_index
+                        ]
                         content = delta_text[end_index + len(self.end_token):]
                         return DeltaMessage(
                             reasoning_content=reasoning_content,
@@ -198,11 +210,15 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
                         )
                     else:
                         # Not confirmed, treat </think> as part of reasoning content
-                        reasoning_content = delta_text[start_index + len(self.start_token):]
-                        return DeltaMessage(reasoning_content=reasoning_content)
+                        reasoning_content = delta_text[start_index + 
+                                                        len(self.start_token):]
+                        return DeltaMessage(
+                            reasoning_content=reasoning_content)
                 else:
                     # </think> is at the end, need to wait for confirmation
-                    reasoning_content = delta_text[start_index + len(self.start_token):end_index]
+                    reasoning_content = delta_text[
+                        start_index + len(self.start_token):end_index
+                    ]
                     self._pending_end_token = True
                     self._pending_end_content = reasoning_content
                     return None  # Wait for next token
@@ -225,7 +241,8 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
                 
                 # Check if special_end_id follows immediately
                 if end_token_index + 1 < len(delta_token_ids):
-                    if delta_token_ids[end_token_index + 1] == self.special_end_id:
+                    if delta_token_ids[end_token_index + 
+                                        1] == self.special_end_id:
                         # Confirmed end of reasoning
                         reasoning_content = delta_text[:end_index]
                         content = delta_text[end_index + len(self.end_token):]
@@ -289,11 +306,14 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         # Check if the start token with newline is present, prioritize it
         # If not found, fall back to start token without newline for compatibility
         if start_token_with_newline in model_output:
-            model_output_parts = model_output.partition(start_token_with_newline)
-            model_output = model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
+            model_output_parts = model_output.partition(
+                start_token_with_newline)
+            model_output = model_output_parts[2] if model_output_parts[
+                1] else model_output_parts[0]
         else:
             model_output_parts = model_output.partition(self.start_token)
-            model_output = model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
+            model_output = model_output_parts[2] if model_output_parts[
+                1] else model_output_parts[0]
 
         # DeepSeek R1 doesn't generate <think> now.
         # Thus we assume the reasoning content is always at the start.
@@ -301,11 +321,13 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         
         # Check for end token with newline first, then fall back to end token without newline
         if end_token_with_newline in model_output:
-            reasoning_content, _, content = model_output.partition(end_token_with_newline)
+            reasoning_content, _, content = model_output.partition(
+                end_token_with_newline)
             final_content = content or None
             return reasoning_content, final_content
         elif self.end_token in model_output:
-            reasoning_content, _, content = model_output.partition(self.end_token)
+            reasoning_content, _, content = model_output.partition(
+                self.end_token)
             final_content = content or None
             return reasoning_content, final_content
         else:


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
To fix the issue in the reasoning_content module where there is no special parsing for the possible presence of <think> and </think> content in user input.

## Test Plan
Add <think> or </think> in the prompt input of the request to reproduce the test process.

## Test Result
<img width="2458" height="1512" alt="企业微信截图_600cc34e-3281-42ab-8c88-e89affc17e2c" src="https://github.com/user-attachments/assets/9121c0c3-a799-4042-ba39-7d8b602ca804" />

## (Optional) Documentation Update

