### PR TITLE
[Bugfix] fix Qwen2.5-Omni processor output mapping

### DIFF
--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -90,7 +90,7 @@ def _qwen2_5_omni_thinker_field_config(hf_inputs: Mapping[str, torch.Tensor]):
 
     # vllm use `second_per_grid_ts` to compute multimodal rotary embedding
     video_second_per_grid = hf_inputs.get("video_second_per_grid", None)
-    if video_second_per_grid:
+    if video_second_per_grid is not None:
         hf_inputs["second_per_grid_ts"] = video_second_per_grid
 
     return dict(

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -88,6 +88,11 @@ def _qwen2_5_omni_thinker_field_config(hf_inputs: Mapping[str, torch.Tensor]):
     video_grid_thw = hf_inputs.get("video_grid_thw", torch.empty((0, 3)))
     video_grid_sizes = video_grid_thw.prod(-1)
 
+    # vllm use `second_per_grid_ts` to compute multimodal rotary embedding
+    video_second_per_grid = hf_inputs.get("video_second_per_grid", None)
+    if video_second_per_grid:
+        hf_inputs["second_per_grid_ts"] = video_second_per_grid
+
     return dict(
         input_audio_features=MultiModalFieldConfig.flat_from_sizes(
             "audio", audio_feature_lengths, dim=1),


### PR DESCRIPTION
## Purpose
Fix #23056 

Add a processor output mapping for Qwen2.5-Omni thinker, to compute video rotary embedding correctly.

## Test Plan
Use the script I provided in #23056 and check the rotary position ids.

## Test Result
The modified code generates rotary position consistent with the hf implementation.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

