### PR TITLE
[CI] Fix `tests/v1/e2e/test_kv_sharing_fast_prefill.py` import on test

### DIFF
--- a/tests/v1/e2e/test_kv_sharing_fast_prefill.py
+++ b/tests/v1/e2e/test_kv_sharing_fast_prefill.py
@@ -11,7 +11,8 @@ from vllm import LLM, SamplingParams
 from vllm.config import CompilationConfig, CompilationLevel
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.forward_context import get_forward_context
-from vllm.model_executor.models.gemma3n import Gemma3nForConditionalGeneration
+from vllm.model_executor.models.gemma3n_mm import (
+    Gemma3nForConditionalGeneration)
 from vllm.model_executor.models.registry import ModelRegistry
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.sequence import IntermediateTensors


### PR DESCRIPTION
Fix:
```
[2025-08-13T12:15:17Z] ________ ERROR collecting tests/v1/e2e/test_kv_sharing_fast_prefill.py _________
[2025-08-13T12:15:17Z] ImportError while importing test module '/vllm-workspace/tests/v1/e2e/test_kv_sharing_fast_prefill.py'.
[2025-08-13T12:15:17Z] Hint: make sure your test modules/packages have valid Python names.
[2025-08-13T12:15:17Z] Traceback:
[2025-08-13T12:15:17Z] /usr/lib/python3.12/importlib/__init__.py:90: in import_module
[2025-08-13T12:15:17Z]     return _bootstrap._gcd_import(name[level:], package, level)
[2025-08-13T12:15:17Z] v1/e2e/test_kv_sharing_fast_prefill.py:14: in <module>
[2025-08-13T12:15:17Z]     from vllm.model_executor.models.gemma3n import Gemma3nForConditionalGeneration
[2025-08-13T12:15:17Z] E   ImportError: cannot import name 'Gemma3nForConditionalGeneration' from 'vllm.model_executor.models.gemma3n' (/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/gemma3n.py)
```

now:
```
.                                                                                                 [100%]
=========================================== warnings summary ============================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/v1/e2e/test_kv_sharing_fast_prefill.py:26
  /home/nicolo/llmd/vllm/tests/v1/e2e/test_kv_sharing_fast_prefill.py:26: PytestCollectionWarning: cannot collect test class 'TestGemma3nForConditionalGeneration' because it has a __init__ constructor (from: tests/v1/e2e/test_kv_sharing_fast_prefill.py)
    class TestGemma3nForConditionalGeneration(Gemma3nForConditionalGeneration):

tests/v1/e2e/test_kv_sharing_fast_prefill.py::test_kv_sharing_fast_prefill[True]
  /home/nicolo/llmd/vllm/tests/utils.py:749: DeprecationWarning: This process (pid=114578) is multi-threaded, use of fork() may lead to deadlocks in the child.
    pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
1 passed, 4 warnings in 40.07s
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

```

by having the test run the newly added gemma3n-mm.