### PR TITLE
[Docs] Hide the navigation and toc sidebars on home page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 # Welcome to vLLM
 
 <figure markdown="span">


### PR DESCRIPTION
Since we no longer duplicate the nav on the home screen, the nav only contains a lonely link to `Home`.

This PR removes both sidebars from the home page to reduce the clutter and prevent users wondering where the rest of the links are on the left (they're on the top!)