### PR TITLE
Add an option to cache torch dynamo artifacts on disk to reduce warm start time.

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -354,6 +354,7 @@ steps:
     - pytest -v -s compile/test_sequence_parallelism.py
     - pytest -v -s compile/test_async_tp.py
     - pytest -v -s compile/test_fusion_all_reduce.py
+    - pytest -v -s compile/test_dynamo_caching.py
 
 - label: PyTorch Fullgraph Smoke Test # 9min
   mirror_hardwares: [amdexperimental]

--- a/tests/compile/test_dynamo_caching.py
+++ b/tests/compile/test_dynamo_caching.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import dataclasses
+import tempfile
+
+import pytest
+import torch
+
+from vllm import LLM, SamplingParams
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import (CompilationConfig, CompilationLevel, VllmConfig,
+                         set_current_vllm_config)
+
+
+class MyMod(torch.nn.Module):
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    def forward(self, x: torch.Tensor):
+        for _ in range(3000):
+            x = x + x.shape[0]
+        return x
+
+
+def test_basic(monkeypatch: pytest.MonkeyPatch):
+    vllm_config = VllmConfig(compilation_config=CompilationConfig(
+        level=CompilationLevel.PIECEWISE, ))
+    mod = MyMod()
+    args = (torch.randn(10, 10), )
+    expected = mod(*args)
+    CompiledMod = support_torch_compile(MyMod)
+    with set_current_vllm_config(vllm_config):
+        ret = CompiledMod(vllm_config=vllm_config)(*args)
+    assert torch.allclose(ret, expected)
+    torch._dynamo.reset()
+
+    try:
+        with torch.compiler.set_stance(
+                "fail_on_recompile"), set_current_vllm_config(vllm_config):
+            ret = CompiledMod(vllm_config=vllm_config)(*args)
+            assert torch.allclose(ret, expected)
+    except RuntimeError as e:
+        assert "Detected recompile" in str(e)
+    else:
+        raise AssertionError("Expected failed recompilation.")
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        vllm_config.compilation_config.cache_dir = tmpdirname
+        with monkeypatch.context() as m, set_current_vllm_config(vllm_config):
+            m.setenv("VLLM_USE_TORCH_DYNAMO_CACHING", "1")
+            CompiledMod(vllm_config=vllm_config)(*args)
+            torch._dynamo.reset()
+            with torch.compiler.set_stance("fail_on_recompile"):
+                ret = CompiledMod(vllm_config=vllm_config)(*args)
+                assert torch.allclose(ret, expected)
+
+
+@dataclasses.dataclass
+class Setting:
+    model: str
+
+
+@pytest.mark.parametrize("test_setting", [
+    Setting(model="Qwen/Qwen3-1.7B", ),
+])
+def test_model(monkeypatch: pytest.MonkeyPatch, test_setting: Setting):
+    monkeypatch.setenv('VLLM_ENABLE_V1_MULTIPROCESSING', '0')
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    sampling_params = SamplingParams(temperature=0)
+
+    llm = LLM(model=test_setting.model, gpu_memory_utilization=0.2)
+    outputs = llm.generate(prompts, sampling_params)
+
+    torch._dynamo.reset()
+    del llm
+
+    try:
+        with torch.compiler.set_stance("fail_on_recompile"):
+            llm = LLM(model=test_setting.model, gpu_memory_utilization=0.2)
+            llm.generate(prompts, sampling_params)
+    except RuntimeError as e:
+        assert "Detected recompile" in str(e)
+    else:
+        raise AssertionError("Expected failed recompilation.")
+
+    monkeypatch.setenv("VLLM_USE_TORCH_DYNAMO_CACHING", "1")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        monkeypatch.setenv("VLLM_CACHE_ROOT", tmpdirname)
+        llm = LLM(model=test_setting.model, gpu_memory_utilization=0.2)
+        outputs_save = llm.generate(prompts, sampling_params)
+        assert len(outputs) == len(outputs_save)
+        for output, output_save in zip(outputs, outputs_save):
+            assert output.outputs[0].text == output_save.outputs[0].text
+        torch._dynamo.reset()
+        del llm
+        with torch.compiler.set_stance("fail_on_recompile"):
+            llm = LLM(model=test_setting.model, gpu_memory_utilization=0.2)
+            outputs_load = llm.generate(prompts, sampling_params)
+        assert len(outputs) == len(outputs_load)
+        for output, output_load in zip(outputs, outputs_load):
+            assert output.outputs[0].text == output_load.outputs[0].text

--- a/tools/check_pickle_imports.py
+++ b/tools/check_pickle_imports.py
@@ -29,6 +29,7 @@ ALLOWED_FILES = set([
     # pickle
     'vllm/v1/serial_utils.py',
     'vllm/v1/executor/multiproc_executor.py',
+    'vllm/compilation/wrapper.py',
     'vllm/multimodal/hasher.py',
     'vllm/transformers_utils/config.py',
     'vllm/model_executor/models/registry.py',

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -1,20 +1,143 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import functools
+import inspect
 import os
+import pickle
 import sys
+import types
 from abc import abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 from types import CodeType
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import torch
 
 import vllm.envs as envs
 from vllm.config import CompilationLevel, get_current_vllm_config
 from vllm.logger import init_logger
+from vllm.utils import is_torch_equal_or_newer
 
 logger = init_logger(__name__)
+
+
+def normalize_graph_module(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    for node in gm.graph.nodes:
+        node.meta.pop("source_fn_stack", None)
+        node.meta.pop("nn_module_stack", None)
+    return gm
+
+
+def _unpickle_c_op(name):
+    return getattr(torch.ops._C, name)
+
+
+def _patch_torch_2_9_pickler():
+    import sympy
+    from torch._dynamo.guards import GuardsStatePickler
+    from torch._subclasses import FakeTensorMode
+    from torch.fx._graph_pickler import GraphPickler
+
+    graph_reducer_override = GraphPickler.reducer_override
+
+    def _graph_reducer_override(self, obj):
+        if (inspect.isclass(obj) and issubclass(obj, sympy.Function)
+                and hasattr(obj, "_torch_unpickler")):
+            return obj._torch_unpickler, (obj._torch_handler_name, )
+        if isinstance(obj, FakeTensorMode):
+            return type(None), ()
+        return graph_reducer_override(self, obj)
+
+    GraphPickler.reducer_override = _graph_reducer_override
+
+    if is_torch_equal_or_newer("2.9"):
+        return
+
+    reducer_override = GuardsStatePickler.reducer_override
+
+    # Porting https://github.com/pytorch/pytorch/pull/158926 from torch 2.9
+    def _reducer_override(self, obj):
+        if isinstance(obj, torch._ops.OpOverloadPacket
+                      ) and obj._qualified_op_name.startswith("_C::"):
+            return _unpickle_c_op, (obj.__name__, )
+
+        if (obj.__class__.__module__ == "builtins"
+                and obj.__class__.__name__ == "PyCapsule"):
+            return object, ()
+
+        if isinstance(obj, types.CodeType):
+            return object, ()
+
+        if inspect.isfunction(obj) and obj.__qualname__ != obj.__name__:
+            return object, ()
+
+        return reducer_override(self, obj)
+
+    GuardsStatePickler.reducer_override = _reducer_override
+
+
+def _patch_torch_2_9_package_install(package):
+    if is_torch_equal_or_newer("2.9"):
+        return
+    # Work around https://github.com/pytorch/pytorch/pull/157285 from torch 2.9
+    from torch._C._dynamo.eval_frame import _load_precompile_entry
+    from torch._dynamo.guards import GuardManagerWrapper, RootGuardManager
+    from torch._dynamo.package import SerializedCode
+
+    for code, entry in package._codes.items():
+        assert len(entry.guarded_codes) == 1
+        for guarded_code in entry.guarded_codes:
+            _load_precompile_entry(
+                code,
+                GuardManagerWrapper(RootGuardManager()),
+                SerializedCode.to_code_object(guarded_code.dynamo_code),
+            )
+
+
+@dataclass
+class SymInput:
+    expr: Any
+    hint: Any
+    pytype: type
+
+    @classmethod
+    def from_sym_node(cls, sym_node):
+        return cls(
+            expr=sym_node.expr,
+            hint=sym_node.hint,
+            pytype=sym_node.pytype,
+        )
+
+    @classmethod
+    def to_sym_node(cls, sym_input, shape_env):
+        from torch.fx.experimental.symbolic_shapes import SymNode
+
+        return SymNode(
+            sym_input.expr,
+            shape_env,
+            sym_input.pytype,
+            sym_input.hint,
+        )
+
+
+@dataclass
+class BackendInputs:
+    inlined_sources: set[str]
+    example_sym_inputs: dict[int, SymInput]
+
+    @classmethod
+    def save(cls, filename, **kwargs):
+        with open(filename, "wb") as f:
+            pickle.dump(cls(**kwargs), f)
+
+    @classmethod
+    def load(cls, filename) -> "BackendInputs":
+        with open(filename, "rb") as f:
+            ret = pickle.load(f)
+        assert isinstance(ret, cls)
+        return ret
 
 
 class TorchCompileWrapperWithCustomDispatcher:
@@ -30,10 +153,11 @@ class TorchCompileWrapperWithCustomDispatcher:
         `torch.compile` over the forward method.
     """
 
-    def __init__(self,
-                 compiled_callable: Optional[Callable] = None,
-                 compilation_level: int = 0):
-
+    def __init__(
+        self,
+        compiled_callable: Optional[Callable] = None,
+        compilation_level: int = 0,
+    ):
         vllm_config = get_current_vllm_config()
         self.vllm_config = vllm_config
         if compiled_callable is None:
@@ -46,11 +170,16 @@ class TorchCompileWrapperWithCustomDispatcher:
                 options = get_current_vllm_config(
                 ).compilation_config.inductor_compile_config
 
-            compiled_callable = torch.compile(
+            torch_compile = torch.compile
+            if envs.VLLM_USE_TORCH_DYNAMO_CACHING:
+                torch_compile = self._torch_compile_with_dynamo_cache
+
+            compiled_callable = torch_compile(
                 self.forward,
                 fullgraph=envs.VLLM_TEST_DYNAMO_FULLGRAPH_CAPTURE,
                 backend=backend,
-                options=options)
+                options=options,
+            )
 
         self.compiled_callable = compiled_callable
         self.original_code_object = self.__class__.forward.__code__
@@ -60,8 +189,144 @@ class TorchCompileWrapperWithCustomDispatcher:
         # read the env var to determine whether to use the custom dispatcher
         # subclasses can use this to switch between the custom dispatcher
         # and the default Dynamo guard mechanism.
-        self.use_custom_dispatcher: bool = \
-            compilation_level >= CompilationLevel.DYNAMO_ONCE
+        self.use_custom_dispatcher: bool = (compilation_level
+                                            >= CompilationLevel.DYNAMO_ONCE)
+
+    def _torch_compile_with_dynamo_cache(self, model, fullgraph, backend,
+                                         options):
+        from torch._dynamo.package import CompilePackage
+        from torch._guards import TracingContext, tracing
+        from torch._subclasses import FakeTensorMode
+        from torch.fx._graph_pickler import GraphPickler, Options
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        try:
+            # torch 2.9+
+            from torch._dynamo.package import DiskDynamoStore
+        except ImportError:
+            # torch 2.8
+            from torch._dynamo.package import DynamoStore as DiskDynamoStore
+
+        _patch_torch_2_9_pickler()
+        package = CompilePackage(model)
+        hash_key = package.source_id
+
+        cache_dir = os.path.join(
+            envs.VLLM_CACHE_ROOT,
+            "torch_dynamo_cache",
+            hash_key,
+        )
+
+        rank = self.vllm_config.parallel_config.rank
+        dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+        local_cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}")
+
+        loading = False
+        store = DiskDynamoStore()
+        eager_backends = {}
+        try:
+            package, eager_backends = store.load_package(
+                model, local_cache_dir)
+            logger.info("Loaded dynamo cache from %s", local_cache_dir)
+            loading = True
+        except Exception:
+            pass
+
+        inlined_sources = set()
+        example_sym_inputs = {}
+
+        if loading:
+
+            loaded_backends = {}
+            vllm_config = self.vllm_config
+            vllm_extras = BackendInputs.load(
+                os.path.join(local_cache_dir, "vllm_extras.pickle"))
+            inlined_sources = vllm_extras.inlined_sources
+            example_sym_inputs = vllm_extras.example_sym_inputs
+
+            class CompiledGraph:
+
+                def __init__(self, gm, fake_mode):
+                    self._callback = None
+                    self._gm = gm
+                    self._fake_mode = fake_mode
+
+                def __call__(self, *example_inputs):
+                    if self._callback is None:
+                        vllm_config.compilation_config.traced_files = (
+                            inlined_sources)
+                        compile_inputs = list(example_inputs)
+                        for i, example_sym_input in example_sym_inputs.items():
+                            compile_inputs[i] = torch.SymInt(
+                                SymInput.to_sym_node(example_sym_input,
+                                                     fake_mode.shape_env))
+                        with tracing(TracingContext(fake_mode)):
+                            self._callback = backend(gm, compile_inputs)
+                    return self._callback(*example_inputs)
+
+                def after_deserialization(self):
+                    return self
+
+            for k, v in eager_backends.items():
+                fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+                backend_content = v
+                if hasattr(backend_content, "after_deserialization"):
+                    backend_content = backend_content.after_deserialization()
+                assert isinstance(backend_content, bytes)
+                gm = GraphPickler.loads(backend_content, fake_mode)
+
+                loaded_backends[k] = CompiledGraph(gm, fake_mode)
+
+            package.install(loaded_backends)
+            _patch_torch_2_9_package_install(package)
+            vllm_config.compilation_config.load_dynamo_cache = True
+
+        vllm_to_eager_backends = {}
+
+        def _custom_backend(gm, example_inputs):
+            if not loading:
+                inlined_sources.update(
+                    self.vllm_config.compilation_config.traced_files)
+                for i, example_input in enumerate(example_inputs):
+                    if isinstance(example_input, torch.SymInt):
+                        example_sym_inputs[i] = SymInput.from_sym_node(
+                            example_input.node)
+            ret = backend(gm, example_inputs)
+            if not loading:
+                vllm_to_eager_backends[ret] = gm
+            return ret
+
+        _compiled_callable = torch._dynamo.optimize(
+            backend=_custom_backend,
+            nopython=fullgraph,
+            package=package,
+            guard_filter_fn=lambda gs: [False for x in gs],
+        )(model)
+
+        @functools.wraps(_compiled_callable)
+        def compiled_callable(*args, **kwargs):
+            ret = _compiled_callable(*args, **kwargs)
+            if not loading:
+                for k, v in package.cached_backends.items():
+                    store.record_eager_backend(
+                        k,
+                        GraphPickler.dumps(
+                            normalize_graph_module(vllm_to_eager_backends[v]),
+                            Options(ops_filter=None),
+                        ),
+                    )
+                if not is_torch_equal_or_newer("2.9"):
+                    os.makedirs(local_cache_dir, exist_ok=True)
+
+                store.save_package(package, local_cache_dir)
+                BackendInputs.save(
+                    os.path.join(local_cache_dir, "vllm_extras.pickle"),
+                    inlined_sources=inlined_sources,
+                    example_sym_inputs=example_sym_inputs,
+                )
+            return ret
+
+        return compiled_callable
 
     def __call__(self, *args, **kwargs):
         """Implement the dispatch logic here, beyond the torch.compile level.

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -2864,24 +2864,24 @@ class PoolerConfig:
     ## for embeddings models
     normalize: Optional[bool] = None
     """
-    Whether to normalize the embeddings outputs. 
+    Whether to normalize the embeddings outputs.
     """
     dimensions: Optional[int] = None
     """
-    Reduce the dimensions of embeddings if model 
+    Reduce the dimensions of embeddings if model
     support matryoshka representation.
     """
 
     ## for classification models
     activation: Optional[bool] = None
     """
-    Whether to apply activation function to the classification outputs. 
+    Whether to apply activation function to the classification outputs.
     """
 
     ## for reward models
     softmax: Optional[bool] = None
     """
-    Whether to apply softmax to the reward outputs. 
+    Whether to apply softmax to the reward outputs.
     """
     step_tag_id: Optional[int] = None
     """

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -246,6 +246,7 @@ class CompilationConfig:
     """files that are traced for compilation"""
     compilation_time: float = field(default=0.0, init=False)
     """time taken for compilation"""
+    load_dynamo_cache: bool = False
 
     static_forward_context: dict[str, Any] = field(default_factory=dict,
                                                    init=False)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -353,6 +353,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_USE_STANDALONE_COMPILE":
     lambda: os.environ.get("VLLM_USE_STANDALONE_COMPILE", "1") == "1",
 
+    "VLLM_USE_TORCH_DYNAMO_CACHING":
+    lambda: os.environ.get("VLLM_USE_TORCH_DYNAMO_CACHING", "0") == "1",
+
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK":


### PR DESCRIPTION
Summary:
Addressing RFC https://github.com/vllm-project/vllm/issues/20402
Adding a new option VLLM_USE_TORCH_DYNAMO_CACHING so that it will try to cache
dynamo compilation artifact and skip the compilation the 2nd time the model is
loaded.

Based on some small benchmark on Qwen-32B, this can reduce warm start time of dynamo
from ~8 seconds down to ~0.3 seconds.

Currently this is an opt-in since there should be a couple of corner cases
uncovered and we expect to fix this along the way.

Test Plan:

pytest tests/compile/test_dynamo_caching.py

Reviewers:

Subscribers:

Tasks:

Tags:

# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

