### PR TITLE
[Bugfix] Fix pooling models on non-CUDA devices

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1469,9 +1469,10 @@ def current_stream() -> torch.cuda.Stream:
             _current_stream_tls.value = torch.cuda.Stream()
         elif current_platform.is_cpu():
             _current_stream_tls.value = _StreamPlaceholder()
-        else:
+        elif current_platform.is_cuda():
             _current_stream_tls.value = torch.cuda.current_stream()
-
+        else:
+            _current_stream_tls.value = current_platform.current_stream
     return _current_stream_tls.value
 
 

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1440,6 +1440,12 @@ def _patched_set_stream(stream: torch.cuda.Stream) -> None:
 torch.cuda.set_stream = _patched_set_stream
 
 
+class _StreamPlaceholder:
+
+    def __init__(self):
+        self.synchronize = lambda: None
+
+
 def current_stream() -> torch.cuda.Stream:
     """
     replace `torch.cuda.current_stream()` with `vllm.utils.current_stream()`.
@@ -1459,8 +1465,13 @@ def current_stream() -> torch.cuda.Stream:
         # On ROCm using the default 0 stream in combination with RCCL
         # is hurting performance. Therefore creating a dedicated stream
         # per process
-        _current_stream_tls.value = torch.cuda.Stream(
-        ) if current_platform.is_rocm() else torch.cuda.current_stream()
+        if current_platform.is_rocm():
+            _current_stream_tls.value = torch.cuda.Stream()
+        elif current_platform.is_cpu():
+            _current_stream_tls.value = _StreamPlaceholder()
+        else:
+            _current_stream_tls.value = torch.cuda.current_stream()
+
     return _current_stream_tls.value
 
 

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1469,10 +1469,14 @@ def current_stream() -> torch.cuda.Stream:
             _current_stream_tls.value = torch.cuda.Stream()
         elif current_platform.is_cpu():
             _current_stream_tls.value = _StreamPlaceholder()
-        elif current_platform.is_cuda():
-            _current_stream_tls.value = torch.cuda.current_stream()
         else:
-            _current_stream_tls.value = current_platform.current_stream
+            current_stream = current_platform.current_stream
+            if current_stream is not None:
+                _current_stream_tls.value = current_stream()
+            else:
+                raise ValueError(
+                    "Fail to set current stream, current platform "
+                    "may not support current_stream with torch API")
     return _current_stream_tls.value
 
 


### PR DESCRIPTION

## Purpose

To make #23162 compatible with the CPU backend, add ```_StreamPlaceholder``` as we did for Triton.   

Also pick changes from #23397 

## Test Plan

CI pipeline

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

