### PR TITLE
bugfix: Fix nvfp4 FusedMoE flashinfer-cutlass

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -976,6 +976,9 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         if not self.allow_flashinfer:
             return super().maybe_make_prepare_finalize(moe)
 
+        if self.fused_experts is not None:
+            return None
+
         prepare_finalize = build_flashinfer_fp4_cutlass_moe_prepare_finalize(
             moe,
             a1_gscale=self.layer.w13_input_scale_quant,
@@ -1294,6 +1297,9 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             del layer.w2_input_scale_quant
             del layer.w13_blockscale_swizzled
             del layer.w2_blockscale_swizzled
+
+        if self.allow_flashinfer:
+            self.init_prepare_finalize()
 
     def apply(
         self,


### PR DESCRIPTION
## Purpose
Following the refactor in https://github.com/vllm-project/vllm/issues/22035 , when using nvfp4 FusedMoE with flashinfer CUTLASS backend enabled, there is a quality degradation when evaluating models (in TP1).
Note that this stems from the fact that `init_prepare_finalize` is only called when `TP>1 or EP>1` which in turn means that the cutlass backend is not initialized. However, in `process_weights_after_loading` the weights are reordered as preparation for using `cutlass` backend implementation which causes the quality degradation.

On current `main`:
```
VLLM_USE_FLASHINFER_MOE_FP4=1 CUDA_VISIBLE_DEVICES=0 VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=FLASHINFER lm_eval --model vllm --model_args pretrained=<ckpt_path>,quantization=modelopt_fp4,tensor_parallel_size=1,max_model_len=2048,kv_cache_dtype=auto --gen_kwargs temperature=0.0 --limit 500 --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size 200
...
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.012|±  |0.0049|
|     |       |strict-match    |     5|exact_match|↑  |0.002|±  |0.0020|
```

with the fix in this PR:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.918|±  |0.0123|
|     |       |strict-match    |     5|exact_match|↑  |0.900|±  |0.0134|
```