### PR TITLE
[Bugfix] Add fake mode around passes

### DIFF
--- a/vllm/compilation/activation_quant_fusion.py
+++ b/vllm/compilation/activation_quant_fusion.py
@@ -10,6 +10,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
+from .inductor_pass import enable_fake_mode
 from .vllm_inductor_pass import VllmInductorPass
 
 logger = init_logger(__name__)
@@ -61,6 +62,7 @@ class ActivationQuantFusionPass(VllmInductorPass):
     https://github.com/pytorch/pytorch/pull/139321#issuecomment-2452354980
     """
 
+    @enable_fake_mode
     def __init__(self, config: VllmConfig):
         super().__init__(config)
 

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -19,6 +19,7 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
 
+from .inductor_pass import enable_fake_mode
 from .vllm_inductor_pass import VllmInductorPass
 
 FP8_DTYPE = current_platform.fp8_dtype()
@@ -349,6 +350,7 @@ class AllGatherCutlassScaledMMPattern(BasePattern):
 
 class AsyncTPPass(VllmInductorPass):
 
+    @enable_fake_mode
     def __init__(self, config: VllmConfig):
         super().__init__(config)
 
@@ -1068,6 +1070,7 @@ class AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(BasePattern):
 
 class AllReduceFusionPass(VllmInductorPass):
 
+    @enable_fake_mode
     def __init__(self, config: VllmConfig):
         super().__init__(config)
         self.disabled = True

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -1070,7 +1070,6 @@ class AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(BasePattern):
 
 class AllReduceFusionPass(VllmInductorPass):
 
-    @enable_fake_mode
     def __init__(self, config: VllmConfig):
         super().__init__(config)
         self.disabled = True
@@ -1124,6 +1123,10 @@ class AllReduceFusionPass(VllmInductorPass):
             # in fallback path, when we don't use flashinfer
             fuse_rms_quant=config.compilation_config.pass_config.enable_fusion)
 
+        self.register_patterns()
+
+    @enable_fake_mode
+    def register_patterns(self):
         for epsilon in [1e-5, 1e-6]:
             AllReduceFusedRMSNormStaticQuantFP8Pattern(
                 epsilon,

--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 
 from .fx_utils import find_getitem_maybe
+from .inductor_pass import enable_fake_mode
 from .multi_output_match import MultiOutputMatch
 from .vllm_inductor_pass import VllmInductorPass
 
@@ -528,6 +529,7 @@ class FusionPass(VllmInductorPass):
             cls._instance.pass_config = config.compilation_config.pass_config
         return cls._instance
 
+    @enable_fake_mode
     def __init__(self, config: VllmConfig):
         assert self.__class__._instance is None, \
             "FusionPass singleton instance already exists"

--- a/vllm/compilation/sequence_parallelism.py
+++ b/vllm/compilation/sequence_parallelism.py
@@ -14,6 +14,7 @@ from vllm.distributed.parallel_state import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
+from .inductor_pass import enable_fake_mode
 from .vllm_inductor_pass import VllmInductorPass
 
 logger = init_logger(__name__)
@@ -436,6 +437,7 @@ class SequenceParallelismPass(VllmInductorPass):
     performance.
     """
 
+    @enable_fake_mode
     def __init__(self, config: VllmConfig):
         super().__init__(config)
 


### PR DESCRIPTION
## Purpose

Actually fixes https://github.com/vllm-project/vllm/issues/22250 .. maybe 😅

VLLM is trying to register inductor pattern/replacement graphs. When calling `register_replacement`, inductor will trace the pattern/replacement graphs with sample inputs. If the sample inputs are real tensors, then it will require you to have the right hardware to run these operators. The issue occurs when we're trying to register pattern/replacement graphs for scaled_mm for fp8 tensors, on A100s, which don't support fp8. 

One solution is to disable registering these graphs when fp8 is unsupported (https://github.com/vllm-project/vllm/pull/23288), or another solution is to trace with [fake tensors](https://docs.pytorch.org/docs/stable/torch.compiler_fake_tensor.html) which will not require the specific hardware in order to trace the graphs (because we will be running the fake kernels instead of the actual kernel). This PR adds the FakeTensorMode context around the initialization of all the passes, so that other passes that create these pattern/replacement graphs can also be traced with fake tensors.

This follows what Inductor does today, where it registers an [init_once_fakemode](https://github.com/pytorch/pytorch/blob/44549c7146bd6c4166f97e856037babe1b7f4f49/torch/_inductor/pattern_matcher.py#L2221-L2222) context when [registering](https://github.com/pytorch/pytorch/blob/a6401cb5aa51622045c3f9a03b2cebef236e4182/torch/_inductor/fx_passes/post_grad.py#L642-L661) pattern/replacement graphs.


Unrelated, but while looking around I saw there's a function [gen_register_replacement](https://github.com/pytorch/pytorch/blob/a6401cb5aa51622045c3f9a03b2cebef236e4182/torch/_inductor/pattern_matcher.py#L22-L27) which seems to precompile these traced graphs. If VLLM runs into compile-time overhead this could be something to look at. 

## Test Plan

Tested the repro in the issue locally + CI

## Test Result

Repro in issue succeeds!
