### PR TITLE
Only enable commentary channel for GPT-OSS when really necessary

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -37,6 +37,7 @@ def get_encoding():
             HarmonyEncodingName.HARMONY_GPT_OSS)
     return _harmony_encoding
 
+
 def get_system_message(
     model_identity: Optional[str] = None,
     reasoning_effort: Optional[Literal["high", "medium", "low"]] = None,
@@ -45,11 +46,14 @@ def get_system_message(
     python_description: Optional[str] = None,
     has_tools: bool = False,
 ) -> Message:
-    needs_commentary = has_tools or browser_description is not None or python_description is not None
+    needs_commentary = (has_tools or browser_description is not None
+                        or python_description is not None)
     if needs_commentary:
-        sys_msg_content = SystemContent.new().with_required_channels(["analysis", "commentary", "final"])
+        sys_msg_content = SystemContent.new().with_required_channels(
+            ["analysis", "commentary", "final"])
     else:
-        sys_msg_content = SystemContent.new().with_required_channels(["analysis", "final"])
+        sys_msg_content = SystemContent.new().with_required_channels(
+            ["analysis", "final"])
     if model_identity is not None:
         sys_msg_content = sys_msg_content.with_model_identity(model_identity)
     if reasoning_effort is not None:

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -37,15 +37,19 @@ def get_encoding():
             HarmonyEncodingName.HARMONY_GPT_OSS)
     return _harmony_encoding
 
-
 def get_system_message(
     model_identity: Optional[str] = None,
     reasoning_effort: Optional[Literal["high", "medium", "low"]] = None,
     start_date: Optional[str] = None,
     browser_description: Optional[str] = None,
     python_description: Optional[str] = None,
+    has_tools: bool = False,
 ) -> Message:
-    sys_msg_content = SystemContent.new()
+    needs_commentary = has_tools or browser_description is not None or python_description is not None
+    if needs_commentary:
+        sys_msg_content = SystemContent.new().with_required_channels(["analysis", "commentary", "final"])
+    else:
+        sys_msg_content = SystemContent.new().with_required_channels(["analysis", "final"])
     if model_identity is not None:
         sys_msg_content = sys_msg_content.with_model_identity(model_identity)
     if reasoning_effort is not None:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1455,7 +1455,8 @@ class OpenAIServingChat(OpenAIServing):
         sys_msg = get_system_message(
             reasoning_effort=request.reasoning_effort,
             browser_description=None,
-            python_description=None)
+            python_description=None,
+            has_tools = bool(request.tools))
         messages.append(sys_msg)
 
         # Add developer message.

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -629,7 +629,7 @@ class OpenAIServingResponses(OpenAIServing):
                 python_description=self.tool_server.get_tool_description(
                     "python") if enable_code_interpreter
                 and self.tool_server is not None else None,
-                has_tools = bool(request.tools),
+                has_tools=bool(request.tools),
             )
             messages.append(sys_msg)
             dev_msg = get_developer_message(request.instructions,

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -629,6 +629,7 @@ class OpenAIServingResponses(OpenAIServing):
                 python_description=self.tool_server.get_tool_description(
                     "python") if enable_code_interpreter
                 and self.tool_server is not None else None,
+                has_tools = bool(request.tools),
             )
             messages.append(sys_msg)
             dev_msg = get_developer_message(request.instructions,


### PR DESCRIPTION
## Purpose
In the current configuration, both GPT-OSS models would sometimes - in certain scenarios reliably - emit messages on the commentary channel despite not having access to any tools. This behavior is especially prevalent when the models are used with non-native tool calling, e.g. the "Code Interpreter" tool of Open WebUI, which asks the model to call the tool within `<code_interpreter></code_interpreter>` tags. Most of the time such calls would not be emitted in the final channel or even the analysis channel, but on commentary. Generation will eventually stop without the requester receiving the tool calling content.

When researching the harmony library, I found that the activated channels are set in the system message and by default analysis, commentary, final are all active. Because vllm currently doesn't actively configure the channels, this default is used regardless of active tools. The present PR changes this, such that commentary channel is only active when there is at least one tool of any kind enabled.

I don't expect any regression from this, but evaluations should be re-run to see potential effects. If anything, this should improve results.

## Test Plan
Testing with Open WebUI via LiteLLM against /chat/completions and /responses API of vllm (using GPT OSS 20B). Using no tools, "non-native tools" and native tools and observing the generated system message / activated channels.

Testing whether Code Interpreter "tool" of Open WebUI can be used reliably now.

## Test Result
Commentary channel is only active when tools are passed. Code Interpeter tool of Open WebUI is reliably used by the model now.
