### PR TITLE
Fix cuda illegal mem access with Llama4 TP8 + rms_norm custom op

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -224,10 +224,14 @@ class Llama4Attention(nn.Module):
 
         if self.rotary_emb is not None:
             q, k = self.rotary_emb(positions, q, k)
+
         if self.qk_norm is not None:
-            q = q.reshape(-1, self.num_heads, self.head_dim)
+            # Normalization is applied on the head_dim dimension. The rest of
+            # the dimensions are collapsed into a single dimension to support
+            # custom rms_norm cuda kernel.
+            q = q.reshape(-1, self.head_dim)
             q = self.qk_norm(q.float()).reshape(-1, self.q_size).to(q.dtype)
-            k = k.reshape(-1, self.num_kv_heads, self.head_dim)
+            k = k.reshape(-1, self.head_dim)
             k = self.qk_norm(k.float()).reshape(-1, self.kv_size).to(k.dtype)
 
         # We are applying temperature tuning (https://arxiv.org/abs/2501.19399)


### PR DESCRIPTION
The rms_norm custom op cuda kernel supports non-contiguous striding on the "num_tokens" dim, but it assumes that all the num_tokens dims (if there are more than one num_tokens dim) are contiguous.

This causes a CUDA illegal mem access when running Llama4 with TP8 with +rms_norm custom op.

To work around this issue, reshape the Q/K to 2D tensors before calling the qk_norm. This makes the num_tokens dims collapse into one dim and it will be obviously contiguous.

When rms_norm custom op is disabled, this reshape will be fused with the RMSNorm's forward_native() anyway so there is no perf impact.

I will add additional checks in the custom rms_norm kernel in another PR.

# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

Llama4 FP4 accuracy

## Test Result

```
local-completions (base_url=nvidia/Llama-4-Scout-17B-16E-Instruct-FP4,tokenized_requests=False,tokenizer_backend=None,num_concurrent=128,timeout=120,max_retries=5), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9007|±  |0.0082|
|     |       |strict-match    |     5|exact_match|↑  |0.8848|±  |0.0088|
```

## (Optional) Documentation Update

