### PR TITLE
[Bugfix] Add strong reference to CUDA pluggable allocator callbacks

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -152,7 +152,7 @@ class CuMemAllocator:
         self.pointer_to_data: dict[int, AllocationData] = {}
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
-        # Creating a strong reference to the two callbacks here to prevent
+        # Creating strong references to the two callbacks here to prevent
         # these ephemeral bound-method objects being garbbage collected.
         # Without this, `my_free` may call GC-ed callbacks causing failure.
         # See discussions in https://github.com/vllm-project/vllm/pull/22724

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -153,7 +153,7 @@ class CuMemAllocator:
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
         # Creating strong references to the two callbacks here to prevent
-        # these ephemeral bound-method objects being garbbage collected.
+        # these ephemeral bound-method objects being garbage collected.
         # See discussions in https://github.com/vllm-project/vllm/pull/22724
         self.python_malloc_callback = self._python_malloc_callback
         self.python_free_callback = self._python_free_callback

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -152,6 +152,10 @@ class CuMemAllocator:
         self.pointer_to_data: dict[int, AllocationData] = {}
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
+        # Creating a strong reference to the two callbacks here to prevent
+        # these ephemeral bound-method objects being garbbage collected.
+        # Without this, `my_free` may call GC-ed callbacks causing failure.
+        # See discussions in https://github.com/vllm-project/vllm/pull/22724
         self.python_malloc_callback = self._python_malloc_callback
         self.python_free_callback = self._python_free_callback
 

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -152,10 +152,10 @@ class CuMemAllocator:
         self.pointer_to_data: dict[int, AllocationData] = {}
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
-        self.python_malloc_callback_ref = self.python_malloc_callback
-        self.python_free_callback_ref = self.python_free_callback
+        self.python_malloc_callback = self._python_malloc_callback
+        self.python_free_callback = self._python_free_callback
 
-    def python_malloc_callback(self, allocation_handle: HandleType) -> None:
+    def _python_malloc_callback(self, allocation_handle: HandleType) -> None:
         """
         Internal method to store the allocation data
         when memory is allocated in the memory pool."""
@@ -164,7 +164,7 @@ class CuMemAllocator:
             allocation_handle, self.current_tag)
         return
 
-    def python_free_callback(self, ptr: int) -> HandleType:
+    def _python_free_callback(self, ptr: int) -> HandleType:
         """
         Internal method to look up the allocation data
         when memory is freed in the memory pool."""
@@ -251,9 +251,8 @@ class CuMemAllocator:
 
         old_tag = self.current_tag
         self.current_tag = tag
-        with use_memory_pool_with_allocator(
-                self.python_malloc_callback_ref,
-                self.python_free_callback_ref) as data:
+        with use_memory_pool_with_allocator(self.python_malloc_callback,
+                                            self.python_free_callback) as data:
             # start to hit another PyTorch bug in PyTorch 2.6,
             # possibly because of gc-related issue w.r.t. the allocator and
             # the memory pool.

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -154,7 +154,6 @@ class CuMemAllocator:
         self.allocator_and_pools: dict[str, Any] = {}
         # Creating strong references to the two callbacks here to prevent
         # these ephemeral bound-method objects being garbbage collected.
-        # Without this, `my_free` may call GC-ed callbacks causing failure.
         # See discussions in https://github.com/vllm-project/vllm/pull/22724
         self.python_malloc_callback = self._python_malloc_callback
         self.python_free_callback = self._python_free_callback


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This is the Python-only fix version of #22724. See context and discussions there.
Thanks @EricMarcus-ai for the awesome work!

Related:
vLLM: https://github.com/vllm-project/vllm/issues/20431
vLLM: https://github.com/vllm-project/vllm/issues/16993
OpenRLHF: https://github.com/OpenRLHF/OpenRLHF/issues/1052
ModelScope: https://github.com/modelscope/ms-swift/issues/4353

## Test Plan
Below is a minor modification to the initial test added in #22724. Because this is a stress test, will not add to CI for cost/perf reason.

```python
# Helper churn to pressure CPython's small-object allocator so that
# temporary bound-method objects get collected and their memory is reused.
class _Churn:

    def cb(self):
        return 1


def _churn_bound_methods(n: int = 500_000):
    for _ in range(n):
        _ = _Churn().cb  # create & drop a temporary bound-method object


def _churn_small_objs(n: int = 2_000_000):
    for _ in range(n):
        _ = object()


@create_new_process_for_each_test()
def test_cumem_callback_lifetime_regression():
    """
    Test for the borrowed callback bug
    Context
    -------
    The C++ extension originally borrowed references to the Python
    bound methods passed into `init_module`. After leaving the Python
    context that created those bound methods, CPython can free them.
    Later, when tensors that were allocated by the pluggable allocator
    are freed, `my_free` calls back into C++; Python using those
    now-dangling pointers, causing UB / segfaults.
    What this test does
    -------------------
    1) Create the singleton `CuMemAllocator` and build a pluggable
       allocator by calling `get_pluggable_allocator(A.python_malloc_callback,
       A.python_free_callback)`. This mirrors the setup in cumem.py
    2) Aggressively churn Python objects to encourage CPython to reuse
       the memory that held those temporaries.
    3) Perform allocate inside the pluggable mem-pool to
       drive calls into `my_malloc`/`my_free`.
    Expected outcome
    ----------------
    • With the original extension that borrows refs:
      this test aborts (segfault) during or after
      the first/second allocate.
    • With the updated extension (explicit referencing in `init_module`) 
      the test should complete without crashing.
    Pass criterion
    --------------
    The test passes if the process completes the allocate/free cycles
    without aborting. There are no numeric assertions; a failure will
    manifest as a process crash.
    """

    if torch.cuda.device_count() == 0:
        pytest.skip("No CUDA device available")

    A = CuMemAllocator.get_instance()

    # calling this creates temporary bound-method objects.
    alloc = get_pluggable_allocator(A.python_malloc_callback,
                                    A.python_free_callback)
    mpool = torch.cuda.memory.MemPool(alloc._allocator)

    _churn_bound_methods(400_000)
    _churn_small_objs(500_000)
    gc.collect()

    with torch.cuda.memory.use_mem_pool(mpool):
        bufs = [
            torch.empty(1 << 20, dtype=torch.uint8, device="cuda")
            for _ in range(128)
        ]  # ~ 128 MiB
        del bufs
        gc.collect()

    # churn harder
    _churn_bound_methods(1_000_000)
    gc.collect()

    with torch.cuda.memory.use_mem_pool(mpool):
        buf = torch.empty(1 << 20, dtype=torch.uint8, device="cuda")
        del buf
        gc.collect()

    # Clean shutdown
    torch.cuda.synchronize()
    del mpool, alloc
    gc.collect()
```

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

