### PR TITLE
[ROCm][Bugfix] Add missing max_qlen argument

### DIFF
--- a/vllm/attention/ops/rocm_aiter_paged_attn.py
+++ b/vllm/attention/ops/rocm_aiter_paged_attn.py
@@ -97,6 +97,6 @@ class AITERPagedAttention(PagedAttention):
         max_num_blocks_per_seq = cdiv(max_seq_len, block_size)
 
         rocm_aiter.pa_fwd_asm(query, key_cache, value_cache, block_tables,
-                              seq_lens, max_num_blocks_per_seq, k_scale,
+                              seq_lens, max_num_blocks_per_seq, 1, k_scale,
                               v_scale, output)
         return output


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose
The purpose of this PR is to fix call to `pa_fwd_asm` interface of which was changed some time ago.

Recently in https://github.com/ROCm/aiter.git new argument was added to interface of `pa_fwd_asm`. This is a breaking change since it changes the order of arguments. Apparently, the breaking change was introduced in commit
[e44b95cf add pa qlen for mtp (#320)](https://github.com/ROCm/aiter/commit/e44b95cfaa80bf96c9790a7bea037801ca665573) in aiter. Without adding the missing argument calls to `pa_fwd_asm` error with `TypeError: max_qlen needs to be <class 'int'> but got <class 'torch.Tensor'>`.

Alternative way to fix this would be to change aiter's interface.

## Test Plan
Test for example with Llama 3.1 8B instruct.
```
export VLLM_USE_V1=0 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_PAGED_ATTN=1 VLLM_USE_TRITON_FLASH_ATTN=0
vllm serve meta-llama/Llama-3.1-8B-Instruct --dtype bfloat16 --num_scheduler_steps 32 --enable_prefix_caching --kv_cache_dtype fp8 --tensor_parallel 1
```

## Test Result
Before this change
```
TypeError: max_qlen needs to be <class 'int'> but got <class 'torch.Tensor'>
```

After this change and rebuilding and reinstalling vllm it works.

## (Optional) Documentation Update

---
