### PR TITLE
[Frontend] Add Sentry SDK for error reporting

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -49,3 +49,4 @@ pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects
 setproctitle # Used to set process names for better debugging and monitoring
 openai-harmony >= 0.0.3  # Required for gpt-oss
+sentry-sdk[fastapi] >= 2.34.0, <3.0.0

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1519,6 +1519,10 @@ def build_app(args: Namespace) -> FastAPI:
         allow_headers=args.allowed_headers,
     )
 
+    if sentry_dsn := args.sentry_dsn:
+        import sentry_sdk
+        sentry_sdk.init(dsn=sentry_dsn)
+
     @app.exception_handler(HTTPException)
     async def http_exception_handler(_: Request, exc: HTTPException):
         err = ErrorResponse(

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -189,6 +189,8 @@ class FrontendArgs:
     Helps mitigate header abuse. Default: 256."""
     log_error_stack: bool = envs.VLLM_SERVER_DEV_MODE
     """If set to True, log the stack trace of error responses"""
+    sentry_dsn: Optional[str] = None
+    """Enables Sentry error reporting to the specified data source name."""
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:


### PR DESCRIPTION
## Purpose

We make use of [Sentry](https://sentry.io) for our deployments, so adding it to the OpenAPI server would be a great addition.
This PR adds the `sentry-sdk` with its integration with FastAPI.  It is enabled by the `--sentry-dsn` flag passed to the `vllm serve` command.

This complements what has been added in https://github.com/vllm-project/production-stack/pull/395.

## Test Plan

Enable Sentry's error reporting by passing `--sentry-dsn` with a valid Data Source Name (DSN)  to the `vllm serve` command. This should report any unhandled exceptions to Sentry's server together with useful metadata.

## Test Result

I've tested this locally with a self-hosted deployment of Sentry, introducing a hardcoded exception so I could test this. Everything worked as expected.
