### PR TITLE
[Nixl][CI] Fix tests

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -229,6 +229,7 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
                 num_blocks=1,
                 block_len=self.block_len,
                 attn_backend_name=self.backend_name,
+                kv_cache_layout="HND",
             ),
             remote_tp_size=remote_tp_size)
         return {0: remote_agent_name}

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -229,6 +229,8 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
                 num_blocks=1,
                 block_len=self.block_len,
                 attn_backend_name=self.backend_name,
+                # `self.kv_cache_layout` is only forced to HND when vllm engine
+                # is started. We mock HND here.
                 kv_cache_layout="HND",
             ),
             remote_tp_size=remote_tp_size)


### PR DESCRIPTION
I broke some of the NIXL tests in this PR https://github.com/vllm-project/vllm/pull/22745 by adding the `kv_cache_layout` to the exchange metadata.
My bad, fixing it here!

```
# before
python -m pytest -q tests/v1/kv_connector/unit/test_nixl_connector.py
FAILED tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_multi_xfer_one_engine - KeyError: 'remote_engine'
FAILED tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_async_load_kv[1-1] - KeyError: 'remote_engine'
FAILED tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_async_load_kv[2-1] - KeyError: 'remote_engine'
FAILED tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_async_load_kv[4-2] - KeyError: 'remote_engine'
FAILED tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_async_load_kv[4-4] - KeyError: 'remote_engine'
FAILED tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_concurrent_load_kv - KeyError: 'remote_engine'
```

```
# now
python -m pytest -q tests/v1/kv_connector/unit/test_nixl_connector.py
...........                                                                                                                                                   [100%]
========================================================================= warnings summary ==========================================================================
tests/v1/kv_connector/unit/test_nixl_connector.py::test_abort_timeout_on_prefiller[None]
  /home/nicolo/llmd/.venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2356: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
  If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
11 passed, 1 warning in 80.68s (0:01:20)
```
