### PR TITLE
Add Enum support to argument parsing utilities

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -5,6 +5,7 @@ import json
 from argparse import ArgumentError
 from contextlib import nullcontext
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Annotated, Literal, Optional, Union
 
 import pytest
@@ -37,13 +38,17 @@ def test_optional_type():
     assert optional_type_func("42") == 42
 
 
-@pytest.mark.parametrize(("type_hint", "type", "expected"), [
-    (int, int, True),
-    (int, float, False),
-    (list[int], list, True),
-    (list[int], tuple, False),
-    (Literal[0, 1], Literal, True),
-])
+class TestEnum(Enum):
+    X = 1
+    Y = 2
+
+
+@pytest.mark.parametrize(
+    ("type_hint", "type", "expected"), [(int, int, True), (int, float, False),
+                                        (list[int], list, True),
+                                        (list[int], tuple, False),
+                                        (Literal[0, 1], Literal, True),
+                                        (TestEnum, Enum, True)])
 def test_is_type(type_hint, type, expected):
     assert is_type(type_hint, type) == expected
 

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -11,10 +11,10 @@ from typing import Annotated, Literal, Optional, Union
 import pytest
 
 from vllm.config import CompilationConfig, config
-from vllm.engine.arg_utils import (EngineArgs, contains_type, get_kwargs,
-                                   get_type, get_type_hints, is_not_builtin,
-                                   is_type, literal_to_kwargs, optional_type,
-                                   parse_type)
+from vllm.engine.arg_utils import (EngineArgs, contains_type, enum_to_kwargs,
+                                   get_kwargs, get_type, get_type_hints,
+                                   is_not_builtin, is_type, literal_to_kwargs,
+                                   optional_type, parse_type)
 from vllm.utils import FlexibleArgumentParser
 
 
@@ -89,6 +89,20 @@ def test_literal_to_kwargs(type_hints, expected):
         context = pytest.raises(expected)
     with context:
         assert literal_to_kwargs(type_hints) == expected
+
+
+@pytest.mark.parametrize(("type_hints", "expected"), [
+    ({TestEnum}, {
+        "type": TestEnum,
+        "choices": [1, 2]
+    }),
+    ({str, TestEnum}, {
+        "type": str,
+        "metavar": [1, 2]
+    }),
+])
+def test_enum_to_kwargs(type_hints, expected):
+    assert enum_to_kwargs(type_hints) == expected
 
 
 @config

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -9,6 +9,7 @@ import functools
 import json
 import sys
 from dataclasses import MISSING, dataclass, fields, is_dataclass
+from enum import Enum
 from itertools import permutations
 from typing import (TYPE_CHECKING, Annotated, Any, Callable, Dict, List,
                     Literal, Optional, Type, TypeVar, Union, cast, get_args,
@@ -127,6 +128,20 @@ def literal_to_kwargs(type_hints: set[TypeHint]) -> dict[str, Any]:
             f"Got {options} with types {[type(c) for c in options]}")
     kwarg = "metavar" if contains_type(type_hints, str) else "choices"
     return {"type": option_type, kwarg: sorted(options)}
+
+
+def enum_to_kwargs(type_hints: set[TypeHint]) -> dict[str, Any]:
+    """Get the `type` and `choices` from a `Enum` type hint in `type_hints`.
+
+    If `type_hints` also contains `str`, we use `metavar` instead of `choices`
+    and `str` instead of constructing the `Enum` member.
+    """
+    type_hint = get_type(type_hints, Enum)
+    options = [f.value for f in type_hint]
+    could_be_string = contains_type(type_hints, str)
+    kwarg = "metavar" if could_be_string else "choices"
+    type = str if could_be_string else type_hint
+    return {"type": type, kwarg: sorted(options)}
 
 
 def is_not_builtin(type_hint: TypeHint) -> bool:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -23,17 +23,17 @@ from typing_extensions import TypeIs, deprecated
 
 import vllm.envs as envs
 from vllm.config import (BlockSize, CacheConfig, CacheDType, CompilationConfig,
-                         ConfigFormat, ConfigType, ConvertOption,
-                         DecodingConfig, DetailedTraceModules, Device,
-                         DeviceConfig, DistributedExecutorBackend, EPLBConfig,
+                         ConfigType, ConvertOption, DecodingConfig,
+                         DetailedTraceModules, Device, DeviceConfig,
+                         DistributedExecutorBackend, EPLBConfig,
                          GuidedDecodingBackend, HfOverrides, KVEventsConfig,
                          KVTransferConfig, LoadConfig, LogprobsMode,
                          LoRAConfig, MambaDType, MMEncoderTPMode, ModelConfig,
-                         ModelDType, ModelImpl, MultiModalConfig,
-                         ObservabilityConfig, ParallelConfig, PoolerConfig,
-                         PrefixCachingHashAlgo, RunnerOption, SchedulerConfig,
-                         SchedulerPolicy, SpeculativeConfig, TaskOption,
-                         TokenizerMode, VllmConfig, get_attr_docs, get_field)
+                         ModelDType, MultiModalConfig, ObservabilityConfig,
+                         ParallelConfig, PoolerConfig, PrefixCachingHashAlgo,
+                         RunnerOption, SchedulerConfig, SchedulerPolicy,
+                         SpeculativeConfig, TaskOption, TokenizerMode,
+                         VllmConfig, get_attr_docs, get_field)
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.plugins import load_general_plugins
@@ -215,6 +215,8 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, Any]:
             kwargs[name]["action"] = argparse.BooleanOptionalAction
         elif contains_type(type_hints, Literal):
             kwargs[name].update(literal_to_kwargs(type_hints))
+        elif contains_type(type_hints, Enum):
+            kwargs[name].update(enum_to_kwargs(type_hints))
         elif contains_type(type_hints, tuple):
             type_hint = get_type(type_hints, tuple)
             types = get_args(type_hint)
@@ -532,7 +534,6 @@ class EngineArgs:
         model_group.add_argument("--max-logprobs",
                                  **model_kwargs["max_logprobs"])
         model_group.add_argument("--logprobs-mode",
-                                 choices=[f.value for f in LogprobsMode],
                                  **model_kwargs["logprobs_mode"])
         model_group.add_argument("--disable-sliding-window",
                                  **model_kwargs["disable_sliding_window"])
@@ -553,7 +554,6 @@ class EngineArgs:
             help="Disable async output processing. This may result in "
             "lower performance.")
         model_group.add_argument("--config-format",
-                                 choices=[f.value for f in ConfigFormat],
                                  **model_kwargs["config_format"])
         # This one is a special case because it can bool
         # or str. TODO: Handle this in get_kwargs
@@ -577,9 +577,7 @@ class EngineArgs:
                                  **model_kwargs["override_generation_config"])
         model_group.add_argument("--enable-sleep-mode",
                                  **model_kwargs["enable_sleep_mode"])
-        model_group.add_argument("--model-impl",
-                                 choices=[f.value for f in ModelImpl],
-                                 **model_kwargs["model_impl"])
+        model_group.add_argument("--model-impl", **model_kwargs["model_impl"])
         model_group.add_argument("--override-attention-dtype",
                                  **model_kwargs["override_attention_dtype"])
         model_group.add_argument("--logits-processors",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -97,7 +97,10 @@ def union_dict_and_str(val: str) -> Optional[Union[str, dict[str, str]]]:
 
 def is_type(type_hint: TypeHint, type: TypeHintT) -> TypeIs[TypeHintT]:
     """Check if the type hint is a specific type."""
-    return type_hint is type or get_origin(type_hint) is type
+    is_enum = lambda cls: any("Enum" in base.__name__
+                              for base in getattr(cls, "__mro__", []))
+    return (type_hint is type or get_origin(type_hint) is type
+            or (is_enum(type) and is_enum(type_hint)))
 
 
 def contains_type(type_hints: set[TypeHint], type: TypeHintT) -> bool:


### PR DESCRIPTION
Introduce full support for `Enum` types in the argument parsing utilities, enhancing type checking and argument handling. Implement `enum_to_kwargs` to convert `Enum` type hints into appropriate keyword arguments for argument parsing. Remove previous workarounds in favor of the new functionality.

Should be functionally identical except the CLI will now include `choices` or `metavar` for CLI args which are passed into `Enum`s