### PR TITLE
[Bugfix] Make unspecified --host bind to dual stack

### DIFF
--- a/tests/entrypoints/openai/test_basic.py
+++ b/tests/entrypoints/openai/test_basic.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import os
+import socket
 from http import HTTPStatus
 
 import openai
@@ -9,11 +11,13 @@ import pytest
 import pytest_asyncio
 import requests
 
+from vllm.utils import is_valid_ipv4_address, is_valid_ipv6_address
 from vllm.version import __version__ as VLLM_VERSION
 
 from ...utils import RemoteOpenAIServer
 
 MODEL_NAME = "HuggingFaceH4/zephyr-7b-beta"
+FAST_MODEL_NAME = "facebook/opt-125m"
 
 
 @pytest.fixture(scope='module')
@@ -67,6 +71,23 @@ def server(server_args):
     ]
 
     with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture(scope="module")
+def fast_server(server_args):
+    args = [
+        # use half precision for speed and memory savings in CI environment
+        "--dtype",
+        "bfloat16",
+        *server_args,
+    ]
+
+    os.environ['VLLM_USE_V1'] = '1'
+    with RemoteOpenAIServer(
+            FAST_MODEL_NAME,
+            args,
+    ) as remote_server:
         yield remote_server
 
 
@@ -220,3 +241,50 @@ async def test_server_load(server: RemoteOpenAIServer):
     response = requests.get(server.url_for("load"))
     assert response.status_code == HTTPStatus.OK
     assert response.json().get("server_load") == 0
+
+
+@pytest.mark.parametrize(
+    ("server_args", "expected_addrs", "unexpected_addrs"),
+    [
+        pytest.param([], ["127.0.0.1", "::1"], [], id="default"),
+        pytest.param(["--host=0.0.0.0"], ["127.0.0.1"], ["::1"],
+                     id="0-0-0-0-ipv4"),
+        pytest.param(["--host=127.0.0.1"], ["127.0.0.1"], ["::1"],
+                     id="127-0-0-1-ipv4"),
+        pytest.param(["--host=::1"], ["::1"], ["127.0.0.1"], id="_-_-1-ipv4"),
+        pytest.param(["--host=::"], ["127.0.0.1", "::1"], [], id="_-_-all"),
+        pytest.param(["--host=localhost"], ["127.0.0.1", "::1"], [],
+                     id="localhost"),
+    ],
+    indirect=["server_args"],
+)
+@pytest.mark.asyncio
+async def test_bind_ipv4_ipv6(fast_server: RemoteOpenAIServer,
+                              expected_addrs: list[str],
+                              unexpected_addrs: list[str]):
+    # if the test system lacks IPv4 or IPv6, move addresses of those types
+    # to unexpected_addrs
+    has_ipv4, has_ipv6 = False, False
+    for family, _, _, _, _ in socket.getaddrinfo(None,
+                                                 fast_server.port,
+                                                 type=socket.SOCK_STREAM,
+                                                 flags=socket.AI_PASSIVE):
+        if family == socket.AF_INET:
+            has_ipv4 = True
+        if family == socket.AF_INET6:
+            has_ipv6 = True
+    for addr in expected_addrs:
+        if (not has_ipv6 and is_valid_ipv6_address(addr)) or (
+                not has_ipv4 and is_valid_ipv4_address(addr)):
+            expected_addrs.remove(addr)
+            unexpected_addrs.append(addr)
+
+    for addr in expected_addrs:
+        response = requests.get(fast_server.url_for_host(addr, "health"),
+                                timeout=1)
+        assert response.status_code == HTTPStatus.OK
+
+    for addr in unexpected_addrs:
+        with pytest.raises(requests.ConnectionError):
+            response = requests.get(fast_server.url_for_host(addr, "health"),
+                                    timeout=1)

--- a/tests/entrypoints/openai/test_bind.py
+++ b/tests/entrypoints/openai/test_bind.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import socket
+from http import HTTPStatus
+
+import openai
+import pytest
+import pytest_asyncio
+import requests
+
+from vllm.utils import is_valid_ipv4_address, is_valid_ipv6_address
+from vllm.version import __version__ as VLLM_VERSION
+
+from ...utils import RemoteOpenAIServer
+
+MODEL_NAME = "facebook/opt-125m"
+
+
+@pytest.fixture(scope='function')
+def server_args(request: pytest.FixtureRequest) -> list[str]:
+    """ Provide extra arguments to the server via indirect parametrization
+
+    Usage:
+
+    >>> @pytest.mark.parametrize(
+    >>>     "server_args",
+    >>>     [
+    >>>         ["--disable-frontend-multiprocessing"],
+    >>>         [
+    >>>             "--model=NousResearch/Hermes-3-Llama-3.1-70B",
+    >>>             "--enable-auto-tool-choice",
+    >>>         ],
+    >>>     ],
+    >>>     indirect=True,
+    >>> )
+    >>> def test_foo(server, client):
+    >>>     ...
+
+    This will run `test_foo` twice with servers with:
+    - `--disable-frontend-multiprocessing`
+    - `--model=NousResearch/Hermes-3-Llama-3.1-70B --enable-auto-tool-choice`.
+
+    """
+    if not hasattr(request, "param"):
+        return []
+
+    val = request.param
+
+    if isinstance(val, str):
+        return [val]
+
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def server(server_args):
+    args = [
+        # use half precision for speed and memory savings in CI environment
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--enforce-eager",
+        "--max-num-seqs",
+        "128",
+        *server_args,
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+@pytest.mark.parametrize(
+    ("server_args", "expected_addrs", "unexpected_addrs"),
+    [
+        pytest.param([], ["127.0.0.1", "::1"], [], id="default"),
+        pytest.param(["--host=0.0.0.0"], ["127.0.0.1"], ["::1"],
+                     id="0-0-0-0-ipv4"),
+        pytest.param(["--host=127.0.0.1"], ["127.0.0.1"], ["::1"],
+                     id="127-0-0-1-ipv4"),
+        pytest.param(["--host=::1"], ["::1"], ["127.0.0.1"], id="_-_-1-ipv4"),
+        pytest.param(["--host=::"], ["127.0.0.1", "::1"], [], id="_-_-all"),
+        pytest.param(["--host=localhost"], ["127.0.0.1", "::1"], [],
+                     id="localhost"),
+    ],
+    indirect=["server_args"],
+)
+@pytest.mark.asyncio
+async def test_bind_ipv4_ipv6(server: RemoteOpenAIServer,
+                              expected_addrs: list[str],
+                              unexpected_addrs: list[str]):
+    # if the test system lacks IPv4 or IPv6, move addresses of those types
+    # to unexpected_addrs
+    has_ipv4, has_ipv6 = False, False
+    for family, _, _, _, _ in socket.getaddrinfo(None,
+                                                 server.port,
+                                                 type=socket.SOCK_STREAM,
+                                                 flags=socket.AI_PASSIVE):
+        if family == socket.AF_INET:
+            has_ipv4 = True
+        if family == socket.AF_INET6:
+            has_ipv6 = True
+    for addr in expected_addrs:
+        if (not has_ipv6 and is_valid_ipv6_address(addr)) or (
+                not has_ipv4 and is_valid_ipv4_address(addr)):
+            expected_addrs.remove(addr)
+            unexpected_addrs.append(addr)
+
+    for addr in expected_addrs:
+        response = requests.get(server.url_for_host(addr, "health"), timeout=1)
+        assert response.status_code == HTTPStatus.OK
+
+    for addr in unexpected_addrs:
+        with pytest.raises(requests.ConnectionError):
+            _response = requests.get(server.url_for_host(addr, "health"),
+                                     timeout=1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,7 +38,8 @@ from vllm.model_executor.model_loader import get_model_loader
 from vllm.platforms import current_platform
 from vllm.transformers_utils.tokenizer import get_tokenizer
 from vllm.utils import (FlexibleArgumentParser, GB_bytes,
-                        cuda_device_count_stateless, get_open_port)
+                        cuda_device_count_stateless, get_open_port,
+                        join_host_port)
 
 if current_platform.is_rocm():
     from amdsmi import (amdsmi_get_gpu_vram_usage,
@@ -199,11 +200,15 @@ class RemoteOpenAIServer:
 
     @property
     def url_root(self) -> str:
-        return (f"http://{self.uds.split('/')[-1]}"
-                if self.uds else f"http://{self.host}:{self.port}")
+        if self.uds:
+            return f"http://{self.uds.split('/')[-1]}"
+        return f"http://{join_host_port(self.host, self.port)}"
 
     def url_for(self, *parts: str) -> str:
         return self.url_root + "/" + "/".join(parts)
+
+    def url_for_host(self, host: str, *parts: str):
+        return f"http://{join_host_port(host, self.port)}/" + "/".join(parts)
 
     def get_client(self, **kwargs):
         if "timeout" not in kwargs:

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -146,7 +146,7 @@ def run_multi_api_server(args: argparse.Namespace):
         # Not compatible with API server scale-out
         args.mm_processor_cache_gb = 0
 
-    listen_address, sock = setup_server(args)
+    listen_address, sockets = setup_server(args)
 
     engine_args = vllm.AsyncEngineArgs.from_cli_args(args)
     usage_context = UsageContext.OPENAI_API_SERVER
@@ -184,7 +184,7 @@ def run_multi_api_server(args: argparse.Namespace):
         api_server_manager_kwargs = dict(
             target_server_fn=run_api_server_worker_proc,
             listen_address=listen_address,
-            sock=sock,
+            sockets=sockets,
             args=args,
             num_servers=num_api_servers,
             input_addresses=addresses.inputs,
@@ -216,7 +216,7 @@ def run_multi_api_server(args: argparse.Namespace):
 
 
 def run_api_server_worker_proc(listen_address,
-                               sock,
+                               sockets,
                                args,
                                client_config=None,
                                **uvicorn_kwargs) -> None:
@@ -228,5 +228,5 @@ def run_api_server_worker_proc(listen_address,
     decorate_logs()
 
     uvloop.run(
-        run_server_worker(listen_address, sock, args, client_config,
+        run_server_worker(listen_address, sockets, args, client_config,
                           **uvicorn_kwargs))

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -25,7 +25,7 @@ logger = init_logger(__name__)
 
 
 async def serve_http(app: FastAPI,
-                     sock: Optional[socket.socket],
+                     sockets: Optional[list[socket.socket]],
                      enable_ssl_refresh: bool = False,
                      **uvicorn_kwargs: Any):
     """
@@ -67,7 +67,7 @@ async def serve_http(app: FastAPI,
     watchdog_task = loop.create_task(
         watchdog_loop(server, app.state.engine_client))
     server_task = loop.create_task(
-        server.serve(sockets=[sock] if sock else None))
+        server.serve(sockets=sockets if sockets else None))
 
     ssl_cert_refresher = None if not enable_ssl_refresh else SSLCertRefresher(
         ssl_context=config.ssl,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -19,7 +19,7 @@ from collections.abc import AsyncIterator, Awaitable
 from contextlib import asynccontextmanager
 from functools import partial
 from http import HTTPStatus
-from typing import Annotated, Any, Callable, Optional
+from typing import Annotated, Any, Callable, Optional, Union
 
 import prometheus_client
 import pydantic
@@ -105,8 +105,8 @@ from vllm.transformers_utils.config import (
 from vllm.transformers_utils.tokenizer import MistralTokenizer
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import (Device, FlexibleArgumentParser, decorate_logs,
-                        get_open_zmq_ipc_path, is_valid_ipv6_address,
-                        set_ulimit)
+                        get_open_zmq_ipc_path, is_valid_ipv4_address,
+                        is_valid_ipv6_address, set_ulimit)
 from vllm.v1.metrics.prometheus import get_prometheus_registry
 from vllm.version import __version__ as VLLM_VERSION
 
@@ -1840,23 +1840,51 @@ async def init_app_state(
     state.server_load_metrics = 0
 
 
-def create_server_socket(addr: tuple[str, int]) -> socket.socket:
-    family = socket.AF_INET
-    if is_valid_ipv6_address(addr[0]):
-        family = socket.AF_INET6
+def create_server_sockets(
+        addr: tuple[Optional[str], int]) -> list[socket.socket]:
+    """Create and bind server sockets for each resolved address."""
 
-    sock = socket.socket(family=family, type=socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-    sock.bind(addr)
+    # This method is a subset of the asyncio.loop.create_server
+    # logic for name resolution for host binding.
+    sockets = []
 
-    return sock
+    # Avoid name resolution on already resolved IP addresses
+    infos: list[Union[tuple[socket.AddressFamily, socket.SocketKind, int, str,
+                            Union[tuple[str, int], tuple[str, int, int,
+                                                         int]]]]]
+    host, port = addr
+    if host and is_valid_ipv6_address(host):
+        infos = [(socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+                  (host, port))]
+    elif host and is_valid_ipv4_address(host):
+        infos = [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+                  (host, port))]
+    else:
+        infos = socket.getaddrinfo(host,
+                                   port,
+                                   type=socket.SOCK_STREAM,
+                                   flags=socket.AI_PASSIVE)
+
+    for family, socktype, proto, _, sa in infos:
+        sock = socket.socket(family, socktype, proto)
+        sockets.append(sock)
+
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # Since Linux 6.12.9, SO_REUSEPORT is not allowed
+        # on other address families than AF_INET/AF_INET6
+        if family in (socket.AF_INET, socket.AF_INET6):
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+
+        logger.debug("binding to socket family=%d socktype=%d proto=%d: %s",
+                     family, socktype, proto, sa)
+        sock.bind(sa)
+    return sockets
 
 
-def create_server_unix_socket(path: str) -> socket.socket:
+def create_server_unix_sockets(path: str) -> list[socket.socket]:
     sock = socket.socket(family=socket.AF_UNIX, type=socket.SOCK_STREAM)
     sock.bind(path)
-    return sock
+    return [sock]
 
 
 def validate_api_server_args(args):
@@ -1890,10 +1918,10 @@ def setup_server(args):
     # This avoids race conditions with ray.
     # see https://github.com/vllm-project/vllm/issues/8204
     if args.uds:
-        sock = create_server_unix_socket(args.uds)
+        sockets = create_server_unix_sockets(args.uds)
     else:
-        sock_addr = (args.host or "", args.port)
-        sock = create_server_socket(sock_addr)
+        sock_addr = (args.host or None, args.port)
+        sockets = create_server_sockets(sock_addr)
 
     # workaround to avoid footguns where uvicorn drops requests with too
     # many concurrent requests active
@@ -1910,10 +1938,9 @@ def setup_server(args):
     else:
         addr, port = sock_addr
         is_ssl = args.ssl_keyfile and args.ssl_certfile
-        host_part = f"[{addr}]" if is_valid_ipv6_address(
-            addr) else addr or "0.0.0.0"
+        host_part = f"[{addr}]" if is_valid_ipv6_address(addr) else addr or ""
         listen_address = f"http{'s' if is_ssl else ''}://{host_part}:{port}"
-    return listen_address, sock
+    return listen_address, sockets
 
 
 async def run_server(args, **uvicorn_kwargs) -> None:
@@ -1922,12 +1949,12 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     # Add process-specific prefix to stdout and stderr.
     decorate_logs("APIServer")
 
-    listen_address, sock = setup_server(args)
-    await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
+    listen_address, sockets = setup_server(args)
+    await run_server_worker(listen_address, sockets, args, **uvicorn_kwargs)
 
 
 async def run_server_worker(listen_address,
-                            sock,
+                            sockets,
                             args,
                             client_config=None,
                             **uvicorn_kwargs) -> None:
@@ -1957,7 +1984,7 @@ async def run_server_worker(listen_address,
                     listen_address)
         shutdown_task = await serve_http(
             app,
-            sock=sock,
+            sockets=sockets,
             enable_ssl_refresh=args.enable_ssl_refresh,
             host=args.host,
             port=args.port,
@@ -1979,7 +2006,8 @@ async def run_server_worker(listen_address,
     try:
         await shutdown_task
     finally:
-        sock.close()
+        for sock in sockets:
+            sock.close()
 
 
 if __name__ == "__main__":

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -874,7 +874,15 @@ def get_loopback_ip() -> str:
             "Set the VLLM_LOOPBACK_IP environment variable explicitly.")
 
 
-def is_valid_ipv6_address(address: str) -> bool:
+def is_valid_ipv4_address(address: str | None) -> bool:
+    try:
+        ipaddress.IPv4Address(address)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_ipv6_address(address: str | None) -> bool:
     try:
         ipaddress.IPv6Address(address)
         return True


### PR DESCRIPTION
Fixes #22816

## Purpose

Passing `--host=""` does not listen on all interfaces, which prevents standard dual-stack and multi-home binding defaulting from working out of the box.  It only binds to IPv4 addresses for "" and "0.0.0.0", and only selects ipv4 addresses when `localhost` is provided.

The convention for binding hosts in Python and in several other language stdlib is that an absent host binds to all addresses for listening. This is the default behavior in uvicorn - resolve the None host via a call to getaddrinfo which returns two addresses for ipv4 and ipv6.

This PR changes the create_server_socket method to create a list of sockets propagate that to the callers.  It is intended to ensure that the same configuration can work in multiple environments regardless of dual-stack, ipv4 only, or ipv6 only enablement.  

* Make `""` listen on all interfaces.
* Make `localhost` listen on all local interfaces

## Test Plan

Tested with the following options to `--host` and expected outcomes:

```
--host     @HEAD                       this change                        why
None/""    all ipv4 addresses          all ipv4 and ipv6 addresses        bind to everything by default
0.0.0.0    all ipv4 addresses          all ipv4 addresses                 consistent with how uvicorn behaves
::         all ipv4 and ipv6 addresses all ipv4 and ipv6 addresses        requires IPv6 to be enabled or fails to listen
127.0.0.1  ipv4 127.0.0.1              ipv4 127.0.0.1                     explicit address binding
::1        ipv6 ::1                    ipv6 ::1                           explicit address binding
localhost  all local ipv4 addresses    all local ipv4 and ipv6 addresses  listening on all local devices should be more convenient
```

## (Optional) Documentation Update

TODO