### PR TITLE
[CI] Block the cu126 wheel build while broken

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -32,7 +32,7 @@ steps:
     depends_on: ~
 
   - label: "Build wheel - CUDA 12.6"
-    depends_on: block-build-cu118-wheel
+    depends_on: block-build-cu126-wheel
     id: build-wheel-cuda-12-6
     agents:
       queue: cpu_queue_postmerge

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -27,7 +27,12 @@ steps:
     env:
       DOCKER_BUILDKIT: "1"
 
+  - block: "Build CUDA 12.6 wheel"
+    key: block-build-cu126-wheel
+    depends_on: ~
+
   - label: "Build wheel - CUDA 12.6"
+    depends_on: block-build-cu118-wheel
     id: build-wheel-cuda-12-6
     agents:
       queue: cpu_queue_postmerge


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The CUDA 12.6 wheel build has been broken on the "release" job on main for several days due to a FlashAttention compilation issue on CUDA 12.6. We should disable it for now to keep main green.

```
[2025-08-19T10:36:40Z] #20 776.1 FAILED: [code=255] vllm-flash-attn/CMakeFiles/_vllm_fa3_C.dir/hopper/instantiations/flash_fwd_hdim192_128_e4m3_paged_sm90.cu.o
```

https://buildkite.com/vllm/release/builds/7472/steps/canvas?sid=0198c912-0e89-4296-a799-9b8275153f55

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

