### PR TITLE
[Misc] Modify CacheConfig import

### DIFF
--- a/vllm/attention/layers/encoder_only_attention.py
+++ b/vllm/attention/layers/encoder_only_attention.py
@@ -5,13 +5,13 @@ from copy import copy
 from typing import Optional
 
 import torch
-from transformers import CacheConfig
 
 from vllm import envs
 from vllm.attention.backends.abstract import (AttentionBackend,
                                               AttentionMetadata, AttentionType)
 from vllm.attention.layer import Attention
 from vllm.attention.selector import get_attn_backend
+from vllm.config import CacheConfig
 from vllm.v1.attention.backends.utils import (CommonAttentionMetadata,
                                               subclass_attention_backend)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When using the latest main branch of `transformers`, encounter the following import error
```text
ERROR 08-23 02:59:11 [registry.py:430]   File "/root/Code/vllm_dev/vllm/vllm/attention/layers/encoder_only_attention.py", line 8, in <module>
ERROR 08-23 02:59:11 [registry.py:430]     from transformers import CacheConfig
ERROR 08-23 02:59:11 [registry.py:430] ImportError: cannot import name 'CacheConfig' from 'transformers' (/root/Code/vllm_dev/transformers/src/transformers/__init__.py)
```
In addition, based on the parameters of the [Attention](https://github.com/vllm-project/vllm/blob/main/vllm/attention/layer.py#L57), `CacheConfig ` should come from `vllm.config`.

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

