### PR TITLE
[Bugfix] Fix Qwen2.5-VL quantized model weights loading

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -853,9 +853,7 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
                                          SupportsQuant):
 
     packed_modules_mapping = {
-        "gate_up_proj": [
-            "gate_proj", "up_proj"
-        ],
+        "gate_up_proj": ["gate_proj", "up_proj"],
     }
 
     # To ensure correct weight loading and mapping.

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -135,7 +135,7 @@ class Qwen2_5_VLVideoPixelInputs(TypedDict):
 
     second_per_grid_ts: torch.Tensor
     """
-    The video time interval (in seconds) for each grid along the temporal 
+    The video time interval (in seconds) for each grid along the temporal
     dimension in the 3D position IDs. Returned when `videos` is not `None`.
     """
 
@@ -851,6 +851,12 @@ class Qwen2_5_VLMultiModalProcessor(Qwen2VLMultiModalProcessor):
 class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
                                          SupportsLoRA, SupportsPP,
                                          SupportsQuant):
+
+    packed_modules_mapping = {
+        "gate_up_proj": [
+            "gate_proj", "up_proj"
+        ],
+    }
 
     # To ensure correct weight loading and mapping.
     hf_to_vllm_mapper = WeightsMapper(


### PR DESCRIPTION
This PR makes sure quantized model weights are loaded correctly. Currently, loading `RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic` will crash on A100s:
```
[core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py", line 661, in process_weights_after_loading
[core.py:708]     layer.scheme.process_weights_after_loading(layer)
[core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py", line 59, in process_weights_after_loading
[core.py:708]     prepare_fp8_layer_for_marlin(layer)
[core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py", line 107, in prepare_fp8_layer_for_marlin
[core.py:708]     marlin_qweight = ops.gptq_marlin_repack(b_q_weight=qweight,
[core.py:708]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/_custom_ops.py", line 938, in gptq_marlin_repack
[core.py:708]     return torch.ops._C.gptq_marlin_repack(b_q_weight, perm, size_k, size_n,
[core.py:708]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[core.py:708]   File "/opt/venv/lib/python3.12/site-packages/torch/_ops.py", line 1243, in __call__
[core.py:708]     return self._op(*args, **kwargs)
[core.py:708]            ^^^^^^^^^^^^^^^^^^^^^^^^^
[core.py:708] RuntimeError: size_n = 6840 is not divisible by tile_n_size = 64
```

The issue is introduced in #22066 which changed the model implementation to use MergedColumnParallelLinear layer and pack 'gate_proj' and 'up_proj' params.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

