### PR TITLE
[Frontend] Deprecate per-request structured output backend

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -528,8 +528,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
         default=None,
         description=(
             "If specified, will override the default guided decoding backend "
-            "of the server for this specific request. If set, must be either "
-            "'outlines' / 'lm-format-enforcer'"),
+            "of the server for this specific request. If set, must be one of "
+            "'outlines', 'lm-format-enforcer', 'xgrammar', 'guidance'"),
     )
     guided_whitespace_pattern: Optional[str] = Field(
         default=None,
@@ -1014,7 +1014,7 @@ class CompletionRequest(OpenAIBaseModel):
         description=(
             "If specified, will override the default guided decoding backend "
             "of the server for this specific request. If set, must be one of "
-            "'outlines' / 'lm-format-enforcer'"),
+            "'outlines', 'lm-format-enforcer', 'xgrammar', 'guidance'"),
     )
     guided_whitespace_pattern: Optional[str] = Field(
         default=None,

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -526,10 +526,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
     )
     guided_decoding_backend: Optional[str] = Field(
         default=None,
-        description=(
-            "If specified, will override the default guided decoding backend "
-            "of the server for this specific request. If set, must be one of "
-            "'outlines', 'lm-format-enforcer', 'xgrammar', 'guidance'"),
+        deprecated="The guided decoding backend is now managed centrally by "
+        "the `StructuredOutputManager` within the `EngineCore`. Therefore, it "
+        "must be configured globally during engine initialization and can no "
+        "longer be overridden on a per-request basis. "
+        "This parameter will be removed in a future version.",
     )
     guided_whitespace_pattern: Optional[str] = Field(
         default=None,
@@ -1011,10 +1012,11 @@ class CompletionRequest(OpenAIBaseModel):
     )
     guided_decoding_backend: Optional[str] = Field(
         default=None,
-        description=(
-            "If specified, will override the default guided decoding backend "
-            "of the server for this specific request. If set, must be one of "
-            "'outlines', 'lm-format-enforcer', 'xgrammar', 'guidance'"),
+        deprecated="The guided decoding backend is now managed centrally by "
+        "the `StructuredOutputManager` within the `EngineCore`. Therefore, it "
+        "must be configured globally during engine initialization and can no "
+        "longer be overridden on a per-request basis. "
+        "This parameter will be removed in a future version.",
     )
     guided_whitespace_pattern: Optional[str] = Field(
         default=None,


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

<details><summary>Original PR content</summary>
<p>

Fix inconsistency between API protocol documentation and actual implementation for `guided_decoding_backend` field.

**Issue**: The field description in `protocol.py` only mentions `'outlines'` and `'lm-format-enforcer'` as supported backends, but the actual implementation supports four backends: `'outlines'`, `'lm-format-enforcer'`, `'xgrammar'`, and `'guidance'`. This causes user confusion when they receive error messages mentioning all four backends while the API documentation only shows two.

**Solution**: Update the field descriptions in both `ChatCompletionRequest` and `CompletionRequest` classes to include all supported backends, aligning the API documentation with the actual implementation.

</p>
</details> 


As shown by the error message below, the vLLM API server correctly rejects requests that specify the `guided_decoding_backend`, as this must now be configured at the engine level.


```json
{
  "error": {
    "message": "Request-level structured output backend selection is no longer supported. The request specified 'outlines', but vLLM was initialised with 'auto'. This error can be resolved by removing backend selection from the request.",
    "type": "BadRequestError",
    "param": null,
    "code": 400
  }
}
```

However, I noticed that the corresponding field in the API schema (`protocol.py`) is not marked as deprecated.
This creates a mismatch between the API's definition and its actual behavior.

I have made a modification to deprecate this field in protocol.py to ensure the API schema accurately reflects the current implementation.

## (Optional) Documentation Update

No additional documentation updates needed as this PR directly fixes the API protocol documentation itself.