### PR TITLE
[CI Failure] Use float32 for tests/entrypoints/openai/test_audio.py

### DIFF
--- a/tests/entrypoints/openai/test_audio.py
+++ b/tests/entrypoints/openai/test_audio.py
@@ -23,6 +23,8 @@ MAXIMUM_AUDIOS = 2
 @pytest.fixture(scope="module")
 def server():
     args = [
+        "--dtype",
+        "float32",
         "--max-model-len",
         "2048",
         "--max-num-seqs",


### PR DESCRIPTION
Helps fix failures in `Entrypoints Test (API Server)`. Two of the streaming tests in this file seem to fail in CI due to differences in streaming vs non-streaming. These differences go away if I increase the model precision to FP32

https://buildkite.com/vllm/ci/builds/26600/steps/canvas?sid=01989a3b-925f-4238-baf6-585eaa624c67#01989a3b-9312-43b1-8fce-11b76d79782c/7-12775
```
[2025-08-11T20:34:52Z] FAILED entrypoints/openai/test_audio.py::test_chat_streaming_audio[https://vllm-public-assets.s3.us-west-2.amazonaws.com/multimodal_asset/mary_had_lamb.ogg-fixie-ai/ultravox-v0_5-llama-3_2-1b] - AssertionError: assert 'This audio a... snippet from' == 'This appears...nippet from a'
[2025-08-11T20:34:52Z]
[2025-08-11T20:34:52Z]   - This appears to be a snippet from a
[2025-08-11T20:34:52Z]   ?                                  --
[2025-08-11T20:34:52Z]   + This audio appears to be a snippet from
[2025-08-11T20:34:52Z]   ?     ++++++
[2025-08-11T20:34:52Z] FAILED entrypoints/openai/test_audio.py::test_chat_streaming_input_audio[https://vllm-public-assets.s3.us-west-2.amazonaws.com/multimodal_asset/mary_had_lamb.ogg-fixie-ai/ultravox-v0_5-llama-3_2-1b] - AssertionError: assert 'This appears...ning lines of' == 'This audio a... snippet from'
[2025-08-11T20:34:52Z]
[2025-08-11T20:34:52Z]   - This audio appears to be a snippet from
[2025-08-11T20:34:52Z]   + This appears to be the opening lines of
```