### PR TITLE
[Flaky CI] Increase timeout tolerance for test_mp_crash_detection+test_default_mm_lora_chat_completions

### DIFF
--- a/tests/entrypoints/openai/test_default_mm_loras.py
+++ b/tests/entrypoints/openai/test_default_mm_loras.py
@@ -48,7 +48,8 @@ def multimodal_server():  # noqa: F811
         f"{{\"audio\": \"{AUDIO_LORA_PATH}\"}}",
     ]
 
-    with RemoteOpenAIServer(MULTIMODAL_MODEL_NAME, args) as remote_server:
+    with RemoteOpenAIServer(MULTIMODAL_MODEL_NAME, args,
+                            max_wait_seconds=480) as remote_server:
         yield remote_server
 
 

--- a/tests/mq_llm_engine/test_error_handling.py
+++ b/tests/mq_llm_engine/test_error_handling.py
@@ -255,8 +255,8 @@ async def test_mp_crash_detection(monkeypatch: pytest.MonkeyPatch):
             pass
         end = time.perf_counter()
 
-        assert end - start < 60, (
-            "Expected vLLM to gracefully shutdown in <60s "
+        assert end - start < 100, (
+            "Expected vLLM to gracefully shutdown in <100s "
             "if there is an error in the startup.")
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

* Increase server startup timeout from 240s to 480s for `test_default_mm_loras.py`. The multimodal model with LoRA adapters requires additional time for initialization, especially under memory pressure. CI logs show the server was taking 253+ seconds to start, exceeding the default 240s timeout and causing spurious test failures.

https://buildkite.com/vllm/ci/builds/27187/steps/canvas?sid=0198af26-82ab-491c-be3c-f7168b11e289#0198af26-8380-4d5e-a0af-7808a6d4c921/7-17937
```
[2025-08-15T21:15:41Z] ERROR entrypoints/openai/test_default_mm_loras.py::test_default_mm_lora_chat_completions[/fsx/hf_cache/hub/models--microsoft--Phi-4-multimodal-instruct/snapshots/33e62acdd07cd7d6635badd529aa0a3467bb9c6a] - RuntimeError: Server failed to start in time.
[2025-08-15T21:15:41Z] ERROR entrypoints/openai/test_default_mm_loras.py::test_default_mm_lora_chat_completions[speech] - RuntimeError: Server failed to start in time.
```

* `test_mp_crash_detection` seems to be regularly on the edge of 60s and fails sometimes due to going over, so increase the time to 100s

https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests/9614aa7b-4078-86c0-a06d-437ff179db74?branch=main&period=7days
<img width="1333" height="645" alt="Screenshot 2025-08-16 at 11 40 08 AM" src="https://github.com/user-attachments/assets/add5c68b-8976-4b31-a045-ee807ff587eb" />


## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

