### PR TITLE
[Doc] Add max_lora_rank configuration guide

### DIFF
--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -351,3 +351,22 @@ vllm serve ibm-granite/granite-speech-3.3-2b \
 ```
 
 Note: Default multimodal LoRAs are currently only available for `.generate` and chat completions.
+
+## Using Tips
+
+### Configuring `max_lora_rank`
+
+The `--max-lora-rank` parameter controls the maximum rank allowed for LoRA adapters. This setting affects memory allocation and performance:
+
+- **Set it to the maximum rank** among all LoRA adapters you plan to use
+- **Avoid setting it too high** - using a value much larger than needed wastes memory and can cause performance issues
+
+For example, if your LoRA adapters have ranks [16, 32, 64], use `--max-lora-rank 64` rather than 256
+
+```bash
+# Good: matches actual maximum rank
+vllm serve model --enable-lora --max-lora-rank 64
+
+# Bad: unnecessarily high, wastes memory
+vllm serve model --enable-lora --max-lora-rank 256
+```

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -108,6 +108,15 @@ class WorkerLoRAManager(AbstractWorkerManager):
             # loading weights, throwing an exception if validation fails.
             peft_helper.validate_legal(self.lora_config)
 
+            # Warn if max_lora_rank is larger than actual rank
+            if peft_helper.r < self.lora_config.max_lora_rank:
+                logger.warning(
+                    "max_lora_rank (%d) is larger than LoRA rank (%d). "
+                    "This may increase memory usage and impact performance. "
+                    "Consider setting --max-lora-rank %d.",
+                    self.lora_config.max_lora_rank, peft_helper.r,
+                    peft_helper.r)
+
             # For some models like Qwen2VL, we need to use hf_to_vllm_mapper
             # to ensure correct loading of lora weights.
             model = self._adapter_manager.model

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -108,15 +108,6 @@ class WorkerLoRAManager(AbstractWorkerManager):
             # loading weights, throwing an exception if validation fails.
             peft_helper.validate_legal(self.lora_config)
 
-            # Warn if max_lora_rank is larger than actual rank
-            if peft_helper.r < self.lora_config.max_lora_rank:
-                logger.warning(
-                    "max_lora_rank (%d) is larger than LoRA rank (%d). "
-                    "This may increase memory usage and impact performance. "
-                    "Consider setting --max-lora-rank %d.",
-                    self.lora_config.max_lora_rank, peft_helper.r,
-                    peft_helper.r)
-
             # For some models like Qwen2VL, we need to use hf_to_vllm_mapper
             # to ensure correct loading of lora weights.
             model = self._adapter_manager.model


### PR DESCRIPTION
## Purpose

Add documentation to help users properly configure `max_lora_rank` parameter to avoid performance issues.

## Context

As discussed with @jeejeelee , in multi-LoRA serving scenarios, `max_lora_rank` must be set to accommodate the largest rank among all LoRA adapters that might be loaded. However, setting it unnecessarily high wastes memory and can cause  performance issues.

## Changes

  Added a new section "Configuring `max_lora_rank`" at the end of `docs/features/lora.md` that explains:
  - How to set the parameter correctly for multi-LoRA scenarios
  - Performance implications of setting it too high
  - Examples of good vs bad configuration
  - What happens when a LoRA's rank exceeds the configured limit

**Case:**
- Default `max_lora_rank` is 16
- When set higher than actual adapter rank, causes memory over-allocation and performance loss
- Users often don't realize this misconfiguration is causing slowdowns

**Why this causes performance degradation:**
- vLLM pre-allocates GPU memory tensors based on `max_lora_rank` for all LoRA operations
- When `max_lora_rank > actual rank`, the system allocates more tensors
- During inference, Punica kernels (lora_shrink/lora_expand) compute on the entire pre-allocated tensor
- This results in some wasted computation on zero-padded values
- Large tensors also cause L2 cache thrashing (hit rate drops)
- Memory bandwidth becomes saturated moving unnecessary zeros

**Performance comparison (production workload A100-80GB):**
- Gemma-3-27B + rank=16 LoRA
- With `max_lora_rank=256`: 3.649s per request
- With `max_lora_rank=16`: 2.292s per request
- **59% performance improvement after fixing configuration**

**Memory usage:**
- With `max_lora_rank=256`: 3.18GB GPU memory for LoRA
- With `max_lora_rank=16`: 0.20GB GPU memory for LoRA
- **15.9x memory reduction**

## (Optional) Documentation Update

Not required - this is a diagnostic improvement only.

