### PR TITLE
[Feature][Responses API] Support logprobs(non-stream)

### DIFF
--- a/tests/v1/entrypoints/openai/responses/test_basic.py
+++ b/tests/v1/entrypoints/openai/responses/test_basic.py
@@ -73,3 +73,16 @@ async def test_chat_with_input_type(client: openai.AsyncOpenAI):
     ], )
     print(response)
     assert response.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_logprobs(client: openai.AsyncOpenAI):
+    response = await client.responses.create(
+        include=["message.output_text.logprobs"],
+        input="What is 13 * 24?",
+        top_logprobs=5,
+    )
+    print(response)
+    outputs = response.output
+    assert outputs[-1].content[-1].logprobs
+    assert len(outputs[-1].content[-1].logprobs[0].top_logprobs) == 5

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -357,12 +357,21 @@ class ResponsesRequest(OpenAIBaseModel):
             temperature=temperature,
             top_p=top_p,
             max_tokens=max_tokens,
-            logprobs=self.top_logprobs,
+            logprobs=self.top_logprobs
+            if self.is_include_output_logprobs() else None,
             stop_token_ids=stop_token_ids,
             output_kind=(RequestOutputKind.DELTA
                          if self.stream else RequestOutputKind.FINAL_ONLY),
             guided_decoding=guided_decoding,
         )
+
+    def is_include_output_logprobs(self) -> bool:
+        """Check if the request includes output logprobs."""
+        if self.include is None:
+            return False
+        return isinstance(
+            self.include,
+            list) and "message.output_text.logprobs" in self.include
 
     @model_validator(mode="before")
     def validate_background(cls, data):
@@ -1808,7 +1817,7 @@ class ResponsesResponse(OpenAIBaseModel):
     service_tier: Literal["auto", "default", "flex", "scale", "priority"]
     status: ResponseStatus
     text: Optional[ResponseTextConfig] = None
-    top_logprobs: int
+    top_logprobs: Optional[int] = None
     truncation: Literal["auto", "disabled"]
     usage: Optional[ResponseUsage] = None
     user: Optional[str] = None


### PR DESCRIPTION
Related issue https://github.com/vllm-project/vllm/issues/23225

## Purpose

Support logprobs for Response API (non-stream).

Stream mode is currently divided into several cases:
`gpt-oss` models use Harmony, as they use a custom parser, and logprobs are not implemented yet. `gpt-5-mini` also does not support logprobs.
```
➜  ~ curl https://api.openai.com/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-proj-xxx" \
  -d '{
    "include": ["message.output_text.logprobs"],
    "model": "gpt-5-mini",
    "input": "hello, ",
    "store": true,
    "top_logprobs": 3
  }'

{
  "error": {
    "message": "logprobs are not supported with reasoning models.",
    "type": "invalid_request_error",
    "param": "include",
    "code": "unsupported_parameter"
  }
}
```

Other models have not yet fully implemented the Response Streaming API, so support is temporarily unavailable.

https://github.com/vllm-project/vllm/blob/2e2000f352d861dd2b527a48c5f12d295a93c3dd/vllm/entrypoints/openai/serving_responses.py#L795-L798

## Test Plan

Added unit tests.

## Test Result

See CI.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

