### PR TITLE
[Misc] fix typo in the multimodal doc

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -216,7 +216,7 @@ Instead of NumPy arrays, you can also pass `'torch.Tensor'` instances, as shown 
     from vllm import LLM, SamplingParams
     from qwen_vl_utils import process_vision_info
 
-    model_path = "Qwen/Qwen2.5-VL-3B-Instruct/"
+    model_path = "Qwen/Qwen2.5-VL-3B-Instruct"
     video_path = "https://content.pexels.com/videos/free-videos.mp4"
 
     llm = LLM(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
A typo in [Multimodal Inputs](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html#video-inputs). The model repo id must be in the form 'repo_name' of Huggingface.

## Test Plan
NA

## Test Result
NA

## (Optional) Documentation Update
Update [Multimodal Inputs](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html#multimodal-inputs).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

