### PR TITLE
Remove unneeded ROCm platform import when using CUDA

### DIFF
--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -22,7 +22,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape)
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import use_rocm_custom_paged_attention
 
 if TYPE_CHECKING:
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
@@ -886,6 +885,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
             num_seqs, num_heads, head_size = decode_query.shape
             block_size = value_cache.shape[3]
             gqa_ratio = num_heads // self.num_kv_heads
+            from vllm.platforms.rocm import use_rocm_custom_paged_attention
             use_custom = use_rocm_custom_paged_attention(
                 decode_query.dtype, head_size, block_size, gqa_ratio,
                 decode_meta.max_decode_seq_len, self.sliding_window,

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -11,7 +11,6 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import use_rocm_custom_paged_attention
 from vllm.triton_utils import tl, triton
 
 from .prefix_prefill import context_attention_fwd
@@ -296,6 +295,7 @@ def chunked_prefill_paged_decode(
     num_queries_per_kv_padded = max(triton.next_power_of_2(num_queries_per_kv),
                                     16)
 
+    from vllm.platforms.rocm import use_rocm_custom_paged_attention
     use_custom = use_rocm_custom_paged_attention(
         query.dtype,
         head_size,


### PR DESCRIPTION
Without this move, we were importing and warning about rocm libraries not available on cuda

```
vllm serve
...
(EngineCore_0 pid=1696779) WARNING 08-12 17:06:03 [rocm.py:29] Failed to import from amdsmi with ModuleNotFoundError("No module named 'amdsmi'")
(EngineCore_0 pid=1696779) WARNING 08-12 17:06:03 [rocm.py:40] Failed to import from vllm._rocm_C with ModuleNotFoundError("No module named 'vllm._rocm_C'")
```

Here is the full stacktrace to see why it was being called. It seems due to the recent changes in EAGLE
```
EngineCore_0 pid=2806897)   File "<string>", line 1, in <module>
(EngineCore_0 pid=2806897)   File "/home/mgoin/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/multiprocessing/spawn.py", line 122, in spawn_main
(EngineCore_0 pid=2806897)     exitcode = _main(fd, parent_sentinel)
(EngineCore_0 pid=2806897)   File "/home/mgoin/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/multiprocessing/spawn.py", line 135, in _main
(EngineCore_0 pid=2806897)     return self._bootstrap(parent_sentinel)
(EngineCore_0 pid=2806897)   File "/home/mgoin/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_0 pid=2806897)     self.run()
(EngineCore_0 pid=2806897)   File "/home/mgoin/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore_0 pid=2806897)     self._target(*self._args, **self._kwargs)
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 674, in run_engine_core
(EngineCore_0 pid=2806897)     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 475, in __init__
(EngineCore_0 pid=2806897)     super().__init__(vllm_config, executor_class, log_stats,
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 78, in __init__
(EngineCore_0 pid=2806897)     self.model_executor = executor_class(vllm_config)
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/executor/executor_base.py", line 54, in __init__
(EngineCore_0 pid=2806897)     self._init_executor()
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/executor/uniproc_executor.py", line 47, in _init_executor
(EngineCore_0 pid=2806897)     self.collective_rpc("init_worker", args=([kwargs], ))
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
(EngineCore_0 pid=2806897)     answer = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/utils/__init__.py", line 2977, in run_method
(EngineCore_0 pid=2806897)     return func(*args, **kwargs)
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/worker/worker_base.py", line 556, in init_worker
(EngineCore_0 pid=2806897)     worker_class = resolve_obj_by_qualname(
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/utils/__init__.py", line 2538, in resolve_obj_by_qualname
(EngineCore_0 pid=2806897)     module = importlib.import_module(module_name)
(EngineCore_0 pid=2806897)   File "/home/mgoin/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py", line 90, in import_module
(EngineCore_0 pid=2806897)     return _bootstrap._gcd_import(name[level:], package, level)
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/v1/worker/gpu_worker.py", line 33, in <module>
(EngineCore_0 pid=2806897)     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/v1/worker/gpu_model_runner.py", line 69, in <module>
(EngineCore_0 pid=2806897)     from vllm.v1.spec_decode.eagle import EagleProposer
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/v1/spec_decode/eagle.py", line 27, in <module>
(EngineCore_0 pid=2806897)     from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/v1/attention/backends/triton_attn.py", line 14, in <module>
(EngineCore_0 pid=2806897)     from vllm.attention.ops.chunked_prefill_paged_decode import (
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/attention/ops/chunked_prefill_paged_decode.py", line 14, in <module>
(EngineCore_0 pid=2806897)     from vllm.platforms.rocm import use_rocm_custom_paged_attention
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
(EngineCore_0 pid=2806897)   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
(EngineCore_0 pid=2806897)   File "/home/mgoin/code/vllm/vllm/platforms/rocm.py", line 26, in <module>
(EngineCore_0 pid=2806897)     traceback.print_stack()
```