### PR TITLE
[Bug fix] Dynamically setting the backend variable for genai_perf_tests in the run-nightly-benchmark script

### DIFF
--- a/.buildkite/nightly-benchmarks/scripts/run-nightly-benchmarks.sh
+++ b/.buildkite/nightly-benchmarks/scripts/run-nightly-benchmarks.sh
@@ -382,7 +382,7 @@ run_genai_perf_tests() {
       client_command="genai-perf profile \
         -m $model \
         --service-kind openai \
-        --backend $backend \
+        --backend "$backend" \
         --endpoint-type chat \
         --streaming \
         --url localhost:$port \

--- a/.buildkite/nightly-benchmarks/scripts/run-nightly-benchmarks.sh
+++ b/.buildkite/nightly-benchmarks/scripts/run-nightly-benchmarks.sh
@@ -382,7 +382,7 @@ run_genai_perf_tests() {
       client_command="genai-perf profile \
         -m $model \
         --service-kind openai \
-        --backend vllm \
+        --backend $backend \
         --endpoint-type chat \
         --streaming \
         --url localhost:$port \


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixing the bug mentioned here: https://github.com/vllm-project/vllm/issues/23374

## Purpose

## Test Plan
Ran the script in the local to verify that the backend was being set dynamically.
```shell
CURRENT_LLM_SERVING_ENGINE=sglang bash .buildkite/nightly-benchmarks/scripts/run-nightly-benchmarks.sh
``` 

## Test Result
<img width="1012" height="245" alt="Screenshot 2025-08-21 at 2 08 13 PM" src="https://github.com/user-attachments/assets/88b69ea3-123b-4c5a-9db6-4b26fe70a363" />


## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

