### PR TITLE
[quantization] use channel scales for w4a8 + misc fixes

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -690,10 +690,9 @@ def test_compressed_tensors_nvfp4(vllm_runner, args):
     or not current_platform.has_device_capability(90),
     reason="W4A8 FP8 is not yet supported on this GPU type.",
 )
-@pytest.mark.parametrize(
-    "args",
-    [("czhu-cohere/Meta-Llama-3-8B-Instruct-W4A8-compressed-tensors-test",
-      CompressedTensorsW4A8Fp8)])
+@pytest.mark.parametrize("args", [
+    ("czhu-cohere/TinyLlama-1.1B-Chat-v1.0-W4A8-e2e", CompressedTensorsW4A8Fp8)
+])
 def test_compressed_tensors_w4a8_fp8(vllm_runner, args):
     model, scheme = args
     with vllm_runner(model, enforce_eager=True) as llm:

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -14,10 +14,10 @@ from compressed_tensors.quantization import QuantizationType
 from tests.models.utils import check_logprobs_close
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
     CompressedTensors24, CompressedTensorsLinearMethod,
-    CompressedTensorsW4A4Fp4, CompressedTensorsW4A16Fp4,
-    CompressedTensorsW4A16Sparse24, CompressedTensorsW8A8Fp8,
-    CompressedTensorsW8A8Int8, CompressedTensorsW8A16Fp8,
-    CompressedTensorsWNA16)
+    CompressedTensorsW4A4Fp4, CompressedTensorsW4A8Fp8,
+    CompressedTensorsW4A16Fp4, CompressedTensorsW4A16Sparse24,
+    CompressedTensorsW8A8Fp8, CompressedTensorsW8A8Int8,
+    CompressedTensorsW8A16Fp8, CompressedTensorsWNA16)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     cutlass_fp4_supported)
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
@@ -678,6 +678,43 @@ def test_compressed_tensors_nvfp4(vllm_runner, args):
                 raise AssertionError("FP4 Scheme Mismatch")
 
             assert qkv_proj.scheme.group_size == 16
+
+        llm.apply_model(check_model)
+        output = llm.generate_greedy("Hello my name is", max_tokens=20)
+        print(output)
+        assert output
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda()
+    or not current_platform.has_device_capability(90),
+    reason="W4A8 FP8 is not yet supported on this GPU type.",
+)
+@pytest.mark.parametrize(
+    "args",
+    [("czhu-cohere/Meta-Llama-3-8B-Instruct-W4A8-compressed-tensors-test",
+      CompressedTensorsW4A8Fp8)])
+def test_compressed_tensors_w4a8_fp8(vllm_runner, args):
+    model, scheme = args
+    with vllm_runner(model, enforce_eager=True) as llm:
+
+        def check_model(model):
+            layer = model.model.layers[0]
+
+            qkv_proj = layer.self_attn.qkv_proj
+            o_proj = layer.self_attn.o_proj
+            gate_up_proj = layer.mlp.gate_up_proj
+            down_proj = layer.mlp.down_proj
+
+            for proj in (qkv_proj, o_proj, gate_up_proj, down_proj):
+                assert isinstance(proj.quant_method,
+                                  CompressedTensorsLinearMethod)
+                assert isinstance(proj.scheme, scheme)
+
+                assert proj.weight_packed.dtype is torch.int32
+                assert proj.weight_scale.dtype is torch.float8_e4m3fn
+                assert proj.weight_chan_scale.dtype is torch.float32
+                assert proj.scheme.group_size == 128
 
         llm.apply_model(check_model)
         output = llm.generate_greedy("Hello my name is", max_tokens=20)

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py
@@ -20,6 +20,7 @@ class MPLinearLayerConfig:
     group_size: int
     zero_points: bool
     has_g_idx: bool
+    out_type: Optional[torch.dtype] = None
 
 
 class MPLinearKernel(ABC):


### PR DESCRIPTION
## Purpose
Load per-channel scales for w4a8. This can recover the quality drop from naively casting bf16 scales to fp8 on certain benchmarks (mmlu pro). Computationally, this is 'free' since the [previous implementation](https://github.com/vllm-project/vllm/pull/23198) used `torch.ones` as a placeholder.

The `fp8` group scales and `fp32` per-channel scales can be generated as a post-processing step after we have a w4a16 checkpoint with `bf16` scales. For testing we used an adhoc workflow to generate the checkpoint but will look at integrating that into `llm-compressor` as a next step:
1. Take bf16 scales from the w4a16 checkpoint
2. do `fp8_scales, fp32_chan_scales = quantfp8(bf16_scales)`
3. divide `fp8_scales` by 8 to avoid saturation when multiplied by int4
4. multiply `fp32_chan_scales` by 8 to compensate

Then pass the adjusted `fp8_scales/fp32_chan_scales` to the `w4a8` kernel.

## Test Plan
lm-eval (gsm8k, mmlu pro) compare to w4a16 and previous w4a8 (Cohere Command A)

also add an example model `czhu-cohere/TinyLlama-1.1B-Chat-v1.0-W4A8-e2e` and add corresponding test in `tests/quantization/test_compressed_tensors.py`
```
pytest tests/quantization/test_compressed_tensors.py::test_compressed_tensors.py::test_compressed_tensors_w4a8_fp8
```
## Test Result
```
Cohere Command A (111B)
|model        |gsm8k       |mmlu pro    |
|-------------|------------|------------|
|w4a16        |0.8483699773|0.6907413564|
|w4a8 (before)|0.8476118271|0.6760305851|
|w4a8 (after) |0.8514025777|0.6880817819|
```

```
pytest tests/quantization/test_compressed_tensors.py::test_compressed_tensors.py::test_compressed_tensors_w4a8_fp8
...
collected 1 item                                                                                                                

test_compressed_tensors.py::test_compressed_tensors_w4a8_fp8[args0] PASSED                                                [100%]

====================================================== 1 passed in 52.44s =======================================================
```
## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

