### PR TITLE
[FEAT] add 'include_finished_set' parameter to scheduler config

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -159,6 +159,11 @@ class SchedulerConfig:
     structured outputs, speculative decoding, and pipeline parallelism.
     """
 
+    include_finished_set: bool = False
+    """If set to True, a separate set of finished request ids will be included 
+    in the EngineCoreOutputs returned by update_from_outputs(). 
+    """
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -380,6 +380,9 @@ class EngineArgs:
     disable_hybrid_kv_cache_manager: bool = (
         SchedulerConfig.disable_hybrid_kv_cache_manager)
 
+    include_finished_set: bool = (
+        SchedulerConfig.include_finished_set)
+
     guided_decoding_backend: GuidedDecodingBackend = DecodingConfig.backend
     guided_decoding_disable_fallback: bool = DecodingConfig.disable_fallback
     guided_decoding_disable_any_whitespace: bool = \
@@ -814,6 +817,8 @@ class EngineArgs:
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"])
         scheduler_group.add_argument("--async-scheduling",
                                      **scheduler_kwargs["async_scheduling"])
+        scheduler_group.add_argument("--include-finished-set",
+                                     **scheduler_kwargs["include_finished_set"])
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)
@@ -1280,6 +1285,7 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.
             disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
+            include_finished_set=self.include_finished_set,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -380,8 +380,7 @@ class EngineArgs:
     disable_hybrid_kv_cache_manager: bool = (
         SchedulerConfig.disable_hybrid_kv_cache_manager)
 
-    include_finished_set: bool = (
-        SchedulerConfig.include_finished_set)
+    include_finished_set: bool = (SchedulerConfig.include_finished_set)
 
     guided_decoding_backend: GuidedDecodingBackend = DecodingConfig.backend
     guided_decoding_disable_fallback: bool = DecodingConfig.disable_fallback
@@ -817,8 +816,9 @@ class EngineArgs:
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"])
         scheduler_group.add_argument("--async-scheduling",
                                      **scheduler_kwargs["async_scheduling"])
-        scheduler_group.add_argument("--include-finished-set",
-                                     **scheduler_kwargs["include_finished_set"])
+        scheduler_group.add_argument(
+            "--include-finished-set",
+            **scheduler_kwargs["include_finished_set"])
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -121,7 +121,7 @@ class EngineCore:
             kv_cache_config=kv_cache_config,
             structured_output_manager=self.structured_output_manager,
             include_finished_set=vllm_config.parallel_config.data_parallel_size
-            > 1,
+            > 1 or vllm_config.scheduler_config.include_finished_set,
             log_stats=self.log_stats,
         )
 


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose
To fix issue https://github.com/vllm-project/vllm/issues/22545, I exposed the `include_finished_set` parameter. When this parameter is enabled, a separate set of finished request ids will be included in the `EngineCoreOutputs`. This allows stats to be updated when all requests are aborted.

## (Optional) Documentation Update

