### PR TITLE
[Bugfix] fix qwen3 moe fp8 accuracy issue

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -125,6 +125,10 @@ class Fp8Config(QuantizationConfig):
         ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"],
                                                  None)
+        if not ignored_layers:
+            ignored_layers = cls.get_from_keys_or(config,
+                                                  ["modules_to_not_convert"],
+                                                  None)
         return cls(is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
                    activation_scheme=activation_scheme,
                    ignored_layers=ignored_layers,


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/22881 .
The origin issue is introduced by https://github.com/vllm-project/vllm/pull/22017 . The `gate` layer is initilized with fp8 quantization, but the origin weight is bf16.