### PR TITLE
[Docs] Improve docs navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,8 @@ venv.bak/
 # mkdocs documentation
 /site
 docs/argparse
-docs/examples
+docs/examples/*
+!docs/examples/README.md
 
 # mypy
 .mypy_cache/

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,17 +1,5 @@
 nav:
-  - Home:
-    - README.md
-    - User Guide:
-      - usage/README.md
-      - getting_started/quickstart.md
-      - getting_started/installation/README.md
-      - examples/README.md
-    - Developer Guide: contributing/README.md
-    - API Reference: api/README.md
-    - CLI Reference: cli/README.md
-    - Timeline:
-      - Roadmap: https://roadmap.vllm.ai
-      - Releases: https://github.com/vllm-project/vllm/releases
+  - Home: README.md
   - User Guide:
     - usage/README.md
     - Getting Started:

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,25 +1,29 @@
 nav:
   - Home:
-    - vLLM: README.md
-    - Getting Started:
+    - README.md
+    - User Guide:
+      - usage/README.md
       - getting_started/quickstart.md
-      - getting_started/installation
-    - Examples:
-      - Offline Inference: examples/offline_inference
-      - Online Serving: examples/online_serving
-      - Others: examples/others
-    - Quick Links:
-      - User Guide: usage/README.md
-      - Developer Guide: contributing/README.md
-      - API Reference: api/README.md
-      - CLI Reference: cli/README.md
+      - getting_started/installation/README.md
+      - examples/README.md
+    - Developer Guide: contributing/README.md
+    - API Reference: api/README.md
+    - CLI Reference: cli/README.md
     - Timeline:
       - Roadmap: https://roadmap.vllm.ai
       - Releases: https://github.com/vllm-project/vllm/releases
   - User Guide:
-    - Summary: usage/README.md
-    - usage/v1_guide.md
+    - usage/README.md
+    - Getting Started:
+      - getting_started/quickstart.md
+      - getting_started/installation
+    - Examples:
+      - examples/README.md
+      - Offline Inference: examples/offline_inference
+      - Online Serving: examples/online_serving
+      - Others: examples/others
     - General:
+      - usage/v1_guide.md
       - usage/*
     - Inference and Serving:
       - serving/offline_inference.md
@@ -32,7 +36,7 @@ nav:
       - deployment/integrations
     - Training: training
     - Configuration:
-      - Summary: configuration/README.md
+      - configuration/README.md
       - configuration/*
     - Models:
       - models/supported_models.md
@@ -45,7 +49,7 @@ nav:
       - features/*
       - features/quantization
   - Developer Guide:
-    - Summary: contributing/README.md
+    - contributing/README.md
     - General:
       - glob: contributing/*
         flatten_single_child_sections: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,17 @@ vLLM is a fast and easy-to-use library for LLM inference and serving.
 
 Originally developed in the [Sky Computing Lab](https://sky.cs.berkeley.edu) at UC Berkeley, vLLM has evolved into a community-driven project with contributions from both academia and industry.
 
+Where to get started with vLLM depends on the type of user. If you are looking to:
+
+- Run open-source models on vLLM, we recommend starting with the [Quickstart Guide](./getting_started/quickstart.md)
+- Build applications with vLLM, we recommend starting with the [User Guide](./usage)
+- Build vLLM, we recommend starting with [Developer Guide](./contributing)
+
+For information about the development of vLLM, see:
+
+- [Roadmap](https://roadmap.vllm.ai)
+- [Releases](https://github.com/vllm-project/vllm/releases)
+
 vLLM is fast with:
 
 - State-of-the-art serving throughput
@@ -42,12 +53,6 @@ vLLM is flexible and easy to use with:
 - Support NVIDIA GPUs, AMD CPUs and GPUs, Intel CPUs, Gaudi® accelerators and GPUs, IBM Power CPUs, TPU, and AWS Trainium and Inferentia Accelerators.
 - Prefix caching support
 - Multi-LoRA support
-
-Where to get started with vLLM depends on the type of user. If you are looking to:
-
-- run open-source models on vLLM, we recommend starting with [quickstart](./getting_started/quickstart.md) and branching out from there as you learn more
-- build applications with vLLM, we recommend starting with the [User Guide](./usage)
-- build vLLM, we recommend starting with [Developer Guide](./contributing)
 
 For more information, check out the following:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,12 @@ vLLM is flexible and easy to use with:
 - Prefix caching support
 - Multi-LoRA support
 
+Where to get started with vLLM depends on the type of user. If you are looking to:
+
+- run open-source models on vLLM, we recommend starting with [quickstart](./getting_started/quickstart.md) and branching out from there as you learn more
+- build applications with vLLM, we recommend starting with the [User Guide](./usage)
+- build vLLM, we recommend starting with [Developer Guide](./contributing)
+
 For more information, check out the following:
 
 - [vLLM announcing blog post](https://vllm.ai) (intro to PagedAttention)

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,7 @@
+# Examples
+
+vLLM's examples are split into three categories:
+
+- If you are using vLLM from within Python code, see [Offline Inference](./offline_inference/)
+- If you are using vLLM from an HTTP application or client, see [Online Serving](./online_serving/)
+- For examples of using some of vLLM's advanced features (e.g. LMCache or Tensorizer) which are not specific to either of the above use cases, see [Others](./others/)

--- a/docs/mkdocs/stylesheets/extra.css
+++ b/docs/mkdocs/stylesheets/extra.css
@@ -25,6 +25,7 @@ a:not(:has(svg)):not(.md-icon):not(.autorefs-external) {
 
 a[href*="localhost"]::after,
 a[href*="127.0.0.1"]::after,
+a[href*="org.readthedocs.build"]::after,
 a[href*="docs.vllm.ai"]::after {
     display: none !important;
 }

--- a/docs/mkdocs/stylesheets/extra.css
+++ b/docs/mkdocs/stylesheets/extra.css
@@ -23,6 +23,12 @@ a:not(:has(svg)):not(.md-icon):not(.autorefs-external) {
     }
 }
 
+a[href*="localhost"]::after,
+a[href*="127.0.0.1"]::after,
+a[href*="docs.vllm.ai"]::after {
+    display: none !important;
+}
+
 /* Light mode: darker section titles */
 body[data-md-color-scheme="default"] .md-nav__item--section > label.md-nav__link .md-ellipsis {
   color: rgba(0, 0, 0, 0.7) !important;

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,6 +1,8 @@
 # Using vLLM
 
-vLLM supports the following usage patterns:
+First, vLLM must be [installed](../getting_started/installation) for your chosen device in either a Python or Docker environment.
+
+Then, vLLM supports the following usage patterns:
 
 - [Inference and Serving](../serving/offline_inference.md): Run a single instance of a model.
 - [Deployment](../deployment/docker.md): Scale up model instances for production.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -34,6 +34,8 @@ theme:
     - content.action.edit
     - content.code.copy
     - content.tabs.link
+    - navigation.instant
+    - navigation.instant.progress
     - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -38,9 +38,8 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.sections
-    - navigation.prune
-    - navigation.top
     - navigation.indexes
+    - navigation.top
     - search.highlight
     - search.share
     - toc.follow


### PR DESCRIPTION
- Removes all extra nav from the home screen:
  - This makes browsing on mobile a significantly better experience
  - We have had MkDocs Material long enough and the tabs at the top are good enough that these can go now
- READMEs:
  - Add link to install on user guide readme
  - Add README for examples
  - Add some links to different sections in the page content of the top README
- Enable instant nav to prevent page reloads and to make the search stay populated after navigating

---

| Desktop | Mobile |
|---|---|
| <img width="1265" height="961" alt="image" src="https://github.com/user-attachments/assets/aa48d9f7-6d09-4ee2-a59a-4b41f79d49ec" /> |  <img width="547" height="952" alt="image" src="https://github.com/user-attachments/assets/094c68bb-3215-450b-8eec-dbbe3b0c19df" /> |
