### PR TITLE
[Misc] Set correct OMP_NUM_THREADS for executors

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3346,3 +3346,19 @@ def decorate_logs(process_name: Optional[str] = None) -> None:
     pid = os.getpid()
     _add_prefix(sys.stdout, process_name, pid)
     _add_prefix(sys.stderr, process_name, pid)
+
+
+# Count number of CPUs in a string (e.g., 14 for "1-8,10,17-21")
+# NOTE: may return negative number for wrong string like "8-1"
+def count_cpus_in_string(cpulist: str) -> int:
+    if not cpulist or cpulist.strip() == '':
+        return 0
+    count = 0
+    for part in cpulist.split(','):
+        part = part.strip()
+        if '-' in part:
+            start, end = map(int, part.split('-'))
+            count += end - start + 1
+        else:
+            count += 1
+    return count


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
Run vLLM on an Arm server, we observed only one CPU is busy for multi-thread run, which results to very bad performance. There's a similar bug report in community.
https://github.com/vllm-project/vllm/issues/10971

This issue happens on pytorch mkldnn backend, when the threading is initialized at "import torch" time, earlier than vLLM sets the correct thread number and affinity in executor process, CPUWorker.init_device().

E.g., On a server with 256 CPUs, we run vLLM by setting VLLM_CPU_OMP_THREADS_BIND="1-8". Without explicitly setting OMP_NUM_THREADS, defaults to use all CPUs. It leads to a messy situation that oneDNN schedules tasks to 256 threads, but the process is limited to use only 8 CPUs. Per our debug, 249 threads are competing for the first CPU, and other 7 threads are mostly idle waiting for all the tasks on the first CPU to finish.

This PR fixes the issue by setting correct OMP_NUM_THREADS *before* executor processes are created, for both uni and mp executors. The number is inferred from VLLM_CPU_OMP_THREADS_BIND string.

## Test Plan
Set VLLM_CPU_OMP_THREADS_BIND to run multi thread benchmark. And check CPU usage.

## Test Result
```
# run benchmark on CPU0~15
LD_PRELOAD="/usr/lib/aarch64-linux-gnu/libtcmalloc_minimal.so.4:/usr/lib/aarch64-linux-gnu/libgomp.so.1" \
VLLM_CPU_OMP_THREADS_BIND="0-15" \
VLLM_TARGET_DEVICE=cpu \
VLLM_CPU_KVCACHE_SPACE=20 \
vllm bench latency \
  --model meta-llama/Meta-Llama-3-8B-Instruct \
  --input-len 32 \
  --output-len 1 \
  --enforce-eager \
  --load-format dummy \
  --num-iters-warmup 3 \
  --num-iters 5 \
  --trust-remote-code \
  --max_model_len=4096

# check CPU usage
sar -P 0-15 1

# without this patch, only CPU0 is busy
01:48:40 AM     CPU     %user     %nice   %system   %iowait    %steal     %idle
01:48:41 AM       0     87.88      0.00     12.12      0.00      0.00      0.00
01:48:41 AM       1      3.03      0.00      0.00      0.00      0.00     96.97
01:48:41 AM       2      2.00      0.00      0.00      0.00      0.00     98.00
01:48:41 AM       3      2.00      0.00      0.00      0.00      0.00     98.00
01:48:41 AM       4      1.98      0.00      0.99      0.00      0.00     97.03
01:48:41 AM       5      2.00      0.00      0.00      0.00      0.00     98.00
01:48:41 AM       6      2.02      0.00      0.00      0.00      0.00     97.98
01:48:41 AM       7      2.97      0.00      0.00      0.00      0.00     97.03
01:48:41 AM       8      2.02      0.00      0.00      0.00      0.00     97.98
01:48:41 AM       9      2.02      0.00      0.00      0.00      0.00     97.98
01:48:41 AM      10      2.00      0.00      0.00      0.00      0.00     98.00
01:48:41 AM      11      1.98      0.00      0.99      0.00      0.00     97.03
01:48:41 AM      12      2.00      0.00      0.00      0.00      0.00     98.00
01:48:41 AM      13      3.00      0.00      0.00      0.00      0.00     97.00
01:48:41 AM      14      2.00      0.00      0.00      0.00      0.00     98.00
01:48:41 AM      15      2.00      0.00      0.00      0.00      0.00     98.00

# with this patch, all CPUs are busy
01:41:29 AM     CPU     %user     %nice   %system   %iowait    %steal     %idle
01:41:30 AM       0     96.04      0.00      3.96      0.00      0.00      0.00
01:41:30 AM       1     92.93      0.00      1.01      0.00      0.00      6.06
01:41:30 AM       2     92.00      0.00      1.00      0.00      0.00      7.00
01:41:30 AM       3     91.92      0.00      1.01      0.00      0.00      7.07
01:41:30 AM       4     82.65      0.00      1.02      0.00      0.00     16.33
01:41:30 AM       5     82.00      0.00      1.00      0.00      0.00     17.00
01:41:30 AM       6     78.79      0.00      1.01      0.00      0.00     20.20
01:41:30 AM       7     79.00      0.00      1.00      0.00      0.00     20.00
01:41:30 AM       8     78.79      0.00      1.01      0.00      0.00     20.20
01:41:30 AM       9     78.79      0.00      1.01      0.00      0.00     20.20
01:41:30 AM      10     81.00      0.00      2.00      0.00      0.00     17.00
01:41:30 AM      11     81.00      0.00      2.00      0.00      0.00     17.00
01:41:30 AM      12     80.81      0.00      1.01      0.00      0.00     18.18
01:41:30 AM      13     80.81      0.00      1.01      0.00      0.00     18.18
01:41:30 AM      14     82.65      0.00      0.00      0.00      0.00     17.35
01:41:30 AM      15     82.00      0.00      1.00      0.00      0.00     17.00
```

## (Optional) Documentation Update

