### PR TITLE
[CI Bugfix] Pin `openai<1.100` to unblock CI

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,7 +12,7 @@ tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
-openai >= 1.99.1  # For Responses API with reasoning content
+openai >= 1.99.1, < 1.100.0  # For Responses API with reasoning content
 pydantic >= 2.10
 prometheus_client >= 0.18.0
 pillow  # Required for image processing

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ cbor2
 cloudpickle
 fastapi
 msgspec
-openai
+openai < 1.100.0
 openai-harmony
 partial-json-parser
 pillow


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

It seems the latest openai python package release broke our CI, so let us pin below for now

https://app.readthedocs.org/projects/vllm/builds/29239011/

```
File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/22023/vllm/reasoning/deepseek_r1_reasoning_parser.py", line 9, in <module>
--
  | from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/22023/vllm/entrypoints/openai/protocol.py", line 20, in <module>
  | from openai.types.responses import (ResponseFunctionToolCall,
  | ImportError: cannot import name 'ResponseTextConfig' from 'openai.types.responses' (/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/22023/lib/python3.12/site-packages/openai/types/responses/__init__.py). Did you mean: 'ResponseFormatTextConfig'?
```

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

