### PR TITLE
[Core] Restructure core loop for async input preparation 

### DIFF
--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorBase_V1
-    from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.core.sched.output import GrammarBitmask, SchedulerOutput
     from vllm.v1.engine import EngineCoreOutputs
     from vllm.v1.metrics.stats import SchedulerStats
     from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
@@ -39,6 +39,14 @@ class SchedulerInterface(ABC):
             A SchedulerOutput object containing information about the scheduled
             requests.
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_grammar_bitmask(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> Optional["GrammarBitmask"]:
+        """Get the grammar bitmask for the scheduled requests."""
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -147,11 +147,15 @@ class SchedulerOutput:
     # Used to free the encoder cache.
     free_encoder_input_ids: list[tuple[str, int]]
 
+    # KV Cache Connector metadata.
+    kv_connector_metadata: Optional[KVConnectorMetadata] = None
+
+
+@dataclass
+class GrammarBitmask:
+
     # Dict of request ids to their index within the batch
     # for filling the next token bitmask
     structured_output_request_ids: dict[str, int]
     # the bitmask for the whole batch
     grammar_bitmask: Optional[npt.NDArray[np.int32]]
-
-    # KV Cache Connector metadata.
-    kv_connector_metadata: Optional[KVConnectorMetadata] = None

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -289,9 +289,9 @@ class EngineCore:
         self.model_executor.prepare_inputs(scheduler_output)
         self.model_executor.execute_model()
         bitmask = self.scheduler.get_grammar_bitmask(scheduler_output)
-        model_output = self.model_executor.sample(bitmask)
+        model_output = self.model_executor.sample(bitmask, non_block=False)
         engine_core_outputs = self.scheduler.update_from_output(
-            scheduler_output, model_output)
+            scheduler_output, model_output)  # type: ignore
         return (engine_core_outputs,
                 scheduler_output.total_num_scheduled_tokens > 0)
 
@@ -375,7 +375,7 @@ class EngineCore:
 
         if model_output is not None:
             engine_core_outputs = self.scheduler.update_from_output(
-                self.prev_scheduler_output, model_output)
+                self.prev_scheduler_output, model_output.result())
 
         self.inflight_batch = is_scheduled
         self.prev_scheduler_output = scheduler_output

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Callable, Optional
+from concurrent.futures import Future
+from typing import Callable, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -85,7 +86,12 @@ class Executor(ExecutorBase):
     def execute_model(self) -> None:
         self.collective_rpc("execute_model")
 
-    def sample(self, grammar_bitmask) -> ModelRunnerOutput:
+    def sample(
+        self,
+        grammar_bitmask,
+        non_block: bool = True,
+    ) -> Union[ModelRunnerOutput, Future[ModelRunnerOutput]]:
+        del non_block
         output = self.collective_rpc("sample", args=(grammar_bitmask, ))
         return output[0]
 

--- a/vllm/v1/executor/ray_distributed_executor.py
+++ b/vllm/v1/executor/ray_distributed_executor.py
@@ -58,8 +58,6 @@ class RayDistributedExecutor(RayDistributedExecutorV0, Executor):
         """Ray distributed executor supports pipeline parallelism,
         meaning that it allows PP size batches to be executed concurrently.
         """
-        if self.scheduler_config.async_scheduling:
-            return 2
         return self.parallel_config.pipeline_parallel_size
 
     def execute_model(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1513,7 +1513,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self._sample_scheduler_output = scheduler_output
         self._update_states(scheduler_output)
         if not scheduler_output.total_num_scheduled_tokens:
-            return
+            return None
 
         # Prepare the decoder inputs.
         (attn_metadata, logits_indices, spec_decode_metadata,
@@ -1665,6 +1665,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self._sample_hidden_states = sample_hidden_states
         self._logits = logits
         self._kv_connector_output = kv_connector_output
+        return None
 
     def sample(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1313,7 +1313,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def apply_grammar_bitmask(
         self,
         scheduler_output: "SchedulerOutput",
-        bitmask: Optional[GrammarBitmask],
+        bitmask: Optional["GrammarBitmask"],
         logits: torch.Tensor,
     ):
         if bitmask is None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1639,9 +1639,13 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                                             all_gather_group=get_tp_group())
             sample_hidden_states = None
             logits = None
-        elif not self.input_batch.pooling_params:
-            sample_hidden_states = hidden_states[logits_indices]
-            logits = self.model.compute_logits(sample_hidden_states, None)
+        else:
+            if self.input_batch.pooling_params:
+                sample_hidden_states = None
+                logits = None
+            else:
+                sample_hidden_states = hidden_states[logits_indices]
+                logits = self.model.compute_logits(sample_hidden_states, None)
 
         if broadcast_pp_output:
             model_output_broadcast_data = {

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1513,7 +1513,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self._sample_scheduler_output = scheduler_output
         self._update_states(scheduler_output)
         if not scheduler_output.total_num_scheduled_tokens:
-            print("NO SCHEDULED TOKENS **********************************")
             return
 
         # Prepare the decoder inputs.


### PR DESCRIPTION
Closes #23233 

This PR restructures the core loop for both synchronous and asynchronous scheduling.

For sync scheduling, this allows overlapping bitmask construction with the model execution.
For async scheduling, this allows overlapping input preparation (and bitmask) with the model execution. Currently, only deserialization of scheduler outputs is overlapped. This could be expanded in future PRs.
Besides, this PR refactors the async scheduling loop to be easier to understand, and enables structured outputs support.