### PR TITLE
[V1] Remove unnecessary check for main thread

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -8,7 +8,6 @@ import dataclasses
 import functools
 import json
 import sys
-import threading
 from dataclasses import MISSING, dataclass, fields, is_dataclass
 from itertools import permutations
 from typing import (TYPE_CHECKING, Annotated, Any, Callable, Dict, List,
@@ -1525,11 +1524,6 @@ class EngineArgs:
             return False
         #############################################################
         # Experimental Features - allow users to opt in.
-
-        # Signal Handlers requires running in main thread.
-        if (threading.current_thread() != threading.main_thread()
-                and _warn_or_fallback("Engine in background thread")):
-            return False
 
         if self.pipeline_parallel_size > 1:
             supports_pp = getattr(self.distributed_executor_backend,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- remove guard for running in main thread
- this issue was resolved many months ago by moving away from signals for error handling

This PR is useful for customers running in Ray Serve or TritonServer, which put vllm in a background thread

## Test Plan

```python
import threading
import vllm

def run():
    model = vllm.LLM(model="Qwen/Qwen3-0.6B", tensor_parallel_size=2, enforce_eager=True)
    print(model.generate("Hello!"))

t = threading.Thread(target=run)
t.start()
t.join()
```

## Test Result
- it does not crash

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

