### PR TITLE
[gpt-oss] use reasoning channel for reasoning text in serving_chat

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -663,9 +663,9 @@ class OpenAIServingChat(OpenAIServing):
                         harmony_parser = harmony_parsers[i]
                         for token_id in output.token_ids:
                             harmony_parser.process(token_id)
-                        # FIXME(woosuk): Support function calling
-                        is_final = harmony_parser.current_channel == "final"
-                        if not (request.include_reasoning or is_final):
+                        is_reasoning = \
+                            harmony_parser.current_channel == "analysis"
+                        if not request.include_reasoning and is_reasoning:
                             # Skip the reasoning content.
                             continue
                         delta_text = harmony_parser.last_content_delta or ""
@@ -695,11 +695,11 @@ class OpenAIServingChat(OpenAIServing):
                             current_token_ids = as_list(output.token_ids)
 
                     if self.use_harmony:
-                        if is_final:
-                            delta_message = DeltaMessage(content=delta_text)
-                        else:
+                        if is_reasoning:
                             delta_message = DeltaMessage(
                                 reasoning_content=delta_text)
+                        else:
+                            delta_message = DeltaMessage(content=delta_text)
                     # handle streaming deltas for tools with named tool_choice
                     elif tool_choice_function_name:
                         if (self.reasoning_parser and not reasoning_end_arr[i]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose


currently the final channel is used for non-reasoning text, whereas from https://cookbook.openai.com/articles/openai-harmony#channels there is a commentary channel for tools. In this PR we directly use the analysis channel for reasoning text. 

## Test Plan
pytest tests/entrypoints/openai/test_serving_chat.py


## Test Result
================================================= test session starts ==================================================
platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
rootdir: /data/users/yuguo/vllm
configfile: pyproject.toml
plugins: hypothesis-6.131.0, anyio-4.6.2.post1, timeout-2.3.1, subtests-0.14.1, shard-0.1.2, rerunfailures-14.0, mock-3.14.0, forked-1.6.0, asyncio-0.24.0, buildkite-test-collector-0.1.9, schemathesis-3.39.15, hydra-core-1.3.2
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 4 items
Running 4 items in this shard

tests/entrypoints/openai/test_serving_chat.py ....                                                               [100%]
4 passed, 29 warnings in 3.55s
## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

