### PR TITLE
[CI/Build] Skip Mllama HF runner tests with Transformers v4.55.0

### DIFF
--- a/tests/models/multimodal/generation/test_mllama.py
+++ b/tests/models/multimodal/generation/test_mllama.py
@@ -6,6 +6,7 @@ from typing import Optional, overload
 import pytest
 import torch
 from transformers import AutoConfig, AutoModelForImageTextToText, AutoTokenizer
+from transformers import __version__ as TRANSFORMERS_VERSION
 
 from vllm import LLM, SamplingParams
 from vllm.attention.backends.flash_attn import FlashAttentionMetadata
@@ -285,6 +286,10 @@ def clear_cache():
 @pytest.mark.parametrize("max_tokens", [128])
 @pytest.mark.parametrize("num_logprobs", [5])
 @pytest.mark.parametrize("attn_backend", LIST_ENC_DEC_SUPPORTED_BACKENDS)
+@pytest.mark.skipif(
+    TRANSFORMERS_VERSION == "4.55.0",
+    reason="Transformers v4.55.0 has a regression issue on mllama, "
+    "see: https://github.com/huggingface/transformers/pull/40083")
 def test_models_single_leading_image(hf_runner, vllm_runner, image_assets,
                                      model, sizes, dtype, max_tokens,
                                      num_logprobs,
@@ -313,6 +318,10 @@ def test_models_single_leading_image(hf_runner, vllm_runner, image_assets,
 @pytest.mark.parametrize("max_tokens", [128])
 @pytest.mark.parametrize("num_logprobs", [5])
 @pytest.mark.parametrize("attn_backend", LIST_ENC_DEC_SUPPORTED_BACKENDS)
+@pytest.mark.skipif(
+    TRANSFORMERS_VERSION == "4.55.0",
+    reason="Transformers v4.55.0 has a regression issue on mllama, "
+    "see: https://github.com/huggingface/transformers/pull/40083")
 def test_models_multi_leading_images(hf_runner, vllm_runner, image_assets,
                                      model, dtype, max_tokens, num_logprobs,
                                      attn_backend: _Backend) -> None:
@@ -362,6 +371,10 @@ def test_models_multi_leading_images(hf_runner, vllm_runner, image_assets,
 @pytest.mark.parametrize("max_tokens", [128])
 @pytest.mark.parametrize("num_logprobs", [5])
 @pytest.mark.parametrize("attn_backend", LIST_ENC_DEC_SUPPORTED_BACKENDS)
+@pytest.mark.skipif(
+    TRANSFORMERS_VERSION == "4.55.0",
+    reason="Transformers v4.55.0 has a regression issue on mllama, "
+    "see: https://github.com/huggingface/transformers/pull/40083")
 def test_models_interleaved_images(hf_runner, vllm_runner, image_assets, model,
                                    dtype, max_tokens, num_logprobs,
                                    attn_backend: _Backend) -> None:
@@ -402,6 +415,10 @@ def test_models_interleaved_images(hf_runner, vllm_runner, image_assets, model,
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])
+@pytest.mark.skipif(
+    TRANSFORMERS_VERSION == "4.55.0",
+    reason="Transformers v4.55.0 has a regression issue on mllama, "
+    "see: https://github.com/huggingface/transformers/pull/40083")
 def test_models_distributed(
     hf_runner,
     vllm_runner,


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Fix #22559
- Transformers v4.55.0 has a regression issue about mllama, this PR skip them temporarily to make CI green until corresponding fix   PR (https://github.com/huggingface/transformers/pull/40083) is included in patch release.

## Test Plan
```
pytest -s -v tests/models/multimodal/generation/test_mllama.py -k test_models_distributed
```

## Test Result
Test should be skipped on CI now.

## (Optional) Documentation Update

