### PR TITLE
[Bugfix]Enable zmq router handover to handle scaling-up after scaling-down in EEP

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -2858,6 +2858,9 @@ def make_zmq_socket(
     if socket_type == zmq.XPUB:
         socket.setsockopt(zmq.XPUB_VERBOSE, True)
 
+    if socket_type == zmq.ROUTER:
+        socket.setsockopt(zmq.ROUTER_HANDOVER, True)
+
     # Determine if the path is a TCP socket with an IPv6 address.
     # Enable IPv6 on the zmq socket if so.
     scheme, host, _ = split_zmq_path(path)


### PR DESCRIPTION

## Purpose
In Elastic Expert Parallelism, it will be stuck when we scaling up after scaling down, e.g. DP8 --> DP7 --> DP8.
The root cause is found out by Gemini and quoted here:

> This is a classic and subtle issue with how ZeroMQ (ZMQ) [ROUTER] sockets handle identities and unclean disconnections. The [poll] is stuck because the [ROUTER] socket believes the identity b'\x07\x00' is still associated with the old, dead connection and is ignoring or mishandling the new connection attempt from the new process.

There are three options to fix this (also given by Gemini):

1. Use Unique Identities : like uuid
2. Socket Heartbeats : use zmq heartbeat
3. ROUTER_HANDOVER Option: use zmq router hand over

Option 3 is recommanded. And this PR takes option 3 to fix the bug.

## Test Plan
Deepseek-V2-Lite dp size 8->7->8
## Test Result
Each time of scaling up and down returns 200 and inference is functional afterwards.


## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

