### PR TITLE
[V1] check request priority if scheduler policy is fcfs

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1008,7 +1008,8 @@ class OpenAIServing:
             sampling_params.max_tokens = (self.max_model_len -
                                           len(prompt_token_ids))
             # OPTIMIZATION
-            priority = orig_priority - 1
+            if orig_priority != 0:
+                priority = orig_priority - 1
 
     @staticmethod
     def _load_prompt_embeds(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1052,6 +1052,11 @@ class Scheduler(SchedulerInterface):
         return len(self.running), len(self.waiting)
 
     def add_request(self, request: Request) -> None:
+        if (request.priority != 0
+                and not self.scheduler_config.policy == "priority"):
+            raise ValueError(f"Got priority {request.priority} but "
+                             "Priority scheduling is not enabled.")
+
         self.waiting.add_request(request)
         self.requests[request.request_id] = request
         if self.log_stats:


### PR DESCRIPTION
Fix: [#22997](https://github.com/vllm-project/vllm/issues/22997)

Currently, in v1, if scheduler.policy is set to FCFS, the priority value in the request will be ignored and will have no effect even if it is set. The priority value in the request only takes effect when scheduler.policy is set to PRIORITY.

By default, the scheduler.policy is FCFS, so setting the priority in the request will be ineffective. An error should be thrown to avoid misunderstandings.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

