### PR TITLE
Remove duplicate entry in vllm.attention.__all__

### DIFF
--- a/vllm/attention/__init__.py
+++ b/vllm/attention/__init__.py
@@ -14,7 +14,6 @@ __all__ = [
     "AttentionMetadata",
     "AttentionType",
     "AttentionMetadataBuilder",
-    "Attention",
     "AttentionState",
     "get_attn_backend",
 ]


### PR DESCRIPTION
`Attention` was in here twice.

This is an unrelated change pulled out of #21088.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
