### PR TITLE
[CI Perf] Prune tests in `tests/kernels/moe/`

### DIFF
--- a/tests/kernels/moe/test_batched_moe.py
+++ b/tests/kernels/moe/test_batched_moe.py
@@ -89,14 +89,11 @@ class BatchedMMTensors:
         return BatchedMMTensors(A, B, C, num_expert_tokens)
 
 
-@pytest.mark.parametrize("num_experts", [8, 16, 32])
-@pytest.mark.parametrize("max_tokens_per_expert",
-                         [32, 64, 128, 192, 224, 256, 512])
-@pytest.mark.parametrize("K", [128, 256, 1024])
-@pytest.mark.parametrize("N", [128, 256, 1024])
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float8_e4m3fn, torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_experts", [8, 32])
+@pytest.mark.parametrize("max_tokens_per_expert", [32, 224, 512])
+@pytest.mark.parametrize("K", [128, 1024])
+@pytest.mark.parametrize("N", [128, 1024])
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.bfloat16])
 @pytest.mark.parametrize("block_shape", [None, [128, 128]])
 @pytest.mark.parametrize("per_act_token_quant", [False, True])
 def test_batched_mm(num_experts: int, max_tokens_per_expert: int, K: int,

--- a/tests/kernels/moe/test_count_expert_num_tokens.py
+++ b/tests/kernels/moe/test_count_expert_num_tokens.py
@@ -113,8 +113,7 @@ def do_test_compute_expert_num_tokens(num_tokens: int, num_topk: int,
                                    rtol=0)
 
 
-@pytest.mark.parametrize(
-    "num_tokens", [1, 4, 8, 11, 19, 128, 127, 405, 1024, 3333, 6666, 7317])
+@pytest.mark.parametrize("num_tokens", [1, 4, 8, 11, 127, 128, 3333, 7317])
 @pytest.mark.parametrize("num_topk", [2, 6, 8])
 @pytest.mark.parametrize("num_experts", [64])
 @pytest.mark.parametrize("ep_size", [1, 2, 4])
@@ -126,7 +125,7 @@ def test_compute_expert_num_tokens(num_tokens: int, num_topk: int,
                                       ep_size, topk_ids_dtype)
 
 
-@pytest.mark.parametrize("numel", list(range(1, 8192, 11)))
+@pytest.mark.parametrize("numel", list(range(1, 8192, 111)))
 @pytest.mark.parametrize("num_experts", [32])
 @pytest.mark.parametrize("ep_size", [2])
 @pytest.mark.parametrize("topk_ids_dtype", [torch.int64])

--- a/tests/kernels/moe/test_moe_align_block_size.py
+++ b/tests/kernels/moe/test_moe_align_block_size.py
@@ -15,10 +15,10 @@ from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
 from vllm.platforms import current_platform
 from vllm.utils import round_up
 
-NUM_TOKENS = [1, 3, 7, 16, 256, 2256, 4096]
-NUM_EXPERTS = [32, 160, 256, 257, 512]
+NUM_TOKENS = [1, 3, 256, 2256, 4096]
+NUM_EXPERTS = [32, 160, 256, 257]
 TOP_KS = [1, 2, 16, 32]
-BLOCK_SIZES = [32, 64, 128, 256]
+BLOCK_SIZES = [32, 128]
 current_platform.seed_everything(0)
 
 

--- a/tests/kernels/moe/test_moe_permute_unpermute.py
+++ b/tests/kernels/moe/test_moe_permute_unpermute.py
@@ -18,7 +18,7 @@ from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
 from vllm.platforms import current_platform
 
 NUM_EXPERTS = [16, 64, 256]
-TOP_KS = [2, 4, 6, 8]
+TOP_KS = [2, 6, 8]
 EP_SIZE = [1, 4, 16]
 current_platform.seed_everything(0)
 
@@ -177,11 +177,11 @@ def torch_unpermute(permuted_hidden_states: torch.Tensor,
     return output
 
 
-@pytest.mark.parametrize("n_token", [1, 33, 64, 222, 1024, 2048, 3000, 5000])
-@pytest.mark.parametrize("n_hidden", [2048, 4096, 7168])
+@pytest.mark.parametrize("n_token", [1, 33, 1024, 5000])
+@pytest.mark.parametrize("n_hidden", [2048, 7168])
 @pytest.mark.parametrize("n_expert", NUM_EXPERTS)
 @pytest.mark.parametrize("topk", TOP_KS)
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("ep_size", EP_SIZE)
 @pytest.mark.parametrize("align_block_size", [None, 128])
 def test_moe_permute_unpermute(n_token: int, n_hidden: int, topk: int,

--- a/tests/kernels/moe/test_pplx_moe.py
+++ b/tests/kernels/moe/test_pplx_moe.py
@@ -44,6 +44,14 @@ requires_pplx = pytest.mark.skipif(
     reason="Requires PPLX kernels",
 )
 
+BATCHED_MOE_MNK_FACTORS = [
+    (1, 128, 128),
+    (33, 2048, 128),
+    (64, 128, 2048),
+    (222, 128, 128),
+    (222, 2048, 1024),
+]
+
 PPLX_COMBOS = [
     # TODO: figure out why this fails, seems to be test problem
     #(1, 128, 128),
@@ -152,9 +160,7 @@ def torch_batched_moe(
     return torch_finalize(out, topk_weight, topk_ids)
 
 
-@pytest.mark.parametrize("m", [1, 33, 64, 222])
-@pytest.mark.parametrize("n", [128, 1024, 2048])
-@pytest.mark.parametrize("k", [128, 512, 1024])
+@pytest.mark.parametrize("m,n,k", BATCHED_MOE_MNK_FACTORS)
 @pytest.mark.parametrize("e", NUM_EXPERTS)
 @pytest.mark.parametrize("topk", TOP_KS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

```
pytest --collect-only -qq tests/kernels/moe

# main
tests/kernels/moe/test_batched_deepgemm.py: 32
tests/kernels/moe/test_batched_moe.py: 3936
tests/kernels/moe/test_block_fp8.py: 450
tests/kernels/moe/test_block_int8.py: 224
tests/kernels/moe/test_count_expert_num_tokens.py: 853
tests/kernels/moe/test_cutlass_grouped_gemm.py: 6
tests/kernels/moe/test_cutlass_moe.py: 462
tests/kernels/moe/test_deepep_deepgemm_moe.py: 34
tests/kernels/moe/test_deepep_moe.py: 56
tests/kernels/moe/test_deepgemm.py: 12
tests/kernels/moe/test_modular_kernel_combinations.py: 108
tests/kernels/moe/test_moe.py: 9105
tests/kernels/moe/test_moe_align_block_size.py: 1125
tests/kernels/moe/test_moe_permute_unpermute.py: 3456
tests/kernels/moe/test_mxfp4_moe.py: 3
tests/kernels/moe/test_nvfp4_moe.py: 180
tests/kernels/moe/test_pplx_cutlass_moe.py: 32
tests/kernels/moe/test_pplx_moe.py: 986
tests/kernels/moe/test_rocm_aiter_topk.py: 4
tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py: 5
tests/kernels/moe/test_triton_moe_ptpc_fp8.py: 32

# pr
tests/kernels/moe/test_batched_deepgemm.py: 32
tests/kernels/moe/test_batched_moe.py: 1104
tests/kernels/moe/test_block_fp8.py: 450
tests/kernels/moe/test_block_int8.py: 224
tests/kernels/moe/test_count_expert_num_tokens.py: 146
tests/kernels/moe/test_cutlass_grouped_gemm.py: 6
tests/kernels/moe/test_cutlass_moe.py: 462
tests/kernels/moe/test_deepep_deepgemm_moe.py: 34
tests/kernels/moe/test_deepep_moe.py: 56
tests/kernels/moe/test_deepgemm.py: 12
tests/kernels/moe/test_modular_kernel_combinations.py: 108
tests/kernels/moe/test_moe.py: 3701
tests/kernels/moe/test_moe_align_block_size.py: 325
tests/kernels/moe/test_moe_permute_unpermute.py: 432
tests/kernels/moe/test_mxfp4_moe.py: 3
tests/kernels/moe/test_nvfp4_moe.py: 180
tests/kernels/moe/test_pplx_cutlass_moe.py: 32
tests/kernels/moe/test_pplx_moe.py: 800
tests/kernels/moe/test_rocm_aiter_topk.py: 4
tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py: 5
tests/kernels/moe/test_triton_moe_ptpc_fp8.py: 32
```

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

