### PR TITLE
[Frontend] Add deepseek v3.1 reasoning parser

### DIFF
--- a/tests/reasoning/test_granite_reasoning_parser.py
+++ b/tests/reasoning/test_granite_reasoning_parser.py
@@ -4,6 +4,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from tests.reasoning.utils import DeltaMessage, run_reasoning_extraction
+from vllm.entrypoints.openai.protocol import ChatCompletionRequest
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
 parser_name = "granite"
@@ -333,7 +334,7 @@ def test_streaming_subcases(param_dict):
         previous_token_ids=previous_token_ids,
         current_token_ids=current_token_ids,
         delta_token_ids=delta_token_ids,
-    )
+        request=ChatCompletionRequest(model="test-model"))
     # Streaming currently expects at least one of reasoning content / content,
     # so the response should return None in that case.
     if param_dict["reasoning_content"] is None and param_dict["content"] is None:

--- a/tests/reasoning/test_granite_reasoning_parser.py
+++ b/tests/reasoning/test_granite_reasoning_parser.py
@@ -334,7 +334,8 @@ def test_streaming_subcases(param_dict):
         previous_token_ids=previous_token_ids,
         current_token_ids=current_token_ids,
         delta_token_ids=delta_token_ids,
-        request=ChatCompletionRequest(model="test-model"))
+        request=ChatCompletionRequest(model="test-model"),
+    )
     # Streaming currently expects at least one of reasoning content / content,
     # so the response should return None in that case.
     if param_dict["reasoning_content"] is None and param_dict["content"] is None:

--- a/tests/reasoning/utils.py
+++ b/tests/reasoning/utils.py
@@ -118,6 +118,7 @@ def run_reasoning_extraction_streaming(
             previous_tokens,
             current_tokens,
             token_delta,
+            request,
         )
         if delta_message is not None:
             reconstructor.append_delta(delta_message)
@@ -150,6 +151,7 @@ def run_reasoning_extraction_streaming_mistral(
             previous_tokens,
             current_tokens,
             token_delta,
+            request,
         )
         if delta_message is not None:
             reconstructor.append_delta(delta_message)

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -855,6 +855,7 @@ class OpenAIServingChat(OpenAIServing):
                                     previous_token_ids,
                                     current_token_ids,
                                     output.token_ids,
+                                    request,
                                 )
                             )
                             # When encountering think end id in delta_token_ids
@@ -953,6 +954,7 @@ class OpenAIServingChat(OpenAIServing):
                                     previous_token_ids,
                                     current_token_ids,
                                     output_token_ids,
+                                    request,
                                 )
                             )
                             # When encountering think end id in prompt_token_ids
@@ -1039,6 +1041,7 @@ class OpenAIServingChat(OpenAIServing):
                                 previous_token_ids,
                                 current_token_ids,
                                 output.token_ids,
+                                request,
                             )
                         )
                     # handle streaming just a content delta

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -1127,6 +1127,7 @@ class OpenAIServingResponses(OpenAIServing):
                             previous_token_ids=previous_token_ids,
                             current_token_ids=previous_token_ids + output.token_ids,
                             delta_token_ids=output.token_ids,
+                            request=request,
                         )
                     )
                 else:

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -4,6 +4,7 @@
 from .abs_reasoning_parsers import ReasoningParser, ReasoningParserManager
 from .basic_parsers import BaseThinkingReasoningParser
 from .deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+from .deepseek_v31_reasoning_parser import DeepSeekV31ReasoningParser
 from .glm4_moe_reasoning_parser import Glm4MoeModelReasoningParser
 from .gptoss_reasoning_parser import GptOssReasoningParser
 from .granite_reasoning_parser import GraniteReasoningParser
@@ -19,6 +20,7 @@ __all__ = [
     "BaseThinkingReasoningParser",
     "ReasoningParserManager",
     "DeepSeekR1ReasoningParser",
+    "DeepSeekV31ReasoningParser",
     "GraniteReasoningParser",
     "HunyuanA13BReasoningParser",
     "Qwen3ReasoningParser",

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -107,6 +107,7 @@ class ReasoningParser:
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         """
         Instance method that should be implemented for extracting reasoning

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -78,6 +78,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         """
         Extract reasoning content from a delta message.

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -4,7 +4,11 @@
 from collections.abc import Sequence
 from typing import Union
 
-from vllm.entrypoints.openai.protocol import DeltaMessage
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    ResponsesRequest,
+)
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 
@@ -36,6 +40,7 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         ret = super().extract_reasoning_content_streaming(
             previous_text,
@@ -44,6 +49,7 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
             previous_token_ids,
             current_token_ids,
             delta_token_ids,
+            request,
         )
         if (
             ret is not None

--- a/vllm/reasoning/deepseek_v31_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v31_reasoning_parser.py
@@ -17,7 +17,6 @@ logger = init_logger(__name__)
 
 @ReasoningParserManager.register_module("deepseek_v31")
 class DeepSeekV31ReasoningParser(DeepSeekR1ReasoningParser):
-
     def extract_reasoning_content_streaming(
         self,
         previous_text: str,
@@ -28,8 +27,10 @@ class DeepSeekV31ReasoningParser(DeepSeekR1ReasoningParser):
         delta_token_ids: Sequence[int],
         request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
-        if request.chat_template_kwargs is not None and \
-           request.chat_template_kwargs.get("thinking", False):
+        if (
+            request.chat_template_kwargs is not None
+            and request.chat_template_kwargs.get("thinking", False) is True
+        ):
             return super().extract_reasoning_content_streaming(
                 previous_text,
                 current_text,
@@ -45,8 +46,10 @@ class DeepSeekV31ReasoningParser(DeepSeekR1ReasoningParser):
     def extract_reasoning_content(
         self, model_output: str, request: Union[ChatCompletionRequest, ResponsesRequest]
     ) -> tuple[Optional[str], Optional[str]]:
-        if request.chat_template_kwargs is not None and \
-           request.chat_template_kwargs.get("thinking", False):
+        if (
+            request.chat_template_kwargs is not None
+            and request.chat_template_kwargs.get("thinking", False) is True
+        ):
             return super().extract_reasoning_content(model_output, request)
 
         return None, model_output

--- a/vllm/reasoning/deepseek_v31_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v31_reasoning_parser.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+from typing import Optional, Union
+
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    ResponsesRequest,
+)
+from vllm.logger import init_logger
+from vllm.reasoning import DeepSeekR1ReasoningParser, ReasoningParserManager
+
+logger = init_logger(__name__)
+
+
+@ReasoningParserManager.register_module("deepseek_v31")
+class DeepSeekV31ReasoningParser(DeepSeekR1ReasoningParser):
+
+    def extract_reasoning_content_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
+    ) -> Union[DeltaMessage, None]:
+        if request.chat_template_kwargs is not None and \
+           request.chat_template_kwargs.get("thinking", False):
+            return super().extract_reasoning_content_streaming(
+                previous_text,
+                current_text,
+                delta_text,
+                previous_token_ids,
+                current_token_ids,
+                delta_token_ids,
+                request,
+            )
+
+        return DeltaMessage(content=delta_text)
+
+    def extract_reasoning_content(
+        self, model_output: str, request: Union[ChatCompletionRequest, ResponsesRequest]
+    ) -> tuple[Optional[str], Optional[str]]:
+        if request.chat_template_kwargs is not None and \
+           request.chat_template_kwargs.get("thinking", False):
+            return super().extract_reasoning_content(model_output, request)
+
+        return None, model_output

--- a/vllm/reasoning/glm4_moe_reasoning_parser.py
+++ b/vllm/reasoning/glm4_moe_reasoning_parser.py
@@ -6,7 +6,11 @@ from typing import Optional, Union
 
 from transformers import PreTrainedTokenizerBase
 
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, DeltaMessage
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    ResponsesRequest,
+)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
@@ -80,6 +84,7 @@ class Glm4MoeModelReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         """
         Extract reasoning content from a delta message.
@@ -136,7 +141,7 @@ class Glm4MoeModelReasoningParser(ReasoningParser):
             return DeltaMessage(content=delta_text)
 
     def extract_reasoning_content(
-        self, model_output: str, request: ChatCompletionRequest
+        self, model_output: str, request: Union[ChatCompletionRequest, ResponsesRequest]
     ) -> tuple[Optional[str], Optional[str]]:
         """
         Extract reasoning content from the model output.

--- a/vllm/reasoning/gptoss_reasoning_parser.py
+++ b/vllm/reasoning/gptoss_reasoning_parser.py
@@ -7,7 +7,11 @@ from typing import Optional, Union
 from transformers import PreTrainedTokenizerBase
 
 from vllm.entrypoints.harmony_utils import parse_chat_output
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, DeltaMessage
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    ResponsesRequest,
+)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
@@ -53,6 +57,7 @@ class GptOssReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         prev_reasoning, prev_content, _ = parse_chat_output(list(previous_token_ids))
         cur_reasoning, cur_content, _ = parse_chat_output(list(current_token_ids))
@@ -77,7 +82,7 @@ class GptOssReasoningParser(ReasoningParser):
     def extract_reasoning_content(
         self,
         model_output: str,
-        request: ChatCompletionRequest,
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> tuple[Optional[str], Optional[str]]:
         raise NotImplementedError(
             "gpt-oss has a special branch for parsing reasoning in non-streaming mode. This method shouldn't be used."  # noqa: E501

--- a/vllm/reasoning/granite_reasoning_parser.py
+++ b/vllm/reasoning/granite_reasoning_parser.py
@@ -7,7 +7,11 @@ from typing import Optional, Union
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, DeltaMessage
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    ResponsesRequest,
+)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
@@ -52,7 +56,7 @@ class GraniteReasoningParser(ReasoningParser):
         )
 
     def extract_reasoning_content(
-        self, model_output: str, request: ChatCompletionRequest
+        self, model_output: str, request: Union[ChatCompletionRequest, ResponsesRequest]
     ) -> tuple[Optional[str], Optional[str]]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
@@ -82,6 +86,7 @@ class GraniteReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         """Extract the reasoning content / content emitted by granite models;
         If the sequence doesn't match what we expect, i.e., the model generates

--- a/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
+++ b/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
@@ -7,7 +7,11 @@ from typing import Optional, Union
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, DeltaMessage
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    ResponsesRequest,
+)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
@@ -89,7 +93,7 @@ class HunyuanA13BReasoningParser(ReasoningParser):
         return []
 
     def extract_reasoning_content(
-        self, model_output: str, request: ChatCompletionRequest
+        self, model_output: str, request: Union[ChatCompletionRequest, ResponsesRequest]
     ) -> tuple[Optional[str], Optional[str]]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
@@ -150,6 +154,7 @@ class HunyuanA13BReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         """Extract content using token ID sequence state machine"""
         # Define sequences

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -287,6 +287,7 @@ class Olmo3ReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         """Extract content using token ID sequence state machine"""
 

--- a/vllm/reasoning/step3_reasoning_parser.py
+++ b/vllm/reasoning/step3_reasoning_parser.py
@@ -7,7 +7,11 @@ from typing import Optional, Union
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, DeltaMessage
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    ResponsesRequest,
+)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
@@ -50,6 +54,7 @@ class Step3ReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
+        request: Union[ChatCompletionRequest, ResponsesRequest],
     ) -> Union[DeltaMessage, None]:
         """
         Extract reasoning content from a delta message.
@@ -80,7 +85,7 @@ class Step3ReasoningParser(ReasoningParser):
             return DeltaMessage(reasoning_content=delta_text)
 
     def extract_reasoning_content(
-        self, model_output: str, request: ChatCompletionRequest
+        self, model_output: str, request: Union[ChatCompletionRequest, ResponsesRequest]
     ) -> tuple[Optional[str], Optional[str]]:
         # Check if the model output contains the </think> token
         if self.think_end_token not in model_output:


### PR DESCRIPTION
## Purpose

DeepSeek v3.1 is conditionally thinking, so using the existing r1 parser does not work correctly when a non-thinking request is submitted. (All the content ends up in reasoning_content as the expected `</think>` is not found.) This adds a new parser that conditionally handles thinking (with the r1 parser) when a request is submitted with the `chat_template_kwargs` of `thinking` set to `true`. (This follows the behavior of the chat template used by the model.)

To include the conditional behavior in the `extract_reasoning_content_streaming` method, the `request` is added as an additional argument (this aligns with prior changes to the `extract_reasoning_content` method to include the `request` as an argument).

## Test Plan

Tested by running a simple completions request with thinking enabled and disabled (base payload derived from a basic example) with the model using the new parser `deepseek_v31`:
```json
{
  "model": "deepseek-ai/DeepSeek-V3.1",
  "messages": [
    {
      "role": "assistant",
      "content": "<think>Hmm</think>"
    },
    {
      "role": "user",
      "content": "9.11 and 9.8, which is greater?"
    }
  ],
  "max_tokens": 2000,
  "stream": false,
  "chat_template_kwargs": {
    "thinking": true
  }
}
```

## Test Result

With thinking (output filtered to only relevant sections):
``` json
{
"choices":[
  {
    "index":0,
    "message": { 
      "role":"assistant",
      "content":"To determine which number is greater between 9.11 and 9.8, compare their decimal parts.\n\n- 9.11 has a decimal part of 0.11 (11 hundredths).\n- 9.8 can be written as 9.80, which has a decimal part of 0.80 (80 hundredths).\n\nSince 0.80 is greater than 0.11, 9.8 is greater than 9.11.\n\nThis can also be verified by subtraction:  \n9.80 - 9.11 = 0.69, which is positive, confirming that 9.8 is greater.\n\nThus, 9.8 is greater than 9.11.",
      "function_call": null,
      "tool_calls": [],
      "reasoning_content": "I have two numbers: 9.11 and 9.8. I need to figure out which one is greater. Both are decimals, so I should compare them digit by digit.\n\nFirst, I look at the whole number part. Both have 9 as the whole number, so that doesn't help. I need to compare the decimal parts.\n\nThe decimal part of 9.11 is 0.11, and for 9.8, it's 0.8. But 0.8 is the same as 0.80, which is greater than 0.11. Let me think carefully.\n\nI can also think of them as fractions. 9.11 is 911/100, and 9.8 is 98/10, but I should make the denominators the same.\n\n9.8 is equal to 9.80, because adding a zero at the end doesn't change the value. So, comparing 9.80 and 9.11, clearly 9.80 is larger because 80 hundredths is more than 11 hundredths.\n\nSo, 9.8 is greater than 9.11.\n\nI recall that sometimes people get confused because 11 is greater than 8, but that's only if we think of the digits without considering the decimal places. In decimals, the first digit after the decimal is tenths, so for 9.8, it's 8 tenths, which is 0.8, and for 9.11, it's 1 tenth and 1 hundredth, so 0.11, and 0.8 is greater than 0.11.\n\nYes, that makes sense.\n\nSo, to be thorough, I can subtract them. 9.8 minus 9.11 equals 0.69, which is positive, so 9.8 is greater.\n\nTherefore, 9.8 is greater than 9.11."
    }
  }]
}
```

Without thinking (output filtered to only relevant sections)::
``` json
{
"choices": [
  {
    "index":0,
    "message": {
      "role":"assistant",
      "content":"To determine which number is greater between 9.11 and 9.8, you can compare them digit by digit:\n\n- Both numbers have the same whole number part (9).\n- Compare the tenths place: 9.11 has a 1 in the tenths place, while 9.8 has an 8 in the tenths place. Since 8 is greater than 1, 9.8 is greater than 9.11.\n\nTherefore, **9.8 is greater than 9.11**.",
      "function_call":null,
      "tool_calls":[],
      "reasoning_content":null
    }
  }]
}
```

## (Optional) Documentation Update
N/A
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
