### PR TITLE
[Feature] DCCP supported

### DIFF
--- a/tests/benchmarks/test_dcpp_performance.py
+++ b/tests/benchmarks/test_dcpp_performance.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#python -m pytest -o log_cli=true -o log_cli_level=INFO -q test_dcpp_performance.py
+import os
+from statistics import mean, stdev
+
+import pytest
+import torch
+
+from vllm import LLM, SamplingParams
+from vllm.logger import init_logger
+from vllm.sampling_params import RequestOutputKind
+
+# Allow function objects to be serialized in collective_rpc for this test
+os.environ.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+
+def _enable_worker_timing(worker) -> bool:  # executed inside worker via RPC
+
+    if getattr(worker, "_orig_execute_model", None) is not None:
+        return True
+
+    worker._timed_steps = []
+    orig_execute_model = worker.execute_model
+
+    def wrapped_execute_model(scheduler_output):
+        total_tokens = getattr(scheduler_output,
+                               "total_num_scheduled_tokens", 0) or 0
+        is_prefill_step = total_tokens > 1
+        if is_prefill_step and torch.cuda.is_available():
+            start_evt = torch.cuda.Event(enable_timing=True)
+            end_evt = torch.cuda.Event(enable_timing=True)
+            torch.cuda.synchronize()
+            start_evt.record()
+            result = orig_execute_model(scheduler_output)
+            end_evt.record()
+            torch.cuda.synchronize()
+            elapsed_ms = start_evt.elapsed_time(end_evt)
+            worker._timed_steps.append((int(total_tokens), float(elapsed_ms)
+                                        / 1000.0))
+            return result
+        return orig_execute_model(scheduler_output)
+
+    worker._orig_execute_model = orig_execute_model
+    worker.execute_model = wrapped_execute_model
+    return True
+
+
+def _get_worker_timing(worker):  # executed inside worker via RPC
+    return list(getattr(worker, "_timed_steps", []))
+
+
+def _disable_worker_timing(worker):  # executed inside worker via RPC
+    data = list(getattr(worker, "_timed_steps", []))
+    if getattr(worker, "_orig_execute_model", None) is not None:
+        worker.execute_model = worker._orig_execute_model
+        delattr(worker, "_orig_execute_model")
+    worker._timed_steps = []
+    return data
+
+
+# Mark this module as a performance-related test
+pytestmark = pytest.mark.performance
+
+logger = init_logger(__name__)
+
+# A small model that is quick to load and run
+MODEL_NAME = "qwen/Qwen2.5-3B"
+# Use a sequence length that is long enough to show the performance trend
+# but not too long to make the test run for ages.
+LONG_SEQ_LEN = 16384
+# The "large" sequence threshold to activate DCPP
+LARGE_SEQ_THRESHOLD = 1024
+# max batched tokens
+MAX_BATCHED_TOKENS = 4096
+# The baseline chunk size for prefill (set high so DCPP can shrink it)
+PREFILL_CHUNK_SIZE = MAX_BATCHED_TOKENS
+
+
+@pytest.fixture(scope="module")
+def long_prompt_text():
+    """Create a long prompt for testing; token expansion is handled later."""
+    return "a " * LONG_SEQ_LEN
+
+
+def _run_and_profile(llm: LLM, prompt: str, warmup_runs: int = 1) -> tuple[list[tuple[int, float]], float]:
+    """
+    Run generation on the LLM engine while profiling the execution time
+    of each prefill step. In current vLLM, hook into the engine's
+    model executor rather than a worker attribute.
+    """
+    # Ensure prompt has enough tokens to trigger multiple prefill steps.
+    # Some models (e.g., Qwen) compress repeated characters heavily.
+    # Expand the prompt based on tokenizer token count.
+    try:
+        tok = llm.get_tokenizer()
+        def token_count(p: str) -> int:
+            return len(tok.encode(p, add_special_tokens=False))
+
+        # Target at least two chunks plus a small buffer, and over large-seq threshold
+        min_tokens = max(LARGE_SEQ_THRESHOLD + PREFILL_CHUNK_SIZE,
+                         PREFILL_CHUNK_SIZE * 2 + 256)
+        if token_count(prompt) < min_tokens:
+            filler = " foo123"
+            # Append in blocks to avoid too many tokenizer calls
+            while token_count(prompt) < min_tokens:
+                prompt += filler * 64
+                # Safety cap to avoid runaway strings
+                if len(prompt) > LONG_SEQ_LEN * 8:
+                    break
+    except Exception:
+        # If tokenizer access fails, proceed with original prompt
+        pass
+
+    # Optional warmup to avoid cold-start bias in first measured chunk
+    if warmup_runs > 0:
+        try:
+            warmup_prompt = "warmup"
+            for _ in range(warmup_runs):
+                llm.generate(warmup_prompt,
+                             SamplingParams(max_tokens=1,
+                                            output_kind=RequestOutputKind.FINAL_ONLY))
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+        except Exception:
+            pass
+
+    # Enable timing hook inside V1 workers via RPC
+    llm.collective_rpc(_enable_worker_timing)
+    try:
+        # Run generation to trigger the wrapped execute_model in workers
+        import time as _time
+        _host_t0 = _time.monotonic()
+        llm.generate(prompt, SamplingParams(max_tokens=1, output_kind=RequestOutputKind.FINAL_ONLY))
+        _host_t1 = _time.monotonic()
+        # Retrieve timing data from workers
+        timing_data_per_worker = llm.collective_rpc(_get_worker_timing)
+    finally:
+        # Clean up hooks
+        llm.collective_rpc(_disable_worker_timing)
+
+    # Use the first worker's data (single-GPU typical). Merge if multiple.
+    for data in timing_data_per_worker:
+        if data:
+            return data, (_host_t1 - _host_t0)
+    return [], (_host_t1 - _host_t0)
+
+
+def _print_results(title: str, steps: list[tuple[int, float]], wall_time_s: float | None = None):
+    """Helper function to log formatted results via vLLM logger."""
+    logger.info("\n--- %s ---", title)
+    header = f"{'Step':<5} | {'Chunk Size':<12} | {'Exec Time (ms)':<15}"
+    logger.info("%s", header)
+    logger.info("%s", "-" * 45)
+    for i, (chunk_size, exec_time) in enumerate(steps):
+        logger.info("%s", f"{i:<5} | {chunk_size:<12} | {exec_time * 1000:<15.2f}")
+
+    times = [t for _, t in steps]
+    if len(times) > 1:
+        logger.info("%s", "-" * 45)
+        logger.info("Avg Time: %.2f ms", mean(times) * 1000)
+        logger.info("Std Dev:  %.2f ms", stdev(times) * 1000)
+        logger.info("CoV:      %.2f%%", (stdev(times) / mean(times) * 100))
+    if times:
+        total_s = sum(times)
+        logger.info("Total Prefill Time: %.2f ms", total_s * 1000)
+        # CPP chunk bubble time: sum of positive deltas between consecutive steps
+        if len(times) > 1:
+            bubble_cpp_s = 0.0
+            prev = times[0]
+            for t in times[1:]:
+                if t > prev:
+                    bubble_cpp_s += (t - prev)
+                prev = t
+            logger.info("CPP Bubble Time: %.2f ms", bubble_cpp_s * 1000)
+        if wall_time_s is not None and wall_time_s > 0:
+            bubble_wall_s = max(0.0, wall_time_s - total_s)
+            logger.info("E2E Wall Time: %.2f ms", wall_time_s * 1000)
+            logger.info("Wall Bubble: %.2f ms (%.2f%%)", bubble_wall_s * 1000,
+                        (bubble_wall_s / wall_time_s * 100) if wall_time_s else 0.0)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 1,
+                    reason="Need at least 1 GPU to run this performance test.")
+def test_dcpp_execution_time_stability(long_prompt_text):
+    """
+    Tests the end-to-end effect of DCPP on execution time stability.
+
+    This test runs a long prefill with and without DCPP enabled and
+    compares the wall-clock time of each model execution step.
+
+    Without DCPP, execution time per step should increase as the KV cache grows.
+    With DCPP, execution time per step should remain relatively stable.
+    """
+    # Case 1: DCPP Disabled (baseline)
+    llm_no_dcpp = LLM(
+        model=MODEL_NAME,
+        enforce_eager=True,
+        # Set a large token threshold to ensure it's not hit
+        max_num_batched_tokens=MAX_BATCHED_TOKENS,
+        # Force chunked prefill in baseline so we see multiple steps
+        enable_chunked_prefill=True,
+        long_prefill_token_threshold=PREFILL_CHUNK_SIZE,
+    )
+    no_dcpp_steps, no_dcpp_wall = _run_and_profile(llm_no_dcpp, long_prompt_text)
+    _print_results("DCPP Disabled", no_dcpp_steps, no_dcpp_wall)
+    del llm_no_dcpp
+
+    # Case 2: DCPP Enabled
+    llm_dcpp = LLM(
+        model=MODEL_NAME,
+        enforce_eager=True,
+        max_num_batched_tokens=MAX_BATCHED_TOKENS,
+        enable_chunked_prefill=True,
+        # DCPP specific settings
+        enable_dcpp=True,
+        dcpp_length_threshold=LARGE_SEQ_THRESHOLD,
+        long_prefill_token_threshold=PREFILL_CHUNK_SIZE,
+        dcpp_min_chunk=256,
+    )
+    dcpp_steps, dcpp_wall = _run_and_profile(llm_dcpp, long_prompt_text)
+    _print_results("DCPP Enabled", dcpp_steps, dcpp_wall)
+    del llm_dcpp
+
+    # --- Analysis and Assertions ---
+    assert len(no_dcpp_steps) > 1, "Should have multiple prefill steps"
+    assert len(dcpp_steps) > 1, "Should have multiple prefill steps"
+
+    # Verify that without DCPP, chunk size is constant
+    no_dcpp_chunks = [c for c, _ in no_dcpp_steps]
+    assert all(c == no_dcpp_chunks[0] for c in no_dcpp_chunks)
+
+    # Verify that with DCPP, chunk size decreases
+    dcpp_chunks = [c for c, _ in dcpp_steps]
+    assert dcpp_chunks[-1] < dcpp_chunks[0]
+
+    no_dcpp_times = [t for _, t in no_dcpp_steps]
+    dcpp_times = [t for _, t in dcpp_steps]
+
+    # Verify that without DCPP, execution time increases
+    # We check if the last step is at least 20% slower than the first.
+    # This is a robust way to check for the increasing trend.
+    assert no_dcpp_times[-1] > no_dcpp_times[0] * 1.2
+
+    # The core assertion: DCPP execution times are more stable.
+    # We measure this using the Coefficient of Variation (CoV = stdev / mean).
+    # A lower CoV means more stability.
+    if len(no_dcpp_times) > 1 and len(dcpp_times) > 1:
+        no_dcpp_cov = stdev(no_dcpp_times) / mean(no_dcpp_times)
+        dcpp_cov = stdev(dcpp_times) / mean(dcpp_times)
+        # We expect the CoV of DCPP to be at least 2x smaller than without.
+        assert dcpp_cov < no_dcpp_cov / 2

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -159,6 +159,18 @@ class SchedulerConfig:
     structured outputs, speculative decoding, and pipeline parallelism.
     """
 
+    # --- DCPP (Dynamic Chunked Prefill Planning) ---
+    enable_dcpp: bool = False
+    """EXPERIMENTAL: Enable dynamic chunked prefill planning (DCPP)."""
+
+    dcpp_min_chunk: Optional[int] = None
+    """Minimum prefill chunk size when DCPP is enabled. If None, a backend
+    specific default will be used."""
+
+    dcpp_length_threshold: int = 0
+    """Input length threshold to trigger DCPP logic. Requests with prompt
+    length below this value will not use DCPP even if enabled."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -447,6 +447,10 @@ class EngineArgs:
     kv_sharing_fast_prefill: bool = \
         CacheConfig.kv_sharing_fast_prefill
 
+    enable_dcpp: bool = SchedulerConfig.enable_dcpp
+    dcpp_min_chunk: Optional[int] = SchedulerConfig.dcpp_min_chunk
+    dcpp_length_threshold: int = SchedulerConfig.dcpp_length_threshold
+
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
         # without having to manually construct a
@@ -861,6 +865,13 @@ class EngineArgs:
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"])
         scheduler_group.add_argument("--async-scheduling",
                                      **scheduler_kwargs["async_scheduling"])
+        # DCPP-related flags (experimental)
+        scheduler_group.add_argument("--enable-dcpp",
+                                     **scheduler_kwargs["enable_dcpp"])
+        scheduler_group.add_argument("--dcpp-min-chunk",
+                                     **scheduler_kwargs["dcpp_min_chunk"])
+        scheduler_group.add_argument("--dcpp-length-threshold",
+                                     **scheduler_kwargs["dcpp_length_threshold"])
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)
@@ -1340,6 +1351,9 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.
             disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
+            enable_dcpp=self.enable_dcpp,
+            dcpp_min_chunk=self.dcpp_min_chunk,
+            dcpp_length_threshold=self.dcpp_length_threshold,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/model_executor/flops_estimator.py
+++ b/vllm/model_executor/flops_estimator.py
@@ -1,0 +1,886 @@
+"""
+Model Configuration P-Value Estimator
+Estimate non-attention and attention calculation ratio for different model architectures
+"""
+
+import json
+import argparse
+from abc import ABC, abstractmethod
+from typing import Dict, Tuple, List, Optional
+import logging
+
+# Global logger: prefer vllm logger if available, else fallback to std logging
+try:
+    from vllm.logger import init_logger as _vllm_init_logger  # type: ignore
+    logger = _vllm_init_logger(__name__)
+except Exception:  # noqa: BLE001
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        _handler = logging.StreamHandler()
+        _formatter = logging.Formatter(
+            fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        _handler.setFormatter(_formatter)
+        logger.addHandler(_handler)
+    logger.setLevel(logging.INFO)
+
+
+class BaseModelEstimator(ABC):
+    """Abstract base class for model p-value estimators"""
+    
+    def __init__(self, config: Dict):
+        """
+        Initialize estimator with model config
+        
+        Args:
+            config: Model configuration dictionary
+        """
+        self.config = config
+        # Predefine attributes that may be populated by subclasses
+        self.effective_kv_dim = None
+        self.effective_q_dim = None
+        self._parse_common_config()
+        self._parse_architecture_specific_config()
+        self._validate_config()
+        # Baseline and attention-equivalent tokens configured from scheduler
+        self.attn_equiv_baseline_c: int = 0
+        self.attn_equiv_tokens: int = 0
+    
+    def _parse_common_config(self):
+        """Parse common configuration parameters"""
+        self.model_type = self.config.get('model_type', 'unknown')
+        self.hidden_size = self.config.get('hidden_size')
+        # Some architectures may override or refine this later.
+        self.intermediate_size = self.config.get('intermediate_size')
+        self.num_attention_heads = self.config.get('num_attention_heads')
+        self.num_key_value_heads = self.config.get('num_key_value_heads', self.num_attention_heads)
+        self.num_hidden_layers = self.config.get('num_hidden_layers')
+        self.vocab_size = self.config.get('vocab_size', 32000)
+        # Optional calibration factor to account for softmax/RoPE and kernel overheads
+        self.attn_flops_scale = float(self.config.get('attn_flops_scale', 1.0))
+        
+        # Calculate common derived values
+        if self.hidden_size and self.num_attention_heads:
+            self.head_dim = self.hidden_size // self.num_attention_heads
+            self.gqa_ratio = self.num_attention_heads // self.num_key_value_heads
+    
+    @abstractmethod
+    def _parse_architecture_specific_config(self):
+        """Parse architecture-specific configuration parameters"""
+        raise NotImplementedError
+    
+    def _validate_config(self):
+        """Validate required configuration parameters"""
+        if not all([self.hidden_size, self.num_attention_heads, self.num_hidden_layers]):
+            raise ValueError(f"Missing required parameters for {self.model_type} model")
+    
+    @abstractmethod
+    def calculate_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """
+        Calculate attention FLOPs
+        
+        Args:
+            chunk_size: Input chunk size
+            seq_len: Total sequence length
+            
+        Returns:
+            (projection_flops, attention_computation_flops)
+        """
+        raise NotImplementedError
+    
+    @abstractmethod
+    def calculate_ffn_flops(self, chunk_size: int, layer_idx: Optional[int] = None) -> int:
+        """
+        Calculate FFN FLOPs
+        
+        Args:
+            chunk_size: Input chunk size  
+            layer_idx: Layer index (for models with varying layer types)
+            
+        Returns:
+            FFN FLOPs
+        """
+        raise NotImplementedError
+    
+    def calculate_other_flops(self, chunk_size: int) -> int:
+        """Calculate other FLOPs (LayerNorm, residual connections, etc.)"""
+        # Standard: 2 LayerNorms per layer
+        norm_flops = chunk_size * self.hidden_size * 2
+        
+        # Residual connections
+        residual_flops = chunk_size * self.hidden_size * 2
+        
+        return norm_flops + residual_flops
+
+    # -------------------------
+    # Shared FLOPs helpers
+    # -------------------------
+    def _standard_attention_flops(self, 
+                                  chunk_size: int, 
+                                  seq_len: int, 
+                                  *, 
+                                  kv_dim: Optional[int] = None, 
+                                  effective_seq_len: Optional[int] = None
+                                  ) -> Tuple[int, int]:
+        """
+        Standard scaled dot-product attention FLOPs with GQA.
+
+        Args:
+            chunk_size: Number of tokens processed this step.
+            seq_len: Total attention context length (KV cache + chunk).
+            kv_dim: Dimension used for K/V projections per token.
+                    Defaults to hidden_size // gqa_ratio.
+            effective_seq_len: Effective attention length if using sliding
+                               window or other sparsity; defaults to seq_len.
+        Returns:
+            (projection_flops, attention_compute_flops)
+        """
+        kv_dim = kv_dim if kv_dim is not None else (self.hidden_size // self.gqa_ratio)
+        eff_len = effective_seq_len if effective_seq_len is not None else seq_len
+
+        q_flops = chunk_size * self.hidden_size * self.hidden_size
+        kv_flops = chunk_size * self.hidden_size * kv_dim * 2
+        score_flops = chunk_size * eff_len * self.hidden_size
+        value_flops = chunk_size * eff_len * self.hidden_size
+        out_flops = chunk_size * self.hidden_size * self.hidden_size
+
+        return q_flops + kv_flops + out_flops, score_flops + value_flops
+
+    def _ffn_swiglu_like_flops(self, chunk_size: int, *, intermediate_size: Optional[int] = None) -> int:
+        """
+        FLOPs for FFN with gate+up and down projections (SwiGLU/GeGLU).
+        The activation doesn't change matmul FLOPs.
+        """
+        inter_size = intermediate_size if intermediate_size is not None else self.intermediate_size
+        # Support configs that use `ffn_dim` (e.g., OPT) without guessing.
+        if inter_size is None:
+            inter_size = self.config.get('ffn_dim')
+        if inter_size is None or self.hidden_size is None:
+            raise ValueError("Missing FFN dimension: expected 'intermediate_size' or 'ffn_dim' in config")
+        up_gate_flops = chunk_size * self.hidden_size * inter_size * 2
+        down_flops = chunk_size * inter_size * self.hidden_size
+        return up_gate_flops + down_flops
+
+    # -------------------------
+    # Dynamic chunk sizing helper (DCPP-style)
+    # -------------------------
+    def configure_baseline_from_scheduler(self, scheduler_config) -> None:
+        """Configure baseline chunk and attention-equivalent tokens using scheduler config."""
+        baseline_c = getattr(scheduler_config, 'long_prefill_token_threshold', None)
+        if baseline_c is None or baseline_c <= 0:
+            baseline_c = 2048
+        self.attn_equiv_baseline_c = int(baseline_c)
+        self.attn_equiv_tokens = int(self.estimate_flops_ratio_scaled(self.attn_equiv_baseline_c, 0))
+
+    def compute_chunk_size_with_overhead(self,
+                                         hist_seq_len: int,
+                                         seq_len: int,
+                                         chunk_size: int,
+                                         block_size: int) -> tuple[int, int]:
+        """
+        Compute shortened chunk to offset long-KV attention overhead.
+
+        Returns (dcpp_chunk, scheduled_chunk):
+        - dcpp_chunk: actual reduced chunk length to run this step (block-aligned)
+        - scheduled_chunk: the baseline chunk length used for budgeting/accounting
+        """
+        # Must be configured once by the scheduler
+        assert self.attn_equiv_tokens > 0, "Call configure_baseline_from_scheduler() before chunk computation."
+
+        target_time = chunk_size * (self.attn_equiv_tokens + chunk_size)
+        discriminant = (self.attn_equiv_tokens + hist_seq_len) ** 2 + 4 * target_time
+        dcpp_chunk = int((-(self.attn_equiv_tokens + hist_seq_len) + discriminant ** 0.5) / 2)
+        # align to block size
+        dcpp_chunk = (dcpp_chunk + block_size - 1) // block_size * block_size
+        scheduled_chunk = dcpp_chunk
+        # do not exceed remaining tokens
+        dcpp_chunk = min(dcpp_chunk, seq_len - hist_seq_len)
+        return dcpp_chunk, scheduled_chunk
+    
+    def estimate_flops_ratio(self, chunk_size: int, kv_cache_len: int, layer_idx: Optional[int] = None) -> float:
+        """
+        Estimate FLOPs ratio (non-attention / attention)
+        
+        Args:
+            chunk_size: Current chunk size
+            kv_cache_len: KV cache length (number of processed tokens)
+            layer_idx: Specific layer index
+        
+        Returns:
+            non-attention FLOPs / attention FLOPs
+        """
+        seq_len = kv_cache_len + chunk_size
+        
+        proj_flops, attn_flops = self.calculate_attention_flops(chunk_size, seq_len)
+        # Apply global attention calibration to better match wall-clock
+        attn_flops = attn_flops * self.attn_flops_scale
+        ffn_flops = self.calculate_ffn_flops(chunk_size, layer_idx)
+        other_flops = self.calculate_other_flops(chunk_size)
+        
+        non_attn_flops = ffn_flops + other_flops + proj_flops
+        
+        if attn_flops == 0:
+            return float('inf')
+        
+        return non_attn_flops / attn_flops
+    
+    def estimate_flops_ratio_average(self, chunk_size: int, kv_cache_len: int) -> float:
+        """Average FLOPs ratio across layers (default: uniform layers)."""
+        return self.estimate_flops_ratio(chunk_size, kv_cache_len)
+    
+    def estimate_flops_ratio_scaled(self, chunk_size: int, kv_cache_len: int) -> float:
+        """Estimate FLOPs ratio scaled by chunk size (ratio * chunk_size)."""
+        return self.estimate_flops_ratio_average(chunk_size, kv_cache_len) * chunk_size
+
+    # Backward-compatible aliases
+    def estimate_p(self, chunk_size: int, kv_cache_len: int, layer_idx: Optional[int] = None) -> float:
+        return self.estimate_flops_ratio(chunk_size, kv_cache_len, layer_idx)
+
+    def estimate_p_average(self, chunk_size: int, kv_cache_len: int) -> float:
+        return self.estimate_flops_ratio_average(chunk_size, kv_cache_len)
+
+    def estimate_p_times_c(self, chunk_size: int, kv_cache_len: int) -> float:
+        return self.estimate_flops_ratio_scaled(chunk_size, kv_cache_len)
+    
+    def print_model_info(self):
+        """Print model information (common + subclass extras)."""
+        logger.info("Model Type: %s", self.model_type)
+        logger.info("Hidden Size: %s", self.hidden_size)
+        logger.info("Attention Heads: %s", self.num_attention_heads)
+        logger.info("KV Heads: %s (GQA ratio: %s:1)", self.num_key_value_heads, self.gqa_ratio)
+        logger.info("Layers: %s", self.num_hidden_layers)
+        logger.info("Head Dimension: %s", self.head_dim)
+        # Subclass-provided extra details
+        for line in self._extra_model_info():
+            logger.info("%s", line)
+    
+    def get_flops_ratio_table(self, chunk_sizes: List[int] = None, 
+                              kv_cache_lens: List[int] = None) -> Dict:
+        """Generate FLOPs ratio table for different chunk sizes and cache lengths"""
+        if chunk_sizes is None:
+            chunk_sizes = [512, 1024, 2048, 4096]
+        
+        if kv_cache_lens is None:
+            kv_cache_lens = [0, 2048, 8192, 16384, 32768, 65536, 98304]
+        
+        table = {}
+        for chunk_size in chunk_sizes:
+            table[chunk_size] = {}
+            for kv_len in kv_cache_lens:
+                ratio = self.estimate_flops_ratio_average(chunk_size, kv_len)
+                table[chunk_size][kv_len] = ratio
+        
+        return table
+    
+    def print_flops_ratio_table(self, chunk_sizes: List[int] = None, 
+                                kv_cache_lens: List[int] = None):
+        """Print FLOPs ratio table"""
+        table = self.get_flops_ratio_table(chunk_sizes, kv_cache_lens)
+        
+        logger.info("\nFLOPs Ratio Table (non-attention / attention)")
+        logger.info("%s", "=" * 80)
+        header = ["KV Cache"] + [f"C={cs:<6}" for cs in sorted(table.keys())]
+        logger.info("%s", "".join(f"{h:<10}" for h in header))
+        logger.info("%s", "-" * 80)
+        
+        all_kv_lens = sorted(next(iter(table.values())).keys())
+        for kv_len in all_kv_lens:
+            row = [f"{kv_len:<10}"]
+            for chunk_size in sorted(table.keys()):
+                ratio = table[chunk_size][kv_len]
+                row.append(f"{ratio:8.2f}")
+            logger.info("%s", "".join(row))
+        # Allow subclasses to append extra table-related info
+        self._extra_p_table_info()
+
+    # Backward-compatible aliases
+    def get_p_table(self, chunk_sizes: List[int] = None, 
+                    kv_cache_lens: List[int] = None) -> Dict:
+        return self.get_flops_ratio_table(chunk_sizes, kv_cache_lens)
+
+    def print_p_table(self, chunk_sizes: List[int] = None, 
+                      kv_cache_lens: List[int] = None):
+        return self.print_flops_ratio_table(chunk_sizes, kv_cache_lens)
+
+    # -------------------------
+    # Subclass hooks
+    # -------------------------
+    def _extra_model_info(self) -> List[str]:
+        """Override to append subclass-specific info lines."""
+        return []
+
+    def _extra_p_table_info(self) -> None:
+        """Override to print additional info after p-table (e.g., layer analysis)."""
+        return None
+
+
+class LlamaEstimator(BaseModelEstimator):
+    """FLOP estimator for Llama models (standard transformer architecture)"""
+    
+    def _parse_architecture_specific_config(self):
+        """Parse Llama-specific configuration"""
+        inter_size = self.config.get('intermediate_size')
+        if inter_size is None:
+            inter_size = self.config.get('ffn_dim')  # e.g., OPT family
+        if inter_size is None:
+            raise ValueError(
+                "Missing FFN size in config: expected 'intermediate_size' or 'ffn_dim'")
+        self.intermediate_size = inter_size
+        self.ffn_expansion = self.intermediate_size / self.hidden_size if self.hidden_size else 0
+        
+        # Llama uses SwiGLU activation (gate + up projections)
+        self.has_gate_proj = True
+    
+    def calculate_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """Standard transformer attention FLOPs (Llama)."""
+        return self._standard_attention_flops(chunk_size, seq_len)
+    
+    def calculate_ffn_flops(self, chunk_size: int, layer_idx: Optional[int] = None) -> int:
+        """FFN FLOPs for Llama (SwiGLU)."""
+        return self._ffn_swiglu_like_flops(chunk_size)
+    
+    def _extra_model_info(self) -> List[str]:
+        return [
+            "Architecture: Standard Transformer (Llama)",
+            f"Intermediate Size: {self.intermediate_size} ({self.ffn_expansion:.1f}x expansion)",
+            "Activation: SwiGLU",
+        ]
+
+
+class QwenEstimator(BaseModelEstimator):
+    """FLOP estimator for Qwen models"""
+    
+    def _parse_architecture_specific_config(self):
+        """Parse Qwen-specific configuration"""
+        inter_size = self.config.get('intermediate_size')
+        if inter_size is None:
+            inter_size = self.config.get('ffn_dim')
+        if inter_size is None:
+            raise ValueError(
+                "Missing FFN size in config: expected 'intermediate_size' or 'ffn_dim'")
+        self.intermediate_size = inter_size
+        self.ffn_expansion = self.intermediate_size / self.hidden_size if self.intermediate_size else 0
+        
+        # Qwen also uses SwiGLU but may have different parameter names
+        self.has_gate_proj = True
+        
+        # Qwen-specific parameters
+        self.max_position_embeddings = self.config.get('max_position_embeddings', 32768)
+        self.use_sliding_window = self.config.get('use_sliding_window', False)
+        self.sliding_window = self.config.get('sliding_window')
+    
+    def calculate_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """Qwen attention FLOPs with optional sliding window sparsity."""
+        effective_seq_len = (min(seq_len, self.sliding_window)
+                             if self.use_sliding_window and self.sliding_window
+                             else seq_len)
+        return self._standard_attention_flops(
+            chunk_size, seq_len, effective_seq_len=effective_seq_len)
+    
+    def calculate_ffn_flops(self, chunk_size: int, layer_idx: Optional[int] = None) -> int:
+        """FFN FLOPs for Qwen (SwiGLU)."""
+        return self._ffn_swiglu_like_flops(chunk_size)
+    
+    def _extra_model_info(self) -> List[str]:
+        lines = [
+            "Architecture: Qwen Transformer",
+            f"Intermediate Size: {self.intermediate_size} ({self.ffn_expansion:.1f}x expansion)",
+            f"Max Position Embeddings: {self.max_position_embeddings}",
+        ]
+        if self.use_sliding_window:
+            lines.append(f"Sliding Window: {self.sliding_window}")
+        return lines
+
+
+class DeepSeekEstimator(BaseModelEstimator):
+    """FLOP estimator for DeepSeek models (supports MLA + MoE)"""
+    
+    def _parse_architecture_specific_config(self):
+        """Parse DeepSeek-specific configuration"""
+        # Standard FFN parameters
+        self.intermediate_size = self.config.get('intermediate_size')
+        
+        # MLA (Multi-head Latent Attention) parameters
+        self.kv_lora_rank = self.config.get('kv_lora_rank')
+        self.q_lora_rank = self.config.get('q_lora_rank')
+        self.qk_rope_head_dim = self.config.get('qk_rope_head_dim', 64)
+        
+        # MoE parameters
+        self.moe_intermediate_size = self.config.get('moe_intermediate_size')
+        self.first_k_dense_replace = self.config.get('first_k_dense_replace', 0)
+        self.n_routed_experts = self.config.get('n_routed_experts', 0)
+        self.num_experts_per_tok = self.config.get('num_experts_per_tok', 1)
+        self.n_shared_experts = self.config.get('n_shared_experts', 0)
+        
+        # Architecture flags
+        self.is_mla = self._is_mla_architecture()
+        self.is_moe = self._is_moe_architecture()
+        
+        # Calculate effective dimensions
+        self._calculate_effective_dims()
+        self.ffn_expansion = self.intermediate_size / self.hidden_size if self.intermediate_size else 0
+    
+    def _is_mla_architecture(self) -> bool:
+        """Check if model uses MLA (Multi-head Latent Attention)"""
+        kv = self.kv_lora_rank
+        q = self.q_lora_rank
+        return (isinstance(kv, int) and kv > 0 and
+                isinstance(q, int) and q > 0)
+    
+    def _is_moe_architecture(self) -> bool:
+        """Check if model uses MoE (Mixture of Experts)"""
+        return (self.moe_intermediate_size is not None and 
+                self.n_routed_experts > 0)
+    
+    def _calculate_effective_dims(self):
+        """Calculate effective dimensions for MLA"""
+        if self.is_mla:
+            # MLA uses compressed K/V representations. Do not add RoPE dim here
+            # to avoid double-counting; RoPE cost is captured separately.
+            self.effective_kv_dim = self.kv_lora_rank
+            self.effective_q_dim = self.q_lora_rank
+        else:
+            # Standard dimensions
+            self.effective_kv_dim = self.hidden_size // self.gqa_ratio
+            self.effective_q_dim = self.hidden_size
+    
+    def _is_dense_layer(self, layer_idx: int) -> bool:
+        """Check if a specific layer is dense (not MoE)"""
+        return layer_idx < self.first_k_dense_replace
+    
+    def calculate_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """Calculate attention FLOPs with MLA support"""
+        if self.is_mla:
+            return self._calculate_mla_attention_flops(chunk_size, seq_len)
+        else:
+            return self._calculate_standard_attention_flops(chunk_size, seq_len)
+    
+    def _calculate_mla_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """Calculate FLOPs for MLA (Multi-head Latent Attention)"""
+        # Q projections: q_a (to LoRA rank) + q_b (LoRA to heads)
+        q_a_flops = chunk_size * self.hidden_size * self.q_lora_rank
+        q_b_flops = chunk_size * self.q_lora_rank * (self.num_attention_heads * self.head_dim)
+        
+        # KV projections: kv_a (to LoRA rank) + kv_b (LoRA to compressed KV)
+        kv_a_flops = chunk_size * self.hidden_size * self.effective_kv_dim
+        kv_b_flops = chunk_size * self.effective_kv_dim * (self.num_key_value_heads * self.head_dim * 2)
+        
+        # Attention computation using compressed dimensions
+        # MLA uses two components: compressed KV and RoPE
+        # Score computation: Q^T @ K^C (compressed) + Q^TR @ K^R (RoPE)
+        # The effective computation is with compressed dimensions, not full hidden_size
+        compressed_score_flops = chunk_size * seq_len * self.effective_kv_dim
+        rope_score_flops = chunk_size * seq_len * self.qk_rope_head_dim * self.num_attention_heads
+        
+        # Value computation: attention_weights @ V^C (compressed)
+        value_flops = chunk_size * seq_len * self.effective_kv_dim
+        
+        # Output projection
+        out_flops = chunk_size * self.hidden_size * self.hidden_size
+        
+        proj_flops = q_a_flops + q_b_flops + kv_a_flops + kv_b_flops + out_flops
+        attn_flops = compressed_score_flops + rope_score_flops + value_flops
+        
+        return proj_flops, attn_flops
+    
+    def _calculate_standard_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """Calculate FLOPs for standard transformer attention"""
+        return self._standard_attention_flops(chunk_size, seq_len, kv_dim=self.effective_kv_dim)
+    
+    def calculate_ffn_flops(self, chunk_size: int, layer_idx: Optional[int] = None) -> int:
+        """Calculate FFN FLOPs with MoE support"""
+        if self.is_moe and (layer_idx is None or not self._is_dense_layer(layer_idx)):
+            return self._calculate_moe_ffn_flops(chunk_size)
+        else:
+            return self._calculate_dense_ffn_flops(chunk_size)
+    
+    def _calculate_dense_ffn_flops(self, chunk_size: int) -> int:
+        """Calculate dense FFN FLOPs"""
+        # Gate and Up projections (SwiGLU)
+        up_gate_flops = chunk_size * self.hidden_size * self.intermediate_size * 2
+        
+        # Down projection
+        down_flops = chunk_size * self.intermediate_size * self.hidden_size
+        
+        return up_gate_flops + down_flops
+    
+    def _calculate_moe_ffn_flops(self, chunk_size: int) -> int:
+        """Calculate MoE FFN FLOPs"""
+        # Shared experts (if exist)
+        shared_flops = 0
+        if self.n_shared_experts > 0:
+            shared_flops = self._calculate_single_expert_flops(chunk_size, self.moe_intermediate_size)
+        
+        # Routed experts (only active ones)
+        routed_flops = (self._calculate_single_expert_flops(chunk_size, self.moe_intermediate_size) * 
+                       self.num_experts_per_tok)
+        
+        # Gating network
+        gate_flops = chunk_size * self.hidden_size * self.n_routed_experts
+        
+        return shared_flops + routed_flops + gate_flops
+    
+    def _calculate_single_expert_flops(self, chunk_size: int, expert_size: int) -> int:
+        """Calculate FLOPs for a single expert"""
+        # Gate and Up projections
+        up_gate_flops = chunk_size * self.hidden_size * expert_size * 2
+        
+        # Down projection  
+        down_flops = chunk_size * expert_size * self.hidden_size
+        
+        return up_gate_flops + down_flops
+    
+    def calculate_other_flops(self, chunk_size: int) -> int:
+        """Calculate other FLOPs with MLA-specific normalization"""
+        # MLA has additional normalization layers
+        norm_multiplier = 6 if self.is_mla else 2
+        norm_flops = chunk_size * self.hidden_size * norm_multiplier
+        
+        # Residual connections
+        residual_flops = chunk_size * self.hidden_size * 2
+        
+        return norm_flops + residual_flops
+    
+    def estimate_flops_ratio_average(self, chunk_size: int, kv_cache_len: int) -> float:
+        """Average FLOPs ratio across layers (MoE uses per-layer averaging)."""
+        if not self.is_moe:
+            return super().estimate_flops_ratio_average(chunk_size, kv_cache_len)
+        total_ratio = 0.0
+        for layer_idx in range(self.num_hidden_layers):
+            layer_ratio = self.estimate_flops_ratio(chunk_size, kv_cache_len, layer_idx)
+            total_ratio += layer_ratio
+        return total_ratio / self.num_hidden_layers
+    
+    def get_layer_analysis(self, chunk_size: int = 2048, kv_cache_len: int = 16384) -> Dict:
+        """Analyze p values for each layer type (useful for MoE models)"""
+        analysis = {
+            'dense_layers': [],
+            'moe_layers': [],
+            'layer_p_values': {}
+        }
+        
+        for layer_idx in range(self.num_hidden_layers):
+            is_dense = self._is_dense_layer(layer_idx)
+            p_value = self.estimate_p(chunk_size, kv_cache_len, layer_idx)
+            
+            analysis['layer_p_values'][layer_idx] = {
+                'p_value': p_value,
+                'is_dense': is_dense,
+                'layer_type': 'dense' if is_dense else 'moe'
+            }
+            
+            if is_dense:
+                analysis['dense_layers'].append(layer_idx)
+            else:
+                analysis['moe_layers'].append(layer_idx)
+        
+        return analysis
+    
+    def _extra_model_info(self) -> List[str]:
+        architecture_type = f"{'MLA' if self.is_mla else 'Standard'} + {'MoE' if self.is_moe else 'Dense'}"
+        lines: List[str] = [f"Architecture: {architecture_type}"]
+        if self.is_mla:
+            lines += [
+                f"Q LoRA Rank: {self.q_lora_rank}",
+                f"KV LoRA Rank: {self.kv_lora_rank}",
+                f"Effective KV Dim: {self.effective_kv_dim}",
+            ]
+        if self.is_moe:
+            lines += [
+                f"MoE Intermediate Size: {self.moe_intermediate_size}",
+                f"Routed Experts: {self.n_routed_experts}",
+                f"Experts per Token: {self.num_experts_per_tok}",
+                f"First K Dense Layers: {self.first_k_dense_replace}",
+            ]
+            if self.n_shared_experts:
+                lines.append(f"Shared Experts: {self.n_shared_experts}")
+        else:
+            lines.append(
+                f"Intermediate Size: {self.intermediate_size} ({self.ffn_expansion:.1f}x expansion)")
+        return lines
+    
+    def _extra_p_table_info(self) -> None:
+        if self.is_moe:
+            logger.info("\nLayer Analysis:")
+            logger.info("%s", "-" * 50)
+            analysis = self.get_layer_analysis()
+            logger.info("Dense layers (0-%d): %d", self.first_k_dense_replace - 1, len(analysis['dense_layers']))
+            logger.info("MoE layers (%d-%d): %d", self.first_k_dense_replace, self.num_hidden_layers - 1, len(analysis['moe_layers']))
+
+
+class MixtralEstimator(BaseModelEstimator):
+    """FLOP estimator for Mixtral models (MoE architecture)"""
+    
+    def _parse_architecture_specific_config(self):
+        """Parse Mixtral-specific configuration"""
+        self.intermediate_size = self.config.get('intermediate_size')
+        self.num_local_experts = self.config.get('num_local_experts', 8)
+        self.num_experts_per_tok = self.config.get('num_experts_per_tok', 2)
+        
+        # Mixtral specific parameters
+        self.max_position_embeddings = self.config.get('max_position_embeddings', 32768)
+        self.sliding_window = self.config.get('sliding_window')
+        
+        # Architecture flags
+        self.is_moe = True
+        self.ffn_expansion = self.intermediate_size / self.hidden_size if self.intermediate_size else 0
+    
+    def calculate_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """Attention FLOPs for Mixtral with optional sliding window."""
+        effective_seq_len = min(seq_len, self.sliding_window) if self.sliding_window else seq_len
+        return self._standard_attention_flops(
+            chunk_size, seq_len, effective_seq_len=effective_seq_len)
+    
+    def calculate_ffn_flops(self, chunk_size: int, layer_idx: Optional[int] = None) -> int:
+        """Calculate MoE FFN FLOPs for Mixtral"""
+        # Only active experts are computed
+        active_expert_flops = self._calculate_single_expert_flops(chunk_size) * self.num_experts_per_tok
+        
+        # Gating network
+        gate_flops = chunk_size * self.hidden_size * self.num_local_experts
+        
+        return active_expert_flops + gate_flops
+    
+    def _calculate_single_expert_flops(self, chunk_size: int) -> int:
+        """Calculate FLOPs for a single Mixtral expert"""
+        # Gate, Up and Down projections (SwiGLU)
+        up_gate_flops = chunk_size * self.hidden_size * self.intermediate_size * 2
+        down_flops = chunk_size * self.intermediate_size * self.hidden_size
+        
+        return up_gate_flops + down_flops
+    
+    def _extra_model_info(self) -> List[str]:
+        lines = [
+            "Architecture: Mixtral (MoE)",
+            f"Intermediate Size: {self.intermediate_size} ({self.ffn_expansion:.1f}x expansion)",
+            f"Local Experts: {self.num_local_experts}",
+            f"Experts per Token: {self.num_experts_per_tok}",
+        ]
+        if self.sliding_window:
+            lines.append(f"Sliding Window: {self.sliding_window}")
+        return lines
+
+
+class GemmaEstimator(BaseModelEstimator):
+    """FLOP estimator for Gemma models"""
+    
+    def _parse_architecture_specific_config(self):
+        """Parse Gemma-specific configuration"""
+        inter_size = self.config.get('intermediate_size')
+        if inter_size is None:
+            inter_size = self.config.get('ffn_dim')
+        if inter_size is None:
+            raise ValueError(
+                "Missing FFN size in config: expected 'intermediate_size' or 'ffn_dim'")
+        self.intermediate_size = inter_size
+        self.ffn_expansion = self.intermediate_size / self.hidden_size if self.intermediate_size else 0
+        
+        # Gemma specific parameters
+        self.head_dim = self.config.get('head_dim', self.hidden_size // self.num_attention_heads)
+        self.max_position_embeddings = self.config.get('max_position_embeddings', 8192)
+        
+        # Gemma uses GeGLU activation instead of SwiGLU
+        self.activation_type = 'gelu'
+    
+    def calculate_attention_flops(self, chunk_size: int, seq_len: int) -> Tuple[int, int]:
+        """Calculate attention FLOPs for Gemma"""
+        return self._standard_attention_flops(chunk_size, seq_len)
+    
+    def calculate_ffn_flops(self, chunk_size: int, layer_idx: Optional[int] = None) -> int:
+        """FFN FLOPs for Gemma (GeGLU)."""
+        return self._ffn_swiglu_like_flops(chunk_size)
+    
+    def _extra_model_info(self) -> List[str]:
+        return [
+            "Architecture: Gemma Transformer",
+            f"Intermediate Size: {self.intermediate_size} ({self.ffn_expansion:.1f}x expansion)",
+            "Activation: GeGLU",
+            f"Max Position Embeddings: {self.max_position_embeddings}",
+        ]
+
+
+# Registry of model estimators
+MODEL_ESTIMATOR_REGISTRY = {
+    # Llama family
+    'llama': LlamaEstimator,
+    'llama2': LlamaEstimator,
+    'llama3': LlamaEstimator,
+    'llama4': LlamaEstimator,
+    'code_llama': LlamaEstimator,
+    
+    # Qwen family  
+    'qwen': QwenEstimator,
+    'qwen2': QwenEstimator,
+    'qwen2_moe': QwenEstimator,
+    'qwen2.5': QwenEstimator,
+    
+    # DeepSeek family
+    'deepseek': DeepSeekEstimator,
+    'deepseek_v2': DeepSeekEstimator,
+    'deepseek_v3': DeepSeekEstimator,
+    'deepseek_mtp': DeepSeekEstimator,  # Unified model type for DeepSeek
+    
+    # Mixtral family
+    'mixtral': MixtralEstimator,
+    'mixtral_8x7b': MixtralEstimator,
+    'mixtral_8x22b': MixtralEstimator,
+    
+    # Gemma family
+    'gemma': GemmaEstimator,
+    'gemma2': GemmaEstimator,
+    
+    # Add other models as needed
+    # 'phi': PhiEstimator,
+    # 'chatglm': ChatGLMEstimator,
+    # etc.
+}
+
+
+def create_estimator(config_path: str = None, config_dict: Dict = None) -> BaseModelEstimator:
+    """
+    Factory function to create appropriate model estimator based on model type
+    
+    Args:
+        config_path: Path to config file
+        config_dict: Config dictionary
+        
+    Returns:
+        Appropriate model estimator instance
+    """
+    # Load config
+    if config_path:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+    elif config_dict:
+        config = config_dict
+    else:
+        raise ValueError("Must provide either config_path or config_dict")
+    
+    # Determine model type
+    model_type = config.get('model_type', 'unknown').lower()
+    
+    # Handle special cases and mappings
+    if model_type == 'deepseek_v3':
+        model_type = 'deepseek_mtp'  # Use unified DeepSeek estimator
+    
+    # Find appropriate estimator class
+    estimator_class = MODEL_ESTIMATOR_REGISTRY.get(model_type)
+    
+    if estimator_class is None:
+        # Fallback to Llama estimator for unknown models (most are transformer-based)
+        logger.warning("Unknown model type '%s', falling back to Llama estimator",
+                       model_type)
+        estimator_class = LlamaEstimator
+    
+    return estimator_class(config)
+
+
+# Backward compatibility: keep the original ModelPEstimator as an alias
+class ModelPEstimator:
+    """Backward compatibility wrapper - use create_estimator() for new code"""
+    
+    def __init__(self, config_path: str = None, config_dict: Dict = None):
+        # Create appropriate estimator and delegate to it
+        self._estimator = create_estimator(config_path, config_dict)
+        
+        # Copy attributes for backward compatibility
+        self.__dict__.update(self._estimator.__dict__)
+    
+    def __getattr__(self, name):
+        """Delegate any missing methods to the underlying estimator"""
+        return getattr(self._estimator, name)
+
+
+def create_estimator_safely(
+    hf_config_obj: object | None = None,
+    config_path: str | None = None,
+    scheduler_config: object | None = None,
+):
+    """Best-effort estimator factory.
+
+    - Prefer building from an in-memory HF config object (with to_dict()).
+    - Fallback to reading a JSON config from disk.
+    - If provided, configure baseline from scheduler config.
+
+    Returns an estimator instance or None on failure.
+    """
+    estimator = None
+    # Try HF config object first
+    if hf_config_obj is not None:
+        try:
+            to_dict_fn = getattr(hf_config_obj, "to_dict", None)
+            cfg_dict = to_dict_fn() if callable(to_dict_fn) else dict(
+                getattr(hf_config_obj, "__dict__", {}))
+            estimator = create_estimator(config_dict=cfg_dict)
+        except (AttributeError, TypeError, ValueError):
+            estimator = None
+
+    # Fallback to disk json
+    if estimator is None and config_path:
+        try:
+            estimator = create_estimator(config_path=config_path)
+        except (OSError, json.JSONDecodeError, ValueError):
+            estimator = None
+
+    # Configure baseline if possible
+    if estimator is not None and scheduler_config is not None:
+        try:
+            estimator.configure_baseline_from_scheduler(scheduler_config)
+        except AttributeError:
+            # Non-fatal; leave estimator as-is
+            pass
+
+    return estimator
+
+
+def main():
+    """Command line interface"""
+    parser = argparse.ArgumentParser(description='Estimate p-values from model config')
+    parser.add_argument('--config-path', type=str, help='Path to model config.json')
+    parser.add_argument('--chunk-size', type=int, default=2048, 
+                       help='Chunk size for estimation')
+    parser.add_argument('--kv-cache-len', type=int, default=0,
+                       help='KV cache length')
+    parser.add_argument('--table', action='store_true',
+                       help='Print p-value table')
+    parser.add_argument('--estimator-type', type=str, 
+                       help='Force specific estimator type (llama, qwen, deepseek)')
+    
+    args = parser.parse_args()
+    
+    # Create estimator
+    if args.estimator_type:
+        # Override model type for testing
+        config = json.load(open(args.config_path, 'r', encoding='utf-8'))
+        config['model_type'] = args.estimator_type
+        estimator = create_estimator(config_dict=config)
+    else:
+        # Auto-detect from config
+        estimator = create_estimator(config_path=args.config_path)
+    
+    # Print info and calculate ratios
+    estimator.print_model_info()
+    
+    ratio = estimator.estimate_flops_ratio(args.chunk_size, args.kv_cache_len)
+    ratio_scaled = estimator.estimate_flops_ratio_scaled(args.chunk_size, args.kv_cache_len)
+    
+    print("\nEstimated values:")
+    print(f"flops_ratio = {ratio:.4f}")
+    print(f"flops_ratio × chunk_size = {ratio_scaled:.4f}")
+    
+    # Print ratio table if requested
+    if args.table:
+        estimator.print_flops_ratio_table()
+    
+    estimator.configure_baseline_from_scheduler(None)
+    seq_len = 128000
+    chunk_size = 2048
+    hist_seq_len = 0
+    block_size = 16
+    while(hist_seq_len < seq_len):
+        chunk_size_with_overhead = estimator.compute_chunk_size_with_overhead(
+            hist_seq_len, seq_len, chunk_size, block_size)
+        print(f"chunk_size_with_overhead = {chunk_size_with_overhead}")
+        hist_seq_len += chunk_size_with_overhead[0]
+
+if __name__ == "__main__":
+    main()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 import time
 from collections import defaultdict
 from collections.abc import Iterable
@@ -34,6 +35,7 @@ from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
+from vllm.model_executor.flops_estimator import create_estimator_safely
 
 logger = init_logger(__name__)
 
@@ -160,6 +162,15 @@ class Scheduler(SchedulerInterface):
         )
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
 
+        # DCPP estimator init (experimental): prefer in-memory hf_config, fallback to disk
+        self.attn_estimator = None
+        self.enable_dcpp = self.scheduler_config.enable_dcpp
+        self.dcpp_length_threshold = self.scheduler_config.dcpp_length_threshold
+        self.dcpp_min_chunk = self.scheduler_config.dcpp_min_chunk or 0
+        self._maybe_init_dcpp(vllm_config)
+
+
+
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
@@ -192,11 +203,15 @@ class Scheduler(SchedulerInterface):
         # First, schedule the RUNNING requests.
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
+            dcpp_equitable_tokens = None
             request = self.running[req_index]
 
+            if request.num_tokens - request.num_computed_tokens < request.dcpp_scheduled_chunk:
+                request.is_dcpp = False
+
             num_new_tokens = (request.num_tokens_with_spec +
-                              request.num_output_placeholders -
-                              request.num_computed_tokens)
+                                request.num_output_placeholders -
+                                request.num_computed_tokens)
             if (0 < self.scheduler_config.long_prefill_token_threshold <
                     num_new_tokens):
                 num_new_tokens = (
@@ -217,6 +232,29 @@ class Scheduler(SchedulerInterface):
                  new_encoder_budget) = self._try_schedule_encoder_inputs(
                      request, request.num_computed_tokens, num_new_tokens,
                      encoder_budget)
+
+
+            if self.enable_dcpp and request.is_dcpp and self.attn_estimator is not None:
+                # Shorten length to reduce long kv history effect
+                # Target execution time is num_new_tokens execution time without history
+                dcpp_equitable_tokens = num_new_tokens
+                target_tokens = self.scheduler_config.long_prefill_token_threshold \
+                    if self.scheduler_config.long_prefill_token_threshold > 0 else token_budget
+                num_new_tokens, dcpp_scheduled_chunk = self.attn_estimator.compute_chunk_size_with_overhead(
+                                                                        request.num_computed_tokens,
+                                                                        request.num_tokens,
+                                                                        target_tokens,
+                                                                        self.cache_config.block_size)
+                # NOTE: Prevent short tail effect
+                floor = self.dcpp_min_chunk if self.dcpp_min_chunk and self.dcpp_min_chunk > 0 else 0
+                num_new_tokens = min(num_new_tokens, dcpp_equitable_tokens)
+                num_new_tokens = min(request.num_tokens - request.num_computed_tokens,
+                                     max(floor, num_new_tokens))
+                request.dcpp_scheduled_chunk = dcpp_scheduled_chunk
+                logger.debug(
+                    "DCPP adjusted chunk from %d to %d (hist=%d, total=%d)",
+                    dcpp_equitable_tokens, num_new_tokens, request.num_computed_tokens, request.num_tokens)
+
 
             if num_new_tokens == 0:
                 # The request cannot be scheduled because one of the following
@@ -276,7 +314,10 @@ class Scheduler(SchedulerInterface):
             scheduled_running_reqs.append(request)
             req_to_new_blocks[request.request_id] = new_blocks
             num_scheduled_tokens[request.request_id] = num_new_tokens
-            token_budget -= num_new_tokens
+            # NOTE: If dcpp is enabled, use the original chunk size to update token budget but 
+            # keep the shortened chunk size for the request to keep similar execution time between each step.
+            # Otherwise, use the scheduled chunk size
+            token_budget -= (num_new_tokens if dcpp_equitable_tokens is None else dcpp_equitable_tokens)
             req_index += 1
 
             # Speculative decode related.
@@ -393,6 +434,12 @@ class Scheduler(SchedulerInterface):
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
+                    if (self.enable_dcpp and self.attn_estimator is not None
+                            and num_new_tokens > self.dcpp_length_threshold):
+                        logger.debug("Enable DCPP for req %s: tokens=%d threshold=%d",
+                                     request.request_id, num_new_tokens, self.dcpp_length_threshold)
+                        request.is_dcpp = True
+
                     if (0 < self.scheduler_config.long_prefill_token_threshold
                             < num_new_tokens):
                         num_new_tokens = (
@@ -1105,6 +1152,30 @@ class Scheduler(SchedulerInterface):
     def shutdown(self) -> None:
         if self.kv_event_publisher:
             self.kv_event_publisher.shutdown()
+
+    # -------------------------
+    # DCPP helpers
+    # -------------------------
+    def _maybe_init_dcpp(self, vllm_config: VllmConfig) -> None:
+        """Initialize FLOPs estimator using a helper from flops_estimator.
+
+        Keeps changes minimal in scheduler; helper handles all fallbacks.
+        """
+        if not self.enable_dcpp:
+            return
+        hf_cfg = (getattr(vllm_config.model_config, "hf_text_config", None)
+                  or getattr(vllm_config.model_config, "hf_config", None))
+        # Prefer HF config object; only use on-disk config.json if model is a
+        # local directory. ModelConfig does not expose `model_path`.
+        model_root = getattr(vllm_config.model_config, "model", None)
+        cfg_path = (os.path.join(model_root, "config.json")
+                    if isinstance(model_root, str) and os.path.isdir(model_root)
+                    else None)
+        self.attn_estimator = create_estimator_safely(
+            hf_config_obj=hf_cfg,
+            config_path=cfg_path,
+            scheduler_config=self.scheduler_config,
+        )
 
     ########################################################################
     # KV Connector Related Methods

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -40,6 +40,8 @@ class Request:
         priority: int = 0,
         block_hasher: Optional[Callable[["Request"],
                                         list["BlockHash"]]] = None,
+        is_dcpp: Optional[bool] = False,
+        dcpp_scheduled_chunk: Optional[int] = 0
     ) -> None:
         self.request_id = request_id
         self.client_index = client_index
@@ -113,6 +115,8 @@ class Request:
         # The number of NaNs in logits. A value greater than 0
         # indicates that the output is corrupted
         self.num_nans_in_logits = 0
+        self.is_dcpp = is_dcpp
+        self.dcpp_scheduled_chunk = dcpp_scheduled_chunk
 
         self.block_hashes: list[BlockHash] = []
         self.get_hash_new_full_blocks: Optional[Callable[


### PR DESCRIPTION
## Dynamic Chunked Pipeline Parallelism (DCPP) for Long-Context Inference

### TL;DR

This PR adds **Dynamic Chunked Pipeline Parallelism (DCPP)**, which adapts chunk size based on attention cost instead of using a fixed size.

* On **Qwen-72B (TP=1, PP=8, A100, chunk=4096)**: DCPP reduces pipeline bubbles and improves throughput (\~10%).
* On smaller chunks (**2048**): gains are marginal (~1%).

I’m opening this PR to share the code and results, and to ask for feedback on whether this direction makes sense, or if there are better alternatives.

---

### Background

vLLM already supports:

* Pipeline parallelism
* Chunked prefill

Together, these form fixed-size **Chunked Pipeline Parallelism (CPP)**.
The problem: in long-context runs, fixed CPP creates **imbalanced computation**:

* Early chunks (short history) are faster
* Later chunks (long history) are slower
* Pipeline bubbles appear as a result

---

### What this PR does

* Implements a cost model to adjust chunk size dynamically using the solution we provided [dcpp chunk scheduler](https://docs.google.com/document/d/1AISAuSQ9rCgMYMq_ciLWx7clKZmY8164JWDQ-0COe2s/edit?usp=sharing) 

  ```python
  estimated_cost ∝ num_tokens × (kv_len + num_tokens)
  ```
* Scheduler shrinks chunk size when history grows.
* Goal: balance per-chunk latency across pipeline stages, reduce idle time, and improve throughput.

---

### Observations

Benchmarks on RandomDataset (PP8/TP1 on A100):

| Chunk Size | Pipeline Bubbles | DCPP Speedup | Notes                  |
| ---------- | ---------------- | ------------ | ---------------------- |
| 4096       | Severe           | \~10%        | Noticeable improvement |
| 2048       | Moderate         | ~1%          | Close to fixed CPP     |

**Benchmark1: both chunk size = 4096**
CPP
<img src="https://github.com/user-attachments/assets/63942ae6-8eaf-4a53-bd40-ac6bd58f20a7"
     style="width:392px; height:340px; object-fit:fill;" />
DCPP
<img width="521" height="337" alt="image" src="https://github.com/user-attachments/assets/094728cc-5a7e-4d29-9c9f-4ccd306debe5" />




**Benchmark2: cpp chunk size = 2048, dcpp chunk size = 4096**
CPP
<img width="440" height="327" alt="image" src="https://github.com/user-attachments/assets/333ca473-8ca9-4284-af48-4c367611ae3f" />
DCPP
<img width="363" height="328" alt="image" src="https://github.com/user-attachments/assets/68f6067f-6b1b-491e-9886-aaf516cca35e" />



Visualization (left=fixed CPP, right=DCPP, pp=1 for clarity): 
<img width="1218" height="393" alt="image" src="https://github.com/user-attachments/assets/adbc2447-c881-421c-996d-76717c267e59" />


---


### Usage

This PR adds three parameters to control DCPP:

* `--enable-dcpp`: enable or disable DCPP
* `--dcpp-min-chunk`: minimum chunk size allowed by DCPP
* `--dcpp-length-threshold`: minimum request length for applying dynamic chunking

For evaluation a single pp stage, we provide `tests/benchmark/test_dcpp_performance.py`, which compares fixed-size chunking against dynamic chunking.


### Limitations

* Clear improvements at large chunk sizes, but limited gains when chunk = 2048.
* Currently implemented for models like LLaMA / Mixtral / DeepSeek / Qwen, but broader testing is limited due to compute constraints.

---

### Related Work

* **BladeLLM (Alibaba, 2024)** ([arXiv:2501.15383](https://arxiv.org/abs/2501.15383))  ([GTC 25, Accelerate Super Long-Context LLM Inference](https://www.nvidia.com/en-us/on-demand/session/gtc25-s72568/))  shows strong gains from dynamic chunking.
* **Token Throttling** (#20359) in vLLM adjusts batch sizes but does not address history-dependent attention FLOPs imbalance. DCPP tries to fill that gap.

---

### Questions for Reviewers

1. Do you think DCPP (or cost-aware chunking in general) is a good fit for vLLM?
2. Should we keep pushing on this prototype (tuning thresholds, hybridizing with throttling), or do you see better directions?
3. Any advice on benchmarking methodology / integration into the scheduler?



