### PR TITLE
[gpt-oss] add input/output usage in responses api when harmony context is leveraged

### DIFF
--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -68,8 +68,9 @@ class HarmonyContext(ConversationContext):
         self.parser = get_streamable_parser_for_assistant()
         self.num_init_messages = len(messages)
         self.num_prompt_tokens = 0
-        self.num_cached_tokens = 0
         self.num_output_tokens = 0
+        # TODO(woosuk): Implement the following fields.
+        self.num_cached_tokens = 0
         self.num_reasoning_tokens = 0
 
     def _update_prompt_tokens(self, output: RequestOutput):


### PR DESCRIPTION
## Purpose

Dedicated classes for GPT-OSS have been introduced in https://github.com/vllm-project/vllm/pull/22340 in order to handle the specifics of harmony. However currently the [token usage statistics are not outputed](https://github.com/vllm-project/vllm/blob/458e74eb907f96069e6d8a4f3c9f457001fef2ea/vllm/entrypoints/context.py#L65) when serving requests for gpt-oss.

This PR aims to add usage statistics

cc: @WoosukKwon 

## Test Plan

## Test Result

## (Optional) Documentation Update

