### PR TITLE
[Model] Removes redundant all-reduce operation in Qwen3MoeSparseMoeBlock

### DIFF
--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -139,7 +139,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
                                 top_k=config.num_experts_per_tok,
                                 hidden_size=config.hidden_size,
                                 intermediate_size=config.moe_intermediate_size,
-                                reduce_results=False,
+                                reduce_results=True,
                                 renormalize=config.norm_topk_prob,
                                 quant_config=quant_config,
                                 prefix=f"{prefix}.experts",
@@ -162,10 +162,6 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(hidden_states=hidden_states,
                                            router_logits=router_logits)
-
-        if self.tp_size > 1:
-            final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(  # noqa E501
-                final_hidden_states)
 
         return final_hidden_states.view(orig_shape)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Remove redundant all-reduce operation and reuse the all-reduce implementation provided by `FusedMoE` (see [`vllm/model_executor/layers/fused_moe/layer.py#L1672`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fused_moe/layer.py#L1672)).

## Test plan
The existing test cases are sufficient.

## Test results
Passed.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [√] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [×] The test plan, such as providing test command.
- [×] The test results, such as pasting the results comparison before and after, or e2e results
- [×] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

