### PR TITLE
[BugFix] Fix Python 3.9 Support

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -28,7 +28,7 @@ class RequestFuncInput:
     model_name: Optional[str] = None
     logprobs: Optional[int] = None
     extra_body: Optional[dict] = None
-    multi_modal_content: Optional[Union[dict,list[dict]]] = None
+    multi_modal_content: Optional[Union[dict, list[dict]]] = None
     ignore_eos: bool = False
     language: Optional[str] = None
     request_id: Optional[str] = None

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -9,7 +9,7 @@ import sys
 import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Union
 
 import aiohttp
 from tqdm.asyncio import tqdm
@@ -28,7 +28,7 @@ class RequestFuncInput:
     model_name: Optional[str] = None
     logprobs: Optional[int] = None
     extra_body: Optional[dict] = None
-    multi_modal_content: Optional[dict | list[dict]] = None
+    multi_modal_content: Optional[Union[dict,list[dict]]] = None
     ignore_eos: bool = False
     language: Optional[str] = None
     request_id: Optional[str] = None


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix a change introduced in #22534 
That PR used the pipe operator `|`, which only supports being used in place of union in Python 3.10 and newer. So this switches the file to use the python 3.9 supported method.

There was no indication that Python 3.9 was officially dropped, and the documentation still lists 3.9 as the minimum version, so this PR makes the code reflect that.

Here is the error that happens if you run the latest release on Python 3.9:
```
Traceback (most recent call last):
  File "/root/joconnel/vllm/.venv/bin/vllm", line 5, in <module>
    from vllm.entrypoints.cli.main import main
  File "/root/joconnel/vllm/.venv/lib64/python3.9/site-packages/vllm/entrypoints/cli/__init__.py", line 4, in <module>
    from vllm.entrypoints.cli.benchmark.serve import BenchmarkServingSubcommand
  File "/root/joconnel/vllm/.venv/lib64/python3.9/site-packages/vllm/entrypoints/cli/benchmark/serve.py", line 5, in <module>
    from vllm.benchmarks.serve import add_cli_args, main
  File "/root/joconnel/vllm/.venv/lib64/python3.9/site-packages/vllm/benchmarks/serve.py", line 38, in <module>
    from vllm.benchmarks.lib.endpoint_request_func import (
  File "/root/joconnel/vllm/.venv/lib64/python3.9/site-packages/vllm/benchmarks/lib/endpoint_request_func.py", line 21, in <module>
    class RequestFuncInput:
  File "/root/joconnel/vllm/.venv/lib64/python3.9/site-packages/vllm/benchmarks/lib/endpoint_request_func.py", line 31, in RequestFuncInput
    multi_modal_content: Optional[dict | list[dict]] = None
TypeError: unsupported operand type(s) for |: 'type' and 'types.GenericAlias'
```

## Test Plan
Since this is a two-line bug fix, the plan was to run it locally.

## Test Result
With this change I was successfully able to run vLLM with Python 3.9.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

