### PR TITLE
[XPU] Fix compile size for xpu

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -3548,7 +3548,7 @@ class VllmConfig:
         if self.compilation_config.pass_config.enable_sequence_parallelism:
             self.compilation_config.custom_ops.append("+rms_norm")
 
-        if current_platform.is_cuda_alike():
+        if current_platform.is_cuda_alike() or current_platform.is_xpu():
             # if cudagraph_mode is not explicitly set by users, set default
             # value
             if self.compilation_config.cudagraph_mode is None:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
xpu will throw `AttributeError: 'NoneType' object has no attribute 'copy'` in compile_or_warm_up_model method. 
this PR fix this issue.

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

