### PR TITLE
[Bug] Fix Unexpected Keyword Argument 'w1_bias'

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -488,8 +488,11 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 global_num_experts=global_num_experts,
                 expert_map=expert_map,
             )
-            if self.has_bias and not isinstance(self.fused_experts,
-                                                FusedMoEModularKernel):
+            if isinstance(self.fused_experts,
+                          FusedMoEModularKernel) and self.has_bias:
+                raise ValueError(
+                    "FusedMoEModularKernel does not support bias.")
+            if self.has_bias:
                 kwargs.update({
                     "w1_bias": getattr(layer, "w13_bias", None),
                     "w2_bias": getattr(layer, "w2_bias", None),

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -488,7 +488,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 global_num_experts=global_num_experts,
                 expert_map=expert_map,
             )
-            if self.has_bias:
+            if self.has_bias and not isinstance(self.fused_experts,
+                                                FusedMoEModularKernel):
                 kwargs.update({
                     "w1_bias": getattr(layer, "w13_bias", None),
                     "w2_bias": getattr(layer, "w2_bias", None),


### PR DESCRIPTION
## Purpose

Fix TypeError: FusedMoEModularKernel.forward() got an unexpected keyword argument 'w1_bias'

## Test

Origin

`vllm serve deepseek-ai/DeepSeek-V2-Lite --port 10256 --enable-expert-parallel --data-parallel-size 2 --trust_remote_code  -O '{"full_cuda_graph": true}' --cuda-graph-sizes 16 32 64 128 256 512`

```bash
(EngineCore_1 pid=2453091)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 478, in forward_cuda
(EngineCore_1 pid=2453091)     return self.fused_experts(
(EngineCore_1 pid=2453091)            ^^^^^^^^^^^^^^^^^^^
(EngineCore_1 pid=2453091)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(EngineCore_1 pid=2453091)     return self._call_impl(*args, **kwargs)
(EngineCore_1 pid=2453091)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_1 pid=2453091)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(EngineCore_1 pid=2453091)     return forward_call(*args, **kwargs)
(EngineCore_1 pid=2453091)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_1 pid=2453091) TypeError: FusedMoEModularKernel.forward() got an unexpected keyword argument 'w1_bias'
```

Now it is fixed