### PR TITLE
[#20711] Use QuantFp8 CustomOp-abstraction for MoE layers

### DIFF
--- a/benchmarks/kernels/benchmark_moe_permute_unpermute.py
+++ b/benchmarks/kernels/benchmark_moe_permute_unpermute.py
@@ -15,7 +15,7 @@ from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
     moe_permute,
     moe_unpermute,
 )
-from vllm.model_executor.layers.fused_moe.utils import _fp8_quantize
+from vllm.model_executor.layers.fused_moe.utils import MoEInputQuantizer
 from vllm.platforms import current_platform
 from vllm.utils import FlexibleArgumentParser
 
@@ -47,7 +47,9 @@ def benchmark_permute(
     # output_hidden_states = torch.empty_like(hidden_states)
     if use_fp8_w8a8:
         align_block_size = 128  # deepgemm needs 128 m aligned block
-        qhidden_states, scale = _fp8_quantize(hidden_states, None, None)
+        qhidden_states, scale = MoEInputQuantizer._fp8_quantize(
+            hidden_states, None, None
+        )
     else:
         align_block_size = None
         qhidden_states = hidden_states
@@ -139,7 +141,9 @@ def benchmark_unpermute(
     output_hidden_states = torch.empty_like(hidden_states)
     if use_fp8_w8a8:
         align_block_size = 128  # deepgemm needs 128 m aligned block
-        qhidden_states, scale = _fp8_quantize(hidden_states, None, None)
+        qhidden_states, scale = MoEInputQuantizer._fp8_quantize(
+            hidden_states, None, None
+        )
     else:
         align_block_size = None
         qhidden_states = hidden_states

--- a/tests/kernels/moe/modular_kernel_tools/mk_objects.py
+++ b/tests/kernels/moe/modular_kernel_tools/mk_objects.py
@@ -374,7 +374,11 @@ def make_prepare_finalize(
             a1_gscale=_make_gscale(moe.num_local_experts),
         )
     else:
-        return MoEPrepareAndFinalizeNoEP()
+        return MoEPrepareAndFinalizeNoEP(
+            quant_dtype=moe.quant_dtype,
+            per_act_token_quant=moe.per_act_token_quant,
+            block_shape=moe.block_shape,
+        )
 
 
 def _slice(rank: int, num_local_experts: int, t: torch.Tensor) -> torch.Tensor:

--- a/tests/kernels/moe/test_pplx_cutlass_moe.py
+++ b/tests/kernels/moe/test_pplx_cutlass_moe.py
@@ -123,7 +123,11 @@ def pplx_cutlass_moe(
         ata,
         max_num_tokens=max_num_tokens,
         num_local_experts=num_local_experts,
-        num_dispatchers=num_dispatchers)
+        num_dispatchers=num_dispatchers,
+        quant_dtype=torch.float8_e4m3fn,
+        per_act_token_quant=per_act_token,
+        block_shape=None,
+    )
 
     ab_strides1 = torch.full((num_local_experts, ),
                              hidden_dim,

--- a/tests/kernels/moe/test_pplx_moe.py
+++ b/tests/kernels/moe/test_pplx_moe.py
@@ -249,6 +249,9 @@ def create_pplx_prepare_finalize(
         max_num_tokens=max_num_tokens,
         num_local_experts=num_local_experts,
         num_dispatchers=world_size // dp_size,
+        quant_dtype=quant_dtype,
+        per_act_token_quant=per_act_token_quant,
+        block_shape=block_shape,
     )
 
     return prepare_finalize, ata

--- a/vllm/model_executor/layers/fused_moe/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cutlass_moe.py
@@ -484,7 +484,10 @@ def cutlass_moe_fp8(
         0)
 
     fn = mk.FusedMoEModularKernel(
-        MoEPrepareAndFinalizeNoEP(),
+        MoEPrepareAndFinalizeNoEP(
+            quant_dtype=torch.float8_e4m3fn,
+            per_act_token_quant=per_act_token,
+        ),
         CutlassExpertsFp8(
             out_dtype=a.dtype,
             per_act_token_quant=per_act_token,

--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -12,7 +12,7 @@ from vllm.model_executor.layers.fused_moe.fused_moe import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate, TopKWeightAndReduceNaiveBatched)
 from vllm.model_executor.layers.fused_moe.utils import (
-    _resize_cache, moe_kernel_quantize_input, normalize_batched_scales_shape,
+    MoEInputQuantizer, _resize_cache, normalize_batched_scales_shape,
     normalize_scales_shape)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     group_broadcast)
@@ -481,6 +481,7 @@ class BatchedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         self.num_local_experts = num_local_experts
         self.rank = rank
         self.num_dispatchers_ = num_dispatchers
+        self.quantizer = MoEInputQuantizer()
 
     @property
     def activation_format(self) -> mk.FusedMoEActivationFormat:
@@ -572,7 +573,7 @@ class BatchedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
                         rhs_a1_scale = a1_scale
                 else:
                     rhs_a1_scale = None
-                b_a1[idx, :rows, :], b_s = moe_kernel_quantize_input(
+                b_a1[idx, :rows, :], b_s = self.quantizer(
                     rhs,
                     rhs_a1_scale,
                     quant_config.quant_dtype,
@@ -773,6 +774,8 @@ def batched_moe_kernel_quantize_input(
     per_act_token_quant: bool,
     block_shape: Optional[list[int]] = None,
 ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    quantizer = MoEInputQuantizer()
+
     if (torch.compiler.is_compiling()
             or torch.cuda.is_current_stream_capturing()):
         # Note: this does a bunch of extra work because expert_num_tokens is
@@ -780,10 +783,13 @@ def batched_moe_kernel_quantize_input(
         hidden_dim = A.size(-1)
         assert A_scale is None or A_scale.ndim <= 2, (
             f"{A_scale.shape if A_scale is not None else None}")
-        A_q, A_q_scale = moe_kernel_quantize_input(A.view(-1,
-                                                          hidden_dim), A_scale,
-                                                   qtype, per_act_token_quant,
-                                                   block_shape)
+        A_q, A_q_scale = quantizer(
+            A.view(-1, hidden_dim),
+            A_scale,
+            qtype,
+            per_act_token_quant,
+            block_shape,
+        )
         A_q = A_q.view(E, -1, hidden_dim)
         A_q_scale = normalize_batched_scales_shape(A_q_scale, E)
 
@@ -818,7 +824,7 @@ def batched_moe_kernel_quantize_input(
                     scales = A_scale[e, :min(num_tokens, A_scale.shape[1])]
                 else:
                     scales = None
-                A_q[e, :num_tokens], tmp_scale = moe_kernel_quantize_input(
+                A_q[e, :num_tokens], tmp_scale = quantizer(
                     A[e, :num_tokens],
                     scales,
                     qtype,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -32,7 +32,7 @@ from vllm.model_executor.layers.fused_moe.prepare_finalize import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP)
 from vllm.model_executor.layers.fused_moe.utils import (
-    _resize_cache, moe_kernel_quantize_input, per_token_group_quant_fp8)
+    MoEInputQuantizer, _resize_cache, per_token_group_quant_fp8)
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     calculate_tile_tokens_dim)
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
@@ -1199,11 +1199,13 @@ def flashinfer_fused_moe_per_tensor_scale_fp8(
     num_expert_group = num_expert_group if num_expert_group is not None else 0
     topk_group = topk_group if topk_group is not None else 0
 
-    quant_hidden_states, _ = moe_kernel_quantize_input(
+    quantizer = MoEInputQuantizer()
+    quant_hidden_states, _ = quantizer(
         hidden_states,
         input_scale,
         quant_dtype=torch.float8_e4m3fn,
-        per_act_token_quant=False)
+        per_act_token_quant=False,
+    )
 
     from vllm.utils.flashinfer import (
         flashinfer_trtllm_fp8_per_tensor_scale_moe)
@@ -1565,6 +1567,8 @@ def fused_experts_impl(
         w2 = dequant_mxfp4(w2, w2_scale, hidden_states.dtype)
         w2_scale = None
 
+    quantizer = MoEInputQuantizer()
+
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
         begin_chunk_idx, end_chunk_idx = (chunk * CHUNK_SIZE,
                                           min((chunk + 1) * CHUNK_SIZE,
@@ -1588,12 +1592,13 @@ def fused_experts_impl(
 
         curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
         curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
-        qcurr_hidden_states, a1q_scale = moe_kernel_quantize_input(
+        qcurr_hidden_states, a1q_scale = quantizer(
             A=curr_hidden_states,
             A_scale=a1_scale,
             quant_dtype=qtype,
             per_act_token_quant=per_channel_quant,
-            block_shape=block_shape)
+            block_shape=block_shape,
+        )
 
         sorted_token_ids, expert_ids, num_tokens_post_padded = (
             moe_align_block_size(curr_topk_ids, config['BLOCK_SIZE_M'],
@@ -1642,12 +1647,13 @@ def fused_experts_impl(
             raise ValueError(f"Unsupported FusedMoe activation: {activation}, "
                              f"with is_act_and_mul={is_act_and_mul}.")
 
-        qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
+        qintermediate_cache2, a2q_scale = quantizer(
             A=intermediate_cache2,
             A_scale=a2_scale,
             quant_dtype=qtype,
             per_act_token_quant=per_channel_quant,
-            block_shape=block_shape)
+            block_shape=block_shape,
+        )
 
         invoke_fused_moe_kernel(qintermediate_cache2,
                                 w2,
@@ -1836,6 +1842,12 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         self.use_int8_w8a16 = use_int8_w8a16
         self.use_mxfp4_w4a4 = use_mxfp4_w4a4
 
+        self.quantizer = MoEInputQuantizer(
+            not self.quant_config.is_per_tensor,
+            self.quant_config.quant_dtype,
+            self.quant_config.block_shape,
+        )
+
     @property
     def activation_formats(
         self
@@ -1983,7 +1995,7 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
 
         a2q_scale: Optional[torch.Tensor] = None
 
-        qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
+        qintermediate_cache2, a2q_scale = self.quantizer(
             intermediate_cache2, a2_scale, self.quant_dtype,
             self.per_act_token_quant, self.block_shape)
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -2036,7 +2036,17 @@ def modular_triton_fused_moe(
     block_shape: Optional[list[int]] = None,
 ) -> mk.FusedMoEModularKernel:
     return mk.FusedMoEModularKernel(
-        MoEPrepareAndFinalizeNoEP(),
+        MoEPrepareAndFinalizeNoEP(
+            quant_dtype=get_config_quant_dtype(
+                use_fp8_w8a8,
+                use_int8_w8a8,
+                use_int8_w8a16,
+                use_int4_w4a16,
+                use_mxfp4_w4a4,
+            ),
+            per_act_token_quant=per_act_token_quant,
+            block_shape=block_shape,
+        ),
         TritonExperts(
             use_fp8_w8a8=use_fp8_w8a8,
             use_int8_w8a8=use_int8_w8a8,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1843,9 +1843,9 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         self.use_mxfp4_w4a4 = use_mxfp4_w4a4
 
         self.quantizer = MoEInputQuantizer(
-            not self.quant_config.is_per_tensor,
-            self.quant_config.quant_dtype,
-            self.quant_config.block_shape,
+            per_act_token_quant=not self.quant_config.is_per_tensor,
+            quant_dtype=self.quant_config.quant_dtype,
+            block_shape=self.quant_config.block_shape,
         )
 
     @property

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -148,6 +148,9 @@ class FusedMoEMethodBase(QuantizeMethodBase):
                 max_num_tokens=moe.max_num_tokens,
                 num_local_experts=moe.num_local_experts,
                 num_dispatchers=num_dispatchers,
+                quant_dtype=moe.quant_dtype,
+                per_act_token_quant=moe.per_act_token_quant,
+                block_shape=moe.block_shape,
             )
         elif moe.use_deepep_ht_kernels:
             assert moe.dp_size == all2all_manager.dp_world_size
@@ -160,6 +163,9 @@ class FusedMoEMethodBase(QuantizeMethodBase):
                 dp_size=all2all_manager.dp_world_size,
                 rank_expert_offset=all2all_manager.rank *
                 moe.num_local_experts,
+                quant_dtype=moe.quant_dtype,
+                per_act_token_quant=moe.per_act_token_quant,
+                block_shape=moe.block_shape,
             )
 
         elif moe.use_deepep_ll_kernels:
@@ -185,6 +191,9 @@ class FusedMoEMethodBase(QuantizeMethodBase):
                 max_tokens_per_rank=moe.max_num_tokens,
                 num_dispatchers=all2all_manager.world_size,
                 use_fp8_dispatch=use_fp8_dispatch,
+                quant_dtype=moe.quant_dtype,
+                per_act_token_quant=moe.per_act_token_quant,
+                block_shape=moe.block_shape,
             )
 
         return prepare_finalize

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -258,6 +258,10 @@ class MoEInputQuantizer:
         :param A_scale: Optional static/per-tensor scale for FP8.
         :return: (A_q, A_scale_out) FP8-quantized activations and scale.
         """
+        assert self.quant_fp8 is not None, (
+            "QuantFP8 quantizer not initialized, " +
+            "QuantFP8 is supported only with " +
+            "quant_dtype=torch.float8_e4m3fn and block_shape=None", )
         return self.quant_fp8(A, A_scale)
 
     def forward_native(

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -161,8 +161,8 @@ class MoEInputQuantizer:
     """
     Quantize MoE activations via a unified API.
 
-    When configured for FP8 without block quantization, initializes a QuantFP8
-    CustomOp for Inductor-friendly FP8. Otherwise, defers to native paths for
+    When configured for FP8 without block quantization, initializes a `QuantFP8`
+    `CustomOp` for Inductor-friendly FP8. Otherwise, defers to native paths for
     FP8, INT8, NVFP4, or MXFP4.
     """
 
@@ -213,7 +213,7 @@ class MoEInputQuantizer:
         """
         Quantize activations and return (quantized, scale).
 
-        Uses the FP8 CustomOp when available; otherwise selects the native
+        Uses the FP8 `CustomOp` when available; otherwise selects the native
         path based on the requested quantization type.
 
         :param A: Input activations of shape [tokens, hidden_dim].
@@ -247,7 +247,7 @@ class MoEInputQuantizer:
         A_scale: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         """
-        Apply the configured FP8 CustomOp (QuantFP8).
+        Apply the configured FP8 `CustomOp` (`QuantFP8`).
 
         Requires the instance to be configured for FP8 without block
         quantization. Uses dynamic per-token quantization if enabled;
@@ -313,9 +313,12 @@ class MoEInputQuantizer:
                 is_sf_swizzled_layout=is_fp4_scale_swizzled,
             )
         elif quant_dtype == "mxfp4":
-            return MoEInputQuantizer._mxfp4_quantize(A, A_scale,
-                                                     per_act_token_quant,
-                                                     block_shape)
+            return MoEInputQuantizer._mxfp4_quantize(
+                A,
+                A_scale,
+                per_act_token_quant,
+                block_shape,
+            )
         else:
             return A, A_scale
 


### PR DESCRIPTION
## Purpose
Refactor MoE FP8 activation quantization to use the QuantFP8 CustomOp abstraction, exposing quantization to Torch Inductor for fusion and unifying static/dynamic per-tensor and per-token semantics. Keep block/group FP8 quantization unchanged.

The main changes include:
- Add a MoEInputQuantizer class with init/forward (and callable) interface for FP8/INT8/NVFP4/MXFP4 activation quantization.
	- Make the class abstract out details on decision of the quant fp8 op to be used


## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

