### PR TITLE
[CI] Re-enable transcriptions `test_long_audio_request`

### DIFF
--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -80,9 +80,6 @@ async def test_bad_requests(mary_had_lamb):
 async def test_long_audio_request(mary_had_lamb, model_name):
     server_args = ["--enforce-eager"]
 
-    if model_name.startswith("openai"):
-        return
-
     mary_had_lamb.seek(0)
     audio, sr = librosa.load(mary_had_lamb)
     # Add small silence after each audio for repeatability in the split process


### PR DESCRIPTION
This is a cruft from Voxtral integration, this test is supposed to run (and pass) on whisper, but not on Voxtral.
Thanks to @mgoin for reporting.
