### PR TITLE
[Feature] Make ModelConfig caching opt-out by default

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -11,7 +11,7 @@ import json
 import textwrap
 import uuid
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from dataclasses import MISSING, Field, field, fields, is_dataclass, replace
 from functools import cached_property, lru_cache
@@ -471,7 +471,7 @@ class ModelConfig:
     """One or more logits processors' fully-qualified class names or class
     definitions"""
 
-    def compute_hash(self, extra_ignored_fields: list[str] | set[str] = []) -> str:
+    def compute_hash(self, extra_ignored_fields: Iterable[str] = ()) -> str:
         """
         WARNING: Whenever a new field is added to this config,
         ensure that it is included in the factors list if
@@ -493,7 +493,8 @@ class ModelConfig:
             "seed",
             "allowed_local_media_path",
             "tokenizer_revision",
-            "spec_target_max_model_len", # TODO: if max_model_len needs hashing, why not this?
+            # TODO: if max_model_len needs hashing, why not spec_target_?
+            "spec_target_max_model_len",
             "ehforce_eager",
             "logprobs_mode",
             "disable_cascade_attn",

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -522,7 +522,7 @@ class ModelConfig:
         all_fields = set([i.name for i in fields(self)])
         all_hashed_fields = list(all_fields - all_ignored_factors)
 
-        for field_name in all_hashed_fields:
+        for field_name in sorted(all_hashed_fields):
             field_v = getattr(self, field_name)
             if field_name == "hf_config":
                 factors.append(field_v.to_json_string())


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Implement RFC/Resolves https://github.com/vllm-project/vllm/issues/16501

## Test Plan
1. `rm -rf ~/.cache/vllm/torch_compile_cache`
2. `vllm serve "qwen/qwen3-0.6b" --max_ model_len 1000`, (also repeat, verify no new cache dir is created)
3. `vllm serve "qwen/qwen3-0.6b" --max_ model_len 2000`, verify one additional cache dir is created

## Test Result
Cache behavior matches expected

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

