### PR TITLE
Remove unnecessary CUDA sync of qwen image and video preprocess

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -978,9 +978,8 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
         # Split concatenated embeddings for each image item.
         # Using prod on grid_thw_list instead of grid_thw.prod avoids CUDA sync
         merge_size = self.visual.spatial_merge_size
-        sizes = (
-            torch.tensor(grid_thw_list, dtype=torch.long).prod(-1) //
-            merge_size // merge_size).tolist()
+        sizes = (torch.tensor(grid_thw_list, dtype=torch.long).prod(-1) //
+                 (merge_size * merge_size)).tolist()
 
         return image_embeds.split(sizes)
 
@@ -1002,9 +1001,8 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
         # Split concatenated embeddings for each video item.
         merge_size = self.visual.spatial_merge_size
         # Using prod on grid_thw_list instead of grid_thw.prod avoids CUDA sync
-        sizes = (
-            torch.prod(torch.tensor(grid_thw_list, dtype=torch.long), -1) //
-            merge_size // merge_size).tolist()
+        sizes = (torch.tensor(grid_thw_list, dtype=torch.long).prod(-1) //
+                 (merge_size * merge_size)).tolist()
 
         return video_embeds.split(sizes)
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -979,7 +979,7 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
         # Using prod on grid_thw_list instead of grid_thw.prod avoids CUDA sync
         merge_size = self.visual.spatial_merge_size
         sizes = (
-            torch.prod(torch.tensor(grid_thw_list, dtype=torch.long), -1) //
+            torch.tensor(grid_thw_list, dtype=torch.long).prod(-1) //
             merge_size // merge_size).tolist()
 
         return image_embeds.split(sizes)

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -976,10 +976,13 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
             image_embeds = self.visual(pixel_values, grid_thw=grid_thw_list)
 
         # Split concatenated embeddings for each image item.
+        # Using prod on grid_thw_list instead of grid_thw.prod avoids CUDA sync
         merge_size = self.visual.spatial_merge_size
-        sizes = grid_thw.prod(-1) // merge_size // merge_size
+        sizes = (
+            torch.prod(torch.tensor(grid_thw_list, dtype=torch.long), -1) //
+            merge_size // merge_size).tolist()
 
-        return image_embeds.split(sizes.tolist())
+        return image_embeds.split(sizes)
 
     def _process_video_input(
             self,
@@ -998,9 +1001,12 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
 
         # Split concatenated embeddings for each video item.
         merge_size = self.visual.spatial_merge_size
-        sizes = grid_thw.prod(-1) // merge_size // merge_size
+        # Using prod on grid_thw_list instead of grid_thw.prod avoids CUDA sync
+        sizes = (
+            torch.prod(torch.tensor(grid_thw_list, dtype=torch.long), -1) //
+            merge_size // merge_size).tolist()
 
-        return video_embeds.split(sizes.tolist())
+        return video_embeds.split(sizes)
 
     def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
         mm_input_by_modality = {}


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist
This PR removes unnecessary CUDA sync in _process_image_input and _process_video_input of vllm/model_executor/models/qwen2_5_vl.py by utilising grid_thw_list.

Before the fix, the _process_image_input function of vllm/model_executor/models/qwen2_5_vl.py could take near 1/4 of the `OwnTime` as measured by py-spy, see:
<img width="1277" height="341" alt="image" src="https://github.com/user-attachments/assets/bf85e0d3-7735-4acb-b13e-b9101c6da8be" />

After the fix, the bottlenecks have been moved to other places, and there are further fixes. However, this fix is quite simple that I want to submit first.
<img width="1276" height="458" alt="image" src="https://github.com/user-attachments/assets/3ea5cd15-53fb-45e5-a5ec-3e2b2ede0642" />


