### PR TITLE
[Bugfix][CI] Fix `test_remote_decode_lifecycle.py::test_short_prompt_lifecycle`

### DIFF
--- a/tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py
@@ -130,8 +130,9 @@ def test_short_prompt_lifecycle():
     # Confirm we do not have any memory leaks after req lifecycle.
     # We need to mark sending finish to clear data for persistent batch.
     scheduler_output = scheduler.schedule()
-    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
-    model_runner_output.finished_sending = [request.request_id]
+    # Use create_model_runner_output to pass kv_connector_output along
+    model_runner_output = create_model_runner_output(
+        reqs=[request], finished_sending=[request.request_id])
     scheduler.update_from_output(scheduler_output, model_runner_output)
     assert_scheduler_empty(scheduler)
 


### PR DESCRIPTION
This test is failing on main, preventing clean merges. With this PR it fails no more
```
(llmd) ➜  vllm git:(78077d541) ✗ glog | head -n 1                                                                                         
* 78077d541 (HEAD, upstream/main) Move `SchedulerConfig` from `config/__init__.py` to `config/scheduler.py` (#22626)
(llmd) ➜  vllm git:(78077d541) ✗ p -m pytest -q --tb=no tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py::test_short_prompt_lifecycle 

F                                                                                                                                                              [100%]
====================================================================== short test summary info =======================================================================
FAILED tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py::test_short_prompt_lifecycle - AssertionError
1 failed in 10.59s
(llmd) ➜  vllm git:(78077d541) ✗ 
(llmd) ➜  vllm git:(78077d541) ✗ gsw pd-fix-test 
Previous HEAD position was 78077d541 Move `SchedulerConfig` from `config/__init__.py` to `config/scheduler.py` (#22626)
Switched to branch 'pd-fix-test'
(llmd) ➜  vllm git:(pd-fix-test) ✗ p -m pytest -q --tb=no       tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py::test_short_prompt_lifecycle
.                                                                                                                                                              [100%]
1 passed in 10.94s
```

Test introduced in https://github.com/vllm-project/vllm/issues/21074.