### PR TITLE
[Compile] Fix Compile Warning SM100 Cutlass MLA

### DIFF
--- a/csrc/attention/mla/sm100_cutlass_mla_kernel.cu
+++ b/csrc/attention/mla/sm100_cutlass_mla_kernel.cu
@@ -167,7 +167,7 @@ typename T::Fmha::Arguments args_from_options(
       // TODO(trevor-m): Change split_kv back to -1 when
       // https://github.com/NVIDIA/cutlass/issues/2274 is fixed. Split_kv=1 will
       // perform worse with larger context length and smaller batch sizes.
-      num_kv_splits, // split_kv
+      static_cast<int>(num_kv_splits), // split_kv
       nullptr,       // is_var_split_kv
   };
   // TODO(kaixih@nvidia): When split_kv=-1 and is_var_split_kv=false, we compute
@@ -264,7 +264,7 @@ int64_t sm100_cutlass_mla_get_workspace_size(int64_t max_seq_len, int64_t num_ba
   // Assumes device 0 when getting sm_count.
   arguments.hw_info.sm_count =
       sm_count <= 0 ? cutlass::KernelHardwareInfo::query_device_multiprocessor_count(/*device_id=*/0) : sm_count;
-  arguments.split_kv = num_kv_splits;
+  arguments.split_kv = static_cast<int>(num_kv_splits);
   MlaSm100Type::Fmha::set_split_kv(arguments);
 
   return MlaSm100Type::Fmha::get_workspace_size(arguments);


### PR DESCRIPTION
## Purpose

Fix compile warning

```bash
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:149:400: warning: narrowing conversion of ‘num_kv_splits’ from ‘int64_t’ {aka ‘long int’} to ‘int’ [-Wnarrowing]
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu: In instantiation of ‘typename T::Fmha::Arguments args_from_options(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double, int64_t) [with T = MlaSm100<cutlass::bfloat16_t, false, IsPersistent<true> >; typename T::Fmha::Arguments = cutlass::fmha::kernel::Sm100FmhaMlaKernelTmaWarpspecialized<cute::tuple<cute::C<128>, cute::C<128>, cute::tuple<cute::C<512>, cute::C<64> > >, cutlass::bfloat16_t, float, cutlass::bfloat16_t, float, cutlass::fmha::kernel::Sm100MlaPersistentTileScheduler, true>::Arguments; typename T::Fmha = cutlass::fmha::device::MLA<cutlass::fmha::kernel::Sm100FmhaMlaKernelTmaWarpspecialized<cute::tuple<cute::C<128>, cute::C<128>, cute::tuple<cute::C<512>, cute::C<64> > >, cutlass::bfloat16_t, float, cutlass::bfloat16_t, float, cutlass::fmha::kernel::Sm100MlaPersistentTileScheduler, true> >; int64_t = long int]’:
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:195:89:   required from ‘void runMla(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double, int64_t, cudaStream_t) [with Element = cutlass::bfloat16_t; bool IsPaged128 = false; PersistenceOption = IsPersistent<true>; int64_t = long int; cudaStream_t = CUstream_st*]’
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:233:542:   required from here
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:149:400: warning: narrowing conversion of ‘num_kv_splits’ from ‘int64_t’ {aka ‘long int’} to ‘int’ [-Wnarrowing]
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu: In instantiation of ‘typename T::Fmha::Arguments args_from_options(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double, int64_t) [with T = MlaSm100<cutlass::float_e4m3_t, false, IsPersistent<true> >; typename T::Fmha::Arguments = cutlass::fmha::kernel::Sm100FmhaMlaKernelTmaWarpspecialized<cute::tuple<cute::C<128>, cute::C<128>, cute::tuple<cute::C<512>, cute::C<64> > >, cutlass::float_e4m3_t, float, cutlass::float_e4m3_t, float, cutlass::fmha::kernel::Sm100MlaPersistentTileScheduler, true>::Arguments; typename T::Fmha = cutlass::fmha::device::MLA<cutlass::fmha::kernel::Sm100FmhaMlaKernelTmaWarpspecialized<cute::tuple<cute::C<128>, cute::C<128>, cute::tuple<cute::C<512>, cute::C<64> > >, cutlass::float_e4m3_t, float, cutlass::float_e4m3_t, float, cutlass::fmha::kernel::Sm100MlaPersistentTileScheduler, true> >; int64_t = long int]’:
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:195:89:   required from ‘void runMla(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double, int64_t, cudaStream_t) [with Element = cutlass::float_e4m3_t; bool IsPaged128 = false; PersistenceOption = IsPersistent<true>; int64_t = long int; cudaStream_t = CUstream_st*]’
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:233:774:   required from here
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:149:400: warning: narrowing conversion of ‘num_kv_splits’ from ‘int64_t’ {aka ‘long int’} to ‘int’ [-Wnarrowing]
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu: In instantiation of ‘typename T::Fmha::Arguments args_from_options(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double, int64_t) [with T = MlaSm100<cutlass::half_t, false, IsPersistent<false> >; typename T::Fmha::Arguments = cutlass::fmha::kernel::Sm100FmhaMlaKernelTmaWarpspecialized<cute::tuple<cute::C<128>, cute::C<128>, cute::tuple<cute::C<512>, cute::C<64> > >, cutlass::half_t, float, cutlass::half_t, float, cutlass::fmha::kernel::Sm100MlaIndividualTileScheduler, true>::Arguments; typename T::Fmha = cutlass::fmha::device::MLA<cutlass::fmha::kernel::Sm100FmhaMlaKernelTmaWarpspecialized<cute::tuple<cute::C<128>, cute::C<128>, cute::tuple<cute::C<512>, cute::C<64> > >, cutlass::half_t, float, cutlass::half_t, float, cutlass::fmha::kernel::Sm100MlaIndividualTileScheduler, true> >; int64_t = long int]’:
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:195:89:   required from ‘void runMla(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double, int64_t, cudaStream_t) [with Element = cutlass::half_t; bool IsPaged128 = false; PersistenceOption = IsPersistent<false>; int64_t = long int; cudaStream_t = CUstream_st*]’
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:233:196:   required from here
/home/wentao/vllm-source/csrc/attention/mla/sm100_cutlass_mla_kernel.cu:149:400: warning: narrowing conversion of ‘num_kv_splits’ from ‘int64_t’ {aka ‘long int’} to ‘int’ [-Wnarrowing]
```

## Test

Now no warnings

```bash
-- CUDA target architectures: 10.0
-- CUDA supported target architectures: 10.0
-- FA2_ARCHS: 8.0+PTX
-- FA3_ARCHS: 
-- vllm-flash-attn is available at /home/wentao/vllm-source/cmake-build-release/_deps/vllm-flash-attn-src
-- Configuring done (28.5s)
-- Generating done (0.0s)
-- Build files have been written to: /home/wentao/vllm-source/cmake-build-release
[10/11] Install the project...
-- Install configuration: "Release"
```