### PR TITLE
[CI] Skip Tree Attn Test in `test_max_len.py` to unblock CI

### DIFF
--- a/tests/v1/spec_decode/test_max_len.py
+++ b/tests/v1/spec_decode/test_max_len.py
@@ -40,8 +40,10 @@ def test_eagle_max_len(monkeypatch: pytest.MonkeyPatch,
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")
 
-        if attn_backend == "TREE_ATTN":
-            pytest.skip("TREE_ATTN is skipped on current platform")
+        if attn_backend == "TREE_ATTN" and num_speculative_tokens > 1:
+            # TREE_ATTN fails the test with multi-token spec decode
+            # TODO: Investigate why
+            pytest.skip("TREE_ATTN fails the test")
 
         m.setenv("VLLM_ATTENTION_BACKEND", attn_backend)
 

--- a/tests/v1/spec_decode/test_max_len.py
+++ b/tests/v1/spec_decode/test_max_len.py
@@ -40,6 +40,9 @@ def test_eagle_max_len(monkeypatch: pytest.MonkeyPatch,
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")
 
+        if attn_backend == "TREE_ATTN":
+            pytest.skip("TREE_ATTN is skipped on current platform")
+
         m.setenv("VLLM_ATTENTION_BACKEND", attn_backend)
 
         if (attn_backend == "TRITON_ATTN_VLLM_V1"


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Fix https://github.com/vllm-project/vllm/issues/22662 .

Originally, even before this PR https://github.com/vllm-project/vllm/pull/21496, the TREE ATTN backend test is not enabled for this `test_max_len.py::test_eagle_max_len` unit tests.

The reason of the failure is unknown, required further investigation by original authors or who is familiar with Tree Attention implementation.

Current solution is to skip the test as it seems original it is not intended to enable the TREE ATTN backend for this test.

## Test Plan

## Test Result

## (Optional) Documentation Update

