### PR TITLE
Add Predicted Outputs API

### DIFF
--- a/tests/v1/spec_decode/test_predicted.py
+++ b/tests/v1/spec_decode/test_predicted.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import time
+import uuid
+from typing import Optional
+
+import pytest
+from transformers import AutoTokenizer
+
+from vllm import LLM, SamplingParams
+from vllm.config import ModelConfig, SpeculativeConfig, VllmConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.usage.usage_lib import UsageContext
+from vllm.utils import set_default_torch_num_threads
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.core_client import EngineCoreClient
+from vllm.v1.executor.abstract import Executor
+from vllm.v1.spec_decode.predicted_proposer import PredictedProposer
+
+MODEL_NAME = "facebook/opt-125m"
+TOKENIZER = AutoTokenizer.from_pretrained(MODEL_NAME)
+PROMPT = "Hello my name is Bram and I love speculative decoding"
+PROMPT_TOKENS = TOKENIZER(PROMPT).input_ids
+PREDICTED_TOKENS = TOKENIZER("test prediction").input_ids
+
+
+def test_predicted_proposer():
+
+    def predicted_proposer() -> PredictedProposer:
+        # Dummy model config. Just to set max_model_len.
+        model_config = ModelConfig(model=MODEL_NAME)
+        return PredictedProposer(vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                method="predicted",
+                num_speculative_tokens=32,  # maximum tokens
+            )))
+
+    result = predicted_proposer().propose(context_token_ids=[[1, 2, 3, 4, 5]],
+                                          predicted_tokens=[[1, 2, 3, 4, 5]])
+    assert len(result[0]) == 5
+
+
+class TestPredictedOutputsProposer:
+
+    @pytest.fixture(scope="class")
+    def llm_instance(self):
+        """Create a single LLM instance for the entire test class"""
+        llm = LLM(
+            model=MODEL_NAME,
+            gpu_memory_utilization=0.1,
+            speculative_config={
+                "method": "predicted",
+                "num_speculative_tokens": 32
+            },
+            max_model_len=512,
+        )
+        yield llm
+
+    @pytest.fixture(scope="session")
+    def engine_client_instance(self):
+        engine_args = EngineArgs(model=MODEL_NAME,
+                                 enforce_eager=True,
+                                 gpu_memory_utilization=0.8)
+        vllm_config = engine_args.create_engine_config(
+            UsageContext.UNKNOWN_CONTEXT)
+        executor_class = Executor.get_class(vllm_config)
+
+        with set_default_torch_num_threads(1):
+            client = EngineCoreClient.make_client(
+                multiprocess_mode=False,
+                asyncio_mode=False,
+                vllm_config=vllm_config,
+                executor_class=executor_class,
+                log_stats=False,
+            )
+            yield client
+
+    def test_single_predicted_output(self, llm_instance):
+        """Test single request with predicted output"""
+        sampling_params = SamplingParams(predicted_outputs="test prediction",
+                                         max_tokens=10,
+                                         temperature=0.0)
+
+        outputs = llm_instance.generate("Hello world", sampling_params)
+        assert len(outputs) == 1
+        assert outputs[0].outputs[0].text is not None
+
+    def test_different_sampling_params_per_prompt(self, llm_instance):
+        """Test different predicted_outputs for each prompt"""
+        prompts = [
+            "The capital of France is",
+            "Python is a programming language that",
+            "Machine learning is",
+        ]
+
+        sampling_params_list = [
+            SamplingParams(predicted_outputs=" Paris, the beautiful city",
+                           max_tokens=10,
+                           temperature=0.0),
+            SamplingParams(predicted_outputs=" is easy to learn and powerful",
+                           max_tokens=10,
+                           temperature=0.0),
+            SamplingParams(
+                predicted_outputs=" a field of artificial intelligence",
+                max_tokens=10,
+                temperature=0.0),
+        ]
+
+        outputs = llm_instance.generate(prompts, sampling_params_list)
+        assert len(outputs) == len(prompts)
+
+    def test_large_batch_mixed_params(self, llm_instance):
+        """Test large batch with varied sampling parameters"""
+        batch_size = 20
+
+        prompts = [f"Request {i}:" for i in range(batch_size)]
+        sampling_params_list = []
+
+        for i in range(batch_size):
+            sampling_params_list.append(
+                SamplingParams(
+                    predicted_outputs=f" prediction {i}",
+                    max_tokens=5,
+                    temperature=0.0,
+                ))
+
+        outputs = llm_instance.generate(prompts, sampling_params_list)
+        assert len(outputs) == batch_size
+
+    def test_mixed_predicted_outputs(self, llm_instance):
+        """Test batch where only some prompts have predicted_outputs"""
+        prompts = [
+            "Prompt with prediction:",
+            "Prompt without prediction:",
+            "Another with prediction:",
+            "Another without prediction:",
+        ]
+
+        sampling_params_list = [
+            SamplingParams(predicted_outputs=" this has a prediction",
+                           max_tokens=5),
+            SamplingParams(predicted_outputs=None, max_tokens=5),
+            SamplingParams(predicted_outputs=" another prediction",
+                           max_tokens=5),
+            SamplingParams(predicted_outputs=None, max_tokens=5),
+        ]
+
+        outputs = llm_instance.generate(prompts, sampling_params_list)
+        assert len(outputs) == 4
+
+    def make_request(self,
+                     params: SamplingParams,
+                     prompt_tokens_ids: Optional[list[int]] = None,
+                     req_id: str = '') -> EngineCoreRequest:
+        if not prompt_tokens_ids:
+            prompt_tokens_ids = PROMPT_TOKENS
+
+        return EngineCoreRequest(
+            request_id=req_id if req_id else str(uuid.uuid4()),
+            prompt_token_ids=prompt_tokens_ids,
+            mm_features=None,
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=None,
+            arrival_time=time.time(),
+            lora_request=None,
+            cache_salt=None,
+            data_parallel_rank=None,
+        )
+
+    def test_client_add_request_codepath_directly(self,
+                                                  engine_client_instance):
+        """Directly test the add_request code path"""
+        sampling_params = SamplingParams(predicted_outputs=PREDICTED_TOKENS,
+                                         max_tokens=5)
+
+        requests = [self.make_request(sampling_params) for _ in range(10)]
+        request_ids = [req.request_id for req in requests]
+        for request in requests:
+            engine_client_instance.add_request(request)
+            time.sleep(0.01)
+
+        # Step until completion
+        outputs: dict[str, list] = {req_id: [] for req_id in request_ids}
+        while True:
+            engine_core_outputs = engine_client_instance.get_output().outputs
+            if len(engine_core_outputs) == 0:
+                continue
+            all_finished = True
+            for out in engine_core_outputs:
+                outputs[out.request_id].append(out)
+                if not out.finished:
+                    all_finished = False
+            if all_finished:
+                break
+
+    def test_client_add_request_multiple_individual(self,
+                                                    engine_client_instance):
+        """Test multiple individual add_request calls"""
+        request_ids = []
+        for i in range(5):
+            request_id = f"request_{i}"
+            predicted_outputs = TOKENIZER(f"prediction {i}").input_ids
+            sampling_params = SamplingParams(
+                predicted_outputs=predicted_outputs, max_tokens=5)
+
+            engine_client_instance.add_request(
+                self.make_request(sampling_params, req_id=request_id))
+            request_ids.append(request_id)
+
+        # Step until completion
+        outputs: dict[str, list] = {req_id: [] for req_id in request_ids}
+        while True:
+            engine_core_outputs = engine_client_instance.get_output().outputs
+            if len(engine_core_outputs) == 0:
+                continue
+            all_finished = True
+            for out in engine_core_outputs:
+                outputs[out.request_id].append(out)
+                if not out.finished:
+                    all_finished = False
+            if all_finished:
+                break
+
+    @pytest.mark.parametrize("batch_size", [1, 3, 5])
+    def test_various_batch_sizes(self, llm_instance, batch_size):
+        """Test with different batch sizes"""
+        prompts = ["Hello world"] * batch_size
+        sampling_params = SamplingParams(
+            predicted_outputs="this is a prediction", max_tokens=5)
+
+        outputs = llm_instance.generate(prompts, sampling_params)
+        assert len(outputs) == batch_size
+
+    def test_empty_predicted_outputs(self, llm_instance):
+        """Test edge cases with predicted outputs"""
+        test_cases = [
+            ("", "Empty string"),
+            (None, "None value"),
+            ("   ", "Whitespace only"),
+        ]
+
+        for predicted_output, description in test_cases:
+            sampling_params = SamplingParams(
+                predicted_outputs=predicted_output, max_tokens=5)
+
+            outputs = llm_instance.generate("Test prompt", sampling_params)
+            assert len(outputs) == 1
+
+    def test_very_long_predicted_outputs(self, llm_instance):
+        """Test with very long predicted outputs"""
+        long_prediction = "This is a very long prediction " * 20  # 600+ chars
+
+        sampling_params = SamplingParams(predicted_outputs=long_prediction,
+                                         max_tokens=5)
+
+        outputs = llm_instance.generate("Test:", sampling_params)
+        assert len(outputs) == 1
+
+    def test_special_characters_predicted_outputs(self, llm_instance):
+        """Test predicted outputs with special characters"""
+        special_predictions = [
+            "Hello! 🌟 How are you?",  # Emojis
+            "Code: print('hello')",  # Code
+            "Math: 2 + 2 = 4",  # Numbers
+            "Symbols: @#$%^&*()",  # Special chars
+        ]
+
+        for prediction in special_predictions:
+            sampling_params = SamplingParams(predicted_outputs=prediction,
+                                             max_tokens=5)
+
+            outputs = llm_instance.generate("Input:", sampling_params)
+            assert len(outputs) == 1

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1920,7 +1920,7 @@ class DeviceConfig:
             self.device = torch.device(self.device_type)
 
 
-SpeculativeMethod = Literal["ngram", "eagle", "eagle3", "medusa",
+SpeculativeMethod = Literal["predicted", "ngram", "eagle", "eagle3", "medusa",
                             "mlp_speculator", "draft_model", "deepseek_mtp",
                             "ernie_mtp"]
 
@@ -2089,6 +2089,8 @@ class SpeculativeConfig:
                 self.model = self.target_model_config.model
             elif self.method in ("ngram", "[ngram]"):
                 self.model = "ngram"
+            elif self.method in ("predicted", "[predicted]"):
+                self.model = "predicted"
             else:
                 raise ValueError("num_speculative_tokens was provided without "
                                  "speculative model.")
@@ -2130,6 +2132,10 @@ class SpeculativeConfig:
             # TODO: current we still need extract vocab_size from target model
             # config, in future, we may try refactor it out, and set
             # draft related config as None here.
+            self.draft_model_config = self.target_model_config
+            self.draft_parallel_config = self.target_parallel_config
+        elif self.method in ("predicted", "[predicted]"):
+            self.method = "predicted"
             self.draft_model_config = self.target_model_config
             self.draft_parallel_config = self.target_parallel_config
         else:
@@ -2410,7 +2416,8 @@ class SpeculativeConfig:
 
     def __repr__(self) -> str:
         method = self.method
-        model = None if method == "ngram" else self.draft_model_config.model
+        model = None if method in ["ngram", "predicted"
+                                   ] else self.draft_model_config.model
         num_spec_tokens = self.num_speculative_tokens
         return f"SpeculativeConfig({method=}, {model=}, {num_spec_tokens=})"
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -674,6 +674,13 @@ class LLMEngine:
             raise ValueError(
                 "Logits processors are not supported in multi-step decoding")
 
+        if isinstance(params, SamplingParams) and isinstance(
+                params.predicted_outputs, str) and self.tokenizer is not None:
+            params.predicted_outputs = self.tokenizer.encode(
+                params.predicted_outputs,
+                add_special_tokens=False  # Usually don't want special tokens
+            )
+
         if arrival_time is None:
             arrival_time = time.time()
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -210,6 +210,12 @@ class SamplingParams(
     implementations, plugins, etc. Not used by any in-tree sampling
     implementations."""
 
+    # Fields used to invoke speculative execution.
+    """If provided, we will invoke speculative decoding validation
+    with the provided predicted outputs to generate a result.
+    Text and tokens are supported."""
+    predicted_outputs: Optional[Union[str, list[int]]] = None
+
     # Fields used for bad words
     bad_words: Optional[list[str]] = None
     """Words that are not allowed to be generated. More precisely, only the
@@ -250,6 +256,7 @@ class SamplingParams(
         logit_bias: Optional[Union[dict[int, float], dict[str, float]]] = None,
         allowed_token_ids: Optional[list[int]] = None,
         extra_args: Optional[dict[str, Any]] = None,
+        predicted_outputs: Optional[Union[str, list[int]]] = None,
     ) -> "SamplingParams":
         if logit_bias is not None:
             # Convert token_id to integer
@@ -292,6 +299,7 @@ class SamplingParams(
             logit_bias=logit_bias,
             allowed_token_ids=allowed_token_ids,
             extra_args=extra_args,
+            predicted_outputs=predicted_outputs,
         )
 
     def __post_init__(self) -> None:
@@ -560,7 +568,8 @@ class SamplingParams(
             f"{self.spaces_between_special_tokens}, "
             f"truncate_prompt_tokens={self.truncate_prompt_tokens}, "
             f"guided_decoding={self.guided_decoding}, "
-            f"extra_args={self.extra_args})")
+            f"extra_args={self.extra_args}, "
+            f"predicted_outputs={self.predicted_outputs}),")
 
 
 class BeamSearchParams(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -277,6 +277,13 @@ class AsyncLLM(EngineClient):
         # Create a new output collector for the request.
         queue = RequestOutputCollector(output_kind=params.output_kind)
 
+        if isinstance(params, SamplingParams) and isinstance(
+                params.predicted_outputs, str) and self.tokenizer is not None:
+            params.predicted_outputs = self.tokenizer.encode(
+                params.predicted_outputs,
+                add_special_tokens=False  # Usually don't want special tokens
+            )
+
         # Convert Input --> Request.
         prompt_str, request = self.processor.process_inputs(
             request_id, prompt, params, arrival_time, lora_request,

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -202,6 +202,12 @@ class LLMEngine:
             raise TypeError(
                 f"request_id must be a string, got {type(request_id)}")
 
+        if isinstance(params, SamplingParams) and isinstance(
+                params.predicted_outputs, str) and self.tokenizer is not None:
+            params.predicted_outputs = self.tokenizer.encode(
+                params.predicted_outputs,
+                add_special_tokens=False  # Usually don't want special tokens
+            )
         # Process raw inputs into the request.
         prompt_str, request = self.processor.process_inputs(
             request_id, prompt, params, arrival_time, lora_request,

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -404,6 +404,12 @@ class Processor:
             if self.tokenizer is not None:
                 sampling_params.update_from_tokenizer(
                     self.tokenizer.get_lora_tokenizer(lora_request))
+                if isinstance(params.predicted_outputs, str):
+                    params.predicted_outputs = self.tokenizer.encode(
+                        params.predicted_outputs,
+                        add_special_tokens=
+                        False  # Usually don't want special tokens
+                    )
         else:
             pooling_params = params.clone()
 

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -19,6 +19,8 @@ class SamplingMetadata:
     top_p: Optional[torch.Tensor]
     top_k: Optional[torch.Tensor]
 
+    predicted_outputs: list[list[int]]
+
     generators: dict[int, torch.Generator]
 
     # None means no logprobs, 0 means sampled token logprobs only

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -82,7 +82,8 @@ class RejectionSampler(nn.Module):
             output_token_ids (torch.Tensor):
                 A tensor containing the final output token IDs.
         '''
-        assert metadata.max_spec_len <= MAX_SPEC_LEN
+        assert metadata.max_spec_len <= MAX_SPEC_LEN, \
+            f"Spec len {metadata.max_spec_len} > max spec len {MAX_SPEC_LEN}."
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the
         # `compute_probs` function.

--- a/vllm/v1/spec_decode/predicted_proposer.py
+++ b/vllm/v1/spec_decode/predicted_proposer.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.config import VllmConfig
+
+
+class PredictedProposer:
+
+    def __init__(self, vllm_config: VllmConfig):
+        assert vllm_config.speculative_config is not None
+
+        # Maximum length of the model.
+        self.max_model_len = vllm_config.model_config.max_model_len
+        self.num_speculative_tokens = \
+            vllm_config.speculative_config.num_speculative_tokens
+
+    def propose(
+        self,
+        context_token_ids: list[list[int]],
+        predicted_tokens: list[list[int]],
+    ) -> list[list[int]]:
+        """Effectively a passthrough function that simulates other speculative
+        decoding proposers using user request inputs.
+        """
+        assert len(context_token_ids) == len(predicted_tokens) or len(
+            predicted_tokens
+        ) == 1, f"{len(context_token_ids)=} vs {len(predicted_tokens)=}"
+        if len(context_token_ids) != len(predicted_tokens) and len(
+                predicted_tokens) == 1:
+            predicted_tokens = predicted_tokens * len(context_token_ids)
+
+        # Clamp to max length (user may not know the bounds).
+        # TODO(bwasti) optimize as needed
+        clamped_predicted_tokens = []
+        for ct, pt in zip(context_token_ids, predicted_tokens):
+            total_tokens_len = len(ct)
+            predicted_tokens_len = len(pt)
+            k = min(predicted_tokens_len, self.num_speculative_tokens)
+            k = min(k, max(self.max_model_len - total_tokens_len - 1, 0))
+            pt = pt[:k]
+            clamped_predicted_tokens.append(pt)
+
+        return clamped_predicted_tokens
+
+    def load_model(self, *args, **kwargs):
+        # No model to load.
+        pass


### PR DESCRIPTION
## Purpose

As referenced in this issue: #23276, predicted outputs is a nice API from OpenAI that allows user-provided external token predictions to hit the speculative decoding backend.

This PR is the first of a couple to properly thread the API through the stack (looking for an initial review on this).

The key API is the addition of `--speculative-config '{"method": "predicted", "num_speculative_tokens": 4}'` at serving time and an exact replication of the OpenAI API at request:

```
{
"prediction":
    {
    "type": "content",
    "content": "blah blah"
    }
}
```

## Test Plan

```
pytest -s -v tests/v1/spec_decode/test_predicted.py --forked
```

A e2e test:

```
OPENAI_API_KEY=EMPTY python -m vllm.entrypoints.openai.api_server --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --port 8000 --enable-log-outputs --speculative-config '{"method": "predicted", "num_speculative_tokens": 16}'
```

and then benchmark with this gist: https://gist.github.com/bwasti/00ec853a4125b600f2d4506bad03f7c9

```
python benchmark_oai.py  --url http://0.0.0.0:8000 --api-key your-vllm-key --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --show-errors --log-outputs --temperature 0.0 --requests 1 --no-prediction
```


## Test Result

```
13 passed, 14 warnings in 218.36s (0:03:38)
```

It works to some degree, but needs way more optimization

- Without prediction:   Tokens per Second: 373.11
- With prediction (fully predicted):   Tokens per Second: 573.49

It should be faster, but I am testing with a 1B model which is mostly CPU bound.  Traces seem within reason:

<img width="651" height="606" alt="Screenshot 2025-08-26 at 5 47 24 PM" src="https://github.com/user-attachments/assets/2715c3ec-d0cb-4133-9ad0-afdaac1a3106" />


## (Optional) Documentation Update

Added to the speculative decoding section.  Included a code sample and reference to the OpenAI API
