### PR TITLE
[Attention] Optimize make_local_attention_virtual_batches for Flash Attention

### DIFF
--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -464,8 +464,9 @@ def make_local_attention_virtual_batches(
         attn_chunk_size)[arange > 0]
 
     # convert from q_seqlens to cu_seqlens_q
-    cu_seqlens_q_local = np.pad(np.cumsum(seqlens_q_local), (1, 0))\
-        .astype(np.int32)
+    cu_seqlens_q_local = np.empty(virtual_batches + 1, dtype=np.int32)
+    np.cumsum(seqlens_q_local, out=cu_seqlens_q_local[1:])
+    cu_seqlens_q_local[0] = 0
 
     # compute the seqlens_k_local,
     #  basically a full local attention block for all but the last block in each
@@ -508,11 +509,10 @@ def make_local_attention_virtual_batches(
     #     [ 22, 23 ], < local-batch 6, (batch 2, starting from k[4])
     #     [ 24, 25 ], < local-batch 7, (batch 2, starting from k[8])
     #   ]
-    block_indices= np.broadcast_to(
-        np.arange(pages_per_local_batch, dtype=np.int32),
-        (virtual_batches, pages_per_local_batch)) \
-            + np.expand_dims(block_starts, axis=1)
-    block_indices = block_indices.flatten().clip(max=block_table.shape[1] - 1)
+    block_indices = (block_starts[:, None] +
+                     np.arange(pages_per_local_batch, dtype=np.int32))
+    block_indices = block_indices.reshape(-1).clip(max=block_table.shape[1] -
+                                                   1)
     batch_indices = np.repeat(np.arange(actual_batch_size, dtype=np.int32),
                               local_blocks * pages_per_local_batch)
     block_table_local = block_table[batch_indices, block_indices]\


### PR DESCRIPTION
## Purpose
This PR improves efficiency of `cu_seqlens_q_local` and `batch_indices` in `make_local_attention_virtual_batches`.

For `cu_seqlens_q_local`, original code creates multiple intermediate arrays (`np.cumsum`, `np.pad`, `.astype(np.int32)`); also `np.pad` is not necessary. In the new code, we pre-allocate output array and let `np.cumsum` directly write to the pre-allocated array.

For `batch_indices`, used the following operations to avoid potential copies and intermediate arrays:
- Uses broadcasting with `block_starts[:, None]` instead of `np.broadcast_to()` and `np.expand_dims()`
- Uses `reshape(-1)` instead of `flatten()`

## Test Plan
Injected timing code to measure latency improvement, and used loadgen with input_length=2048 and output_length=256

Verified correctness using `gsm8k` eval.

Llama 4:
`cu_seqlens_q_local` consistently improved from 35μs to 6μs
`batch_indices` consistently improved from 53μs to 34μs



## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

