### PR TITLE
[Bugfix]Fix EEP scale-up functionality

### DIFF
--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -565,14 +565,13 @@ class EplbState:
             # Update expert_load_pass tensor size to match
             # model.num_physical_experts
             current_num_experts = self.expert_load_pass.size(-1)
-            if model.num_physical_experts > current_num_experts:
-                padding_needed = (model.num_physical_experts -
-                                  current_num_experts)
+            if num_physical_experts > current_num_experts:
+                padding_needed = (num_physical_experts - current_num_experts)
                 self.expert_load_pass = torch.nn.functional.pad(
                     self.expert_load_pass, (0, padding_needed))
-            elif model.num_physical_experts < current_num_experts:
+            elif num_physical_experts < current_num_experts:
                 self.expert_load_pass = self.expert_load_pass[
-                    ..., :model.num_physical_experts]
+                    ..., :num_physical_experts]
             model.update_expert_load_view(self.expert_load_pass)
 
         if is_main_rank:

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -409,10 +409,7 @@ class EplbState:
             self.expert_rearrangement_step = 0
             self.rearrange(model)
 
-    def _update_expert_tensors_size(
-            self,
-            model: MixtureOfExperts,
-            num_local_physical_experts: Optional[int] = None) -> None:
+    def _update_expert_tensors_size(self, model: MixtureOfExperts) -> None:
         """
         Update the size of expert-related tensors to match
         model.num_physical_experts. This ensures tensors are properly sized
@@ -420,8 +417,6 @@ class EplbState:
 
         Args:
             model: The MoE model instance
-            num_local_physical_experts: Optional new number of local physical
-                experts. If None, uses model.num_local_physical_experts.
         """
         current_size = self.expert_load_pass.size(-1)
         target_size = model.num_physical_experts

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -409,42 +409,6 @@ class EplbState:
             self.expert_rearrangement_step = 0
             self.rearrange(model)
 
-    def _update_expert_tensors_size(self, model: MixtureOfExperts) -> None:
-        """
-        Update the size of expert-related tensors to match
-        model.num_physical_experts. This ensures tensors are properly sized
-        when the number of physical experts changes.
-
-        Args:
-            model: The MoE model instance
-        """
-        current_size = self.expert_load_pass.size(-1)
-        target_size = model.num_physical_experts
-
-        if current_size != target_size:
-            logger.debug("Updating expert_load_pass tensor size from %d to %d",
-                         current_size, target_size)
-
-            # Resize expert_load_pass tensor
-            if current_size < target_size:
-                # Expand tensor by padding with zeros
-                padding_needed = target_size - current_size
-                self.expert_load_pass = torch.nn.functional.pad(
-                    self.expert_load_pass, (0, padding_needed))
-            else:
-                # Truncate tensor to target size
-                self.expert_load_pass = self.expert_load_pass[
-                    ..., :target_size]
-
-            # Update expert load view in the model if supported
-            if hasattr(model, 'update_expert_load_view'):
-                logger.debug("Calling model.update_expert_load_view with "
-                             "resized expert_load_pass tensor")
-                model.update_expert_load_view(self.expert_load_pass)
-            else:
-                logger.warning("Model does not support "
-                               "update_expert_load_view interface")
-
     def rearrange(self,
                   model: MixtureOfExperts,
                   is_profile: bool = False,
@@ -467,10 +431,6 @@ class EplbState:
                         "(profile)" if is_profile else "")
 
         if global_expert_load is None:
-            # Update expert_load_pass tensor size to match
-            # model.num_physical_experts
-            self._update_expert_tensors_size(model)
-
             # This mapping is only used here, so we do not store it in the
             # state
             if self.physical_to_logical_map.size(
@@ -488,8 +448,6 @@ class EplbState:
             else:
                 local_physical_to_logical_map = (self.physical_to_logical_map[
                     ..., :model.num_physical_experts])
-                self.expert_load_window = self.expert_load_window[
-                    ..., :model.num_physical_experts]
 
             # Map the local physical expert load to global logical experts
             logical_expert_load_window = torch.zeros(
@@ -598,6 +556,24 @@ class EplbState:
             )
             self.logical_to_physical_map.copy_(new_logical_to_physical_map)
             self.logical_replica_count.copy_(new_logical_replica_count)
+
+            num_physical_experts = self.physical_to_logical_map.shape[-1]
+            if num_physical_experts < self.expert_load_window.shape[-1]:
+                self.expert_load_window = self.expert_load_window[
+                    ..., :num_physical_experts]
+
+            # Update expert_load_pass tensor size to match
+            # model.num_physical_experts
+            current_num_experts = self.expert_load_pass.size(-1)
+            if model.num_physical_experts > current_num_experts:
+                padding_needed = (model.num_physical_experts -
+                                  current_num_experts)
+                self.expert_load_pass = torch.nn.functional.pad(
+                    self.expert_load_pass, (0, padding_needed))
+            elif model.num_physical_experts < current_num_experts:
+                self.expert_load_pass = self.expert_load_pass[
+                    ..., :model.num_physical_experts]
+            model.update_expert_load_view(self.expert_load_pass)
 
         if is_main_rank:
             assert time_start is not None

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1370,6 +1370,23 @@ class FusedMoE(CustomOp):
         self.logical_to_physical_map = logical_to_physical_map[moe_layer_idx]
         self.logical_replica_count = logical_replica_count[moe_layer_idx]
 
+    def update_expert_load_view(
+        self,
+        moe_layer_idx: int,
+        expert_load_view: torch.Tensor,
+    ) -> None:
+        """
+        Update the expert load view tensor for this layer.
+        
+        Args:
+            moe_layer_idx (int): The index of this MoE layer.
+            expert_load_view (torch.Tensor): The new expert load view tensor.
+                                Shape: (num_moe_layers, num_physical_experts)
+        """
+        if (expert_load_view is not None
+                and moe_layer_idx < expert_load_view.size(0)):
+            self.expert_load_view = expert_load_view[moe_layer_idx]
+
     @staticmethod
     def select_experts(
         hidden_states: torch.Tensor,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -823,6 +823,20 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
                 moe.n_redundant_experts = self.num_redundant_experts
                 moe.experts.update_expert_map()
 
+    def update_expert_load_view(
+        self,
+        expert_load_view: torch.Tensor,
+    ) -> None:
+        """
+        Update the expert load view tensor in the MoE model.
+        
+        Args:
+            expert_load_view: A tensor containing expert load metrics.
+                            Shape: (num_moe_layers, num_physical_experts)
+        """
+        for layer_idx, layer in enumerate(self.moe_layers):
+            layer.update_expert_load_view(layer_idx, expert_load_view)
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -655,6 +655,20 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
                 logical_replica_count=logical_replica_count,
             )
 
+    def update_expert_load_view(
+        self,
+        expert_load_view: torch.Tensor,
+    ) -> None:
+        """
+        Update the expert load view tensor in the MoE model.
+        
+        Args:
+            expert_load_view: A tensor containing expert load metrics.
+                            Shape: (num_moe_layers, num_physical_experts)
+        """
+        for layer_idx, layer in enumerate(self.moe_layers):
+            layer.update_expert_load_view(layer_idx, expert_load_view)
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -585,6 +585,24 @@ class MixtureOfExperts(Protocol):
     ) -> None:
         ...
 
+    def update_expert_load_view(
+        self,
+        expert_load_view: Tensor,
+    ) -> None:
+        """
+        Update the expert load view tensor in the MoE model.
+        
+        This method allows updating the expert load metrics tensor that tracks
+        the load (e.g., token count) processed by each physical expert during
+        inference. This is useful when the expert load view tensor needs to be
+        resized or updated due to changes in the number of physical experts.
+        
+        Args:
+            expert_load_view: A tensor containing expert load metrics.
+                            Shape: (num_moe_layers, num_physical_experts)
+        """
+        ...
+
 
 def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:
     return isinstance(model, MixtureOfExperts)

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -652,6 +652,20 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA,
                 moe.n_redundant_experts = self.num_redundant_experts
                 moe.experts.update_expert_map()
 
+    def update_expert_load_view(
+        self,
+        expert_load_view: torch.Tensor,
+    ) -> None:
+        """
+        Update the expert load view tensor in the MoE model.
+        
+        Args:
+            expert_load_view: A tensor containing expert load metrics.
+                            Shape: (num_moe_layers, num_physical_experts)
+        """
+        for layer_idx, layer in enumerate(self.moe_layers):
+            layer.update_expert_load_view(layer_idx, expert_load_view)
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -222,6 +222,8 @@ class DPCoordinatorProc:
                 events = dict(events)
                 wave_state_changed = False
 
+                # Dynamic scaling engines will send messages
+                # to the back socket. So just reply with "READY"
                 if publish_back in events:
                     buffer = publish_back.recv()
                     if buffer == b"\x01":

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -189,6 +189,7 @@ class DPCoordinatorProc:
             poller = zmq.Poller()
             poller.register(publish_front, zmq.POLLIN)
             poller.register(output_back, zmq.POLLIN)
+            poller.register(publish_back, zmq.POLLIN)
             last_publish_time = 0
             while True:
                 elapsed = int(time.time() * 1000) - last_publish_time
@@ -220,6 +221,11 @@ class DPCoordinatorProc:
 
                 events = dict(events)
                 wave_state_changed = False
+
+                if publish_back in events:
+                    buffer = publish_back.recv()
+                    if buffer == b"\x01":
+                        publish_back.send(b"READY")
 
                 if publish_front in events:
                     buffer = publish_front.recv()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -865,6 +865,9 @@ class EngineCoreProc(EngineCore):
                     # (RequestType, RequestData)
                     type_frame, *data_frames = input_socket.recv_multipart(
                         copy=False)
+                    if type_frame.buffer == b"READY":
+                        # This may occur when dp scale-up, so just ignore it.
+                        continue
                     request_type = EngineCoreRequestType(
                         bytes(type_frame.buffer))
 


### PR DESCRIPTION

## Purpose
Since #22167 and #21538 , Elastic Expert Parallelism's scaling up function is broken. Just fix it here.
## Test Plan
Deepseek-V2-Lite dp size 4->5
## Test Result
Scale success and inference is functional afterwards.
## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

