### PR TITLE
[Misc] Convert use_structured_output property into constant

### DIFF
--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -53,12 +53,13 @@ class Request:
         self.arrival_time = arrival_time if arrival_time is not None else \
             time.time()
 
-        self.status = RequestStatus.WAITING
         self.use_structured_output = (sampling_params is not None
                                       and sampling_params.guided_decoding
                                       is not None)
         if self.use_structured_output:
             self.status = RequestStatus.WAITING_FOR_FSM
+        else:
+            self.status = RequestStatus.WAITING
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: Union[int, str, None] = None
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -54,11 +54,11 @@ class Request:
             time.time()
 
         self.status = RequestStatus.WAITING
-        if sampling_params and sampling_params.guided_decoding is not None:
+        self.use_structured_output = (sampling_params is not None
+                                      and sampling_params.guided_decoding
+                                      is not None)
+        if self.use_structured_output:
             self.status = RequestStatus.WAITING_FOR_FSM
-            self.use_structured_output = True
-        else:
-            self.use_structured_output = False
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: Union[int, str, None] = None
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -53,13 +53,8 @@ class Request:
         self.arrival_time = arrival_time if arrival_time is not None else \
             time.time()
 
-        self.use_structured_output = (sampling_params is not None
-                                      and sampling_params.guided_decoding
-                                      is not None)
-        if self.use_structured_output:
-            self.status = RequestStatus.WAITING_FOR_FSM
-        else:
-            self.status = RequestStatus.WAITING
+        self.status = RequestStatus.WAITING
+        self.use_structured_output = False
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: Union[int, str, None] = None
 
@@ -67,12 +62,15 @@ class Request:
         self.kv_transfer_params: Optional[dict[str, Any]] = None
 
         if pooling_params is not None:
+            # Pooling models.
             self.max_tokens = 1
         elif sampling_params is not None:
+            # Generative models.
             assert sampling_params.max_tokens is not None
             self.max_tokens = sampling_params.max_tokens
             if sampling_params.guided_decoding is not None:
                 self.status = RequestStatus.WAITING_FOR_FSM
+                self.use_structured_output = True
 
             if sampling_params.extra_args is not None:
                 self.kv_transfer_params = \

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -56,6 +56,9 @@ class Request:
         self.status = RequestStatus.WAITING
         if sampling_params and sampling_params.guided_decoding is not None:
             self.status = RequestStatus.WAITING_FOR_FSM
+            self.use_structured_output = True
+        else:
+            self.use_structured_output = False
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: Union[int, str, None] = None
 
@@ -191,11 +194,6 @@ class Request:
         assert input_id < len(self.mm_positions)
         num_tokens = self.mm_positions[input_id].length
         return num_tokens
-
-    @property
-    def use_structured_output(self) -> bool:
-        return self.sampling_params is not None and \
-            self.sampling_params.guided_decoding is not None
 
     def record_event(
         self,


### PR DESCRIPTION
This PR converts `use_structured_output` property of `Request` class into a constant, which will help avoid unnecessary Python overheads.