### PR TITLE
[Kernel][AMD] Reduce AITER attention CPU overhead

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -291,6 +291,13 @@ class AiterFlashAttentionMetadataBuilder(
             common_prefix_len=common_prefix_len,
             total_tokens=self.total_tokens,
         )
+
+        # If aiter has these two API, we can use them to avoid
+        # repeatedly calling into torch for stream and warp size.
+        if hasattr(aiter, "aiter_set_gpu_stream"):
+            aiter.aiter_set_gpu_stream(torch.cuda.current_stream())
+        if hasattr(aiter, "aiter_set_warp_size_for_device"):
+            aiter.aiter_set_warp_size_for_device(torch.cuda.current_device())
         return attn_metadata
 
     def can_run_in_cudagraph(


### PR DESCRIPTION
Use AITER's new interface to avoid keeping calling torch.cuda.get_device_property() and torch.cuda.get_current_stream()

To get actual perf gain, we need this AITER PR to be merged (https://github.com/ROCm/aiter/pull/805) and please also see more technical details in the AITER PR



