### PR TITLE
[V1] implement tree sampler for draft token acceptance

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import Any, Optional
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -11,6 +12,7 @@ from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (PLACEHOLDER_TOKEN_ID,
                                               RejectionSampler)
+from vllm.v1.sample.sampler import Sampler, SamplerOutput
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
 DEVICE = current_platform.device_type
@@ -18,7 +20,24 @@ DEVICE = current_platform.device_type
 
 @pytest.fixture
 def rejection_sampler():
-    return RejectionSampler()
+    mock_main_sampler = Mock(spec=Sampler)
+    return RejectionSampler(mock_main_sampler, DEVICE)
+
+
+def mock_main_sampler_output(rejection_sampler: RejectionSampler,
+                             bonus_token_ids: torch.Tensor):
+    rejection_sampler.main_sampler.return_value = SamplerOutput(
+        sampled_token_ids=bonus_token_ids, logprobs_tensors=None)
+
+
+def create_spec_decode_metadata(spec_tokens: list[list[int]],
+                                logits: torch.Tensor) -> SpecDecodeMetadata:
+    metadata = SpecDecodeMetadata.make_dummy(spec_tokens, device=logits.device)
+    metadata.target_logits_indices = torch.arange(logits.shape[0])
+    # Output bonus token ids are mocked, so the bonus logit indices should
+    # be empty.
+    metadata.bonus_logits_indices = torch.empty(0, dtype=torch.int32)
+    return metadata
 
 
 def create_logits_tensor(output_token_ids: list[list[int]],
@@ -83,20 +102,19 @@ def test_perfect_match(rejection_sampler):
     logits = create_logits_tensor(output_tokens)
     bonus_token_tensor = torch.tensor([output_tokens[0][-1]],
                                       device=logits.device)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(spec_tokens,
-                                                         device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
+    mock_main_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=logits,
-        bonus_token_ids=bonus_token_tensor,
+        logits=logits,
         sampling_metadata=metadata,
     )
     expected = torch.tensor([[1, 2, 3, 4]],
                             dtype=torch.int,
                             device=logits.device)
-    assert torch.equal(output, expected)
+    assert torch.equal(output.sampled_token_ids, expected)
 
 
 def test_early_mismatch(rejection_sampler):
@@ -108,14 +126,13 @@ def test_early_mismatch(rejection_sampler):
     logits = create_logits_tensor(output_tokens)
     bonus_token_tensor = torch.tensor([output_tokens[0][-1]],
                                       device=logits.device)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(spec_tokens,
-                                                         device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
+    mock_main_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=logits,
-        bonus_token_ids=bonus_token_tensor,
+        logits=logits,
         sampling_metadata=metadata,
     )
     expected = torch.tensor(
@@ -123,7 +140,7 @@ def test_early_mismatch(rejection_sampler):
         dtype=torch.int,
         device=logits.device,
     )
-    assert torch.equal(output, expected)
+    assert torch.equal(output.sampled_token_ids, expected)
 
 
 def test_multiple_sequences(rejection_sampler):
@@ -136,20 +153,19 @@ def test_multiple_sequences(rejection_sampler):
     logits = create_logits_tensor(output_tokens)
     bonus_token_tensor = torch.tensor(
         [output_tokens[0][-1], output_tokens[1][-1]], device=logits.device)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(spec_tokens,
-                                                         device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
+    mock_main_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=logits,
-        bonus_token_ids=bonus_token_tensor,
+        logits=logits,
         sampling_metadata=metadata,
     )
     expected = torch.tensor([[1, 2, 5], [3, 4, PLACEHOLDER_TOKEN_ID]],
                             dtype=torch.int,
                             device=logits.device)
-    assert torch.equal(output, expected)
+    assert torch.equal(output.sampled_token_ids, expected)
 
 
 def test_single_token_sequence(rejection_sampler):
@@ -161,18 +177,17 @@ def test_single_token_sequence(rejection_sampler):
     logits = create_logits_tensor(output_tokens)
     bonus_token_tensor = torch.tensor([output_tokens[0][-1]],
                                       device=logits.device)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(spec_tokens,
-                                                         device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
+    mock_main_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=logits,
-        bonus_token_ids=bonus_token_tensor,
+        logits=logits,
         sampling_metadata=metadata,
     )
     expected = torch.tensor([[1, 2]], dtype=torch.int, device=logits.device)
-    assert torch.equal(output, expected)
+    assert torch.equal(output.sampled_token_ids, expected)
 
 
 def test_empty_sequence(rejection_sampler):
@@ -184,18 +199,17 @@ def test_empty_sequence(rejection_sampler):
     logits = create_logits_tensor(output_tokens)
     bonus_token_tensor = torch.tensor([output_tokens[0][-1]],
                                       device=logits.device)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(spec_tokens,
-                                                         device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
+    mock_main_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=logits,
-        bonus_token_ids=bonus_token_tensor,
+        logits=logits,
         sampling_metadata=metadata,
     )
     expected = torch.tensor([[5]], dtype=torch.int, device=logits.device)
-    assert torch.equal(output, expected)
+    assert torch.equal(output.sampled_token_ids, expected)
 
 
 def test_multiple_mismatches(rejection_sampler):
@@ -208,14 +222,13 @@ def test_multiple_mismatches(rejection_sampler):
     logits = create_logits_tensor(output_tokens)
     bonus_token_tensor = torch.tensor(
         [output_tokens[0][-1], output_tokens[1][-1]], device=logits.device)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(spec_tokens,
-                                                         device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
+    mock_main_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=logits,
-        bonus_token_ids=bonus_token_tensor,
+        logits=logits,
         sampling_metadata=metadata,
     )
     expected = torch.tensor(
@@ -224,7 +237,7 @@ def test_multiple_mismatches(rejection_sampler):
         dtype=torch.int,
         device=logits.device,
     )
-    assert torch.equal(output, expected)
+    assert torch.equal(output.sampled_token_ids, expected)
 
 
 @pytest.mark.parametrize(
@@ -242,20 +255,19 @@ def test_parametrized_cases(rejection_sampler, spec_tokens, output_tokens,
     logits = create_logits_tensor(output_tokens)
     bonus_token_tensor = torch.tensor([tokens[-1] for tokens in output_tokens],
                                       device=logits.device)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(spec_tokens,
-                                                         device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
+    mock_main_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=logits,
-        bonus_token_ids=bonus_token_tensor,
+        logits=logits,
         sampling_metadata=metadata,
     )
     expected_tensor = torch.tensor(expected,
                                    dtype=torch.int,
                                    device=logits.device)
-    assert torch.equal(output, expected_tensor)
+    assert torch.equal(output.sampled_token_ids, expected_tensor)
 
 
 ########################### Tests for Random Sampling ###################
@@ -305,17 +317,18 @@ def test_deterministic_when_seeded(
         sampling_metadata = create_sampling_metadata(all_greedy=False,
                                                      temperature=temperature,
                                                      generators=seeded_seqs)
-        spec_decode_metadata = SpecDecodeMetadata.make_dummy(
-            draft_token_ids.tolist(), device=DEVICE)
+        spec_decode_metadata = create_spec_decode_metadata(
+            draft_token_ids.tolist(), target_logits)
+
+        mock_main_sampler_output(rejection_sampler, bonus_token_ids)
         rep_result = rejection_sampler(
             spec_decode_metadata,
-            draft_probs=draft_probs,
-            target_logits=target_logits,
-            bonus_token_ids=bonus_token_ids,
+            draft_probs=None,
+            logits=target_logits,
             sampling_metadata=sampling_metadata,
         )
 
-        results.append(rep_result)
+        results.append(rep_result.sampled_token_ids)
 
     for i in range(batch_size):
         if seeded_mask[i]:
@@ -424,7 +437,9 @@ def estimate_rejection_sampling_pdf(
     Returns:
         Estimated probability distribution of the output tokens.
     """
-    rejection_sampler = RejectionSampler()
+    # Mock the main_sampler that TreeRejectionSampler uses
+    mock_main_sampler = Mock(spec=Sampler)
+    rejection_sampler = RejectionSampler(mock_main_sampler, DEVICE)
     num_tokens = num_samples * k
     # Repeat draft probs num_samples * k times.
     draft_probs = draft_probs.reshape(1, 1,
@@ -447,16 +462,17 @@ def estimate_rejection_sampling_pdf(
     temperature = torch.ones(num_samples, dtype=torch.float32, device=DEVICE)
     sampling_metadata = create_sampling_metadata(all_greedy=False,
                                                  temperature=temperature)
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(
-        draft_token_ids.tolist(), device=bonus_token_ids.device)
-    output_token_ids = rejection_sampler(
+    spec_decode_metadata = create_spec_decode_metadata(
+        draft_token_ids.tolist(), target_logits)
+
+    mock_main_sampler_output(rejection_sampler, bonus_token_ids)
+    sampler_output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=draft_probs,
-        target_logits=target_logits,
-        bonus_token_ids=bonus_token_ids,
+        logits=target_logits,
         sampling_metadata=sampling_metadata,
     )
-    output_token_ids = output_token_ids[:, :-1].flatten()
+    output_token_ids = sampler_output.sampled_token_ids[:, :-1].flatten()
 
     hist = torch.histogram(output_token_ids.to(dtype=torch.float,
                                                device="cpu"),
@@ -496,22 +512,20 @@ def _test_masked_logits(
                                   device=DEVICE)
 
     # Create spec decode metadata
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(
-        draft_token_ids,
-        device=DEVICE,
-    )
+    spec_decode_metadata = create_spec_decode_metadata(draft_token_ids,
+                                                       target_logits)
 
     # Run rejection sampling
-    output_token_ids = rejection_sampler(
+    mock_main_sampler_output(rejection_sampler, bonus_token_ids)
+    output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=draft_probs,
-        target_logits=target_logits,
-        bonus_token_ids=bonus_token_ids,
+        logits=target_logits,
         sampling_metadata=sampling_metadata,
     )
 
     # Remove bonus tokens and reshape
-    output_token_ids = output_token_ids[:, :-1].flatten().tolist()
+    output_token_ids = output.sampled_token_ids[:, :-1].flatten().tolist()
 
     # Check that all sampled tokens are within the unmasked indices.
     for i in range(num_tokens):

--- a/tests/v1/sample/test_tree_rejection_sampler.py
+++ b/tests/v1/sample/test_tree_rejection_sampler.py
@@ -156,7 +156,7 @@ def assert_rejection_sample(
 
     # Generate logits that deterministically produce the given sampled
     # tokens.
-    target_logits = torch.cat([
+    logits = torch.cat([
         create_logits_tensor(tree, num_drafts + 1, sample_map)
         for sample_map in target_sample_maps
     ])
@@ -165,11 +165,10 @@ def assert_rejection_sample(
     metadata = create_sampling_metadata(all_greedy=True)
 
     # Rejection sample.
-    output_tokens = tree_rejection_sampler(
+    output = tree_rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
-        target_logits=target_logits,
-        bonus_token_ids=None,
+        logits=logits,
         sampling_metadata=metadata,
     )
 
@@ -178,7 +177,7 @@ def assert_rejection_sample(
         to_output_token_ids(tree, num_drafts, a, b)
         for a, b in zip(expected_accepted_nodes, expected_bonus_nodes)
     ])
-    assert torch.equal(output_tokens, expected_tokens)
+    assert torch.equal(output.sampled_token_ids, expected_tokens)
 
 
 ########################### Tests ###########################

--- a/tests/v1/sample/test_tree_rejection_sampler.py
+++ b/tests/v1/sample/test_tree_rejection_sampler.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any, Optional
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.sampler import Sampler
+from vllm.v1.sample.tree_rejection_sampler import (PLACEHOLDER_TOKEN_ID,
+                                                   TreeRejectionSampler)
+from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+from vllm.v1.tree_spec_decode.tree_drafter_params import TreeDrafterParams
+
+DEVICE = current_platform.device_type
+VOCAB_SIZE = 100
+Node = tuple[int, ...]
+
+########################### Helper Functions ###########################
+
+
+def create_tree_rejection_sampler(tree_structure: list[Node],
+                                  batch_size: int) -> TreeRejectionSampler:
+    tree_drafter_params = TreeDrafterParams.from_spec_token_tree(
+        str(tree_structure))
+    return TreeRejectionSampler(
+        tree_drafter_params=tree_drafter_params,
+        max_batch_size=batch_size,
+        main_sampler=Sampler(),
+        device=DEVICE,
+    )
+
+
+def get_token_id(tree: list[Node], node: Node) -> int:
+    # Token id is just the position of this node in the tree.
+    return tree.index(node)
+
+
+def to_input_draft_token_ids(tree: list[Node], num_drafts: int,
+                             draft_nodes: list[Node]) -> torch.Tensor:
+    """
+    Creates a tensor of draft token ids to input into the rejection sampler.
+    Each given node is mapped to a unique token id. All other positions are
+    given a random token id.
+    """
+    draft_token_ids = torch.randint(
+        # Offset the random token ids by the size of the tree.
+        low=len(tree),
+        high=VOCAB_SIZE,
+        size=(num_drafts, ),
+        device=DEVICE)
+    for draft_node in draft_nodes:
+        # Get the draft node's position in the tree, excluding the root node.
+        index = tree.index(draft_node) - 1
+        # Assign unique token id to the node.
+        token_id = get_token_id(tree, draft_node)
+        draft_token_ids[index] = token_id
+    return draft_token_ids
+
+
+def to_output_token_ids(tree: list[Node], num_drafts: int,
+                        accepted: list[Node], bonus: Node) -> torch.Tensor:
+    """
+    Creates a tensor where only the accepted and bonus nodes are mapped to
+    their token ids.
+    """
+    output_token_ids = torch.empty(num_drafts + 1, device=DEVICE)
+    output_token_ids.fill_(PLACEHOLDER_TOKEN_ID)
+    for accepted_node in accepted:
+        index = tree.index(accepted_node) - 1
+        token_id = get_token_id(tree, accepted_node)
+        output_token_ids[index] = token_id
+    output_token_ids[-1] = get_token_id(tree, bonus)
+    return output_token_ids
+
+
+def create_logits_tensor(tree: list[Node], num_logits: int,
+                         sample_map: dict[Node, Node]) -> torch.Tensor:
+    """
+    Helper function to create logits tensor that will produce the desired
+    token ids on argmax
+    """
+    logits = torch.full((num_logits, VOCAB_SIZE), -100.0, device=DEVICE)
+    for index in range(num_logits):
+        node = tree[index]
+        if node not in sample_map:
+            continue
+        sampled_node = sample_map[node]
+        token_id = get_token_id(tree, sampled_node)
+        logits[index, token_id] = 100.0
+    return logits
+
+
+def create_sampling_metadata(
+    all_greedy: bool,
+    temperature: Optional[torch.Tensor] = None,
+    top_k: Optional[torch.Tensor] = None,
+    top_p: Optional[torch.Tensor] = None,
+    generators: Optional[dict[int, Any]] = None,
+) -> SamplingMetadata:
+    """
+    Create a v1 sampling metadata object with all_greedy set to the given
+    value. Either all greedy or all random sampling is used.
+    """
+    generators = generators or {}
+    if all_greedy:
+        temperature = None
+    else:
+        assert temperature is not None
+
+    return SamplingMetadata(
+        temperature=temperature,
+        all_greedy=all_greedy,
+        all_random=not all_greedy,
+        top_p=top_p,
+        top_k=top_k,
+        generators=generators,
+        max_num_logprobs=0,
+        no_penalties=True,
+        prompt_token_ids=None,
+        frequency_penalties=torch.tensor([]),
+        presence_penalties=torch.tensor([]),
+        repetition_penalties=torch.tensor([]),
+        output_token_ids=[],
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=LogitsProcessors(),
+    )
+
+
+def assert_rejection_sample(
+    draft_tree: list[Node],
+    spec_nodes: list[list[Node]],
+    target_sample_maps: list[dict[Node, Node]],
+    expected_accepted_nodes: list[list[Node]],
+    expected_bonus_nodes: list[Node],
+):
+    num_drafts = len(draft_tree)
+    # Create tree rejection sampler.
+    tree_rejection_sampler = create_tree_rejection_sampler(
+        draft_tree, len(spec_nodes))
+
+    # Create the bonus level.
+    last_level = len(draft_tree[-1])
+    leaves = [node for node in draft_tree if len(node) == last_level]
+    bonus_level = [leaf + (0, ) for leaf in leaves]
+    # Create tree with root node and bonus level added.
+    tree = [()] + draft_tree + bonus_level
+
+    # Convert drafted tokens mapping to tensor representation.
+    input_draft_token_ids = torch.stack(
+        [to_input_draft_token_ids(tree, num_drafts, s) for s in spec_nodes])
+    spec_decode_metadata = SpecDecodeMetadata.make_dummy(
+        input_draft_token_ids.tolist(), device=DEVICE)
+
+    # Generate logits that deterministically produce the given sampled
+    # tokens.
+    target_logits = torch.cat([
+        create_logits_tensor(tree, num_drafts + 1, sample_map)
+        for sample_map in target_sample_maps
+    ])
+
+    # Create greedy sampling metadata.
+    metadata = create_sampling_metadata(all_greedy=True)
+
+    # Rejection sample.
+    output_tokens = tree_rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        target_logits=target_logits,
+        bonus_token_ids=None,
+        sampling_metadata=metadata,
+    )
+
+    # Compare with output with expected.
+    expected_tokens = torch.stack([
+        to_output_token_ids(tree, num_drafts, a, b)
+        for a, b in zip(expected_accepted_nodes, expected_bonus_nodes)
+    ])
+    assert torch.equal(output_tokens, expected_tokens)
+
+
+########################### Tests ###########################
+
+
+def test_single_node():
+    """
+    Test exact match for a single node.
+    """
+    draft_tree: list[Node] = [
+        (0, ),
+    ]
+    drafted_tokens: list[list[Node]] = [
+        [(0, )],
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (0, ),
+        (0, ): (0, 0),
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(0, )],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (0, 0),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_chain_full_acceptance():
+    draft_tree: list[Node] = [
+        (0, ),
+        (0, 0),
+        (0, 0, 0),
+    ]
+    drafted_tokens: list[list[Node]] = [
+        [(0, ), (0, 0), (0, 0, 0)],
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (0, ),
+        (0, ): (0, 0),
+        (0, 0): (0, 0, 0),
+        (0, 0, 0): (0, 0, 0, 0)
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(0, ), (0, 0), (0, 0, 0)],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (0, 0, 0, 0),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_chain_partial_acceptance():
+    draft_tree: list[Node] = [
+        (0, ),
+        (0, 0),
+        (0, 0, 0),
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (0, ),
+        (0, ): (0, 0),
+        (0, 0): (0, 0, 0),
+    }]
+    drafted_tokens: list[list[Node]] = [
+        [(0, ), (0, 0), (0, 0)],  # Mismatch for final draft (expected (0,0,0))
+    ]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(0, ), (0, 0)],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (0, 0, 0),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_tree_full_acceptance():
+    draft_tree: list[Node] = [(0, ), (1, ), (0, 0), (0, 1), (1, 0), (1, 1)]
+    drafted_tokens: list[list[Node]] = [
+        [(1, ), (1, 1)],
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (1, ),
+        (1, ): (1, 1),
+        (1, 1): (1, 1, 0),
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(1, ), (1, 1)],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (1, 1, 0),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_tree_partial_acceptance():
+    draft_tree: list[Node] = [(0, ), (1, ), (0, 0), (0, 1), (1, 0), (1, 1)]
+    drafted_tokens: list[list[Node]] = [
+        [(0, ), (0, 0)],  # Mismatch for final draft (expected (0,0))
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (0, ),
+        (0, ): (0, 1),
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(0, )],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (0, 1),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_tree_early_rejection():
+    draft_tree: list[Node] = [(0, ), (1, ), (0, 0), (0, 1), (1, 0), (1, 1)]
+    drafted_tokens: list[list[Node]] = [
+        [(1, ), (0, 1)],  # Mismatch for the first draft (expected (0,))
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (0, ),
+        (0, ): (0, 0),
+        (0, 0): (0, 0, 0),
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (0, ),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_tree_full_acceptance_multiple_sequences():
+    draft_tree: list[Node] = [(0, ), (1, ), (0, 0), (0, 1), (1, 0), (1, 1)]
+    drafted_tokens: list[list[Node]] = [
+        [(0, ), (0, 1)],  # Sequence 1
+        [(1, ), (1, 0)],  # Sequence 2
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (0, ),
+        (0, ): (0, 1),
+        (0, 1): (0, 1, 0),
+    }, {
+        (): (1, ),
+        (1, ): (1, 0),
+        (1, 0): (1, 0, 0),
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(0, ), (0, 1)],
+        [(1, ), (1, 0)],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (0, 1, 0),
+        (1, 0, 0),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_tree_partial_acceptance_multiple_sequences():
+    draft_tree: list[Node] = [(0, ), (1, ), (0, 0), (0, 1), (1, 0), (1, 1)]
+    drafted_tokens: list[list[Node]] = [
+        [(0, ), (0, 0)],  # Mismatch for the second draft (expected (0,1))
+        [(0, ), (0, 1)],  # Mismatch for the first draft (expected (1,))
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (0, ),
+        (0, ): (0, 1),
+    }, {
+        (): (1, ),
+        (1, ): (1, 0),
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(0, )],
+        [],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (0, 1),
+        (1, ),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)
+
+
+def test_deep_tree_full_acceptance():
+    draft_tree: list[Node] = [
+        (0, ),
+        (1, ),  # Level 1
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),  # Level 2
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 0),
+        (0, 1, 1),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (1, 1, 1)  # Level 3
+    ]
+    drafted_tokens: list[list[Node]] = [
+        [(1, ), (1, 1), (1, 1, 0)],
+    ]
+    target_sample_maps: list[dict[Node, Node]] = [{
+        (): (1, ),
+        (0, ): (0, 1),
+        (1, ): (1, 1),
+        (0, 0): (0, 0, 0),
+        (1, 1): (1, 1, 0),
+        (1, 1, 0): (1, 1, 0, 0),
+    }]
+    expected_accepted_tokens: list[list[Node]] = [
+        [(1, ), (1, 1), (1, 1, 0)],
+    ]
+    expected_bonus_tokens: list[Node] = [
+        (1, 1, 0, 0),
+    ]
+    assert_rejection_sample(draft_tree, drafted_tokens, target_sample_maps,
+                            expected_accepted_tokens, expected_bonus_tokens)

--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -444,7 +444,7 @@ def test_propose_tree(spec_token_tree):
     # Mock the model forward calls.
     forward_returns = [(torch.zeros(total_tokens, hidden_size, device=device),
                         torch.zeros(total_tokens, hidden_size, device=device))]
-    for cu_num_drafts in proposer.cu_drafts_per_level:
+    for cu_num_drafts in proposer.cu_drafts_per_level[1:]:
         h_logits = torch.zeros(batch_size * cu_num_drafts,
                                hidden_size,
                                device=device)
@@ -455,7 +455,7 @@ def test_propose_tree(spec_token_tree):
     model_mock.side_effect = forward_returns
 
     # Mock the compute_logits calls.
-    cu_num_drafts_tensor = torch.tensor([0] + proposer.cu_drafts_per_level,
+    cu_num_drafts_tensor = torch.tensor(proposer.cu_drafts_per_level,
                                         dtype=torch.int32,
                                         device=device)
     logits_returns = []

--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -125,7 +125,7 @@ def test_prepare_inputs():
     proposer = _create_proposer("eagle", 1)
 
     updated_metadata, token_indices = proposer.prepare_inputs(
-        common_attn_metadata, num_rejected_tokens.cpu())
+        common_attn_metadata, num_rejected_tokens.cpu(), [], [])
 
     assert torch.equal(updated_metadata.query_start_loc,
                        expected_cu_num_tokens)
@@ -405,7 +405,9 @@ def test_propose(method, attn_backend, num_speculative_tokens, monkeypatch):
         [(0, ), (1, ), (2, ), (0, 0), (0, 1), (1, 0), (1, 1), (2, 0),
          (2, 1)],  # Tree
     ])
-def test_propose_tree(spec_token_tree):
+def test_propose_tree(spec_token_tree, monkeypatch):
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", "TREE_ATTN")
+
     # Get GPU device.
     device = torch.device(current_platform.device_type)
 

--- a/tests/v1/spec_decode/test_tree_attention.py
+++ b/tests/v1/spec_decode/test_tree_attention.py
@@ -120,9 +120,11 @@ def forward_attention(
     )
 
 
-def test_tree_attn_correctness() -> None:
+def test_tree_attn_correctness(monkeypatch) -> None:
     torch.manual_seed(42)
     torch.cuda.manual_seed_all(42)
+
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", "TREE_ATTN")
 
     device = "cuda"
     tree_attn_masks = {

--- a/vllm/v1/attention/backends/tree_attn.py
+++ b/vllm/v1/attention/backends/tree_attn.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Attention layer with TreeAttention."""
 
-import ast
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -168,21 +167,23 @@ class TreeAttentionMetadataBuilder(
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
 
         self.block_size = kv_cache_spec.block_size
-
         spec_config = vllm_config.speculative_config
-        spec_token_tree = (spec := spec_config) and spec.speculative_token_tree
-        tree_choices: list[tuple[int,
-                                 ...]] = (ast.literal_eval(spec_token_tree)
-                                          if spec_token_tree is not None else
-                                          [(0, )])
-        # Construct the tree attention bias.
-        depth_counts = _get_depth_counts(tree_choices)
-        self.tree_attn_bias = _prepare_tree_attn_bias(
-            tree_choices,
-            depth_counts,
-            dtype=torch.float32,
-            device=device,
-        )
+        tree_drafter_params = (spec :=
+                               spec_config) and spec.tree_drafter_params
+        if tree_drafter_params is None:
+            # Standard decoding.
+            self.tree_attn_bias = torch.zeros((1, 1),
+                                              dtype=torch.float32,
+                                              device=device)
+        else:
+            # Spec decoding.
+            tree_attn_mask = torch.tensor(tree_drafter_params.attn_mask,
+                                          device=device)
+            self.tree_attn_bias = torch.where(tree_attn_mask, 0, -torch.inf)
+        # TODO (TheEpicDolphin): Find a better way to separate prefills and
+        # decodes for tree attention. Currently, prefills <=
+        # self.tree_attn_bias.shape[0] are misclassified as decodes.
+        self.__class__.reorder_batch_threshold = self.tree_attn_bias.shape[0]
 
     def reorder_batch(self, input_batch: "InputBatch",
                       scheduler_output: "SchedulerOutput") -> bool:
@@ -249,58 +250,6 @@ class TreeAttentionMetadataBuilder(
         # Reset the tree attention bias to the original value.
         self.tree_attn_bias = orig_tree_attn_bias
         return attn_metadata
-
-
-def _get_depth_counts(sorted_tree_choices: list[tuple[int, ...]]) -> list[int]:
-    # Count the number of choices at each depth of the tree.
-    depth_counts = []
-    prev_depth = 0
-    for path in sorted_tree_choices:
-        depth = len(path)
-        if depth != prev_depth:
-            depth_counts.append(0)
-        depth_counts[depth - 1] += 1
-        prev_depth = depth
-    return depth_counts
-
-
-def _prepare_tree_attn_bias(
-    sorted_tree_choices: list[tuple[int, ...]],
-    depth_counts: list[int],
-    dtype: Optional[torch.dtype],
-    device: Optional[torch.device],
-) -> torch.Tensor:
-    # +1 comes from the additional root node.
-    tree_len = len(sorted_tree_choices) + 1
-    tree_attn_mask = torch.full((tree_len, tree_len),
-                                -torch.inf,
-                                device=device,
-                                dtype=dtype)
-
-    # Set diagonal to all zeros. Each token should
-    # attend to itself.
-    mask_val = 0
-    for i in range(tree_len):
-        tree_attn_mask[i, i] = mask_val
-
-    # Set root to all zeros. All tokens attend to it.
-    tree_attn_mask[:, 0] = mask_val
-
-    # Set all ancestors to zeros.
-    start = 0
-    for i in range(len(depth_counts)):
-        for j in range(depth_counts[i]):
-            cur_tree_choice = sorted_tree_choices[start + j]
-            # Retrieve ancestor position.
-            if len(cur_tree_choice) == 1:
-                continue
-            ancestor_idx = []
-            for c in range(len(cur_tree_choice) - 1):
-                ancestor_idx.append(
-                    sorted_tree_choices.index(cur_tree_choice[:c + 1]) + 1)
-            tree_attn_mask[j + start + 1, ancestor_idx] = mask_val
-        start += depth_counts[i]
-    return tree_attn_mask
 
 
 class TreeAttentionImpl(AttentionImpl):

--- a/vllm/v1/sample/tree_rejection_sampler.py
+++ b/vllm/v1/sample/tree_rejection_sampler.py
@@ -2,9 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import Optional
 
+import numpy as np
 import torch
 
 from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.sample.rejection_sampler import (PLACEHOLDER_TOKEN_ID,
@@ -14,6 +17,8 @@ from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.tree_spec_decode.tree_drafter_params import TreeDrafterParams
 
 logger = init_logger(__name__)
+
+BLOCK_SIZE: int = 64
 
 
 class TreeRejectionSampler(RejectionSampler):
@@ -25,18 +30,14 @@ class TreeRejectionSampler(RejectionSampler):
         main_sampler: Sampler,
         device: Optional[torch.device],
     ):
-        super().__init__()
-        tree_mask = torch.tensor(tree_drafter_params.attn_mask,
-                                 device=device)[:, 1:].contiguous()
-        self.expanded_tree_mask = tree_mask.expand((max_batch_size, -1, -1))
-        self.batch_indices = torch.arange(max_batch_size, device=device)
+        super().__init__(main_sampler, device)
+        self.tree_mask = torch.tensor(tree_drafter_params.attn_mask,
+                                      device=device)[:, 1:].contiguous()
         # Cumulative # of tokens per level, including the root token.
         self.cu_tokens_per_level = [
             num_drafts + 1
             for num_drafts in tree_drafter_params.cu_drafts_per_level
         ]
-        # Num children at every level.
-        self.main_sampler = main_sampler
 
         # Get tree depth (# levels) and width (# drafts at last level).
         self.tree_depth = len(self.cu_tokens_per_level)
@@ -65,9 +66,8 @@ class TreeRejectionSampler(RejectionSampler):
 
         # Precompute indices for logits corresponding to tree-internal
         # tokens across batches.
-        num_tree_internal_tokens = self.cu_tokens_per_level[-2]
-        self.tree_internal_index_offsets = torch.arange(
-            num_tree_internal_tokens, device=device)
+        self.tree_internal_size = self.cu_tokens_per_level[-2]
+        self.tree_index_offsets = np.arange(self.tree_size)
 
     def forward(
         self,
@@ -75,10 +75,9 @@ class TreeRejectionSampler(RejectionSampler):
         # [num_tokens, vocab_size]
         draft_probs: Optional[torch.Tensor],
         # [num_tokens, vocab_size]
-        target_logits: torch.Tensor,
-        bonus_token_ids: Optional[torch.Tensor],
+        logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
-    ) -> torch.Tensor:
+    ) -> SamplerOutput:
         """
         Args:
             metadata:
@@ -87,15 +86,11 @@ class TreeRejectionSampler(RejectionSampler):
                 Probability distribution for the draft tokens. Shape is
                 [num_tokens, vocab_size]. Can be None if probabilities are
                 not provided, which is the case for ngram spec decode.
-            target_logits (torch.Tensor):
+            logits (torch.Tensor):
                 Target model's logits probability distribution.
                 Shape is [num_tokens, vocab_size]. Here, probabilities from
                 different requests are flattened into a single tensor because
                 this is the shape of the output logits.
-            bonus_token_ids_tensor (Optional[torch.Tensor]):
-                Not used, and expected to be None. This method will generate
-                a bonus token for each request depending on which branch is
-                accepted.
             sampling_metadata (vllm.v1.sample.metadata.SamplingMetadata):
                 Additional metadata needed for sampling, such as temperature,
                 top-k/top-p parameters, or other relevant information.
@@ -103,7 +98,6 @@ class TreeRejectionSampler(RejectionSampler):
             output_token_ids (torch.Tensor):
                 A tensor containing the final output token IDs.
         """
-        assert bonus_token_ids is None
 
         # Example tree structure (2 levels of drafts):
         #         0 (root)
@@ -112,144 +106,234 @@ class TreeRejectionSampler(RejectionSampler):
         #     / |   | \
         #    3  4   5  6    level 2
 
-        device = target_logits.device
-        num_reqs = len(metadata.num_draft_tokens)
-        # [8, 8, 0, 0, 0, 0, 0, 0]
-        num_draft_tokens = torch.tensor(metadata.num_draft_tokens,
-                                        device=device)
         draft_tree_size = self.tree_size - 1
-        # [1, 1, 0, 0, 0, 0, 0, 0]
-        tree_decode_mask = num_draft_tokens == draft_tree_size
-        # [0, 1, 2, 3, 4, 5, 6, 7]
-        start_indices = torch.arange(num_reqs, device=device)
-        # [0, 9, 18, 19, 20, 21, 22, 23]
-        start_indices[1:] += metadata.cu_num_draft_tokens[:-1]
-
-        # Compute target probabilities for all logits corresponding to internal
-        # nodes in the tree.
-        vocab_size = target_logits.shape[-1]
-        # [0, 9]
-        tree_decode_start_indices = start_indices[tree_decode_mask]
-        # [[0, 1, 2],
-        #  [9, 10, 11]]
-        tree_internal_indices = tree_decode_start_indices.unsqueeze(
-            1) + self.tree_internal_index_offsets
-        num_tree_decodes, num_logits_per_batch = tree_internal_indices.shape
-        tree_internal_logits = target_logits[tree_internal_indices.flatten()]
-        target_probs = self.compute_probs(
-            tree_internal_logits,
-            num_logits_per_batch,
-            sampling_metadata,
-        ).view(num_tree_decodes, -1, vocab_size)
-
-        # Sample tokens from the target probabilities.
-        # TODO(TheEpicDolphin): Add support for probabilistic-style rejection
-        # sampling, as used in EAGLE.
-        target_token_ids = target_probs.argmax(dim=-1).cpu()
-
-        # Reshape the draft token ids to [num_tree_decodes, draft_tree_size].
-        draft_token_ids = metadata.draft_token_ids.view(num_tree_decodes, -1)
-
-        # Move sampled target and draft token tensors to CPU.
-        # [[311, 6435, 96618],
-        #  [279, 11, 15861]]
-        target_token_ids_cpu = target_token_ids.cpu()
-        # [[311, 8844, 2349, 387, 4732, 96618, 311, 334],
-        #  [3634, 279, 323, 11, 438, 15861, 3634, 7016]]
+        tree_internal_index_offsets = (
+            self.tree_index_offsets[:self.tree_internal_size])
+        draft_index_offsets = self.tree_index_offsets[:draft_tree_size]
+        draft_token_ids = metadata.draft_token_ids
         draft_token_ids_cpu = draft_token_ids.cpu()
 
-        # For each batch, find longest path from the root node.
-        path_lengths = torch.zeros(
-            # +1 for the root token.
-            (num_tree_decodes, draft_tree_size + 1),
-            dtype=torch.int32)
-        path_lengths[:, 0] = 1
-        for level in range(1, self.tree_depth):
-            # level 2:
-            # (3, 9)
-            start, end = self.draft_slices[level]
-            # [1, 1, 1, 2, 2, 2]
-            parent_indices = self.parent_indices[level]
-            # [[0, 0, 0, 0, 0, 0],
-            #  [0, 1, 0, 1, 0, 0]]
-            sample_match = draft_token_ids_cpu[:, start - 1:end -
-                                               1] == target_token_ids_cpu[:,
-                                                                          parent_indices]
-            nonzero_length = path_lengths[:, parent_indices] > 0
-            # [[1, 2, 0, 0, 0, 0, 0, 0, 0],  ->  [[1, 2, 0, 0, 0, 0, 0, 0, 0],
-            #  [1, 0, 2, 0, 0, 0, 0, 0, 0]]       [1, 0, 2, 0, 0, 0, 3, 0, 0]]
-            path_lengths[:,
-                         start:end].masked_fill_(sample_match & nonzero_length,
-                                                 level + 1)
-        # [1, 6]
-        accepted_token_index_offsets = path_lengths.argmax(dim=-1).to(device)
+        # 8
+        num_reqs = len(metadata.num_draft_tokens)
+        # [1, 8, 8, 0, 0, 0, 0, 0]
+        num_draft_tokens = np.array(metadata.num_draft_tokens)
+        # [2, 9, 9, 1, 1, 1, 1, 1]
+        num_tokens = num_draft_tokens + 1
+        # [0, 1, 1, 0, 0, 0, 0, 0]
+        is_tree_decode = num_draft_tokens == draft_tree_size
 
-        # Get boolean masks for the paths to the accepted tokens.
-        # [0, 1]
-        tree_batch_indices = self.batch_indices[:num_tree_decodes]
-        # [[[1, 0, 0, 0, 0, 0, 0],  <- batch 0
-        #   [1, 1, 0, 0, 0, 0, 0],
-        #   [1, 0, 1, 0, 0, 0, 0],
-        #   [1, 1, 0, 1, 0, 0, 0],
-        #   [1, 1, 0, 0, 1, 0, 0],
-        #   [1, 0, 1, 0, 0, 1, 0],
-        #   [1, 0, 1, 0, 0, 0, 1]],
-        #  [[1, 0, 0, 0, 0, 0, 0],  <- batch 1
-        #   [1, 1, 0, 0, 0, 0, 0],
-        #   [1, 0, 1, 0, 0, 0, 0],
-        #   [1, 1, 0, 1, 0, 0, 0],
-        #   [1, 1, 0, 0, 1, 0, 0],
-        #   [1, 0, 1, 0, 0, 1, 0],
-        #   [1, 0, 1, 0, 0, 0, 1]]]
-        tree_mask = self.expanded_tree_mask[:num_tree_decodes]
-        # [1, 6] => [[1, 0, 0, 0, 0, 0], <- batch 0
-        #            [0, 1, 0, 0, 0, 1]]  <- batch 1
-        path_masks = tree_mask[tree_batch_indices,
-                               accepted_token_index_offsets]
+        # [0, 0, 0, 0, 0, 0, 0, 0]
+        start_indices = np.zeros(num_reqs, dtype=np.int32)
+        # [0, 2, 11, 20, 21, 22, 23, 24]
+        np.cumsum(num_tokens[:-1], out=start_indices[1:])
 
-        # Create output buffer.
+        # Create output token ids buffer.
         output_token_ids = torch.empty(
             # +1 for the bonus token.
             (num_reqs, draft_tree_size + 1),
             dtype=torch.
             int32,  # Consistent with SamplerOutput.sampled_token_ids.
-            device=device,
+            device=self.device,
         )
-        output_token_ids.fill_(PLACEHOLDER_TOKEN_ID)
 
-        # Set accepted draft tokens.
-        accepted_draft_tokens = draft_token_ids[path_masks]
-        scatter_mask = torch.zeros_like(output_token_ids, dtype=torch.bool)
-        scatter_mask[tree_decode_mask, :-1] = path_masks
-        output_token_ids.masked_scatter_(scatter_mask, accepted_draft_tokens)
+        # [0, 0, 0, 0, 0, 0, 0, 0]
+        accepted_index_offsets = np.zeros(num_reqs, dtype=np.int32)
+
+        num_tree_decodes = is_tree_decode.sum()
+        if num_tree_decodes > 0:
+            # Compute target probabilities for all logits corresponding to
+            # internal nodes in the tree.
+            vocab_size = logits.shape[-1]
+            # [2, 11]
+            tree_decode_start_indices = start_indices[is_tree_decode]
+            # [[2, 3, 4],
+            #  [11, 12, 13]]
+            tree_internal_indices = (tree_decode_start_indices[:, None] +
+                                     tree_internal_index_offsets)
+            # [2, 3, 4, 11, 12, 13]
+            tree_internal_indices_tensor = torch.from_numpy(
+                tree_internal_indices.flatten()).to(self.device)
+            target_probs = self.compute_tree_target_probs(
+                logits[tree_internal_indices_tensor],
+                is_tree_decode,
+                num_tree_decodes,
+                sampling_metadata,
+            ).view(num_tree_decodes, -1, vocab_size)
+            # Sample target token ids from the target probabilities.
+            # TODO(TheEpicDolphin): Add support for probabilistic-style
+            # rejection sampling, as used in EAGLE.
+            target_token_ids = target_probs.argmax(dim=-1)
+
+            # Get the draft token ids for batches with full draft trees.
+            # [0, 0]
+            draft_start_indices = np.zeros(num_tree_decodes, dtype=np.int32)
+            # [1, 9]
+            np.cumsum(num_draft_tokens[is_tree_decode][:-1],
+                      out=draft_start_indices[1:])
+            # [[1, 2, 3, ... , 8]
+            #  [9, 10, 11, ... , 16]]
+            tree_draft_indices = (draft_start_indices[:, None] +
+                                  draft_index_offsets)
+            # [[311, 8844, 2349, 387, 4732, 96618, 311, 334],
+            #  [3634, 279, 323, 11, 438, 15861, 3634, 7016]]
+            draft_token_ids_np = draft_token_ids_cpu[tree_draft_indices].numpy(
+            )
+
+            # Move sampled target token ids to CPU.
+            # [[311, 6435, 96618],
+            #  [279, 11, 15861]]
+            target_token_ids_np = target_token_ids.cpu().numpy()
+
+            # For each tree decode batch, find longest path from the root node.
+            path_lengths = np.zeros(
+                # +1 for the root token.
+                (num_tree_decodes, draft_tree_size + 1),
+                dtype=np.int32)
+            path_lengths[:, 0] = 1
+            for level in range(1, self.tree_depth):
+                # level 2:
+                # (3, 9)
+                start, end = self.draft_slices[level]
+                # [1, 1, 1, 2, 2, 2]
+                parent_indices = self.parent_indices[level]
+                # [[0, 0, 0, 0, 0, 0],
+                #  [0, 1, 0, 1, 0, 0]]
+                sample_match = (draft_token_ids_np[:, start - 1:end - 1] ==
+                                target_token_ids_np[:, parent_indices])
+                nonzero_length = path_lengths[:, parent_indices] > 0
+                combined_mask = sample_match & nonzero_length
+                # [[1, 2, 0, 0, 0, 0, 0, 0, 0],-> [[1, 2, 0, 0, 0, 0, 0, 0, 0],
+                #  [1, 0, 2, 0, 0, 0, 0, 0, 0]]    [1, 0, 2, 0, 0, 0, 3, 0, 0]]
+                path_lengths[:, start:end][combined_mask] = level + 1
+            # [1, 6, 0, 0, 0, 0, 0, 0]
+            accepted_index_offsets[is_tree_decode] = path_lengths.argmax(
+                axis=-1)
+
+        # Calculate grid dimensions.
+        grid_dim_0 = num_reqs
+        grid_dim_1 = triton.cdiv(draft_tree_size, BLOCK_SIZE)
+        grid = (grid_dim_0, grid_dim_1)
+
+        # Launch kernel to set accepted draft token ids in output buffer.
+        accepted_index_offsets_tensor = torch.from_numpy(
+            accepted_index_offsets).to(self.device, non_blocking=True)
+        _scatter_accepted_tokens_kernel[grid](
+            draft_token_ids_ptr=draft_token_ids,
+            output_token_ids_ptr=output_token_ids,
+            accepted_offsets_ptr=accepted_index_offsets_tensor,
+            tree_mask_ptr=self.tree_mask,
+            draft_tree_size=draft_tree_size,
+            placeholder_token_id=PLACEHOLDER_TOKEN_ID,
+            block_size=BLOCK_SIZE,
+        )
 
         # Sample and add a bonus token to the accepted paths.
-        bonus_token_indices = start_indices
-        bonus_token_indices[tree_decode_mask] += accepted_token_index_offsets
+        # [0, 2 + 1, 11 + 6, 20, 21, 22, 23, 24]
+        bonus_token_indices = start_indices + accepted_index_offsets
+        bonus_token_indices_tensor = torch.from_numpy(bonus_token_indices).to(
+            self.device, non_blocking=True)
         bonus_sampler_output = self.main_sampler(
-            logits=target_logits[bonus_token_indices],
+            logits=logits[bonus_token_indices_tensor],
             sampling_metadata=sampling_metadata,
         )
         output_token_ids[:,
                          -1] = bonus_sampler_output.sampled_token_ids.view(-1)
-        return output_token_ids
+        return SamplerOutput(
+            sampled_token_ids=output_token_ids,
+            logprobs_tensors=bonus_sampler_output.logprobs_tensors,
+        )
 
-    def compute_probs(self, logits: torch.Tensor, logits_per_batch: int,
-                      sampling_metadata: SamplingMetadata):
+    def compute_tree_target_probs(self, logits: torch.Tensor,
+                                  is_tree_decode: torch.Tensor,
+                                  num_tree_decodes: int,
+                                  sampling_metadata: SamplingMetadata):
         if sampling_metadata.all_greedy:
             return logits
 
+        # How many times to repeat the temperature, top-k, and top-p
+        # for each tree-decode batch.
+        num_repeats = logits.shape[0] // num_tree_decodes
+
         assert sampling_metadata.temperature is not None
-        temperature = sampling_metadata.temperature.repeat_interleave(
-            logits_per_batch)
+        temperature = sampling_metadata.temperature[is_tree_decode]
+        temperature = temperature.repeat_interleave(num_repeats)
         logits.div_(temperature.view(-1, 1))
 
         top_k = None
         if sampling_metadata.top_k is not None:
-            top_k = sampling_metadata.top_k.repeat_interleave(logits_per_batch)
+            top_k = sampling_metadata.top_k[is_tree_decode]
+            top_k = top_k.repeat_interleave(num_repeats)
         top_p = None
         if sampling_metadata.top_p is not None:
-            top_p = sampling_metadata.top_p.repeat_interleave(logits_per_batch)
+            top_p = sampling_metadata.top_p[is_tree_decode]
+            top_p = top_p.repeat_interleave(num_repeats)
         logits = apply_top_k_top_p(logits, top_k, top_p)
         output_probs = logits.softmax(dim=-1, dtype=torch.float32)
         return output_probs
+
+
+@triton.jit
+def _scatter_accepted_tokens_kernel(
+    draft_token_ids_ptr,
+    output_token_ids_ptr,
+    accepted_offsets_ptr,
+    tree_mask_ptr,
+    draft_tree_size,
+    placeholder_token_id: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    """
+    For batches that correspond to tree decodes, accepted token ids from
+    draft_token_ids are scattered to the corresponding indices in
+    output_token_ids. All other indices are set to placeholder_token_id.
+
+    Whether a token from draft_token_ids is accepted or not is determined by
+    indexing into tree_mask via accepted_offsets.
+
+    Args:
+        draft_token_ids_ptr: [num_reqs, draft_tree_size] Draft token ids.
+        output_token_ids_ptr: [num_reqs, draft_tree_size + 1] Output buffer.
+        accepted_offsets_ptr: [num_reqs] - Indices into tree_mask rows.
+        tree_mask_ptr: [draft_tree_size + 1, draft_tree_size] - Boolean masks
+                       for paths to each node in the tree.
+        draft_tree_size: Size of draft tree.
+        placeholder_token_id: Placeholder token id for rejected tokens.
+        block_size: Block size
+
+    Grid: (num_reqs, ceil(draft_tree_size / BLOCK_SIZE))
+    """
+
+    req_idx = tl.program_id(0)
+    block_idx = tl.program_id(1)
+
+    # Get the accepted token index offset for this request.
+    accepted_offset = tl.load(accepted_offsets_ptr + req_idx)
+
+    # Calculate which tokens this block processes.
+    block_start = block_idx * block_size
+    token_offsets = block_start + tl.arange(0, block_size)
+    token_mask = token_offsets < draft_tree_size
+
+    # Get accepted path mask. Index as tree_mask[accepted_offset, :].
+    path_mask_base = accepted_offset * draft_tree_size
+    accepted_path_mask = tl.load(tree_mask_ptr + path_mask_base +
+                                 token_offsets,
+                                 mask=token_mask,
+                                 other=0)
+
+    # Load draft tokens for this request.
+    draft_base = req_idx * draft_tree_size
+    draft_tokens = tl.load(draft_token_ids_ptr + draft_base + token_offsets,
+                           mask=token_mask,
+                           other=placeholder_token_id)
+
+    # Select draft tokens based on the accepted path mask.
+    output_tokens = tl.where(accepted_path_mask, draft_tokens,
+                             placeholder_token_id)
+
+    # Store to output at the same positions.
+    output_width = draft_tree_size + 1
+    output_base = req_idx * output_width
+    tl.store(output_token_ids_ptr + output_base + token_offsets,
+             output_tokens,
+             mask=token_mask)

--- a/vllm/v1/sample/tree_rejection_sampler.py
+++ b/vllm/v1/sample/tree_rejection_sampler.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Optional
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
+from vllm.v1.sample.rejection_sampler import (PLACEHOLDER_TOKEN_ID,
+                                              RejectionSampler)
+from vllm.v1.sample.sampler import Sampler
+from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+from vllm.v1.tree_spec_decode.tree_drafter_params import TreeDrafterParams
+
+logger = init_logger(__name__)
+
+
+class TreeRejectionSampler(RejectionSampler):
+
+    def __init__(
+        self,
+        tree_drafter_params: TreeDrafterParams,
+        max_batch_size: int,
+        main_sampler: Sampler,
+        device: Optional[torch.device],
+    ):
+        super().__init__()
+        tree_mask = torch.tensor(tree_drafter_params.attn_mask,
+                                 device=device)[:, 1:].contiguous()
+        self.expanded_tree_mask = tree_mask.expand((max_batch_size, -1, -1))
+        self.batch_indices = torch.arange(max_batch_size, device=device)
+        # Cumulative # of tokens per level, including the root token.
+        self.cu_tokens_per_level = [
+            num_drafts + 1
+            for num_drafts in tree_drafter_params.cu_drafts_per_level
+        ]
+        # Num children at every level.
+        self.main_sampler = main_sampler
+
+        # Get tree depth (# levels) and width (# drafts at last level).
+        self.tree_depth = len(self.cu_tokens_per_level)
+        self.tree_width = self.cu_tokens_per_level[
+            -1] - self.cu_tokens_per_level[-2]
+        self.tree_size = self.cu_tokens_per_level[-1]
+
+        # Get per-level slices of draft indices, and per-level indices
+        # for their corresponding parents.
+        num_children_per_level = tree_drafter_params.child_drafts_per_level
+        self.draft_slices = [(0, 0)]
+        self.parent_indices: list[list[int]] = [[]]
+        parents_end = 0
+        for level in range(1, self.tree_depth):
+            # Add slice of draft indices for this level.
+            self.draft_slices.append((self.cu_tokens_per_level[level - 1],
+                                      self.cu_tokens_per_level[level]))
+            # Add indices for this level's parents.
+            parents_start = parents_end
+            parents_end = self.cu_tokens_per_level[level - 1]
+            num_children = num_children_per_level[level - 1]
+            indices = []
+            for parent_idx in range(parents_start, parents_end):
+                indices += [parent_idx] * num_children
+            self.parent_indices.append(indices)
+
+        # Precompute indices for logits corresponding to tree-internal
+        # tokens across batches.
+        num_tree_internal_tokens = self.cu_tokens_per_level[-2]
+        self.tree_internal_index_offsets = torch.arange(
+            num_tree_internal_tokens, device=device)
+
+    def forward(
+        self,
+        metadata: SpecDecodeMetadata,
+        # [num_tokens, vocab_size]
+        draft_probs: Optional[torch.Tensor],
+        # [num_tokens, vocab_size]
+        target_logits: torch.Tensor,
+        bonus_token_ids: Optional[torch.Tensor],
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        """
+        Args:
+            metadata:
+                Metadata for spec decoding.
+            draft_probs (Optional[torch.Tensor]):
+                Probability distribution for the draft tokens. Shape is
+                [num_tokens, vocab_size]. Can be None if probabilities are
+                not provided, which is the case for ngram spec decode.
+            target_logits (torch.Tensor):
+                Target model's logits probability distribution.
+                Shape is [num_tokens, vocab_size]. Here, probabilities from
+                different requests are flattened into a single tensor because
+                this is the shape of the output logits.
+            bonus_token_ids_tensor (Optional[torch.Tensor]):
+                Not used, and expected to be None. This method will generate
+                a bonus token for each request depending on which branch is
+                accepted.
+            sampling_metadata (vllm.v1.sample.metadata.SamplingMetadata):
+                Additional metadata needed for sampling, such as temperature,
+                top-k/top-p parameters, or other relevant information.
+        Returns:
+            output_token_ids (torch.Tensor):
+                A tensor containing the final output token IDs.
+        """
+        assert bonus_token_ids is None
+
+        # Example tree structure (2 levels of drafts):
+        #         0 (root)
+        #        / \
+        #       1   2   level 1
+        #     / |   | \
+        #    3  4   5  6    level 2
+
+        device = target_logits.device
+        num_reqs = len(metadata.num_draft_tokens)
+        # [8, 8, 0, 0, 0, 0, 0, 0]
+        num_draft_tokens = torch.tensor(metadata.num_draft_tokens,
+                                        device=device)
+        draft_tree_size = self.tree_size - 1
+        # [1, 1, 0, 0, 0, 0, 0, 0]
+        tree_decode_mask = num_draft_tokens == draft_tree_size
+        # [0, 1, 2, 3, 4, 5, 6, 7]
+        start_indices = torch.arange(num_reqs, device=device)
+        # [0, 9, 18, 19, 20, 21, 22, 23]
+        start_indices[1:] += metadata.cu_num_draft_tokens[:-1]
+
+        # Compute target probabilities for all logits corresponding to internal
+        # nodes in the tree.
+        vocab_size = target_logits.shape[-1]
+        # [0, 9]
+        tree_decode_start_indices = start_indices[tree_decode_mask]
+        # [[0, 1, 2],
+        #  [9, 10, 11]]
+        tree_internal_indices = tree_decode_start_indices.unsqueeze(
+            1) + self.tree_internal_index_offsets
+        num_tree_decodes, num_logits_per_batch = tree_internal_indices.shape
+        tree_internal_logits = target_logits[tree_internal_indices.flatten()]
+        target_probs = self.compute_probs(
+            tree_internal_logits,
+            num_logits_per_batch,
+            sampling_metadata,
+        ).view(num_tree_decodes, -1, vocab_size)
+
+        # Sample tokens from the target probabilities.
+        # TODO(TheEpicDolphin): Add support for probabilistic-style rejection
+        # sampling, as used in EAGLE.
+        target_token_ids = target_probs.argmax(dim=-1).cpu()
+
+        # Reshape the draft token ids to [num_tree_decodes, draft_tree_size].
+        draft_token_ids = metadata.draft_token_ids.view(num_tree_decodes, -1)
+
+        # Move sampled target and draft token tensors to CPU.
+        # [[311, 6435, 96618],
+        #  [279, 11, 15861]]
+        target_token_ids_cpu = target_token_ids.cpu()
+        # [[311, 8844, 2349, 387, 4732, 96618, 311, 334],
+        #  [3634, 279, 323, 11, 438, 15861, 3634, 7016]]
+        draft_token_ids_cpu = draft_token_ids.cpu()
+
+        # For each batch, find longest path from the root node.
+        path_lengths = torch.zeros(
+            # +1 for the root token.
+            (num_tree_decodes, draft_tree_size + 1),
+            dtype=torch.int32)
+        path_lengths[:, 0] = 1
+        for level in range(1, self.tree_depth):
+            # level 2:
+            # (3, 9)
+            start, end = self.draft_slices[level]
+            # [1, 1, 1, 2, 2, 2]
+            parent_indices = self.parent_indices[level]
+            # [[0, 0, 0, 0, 0, 0],
+            #  [0, 1, 0, 1, 0, 0]]
+            sample_match = draft_token_ids_cpu[:, start - 1:end -
+                                               1] == target_token_ids_cpu[:,
+                                                                          parent_indices]
+            nonzero_length = path_lengths[:, parent_indices] > 0
+            # [[1, 2, 0, 0, 0, 0, 0, 0, 0],  ->  [[1, 2, 0, 0, 0, 0, 0, 0, 0],
+            #  [1, 0, 2, 0, 0, 0, 0, 0, 0]]       [1, 0, 2, 0, 0, 0, 3, 0, 0]]
+            path_lengths[:,
+                         start:end].masked_fill_(sample_match & nonzero_length,
+                                                 level + 1)
+        # [1, 6]
+        accepted_token_index_offsets = path_lengths.argmax(dim=-1).to(device)
+
+        # Get boolean masks for the paths to the accepted tokens.
+        # [0, 1]
+        tree_batch_indices = self.batch_indices[:num_tree_decodes]
+        # [[[1, 0, 0, 0, 0, 0, 0],  <- batch 0
+        #   [1, 1, 0, 0, 0, 0, 0],
+        #   [1, 0, 1, 0, 0, 0, 0],
+        #   [1, 1, 0, 1, 0, 0, 0],
+        #   [1, 1, 0, 0, 1, 0, 0],
+        #   [1, 0, 1, 0, 0, 1, 0],
+        #   [1, 0, 1, 0, 0, 0, 1]],
+        #  [[1, 0, 0, 0, 0, 0, 0],  <- batch 1
+        #   [1, 1, 0, 0, 0, 0, 0],
+        #   [1, 0, 1, 0, 0, 0, 0],
+        #   [1, 1, 0, 1, 0, 0, 0],
+        #   [1, 1, 0, 0, 1, 0, 0],
+        #   [1, 0, 1, 0, 0, 1, 0],
+        #   [1, 0, 1, 0, 0, 0, 1]]]
+        tree_mask = self.expanded_tree_mask[:num_tree_decodes]
+        # [1, 6] => [[1, 0, 0, 0, 0, 0], <- batch 0
+        #            [0, 1, 0, 0, 0, 1]]  <- batch 1
+        path_masks = tree_mask[tree_batch_indices,
+                               accepted_token_index_offsets]
+
+        # Create output buffer.
+        output_token_ids = torch.empty(
+            # +1 for the bonus token.
+            (num_reqs, draft_tree_size + 1),
+            dtype=torch.
+            int32,  # Consistent with SamplerOutput.sampled_token_ids.
+            device=device,
+        )
+        output_token_ids.fill_(PLACEHOLDER_TOKEN_ID)
+
+        # Set accepted draft tokens.
+        accepted_draft_tokens = draft_token_ids[path_masks]
+        scatter_mask = torch.zeros_like(output_token_ids, dtype=torch.bool)
+        scatter_mask[tree_decode_mask, :-1] = path_masks
+        output_token_ids.masked_scatter_(scatter_mask, accepted_draft_tokens)
+
+        # Sample and add a bonus token to the accepted paths.
+        bonus_token_indices = start_indices
+        bonus_token_indices[tree_decode_mask] += accepted_token_index_offsets
+        bonus_sampler_output = self.main_sampler(
+            logits=target_logits[bonus_token_indices],
+            sampling_metadata=sampling_metadata,
+        )
+        output_token_ids[:,
+                         -1] = bonus_sampler_output.sampled_token_ids.view(-1)
+        return output_token_ids
+
+    def compute_probs(self, logits: torch.Tensor, logits_per_batch: int,
+                      sampling_metadata: SamplingMetadata):
+        if sampling_metadata.all_greedy:
+            return logits
+
+        assert sampling_metadata.temperature is not None
+        temperature = sampling_metadata.temperature.repeat_interleave(
+            logits_per_batch)
+        logits.div_(temperature.view(-1, 1))
+
+        top_k = None
+        if sampling_metadata.top_k is not None:
+            top_k = sampling_metadata.top_k.repeat_interleave(logits_per_batch)
+        top_p = None
+        if sampling_metadata.top_p is not None:
+            top_p = sampling_metadata.top_p.repeat_interleave(logits_per_batch)
+        logits = apply_top_k_top_p(logits, top_k, top_p)
+        output_probs = logits.softmax(dim=-1, dtype=torch.float32)
+        return output_probs

--- a/vllm/v1/tree_spec_decode/tree_drafter_params.py
+++ b/vllm/v1/tree_spec_decode/tree_drafter_params.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+from dataclasses import dataclass
+
+
+@dataclass
+class TreeDrafterParams:
+    draft_nodes: list[tuple[int, ...]]
+    attn_mask: list[list[bool]]
+    # Cumulative number of drafts at each level.
+    cu_drafts_per_level: list[int]
+    # Number of child drafts that each token has at the given level.
+    child_drafts_per_level: list[int]
+    # Maps each draft token index to its level in the tree.
+    draft_levels: list[int]
+
+    @staticmethod
+    def from_spec_token_tree(spec_token_tree: str) -> "TreeDrafterParams":
+        # Parse the speculative token tree.
+        draft_nodes: list[tuple[int, ...]] = ast.literal_eval(spec_token_tree)
+        # Sort the tree breadth-first.
+        draft_nodes.sort(key=lambda t: (len(t), t))
+        assert len(draft_nodes
+                   ) > 0, "speculative_token_tree must have at least one node."
+        # Only trees with fixed branching factor per level are
+        # currently supported for tree attention.
+        _assert_fixed_branching_factor_per_level(draft_nodes, spec_token_tree)
+
+        tree_depth = len(draft_nodes[-1]) + 1
+        # Precompute per-level properties of the tree.
+        num_nodes_per_level = [0] * tree_depth
+        num_nodes_per_level[0] = 1
+        for node in draft_nodes:
+            num_nodes_per_level[len(node)] += 1
+
+        cu_drafts_per_level = [0]
+        child_drafts_per_level = []
+        draft_levels = []
+        for level in range(1, tree_depth):
+            cu_drafts_per_level.append(cu_drafts_per_level[-1] +
+                                       num_nodes_per_level[level])
+            child_drafts_per_level.append(num_nodes_per_level[level] //
+                                          num_nodes_per_level[level - 1])
+            draft_levels += [level] * num_nodes_per_level[level]
+
+        # Construct the tree attention bias.
+        depth_counts = _get_depth_counts(draft_nodes)
+        attn_mask = _prepare_tree_attn_bias(
+            draft_nodes,
+            depth_counts,
+        )
+
+        return TreeDrafterParams(
+            draft_nodes=draft_nodes,
+            attn_mask=attn_mask,
+            cu_drafts_per_level=cu_drafts_per_level,
+            child_drafts_per_level=child_drafts_per_level,
+            draft_levels=draft_levels,
+        )
+
+
+def _has_fixed_branching_factor(tree_nodes, level):
+    """
+    Checks if all nodes at the given level have the same number of children.
+    """
+    next_level_nodes = [node for node in tree_nodes if len(node) == level + 1]
+    if len(next_level_nodes) == 0:
+        return True
+
+    level_nodes = [node for node in tree_nodes if len(node) == level]
+    child_counts = []
+    for parent in level_nodes:
+        child_counts.append(
+            sum(1 for child in next_level_nodes if child[:-1] == parent))
+    return len(set(child_counts)) <= 1  # All counts are the same.
+
+
+def _assert_fixed_branching_factor_per_level(tree_nodes: list[tuple[int, ...]],
+                                             spec_token_tree: str) -> None:
+    """
+    Asserts that each level of the tree has a fixed branching factor. That is,
+    the number of children per node is the same within a level, but can vary
+    across levels.
+    """
+    tree_depth = len(tree_nodes[-1]) + 1
+    for level in range(1, tree_depth):
+        assert _has_fixed_branching_factor(tree_nodes, level), (
+            f"speculative_token_tree '{spec_token_tree}' has variable "
+            f"branching at level {level}. Tree spec decoding requires "
+            f"a uniform number of children per level.")
+
+
+def _get_depth_counts(sorted_draft_nodes: list[tuple[int, ...]]) -> list[int]:
+    """
+    Counts the number of choices at each depth of the tree.
+    """
+    depth_counts = []
+    prev_depth = 0
+    for path in sorted_draft_nodes:
+        depth = len(path)
+        if depth != prev_depth:
+            depth_counts.append(0)
+        depth_counts[depth - 1] += 1
+        prev_depth = depth
+    return depth_counts
+
+
+def _prepare_tree_attn_bias(
+    sorted_draft_nodes: list[tuple[int, ...]],
+    depth_counts: list[int],
+) -> list[list[bool]]:
+    # +1 comes from the additional root node.
+    tree_len = len(sorted_draft_nodes) + 1
+    tree_attn_mask = [[False for _ in range(tree_len)]
+                      for _ in range(tree_len)]
+
+    mask_val = True
+    for i in range(tree_len):
+        # Set diagonal to all True. Each token should attend to itself.
+        tree_attn_mask[i][i] = mask_val
+        # Set root column to all True. All tokens attend to it.
+        tree_attn_mask[i][0] = mask_val
+
+    # Set all ancestors to True.
+    start = 0
+    for i in range(len(depth_counts)):
+        for j in range(depth_counts[i]):
+            cur_tree_choice = sorted_draft_nodes[start + j]
+            if len(cur_tree_choice) == 1:
+                continue
+
+            for c in range(len(cur_tree_choice) - 1):
+                ancestor_idx = sorted_draft_nodes.index(
+                    cur_tree_choice[:c + 1]) + 1
+                tree_attn_mask[j + start + 1][ancestor_idx] = mask_val
+        start += depth_counts[i]
+    return tree_attn_mask

--- a/vllm/v1/tree_spec_decode/tree_drafter_params.py
+++ b/vllm/v1/tree_spec_decode/tree_drafter_params.py
@@ -4,6 +4,8 @@
 import ast
 from dataclasses import dataclass
 
+from vllm.v1.tree_spec_decode.utils import MAX_TREE_DEPTH
+
 
 @dataclass
 class TreeDrafterParams:
@@ -29,6 +31,8 @@ class TreeDrafterParams:
         _assert_fixed_branching_factor_per_level(draft_nodes, spec_token_tree)
 
         tree_depth = len(draft_nodes[-1]) + 1
+        assert tree_depth <= MAX_TREE_DEPTH
+
         # Precompute per-level properties of the tree.
         num_nodes_per_level = [0] * tree_depth
         num_nodes_per_level[0] = 1

--- a/vllm/v1/tree_spec_decode/utils.py
+++ b/vllm/v1/tree_spec_decode/utils.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.worker.gpu_input_batch import InputBatch
+
+
+def apply_draft_offsets(
+    tree_draft_offsets: list[int],
+    input_batch: "InputBatch",
+    scheduler_output: "SchedulerOutput",
+    query_start_loc_np: np.array,
+    token_positions_np: np.array,
+):
+    """
+    Updates the draft token positions with their offsets (levels) in the tree.
+
+    Args:
+        tree_draft_offsets: Offsets to apply to the draft token positions.
+        input_batch: The input batch.
+        scheduler_output: The scheduler output.
+        query_start_loc_np: Start locations of the queries for each request.
+        token_positions_np: Token positions. Will be updated in-place.
+    """
+
+    draft_token_offsets = np.array(tree_draft_offsets)
+    for (
+            req_id,
+            draft_token_ids,
+    ) in scheduler_output.scheduled_spec_decode_tokens.items():
+        if len(draft_token_ids) == 0:
+            continue
+        req_idx = input_batch.req_id_to_index[req_id]
+        start = query_start_loc_np[req_idx]
+        end = query_start_loc_np[req_idx + 1]
+        token_positions_np[start + 1:end] = (token_positions_np[start] +
+                                             draft_token_offsets)
+
+
+def apply_accepted_draft_indices(
+    sampled_token_indices: list[list[int]],
+    query_start_loc_np: np.array,
+    token_indices_np: np.array,
+):
+    """
+    Updates token_indices_np with the sampled token indices.
+
+    Args:
+        sampled_token_indices: The indices of the accepted draft tokens.
+        query_start_loc_np: Start locations of the queries for each request.
+        token_indices_np: Token indices. Will be updated in-place.
+    """
+
+    for req_idx, seq in enumerate(sampled_token_indices):
+        if len(seq) <= 1:
+            continue
+        start = query_start_loc_np[req_idx] + 1
+        end = query_start_loc_np[req_idx + 1]
+        token_indices_np[start:end] = token_indices_np[start] + np.array(
+            seq[:-1])
+
+
+def copy_kv_cache_slots(
+    kv_caches: list[torch.Tensor],
+    slot_mapping: torch.Tensor,
+    from_token_indices: torch.Tensor,
+    to_token_indices: torch.Tensor,
+):
+    """
+    Copies K/Vs from from_token_indices to to_token_indices. Used for updating
+    the KV cache after tree rejection sampling.
+
+    Args:
+        kv_caches: List of per-layer tensors, each with shape
+                   (2, num_blocks, block_size, num_kv_heads, head_size)
+        slot_mapping: Tensor mapping token indices to positions in the KV
+                      cache.
+        from_token_indices: Tensor containing token indices into slot_mapping
+                            to copy from.
+        to_token_indices: Tensor containing token indices into slot_mapping to
+                            copy to.
+    """
+    if len(kv_caches) == 0:
+        # Nothing to do.
+        return
+
+    # Get block size from first kv_cache tensor.
+    first_kv_cache = kv_caches[0]
+    _, _, block_size, _, _ = first_kv_cache.shape
+
+    # Ignore pairs of token indices that are the same.
+    is_moved = from_token_indices != to_token_indices
+    from_token_indices = from_token_indices[is_moved]
+    to_token_indices = to_token_indices[is_moved]
+
+    # Get KV cache slots.
+    from_slots = slot_mapping[from_token_indices]
+    to_slots = slot_mapping[to_token_indices]
+
+    # Convert slots to blocks and offsets.
+    from_blocks = from_slots // block_size
+    from_offsets = from_slots % block_size
+    to_blocks = to_slots // block_size
+    to_offsets = to_slots % block_size
+
+    # TODO (TheEpicDolphin): Optimize the per-layer KV cache copy.
+    for kv_cache in kv_caches:
+        kv_cache[:, to_blocks, to_offsets, :, :] = kv_cache[:, from_blocks,
+                                                            from_offsets, :, :]

--- a/vllm/v1/tree_spec_decode/utils.py
+++ b/vllm/v1/tree_spec_decode/utils.py
@@ -6,9 +6,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
+from vllm.triton_utils import tl, triton
+
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.worker.gpu_input_batch import InputBatch
+
+HEAD_TILE_SIZE: int = 64
+MAX_TREE_DEPTH: int = 16
 
 
 def apply_draft_offsets(
@@ -39,8 +44,9 @@ def apply_draft_offsets(
         req_idx = input_batch.req_id_to_index[req_id]
         start = query_start_loc_np[req_idx]
         end = query_start_loc_np[req_idx + 1]
+        num_drafts = end - start - 1
         token_positions_np[start + 1:end] = (token_positions_np[start] +
-                                             draft_token_offsets)
+                                             draft_token_offsets[:num_drafts])
 
 
 def apply_accepted_draft_indices(
@@ -90,26 +96,142 @@ def copy_kv_cache_slots(
         # Nothing to do.
         return
 
-    # Get block size from first kv_cache tensor.
+    # Get shape and stride from first kv_cache tensor.
     first_kv_cache = kv_caches[0]
-    _, _, block_size, _, _ = first_kv_cache.shape
+    assert first_kv_cache.dtype == torch.bfloat16, (
+        "Only bfloat16 is supported for now.")
+    device = first_kv_cache.device
+    KV, _, block_size, num_kv_heads, head_size = first_kv_cache.shape
+    s0, s1, s2, s3, s4 = first_kv_cache.stride()
+    assert KV == 2
+    num_layers = len(kv_caches)
 
-    # Ignore pairs of token indices that are the same.
-    is_moved = from_token_indices != to_token_indices
-    from_token_indices = from_token_indices[is_moved]
-    to_token_indices = to_token_indices[is_moved]
+    # Prepare indices.
+    from_indices = from_token_indices.contiguous()
+    to_indices = to_token_indices.contiguous()
+    slot_mapping = slot_mapping.contiguous()
+    num_indices = from_indices.numel()
+    assert to_indices.numel() == num_indices
 
-    # Get KV cache slots.
-    from_slots = slot_mapping[from_token_indices]
-    to_slots = slot_mapping[to_token_indices]
+    # Create array of pointers to kv_cache tensors.
+    kv_cache_ptrs = torch.tensor(
+        [kv_cache.data_ptr() for kv_cache in kv_caches],
+        dtype=torch.int64,
+        device=device,
+    )
 
-    # Convert slots to blocks and offsets.
-    from_blocks = from_slots // block_size
-    from_offsets = from_slots % block_size
-    to_blocks = to_slots // block_size
-    to_offsets = to_slots % block_size
+    # Compute grid dimensions.
+    # Encode KV/layers/heads.
+    grid0 = 2 * num_layers * num_kv_heads
+    # Chunk size is set to the maximum tree depth to prevent a potential
+    # race condition of writing to while reading from the same slot.
+    chunk_size = MAX_TREE_DEPTH
+    # Chunk across indices.
+    grid1 = (num_indices + chunk_size - 1) // chunk_size
+    # Tile across head_size.
+    grid2 = (head_size + HEAD_TILE_SIZE - 1) // HEAD_TILE_SIZE
 
-    # TODO (TheEpicDolphin): Optimize the per-layer KV cache copy.
-    for kv_cache in kv_caches:
-        kv_cache[:, to_blocks, to_offsets, :, :] = kv_cache[:, from_blocks,
-                                                            from_offsets, :, :]
+    # Launch single kernel for all layers.
+    _kv_copy_chunked[grid0, grid1, grid2](
+        kv_cache_ptrs.data_ptr(),
+        slot_mapping.data_ptr(),
+        from_indices.data_ptr(),
+        to_indices.data_ptr(),
+        num_indices,
+        block_size,
+        num_kv_heads,
+        head_size,
+        s0,
+        s1,
+        s2,
+        s3,
+        s4,
+        head_tile_size=HEAD_TILE_SIZE,
+        chunk_size=chunk_size,
+    )
+
+
+@triton.jit
+def _kv_copy_chunked(
+    kv_ptrs_ptr,
+    slot_mapping_ptr,
+    from_indices_ptr,
+    to_indices_ptr,
+    num_indices,
+    block_size,
+    num_kv_heads,
+    head_size,
+    s0,
+    s1,
+    s2,
+    s3,
+    s4,
+    head_tile_size: tl.constexpr,
+    chunk_size: tl.constexpr,
+):
+    pid0 = tl.program_id(0)
+    chunk_id = tl.program_id(1)
+    tile_id = tl.program_id(2)
+
+    # Compute offsets in head dimension for this tile.
+    tile_offsets = tile_id * head_tile_size + tl.arange(0, head_tile_size)
+    mask_tile = tile_offsets < head_size
+
+    # Decode pid0 -> KV, layer, head.
+    tmp = pid0 // num_kv_heads
+    KV = tmp % 2
+    layer = tmp // 2
+    head = pid0 % num_kv_heads
+
+    # Load the pointer for this layer's kv_cache from the array.
+    # 8 bytes per pointer (64-bit).
+    kv_ptr_addr = kv_ptrs_ptr + layer * 8
+    kv_ptr = tl.load(kv_ptr_addr.to(tl.pointer_type(tl.uint64)))
+    src_ptr = kv_ptr.to(tl.pointer_type(tl.bfloat16))
+    # Copying to the same tensor, so dst_ptr == src_ptr.
+    dst_ptr = src_ptr
+
+    # Fixed base depending on kv/head (no layer stride since we select the
+    # tensor).
+    base_fixed = KV * s0 + head * s3
+
+    # Compute chunk bounds.
+    chunk_start = chunk_id * chunk_size
+    chunk_end = tl.minimum(chunk_start + chunk_size, num_indices)
+
+    # Cast pointers to appropriate types.
+    from_idx_base = from_indices_ptr.to(tl.pointer_type(tl.uint64))
+    to_idx_base = to_indices_ptr.to(tl.pointer_type(tl.uint64))
+    slot_mapping_base = slot_mapping_ptr.to(tl.pointer_type(tl.uint64))
+    # Cast block_size to uint64 to match slot type.
+    block_size_u64 = block_size.to(tl.uint64)
+
+    for idx in range(chunk_start, chunk_end):
+        # Load indices into slot_mapping.
+        from_idx = tl.load(from_idx_base + idx)
+        to_idx = tl.load(to_idx_base + idx)
+
+        # Load actual KV cache slots from slot_mapping.
+        from_slot = tl.load(slot_mapping_base + from_idx)
+        to_slot = tl.load(slot_mapping_base + to_idx)
+
+        # Skip copying if from_slot == to_slot.
+        should_copy = from_slot != to_slot
+
+        # Convert slots to blocks and offsets.
+        from_block = from_slot // block_size_u64
+        from_offset = from_slot % block_size_u64
+        to_block = to_slot // block_size_u64
+        to_offset = to_slot % block_size_u64
+
+        src_base = base_fixed + from_block * s1 + from_offset * s2
+        dst_base = base_fixed + to_block * s1 + to_offset * s2
+
+        src_addr = (src_ptr + src_base + tile_offsets * s4).to(
+            tl.pointer_type(tl.bfloat16))
+        dst_addr = (dst_ptr + dst_base + tile_offsets * s4).to(
+            tl.pointer_type(tl.bfloat16))
+
+        copy_mask = mask_tile & should_copy
+        vals = tl.load(src_addr, mask=copy_mask, other=0)
+        tl.store(dst_addr, vals, mask=copy_mask)


### PR DESCRIPTION
# Purpose
Continuing with my work in this PR: #20401 , where I added support for drafting a tree of speculative tokens, that are then validated by the target model. In this PR, I add the class that performs rejection sampling for those draft tokens, so that they conform to the target model's output distribution. This class is based off of RejectionSampler, but with some key differences necessary to support a tree structure for drafted tokens. I added some tests for this new class to verify it's correctness.

In order to make it work with tree-drafted tokens, I also had to "remap" the KV cache immediately after rejection sampling. This is handled by the new `_remap_kv_cache` method I added. It basically takes the KVs for the `N` accepted branch of tokens, and copies them over into the physical KV cache memory corresponding to the first `N` contiguous paged KV slots for the draft request.

In addition, I also made some refactors to the tree attention parameters to improve readability and performance. I created a new class called `TreeDrafterParams` which is created during the `SpeculativeConfig` initialization, and precomputes several properties from the spec token tree so that other tree-attention systems can use it (without re-computing themselves). Examples: attention mask, children per level, etc.

With this PR, we now have a **fully functional** tree speculative decoding implementation in V1!

# Test Plan

## Automated Testing
New tree rejection sampler tests:
```
(py312conda) bash-5.1$ pytest tests/v1/sample/test_tree_rejection_sampler.py
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /data/users/gdelfin/gitrepos/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0, asyncio-1.1.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 9 items                                                                                                                                                                 

tests/v1/sample/test_tree_rejection_sampler.py .........                                                                                                                    [100%]

================================================================================ 9 passed in 6.51s ================================================================================
```

Eagle tree proposer test:
```
(py312conda) bash-5.1$ pytest tests/v1/spec_decode/test_eagle.py -k test_propose_tree
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /data/users/gdelfin/gitrepos/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0, asyncio-1.1.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 47 items / 43 deselected / 4 selected                                                                                                                                   

tests/v1/spec_decode/test_eagle.py ....                                                                                                                                     [100%]

======================================================================== 4 passed, 43 deselected in 10.82s ========================================================================
```

Spec decode e2e test:

```
(py312conda) bash-5.1$ pytest tests/v1/e2e/test_spec_decode.py -k test_tree_eagle_correctness
=============================================================================================================================== test session starts ===============================================================================================================================
platform linux -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /data/users/gdelfin/gitrepos/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0, asyncio-1.1.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 21 items / 13 deselected / 8 selected                                                                                                                                                                                                                                   

tests/v1/e2e/test_spec_decode.py ........                                                                                                                                                                                                                                   [100%]

================================================================================================================================ warnings summary =================================================================================================================================
tests/v1/e2e/test_spec_decode.py: 16 warnings
  /home/gdelfin/.conda/envs/py312conda/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=2475023) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================ 8 passed, 13 deselected, 16 warnings in 382.20s (0:06:22) ============================================================================================================
```

## Manual Testing

I tested manually with the following tree of draft tokens:
```
ROOT
├── 0
│  ├── 0
│  └── 1
│  └── 2
└── 1
   ├── 0
   └── 1
   └── 2
```

**Server**
```
export VLLM_TORCH_PROFILER_DIR=~/traces/vllm
export LLAMA_MODEL=meta-llama/Llama-3.1-8B-Instruct
export DRAFT_MODEL=yuhuili/EAGLE-LLaMA3.1-Instruct-8B
export VLLM_USE_V1=1
export VLLM_ATTENTION_BACKEND=TREE_ATTN
export SPEC_DEC_CONFIG='{"method": "eagle", "model": "'$DRAFT_MODEL'", "num_speculative_tokens": 8, "draft_tensor_parallel_size": 1, "max_model_len": 2048, "speculative_token_tree": "[(0,), (1,), (0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]"}'
vllm serve $LLAMA_MODEL --disable-log-requests --tensor-parallel-size=1 --max-num-seqs=64 --max-model-len=32768 --no-enable-prefix-caching --speculative-config="$SPEC_DEC_CONFIG" 2>&1 | tee ~/server_logs/vllm_server.log
```

**Client**
```
from openai import OpenAI
client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
response = client.chat.completions.create(model="meta-llama/Llama-3.1-8B-Instruct", messages=[{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Explain the theory of relativity in simple terms."}],temperature=0.0)
print(response.choices[0].message.content)
```

**Response**
```
The theory of relativity, developed by Albert Einstein, is a fundamental concept in physics that explains how space and time are connected. It's a bit complex, but I'll try to break it down in simple terms.

**Special Relativity (1905)**

Imagine you're on a train, and you throw a ball straight up in the air. From your perspective on the train, the ball goes up and comes down in a straight line. Now, imagine someone is standing outside the train, watching you throw the ball. From their perspective, the ball doesn't just go up and down – it also moves forward, because the train is moving really fast.

Einstein said that how we measure time and space depends on how fast we're moving and where we are. If you're on the train, time and space seem normal. But if you're standing outside, watching the train, time and space seem different. This is because time and space are connected, and they can appear to change depending on your frame of reference.

**Time Dilation**

Here's a key idea: time can appear to slow down or speed up depending on how fast you're moving. If you were to travel close to the speed of light, time would appear to slow down for you relative to someone who is standing still. This is called time dilation.

**General Relativity (1915)**

Imagine you're standing on a trampoline. If you put a heavy object, like a bowling ball, on the trampoline, it will warp and curve, creating a dent. That's kind of like what gravity does to space and time. According to general relativity, massive objects like planets and stars warp the fabric of space and time, creating gravity.

**Key Takeaways**

1. **Time and space are connected**: How we measure time and space depends on how fast we're moving and where we are.
2. **Time can appear to slow down or speed up**: Time dilation occurs when you're moving at high speeds or in strong gravitational fields.
3. **Gravity warps space and time**: Massive objects create curvatures in space and time, which we experience as gravity.

The theory of relativity revolutionized our understanding of the universe and has had a profound impact on modern physics and astronomy.
```
The response is valid and aligns with what the LLM would output if running with standard decoding or spec decoding with FA3.

# Benchmarks
I benchmarked using the philschmid/mt-bench and likaixin/InstructCoder datasets. Below are the commands I used:
**Server**
```
export VLLM_TORCH_PROFILER_DIR=~/traces/vllm
export LLAMA_MODEL=meta-llama/Llama-3.1-8B-Instruct
export DRAFT_MODEL=yuhuili/EAGLE-LLaMA3.1-Instruct-8B
export VLLM_USE_V1=1
export VLLM_ATTENTION_BACKEND=TREE_ATTN
export SPEC_DEC_CONFIG='{"method": "eagle", "model": "'$DRAFT_MODEL'", "num_speculative_tokens": 8, "draft_tensor_parallel_size": 1, "max_model_len": 2048, "speculative_token_tree": "[(0,), (1,), (0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]"}'
vllm serve $LLAMA_MODEL --disable-log-requests --tensor-parallel-size=1 --max-num-seqs=64 --max-model-len=32768 --no-enable-prefix-caching --speculative-config="$SPEC_DEC_CONFIG" 2>&1 | tee ~/server_logs/vllm_server.log
```

**Client**
```
vllm bench serve --model $LLAMA_MODEL --tokenizer $LLAMA_MODEL --host 0.0.0.0 --dataset-name hf --dataset-path <dataset> --ignore-eos --request-rate inf --max-concurrency <batch_size>
```

Using both datasets and batch sizes 1 and 8, I compared the serving benchmark results for 2 spec tokens (baseline), and a 2 => 3 spec token tree that looks like this:
```
ROOT
├── 0
│  ├── 0
│  └── 1
│  └── 2
└── 1
   ├── 0
   └── 1
   └── 2
```
For the baseline, I decided to use the flash attention 3 backend, since it's the only other one that supports spec decoding in V1. Below is a short summary of the results:

**mt-bench**
| Metric                          | BS=1, FA3 | BS=1, Tree | BS=8, FA3 | BS=8, Tree | BS=16, FA3 | BS=16, Tree |
|---------------------------------|-----------|------------|-----------|------------|------------|-------------|
| Duration (s)                     | 1999.14   | 1990.13    | 269.42    | 265.15     | 118.45     | 131.05      |
| Output Token Throughput (tok/s) | 128.06    | 128.63     | 884.61    | 902.72     | 1813.36    | 1640.95     |
| Mean Acceptance Length           | 2.10      | 2.37       | 2.03      | 2.37       | 2.04       | 2.38        |

In all cases, tree spec decoding **increases** the mean acceptance length. In the mt-bench dataset, tree spec decoding results in a **higher output token throughput** for batch sizes 1 and 8. As batch size gets larger, the benefit of more accepted tokens per decode is not enough to compensate for the added cost during forward attention, and tree spec decoding performs worse. It's important to note that the FA3 kernel is much faster than triton attention, which is used in the Tree Attention backend (with a query-on-query attention bias).

To isolate what we are gaining from tree drafts, I also compared chains vs tree draft structures using the same Tree Attention backend. This eliminates difference in kernel

**mt-bench**
| Metric                          | BS=1, Chain | BS=1, Tree | BS=8, Chain | BS=8, Tree | BS=16, Chain | BS=16, Tree |
|---------------------------------|-------------|------------|-------------|------------|-------------|------------|
| Duration (s)                     | 2240.21           | 1990.13    | 280.96      | 265.15     | 136.86      | 131.05     |
| Output Token Throughput (tok/s) | 114.27       | 128.63     | 847.38      | 902.72     | 1567.5      | 1640.95    |
| Mean Acceptance Length           | 2.05        | 2.37       | 2.06       | 2.37       | 2.05        | 2.38       |


Spec decoding with the tree of drafts performs better than with a chain of 2 drafts for batch sizes 1, 8, and 16. I did not test further with larger batch sizes, but I assume that gain becomes less pronounced.

A detailed breakdown of the benchmark results can be found in [this spreadsheet](https://docs.google.com/spreadsheets/d/1YnOJ2NsUffRjCj0egS_ycPpkeYwpFp4PpH1BBFFaAMs/edit?usp=sharing).

# Next Steps
- Use a different attention kernel because triton attention is slow compared to FA3. From benchmarking, each triton attention forward pass is ~35% slower than the FA3 forward pass. FA2+tree attention mask (https://github.com/vllm-project/flash-attention/pull/81) is a good candidate!
- As @sgrigory pointed out in the comments, this implementation is currently using greedy acceptance, which differs from the probabilistic approach used in EAGLE. The latter should increase the avg # of acceptances and improve performance even further.

