### PR TITLE
[Platform] Make current_stream platform agnostic

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1440,15 +1440,17 @@ def _patched_set_stream(stream: torch.cuda.Stream) -> None:
 torch.cuda.set_stream = _patched_set_stream
 
 
-def current_stream() -> torch.cuda.Stream:
+def current_stream() -> Any:
     """
-    replace `torch.cuda.current_stream()` with `vllm.utils.current_stream()`.
-    it turns out that `torch.cuda.current_stream()` is quite expensive,
+    Replace `current_platform.current_stream()` with
+    `vllm.utils.current_stream()`.
+
+    It turns out that `torch.cuda.current_stream()` is quite expensive,
     as it will construct a new stream object at each call.
-    here we patch `torch.cuda.set_stream` to keep track of the current stream
+    Here we patch `torch.cuda.set_stream` to keep track of the current stream
     directly, so that we can avoid calling `torch.cuda.current_stream()`.
 
-    the underlying hypothesis is that we do not call `torch._C._cuda_setStream`
+    The underlying hypothesis is that we do not call `torch._C._cuda_setStream`
     from C/C++ code.
     """
     from vllm.platforms import current_platform
@@ -1456,11 +1458,19 @@ def current_stream() -> torch.cuda.Stream:
                    "value") or _current_stream_tls.value is None:
         # when this function is called before any stream is set,
         # we return the default stream.
-        # On ROCm using the default 0 stream in combination with RCCL
-        # is hurting performance. Therefore creating a dedicated stream
-        # per process
-        _current_stream_tls.value = torch.cuda.Stream(
-        ) if current_platform.is_rocm() else torch.cuda.current_stream()
+        if current_platform.is_rocm():
+            # On ROCm using the default 0 stream in combination with RCCL
+            # is hurting performance. Therefore creating a dedicated stream
+            # per process
+            _current_stream_tls.value = torch.cuda.Stream()
+        else:
+            current_stream = current_platform.current_stream
+            if current_stream is not None:
+                _current_stream_tls.value = current_stream()
+            else:
+                raise ValueError(
+                    "Fail to set current stream, current platform "
+                    "may not support current_stream with torch API")
     return _current_stream_tls.value
 
 


### PR DESCRIPTION
## Purpose

The commit https://github.com/vllm-project/vllm/pull/23162 add the `current_stream` logic which only works on cuda. https://github.com/vllm-project/vllm/blob/8896eb72ebe90be6f1b83f32b3d3d0c379db4f82/vllm/model_executor/layers/pooler.py#L214

This break the pooling model function for custom platform. To avoid this kind of issue happen again, this PR make `current_stream` function more generic.

## Test Plan

Current test is enough.

## Test Result

All test should pass

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

