### PR TITLE
[BugFix] Fix the bug that enable_eplb cannot be transmited via LLM entrypoint.

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -802,7 +802,9 @@ class FusedMoE(CustomOp):
         compilation_config.static_forward_context[prefix] = self
         self.layer_name = prefix
 
-        self.enable_eplb = enable_eplb
+        self.enable_eplb = (
+            True if vllm_config.parallel_config.enable_eplb else enable_eplb
+        )
         self.expert_load_view: Optional[torch.Tensor] = None
         self.logical_to_physical_map: Optional[torch.Tensor] = None
         self.logical_replica_count: Optional[torch.Tensor] = None


### PR DESCRIPTION
## Purpose
In the current implementation, the enable_eplb argument cannot be passed through the LLM initialization, for example:
```python
model = LLM(model=MODEL_PATH,
            tensor_parallel_size=2,
            enable_expert_parallel=True,
            enable_eplb=True,)
```
```
# debug info added in class FusedMoE, enable_eplb is always false even I passed it in LLM initialization
(VllmWorker rank=0 pid=665042) INFO 08-21 06:08:15 [layer.py:720]use_ep: True, enable_expert_parallel: True, and enable_eplb: False
```
This PR fixed this bug to ensuring that enable_eplb can be successfully transmitted into FusedMoE class.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

