### PR TITLE
[P/D][NIXL]NixlConnector Reliability Enhancement

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -30,6 +30,8 @@ The class provides the following primitives:
 
         get_finished() - called with ids of finished requests, returns
             ids of requests that have completed async sending/recving.
+        get_failure_requests() - called with scheduler output, returns
+            ids of requests that have failed async transfer.
 """
 
 import enum
@@ -221,6 +223,21 @@ class KVConnectorBase_V1(ABC):
             call to this method (this call or a prior one).
         """
         return None, None
+
+    def get_failure_requests(
+            self, scheduler_output: "SchedulerOutput") -> Optional[set[str]]:
+        """
+        Notifies scheduler-side connector ids of requests that have
+        failed during async transfer on the worker.
+        The scheduler process will use this output to track which 
+        requests have failed.
+
+        Returns:
+            ids of requests that have failed asynchronous transfer
+            The failed req ids must belong to a set provided in a
+            call to get_finished().
+        """
+        return None
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -76,6 +76,7 @@ class KVConnectorOutput:
     # [req_ids]
     finished_sending: Optional[set[str]] = None
     finished_recving: Optional[set[str]] = None
+    failure_request: Optional[set[str]] = None
 
 
 # ModelRunnerOutput is serialized and sent to the scheduler process.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -380,11 +380,12 @@ class Worker(WorkerBase):
         if not kv_connector_output:
             return None
 
-        # In case of PP with kv transfer, we need to pass through the
-        # kv_connector_output
-        if (not kv_connector_output.finished_sending
-                and not kv_connector_output.finished_recving):
-            return EMPTY_MODEL_RUNNER_OUTPUT
+            # In case of PP with kv transfer, we need to pass through the
+            # kv_connector_output
+            if (not kv_connector_output.finished_sending
+                    and not kv_connector_output.finished_recving
+                    and not kv_connector_output.failure_request):
+                return EMPTY_MODEL_RUNNER_OUTPUT
 
         output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
         output.kv_connector_output = kv_connector_output

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -1019,6 +1019,7 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.maybe_wait_for_kv_save()
         finished_sending, finished_recving = (
             self.get_finished_kv_transfers(scheduler_output))
+        failure_request = self.get_failure_requests(scheduler_output)
 
         selected_token_ids = torch.cat(combined_selected_tokens, dim=0)
         if tpu_sampling_metadata.logprobs:
@@ -1107,10 +1108,11 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 req_state.output_token_ids.extend(valid_sampled_token_ids[i])
 
         kv_connector_output = None if (
-            finished_sending is None
-            and finished_recving is None) else KVConnectorOutput(
+            finished_sending is None and finished_recving is None
+            and failure_request is None) else KVConnectorOutput(
                 finished_sending=finished_sending,
                 finished_recving=finished_recving,
+                failure_request=failure_request,
             )
 
         model_runner_output = ModelRunnerOutput(


### PR DESCRIPTION
## Purpose:

This PR introduces robust failure handling for KV transfer operations in vLLM. It adds explicit tracking and management of failed KV transfer requests, ensuring that requests which encounter errors (such as timeouts or transfer failures) are properly surfaced and managed throughout the distributed inference workflow.

**Resolves the following issues:**

1. Lack of clear failure reporting for KV transfer requests in vLLM

2. Potential resource leaks and scheduler inconsistencies due to unhandled KV transfer errors

3. Improves stability in distributed deployments by ensuring failed requests are gracefully skipped and cleaned up

**Key Modifications**

1. kv_connector & scheduler: Added `failure_request` field to track failed KV transfer requests; updated logic to propagate and handle failures across connector, worker, and scheduler components.

2. nixl_connector: Enhanced error detection for transfer timeouts and exceptions; In the NixlConnectorWorker, the `self.xfer_timeout` is used as the threshold for transfer timeout. When a transfer timeout is detected in `_pop_done_transfers` (for example, setting `self.xfer_timeout=1.0` can easily trigger it), an warning message will be immediately reported and the request will be added to `failure_request`.

<img width="1038" height="93" alt="image" src="https://github.com/user-attachments/assets/90e51391-0464-4f83-89be-e9086323a0db" />

```
[nixl_connector.py:895] Transfer 860237472 for request cmpl-e57af9d7-54c7-4b1d-b5c6-24531134b294-0 timed out
```

3. outputs.py: Updated KVConnectorOutput to include failure_request for communication between worker and scheduler.

## Test Plan

```bash
NUM_PREFILL_INSTANCES=1 NUM_DECODE_INSTANCES=1 PREFILLER_TP_SIZE=1 DECODER_TP_SIZE=1 bash v1/kv_connector/nixl_integration/run_accuracy_test.sh
```

## Test Result

passed

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

