### PR TITLE
fix: OpenAI SDK compat (ResponseTextConfig)

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,7 +12,7 @@ tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
-openai >= 1.99.1  # For Responses API with reasoning content
+openai >= 1.99.1, < 1.100.0  # For Responses API with reasoning content
 pydantic >= 2.10
 prometheus_client >= 0.18.0
 pillow  # Required for image processing

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,7 +12,7 @@ tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
-openai >= 1.99.1, < 1.100.0  # For Responses API with reasoning content
+openai >= 1.99.1  # For Responses API with reasoning content
 pydantic >= 2.10
 prometheus_client >= 0.18.0
 pillow  # Required for image processing

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ cbor2
 cloudpickle
 fastapi
 msgspec
-openai
+openai < 1.100.0
 openai-harmony
 partial-json-parser
 pillow

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ cbor2
 cloudpickle
 fastapi
 msgspec
-openai < 1.100.0
+openai
 openai-harmony
 partial-json-parser
 pillow

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -22,7 +22,7 @@ from openai.types.responses import (ResponseFunctionToolCall,
                                     ResponsePrompt, ResponseReasoningItem,
                                     ResponseStatus)
 # Backward compatibility for OpenAI client versions
-try:  # OpenAI >= version with ResponseTextConfig
+try:  # For older openai versions (< 1.100.0)
     from openai.types.responses import ResponseTextConfig
 except ImportError:  # Older OpenAI clients expose ResponseFormatTextConfig
     from openai.types.responses import (

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -21,13 +21,14 @@ from openai.types.responses import (ResponseFunctionToolCall,
                                     ResponseInputItemParam, ResponseOutputItem,
                                     ResponsePrompt, ResponseReasoningItem,
                                     ResponseStatus)
+
 # Backward compatibility for OpenAI client versions
 try:  # For older openai versions (< 1.100.0)
     from openai.types.responses import ResponseTextConfig
-except ImportError:  # Older OpenAI clients expose ResponseFormatTextConfig
-    from openai.types.responses import (
-        ResponseFormatTextConfig as ResponseTextConfig
-    )
+except ImportError:  # For newer openai versions (>= 1.100.0)
+    from openai.types.responses import (ResponseFormatTextConfig as
+                                        ResponseTextConfig)
+
 from openai.types.responses.response import ToolChoice
 from openai.types.responses.tool import Tool
 from openai.types.shared import Metadata, Reasoning

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -20,7 +20,14 @@ from openai.types.chat.chat_completion_message import (
 from openai.types.responses import (ResponseFunctionToolCall,
                                     ResponseInputItemParam, ResponseOutputItem,
                                     ResponsePrompt, ResponseReasoningItem,
-                                    ResponseStatus, ResponseTextConfig)
+                                    ResponseStatus)
+# Backward compatibility for OpenAI client versions
+try:  # OpenAI >= version with ResponseTextConfig
+    from openai.types.responses import ResponseTextConfig
+except ImportError:  # Older OpenAI clients expose ResponseFormatTextConfig
+    from openai.types.responses import (
+        ResponseFormatTextConfig as ResponseTextConfig
+    )
 from openai.types.responses.response import ToolChoice
 from openai.types.responses.tool import Tool
 from openai.types.shared import Metadata, Reasoning


### PR DESCRIPTION
## Purpose

Fix ReadTheDocs/MkDocs build failures caused by a recent OpenAI Python SDK type rename.
vllm/entrypoints/openai/protocol.py imported ResponseTextConfig, which is present in openai==1.99.x but renamed to ResponseFormatTextConfig in newer releases (e.g., >=[1.100.0](https://github.com/openai/openai-python/commit/0843a1116498bc3312db9904adf71a4fb0a0a77e)). 


This PR adds a backward/forward compatible import shim so both SDK lines work.

No functional/runtime behavior change in vLLM.

No public API changes.

Keeps docs builds deterministic without requiring a docs-only dependency pin.

## Test Plan

openai update resulted in failing https://app.readthedocs.org/projects/vllm/builds/29240829/

```

python -m mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yaml
--
  | WARNING 08-18 17:18:33 [__init__.py:26] The vLLM package was not found, so its version could not be inspected. This may cause platform detection to fail.
  | INFO 08-18 17:18:33 [__init__.py:245] No platform detected, vLLM is running on UnspecifiedPlatform
  | Traceback (most recent call last):
  | File "<frozen runpy>", line 198, in _run_module_as_main
  | File "<frozen runpy>", line 88, in _run_code
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/__main__.py", line 370, in <module>
  | cli()
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
  | return self.main(*args, **kwargs)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/click/core.py", line 1363, in main
  | rv = self.invoke(ctx)
  | ^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/click/core.py", line 1830, in invoke
  | return _process_result(sub_ctx.command.invoke(sub_ctx))
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/click/core.py", line 1226, in invoke
  | return ctx.invoke(self.callback, **ctx.params)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/click/core.py", line 794, in invoke
  | return callback(*args, **kwargs)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/__main__.py", line 285, in build_command
  | cfg = config.load_config(**kwargs)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/config/base.py", line 374, in load_config
  | errors, warnings = cfg.validate()
  | ^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/config/base.py", line 231, in validate
  | run_failed, run_warnings = self._validate()
  | ^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/config/base.py", line 188, in _validate
  | self[key] = config_option.validate(value)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/config/base.py", line 55, in validate
  | return self.run_validation(value)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/config/config_options.py", line 1187, in run_validation
  | hooks[name] = self._load_hook(name, path)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/mkdocs/config/config_options.py", line 1205, in _load_hook
  | spec.loader.exec_module(module)
  | File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  | File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/23119/docs/mkdocs/hooks/generate_argparse.py", line 18, in <module>
  | from vllm.benchmarks import latency  # noqa: E402
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/23119/vllm/benchmarks/latency.py", line 18, in <module>
  | from vllm.engine.arg_utils import EngineArgs
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/23119/vllm/engine/arg_utils.py", line 40, in <module>
  | from vllm.reasoning import ReasoningParserManager
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/23119/vllm/reasoning/__init__.py", line 5, in <module>
  | from .deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/23119/vllm/reasoning/deepseek_r1_reasoning_parser.py", line 9, in <module>
  | from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
  | File "/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/23119/vllm/entrypoints/openai/protocol.py", line 20, in <module>
  | from openai.types.responses import (ResponseFunctionToolCall,
  | ImportError: cannot import name 'ResponseTextConfig' from 'openai.types.responses' (/home/docs/checkouts/readthedocs.org/user_builds/vllm/envs/23119/lib/python3.12/site-packages/openai/types/responses/__init__.py). Did you mean: 'ResponseFormatTextConfig'?


```
## Test result 

This PR should pass the CI test.
