### PR TITLE
[Model] Added reasoning parser for Seed-Oss model

### DIFF
--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -9,6 +9,7 @@ from .granite_reasoning_parser import GraniteReasoningParser
 from .hunyuan_a13b_reasoning_parser import HunyuanA13BReasoningParser
 from .mistral_reasoning_parser import MistralReasoningParser
 from .qwen3_reasoning_parser import Qwen3ReasoningParser
+from .seed_oss_reasoning_parser import SeedOssReasoningParser
 from .step3_reasoning_parser import Step3ReasoningParser
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "MistralReasoningParser",
     "Step3ReasoningParser",
     "GptOssReasoningParser",
+    "SeedOssReasoningParser",
 ]

--- a/vllm/reasoning/seed_oss_reasoning_parser.py
+++ b/vllm/reasoning/seed_oss_reasoning_parser.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+from typing import Optional, Union
+
+from transformers import PreTrainedTokenizerBase
+
+from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                              DeltaMessage)
+from vllm.logger import init_logger
+from vllm.reasoning import ReasoningParser, ReasoningParserManager
+
+logger = init_logger(__name__)
+
+
+@ReasoningParserManager.register_module("seed_oss")
+class SeedOssReasoningParser(ReasoningParser):
+    """
+    Reasoning parser for the SeedOss model.
+
+    The SeedOss model uses <seed:think>...</seed:think> tokens to denote
+    reasoning text within its output.
+    The model adheres to a user-defineable thinking budget and reflects on it
+    by using <seed:cot_budget_reflect> .. </seed:cot_budget_reflect> tags.
+    This parser extracts the reasoning content enclosed by <seed:think> and
+    </seed:think> tokens from the model's output.
+    """
+
+    def __init__(self, tokenizer: PreTrainedTokenizerBase):
+        super().__init__(tokenizer)
+        self.think_start_token = "<seed:think>"
+        self.think_end_token = "</seed:think>"
+
+        if not self.model_tokenizer:
+            raise ValueError(
+                "The model tokenizer must be passed to the ReasoningParser "
+                "constructor during construction.")
+
+        self.think_start_token_id = self.vocab.get(self.think_start_token)
+        self.think_end_token_id = self.vocab.get(self.think_end_token)
+        if (self.think_start_token_id is None
+                or self.think_end_token_id is None):
+            raise RuntimeError("SeedOss reasoning parser could not locate "
+                               "think start/end tokens in the tokenizer!")
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        return self.think_end_token_id in input_ids
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        """
+        Extract the content after the end tokens
+        """
+        if self.think_end_token_id not in input_ids[:-1]:
+            return []
+        else:
+            return input_ids[input_ids.index(self.think_end_token_id) + 1:]
+
+    def extract_reasoning_content_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> Union[DeltaMessage, None]:
+        """
+        Extract reasoning content from a delta message.
+        Handles streaming output where previous + delta = current.
+        Uses token IDs for faster processing.
+        For text <seed:think>abc</seed:think>xyz:
+        - 'abc' goes to reasoning_content
+        - 'xyz' goes to content
+        """
+        # Skip single special tokens
+        if len(delta_token_ids) == 1 and (delta_token_ids[0] in [
+                self.think_start_token_id, self.think_end_token_id
+        ]):
+            return None
+
+        if self.think_start_token_id in previous_token_ids:
+            if self.think_end_token_id in delta_token_ids:
+                # <seed:think> in previous, </seed:think> in delta,
+                # extract reasoning content
+                end_index = delta_text.find(self.think_end_token)
+                reasoning_content = delta_text[:end_index]
+                content = delta_text[end_index + len(self.think_end_token):]
+                return DeltaMessage(reasoning_content=reasoning_content,
+                                    content=content if content else None)
+            elif self.think_end_token_id in previous_token_ids:
+                # <seed:think> in previous, </seed:think> in previous,
+                # reasoning content continues
+                return DeltaMessage(content=delta_text)
+            else:
+                # <seed:think> in previous, no </seed:think> in previous or
+                # delta, reasoning content continues
+                return DeltaMessage(reasoning_content=delta_text)
+        elif self.think_start_token_id in delta_token_ids:
+            if self.think_end_token_id in delta_token_ids:
+                # <seed:think> in delta, </seed:think> in delta, extract
+                # reasoning content
+                start_index = delta_text.find(self.think_start_token)
+                end_index = delta_text.find(self.think_end_token)
+                reasoning_content = delta_text[start_index +
+                                               len(self.think_start_token
+                                                   ):end_index]
+                content = delta_text[end_index + len(self.think_end_token):]
+                return DeltaMessage(reasoning_content=reasoning_content,
+                                    content=content if content else None)
+            else:
+                # <seed:think> in delta, no </seed:think> in delta,
+                # reasoning content continues
+                return DeltaMessage(reasoning_content=delta_text)
+        else:
+            # just content, even though Seed-Oss is supposed to always think
+            return DeltaMessage(content=delta_text)
+
+    def extract_reasoning_content(
+            self, model_output: str, request: ChatCompletionRequest
+    ) -> tuple[Optional[str], Optional[str]]:
+        """
+        Extract reasoning content from the model output.
+
+        For text <seed:think>abc</seed:think>xyz:
+        - 'abc' goes to reasoning_content
+        - 'xyz' goes to content
+
+        Returns:
+            tuple[Optional[str], Optional[str]]: reasoning content and content
+        """
+
+        # Check if the model output contains the <seed:think> and </seed:think>
+        # tokens.
+        if (self.think_start_token not in model_output
+                or self.think_end_token not in model_output):
+            return None, model_output
+        # Check if the <seed:think> is present in the model output, remove it
+        # if it is present.
+        model_output_parts = model_output.partition(self.think_start_token)
+        model_output = model_output_parts[2] if model_output_parts[
+            1] else model_output_parts[0]
+        # Check if the model output contains the </seed:think> tokens.
+        # If the end token is not found, return the model output as is.
+        if self.think_end_token not in model_output:
+            return None, model_output
+
+        # Extract reasoning content from the model output.
+        reasoning_content, _, content = model_output.partition(
+            self.think_end_token)
+
+        final_content = content or None
+        return reasoning_content, final_content

--- a/vllm/reasoning/seed_oss_reasoning_parser.py
+++ b/vllm/reasoning/seed_oss_reasoning_parser.py
@@ -1,153 +1,40 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Sequence
-from typing import Optional, Union
-
 from transformers import PreTrainedTokenizerBase
 
-from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
-                                              DeltaMessage)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import (
+    DeepSeekR1ReasoningParser)
 
 logger = init_logger(__name__)
 
 
 @ReasoningParserManager.register_module("seed_oss")
-class SeedOssReasoningParser(ReasoningParser):
+class SeedOssReasoningParser(DeepSeekR1ReasoningParser):
     """
-    Reasoning parser for the SeedOss model.
+    Reasoning parser for Seed Oss models.
 
-    The SeedOss model uses <seed:think>...</seed:think> tokens to denote
-    reasoning text within its output.
-    The model adheres to a user-defineable thinking budget and reflects on it
-    by using <seed:cot_budget_reflect> .. </seed:cot_budget_reflect> tags.
-    This parser extracts the reasoning content enclosed by <seed:think> and
-    </seed:think> tokens from the model's output.
+    This model uses <seed:think>...</seed:think> tokens to denote reasoning
+    text. This parser extracts the reasoning content from the model output.
     """
 
     def __init__(self, tokenizer: PreTrainedTokenizerBase):
-        super().__init__(tokenizer)
-        self.think_start_token = "<seed:think>"
-        self.think_end_token = "</seed:think>"
+        ReasoningParser.__init__(self, tokenizer)
 
         if not self.model_tokenizer:
             raise ValueError(
                 "The model tokenizer must be passed to the ReasoningParser "
                 "constructor during construction.")
 
-        self.think_start_token_id = self.vocab.get(self.think_start_token)
-        self.think_end_token_id = self.vocab.get(self.think_end_token)
-        if (self.think_start_token_id is None
-                or self.think_end_token_id is None):
-            raise RuntimeError("SeedOss reasoning parser could not locate "
-                               "think start/end tokens in the tokenizer!")
+        self.start_token = "<seed:think>"
+        self.end_token = "</seed:think>"
 
-    def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        return self.think_end_token_id in input_ids
+        self.start_token_id = self.vocab.get(self.start_token)
+        self.end_token_id = self.vocab.get(self.end_token)
 
-    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
-        """
-        Extract the content after the end tokens
-        """
-        if self.think_end_token_id not in input_ids[:-1]:
-            return []
-        else:
-            return input_ids[input_ids.index(self.think_end_token_id) + 1:]
-
-    def extract_reasoning_content_streaming(
-        self,
-        previous_text: str,
-        current_text: str,
-        delta_text: str,
-        previous_token_ids: Sequence[int],
-        current_token_ids: Sequence[int],
-        delta_token_ids: Sequence[int],
-    ) -> Union[DeltaMessage, None]:
-        """
-        Extract reasoning content from a delta message.
-        Handles streaming output where previous + delta = current.
-        Uses token IDs for faster processing.
-        For text <seed:think>abc</seed:think>xyz:
-        - 'abc' goes to reasoning_content
-        - 'xyz' goes to content
-        """
-        # Skip single special tokens
-        if len(delta_token_ids) == 1 and (delta_token_ids[0] in [
-                self.think_start_token_id, self.think_end_token_id
-        ]):
-            return None
-
-        if self.think_start_token_id in previous_token_ids:
-            if self.think_end_token_id in delta_token_ids:
-                # <seed:think> in previous, </seed:think> in delta,
-                # extract reasoning content
-                end_index = delta_text.find(self.think_end_token)
-                reasoning_content = delta_text[:end_index]
-                content = delta_text[end_index + len(self.think_end_token):]
-                return DeltaMessage(reasoning_content=reasoning_content,
-                                    content=content if content else None)
-            elif self.think_end_token_id in previous_token_ids:
-                # <seed:think> in previous, </seed:think> in previous,
-                # reasoning content continues
-                return DeltaMessage(content=delta_text)
-            else:
-                # <seed:think> in previous, no </seed:think> in previous or
-                # delta, reasoning content continues
-                return DeltaMessage(reasoning_content=delta_text)
-        elif self.think_start_token_id in delta_token_ids:
-            if self.think_end_token_id in delta_token_ids:
-                # <seed:think> in delta, </seed:think> in delta, extract
-                # reasoning content
-                start_index = delta_text.find(self.think_start_token)
-                end_index = delta_text.find(self.think_end_token)
-                reasoning_content = delta_text[start_index +
-                                               len(self.think_start_token
-                                                   ):end_index]
-                content = delta_text[end_index + len(self.think_end_token):]
-                return DeltaMessage(reasoning_content=reasoning_content,
-                                    content=content if content else None)
-            else:
-                # <seed:think> in delta, no </seed:think> in delta,
-                # reasoning content continues
-                return DeltaMessage(reasoning_content=delta_text)
-        else:
-            # just content, even though Seed-Oss is supposed to always think
-            return DeltaMessage(content=delta_text)
-
-    def extract_reasoning_content(
-            self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[Optional[str], Optional[str]]:
-        """
-        Extract reasoning content from the model output.
-
-        For text <seed:think>abc</seed:think>xyz:
-        - 'abc' goes to reasoning_content
-        - 'xyz' goes to content
-
-        Returns:
-            tuple[Optional[str], Optional[str]]: reasoning content and content
-        """
-
-        # Check if the model output contains the <seed:think> and </seed:think>
-        # tokens.
-        if (self.think_start_token not in model_output
-                or self.think_end_token not in model_output):
-            return None, model_output
-        # Check if the <seed:think> is present in the model output, remove it
-        # if it is present.
-        model_output_parts = model_output.partition(self.think_start_token)
-        model_output = model_output_parts[2] if model_output_parts[
-            1] else model_output_parts[0]
-        # Check if the model output contains the </seed:think> tokens.
-        # If the end token is not found, return the model output as is.
-        if self.think_end_token not in model_output:
-            return None, model_output
-
-        # Extract reasoning content from the model output.
-        reasoning_content, _, content = model_output.partition(
-            self.think_end_token)
-
-        final_content = content or None
-        return reasoning_content, final_content
+        if self.start_token_id is None or self.end_token_id is None:
+            raise RuntimeError(
+                "Seed Oss reasoning parser could not locate think start/end "
+                "tokens in the tokenizer!")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Initial reasoning parser for Seed-Oss model, see #23241. ~~It's just copy/pasted from Glm4/Deepseek R1 and minimally adapted and tested.~~ See https://github.com/vllm-project/vllm/pull/23486#issuecomment-3218101292

Note that currently the model reflections (tag: `<seed:cot_budget_reflect>`) about its reasoning budget are not parsed and remain part of the reasoning content.

## Test Plan
`--reasoning-parser seed_oss`

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

