### PR TITLE
Use regex in convert-results-json-to-markdown.py

### DIFF
--- a/.buildkite/nightly-benchmarks/scripts/convert-results-json-to-markdown.py
+++ b/.buildkite/nightly-benchmarks/scripts/convert-results-json-to-markdown.py
@@ -4,7 +4,7 @@
 import argparse
 import json
 import os
-import re
+import regex as re
 import shlex
 from importlib import util
 from pathlib import Path

--- a/.buildkite/nightly-benchmarks/scripts/convert-results-json-to-markdown.py
+++ b/.buildkite/nightly-benchmarks/scripts/convert-results-json-to-markdown.py
@@ -4,7 +4,6 @@
 import argparse
 import json
 import os
-import regex as re
 import shlex
 from importlib import util
 from pathlib import Path
@@ -12,6 +11,7 @@ from typing import Any
 
 import pandas as pd
 import psutil
+import regex as re
 from tabulate import tabulate
 
 # latency results and the keys that will be printed into markdown


### PR DESCRIPTION
Fix precommit error on main

```
Enforce import regex as re..........................................................................Failed
- hook id: enforce-import-regex-instead-of-re
- exit code: 1

❌ .buildkite/nightly-benchmarks/scripts/convert-results-json-to-markdown.py:
  Line 7: import re

💡 Found 1 violation(s).
❌ Please replace 'import re' with 'import regex as re'
   Also replace 'from re import ...' with 'from regex import ...'
✅ Allowed imports:
   - import regex as re
   - import regex

```