### PR TITLE
[Misc] Enable function call for gpt-oss in streaming chat

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -64,6 +64,7 @@ def get_system_message(
     sys_msg = Message.from_role_and_content(Role.SYSTEM, sys_msg_content)
     return sys_msg
 
+
 def get_harmony_tools(tools: Optional[list] = None) -> Optional[list[Tool]]:
     if not tools:
         return None
@@ -79,10 +80,12 @@ def get_harmony_tools(tools: Optional[list] = None) -> Optional[list[Tool]]:
         harmony_tools.append(ft)
     return harmony_tools
 
+
 def trim_function_tool_prefix(tool_name: Optional[str]):
     if tool_name and tool_name.startswith(FUNCTION_TOOLS_PREFIX):
         return tool_name[len(FUNCTION_TOOLS_PREFIX):]
     return tool_name
+
 
 def get_developer_message(instructions: Optional[str] = None,
                           tools: Optional[list[Tool]] = None) -> Message:
@@ -185,13 +188,20 @@ def parse_regular_messages(chat_msgs):
             tool_calls = list(chat_msg["tool_calls"] or [])
             assert len(tool_calls) == 1
             tool_call = tool_calls[0]
-            tool_call_name = f"functions.{tool_call["function"]["name"]}"
+            tool_call_name = "functions." + tool_call["function"]["name"]
             tool_call_arguemtns = tool_call["function"]["arguments"]
             tool_calls_map[tool_call["id"]] = tool_call_name
-            msg = Message.from_role_and_content(role, tool_call_arguemtns).with_channel("commentary").with_recipient(tool_call_name)            
+            msg = (Message.from_role_and_content(
+                role, tool_call_arguemtns).with_channel(
+                    "commentary").with_recipient(tool_call_name))
         elif role == Role.TOOL:
-            assert "tool_call_id" in chat_msg and chat_msg["tool_call_id"] in tool_calls_map
-            msg = Message.from_author_and_content(Author.new(Role.TOOL, tool_calls_map[chat_msg["tool_call_id"]]), content).with_channel("commentary")
+            assert ("tool_call_id" in chat_msg
+                    and chat_msg["tool_call_id"] in tool_calls_map)
+            msg = Message.from_author_and_content(
+                Author.new(Role.TOOL,
+                           tool_calls_map[chat_msg["tool_call_id"]]),
+                content,
+            ).with_channel("commentary")
         else:
             msg = Message.from_role_and_contents(role, contents)
         msgs.append(msg)

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -12,11 +12,11 @@ from openai.types.responses.response_function_web_search import (
     ActionFind, ActionOpenPage, ActionSearch, ResponseFunctionWebSearch)
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent)
-from openai.types.responses.tool import Tool, FunctionTool
+from openai.types.responses.tool import FunctionTool, Tool
 from openai_harmony import (Author, Conversation, DeveloperContent,
                             HarmonyEncodingName, Message, ReasoningEffort,
                             Role, StreamableParser, SystemContent, TextContent,
-                            ToolDescription, ToolNamespaceConfig, load_harmony_encoding)
+                            ToolDescription, load_harmony_encoding)
 
 from vllm.entrypoints.openai.protocol import ResponseInputOutputItem
 from vllm.utils import random_uuid

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -22,10 +22,10 @@ from vllm.entrypoints.chat_utils import (ChatTemplateContentFormatOption,
                                          get_history_tool_calls_cnt,
                                          make_tool_call_id)
 from vllm.entrypoints.harmony_utils import (
-    get_developer_message, get_stop_tokens_for_assistant_actions,
-    get_streamable_parser_for_assistant, get_system_message, parse_chat_input,
-    parse_chat_output, render_for_completion, get_harmony_tools, trim_function_tool_prefix,
-    parse_regular_messages)
+    get_developer_message, get_harmony_tools,
+    get_stop_tokens_for_assistant_actions, get_streamable_parser_for_assistant,
+    get_system_message, parse_chat_output, parse_regular_messages,
+    render_for_completion, trim_function_tool_prefix)
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.protocol import (
     ChatCompletionLogProb, ChatCompletionLogProbs,
@@ -667,8 +667,10 @@ class OpenAIServingChat(OpenAIServing):
                         is_reasoning = \
                             harmony_parser.current_channel == "analysis"
                         # Only return the tool call if the tools are provided.
-                        is_harmony_tool = (harmony_parser.current_channel == "commentary" and request.tools)
-                        harmony_tool = trim_function_tool_prefix(harmony_parser.current_recipient)
+                        is_harmony_tool = (harmony_parser.current_channel
+                                           == "commentary" and request.tools)
+                        harmony_tool = trim_function_tool_prefix(
+                            harmony_parser.current_recipient)
                         if not request.include_reasoning and is_reasoning:
                             # Skip the reasoning content.
                             continue
@@ -707,10 +709,10 @@ class OpenAIServingChat(OpenAIServing):
                                 id=make_tool_call_id(),
                                 type="function",
                                 function=DeltaFunctionCall(
-                                    name=harmony_tool,
-                                    arguments=delta_text),
+                                    name=harmony_tool, arguments=delta_text),
                                 index=i)
-                            delta_message = DeltaMessage(tool_calls=[delta_tool_call])
+                            delta_message = DeltaMessage(
+                                tool_calls=[delta_tool_call])
                         else:
                             delta_message = DeltaMessage(content=delta_text)
                     # handle streaming deltas for tools with named tool_choice


### PR DESCRIPTION

## Purpose
Enable the function calls for gpt-oss 

## Test Plan
Launch the vllm with gpt-oss-20b and let it interact with claude code.

Simply launch with
```
vllm serve gpt-oss-20b --async-scheduling --tensor_parallel_size 2
```


## Test Result
Claude code can successfully interact with the vLLM hosted gpt-oss model using the tools,
e.g. running bash, list files, writing code.

```
> what time is it again?

● Bash(date)
  ⎿  Mon Aug 25 12:19:20 AM PDT 2025

● Mon Aug 25 12:19:20 AM PDT 2025
```

Before this change, the generated function calls can not be parsed and can not use the provided tools.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

