### PR TITLE
[Attention] Cache attention metadata builds across hybrid KV-cache groups

### DIFF
--- a/vllm/attention/layers/chunked_local_attention.py
+++ b/vllm/attention/layers/chunked_local_attention.py
@@ -22,7 +22,7 @@ def create_chunked_local_attention_backend(
     attention_chunk_size: int,
     block_size: int,
 ) -> type[AttentionBackend]:
-    name_prefix = f"ChunkedLocalAttention_{attention_chunk_size}_{block_size}_"
+    prefix = f"ChunkedLocalAttention_{attention_chunk_size}_{block_size}_"
     underlying_builder = underlying_attn_backend.get_builder_cls()
 
     class ChunkedLocalAttentionBuilder(underlying_builder):  # type: ignore
@@ -49,7 +49,7 @@ def create_chunked_local_attention_backend(
                                               slot_mapping)
 
     attn_backend = subclass_attention_backend(
-        name_prefix=name_prefix,
+        name_prefix=prefix,
         attention_backend_cls=underlying_attn_backend,
         builder_cls=ChunkedLocalAttentionBuilder)
 

--- a/vllm/attention/layers/chunked_local_attention.py
+++ b/vllm/attention/layers/chunked_local_attention.py
@@ -26,9 +26,6 @@ def create_chunked_local_attention_backend(
     underlying_builder = underlying_attn_backend.get_builder_cls()
 
     class ChunkedLocalAttentionBuilder(underlying_builder):  # type: ignore
-        # Make sure the unique_cls_id is not the same for different
-        # attention_chunk_size and block_size.
-        __specialization_key__ = (attention_chunk_size, block_size)
 
         def build(self,
                   common_prefix_len: int,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -155,7 +155,7 @@ if TYPE_CHECKING:
     VLLM_USE_CUDNN_PREFILL: bool = False
     VLLM_ENABLE_CUDAGRAPH_GC: bool = False
     VLLM_LOOPBACK_IP: str = ""
-    VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = False
+    VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = True
     VLLM_ENABLE_RESPONSES_API_STORE: bool = False
     VLLM_USE_TRTLLM_ATTENTION: Optional[str] = None
     VLLM_HAS_FLASHINFER_CUBIN: bool = False
@@ -1143,7 +1143,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # TODO(lucas): Remove this flag once latency regression is resolved.
     "VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE":
     lambda: bool(int(os.getenv(\
-            "VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE", "0"))),
+            "VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE", "1"))),
 
     # Enables support for the "store" option in the OpenAI Responses API.
     # When set to 1, vLLM's OpenAI server will retain the input and output

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -369,7 +369,7 @@ class FlashAttentionMetadataBuilder(
         blk_table: torch.Tensor,
         slot_mapping: torch.Tensor,
     ) -> FlashAttentionMetadata:
-        new_metadata = copy.deepcopy(metadata)
+        new_metadata = copy.copy(metadata)
         new_metadata.block_table = blk_table
         new_metadata.slot_mapping = slot_mapping
         return new_metadata

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -185,9 +185,6 @@ class AttentionMetadataBuilder(abc.ABC, Generic[M]):
     # Does this backend/builder support updating the block table in existing
     # metadata
     supports_update_block_table: bool = False
-    # The specialization key can be used by dynamic subclasses to identify
-    # the builder uniquely based on captured values. Affects unique_cls_id.
-    __specialization_key__: tuple = ()
 
     @abstractmethod
     def __init__(self, kv_cache_spec: AttentionSpec, layer_names: list[str],
@@ -268,10 +265,6 @@ class AttentionMetadataBuilder(abc.ABC, Generic[M]):
         num_sms: int,
     ) -> bool:
         return False
-
-    @classmethod
-    def unique_cls_id(cls) -> tuple:
-        return (cls.__mro__, cls.__specialization_key__)
 
 
 @functools.lru_cache

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -919,10 +919,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         slot_mapping,
                     )
                 else:
-                    attn_metadata_i = (builder.build(
+                    attn_metadata_i = builder.build(
                         common_prefix_len=common_prefix_len,
                         common_attn_metadata=common_attn_metadata,
-                    ))
+                    )
                     attn_metadata_cache[cache_key] = attn_metadata_i
 
                 fast_prefill_metadata = attn_metadata_i

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -845,8 +845,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.
-        attn_metadata_cache: dict[tuple[KVCacheSpec, tuple[str, str]],
-                                  Any] = {}
+        attn_metadata_cache: dict[tuple[KVCacheSpec, type], Any] = {}
         for kv_cache_group_id, kv_cache_group_spec in enumerate(
                 self.kv_cache_config.kv_cache_groups):
             kv_cache_spec = kv_cache_group_spec.kv_cache_spec
@@ -910,7 +909,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         builder,
                     )
 
-                cache_key = (kv_cache_spec, builder.unique_cls_id())
+                cache_key = (kv_cache_spec, type(builder))
                 if cache_key in attn_metadata_cache \
                     and builder.supports_update_block_table:
                     cached_attn_metadata = attn_metadata_cache[cache_key]


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

Right now when using the hybrid kv-cache manager we build a new attention metadata from scratch for each kv-cache group even when the kv-cache groups only differ by the block-table. This happens we have a repeated n:1 pattern like Llama4 where we have 3 local chunked attention layers for every one full attention layer. In this example all the local attention layer metadatas are virtually identical and only differ by block table. In this PR we cache metadata across kv-cache groups and do a lightweight `update_block_table` instead of full rebuild.

## Test Plan

lm_eval + benchmarking

## Test Result
```
VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE=1 VLLM_ATTENTION_BACKEND=FLASHINFER python -m lm_eval --model vllm --model_args pretrained=RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic,tensor_parallel_size=2,gpu_memory_utilization=0.8,trust_remote_code=True,max_model_len=32768,disable_hybrid_kv_cache_manager=False,disable_cascade_attn=True --tasks ruler_qa_squad --limit 100 --batch_size auto --metadata='{"max_seq_lengths":[16384]}' 
...
|    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|--------------|------:|------|-----:|-----:|---|-----:|---|------|
|ruler_qa_squad|      1|none  |     0| 16384|↑  | 0.625|±  |   N/A|
|              |       |none  |     0|  4096|↑  |-1.000|±  |   N/A|
```

```
VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE=1 python -m lm_eval --model vllm --model_args pretrained=RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic,tensor_parallel_size=2,gpu_memory_utilization=0.8,trust_remote_code=True,max_model_len=32768,disable_hybrid_kv_cache_manager=False,disable_cascade_attn=True --tasks ruler_qa_squad --limit 100 --batch_size auto --metadata='{"max_seq_lengths":[16384]}' 
...
|    Tasks     |Version|Filter|n-shot|Metric|   | Value |   |Stderr|
|--------------|------:|------|-----:|-----:|---|------:|---|------|
|ruler_qa_squad|      1|none  |     0| 16384|↑  | 0.6325|±  |   N/A|
|              |       |none  |     0|  4096|↑  |-1.0000|±  |   N/A|
```

```
branch   variant                  rate   req/s    median TTFT (ms) median TPOT (ms)
------   -------                  ----   -----    ---------------- ----------------       
MAIN     hybrid-kv-cache-enabled  1.0    0.99     74.78            15.31
PR       hybrid-kv-cache-enabled  1.0    0.99     73.62            14.89           
MAIN     hybrid-kv-cache-enabled  10.0   9.84     109.57           38.55                    
PR       hybrid-kv-cache-enabled  10.0   9.84     110.6            37.71           

branch   variant                  rate   req/s    median TTFT (ms) median TPOT (ms)
------   -------                  ----   -----    ---------------- ----------------
MAIN     hybrid-kv-cache-disabled 1.0    0.99     73.14            14.58
PR       hybrid-kv-cache-disabled 1.0    0.99     74.78            14.48         
MAIN     hybrid-kv-cache-disabled 10.0   9.84     109.26           37.25
PR       hybrid-kv-cache-disabled 10.0   9.84     109.89           37.37

Server commands:
MAIN/hybrid-kv-cache-enabled: env VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE=1 .venv/bin/vllm serve RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic --host localhost --port 3333 --max-model-len 4096 -tp 2 --no-enable-prefix-caching --disable-log-stats --trust-remote-code 
MAIN/hybrid-kv-cache-disabled:  .venv/bin/vllm serve RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic --host localhost --port 3333 --disable-hybrid-kv-cache-manager --max-model-len 4096 -tp 2 --no-enable-prefix-caching --disable-log-stats --trust-remote-code 
PR/hybrid-kv-cache-enabled: env VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE=1 .venv/bin/vllm serve RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic --host localhost --port 3333 --max-model-len 4096 -tp 2 --no-enable-prefix-caching --disable-log-stats --trust-remote-code 
PR/hybrid-kv-cache-disabled:  .venv/bin/vllm serve RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic --host localhost --port 3333 --disable-hybrid-kv-cache-manager --max-model-len 4096 -tp 2 --no-enable-prefix-caching --disable-log-stats --trust-remote-code 

Client command (template):
CLIENT: vllm bench serve --model RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic --host localhost --port 3333 --dataset-name random --random-input-len 1000 --random-output-len 100 --random-range-ratio 0 --num-prompts <req_rate * 120> --request-rate <req_rate> --save-result --result-dir <results_dir> --result-filename <filename> --ignore-eos --trust-remote-code
```

## (Optional) Documentation Update

