### PR TITLE
[CI] Increase timeout for test_completion_with_image_embeds

### DIFF
--- a/tests/v1/entrypoints/openai/test_completion_with_image_embeds.py
+++ b/tests/v1/entrypoints/openai/test_completion_with_image_embeds.py
@@ -38,7 +38,8 @@ def default_image_embeds_server_args() -> list[str]:
 @pytest.fixture(scope="module")
 def server_with_image_embeds(default_image_embeds_server_args):
     with RemoteOpenAIServer(MODEL_NAME,
-                            default_image_embeds_server_args) as remote_server:
+                            default_image_embeds_server_args,
+                            max_wait_seconds=600) as remote_server:
         yield remote_server
 
 


### PR DESCRIPTION
It seems like `tests/v1/entrypoints/openai/test_completion_with_image_embeds.py` is failing sometimes in CI based on server startup timing issues

https://buildkite.com/vllm/ci/builds/26600/steps/canvas?jid=01989a3b-931c-4ed8-b9aa-b3a83b4b14b8#01989a3b-931c-4ed8-b9aa-b3a83b4b14b8/200-7016
```
Loading safetensors checkpoint shards:  67% 2/3 [02:41<01:19, 79.54s/it](APIServer pid=7958) DEBUG 08-11 12:38:36 [utils.py:750] Waiting for 1 local, 0 remote core engine proc(s) to start.
[2025-08-11T19:38:46Z] (APIServer pid=7958) DEBUG 08-11 12:38:46 [utils.py:750] Waiting for 1 local, 0 remote core engine proc(s) to start.
[2025-08-11T19:38:56Z] (APIServer pid=7958) DEBUG 08-11 12:38:56 [utils.py:750] Waiting for 1 local, 0 remote core engine proc(s) to start.
[2025-08-11T19:39:06Z] (APIServer pid=7958) DEBUG 08-11 12:39:06 [utils.py:750] Waiting for 1 local, 0 remote core engine proc(s) to start.
[2025-08-11T19:39:16Z] (APIServer pid=7958) DEBUG 08-11 12:39:16 [utils.py:750] Waiting for 1 local, 0 remote core engine proc(s) to start.
[2025-08-11T19:39:24Z] ERROR
```
https://buildkite.com/vllm/ci/builds/26593/steps/canvas?sid=01989a03-43ae-40b2-ad95-2852057e1969
```
[2025-08-11T18:38:40Z] ERROR v1/entrypoints/openai/test_completion_with_image_embeds.py::test_completions_with_image_embeds[dtype0-llava-hf/llava-1.5-7b-hf] - RuntimeError: Server failed to start in time.
[2025-08-11T18:38:40Z] ERROR v1/entrypoints/openai/test_completion_with_image_embeds.py::test_completions_with_image_embeds[dtype1-llava-hf/llava-1.5-7b-hf] - RuntimeError: Server failed to start in time.
[2025-08-11T18:38:40Z] ERROR v1/entrypoints/openai/test_completion_with_image_embeds.py::test_completions_with_image_embeds[dtype2-llava-hf/llava-1.5-7b-hf] - RuntimeError: Server failed to start in time.
```