### PR TITLE
[Fix] DeepSeek V3.1 tool parser error message

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/deepseekv31_tool_parser.py
@@ -64,8 +64,8 @@ class DeepSeekV31ToolParser(ToolParser):
         if (self.tool_calls_start_token_id is None
                 or self.tool_calls_end_token_id is None):
             raise RuntimeError(
-                "DeepSeek-V3 Tool parser could not locate tool call start/end "
-                "tokens in the tokenizer!")
+                "DeepSeek-V3.1 Tool parser could not locate tool call "
+                "start/end tokens in the tokenizer!")
 
     def extract_tool_calls(
         self,


### PR DESCRIPTION
- Correct error message to show "DeepSeek-V3.1" instead of "DeepSeek-V3"
- Maintain consistency with parser registration name "deepseek_v31"

The error message now correctly reflects the actual model version when tokenizer validation fails during tool parser initialization.

