### PR TITLE
Small fix for Command-A-Vision

### DIFF
--- a/vllm/model_executor/models/cohere2_vision.py
+++ b/vllm/model_executor/models/cohere2_vision.py
@@ -348,7 +348,7 @@ class Cohere2VisionForConditionalGeneration(nn.Module, SupportsMultiModal,
             vllm_config=vllm_config,
             hf_config=config.text_config,
             prefix=maybe_prefix(prefix, "language_model"),
-            architectures=["Cohere2ForCausalLM"])
+            architectures=config.text_config.architectures)
 
     @property
     def dtype(self):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Read text model architecture from config

## Test Plan

## Test Result

```
python3 examples/offline_inference/vision_lan
guage_multi_image.py --model-type command_a_vision

--------------------------------------------------
The first image shows a mallard duck swimming in blue water, while the second image depicts a lion sitting in a field of tall, dry grass.
--------------------------------------------------
```

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

