### PR TITLE
[gpt-oss] Fix mxfp4 support

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -68,7 +68,7 @@ def _can_support_mxfp4(use_grouped_topk: bool = False,
     return not (use_grouped_topk or topk_group or num_expert_group
                 or expert_map or custom_routing_function
                 or e_score_correction_bias or apply_router_weight_on_input
-                or scoring_func != "softmax" or activation != "silu"
+                or scoring_func != "softmax" or activation != "swiglu_oai"
                 or expert_load_view or logical_to_physical_map
                 or logical_replica_count)
 


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
https://github.com/vllm-project/vllm/pull/22508 changes the MOE activation to `swiglu_oai`:
https://github.com/vllm-project/vllm/blob/0c5254b82acc625112ce7adc10811514f1a42d52/vllm/model_executor/models/gpt_oss.py#L165

This causes
```
(EngineCore_0 pid=2413792) ERROR 08-11 20:40:10 [core.py:683]   File "***/vllm/model_executor/layers/quantization/mxfp4.py", line 402, in apply
(EngineCore_0 pid=2413792) ERROR 08-11 20:40:10 [core.py:683]     assert _can_support_mxfp4(
(EngineCore_0 pid=2413792) ERROR 08-11 20:40:10 [core.py:683]            ^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=2413792) ERROR 08-11 20:40:10 [core.py:683] AssertionError: MXFP4 are not supported  
```
when I run mxfp4.

## Test Plan
Run basic.py with gpt-oss-20b, torch 2.9.0.dev20250723+cu128, triton 3.4.0+git663e04e8 , h100
## Test Result
```

Generated Outputs:
------------------------------------------------------------
Prompt:    'Hello, my name is'
Output:    ' $name. I am $age years old.")\n```\n\n---\n\n## Exercise '
------------------------------------------------------------
Prompt:    'The president of the United States is'
Output:    ' a political figure who holds the highest office in the United States government. He or'
------------------------------------------------------------
Prompt:    'The capital of France is'
Output:    ' Paris. The population of Paris is around 2 million." If "Paris"'
------------------------------------------------------------
Prompt:    'The future of AI is'
Output:    ' exciting and promising. The potential of AI to transform various industries and improve our lives'
------------------------------------------------------------
```
## (Optional) Documentation Update

