### PR TITLE
[Core] direct indexing on self.block_table_np in compute_slot_mapping

### DIFF
--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -91,8 +91,7 @@ class BlockTable:
         # block_size.
         block_table_indices = (req_indices * self.max_num_blocks_per_req +
                                positions // self.block_size)
-        block_table_cpu = self.get_cpu_tensor()
-        block_numbers = block_table_cpu.flatten()[block_table_indices].numpy()
+        block_numbers = self.block_table_np.ravel()[block_table_indices]
         block_offsets = positions % self.block_size
         np.add(block_numbers * self.block_size,
                block_offsets,


### PR DESCRIPTION
## Purpose
Streamline slot mapping computation by replacing Torch tensor flattening and conversion with direct NumPy indexing via `ravel`, eliminating redundant copies and conversions

## Test Plan
```
# vLLM Serving
VLLM_USE_V1=1 vllm serve facebook/opt-125m \
    --swap-space 16 \
    --disable-log-requests \
    --host :: \
    --dtype float16

# Capture traces
VLLM_USE_V1=1 vllm bench serve \
    --dataset-name random \
    --model facebook/opt-125m \
    --served-model-name facebook/opt-125m \
    --random-input-len 700 \
    --random-output-len 1 \
    --endpoint /v1/completions \
    --ignore-eos \
    --host localhost \
    --port 8000 \
    --num-prompts 100 \
    --profile
```

Also ran throughput benchmark test:
```
CUDA_VISIBLE_DEVICES=7 VLLM_USE_V1=1 python3 benchmarks/benchmark_throughput.py \
    --model facebook/opt-125m \
    --backend vllm \
    --input-len 800 \
    --output-len 75 \
    --num-prompts 30000
```



## Test Result

Reduced `compute_slot_mapping` from 400+μs to 15-30μs.
Throughput improved 2.07% for opt-125m with input=800 and output=75

Before:
Throughput: 268.45 requests/s, 234888.85 total tokens/s, 20133.98 output tokens/s

<img width="1216" height="535" alt="image" src="https://github.com/user-attachments/assets/355a7899-245b-4bef-b7f3-8f34265ab219" />

After:
Throughput: 274.01 requests/s, 239750.19 total tokens/s, 20550.72 output tokens/s
<img width="1450" height="535" alt="image" src="https://github.com/user-attachments/assets/fa919447-5ac8-4ea1-832f-af5523bab602" />

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

