### PR TITLE
fix(tests): Ensure reliable CUDA cache clearing in MoE test

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -429,11 +429,13 @@ def test_mixtral_moe(dtype: torch.dtype, padding: bool, use_rocm_aiter: bool,
                 vllm_moe.experts.w13_weight, (0, 128), "constant", 0)[...,
                                                                       0:-128],
                                                     requires_grad=False)
+            torch.cuda.synchronize()
             torch.cuda.empty_cache()
             vllm_moe.experts.w2_weight = Parameter(F.pad(
                 vllm_moe.experts.w2_weight, (0, 128), "constant", 0)[...,
                                                                      0:-128],
                                                    requires_grad=False)
+            torch.cuda.synchronize()
             torch.cuda.empty_cache()
 
         # Run forward passes for both MoE blocks

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -429,8 +429,6 @@ def test_mixtral_moe(dtype: torch.dtype, padding: bool, use_rocm_aiter: bool,
                 vllm_moe.experts.w13_weight, (0, 128), "constant", 0)[...,
                                                                       0:-128],
                                                     requires_grad=False)
-            torch.cuda.synchronize()
-            torch.cuda.empty_cache()
             vllm_moe.experts.w2_weight = Parameter(F.pad(
                 vllm_moe.experts.w2_weight, (0, 128), "constant", 0)[...,
                                                                      0:-128],


### PR DESCRIPTION
In `test_mixtral_moe`, `torch.cuda.empty_cache()` is called immediately after an `F.pad` operation.

Due to the asynchronous nature of CUDA kernels, there's no guarantee that the padding operation has completed on the GPU before the cache is cleared. This can make the `empty_cache()` call ineffective.

This commit adds `torch.cuda.synchronize()` before `torch.cuda.empty_cache()` to ensure all pending GPU work is finished, making memory management in the test more reliable and deterministic.


## Purpose
This PR improves the reliability of memory management in the test_mixtral_moe test by addressing a potential race condition between the CPU and GPU.

Currently, torch.cuda.empty_cache() is called immediately after an asynchronous CUDA operation (F.pad). There is no guarantee that the GPU has finished the operation before the cache-clearing command is issued, which can render empty_cache() ineffective.

This change introduces a torch.cuda.synchronize() call before empty_cache() to ensure all pending GPU kernels are complete, making the test's memory handling more robust and deterministic.

## Test Plan

```bash
pytest tests/kernels/test_moe.py -k test_mixtral_moe
```

## Test Result


## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

