### PR TITLE
Propagate exception message to EngineGeneratorError

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -367,7 +367,7 @@ class AsyncLLM(EngineClient):
             await self.abort(request_id)
             if self.log_requests:
                 logger.info("Request %s failed.", request_id)
-            raise EngineGenerateError() from e
+            raise EngineGenerateError(e) from e
 
     def _run_output_handler(self):
         """Background loop: pulls from EngineCore and pushes to AsyncStreams."""
@@ -521,7 +521,7 @@ class AsyncLLM(EngineClient):
             await self.abort(request_id)
             if self.log_requests:
                 logger.info("Request %s failed.", request_id)
-            raise EngineGenerateError() from e
+            raise EngineGenerateError(e) from e
 
     async def get_vllm_config(self) -> VllmConfig:
         return self.vllm_config

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -367,7 +367,7 @@ class AsyncLLM(EngineClient):
             await self.abort(request_id)
             if self.log_requests:
                 logger.info("Request %s failed.", request_id)
-            raise EngineGenerateError(e) from e
+            raise EngineGenerateError(str(e)) from e
 
     def _run_output_handler(self):
         """Background loop: pulls from EngineCore and pushes to AsyncStreams."""
@@ -521,7 +521,7 @@ class AsyncLLM(EngineClient):
             await self.abort(request_id)
             if self.log_requests:
                 logger.info("Request %s failed.", request_id)
-            raise EngineGenerateError(e) from e
+            raise EngineGenerateError(str(e)) from e
 
     async def get_vllm_config(self) -> VllmConfig:
         return self.vllm_config


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Proposing to propagate the exception message to EngineGeneratorError to ease debugging of users of vLLM.

## Test Plan

## Test Result

## (Optional) Documentation Update

Took me some time to debug the following error. Only after debugging the vLLM internal code I could find the error message, which - with this change - would also be bubbled up.
```
Expected there to be 1 prompt updates corresponding to 1 image items, but instead found 0 prompt updates! This is likely because you forgot to include input placeholder tokens (e.g., `<image>`, `<|image_pad|>`) in the prompt. If the model has a chat template, make sure you have applied it before calling `LLM.generate`.
```