### PR TITLE
[gpt-oss][Bugfix] Fix gpt-oss toolcall

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -287,6 +287,8 @@ class InputBatch:
             req_index = self.num_reqs
 
         req_id = request.req_id
+        if req_id in self.req_id_to_index:
+            req_index = self.req_id_to_index[req_id]
         if req_index == len(self._req_ids):
             self._req_ids.append(req_id)
             self.req_output_token_ids.append(request.output_token_ids)


### PR DESCRIPTION
## Purpose
vLLM server breaks down when calls gpt-oss builtin tools. 
> ValueError: operands could not be broadcast together with shape (1,) (2,)  

Related issues:  [23196](https://github.com/vllm-project/vllm/issues/23196) [23108](https://github.com/vllm-project/vllm/issues/23108).

The reason is that, `add_request` receives a request with an existing req_id,  and it is append again into `_req_ids` list.
Then it raises the above error while calling `_prepare_inputs`: 
## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

