### PR TITLE
[BugFix] fix CUTLASS MLA full cudagraph 

### DIFF
--- a/vllm/v1/attention/backends/mla/cutlass_mla.py
+++ b/vllm/v1/attention/backends/mla/cutlass_mla.py
@@ -21,7 +21,7 @@ logger = init_logger(__name__)
 
 class CutlassMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     # enable full CUDA Graph support for decode-only capture
-    attn_cudagraph_support: ClassVar[
+    cudagraph_support: ClassVar[
         AttentionCGSupport] = AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
 


### PR DESCRIPTION
Fix: 
```
EngineCore_0 pid=1248800) ValueError: CUDAGraphMode.FULL is not supported with CutlassMLAMetadataBuilder backend (support: AttentionCGSupport.NEVER); please try cudagraph_mode=PIECEWISE, and make sure compilation level is piecewise
```

caused by CUTLASS MLA getting missed in https://github.com/vllm-project/vllm/pull/20059

thanks @tjtanaa for the find!