### PR TITLE
[Bugfix] Fix MiniCPMV Image input inference failed

### DIFF
--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -92,8 +92,6 @@ class MiniCPMVImagePixelInputs(TensorSchema):
         expected_shape: tuple[Union[int, str], ...],
         dynamic_dims: set[str],
     ) -> tuple[int, ...]:
-        """Validate a list/tuple of tensors and return the actual shape."""
-
         # value[0] is the scaled image,
         # and value[1:] is a collection of image slices.
         # It is ensured that all slices in the collection

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -84,24 +84,27 @@ class MiniCPMVImagePixelInputs(TensorSchema):
         - h: Height
         - w: Width
     """
+
     def _validate_nested_tensors(
-        self, value: Union[list[torch.Tensor, ...],
-                           tuple[torch.Tensor, ...]], field_name: str,
+        self,
+        value: Union[list[torch.Tensor], tuple[torch.Tensor, ...]],
+        field_name: str,
         expected_shape: tuple[Union[int, str], ...],
-        dynamic_dims: set[str, ...]) -> tuple[int, ...]:
-      """Validate a list/tuple of tensors and return the actual shape."""
-          
-      # value[0] is the scaled image,
-      # and value[1:] is a collection of image slices.
-      # It is ensured that all slices in the collection
-      # have the same shape.
-      if field_name == "pixel_values":
-          value = value[1:] if len(value) > 1 else value
-      return super()._validate_nested_tensors(
-        value, field_name, expected_shape, dynamic_dims
-      )
-      
-      type: Literal["pixel_values"] = "pixel_values"
+        dynamic_dims: set[str],
+    ) -> tuple[int, ...]:
+        """Validate a list/tuple of tensors and return the actual shape."""
+
+        # value[0] is the scaled image,
+        # and value[1:] is a collection of image slices.
+        # It is ensured that all slices in the collection
+        # have the same shape.
+        if field_name == "pixel_values":
+            value = value[1:] if len(value) > 1 else value
+
+        return super()._validate_nested_tensors(value, field_name,
+                                                expected_shape, dynamic_dims)
+
+    type: Literal["pixel_values"] = "pixel_values"
 
     # Note that the image size may vary, so we pass it as a list instead of a
     # batched tensor.

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -85,35 +85,19 @@ class MiniCPMVImagePixelInputs(TensorSchema):
         - w: Width
     """
     def _validate_nested_tensors(
-            self, value: Union[list[torch.Tensor, ...],
-                               tuple[torch.Tensor, ...]], field_name: str,
-            expected_shape: tuple[Union[int, str], ...],
-            dynamic_dims: set[str, ...]) -> tuple[int, ...]:
-        """Validate a list/tuple of tensors and return the actual shape."""
-              
-        # value[0] is the scaled image, and value[1:] is a collection of image slices.
-        # It is ensured that all slices in the collection have the same shape.
-        if len(value) <= 1:
-            return (len(value),) + value[0].shape if value else (0,)
+        self, value: Union[list[torch.Tensor, ...],
+                           tuple[torch.Tensor, ...]], field_name: str,
+        expected_shape: tuple[Union[int, str], ...],
+        dynamic_dims: set[str, ...]) -> tuple[int, ...]:
+    """Validate a list/tuple of tensors and return the actual shape."""
           
-        first = value[1]
-        for i, v in enumerate(value[1:]):
-            if not isinstance(v, torch.Tensor):
-                raise ValueError(f"{field_name}[{i}] is not a "
-                                 f"torch.Tensor")
-            if not self._match_shape_with_dynamic(
-                    v.shape,
-                    first.shape,
-                    expected_shape,
-                    dynamic_dims,
-            ):
-                raise ValueError(f"{field_name} contains inconsistent "
-                                 f"shapes: {first.shape} vs {v.shape} "
-                                 f"at index {i}")
-
-        # Treat the list as a stacked tensor:
-        # shape = (len(list), *tensor.shape)
-        return (len(value), ) + first.shape
+    # value[0] is the scaled image,
+    # and value[1:] is a collection of image slices.
+    # It is ensured that all slices in the collection
+    # have the same shape.
+    if field_name == "pixel_values":
+        value = value[1:] if len(value) > 1 else value
+    return super()._validate_nested_tensors(value, field_name, expected_shape, dynamic_dims)
     
     type: Literal["pixel_values"] = "pixel_values"
 

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -89,17 +89,19 @@ class MiniCPMVImagePixelInputs(TensorSchema):
                            tuple[torch.Tensor, ...]], field_name: str,
         expected_shape: tuple[Union[int, str], ...],
         dynamic_dims: set[str, ...]) -> tuple[int, ...]:
-    """Validate a list/tuple of tensors and return the actual shape."""
+      """Validate a list/tuple of tensors and return the actual shape."""
           
-    # value[0] is the scaled image,
-    # and value[1:] is a collection of image slices.
-    # It is ensured that all slices in the collection
-    # have the same shape.
-    if field_name == "pixel_values":
-        value = value[1:] if len(value) > 1 else value
-    return super()._validate_nested_tensors(value, field_name, expected_shape, dynamic_dims)
-    
-    type: Literal["pixel_values"] = "pixel_values"
+      # value[0] is the scaled image,
+      # and value[1:] is a collection of image slices.
+      # It is ensured that all slices in the collection
+      # have the same shape.
+      if field_name == "pixel_values":
+          value = value[1:] if len(value) > 1 else value
+      return super()._validate_nested_tensors(
+        value, field_name, expected_shape, dynamic_dims
+      )
+      
+      type: Literal["pixel_values"] = "pixel_values"
 
     # Note that the image size may vary, so we pass it as a list instead of a
     # batched tensor.

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -90,8 +90,12 @@ class MiniCPMVImagePixelInputs(TensorSchema):
             expected_shape: tuple[Union[int, str], ...],
             dynamic_dims: set[str, ...]) -> tuple[int, ...]:
         """Validate a list/tuple of tensors and return the actual shape."""
-        # Ensure all tensors in the list have the same
-        # shape, besides dynamic dimensions
+              
+        # value[0] is the scaled image, and value[1:] is a collection of image slices.
+        # It is ensured that all slices in the collection have the same shape.
+        if len(value) <= 1:
+            return (len(value),) + value[0].shape if value else (0,)
+          
         first = value[1]
         for i, v in enumerate(value[1:]):
             if not isinstance(v, torch.Tensor):


### PR DESCRIPTION
## Purpose

The image inputs of the MiniCPMV series models are scaled images and sliced images, so there are cases where their sizes are inconsistent. This causes the detection of `pixel_values` in the `TensorSchema` class to fail, resulting in Image input inference failed.

- Modify the inherited class `MiniCPMVImagePixelInputs` of `TensorSchema`, refactor the `_validate_nested_tensors` function, and start the judgment from the first sliced image.

FIX #22833

## Test Plan

<details> 
  <summary>vllm Offline Inference</summary>
	<pre><code>
from transformers import AutoTokenizer
from PIL import Image
from vllm import LLM, SamplingParams
import os
os.environ["CUDA_VISIBLE_DEVICES"] = "3,4"

\# Model configuration
MODEL_NAME = "<model_path>"
\# Option to use HuggingFace model ID
\# MODEL_NAME = "openbmb/MiniCPM-V-4"

\# Load image
image = Image.open("vllm/docs/assets/logos/vllm-logo-only-light.png").convert("RGB")
tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True)

\# Initialize LLM
llm = LLM(
    model=MODEL_NAME, 
    max_model_len=4096,
    trust_remote_code=True,
    disable_mm_preprocessor_cache=True,
    limit_mm_per_prompt={"image": 5},
    tensor_parallel_size=2,
)

\# Build messages
messages = [{
    "role": "user",
    "content": "(<image>./</image>)\nPlease describe the content of this image"
}]

prompt = tokenizer.apply_chat_template(
    messages,
    tokenize=False,
    add_generation_prompt=True
)

\# Single inference
inputs = {
    "prompt": prompt,
    "multi_modal_data": {
        "image": image
        # For multi-image inference, use list format:
        # "image": [image1, image2] 
    },
}

\# Batch inference example
\# inputs = [{
\#     "prompt": prompt,
\#     "multi_modal_data": {
\#         "image": image
\#     },
\# } for _ in range(2)]

\# Set stop tokens
stop_tokens = ['<|im_end|>', '<|endoftext|>']
stop_token_ids = [tokenizer.convert_tokens_to_ids(i) for i in stop_tokens]

\# Sampling parameters
sampling_params = SamplingParams(
    stop_token_ids=stop_token_ids, 
    temperature=0.7,
    top_p=0.8,
    max_tokens=4096
)

\# Generate results
outputs = llm.generate(inputs, sampling_params=sampling_params)
print(outputs[0].outputs[0].text)
  </code></pre>
</details>



## Test Result

<details>
  <summary>result</summary>
  The image features a stylized logo consisting of two geometric shapes that together form the letter "V". The design is simple and modern, with clean lines and a flat appearance.

Here are the detailed elements of the image:

1. **Shapes and Colors**:
   - The logo is composed of two distinct shapes.
   - The left shape is a yellow triangle pointing downward.
   - The right shape is a blue parallelogram pointing to the right.

2. **Arrangement**:
   - The yellow triangle and the blue parallelogram are positioned adjacent to each other.
   - The point of the triangle aligns with one of the edges of the parallelogram, creating a cohesive "V" shape when viewed together.

3. **Design Style**:
   - The shapes are filled with solid colors without any gradients or textures.
   - There is a subtle shadow effect around the edges of the shapes, giving a slight 3D appearance while maintaining a flat design aesthetic.

4. **Background**:
   - The background of the image is plain white, which helps the logo stand out clearly.

This logo design is likely used for branding purposes, representing a company, organization, or product that wants to convey a sense of modernity, simplicity, and clarity through its visual identity.
</details>

