### PR TITLE
Do not use eval() to convert unknown types

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
@@ -208,15 +208,10 @@ class Qwen3CoderToolParser(ToolParser):
                             "valid JSON object in tool '%s', will try other "
                             "methods to parse it.", param_value, param_name,
                             func_name)
-                try:
-                    converted_value = eval(param_value)
-                    return converted_value
-                except Exception:
-                    logger.warning(
-                        "Parsed value '%s' of parameter '%s' cannot be "
-                        "converted via Python `eval()` in tool '%s', "
-                        "degenerating to string.", param_value, param_name,
-                        func_name)
+                logger.warning(
+                    "Parameter '%s' has unknown type '%s'. "
+                    "The value will be treated as a string.", param_name,
+                    param_type)
                 return param_value
 
         # Extract function name


### PR DESCRIPTION
The qwen3_coder tool parser included a fallback to using Python's
`eval()` to attempt to convert an unknown type into a native Python
type. This allowed execution of arbitrary Python code, as long as you
could get that Python code to be passed as an argument to a tool call.

Fixes GHSA-79j6-g2m3-jgfw

Signed-off-by: Russell Bryant <rbryant@redhat.com>
