### PR TITLE
[Doc] fix dead link

### DIFF
--- a/docs/getting_started/installation/README.md
+++ b/docs/getting_started/installation/README.md
@@ -18,7 +18,7 @@ vLLM supports the following hardware platforms:
 ## Hardware Plugins
 
 The backends below live **outside** the main `vllm` repository and follow the
-[Hardware-Pluggable RFC](../design/plugin_system.md).
+[Hardware-Pluggable RFC](../../design/plugin_system.md).
 
 | Accelerator | PyPI / package | Repository |
 |-------------|----------------|------------|


### PR DESCRIPTION

The `Hardware-Pluggable RFC` link on

https://docs.vllm.ai/en/latest/getting_started/installation/index.html

is currently pointing to a (non-existing)

https://docs.vllm.ai/en/latest/getting_started/design/plugin_system.md

It should be pointing at https://docs.vllm.ai/en/latest/design/plugin_system.html, one level above the current.

Signed-off-by: Daniele Trifirò <dtrifiro@redhat.com>
