### PR TITLE
feat: add usage to TranscriptionResponse (text and json response_format)

### DIFF
--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -69,8 +69,11 @@ async def test_basic_audio(mary_had_lamb, model_name):
             language="en",
             response_format="text",
             temperature=0.0)
-        out = json.loads(transcription)['text']
-        assert "Mary had a little lamb," in out
+        out = json.loads(transcription)
+        out_text = out['text']
+        out_usage = out['usage']
+        assert "Mary had a little lamb," in out_text
+        assert out_usage["seconds"] == 16, out_usage["seconds"]
 
 
 @pytest.mark.asyncio
@@ -116,9 +119,12 @@ async def test_long_audio_request(mary_had_lamb, client):
         language="en",
         response_format="text",
         temperature=0.0)
-    out = json.loads(transcription)['text']
-    counts = out.count("Mary had a little lamb")
+    out = json.loads(transcription)
+    out_text = out['text']
+    out_usage = out['usage']
+    counts = out_text.count("Mary had a little lamb")
     assert counts == 10, counts
+    assert out_usage["seconds"] == 161, out_usage["seconds"]
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -2232,9 +2232,29 @@ class TranscriptionRequest(OpenAIBaseModel):
 
 
 # Transcription response objects
+class TranscriptionUsageAudio(OpenAIBaseModel):
+    type: Literal["duration"] = "duration"
+    seconds: int
+
+
+class AudioTokensDetails(OpenAIBaseModel):
+    audio_tokens: int
+    text_tokens: int
+
+
+class TranscriptionUsageTokens(OpenAIBaseModel):
+    type: Literal["tokens"] = "tokens"
+    input_tokens: int
+    input_tokens_details: AudioTokensDetails
+    output_tokens: int
+    total_tokens: int
+
+
 class TranscriptionResponse(OpenAIBaseModel):
     text: str
     """The transcribed text."""
+    usage: Union[TranscriptionUsageAudio,
+                 TranscriptionUsageTokens] = Field(discriminator='type')
 
 
 class TranscriptionWord(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -2237,24 +2237,10 @@ class TranscriptionUsageAudio(OpenAIBaseModel):
     seconds: int
 
 
-class AudioTokensDetails(OpenAIBaseModel):
-    audio_tokens: int
-    text_tokens: int
-
-
-class TranscriptionUsageTokens(OpenAIBaseModel):
-    type: Literal["tokens"] = "tokens"
-    input_tokens: int
-    input_tokens_details: AudioTokensDetails
-    output_tokens: int
-    total_tokens: int
-
-
 class TranscriptionResponse(OpenAIBaseModel):
     text: str
     """The transcribed text."""
-    usage: Union[TranscriptionUsageAudio,
-                 TranscriptionUsageTokens] = Field(discriminator='type')
+    usage: TranscriptionUsageAudio
 
 
 class TranscriptionWord(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text.py
@@ -201,22 +201,28 @@ class OpenAISpeechToText(OpenAIServing):
                 async for op in result_generator:
                     text += op.outputs[0].text
 
-            # build usage dict depending on request format
-            # TODO: add usage for verbose_json when supported
-            if request.response_format in ["text", "json"]:
-                usage = {
-                    "type": "duration",
-                    # rounded up as per openAI specs
-                    "seconds": int(math.ceil(duration_s)),
-                }
+            if self.task_type == "transcribe":
+                # add usage in TranscriptionResponse.
+                # TODO: add usage for verbose_json when supported
+                if request.response_format in ["text", "json"]:
+                    usage = {
+                        "type": "duration",
+                        # rounded up as per openAI specs
+                        "seconds": int(math.ceil(duration_s)),
+                    }
+                else:
+                    # e.g.: verbose_json response format
+                    # NOTE: we should never end up here as response_format
+                    # is already validated above
+                    raise NotImplementedError(
+                        f"usage for `{request.response_format}` not supported")
+                final_response = cast(T, response_class(text=text,
+                                                        usage=usage))
             else:
-                # e.g.: verbose_json response format
-                # NOTE: we should never end up here as response_format
-                # is already validated above
-                raise NotImplementedError(
-                    f"usage for `{request.response_format}` not supported")
-
-            return cast(T, response_class(text=text, usage=usage))
+                # no usage in response for translation
+                final_response = cast(
+                    T, response_class(text=text))  # type: ignore[call-arg]
+            return final_response
         except asyncio.CancelledError:
             return self.create_error_response("Client disconnected")
         except ValueError as e:

--- a/vllm/entrypoints/openai/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text.py
@@ -203,25 +203,18 @@ class OpenAISpeechToText(OpenAIServing):
 
             if self.task_type == "transcribe":
                 # add usage in TranscriptionResponse.
-                # TODO: add usage for verbose_json when supported
-                if request.response_format in ["text", "json"]:
-                    usage = {
-                        "type": "duration",
-                        # rounded up as per openAI specs
-                        "seconds": int(math.ceil(duration_s)),
-                    }
-                else:
-                    # e.g.: verbose_json response format
-                    # NOTE: we should never end up here as response_format
-                    # is already validated above
-                    raise NotImplementedError(
-                        f"usage for `{request.response_format}` not supported")
+                usage = {
+                    "type": "duration",
+                    # rounded up as per openAI specs
+                    "seconds": int(math.ceil(duration_s)),
+                }
                 final_response = cast(T, response_class(text=text,
                                                         usage=usage))
             else:
-                # no usage in response for translation
+                # no usage in response for translation task
                 final_response = cast(
                     T, response_class(text=text))  # type: ignore[call-arg]
+
             return final_response
         except asyncio.CancelledError:
             return self.create_error_response("Client disconnected")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

closes https://github.com/vllm-project/vllm/issues/23575

This PR adds the `usage` in the `TranscriptionResponse` object.

Note that the OpenAI specifications for the `usage` type outputted in the transcription response depends of the `response_format` declared in the request. Currently vLLM only supporting the `text` and `json` response formats, only the basic usage is needed.

## Test Plan

Perform a transcription request against a vllm server serving a model supporting audio transcription.

## Test Result

Ensure the usage field is present in the request and matches the duration of the audio sent (rounded up to nearest integer as per OpenAI specs)

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

