### PR TITLE
[Model] Support DP for ViT on MiniCPM-V-4

### DIFF
--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -173,6 +173,7 @@ Currently, the following models support `mm_encoder_tp_mode="data"`:
 - Llama4 (<gh-pr:18368>)
 - Qwen2.5-VL (<gh-pr:22742>)
 - Step3 (<gh-pr:22697>)
+- MiniCPM-V-4 (<gh-pr:23327>)
 
 ## Input Processing
 

--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -171,9 +171,9 @@ The availablilty of batch-level DP is based on model implementation.
 Currently, the following models support `mm_encoder_tp_mode="data"`:
 
 - Llama4 (<gh-pr:18368>)
+- MiniCPM-V-4 (<gh-pr:23327>)
 - Qwen2.5-VL (<gh-pr:22742>)
 - Step3 (<gh-pr:22697>)
-- MiniCPM-V-4 (<gh-pr:23327>)
 
 ## Input Processing
 

--- a/vllm/model_executor/models/idefics2_vision_model.py
+++ b/vllm/model_executor/models/idefics2_vision_model.py
@@ -31,9 +31,11 @@ from vllm.distributed import divide, get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.activation import get_act_fn
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
+                                               ReplicatedLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.multimodal.utils import run_dp_sharded_vision_model
 
 
 class Idefics2VisionEmbeddings(nn.Module):
@@ -118,6 +120,7 @@ class Idefics2VisionAttention(nn.Module):
         config: Idefics2VisionConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.config = config
@@ -130,22 +133,43 @@ class Idefics2VisionAttention(nn.Module):
                 f" {self.num_heads}).")
         self.scale = self.head_dim**-0.5
         self.dropout = config.attention_dropout
-        self.qkv_proj = QKVParallelLinear(
-            self.embed_dim,
-            self.head_dim,
-            self.num_heads,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkv_proj",
-        )
-        self.out_proj = RowParallelLinear(
-            self.embed_dim,
-            self.embed_dim,
-            bias=True,
-            quant_config=quant_config,
-            prefix=f"{prefix}.out_proj",
-        )
-        self.tp_size = get_tensor_model_parallel_world_size()
-        self.num_heads_per_partition = divide(self.num_heads, self.tp_size)
+        
+        tp_size = (1 if use_data_parallel else
+                   get_tensor_model_parallel_world_size())
+        assert self.num_heads % tp_size == 0
+        self.num_heads_per_partition = self.num_heads // tp_size
+        
+        if use_data_parallel:
+            self.q_size = self.num_heads * self.head_dim
+            self.qkv_proj = ReplicatedLinear(
+                self.embed_dim,
+                3 * self.q_size,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
+            self.out_proj = ReplicatedLinear(
+                self.embed_dim,
+                self.embed_dim,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.out_proj",
+            )
+        else:
+            self.qkv_proj = QKVParallelLinear(
+                self.embed_dim,
+                self.head_dim,
+                self.num_heads,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
+            self.out_proj = RowParallelLinear(
+                self.embed_dim,
+                self.embed_dim,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.out_proj",
+            )
         self.attn = MultiHeadAttention(self.num_heads_per_partition,
                                        self.head_dim, self.scale)
 
@@ -169,18 +193,23 @@ class Idefics2VisionMLP(nn.Module):
         config: Idefics2VisionConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.config = config
         self.activation_fn = get_act_fn(config.hidden_act)
-        self.fc1 = ColumnParallelLinear(
+        cls_fc1 = (ReplicatedLinear
+                   if use_data_parallel else ColumnParallelLinear)
+        self.fc1 = cls_fc1(
             config.hidden_size,
             config.intermediate_size,
             bias=True,
             quant_config=quant_config,
             prefix=f"{prefix}.fc1",
         )
-        self.fc2 = RowParallelLinear(
+        cls_fc2 = (ReplicatedLinear
+                   if use_data_parallel else RowParallelLinear)
+        self.fc2 = cls_fc2(
             config.intermediate_size,
             config.hidden_size,
             bias=True,
@@ -202,17 +231,22 @@ class Idefics2EncoderLayer(nn.Module):
         config: Idefics2Config,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.embed_dim = config.hidden_size
-        self.self_attn = Idefics2VisionAttention(config,
-                                                 quant_config=quant_config,
-                                                 prefix=f"{prefix}.self_attn")
+        self.self_attn = Idefics2VisionAttention(
+            config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+            use_data_parallel=use_data_parallel
+        )
         self.layer_norm1 = nn.LayerNorm(self.embed_dim,
                                         eps=config.layer_norm_eps)
         self.mlp = Idefics2VisionMLP(config,
                                      quant_config=quant_config,
-                                     prefix=f"{prefix}.mlp")
+                                     prefix=f"{prefix}.mlp",
+                                     use_data_parallel=use_data_parallel)
         self.layer_norm2 = nn.LayerNorm(self.embed_dim,
                                         eps=config.layer_norm_eps)
 
@@ -254,6 +288,7 @@ class Idefics2Encoder(nn.Module):
         *,
         num_hidden_layers_override: Optional[int] = None,
         prefix: str = "",
+        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
 
@@ -267,7 +302,8 @@ class Idefics2Encoder(nn.Module):
         self.layers = nn.ModuleList([
             Idefics2EncoderLayer(config,
                                  quant_config=quant_config,
-                                 prefix=f"{prefix}.layers.{layer_idx}")
+                                 prefix=f"{prefix}.layers.{layer_idx}",
+                                 use_data_parallel=use_data_parallel)
             for layer_idx in range(num_hidden_layers)
         ])
 
@@ -301,17 +337,21 @@ class Idefics2VisionTransformer(nn.Module):
         num_hidden_layers_override: Optional[int] = None,
         require_post_norm: bool = True,
         prefix: str = "",
+        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
 
         embed_dim = config.hidden_size
         self.config = config
+        self.use_data_parallel = use_data_parallel
         self.embeddings = Idefics2VisionEmbeddings(config)
         self.encoder = Idefics2Encoder(
             config,
             quant_config=quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
-            prefix=f"{prefix}.encoder")
+            prefix=f"{prefix}.encoder",
+            use_data_parallel=use_data_parallel
+        )
 
         num_hidden_layers = config.num_hidden_layers
         if len(self.encoder.layers) > config.num_hidden_layers:
@@ -340,9 +380,37 @@ class Idefics2VisionTransformer(nn.Module):
             patch_attention_mask=patch_attention_mask,
             tgt_sizes=tgt_sizes,
         )
-        encoder_outputs = self.encoder(hidden_states)
+        if self.use_data_parallel:
+            encoder_outputs = run_dp_sharded_vision_model(
+                hidden_states, self.encoder)
+        else:
+            encoder_outputs = self.encoder(hidden_states)
         last_hidden_state = self.post_layernorm(encoder_outputs)
         return last_hidden_state
+
+    def _consolidate_qkv_weights(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        qkv_idx_mappings = {
+            ".self_attn.q_proj": 0,
+            ".self_attn.k_proj": 1,
+            ".self_attn.v_proj": 2,
+        }
+        qkv_weights = {}
+        for name, loaded_weight in weights:
+            for weight_name, idx in qkv_idx_mappings.items():
+                if weight_name not in name:
+                    continue
+                new_name = name.replace(weight_name, ".self_attn.qkv_proj")
+                if new_name not in qkv_weights:
+                    qkv_weights[new_name] = [None] * 3
+                qkv_weights[new_name][idx] = loaded_weight
+                break
+            else:
+                yield name, loaded_weight
+        for key, weight in qkv_weights.items():
+            qkv_weight = torch.cat(weight, dim=0)
+            yield key, qkv_weight
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
@@ -355,6 +423,9 @@ class Idefics2VisionTransformer(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         layer_count = len(self.encoder.layers)
+
+        if self.use_data_parallel:
+            weights = self._consolidate_qkv_weights(weights)
 
         for name, loaded_weight in weights:
             # skip pooling header
@@ -373,7 +444,7 @@ class Idefics2VisionTransformer(nn.Module):
                     continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
+                if weight_name not in name or self.use_data_parallel:
                     continue
                 name = name.replace(weight_name, param_name)
                 param = params_dict[name]

--- a/vllm/model_executor/models/idefics2_vision_model.py
+++ b/vllm/model_executor/models/idefics2_vision_model.py
@@ -27,7 +27,7 @@ from transformers.models.idefics2.configuration_idefics2 import (
     Idefics2Config, Idefics2VisionConfig)
 
 from vllm.attention.layer import MultiHeadAttention
-from vllm.distributed import divide, get_tensor_model_parallel_world_size
+from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.activation import get_act_fn
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
@@ -133,12 +133,12 @@ class Idefics2VisionAttention(nn.Module):
                 f" {self.num_heads}).")
         self.scale = self.head_dim**-0.5
         self.dropout = config.attention_dropout
-        
+
         tp_size = (1 if use_data_parallel else
                    get_tensor_model_parallel_world_size())
         assert self.num_heads % tp_size == 0
         self.num_heads_per_partition = self.num_heads // tp_size
-        
+
         if use_data_parallel:
             self.q_size = self.num_heads * self.head_dim
             self.qkv_proj = ReplicatedLinear(
@@ -239,8 +239,7 @@ class Idefics2EncoderLayer(nn.Module):
             config,
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
-            use_data_parallel=use_data_parallel
-        )
+            use_data_parallel=use_data_parallel)
         self.layer_norm1 = nn.LayerNorm(self.embed_dim,
                                         eps=config.layer_norm_eps)
         self.mlp = Idefics2VisionMLP(config,
@@ -350,8 +349,7 @@ class Idefics2VisionTransformer(nn.Module):
             quant_config=quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
             prefix=f"{prefix}.encoder",
-            use_data_parallel=use_data_parallel
-        )
+            use_data_parallel=use_data_parallel)
 
         num_hidden_layers = config.num_hidden_layers
         if len(self.encoder.layers) > config.num_hidden_layers:

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1330,8 +1330,7 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
             config.vision_config,
             quant_config=quant_config,
             prefix=prefix,
-            use_data_parallel=self.use_data_parallel
-        )
+            use_data_parallel=self.use_data_parallel)
         if self.config.drop_vision_last_layer:
             model.encoder.layers = model.encoder.layers[:-1]
         return model

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -778,6 +778,7 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         # and config class
         self.config = config
         self.multimodal_config = multimodal_config
+        self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
 
         self.version = get_version_by_config(self.config)
         self.llm = self.init_llm(vllm_config=vllm_config,
@@ -1325,9 +1326,12 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
         prefix: str = "",
     ) -> nn.Module:
         quant_config = self._maybe_ignore_quant_config(quant_config)
-        model = Idefics2VisionTransformer(config.vision_config,
-                                          quant_config=quant_config,
-                                          prefix=prefix)
+        model = Idefics2VisionTransformer(
+            config.vision_config,
+            quant_config=quant_config,
+            prefix=prefix,
+            use_data_parallel=self.use_data_parallel
+        )
         if self.config.drop_vision_last_layer:
             model.encoder.layers = model.encoder.layers[:-1]
         return model

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -461,6 +461,8 @@ def run_dp_sharded_vision_model(image_input: torch.Tensor,
                                               num_chunks_per_rank, ...]
 
     vision_embeddings = vision_model(image_input_per_rank)
+    # Ensure tensor is contiguous before all_gather
+    vision_embeddings = vision_embeddings.contiguous()
     vision_embeddings = tensor_model_parallel_all_gather(vision_embeddings,
                                                          dim=0)
     vision_embeddings = vision_embeddings[:num_chunks, ...]


### PR DESCRIPTION
## Purpose
Add option to run MiniCPM-V-4 vision encoder in data parallel manner while the main model is in TP. Can be enabled by flag: `mm_encoder_tp_mode="data"`

## Test Plan & Result

**lm_eval:**

TP8(baseline):
```
lm_eval \
  --model vllm-vlm \
  --model_args "pretrained=openbmb/MiniCPM-V-4,tensor_parallel_size=8,gpu_memory_utilization=0.9,trust_remote_code=True" \
  --tasks chartqa \
  --limit 100 \
  --batch_size auto
```

```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value |   |Stderr|
|-------|------:|------|-----:|-----------------|---|-----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  |0.5640|±  |0.0099|
|       |       |none  |     0|exact_match      |↑  |0.4792|±  |0.0100|
|       |       |none  |     0|relaxed_accuracy |↑  |0.5640|±  |0.0099|
```

DP8:
```
lm_eval \
  --model vllm-vlm \
  --model_args "pretrained=openbmb/MiniCPM-V-4,mm_encoder_tp_mode=data,tensor_parallel_size=8,gpu_memory_utilization=0.9,trust_remote_code=True" \
  --tasks chartqa \
  --limit 100 \
  --batch_size auto
```

```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value |   |Stderr|
|-------|------:|------|-----:|-----------------|---|-----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  |0.5604|±  |0.0099|
|       |       |none  |     0|exact_match      |↑  |0.4740|±  |0.0100|
|       |       |none  |     0|relaxed_accuracy |↑  |0.5684|±  |0.0099|
```

**Note: The accuracy is lower than the official standard, perhaps because chat_template was not applied, as MiniCPM did not provide it in the uploaded HF model.**

**performance:**

TP8(baseline):
```
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

vllm serve openbmb/MiniCPM-V-4 \
    --gpu-memory-utilization 0.9 \
    --trust-remote-code \
    --tensor-parallel-size 8 \
    --host 0.0.0.0 \
    --port 20001
```

DP8:
```
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

vllm serve openbmb/MiniCPM-V-4 \
    --gpu-memory-utilization 0.9 \
    --mm_encoder_tp_mode data \
    --trust-remote-code \
    --tensor-parallel-size 8 \
    --host 0.0.0.0 \
    --port 20001
```

run `benchmark_serving.py`:
```
python3 benchmarks/benchmark_serving.py  \
    --backend openai-chat   \
    --model openbmb/MiniCPM-V-4 \
    --endpoint /v1/chat/completions   \
    --trust_remote_code \
    --dataset-name hf   \
    --dataset-path lmarena-ai/VisionArena-Chat   \
    --hf-split train   \
    --num-prompts 100 \
    --host localhost \
    --port 20001
```

result:
```
TP8(baseline):
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  26.45     
Total input tokens:                      6975      
Total generated tokens:                  9078      
Request throughput (req/s):              3.78      
Output token throughput (tok/s):         343.22    
Total Token throughput (tok/s):          606.93    
---------------Time to First Token----------------
Mean TTFT (ms):                          8593.27   
Median TTFT (ms):                        9483.75   
P99 TTFT (ms):                           21059.12  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          438.66    
Median TPOT (ms):                        170.73    
P99 TPOT (ms):                           4539.28   
---------------Inter-token Latency----------------
Mean ITL (ms):                           181.50    
Median ITL (ms):                         36.19     
P99 ITL (ms):                            3375.19   
==================================================

DP8:
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  17.58     
Total input tokens:                      6975      
Total generated tokens:                  8920      
Request throughput (req/s):              5.69      
Output token throughput (tok/s):         507.49    
Total Token throughput (tok/s):          904.32    
---------------Time to First Token----------------
Mean TTFT (ms):                          6977.63   
Median TTFT (ms):                        6616.90   
P99 TTFT (ms):                           13008.27  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          180.00    
Median TPOT (ms):                        107.37    
P99 TPOT (ms):                           832.16    
---------------Inter-token Latency----------------
Mean ITL (ms):                           101.05    
Median ITL (ms):                         35.87     
P99 ITL (ms):                            946.84    
==================================================
```

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

