### PR TITLE
[Bugfix][ROCm][CI/Build] Fix ROCm build regression

### DIFF
--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -453,7 +453,7 @@ void topkGatingSoftmaxKernelLauncher(
     static constexpr int WARPS_PER_TB = 4;
     auto warpSize = WARP_SIZE;
     static constexpr int BYTES_PER_LDG_POWER_OF_2 = 16;
-    static constexpr int BYTES_PER_LDG_MULTIPLE_64 = 8;
+    [[maybe_unused]] static constexpr int BYTES_PER_LDG_MULTIPLE_64 = 8;
     switch (num_experts) {
         case 1:
             LAUNCH_SOFTMAX(1, WARPS_PER_TB, BYTES_PER_LDG_POWER_OF_2);


### PR DESCRIPTION
This is a fix for the ROCm build regression introduced in #22211

WARP_SIZE on the host can't be used as a constexpr, i.e. template argument
The reason being that the host code is compiled once and shared with all the supported GPU architectures, which can have different warp sizes.
Currently on CUDA only the value of 32 is supported, but this is not universally true for all platforms
On ROCm the default build offloads device code for both Radeon (Warp Size 32) and Instinct (Warp Size 64), so on host the value is dynamically fetched at runtime.