### PR TITLE
add an env var for path to pre-downloaded flashinfer cubin files

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -159,6 +159,7 @@ if TYPE_CHECKING:
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = False
     VLLM_ENABLE_RESPONSES_API_STORE: bool = False
     VLLM_USE_TRTLLM_ATTENTION: Optional[str] = None
+    VLLM_HAS_FLASHINFER_CUBIN: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_BF16: bool = False
     VLLM_TUNED_CONFIG_FOLDER: Optional[str] = None
@@ -1109,6 +1110,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, use the TRTLLM attention backend in flashinfer.
     "VLLM_USE_TRTLLM_ATTENTION":
     lambda: os.getenv("VLLM_USE_TRTLLM_ATTENTION", None),
+
+    # If set, it means we pre-downloaded cubin files and flashinfer will
+    # read the cubin files directly.
+    "VLLM_HAS_FLASHINFER_CUBIN":
+    lambda: os.getenv("VLLM_HAS_FLASHINFER_CUBIN", False),
 
     # If set to 1, force the use of TRTLLM FP4 GEMM backend in flashinfer.
     # Otherwise, uses the first available of: flashinfer cutlass GEMM,

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -132,6 +132,11 @@ def has_nvidia_artifactory() -> bool:
     This checks connectivity to the kernel inference library artifactory
     which is required for downloading certain cubin kernels like TRTLLM FHMA.
     """
+    # Since FLASHINFER_CUBIN_DIR defines the pre-downloaded cubins path, when
+    # it's true, we could assume the cubins are available.
+    if envs.VLLM_HAS_FLASHINFER_CUBIN:
+        return True
+
     try:
         # Use a short timeout to avoid blocking for too long
         response = requests.get(FLASHINFER_CUBINS_REPOSITORY, timeout=5)


### PR DESCRIPTION
Summary:
Previously https://github.com/vllm-project/vllm/pull/21893 added a check for network access to NV cubin artifact endpoint. And if the check failed, we would opt out from trtllm attn backend.

This PR added a env var `FLASHINFER_CUBIN_DIR` to allow people specify a cubin dir which contains pre-downloaded cubin files. When `FLASHINFER_CUBIN_DIR` is specified, we will directly return True in `has_nvidia_artifactory()`.

Differential Revision: D80035005


