### PR TITLE
Delete images older than 24h.

### DIFF
--- a/.buildkite/scripts/tpu/cleanup_docker.sh
+++ b/.buildkite/scripts/tpu/cleanup_docker.sh
@@ -17,7 +17,7 @@ if [ "$disk_usage" -gt "$threshold" ]; then
   # Remove dangling images (those that are not tagged and not used by any container)
   docker image prune -f
   # Remove unused volumes / force the system prune for old images as well.
-  docker volume prune -f && docker system prune --force --filter "until=72h" --all
+  docker volume prune -f && docker system prune --force --filter "until=24h" --all
   echo "Docker images and volumes cleanup completed."
 else
   echo "Disk usage is below $threshold%. No cleanup needed."


### PR DESCRIPTION
## Purpose
When disk is not enough, delete old images older than 1 day instead of 3 days. 

This is to work with https://github.com/vllm-project/ci-infra/pull/141 where image is not cleaned each time before testing.

