### PR TITLE
[Performance] optimize the loop of decode layer forward

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -357,10 +357,13 @@ class Qwen2Model(nn.Module):
             residual = intermediate_tensors["residual"]
 
         aux_hidden_states = []
-        for idx, layer in enumerate(
-                self.layers[self.start_layer:self.end_layer]):
+        # NOTE(Ronald1995): extract layers to avoid __getattr__ attribute
+        # look-up in the loop.
+        layers = self.layers
+        for idx in range(self.start_layer, self.end_layer):
             if idx in self.aux_hidden_state_layers:
                 aux_hidden_states.append(hidden_states + residual)
+            layer = layers[idx]
             hidden_states, residual = layer(positions, hidden_states, residual)
 
         if not get_pp_group().is_last_rank:


### PR DESCRIPTION

## Purpose
the original loop of decode layer in qwen2 make nn.modules slice `self.layers[self.start_layer:self.end_layer]`,
this will call method of ModuleList.__getitem__ method and do some complicated operations.
so i optimized this by just index the self.layers.
## Test Plan
i have tested it by using benchmark tool in my local env.
A100, eager model, QPS 10, 2K->2K, concurrency 24 , num_prompts 24.

## Test Result
the total token throughput is promoted from 1241 to 1247 
## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

