### PR TITLE
[Frontend] Avoid list copies in `serving_chat.py`

### DIFF
--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -44,7 +44,7 @@ class ReasoningParser:
         return self.model_tokenizer.get_vocab()
 
     @abstractmethod
-    def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
         """
         Check if the reasoning content ends in the input_ids.
 

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1314,6 +1314,11 @@ def common_broadcastable_dtype(dtypes: Collection[torch.dtype]):
     )
 
 
+def as_list(maybe_list: Iterable[T]) -> list[T]:
+    """Convert iterable to list, unless it's already a list."""
+    return maybe_list if isinstance(maybe_list, list) else list(maybe_list)
+
+
 # `collections` helpers
 def is_list_of(
     value: object,


### PR DESCRIPTION
Lots of unnecessary copies. I think `output.token_ids` will always already be a list anyhow in v1.

Noticed while reviewing other PRs.