### PR TITLE
[CI] Fix `tests/distributed/test_ca_buffer_sharing.py`

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -297,7 +297,7 @@ class CustomAllreduce:
     @staticmethod
     def free_shared_buffer(pointers: list[int],
                            group: Optional[ProcessGroup] = None,
-                           rank: Optional[int] = 0) -> None:
+                           rank: Optional[int] = None) -> None:
         if rank is None:
             rank = dist.get_rank(group=group)
         if ops is not None:


### PR DESCRIPTION
Fix #18589
Fix #22840

Changes default parameter of `rank` argument to None instead of 0 in `CustomAllreduce.free_shared_buffer`. It has to be None as by default it the method will just get it from `dist.get_rank()`
```
$ torchrun --nproc_per_node=2 tests/distributed/test_ca_buffer_sharing.py
Rank 1 has pointers [131710626824192, 131710624727040]
Rank 0 has pointers [125588954152960, 125588956250112]
Rank 0 verified all buffers
Rank 1 verified all buffers
```

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

