### PR TITLE
[ROCm] Upgrade aiter version

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -12,7 +12,7 @@ ARG PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
 ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
 ARG FA_BRANCH="1a7f4dfa"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="916bf3c"
+ARG AITER_BRANCH="5ee37dc"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
 FROM ${BASE_IMAGE} AS base


### PR DESCRIPTION
## Purpose
Upgrade the Aiter version `5ee37dc` to introduce performance improvements.

## Test Plan
Perform lm-eval on all of the representative models that are using AITER kernels (all lm-evals are evaluated on V1 Engine).

* `from aiter import gemm_a8w8_CK` (RedHat/Meta-Llama-3.1-405B-Instruct-quantized.w8a8)
* `aiter.flash_attn_varlen_func` (mistral, mistral-fp8, Llama-3, Llama-4 Bf16)
* `aiter.paged_attention_v1` (mistral, mistral-fp8, Llama-3, Llama-4 Bf16)
* `from aiter import topk_softmax` (mistral, mistral-fp8, Llama-4 Bf16)
* `from aiter.fused_moe_bf16_asm import asm_moe_tkw1` (Llama-4 FP8)
* `from aiter import biased_grouped_topk` (DeepSeek-R1)
* `from aiter import grouped_topk` (mistral, mistral-fp8, Llama-4 Bf16)
* `from aiter.fused_moe import fused_moe` (DeepSeek-R1, mistral, mistral-fp8, Llama-4 Bf16)
* `from aiter.ops.shuffle import shuffle_weight` (DeepSeek-R1, mistral, Llama-4)
* `aiter.gemm_a8w8_blockscale` (DeepSeek-R1)
* `from aiter.mla import mla_decode_fwd` (DeepSeek-R1)


Serving flag
```bash
VLLM_USE_V1=1 \
VLLM_ROCM_USE_AITER=1 \
vllm serve <variable> \
--tensor-parallel-size <variable> \
--max-model-len 32768 \
--disable-log-requests \
--compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
--trust-remote-code \
--port 6791 
```

LMEval script
```bash
lm_eval \
--model local-completions \
--tasks gsm8k \
--model_args model=<variable>,base_url=http://127.0.0.1:6789/v1/completions \
--batch_size 100 
```

## Test Result
meta-llama/Llama-3.3-70B-Instruct 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9401|±  |0.0065|
|     |       |strict-match    |     5|exact_match|↑  |0.9105|±  |0.0079|

RedHatAI/Mistral-7B-Instruct-v0.3-FP8 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4655|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.4655|±  |0.0137|

mistralai/Mistral-7B-v0.3
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3609|±  |0.0132|
|     |       |strict-match    |     5|exact_match|↑  |0.3601|±  |0.0132|


EmbeddedLLM/Qwen2.5-32B-Instruct-FP8-Dynamic
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7165|±  |0.0124|
|     |       |strict-match    |     5|exact_match|↑  |0.7551|±  |0.0118|

Qwen/Qwen3-32B
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6103|±  |0.0134|
|     |       |strict-match    |     5|exact_match|↑  |0.7369|±  |0.0121|

deepseek-ai/DeepSeek-R1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9583|±  |0.0055|
|     |       |strict-match    |     5|exact_match|↑  |0.9575|±  |0.0056|


RedHatAI/Meta-Llama-3.1-405B-Instruct-quantized.w8a8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9212|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9204|±  |0.0075|


meta-llama/Llama-4-Scout-17B-16E 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8309|±  |0.0103|
|     |       |strict-match    |     5|exact_match|↑  |0.8294|±  |0.0104|

RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9227|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9014|±  |0.0082|

Qwen/Qwen3-32B-FP8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6513|±  |0.0131|
|     |       |strict-match    |     5|exact_match|↑  |0.7536|±  |0.0119|

RedHatAI/Mixtral-8x7B-Instruct-v0.1-FP8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6035|±  |0.0135|
|     |       |strict-match    |     5|exact_match|↑  |0.6027|±  |0.0135|

mistralai/Mixtral-8x7B-Instruct-v0.1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6444|±  |0.0132|
|     |       |strict-match    |     5|exact_match|↑  |0.6414|±  |0.0132|

Qwen/Qwen2.5-VL-7B-Instruct (chartqa)

```
Metrics:
{
   "explicit_prompt_relaxed_correctness": 0.8636,
   "anywhere_in_answer_relaxed_correctness": 0.8636
}
```

## (Optional) Documentation Update
None
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

