### PR TITLE
[Attention][FA3] Update FA3 to include new swizzle optimization

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,7 +38,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG ea0070674ab9a265e665ab4a9d89b1126b7c45cb
+          GIT_TAG 2adfc8c2177c5b0e8ddeedfd5a8990d80eb496ff
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,7 +38,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 188be16520ceefdc625fdf71365585d2ee348fe2
+          GIT_TAG ea0070674ab9a265e665ab4a9d89b1126b7c45cb
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -308,14 +308,17 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             self.compilation_config.cudagraph_mode.has_full_cudagraphs()
         )
         self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
+        max_num_seqs = vllm_config.scheduler_config.max_num_seqs
 
         if self.use_full_cuda_graph and self.aot_schedule:
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
-            # Use max_cudagraph_size (not max_num_seqs) because during cuda
-            # graph capture the batch size can be up to max_cudagraph_size.
+            # For some tests max_cudagraph_size > max_num_seqs,
+            #   so we need to use the larger one.
+            assert self.max_cudagraph_size is not None
+            buffer_size = max(self.max_cudagraph_size, max_num_seqs) * 4 + 1
             self.scheduler_metadata = torch.zeros(
-                self.max_cudagraph_size * 4 + 1,
+                buffer_size,
                 dtype=torch.int32,
                 device=self.device,
             )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -310,15 +310,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
 
         if self.use_full_cuda_graph and self.aot_schedule:
-            self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
-
-            if self.max_cudagraph_size > 992:
-                # This condition derives from FA3's internal heuristic.
-                # TODO(woosuk): Support larger cudagraph sizes.
-                raise ValueError(
-                    "Capture size larger than 992 is not supported for full cuda graph."
-                )
-
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
             self.scheduler_metadata = torch.zeros(

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -310,8 +310,19 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
 
         if self.use_full_cuda_graph and self.aot_schedule:
+            self.max_cudagraph_size = self.compilation_config.max_capture_size
+
+            if self.max_cudagraph_size > 992:
+                # This condition derives from FA3's internal heuristic.
+                # TODO(woosuk): Support larger cudagraph sizes.
+                raise ValueError(
+                    "Capture size larger than 992 is not supported for "
+                    "full cuda graph.")
+
+            # Times 4 due to:
+            #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
             self.scheduler_metadata = torch.zeros(
-                vllm_config.scheduler_config.max_num_seqs + 1,
+                vllm_config.scheduler_config.max_num_seqs * 4 + 1,
                 dtype=torch.int32,
                 device=self.device,
             )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -310,14 +310,14 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
 
         if self.use_full_cuda_graph and self.aot_schedule:
-            self.max_cudagraph_size = self.compilation_config.max_capture_size
+            self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
 
             if self.max_cudagraph_size > 992:
                 # This condition derives from FA3's internal heuristic.
                 # TODO(woosuk): Support larger cudagraph sizes.
                 raise ValueError(
-                    "Capture size larger than 992 is not supported for "
-                    "full cuda graph.")
+                    "Capture size larger than 992 is not supported for full cuda graph."
+                )
 
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -312,8 +312,10 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         if self.use_full_cuda_graph and self.aot_schedule:
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
+            # Use max_cudagraph_size (not max_num_seqs) because during cuda
+            # graph capture the batch size can be up to max_cudagraph_size.
             self.scheduler_metadata = torch.zeros(
-                vllm_config.scheduler_config.max_num_seqs * 4 + 1,
+                self.max_cudagraph_size * 4 + 1,
                 dtype=torch.int32,
                 device=self.device,
             )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -313,12 +313,10 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         if self.use_full_cuda_graph and self.aot_schedule:
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
-            # For some tests max_cudagraph_size > max_num_seqs,
-            #   so we need to use the larger one.
-            assert self.max_cudagraph_size is not None
-            buffer_size = max(self.max_cudagraph_size, max_num_seqs) * 4 + 1
             self.scheduler_metadata = torch.zeros(
-                buffer_size,
+                # For some tests max_cudagraph_size > max_num_seqs,
+                #   so we need to use the larger one.
+                max(self.max_cudagraph_size or 0, max_num_seqs) * 4 + 1,
                 dtype=torch.int32,
                 device=self.device,
             )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -313,9 +313,9 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         if self.use_full_cuda_graph and self.aot_schedule:
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
+            # For some tests max_cudagraph_size > max_num_seqs,
+            #   so we need to use the larger one.
             self.scheduler_metadata = torch.zeros(
-                # For some tests max_cudagraph_size > max_num_seqs,
-                #   so we need to use the larger one.
                 max(self.max_cudagraph_size or 0, max_num_seqs) * 4 + 1,
                 dtype=torch.int32,
                 device=self.device,

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -129,8 +129,10 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
         self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
 
         if self.use_full_cuda_graph and self.fa_aot_schedule:
+            # Times 4 due to:
+            #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
             self.scheduler_metadata = torch.zeros(
-                vllm_config.scheduler_config.max_num_seqs + 1,
+                vllm_config.scheduler_config.max_num_seqs * 4 + 1,
                 dtype=torch.int32,
                 device=self.device,
             )

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -131,8 +131,10 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
         if self.use_full_cuda_graph and self.fa_aot_schedule:
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
+            # Use max_cudagraph_size (not max_num_seqs) because during cuda
+            # graph capture the batch size can be up to max_cudagraph_size.
             self.scheduler_metadata = torch.zeros(
-                vllm_config.scheduler_config.max_num_seqs * 4 + 1,
+                self.max_cudagraph_size * 4 + 1,
                 dtype=torch.int32,
                 device=self.device,
             )

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -134,10 +134,8 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
             # For some tests max_cudagraph_size > max_num_seqs,
             #   so we need to use the larger one.
-            assert self.max_cudagraph_size is not None
-            buffer_size = max(self.max_cudagraph_size, max_num_seqs) * 4 + 1
             self.scheduler_metadata = torch.zeros(
-                buffer_size,
+                max(self.max_cudagraph_size or 0, max_num_seqs) * 4 + 1,
                 dtype=torch.int32,
                 device=self.device,
             )

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -127,14 +127,17 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
             self.compilation_config.cudagraph_mode.has_full_cudagraphs()
         )
         self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
+        max_num_seqs = vllm_config.scheduler_config.max_num_seqs
 
         if self.use_full_cuda_graph and self.fa_aot_schedule:
             # Times 4 due to:
             #  https://github.com/vllm-project/flash-attention/blob/3223650ccabe622a0fcae65eec706a50186a89f7/hopper/flash_api.cpp#L650-L653
-            # Use max_cudagraph_size (not max_num_seqs) because during cuda
-            # graph capture the batch size can be up to max_cudagraph_size.
+            # For some tests max_cudagraph_size > max_num_seqs,
+            #   so we need to use the larger one.
+            assert self.max_cudagraph_size is not None
+            buffer_size = max(self.max_cudagraph_size, max_num_seqs) * 4 + 1
             self.scheduler_metadata = torch.zeros(
-                self.max_cudagraph_size * 4 + 1,
+                buffer_size,
                 dtype=torch.int32,
                 device=self.device,
             )


### PR DESCRIPTION
vLLM side of https://github.com/vllm-project/flash-attention/pull/82 

`meta-llama/Meta-Llama-3-8B-Instruct`, 1xH100, 4k and 2k out
```
branch   rate     num_prompts  req/s    median TTFT (ms)   std TTFT     p99 TTFT     median TPOT (ms)   std TPOT     p99 TPOT    
------   ----     -----------  -----    ----------------   --------     --------     ----------------   --------     --------    
MAIN     1.00     120          0.88     141.95             29.83        287.21       11.07              0.84         11.67       
PR       1.00     120          0.89     137.69             28.51        277.24       10.81              0.84         11.40       
MAIN     2.00     240          1.53     177.97             54.18        415.02       25.73              4.63         30.20       
PR       2.00     240          1.54     176.99             52.59        403.90       25.72              4.60         30.08       
MAIN     3.00     360          1.65     361.44             18180.54     43681.80     42.99              8.20         52.66       
PR       3.00     360          1.66     345.31             17685.66     42551.03     42.69              8.00         52.07       
MAIN     4.00     480          1.66     54165.70           45848.99     119451.76    49.99              9.37         69.16       
PR       4.00     480          1.67     52780.84           45014.34     117440.91    49.40              9.16         68.40 
```
