### PR TITLE
[Quantization] Bump Compressed Tensors Version

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -39,7 +39,7 @@ pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<80; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
-compressed-tensors == 0.10.2 # required for compressed-tensors
+compressed-tensors == 0.11.0 # required for compressed-tensors
 depyf==0.19.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py
 watchfiles # required for http server to monitor the updates of TLS files


### PR DESCRIPTION
## Purpose ##
* This latest release of compressed tensors adds
  * Better matching utilities to reduce tech debt in vllm
  * More support for transform options such as precision
  * Support for block quantization strategies

## Changes ##
* `compressed-tensors == 0.10.2` -> `compressed-tensors == 0.11.0`