### PR TITLE
[BugFix] Fix initial DP request load imbalance

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1121,10 +1121,13 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
     def get_core_engine_for_request(
             self, request: EngineCoreRequest) -> EngineIdentity:
         # Engines are in rank order.
-        current_counts = self.lb_engines
         if (eng_index := request.data_parallel_rank) is None:
+            current_counts = self.lb_engines
             if not current_counts:
-                return self.core_engine
+                # Initialize counts to zero if we haven't yet received any
+                # from the DP coordinator.
+                current_counts = [[0, 0] for _ in self.core_engines]
+                self.lb_engines = current_counts
             # TODO use P2C alg for larger DP sizes
             num_engines = len(current_counts)
             min_score = sys.maxsize

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -965,7 +965,7 @@ class DPAsyncMPClient(AsyncMPClient):
 
         # List of [waiting, running] pair per engine.
         # Used only by DPLBAsyncMPClient subclass.
-        self.lb_engines: list[list[int]] = []
+        self.lb_engines: list[list[int]] = [[0, 0] for _ in self.core_engines]
 
         self.first_req_sock_addr = get_open_zmq_inproc_path()
         self.first_req_send_socket = self.resources.first_req_send_socket = (
@@ -1123,11 +1123,6 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         # Engines are in rank order.
         if (eng_index := request.data_parallel_rank) is None:
             current_counts = self.lb_engines
-            if not current_counts:
-                # Initialize counts to zero if we haven't yet received any
-                # from the DP coordinator.
-                current_counts = [[0, 0] for _ in self.core_engines]
-                self.lb_engines = current_counts
             # TODO use P2C alg for larger DP sizes
             num_engines = len(current_counts)
             min_score = sys.maxsize


### PR DESCRIPTION
The internal DP load-balancing logic currently only sends requests to the first rank until it receives the first stats update from the coordinator. This means that an initial burst of requests after startup can result in a temporary imbalance.

It was causing the load-balancing test to sometimes fail.