### PR TITLE
[Perf] Add Triton config for DeepSeek V3 FP8 EP32 H200

### DIFF
--- a/benchmarks/kernels/benchmark_w8a8_block_fp8.py
+++ b/benchmarks/kernels/benchmark_w8a8_block_fp8.py
@@ -11,8 +11,8 @@ from datetime import datetime
 from typing import Any
 
 import torch
-import tqdm
 import triton
+from tqdm import tqdm
 
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     _w8a8_block_fp8_matmul,

--- a/vllm/model_executor/layers/fused_moe/configs/E=8,N=2048,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=8,N=2048,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -1,0 +1,154 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "48": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "96": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/vllm/model_executor/layers/quantization/utils/configs/N=2112,K=7168,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/vllm/model_executor/layers/quantization/utils/configs/N=2112,K=7168,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -1,0 +1,26 @@
+{
+    "2048": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/vllm/model_executor/layers/quantization/utils/configs/README.md
+++ b/vllm/model_executor/layers/quantization/utils/configs/README.md
@@ -1,0 +1,1 @@
+Use scripts under `benchmarks/kernels/` to generate these config files.

--- a/vllm/model_executor/layers/quantization/utils/configs/README.md
+++ b/vllm/model_executor/layers/quantization/utils/configs/README.md
@@ -1,1 +1,3 @@
+# Quantization Kernel Config
+
 Use scripts under `benchmarks/kernels/` to generate these config files.


### PR DESCRIPTION
## Purpose

To add optimal triton config for DeepSeek V3 for DP8TP4EP32

This resolves the following warnings:
```
(VllmWorker TP2 pid=1298912) WARNING 08-23 18:31:51 [fp8_utils.py:581] Using default W8A8 Block FP8 kernel config. Performance might be sub-optimal! Config file not found at /data/users/yming/gitrepos/vllm/vllm/model_executor/layers/quantization/utils/configs/N=2112,K=7168,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json
(VllmWorker TP1 pid=1298911) WARNING 08-23 18:32:45 [fused_moe.py:727] Using default MoE config. Performance might be sub-optimal! Config file not found at ['/data/users/yming/gitrepos/vllm/vllm/model_executor/layers/fused_moe/configs/E=8,N=2048,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json']
```

## Test Plan

Testing DeepSeek V3 for DP8TP4EP32

## Test Result

```
python benchmarks/benchmark_serving.py  --model deepseek-ai/DeepSeek-V3-0324 --port 8000  --dataset-name random  --ignore-eos  --num-prompts 4096  --request-rate inf  --random-input-len 2048  --random-output-len 1024 --max-concurrency 2048
```

Updated benchmark without prefix caching:

```
tuned:
============ Serving Benchmark Result ============
Successful requests:                     4096
Maximum request concurrency:             2048
Benchmark duration (s):                  744.88
Total input tokens:                      8373709
Total generated tokens:                  4194304
Request throughput (req/s):              5.50
Output token throughput (tok/s):         5630.83
Total Token throughput (tok/s):          16872.50
---------------Time to First Token----------------
Mean TTFT (ms):                          56772.23
Median TTFT (ms):                        12476.26
P99 TTFT (ms):                           201560.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          305.71
Median TPOT (ms):                        348.72
P99 TPOT (ms):                           354.18
---------------Inter-token Latency----------------
Mean ITL (ms):                           305.71
Median ITL (ms):                         163.62
P99 ITL (ms):                            3149.75
==================================================

untuned
============ Serving Benchmark Result ============
Successful requests:                     4096
Maximum request concurrency:             2048
Benchmark duration (s):                  749.16
Total input tokens:                      8373709
Total generated tokens:                  4194304
Request throughput (req/s):              5.47
Output token throughput (tok/s):         5598.65
Total Token throughput (tok/s):          16776.08
---------------Time to First Token----------------
Mean TTFT (ms):                          56991.46
Median TTFT (ms):                        12523.49
P99 TTFT (ms):                           202456.28
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          307.65
Median TPOT (ms):                        348.01
P99 TPOT (ms):                           358.92
---------------Inter-token Latency----------------
Mean ITL (ms):                           307.65
Median ITL (ms):                         166.44
P99 ITL (ms):                            3157.64
==================================================
```

previous results with prefix caching (pls ignore; kept here just for records)
```
# before adding tuned triton config
============ Serving Benchmark Result ============
Successful requests:                     2048
Maximum request concurrency:             2048
Benchmark duration (s):                  292.73
Total input tokens:                      4186967
Total generated tokens:                  2097152
Request throughput (req/s):              7.00
Output token throughput (tok/s):         7164.09
Total Token throughput (tok/s):          21467.20
---------------Time to First Token----------------
Mean TTFT (ms):                          34949.84
Median TTFT (ms):                        20465.56
P99 TTFT (ms):                           101525.57
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          247.35
Median TPOT (ms):                        260.78
P99 TPOT (ms):                           277.68
---------------Inter-token Latency----------------
Mean ITL (ms):                           247.35
Median ITL (ms):                         180.97
P99 ITL (ms):                            3149.23
==================================================

# after adding tuned triton config
============ Serving Benchmark Result ============
Successful requests:                     2048
Maximum request concurrency:             2048
Benchmark duration (s):                  182.63
Total input tokens:                      4186967
Total generated tokens:                  2097152
Request throughput (req/s):              11.21
Output token throughput (tok/s):         11483.21
Total Token throughput (tok/s):          34409.44
---------------Time to First Token----------------
Mean TTFT (ms):                          7982.04
Median TTFT (ms):                        8701.42
P99 TTFT (ms):                           11587.72
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          170.09
Median TPOT (ms):                        169.37
P99 TPOT (ms):                           175.59
---------------Inter-token Latency----------------
Mean ITL (ms):                           170.10
Median ITL (ms):                         163.11
P99 ITL (ms):                            369.07
==================================================

```



## (Optional) Documentation Update

added a simple readme to help contributors find scripts for config generation

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

