### PR TITLE
[BugFix] pp cannot run successfully under NixlConnector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -85,6 +85,7 @@ class ReqMeta:
     remote_port: int
     remote_engine_id: str
     tp_size: int
+    pp_size: int
 
 
 class NixlConnectorMetadata(KVConnectorMetadata):
@@ -112,6 +113,7 @@ class NixlConnectorMetadata(KVConnectorMetadata):
             remote_port=kv_transfer_params["remote_port"],
             # P workers don't need to receive tp_size from proxy here.
             tp_size=kv_transfer_params.get("tp_size", 1),
+            pp_size=kv_transfer_params.get("pp_size", 1)
         )
         if save_to_host:
             self.reqs_to_save[request_id] = _req
@@ -415,7 +417,8 @@ class NixlConnectorScheduler:
             remote_engine_id=self.engine_id,
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
-            tp_size=self.vllm_config.parallel_config.tensor_parallel_size)
+            tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            pp_size=self.vllm_config.parallel_config.pipeline_parallel_size)
 
 
 class NixlConnectorWorker:
@@ -434,8 +437,9 @@ class NixlConnectorWorker:
 
         # Agent.
         self.nixl_wrapper = NixlWrapper(str(uuid.uuid4()), None)
-        # Map of engine_id -> {rank0: agent_name0, rank1: agent_name1..}.
-        self._remote_agents: dict[EngineId, dict[int, str]] = defaultdict(dict)
+        # Map of engine_id -> {pprank0: {{rank0: agent_name0, rank1: agent_name1}},
+        #                      pprank1: {{rank0: agent_name2, rank1: agent_name3..}..}.
+        self._remote_agents: dict[EngineId, dict[int, dict[int, str]]] = defaultdict(dict)
 
         # NIXL handshake port.
         # NOTE(rob): Within a DP group, each DP rank gets its own
@@ -520,7 +524,7 @@ class NixlConnectorWorker:
             max_workers=1,
             thread_name_prefix="vllm-nixl-handshake-initiator")
         self._ready_requests = queue.Queue[tuple[ReqId, ReqMeta]]()
-        self._handshake_futures: dict[EngineId, Future[dict[int, str]]] = {}
+        self._handshake_futures: dict[EngineId, dict[int, Future[dict[int, str]]]] = {}
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
 
@@ -593,6 +597,7 @@ class NixlConnectorWorker:
         host: str,
         port: int,
         remote_tp_size: int,
+        remote_pp_size: int,
         expected_engine_id: str,
     ) -> dict[int, str]:
         """Do a NIXL handshake with a remote instance."""
@@ -606,10 +611,11 @@ class NixlConnectorWorker:
         # Handshake only with the remote TP rank that current local rank will
         # pull from. With homogeneous TP it happens to be the same rank_i.
         tp_ratio = self._tp_size[self.engine_id] // remote_tp_size
-        p_remote_rank = self.tp_rank // tp_ratio
-        path = make_zmq_path("tcp", host, port + p_remote_rank)
-        logger.debug("Querying metadata on path: %s at remote rank %s", path,
-                     p_remote_rank)
+        p_remote_tp_rank = self.tp_rank // tp_ratio
+        p_remote_pp_rank = self.pp_rank # don't support homogeneous PP
+        path = make_zmq_path("tcp", host, port + remote_tp_size * p_remote_pp_rank + p_remote_tp_rank)
+        logger.debug("Querying metadata on path: %s at remote tp rank %s, remote pp rank %s", path,
+                     p_remote_tp_rank, p_remote_pp_rank)
 
         # Send query for the request.
         with zmq_ctx(zmq.REQ, path) as sock:
@@ -628,14 +634,15 @@ class NixlConnectorWorker:
                                    f"received {metadata.engine_id}.")
 
             # Register Remote agent.
-            remote_agent_name = self.add_remote_agent(metadata, p_remote_rank,
-                                                      remote_tp_size)
+            remote_agent_name = self.add_remote_agent(metadata, p_remote_tp_rank,
+                                                      remote_tp_size, p_remote_pp_rank,
+                                                      remote_pp_size)
             setup_agent_time = time.perf_counter()
             logger.debug("NIXL handshake: add agent took: %s",
                          setup_agent_time - got_metadata_time)
 
         # Remote rank -> agent name.
-        return {p_remote_rank: remote_agent_name}
+        return {p_remote_tp_rank: remote_agent_name}
 
     def initialize_host_xfer_buffer(
             self, kv_caches: dict[str, torch.Tensor]) -> None:
@@ -669,14 +676,14 @@ class NixlConnectorWorker:
         if fut is None:
             fut = self._handshake_initiation_executor.submit(
                 self._nixl_handshake, meta.remote_host, meta.remote_port,
-                meta.tp_size, remote_engine_id)
-            self._handshake_futures[remote_engine_id] = fut
+                meta.tp_size, meta.pp_size, remote_engine_id)
+            self._handshake_futures[remote_engine_id] = {self.pp_rank : fut}
 
             def done_callback(f: Future[dict[int, str]], eid=remote_engine_id):
                 with self._handshake_lock:
-                    del self._handshake_futures[eid]
+                    del self._handshake_futures[eid][self.pp_rank]
                     try:
-                        self._remote_agents[eid] = f.result()
+                        self._remote_agents[eid][self.pp_rank] = f.result()
                     except Exception:
                         logger.exception("Handshake with %s failed", eid)
 
@@ -833,10 +840,13 @@ class NixlConnectorWorker:
         self._nixl_handshake_listener_t.start()
         ready_event.wait()  # Wait for listener ZMQ socket to be ready.
 
+
     def add_remote_agent(self,
                          nixl_agent_meta: NixlAgentMetadata,
                          remote_tp_rank: int = 0,
-                         remote_tp_size: int = 1) -> str:
+                         remote_tp_size: int = 1,
+                         remote_pp_rank: int = 0,
+                         remote_pp_size: int = 1) -> str:
         """
         Add the remote NIXL agent and prepare the descriptors for reading cache
         blocks from remote.
@@ -848,21 +858,29 @@ class NixlConnectorWorker:
 
         Here's an example:
 
-        rank_offset     p_remote_tp_rank
+        rank_offset   p_remote_tp_rank    p_remote_pp_rank 
         (kv split no)    
-        --------------------------------
-            0                 0      Worker0  ---- 1st half of KV ----> Worker0  [ KV Cache ]
-                                                                        /
-            1                 0      Worker1  ---- 2nd half of KV -----/
+        ---------------------------------------------------------------
+            0                 0                  0             Worker0  ---- 1st half of KV ----> Worker0  [ KV Cache ]
+                                                                                                  /
+            1                 0                  0             Worker1  ---- 2nd half of KV -----/
 
-            0                 1      Worker2  ---- 1st half of KV ----> Worker1  [ KV Cache ]
-                                                                        /
-            1                 1      Worker3  ---- 2nd half of KV -----/
+            0                 1                  0             Worker2  ---- 1st half of KV ----> Worker1  [ KV Cache ]
+                                                                                                  /
+            1                 1                  0             Worker3  ---- 2nd half of KV -----/
 
 
                                 Decoder TP workers                     Prefix TP workers
                                   (world_size=4)                         (world_size=2)
                                                  tp_ratio = 4 // 2 = 2                  
+
+            0                 0                  1             Worker4  ---- 1st half of KV ----> Worker2  [ KV Cache ]
+                                                                                                  /
+            1                 0                  1             Worker5  ---- 2nd half of KV -----/
+
+            0                 1                  1             Worker6  ---- 1st half of KV ----> Worker3  [ KV Cache ]
+                                                                                                  /
+            1                 1                  1             Worker7  ---- 2nd half of KV -----/
                                 
         Considering the KV Caches, if P-Worker_i has cache size [2, num_blocksP, kv_heads, block_size, head_dim]  
         then D-Worker_j has [2, num_blocksD, kv_heads//tp_ratio, block_size, head_dim]. Mind the "HND" layout format.
@@ -877,8 +895,8 @@ class NixlConnectorWorker:
         """ # noqa: E501
         engine_id = nixl_agent_meta.engine_id
         # TODO re-evaluate refreshing for scaling/recovery
-        if remote_tp_rank in self._remote_agents.get(engine_id, {}):
-            return self._remote_agents[engine_id][remote_tp_rank]
+        if remote_tp_rank in self._remote_agents.get(engine_id, {}).get(remote_pp_rank, {}):
+            return self._remote_agents[engine_id][remote_pp_rank][remote_tp_rank]
 
         if engine_id not in self._tp_size:
             self._tp_size[engine_id] = remote_tp_size
@@ -951,11 +969,12 @@ class NixlConnectorWorker:
                 # self.block_len == remote_block_len//tp_ratio bytes.
                 addr = base_addr + block_offset + rank_offset
                 # (addr, len, device id)
-                blocks_data.append((addr, self.block_len, remote_tp_rank))
+                # blocks_data.append((addr, self.block_len, remote_tp_rank))
+                blocks_data.append((addr, self.block_len, remote_tp_rank + remote_pp_rank * remote_tp_size))
         logger.debug(
             "Created %s blocks for dst engine %s with remote rank %s and "
-            "local rank %s", len(blocks_data), engine_id, remote_tp_rank,
-            self.tp_rank)
+            "tp local rank %s, device id %s", len(blocks_data), engine_id, remote_tp_rank,
+            self.tp_rank, remote_tp_rank + remote_pp_rank * remote_tp_size)
 
         # Register with NIXL.
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data,
@@ -1005,8 +1024,8 @@ class NixlConnectorWorker:
         done_recving = self._pop_done_transfers(self._recving_transfers)
         if len(done_sending) > 0 or len(done_recving) > 0:
             logger.debug(
-                "Rank %s, get_finished: %s requests done sending "
-                "and %s requests done recving", self.tp_rank,
+                "TP Rank %s, PP Rank %s, get_finished: %s requests done sending "
+                "and %s requests done recving", self.tp_rank, self.pp_rank,
                 len(done_sending), len(done_recving))
 
         if self.use_host_buffer:
@@ -1074,8 +1093,10 @@ class NixlConnectorWorker:
                 xfer_state = self.nixl_wrapper.check_xfer_state(handle)
                 if xfer_state == "DONE":
                     self.nixl_wrapper.release_xfer_handle(handle)
+                    logger.info(f"============transfer req_id {req_id} done")
                 elif xfer_state == "PROC":
                     in_progress = True
+                    logger.info(f"============transfer req_id {req_id} processing")
                     continue
                 else:
                     raise RuntimeError("Transfer failed with state %s",
@@ -1152,7 +1173,8 @@ class NixlConnectorWorker:
         num_local_blocks = len(local_block_ids)
         if num_local_blocks == 0:
             remote_rank = self.tp_rank // tp_ratio
-            agent_name = self._remote_agents[dst_engine_id][remote_rank]
+            remote_pp_rank = self.pp_rank # don't consider heterogeneous PP now
+            agent_name = self._remote_agents[dst_engine_id][remote_pp_rank][remote_rank]
             self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
             return
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -307,6 +307,11 @@ class GroupCoordinator:
         return self.ranks[(rank_in_group + 1) % world_size]
 
     @property
+    def current_rank(self):
+        """Return the current rank of the process"""
+        return self.rank
+
+    @property
     def prev_rank(self):
         """Return the global rank of the process that precedes the caller"""
         rank_in_group = self.rank_in_group
@@ -1229,6 +1234,14 @@ def get_tensor_model_parallel_rank():
 def get_pipeline_model_parallel_rank():
     """Return my rank for the pipeline model parallel group."""
     return get_pp_group().rank_in_group
+
+
+def get_rank():
+    """Return rank for the dp group."""
+    global _WORLD
+    if _WORLD is not None:
+        return _WORLD.current_rank
+    return 0
 
 
 def get_node_count() -> int:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1226,6 +1226,11 @@ def get_tensor_model_parallel_rank():
     return get_tp_group().rank_in_group
 
 
+def get_pipeline_model_parallel_rank():
+    """Return my rank for the pipeline model parallel group."""
+    return get_pp_group().rank_in_group
+
+
 def get_node_count() -> int:
     """Return the total number of nodes in the distributed environment. """
     assert _NODE_COUNT is not None, (

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -143,6 +143,15 @@ try:
                 assert not output or not output.req_ids
                 output = scheduler_output, None
             return output
+        
+        def pull_kvcache_ray(
+            self,
+            scheduler_output: "SchedulerOutput") -> "ModelRunnerOutput":
+            assert self.worker is not None, "Worker is not initialized"
+
+            output = self.worker.model_runner.pull_kvcache(
+                scheduler_output)
+            return output
 
         def override_env_vars(self, vars: Dict[str, str]):
             os.environ.update(vars)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1731,7 +1731,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             req_id = req_ids[req_idx]
             req_state = self.requests[req_id]
             req_state.output_token_ids.extend(sampled_ids)
-
+        logger.info(f"======step valid_sampled_token_ids {valid_sampled_token_ids}")
         if self.speculative_config:
             assert spec_decode_common_attn_metadata is not None
             self._draft_token_ids = self.propose_draft_token_ids(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -350,6 +350,13 @@ class Worker(WorkerBase):
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.model_runner.get_supported_tasks()
+    
+    def pull_kvcache(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> ModelRunnerOutput:
+        output = self.model_runner.pull_kvcache(scheduler_output)
+        return output
 
     @torch.inference_mode()
     def execute_model(
@@ -362,7 +369,6 @@ class Worker(WorkerBase):
             intermediate_tensors = IntermediateTensors(
                 get_pp_group().recv_tensor_dict(
                     all_gather_group=get_tp_group()))
-
         output = self.model_runner.execute_model(scheduler_output,
                                                  intermediate_tensors)
         if isinstance(output, ModelRunnerOutput):

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -90,7 +90,6 @@ class KVConnectorModelRunnerMixin:
         wait_for_save: bool = True
     ) -> Generator[KVConnectorOutput, None, None]:
         output = KVConnectorOutput()
-
         # Update KVConnector with the KVConnector metadata forward().
         kv_connector = get_kv_transfer_group()
         assert isinstance(kv_connector, KVConnectorBase)

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -932,6 +932,16 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # then the embedding layer is not included in the CUDA graph.
             return input_ids, None
 
+    def pull_kvcache(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> ModelRunnerOutput:
+        if not has_kv_transfer_group():
+            # Return empty ModelRunnerOutput if there's no work to do.
+            return EMPTY_MODEL_RUNNER_OUTPUT
+
+        return self.kv_connector_no_forward(scheduler_output, self.vllm_config)
+
     @torch.no_grad()
     def execute_model(
         self,


### PR DESCRIPTION
[BugFix] pp cannot run successfully under NixlConnector 


## Purpose
I previously raised issue #22430 regarding NixlConnector failing with Pipeline Parallelism (PP) + Prefill-Decode (PD) configurations, but it hasn't received attention from the community yet. Since I need PP functionality for my project and my benchmarks show that NixlConnector delivers significantly better performance than LMCacheConnector, I'm motivated to contribute a fix.

My testing on Qwen 2.5 7B demonstrates NixlConnector's clear advantage:

Configuration | TTFT (ms) | Improvement
-- | -- | --
PP1 + TP2 + PD + LMCache | 13,900.61 | Baseline
PP1 + TP2 + PD + Nixl | 10,333.13 | 25.7% faster

The error occurs during KV cache initialization when ```nixl_wrapper.register_memory()``` is called in a Pipeline Parallelism setup. After investigating the codebase, I discovered that the current implementation only considers Tensor Parallelism (TP) when initializing KV caches. 
<img width="440" height="113.5" alt="image" src="https://github.com/user-attachments/assets/6f9d40dc-9714-4141-9b62-9680dd38206f" />
<img width="488" height="296.5" alt="image" src="https://github.com/user-attachments/assets/f9131903-5609-4454-a65d-1e39ae86dc01" />


When registering cache data with NIXL, different PP stages that share the same TP rank are assigned to the same device ID. This causes device conflicts during PP memory registration, leading to the ```NIXL_ERR_BACKEND``` failure. Therefore, I modified the device ID assignment from using TP rank to automatically detecting the current device using ```torch.cuda.current_device()```.


## Test Plan
Tested by running the model under PP + NixlConnector for both PD disaggregation and PD aggregation scenarios.

## Test Result

The error no longer occurs.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

