### PR TITLE
fix incompatibililty with non cuda platform for nvfp4

### DIFF
--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -47,8 +47,10 @@ QUANT_OPS: dict[QuantKey, OpOverload] = {
     torch.ops._C.dynamic_scaled_fp8_quant.default,  # noqa: E501
     kFp8DynamicTokenSym:
     torch.ops._C.dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
-    kNvfp4Quant: torch.ops._C.scaled_fp4_quant.default,  # noqa: E501
 }
+if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
+    QUANT_OPS[
+        kNvfp4Quant] = torch.ops._C.scaled_fp4_quant.default  # noqa: E501
 
 
 class FusedRMSQuantKey(NamedTuple):


### PR DESCRIPTION
Summary:
scaled_fp4_quant is only applicable to cuda platform, it will fail the build for AMD package

bypass-github-export-checks

Test Plan:
before
https://www.internalfb.com/servicelab/experiment/5901642258
after
https://www.internalfb.com/servicelab/experiment/6001641632

bypass-github-export-checks

Rollback Plan:

Differential Revision: D80884348
