### PR TITLE
[Feature] models: pass layer prefix to replace_linear_class for per-layer quantization routing. Addresses #23239

### DIFF
--- a/vllm/model_executor/models/deepseek_vl2.py
+++ b/vllm/model_executor/models/deepseek_vl2.py
@@ -405,13 +405,17 @@ class DeepseekVLV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
             if isinstance(module, nn.Linear):
                 parent, attr_name = self._get_parent_and_attr(vit, name)
                 if isinstance(parent, timm.layers.Mlp) and attr_name == "fc1":
-                    new_linear = replace_linear_class(module, "colwise",
-                                                      quant_config)
+                    new_linear = replace_linear_class(module,
+                                                      "colwise",
+                                                      quant_config,
+                                                      prefix=name)
                     setattr(parent, attr_name, new_linear)
                 elif isinstance(parent,
                                 timm.layers.Mlp) and attr_name == "fc2":
-                    new_linear = replace_linear_class(module, "rowwise",
-                                                      quant_config)
+                    new_linear = replace_linear_class(module,
+                                                      "rowwise",
+                                                      quant_config,
+                                                      prefix=name)
                     setattr(parent, attr_name, new_linear)
 
         return vit


### PR DESCRIPTION
## Purpose

- Add prefix to replace_linear_class and thread through callsites so QuantConfig.get_quant_method can use layer names.
- Fixes [#23239](https://github.com/vllm-project/vllm/issues/23239).

## Test Plan

- Load any model with a quantization config that includes selective per-layer overrides (e.g., exclude model.layers.0.*, include others).
- Confirm unquantized layers remain unquantized and quantized ones route to the expected method.

## Test Result

- With the change, per-layer excludes (e.g., model.layers.0.*) are respected:
- Unquantized: layers matching the exclude pattern report/use UnquantizedLinearMethod.
- Quantized: other layers use the configured quant method.
- No regressions observed in linear replacement or model initialization.

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

