### PR TITLE
[Model] Decouple glm4v

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -615,7 +615,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Gemma3nForConditionalGeneration` | Gemma 3n | T + I + A | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it`, etc. | | | ✅︎ |
 | `GLM4VForCausalLM`<sup>^</sup> | GLM-4V | T + I | `zai-org/glm-4v-9b`, `zai-org/cogagent-9b-20241220`, etc. | ✅︎ | ✅︎ | ✅︎ |
 | `Glm4vForConditionalGeneration` | GLM-4.1V-Thinking | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.1V-9B-Thinking`, etc. | ✅︎ | ✅︎ | ✅︎ |
-| `Glm4vMoeForConditionalGeneration` | GLM-4.5V | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.5V`, etc. | ✅︎ | ✅︎ | ✅︎ |
+| `Glm4vMoeForConditionalGeneration` | GLM-4.5V | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.5V`, etc. | | ✅︎ | ✅︎ |
 | `GraniteSpeechForConditionalGeneration` | Granite Speech | T + A | `ibm-granite/granite-speech-3.3-8b` | ✅︎ | ✅︎ | ✅︎ |
 | `H2OVLChatModel` | H2OVL | T + I<sup>E+</sup> | `h2oai/h2ovl-mississippi-800m`, `h2oai/h2ovl-mississippi-2b`, etc. | | ✅︎ | ✅︎ |
 | `Idefics3ForConditionalGeneration` | Idefics3 | T + I | `HuggingFaceM4/Idefics3-8B-Llama3`, etc. | ✅︎ | | ✅︎ |

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -1227,10 +1227,7 @@ class Glm4vForConditionalGeneration(nn.Module, SupportsMultiModal,
             "k_proj",
             "v_proj",
         ],
-        "gate_up_proj": [
-            "gate_proj",
-            "up_proj",
-        ],
+        "gate_up_proj": ["gate_up_proj"]
     }
 
     # To ensure correct weight loading and mapping.
@@ -1567,7 +1564,26 @@ class Glm4vForConditionalGeneration(nn.Module, SupportsMultiModal,
         Get the module prefix in multimodal models
         """
         return MultiModelKeys.from_string_field(
-            language_model="language_model",
+            language_model="language_model.model",
             connector="visual.merger.",
             tower_model="visual.",
         )
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Glm4vMultiModalProcessor,
+    info=Glm4vProcessingInfo,
+    dummy_inputs=Glm4vDummyInputsBuilder,
+)
+class Glm4vMoeForConditionalGeneration(Glm4vForConditionalGeneration):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -208,7 +208,7 @@ _MULTIMODAL_MODELS = {
     "Gemma3nForConditionalGeneration": ("gemma3n_mm", "Gemma3nForConditionalGeneration"),    # noqa: E501
     "GLM4VForCausalLM": ("glm4v", "GLM4VForCausalLM"),
     "Glm4vForConditionalGeneration": ("glm4_1v", "Glm4vForConditionalGeneration"),  # noqa: E501
-    "Glm4vMoeForConditionalGeneration": ("glm4_1v", "Glm4vForConditionalGeneration"),  # noqa: E501
+    "Glm4vMoeForConditionalGeneration": ("glm4_1v", "Glm4vMoeForConditionalGeneration"),  # noqa: E501
     "GraniteSpeechForConditionalGeneration": ("granite_speech", "GraniteSpeechForConditionalGeneration"),  # noqa: E501
     "H2OVLChatModel": ("h2ovl", "H2OVLChatModel"),
     "InternVLChatModel": ("internvl", "InternVLChatModel"),


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, FIX #22077
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
- Decouple `Glm4vForConditionalGeneration` and `Glm4vMoeForConditionalGeneration`. On one hand, their `packed_modules_mapping` have some differences(the root cause of https://github.com/vllm-project/vllm/issues/22077), and on the other hand, it also facilitates the maintainability of the model code.
- Currently, `Glm4vMoeForConditionalGeneration` does not support LoRA and will raise the following error. I have removed the LoRA label for now and will investigate the issue ASAP
```
(EngineCore_0 pid=1393314) (VllmWorker TP0 pid=1393320) (VllmWorker TP1 pid=1393322) (EngineCore_0 pid=1393314) (VllmWorker TP2 pid=1393324) ERROR 08-12 16:22:17 [multiproc_executor.py:596]   File "/root/anaconda3/envs/py310_vllm_dev/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 08-12 16:22:17 [multiproc_executor.py:596]   File "/root/Code/vllm_dev/vllm/vllm/lora/ops/triton_ops/lora_shrink_op.py", line 139, in _lora_shrink
(VllmWorker TP3 pid=1393326) ERROR 08-12 16:22:17 [multiproc_executor.py:596]   File "/root/Code/vllm_dev/vllm/vllm/lora/ops/triton_ops/lora_shrink_op.py", line 139, in _lora_shrink
(EngineCore_0 pid=1393314) (EngineCore_0 pid=1393314) (VllmWorker TP0 pid=1393320) ERROR 08-12 16:22:17 [multiproc_executor.py:596]     assert inputs.dtype == lora_a_weights[0].dtype
(EngineCore_0 pid=1393314) (VllmWorker TP1 pid=1393322) ERROR 08-12 16:22:17 [multiproc_executor.py:596]     return func(*args, **kwargs)
(EngineCore_0 pid=1393314) (VllmWorker TP2 pid=1393324) ERROR 08-12 16:22:17 [multiproc_executor.py:596]     assert inputs.dtype == lora_a_weights[0].dtype
(EngineCore_0 pid=1393314) (VllmWorker TP3 pid=1393326) ERROR 08-12 16:22:17 [multiproc_executor.py:596]     assert inputs.dtype == lora_a_weights[0].dtype
(EngineCore_0 pid=1393314) (VllmWorker TP0 pid=1393320) ERROR 08-12 16:22:17 [multiproc_executor.py:596] AssertionError
```
cc @zRzRzRzRzRzRzR 

## Test Plan

## Test Result

## (Optional) Documentation Update

