### PR TITLE
[Misc] Limit ray version to 2.48.0

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -5,7 +5,7 @@ numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Req
 numba == 0.61.2; python_version > '3.9'
 
 # Dependencies for NVIDIA GPUs
-ray[cgraph]==2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
+ray[cgraph]>=2.48.0,<2.49.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
 torch==2.7.1
 torchaudio==2.7.1
 # These must be updated alongside torch

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -5,7 +5,7 @@ numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Req
 numba == 0.61.2; python_version > '3.9'
 
 # Dependencies for NVIDIA GPUs
-ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
+ray[cgraph]==2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
 torch==2.7.1
 torchaudio==2.7.1
 # These must be updated alongside torch

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -16,7 +16,7 @@ librosa # required for audio tests
 vocos # required for minicpmo_26 test
 peft
 pqdm
-ray[cgraph,default]>=2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
+ray[cgraph,default]==2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -16,7 +16,7 @@ librosa # required for audio tests
 vocos # required for minicpmo_26 test
 peft
 pqdm
-ray[cgraph,default]==2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
+ray[cgraph,default]>=2.48.0,<2.49.0 # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -17,7 +17,7 @@ vector_quantize_pytorch # required for minicpmo_26 test
 vocos # required for minicpmo_26 test
 peft>=0.15.0 # required for phi-4-mm test
 pqdm
-ray[cgraph,default]>=2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
+ray[cgraph,default]==2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -17,7 +17,7 @@ vector_quantize_pytorch # required for minicpmo_26 test
 vocos # required for minicpmo_26 test
 peft>=0.15.0 # required for phi-4-mm test
 pqdm
-ray[cgraph,default]==2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
+ray[cgraph,default]>=2.48.0,<2.49.0 # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Ray 2.49 has a behavior change of CUDA_VISIBLE_DEVICES which may affect vLLM ray workers.
We limit the version for now, and will lift the restriction after more testing with vllm.

Users always have the option to manually upgrade ray.

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

