### PR TITLE
[Perf] Async logits proc and sampling metadata state update

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -629,12 +629,15 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                                 scheduler_output: "SchedulerOutput") -> None:
         # Initialize generators for new seeded requests.
         for new_req_data in scheduler_output.scheduled_new_reqs:
-            req_state = self.requests[new_req_data.req_id]
+            req_id = new_req_data.req_id
+            req_state = self.requests[req_id]
             sampling_params = req_state.sampling_params
             if sampling_params and \
                     sampling_params.sampling_type == SamplingType.RANDOM_SEED:
                 req_state.generator = torch.Generator(device=self.device)
                 req_state.generator.manual_seed(sampling_params.seed)
+                req_index = self.input_batch.req_id_to_index[req_id]
+                self.input_batch.generators[req_index] = req_state.generator
 
         # Refresh logits processor states and sampling metadata
         # with any pending updates.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -473,13 +473,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             sampling_params = new_req_data.sampling_params
             pooling_params = new_req_data.pooling_params
 
-            if sampling_params and \
-                sampling_params.sampling_type == SamplingType.RANDOM_SEED:
-                generator = torch.Generator(device=self.device)
-                generator.manual_seed(sampling_params.seed)
-            else:
-                generator = None
-
             if pooling_params:
                 task = pooling_params.task
                 assert task is not None, "You did not set `task` in the API"
@@ -495,7 +488,8 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 mm_positions=new_req_data.mm_positions,
                 sampling_params=sampling_params,
                 pooling_params=pooling_params,
-                generator=generator,
+                # generator is populated in _update_sampling_states()
+                generator=None,
                 block_ids=new_req_data.block_ids,
                 num_computed_tokens=new_req_data.num_computed_tokens,
                 output_token_ids=[],
@@ -630,7 +624,20 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.input_batch.condense()
         # Allow attention backend to reorder the batch, potentially
         self._may_reorder_batch(scheduler_output)
-        # Refresh batch metadata with any pending updates.
+
+    def _update_sampling_states(self,
+                                scheduler_output: "SchedulerOutput") -> None:
+        # Initialize generators for new seeded requests.
+        for new_req_data in scheduler_output.scheduled_new_reqs:
+            req_state = self.requests[new_req_data.req_id]
+            sampling_params = req_state.sampling_params
+            if sampling_params and \
+                    sampling_params.sampling_type == SamplingType.RANDOM_SEED:
+                req_state.generator = torch.Generator(device=self.device)
+                req_state.generator.manual_seed(sampling_params.seed)
+
+        # Refresh logits processor states and sampling metadata
+        # with any pending updates.
         self.input_batch.refresh_metadata()
 
     def _extract_mm_kwargs(
@@ -1621,7 +1628,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Broadcast PP output for external_launcher (torchrun)
         # to make sure we are synced across pp ranks
-        # TODO: Support overlapping mirco-batches
+        # TODO: Support overlapping micro-batches
         # https://github.com/vllm-project/vllm/issues/18019
         broadcast_pp_output = \
             self.parallel_config.distributed_executor_backend \
@@ -1637,6 +1644,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             logits = None
         else:
             if self.input_batch.pooling_params:
+                # This is currently required for pooling because the
+                # sampling_metadata.prompt_token_ids tensor might be needed.
+                #TODO(nick) decouple this
+                self.input_batch.refresh_metadata()
+
                 return self._pool(hidden_states, num_scheduled_tokens,
                                   num_scheduled_tokens_np, kv_connector_output)
 
@@ -1650,6 +1662,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 model_output_broadcast_data, src=len(get_pp_group().ranks) - 1)
             assert model_output_broadcast_data is not None
             logits = model_output_broadcast_data["logits"]
+
+        # Apply batch state updates required for sampling stage;
+        # can run in parallel with model forward-pass.
+        self._update_sampling_states(scheduler_output)
 
         # Apply structured output bitmasks if present
         if scheduler_output.grammar_bitmask is not None:


### PR DESCRIPTION
Mentioned by @WoosukKwon in https://github.com/vllm-project/vllm/issues/23233.

The work to update logits processor states and construct the sampling metadata be deferred in model runner `execute_model` to overlap CPU with forward pass.

This has an advantage of taking the logits processor `update_states` calls off the critical path, and means we can trade off a bit of efficiency for simplicity in the API design.

There should be some incremental benefit as we migrate hard-wired sampling parameters into logits processors since their state updates are still happening in `_update_states()` before the forward pass.