### PR TITLE
[Quantization] Use CompressedTensors utils matching utils, support module ignores

### DIFF
--- a/tests/quantization/test_compressed_tensors_matching.py
+++ b/tests/quantization/test_compressed_tensors_matching.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for compressed-tensors matching utilities.
+
+Tests verify that the compressed-tensors library's matching functions work
+correctly for vLLM use cases, including fused modules, regex patterns, and
+class name matching.
+
+Run `pytest tests/quantization/test_compressed_tensors_matching.py`.
+"""
+
+import pytest
+import torch
+from compressed_tensors.utils.match import is_match, match_targets
+
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    LinearBase,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+
+
+class MockLinear(torch.nn.Module):
+    """Mock linear layer for testing."""
+
+    pass
+
+
+class MockAttention(torch.nn.Module):
+    """Mock attention layer for testing."""
+
+    pass
+
+
+def test_exact_name_match():
+    """Test exact layer name matching."""
+    layer = MockLinear()
+
+    assert is_match("layers.0.q_proj", layer, "layers.0.q_proj")
+    assert is_match(
+        "model.layers.5.mlp.gate_proj", layer, "model.layers.5.mlp.gate_proj"
+    )
+    assert not is_match("layers.0.q_proj", layer, "layers.1.q_proj")
+    assert not is_match("layers.0.q_proj", layer, "layers.0.k_proj")
+
+
+def test_regex_pattern_match():
+    """Test regex pattern matching with 're:' prefix."""
+    layer = MockLinear()
+
+    # Test basic regex patterns
+    assert is_match("layers.0.q_proj", layer, "re:.*q_proj")
+    assert is_match("layers.0.self_attn.q_proj", layer, "re:.*self_attn.*")
+    assert is_match("model.layers.5.mlp.gate_proj", layer, "re:.*mlp.*proj")
+
+    # Test layer number patterns
+    assert is_match("layers.0.q_proj", layer, "re:layers\\.[0-9]+\\.q_proj")
+    assert is_match("layers.15.q_proj", layer, "re:layers\\.[0-9]+\\.q_proj")
+
+    # Test non-matching patterns
+    assert not is_match("layers.0.q_proj", layer, "re:.*k_proj")
+    assert not is_match("model.mlp.gate", layer, "re:.*attention.*")
+
+
+def test_multiple_targets():
+    """Test matching against multiple targets."""
+    layer = MockLinear()
+
+    # Should match if any target matches
+    targets = ["layers.0.k_proj", "layers.0.q_proj", "layers.0.v_proj"]
+    assert is_match("layers.0.q_proj", layer, targets)
+    assert is_match("layers.0.k_proj", layer, targets)
+    assert not is_match("layers.0.o_proj", layer, targets)
+
+    # Test with regex patterns
+    targets_with_regex = ["re:.*q_proj", "re:.*k_proj"]
+    assert is_match("layers.5.q_proj", layer, targets_with_regex)
+    assert is_match("model.layers.0.k_proj", layer, targets_with_regex)
+    assert not is_match("layers.0.o_proj", layer, targets_with_regex)
+
+
+def test_fused_module_matching():
+    """Test matching for fused modules like qkv_proj."""
+    layer = MockLinear()
+
+    # Standard vLLM fused module mappings
+    fused_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    # Test qkv_proj fused matching
+    assert is_match("layers.0.qkv_proj", layer, "layers.0.q_proj", fused=fused_mapping)
+    assert is_match("layers.0.qkv_proj", layer, "layers.0.k_proj", fused=fused_mapping)
+    assert is_match("layers.0.qkv_proj", layer, "layers.0.v_proj", fused=fused_mapping)
+    assert not is_match(
+        "layers.0.qkv_proj", layer, "layers.0.o_proj", fused=fused_mapping
+    )
+
+    # Test gate_up_proj fused matching
+    assert is_match(
+        "layers.0.gate_up_proj", layer, "layers.0.gate_proj", fused=fused_mapping
+    )
+    assert is_match(
+        "layers.0.gate_up_proj", layer, "layers.0.up_proj", fused=fused_mapping
+    )
+    assert not is_match(
+        "layers.0.gate_up_proj", layer, "layers.0.down_proj", fused=fused_mapping
+    )
+
+    # Test fused with regex patterns
+    assert is_match("layers.0.qkv_proj", layer, "re:.*q_proj", fused=fused_mapping)
+    assert is_match(
+        "model.layers.5.qkv_proj", layer, "re:.*k_proj", fused=fused_mapping
+    )
+
+
+def test_ignore_matching():
+    """Test ignore list functionality."""
+    layer = MockLinear()
+
+    # Test exact ignore
+    ignore = ["layers.0.q_proj", "layers.1.k_proj"]
+    assert not is_match("layers.0.q_proj", layer, "layers.0.q_proj", ignore=ignore)
+    assert is_match("layers.2.q_proj", layer, "layers.2.q_proj", ignore=ignore)
+
+    # Test regex ignore
+    ignore_regex = ["re:.*\\.0\\..*", "re:.*\\.1\\..*"]
+    assert not is_match(
+        "layers.0.q_proj", layer, "layers.0.q_proj", ignore=ignore_regex
+    )
+    assert not is_match(
+        "layers.1.k_proj", layer, "layers.1.k_proj", ignore=ignore_regex
+    )
+    assert is_match("layers.2.q_proj", layer, "layers.2.q_proj", ignore=ignore_regex)
+
+
+def test_class_name_matching():
+    """Test matching by module class name."""
+
+    # Test with generic torch.nn modules
+    linear = torch.nn.Linear(10, 10)
+    assert is_match("any_name", linear, "Linear")
+
+    attention = MockAttention()
+    assert is_match("any_name", attention, "MockAttention")
+    assert not is_match("any_name", attention, "Linear")
+
+
+def test_vllm_linear_class_matching():
+    """
+    Test that vLLM LinearBase classes match 'Linear' target.
+
+    This verifies the compressed-tensors library's built-in support for
+    vLLM's LinearBase → Linear mapping.
+    """
+    # Note: We can't easily instantiate vLLM linear classes without initializing
+    # distributed state, so we test the class hierarchy instead
+
+    # Verify all vLLM linear classes inherit from LinearBase
+    assert issubclass(ReplicatedLinear, LinearBase)
+    assert issubclass(ColumnParallelLinear, LinearBase)
+    assert issubclass(RowParallelLinear, LinearBase)
+
+    # Verify LinearBase is in the MRO
+    assert LinearBase in ReplicatedLinear.__mro__
+    assert LinearBase in ColumnParallelLinear.__mro__
+    assert LinearBase in RowParallelLinear.__mro__
+
+    # The compressed-tensors library checks:
+    # (cls.__name__ == "LinearBase" and target == "Linear")
+    # This means when iterating through MRO, if any class is named "LinearBase"
+    # and the target is "Linear", it will match.
+    assert LinearBase.__name__ == "LinearBase"
+
+
+def test_match_targets_ordering():
+    """Test that match_targets returns results in priority order."""
+    layer = MockLinear()
+
+    targets = [
+        "re:.*proj",  # regex
+        "MockLinear",  # class name
+        "layers.0.q_proj",  # exact name
+    ]
+
+    # match_targets returns matches ordered by specificity:
+    # 1. exact name matches
+    # 2. regex name matches
+    # 3. class name matches
+    matched = match_targets("layers.0.q_proj", layer, targets)
+
+    # Should match both the exact name and the regex
+    assert "layers.0.q_proj" in matched
+    assert "re:.*proj" in matched
+    assert "MockLinear" in matched
+
+    # Exact match should come first
+    assert matched[0] == "layers.0.q_proj"
+
+
+def test_fused_with_regex_and_ignore():
+    """Test complex scenario with fused modules, regex, and ignore."""
+    layer = MockLinear()
+
+    fused_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+
+    # Match with regex target
+    assert is_match("layers.0.qkv_proj", layer, "re:.*q_proj", fused=fused_mapping)
+
+    # Match with regex target and ignore
+    ignore = ["re:.*\\.0\\..*"]
+    assert not is_match(
+        "layers.0.qkv_proj",
+        layer,
+        "re:.*q_proj",
+        ignore=ignore,
+        fused=fused_mapping,
+    )
+
+    # Different layer should still match
+    assert is_match(
+        "layers.5.qkv_proj",
+        layer,
+        "re:.*q_proj",
+        ignore=ignore,
+        fused=fused_mapping,
+    )
+
+
+def test_empty_and_none_targets():
+    """Test edge cases with empty or None targets."""
+    layer = MockLinear()
+
+    # Empty targets should not match
+    assert not is_match("layers.0.q_proj", layer, [])
+    assert not is_match("layers.0.q_proj", layer, tuple())
+
+    # Empty ignore should allow all matches
+    assert is_match("layers.0.q_proj", layer, "layers.0.q_proj", ignore=[])
+    assert is_match("layers.0.q_proj", layer, "layers.0.q_proj", ignore=tuple())
+
+
+def test_case_sensitivity():
+    """Test that matching is case-sensitive."""
+    layer = MockLinear()
+
+    assert is_match("layers.0.Q_PROJ", layer, "layers.0.Q_PROJ")
+    assert not is_match("layers.0.q_proj", layer, "layers.0.Q_PROJ")
+    assert not is_match("layers.0.Q_PROJ", layer, "layers.0.q_proj")
+
+    # Regex patterns are also case-sensitive by default
+    assert is_match("layers.0.Q_PROJ", layer, "re:.*Q_PROJ")
+    assert not is_match("layers.0.q_proj", layer, "re:.*Q_PROJ")
+
+
+def test_special_characters_in_names():
+    """Test matching with special characters in layer names."""
+    layer = MockLinear()
+
+    # Test with dots, underscores, numbers
+    assert is_match(
+        "model.layer_1.self_attn.q_proj", layer, "model.layer_1.self_attn.q_proj"
+    )
+
+    # Test regex escaping for dots
+    assert is_match("model.layer.proj", layer, "re:model\\.layer\\.proj")
+    # Without escaping, dot matches any character
+    assert is_match("modelXlayerXproj", layer, "re:model.layer.proj")
+
+
+def test_moe_expert_matching():
+    """Test matching for MoE expert layers."""
+    layer = MockLinear()
+
+    # Test matching specific expert
+    assert is_match(
+        "layers.0.mlp.experts.0.gate_proj", layer, "layers.0.mlp.experts.0.gate_proj"
+    )
+
+    # Test regex to match all experts
+    assert is_match(
+        "layers.0.mlp.experts.0.gate_proj", layer, "re:.*experts\\.[0-9]+\\.gate_proj"
+    )
+    assert is_match(
+        "layers.0.mlp.experts.7.gate_proj", layer, "re:.*experts\\.[0-9]+\\.gate_proj"
+    )
+
+    # Test with fused mapping for MoE
+    fused_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+    assert is_match(
+        "layers.0.mlp.experts.0.gate_up_proj",
+        layer,
+        "re:.*experts\\.[0-9]+\\.gate_proj",
+        fused=fused_mapping,
+    )
+
+
+def test_vllm_class_name_mapping_documentation():
+    """
+    Test that VLLM_CLASS_NAME_MAPPING is properly documented.
+
+    This verifies that the mapping exists and is accessible for future
+    extensions.
+    """
+    from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+        VLLM_CLASS_NAME_MAPPING,
+    )
+
+    # Verify the mapping exists
+    assert isinstance(VLLM_CLASS_NAME_MAPPING, dict)
+
+    # Verify the Linear → LinearBase mapping is documented
+    assert "Linear" in VLLM_CLASS_NAME_MAPPING
+    assert VLLM_CLASS_NAME_MAPPING["Linear"] == "LinearBase"
+
+
+def test_embedding_class_hierarchy():
+    """
+    Test vLLM embedding class hierarchy.
+
+    This documents the class structure in case we need to add Embedding
+    class name matching in the future.
+    """
+    # Verify embedding class hierarchy
+    assert issubclass(ParallelLMHead, VocabParallelEmbedding)
+
+    # Document class names for potential future mapping
+    assert VocabParallelEmbedding.__name__ == "VocabParallelEmbedding"
+    assert ParallelLMHead.__name__ == "ParallelLMHead"
+
+    # These don't inherit from torch.nn.Embedding, so we would need
+    # to add explicit mapping if configs use "Embedding" as a target
+    assert not issubclass(VocabParallelEmbedding, torch.nn.Embedding)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -17,6 +17,7 @@ from compressed_tensors.quantization import (
     QuantizationType,
 )
 from compressed_tensors.transform import TransformConfig
+from compressed_tensors.utils.match import is_match
 
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -57,10 +58,14 @@ from vllm.model_executor.layers.quantization.compressed_tensors.transform.linear
     get_linear_transform_schemes,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
-    find_matched_target,
     is_activation_quantization_format,
-    should_ignore_layer,
 )
+
+# Note: is_match from compressed-tensors handles class name matching with support
+# for vLLM-specific classes (see VLLM_CLASS_NAME_MAPPING in utils.py for details).
+# The compressed-tensors library has built-in support for LinearBase → Linear,
+# which covers all vLLM linear classes (ReplicatedLinear, ColumnParallelLinear, etc.)
+# since they inherit from LinearBase.
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.platforms import current_platform
 
@@ -712,12 +717,13 @@ class CompressedTensorsConfig(QuantizationConfig):
             self.sparsity_ignore_list
         )
         sparsity_scheme: SparsityCompressionConfig | None = None
-        with suppress(ValueError):
-            matched_target = find_matched_target(
-                layer_name=layer_name,
-                module=layer,
-                targets=sparsity_targets,
-                fused_mapping=self.packed_modules_mapping,
+        with suppress(StopIteration):
+            matched_target = next(
+                target
+                for target in sparsity_targets
+                if is_match(
+                    layer_name, layer, target, fused=self.packed_modules_mapping
+                )
             )
             sparsity_scheme = self.sparsity_scheme_map[matched_target]
 
@@ -772,19 +778,19 @@ class CompressedTensorsConfig(QuantizationConfig):
                 "format": str | None
             } | None
         """
-        # TODO (@kylesayrs): support ignore module names with ct matching utils
-        if should_ignore_layer(
-            layer_name, ignore=self.ignore, fused_mapping=self.packed_modules_mapping
+        if is_match(
+            layer_name, layer, targets=self.ignore, fused=self.packed_modules_mapping
         ):
             return None
 
         # Will be empty for models with only sparsity
         if self.target_scheme_map:
-            matched_target = find_matched_target(
-                layer_name=layer_name,
-                module=layer,
-                targets=self.target_scheme_map.keys(),
-                fused_mapping=self.packed_modules_mapping,
+            matched_target = next(
+                target
+                for target in self.target_scheme_map.keys()
+                if is_match(
+                    layer_name, layer, target, fused=self.packed_modules_mapping
+                )
             )
             scheme_dict = self.target_scheme_map[matched_target]
             if scheme_dict.get("format") is None:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -1,12 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable, Mapping
-from types import MappingProxyType
-
-import regex as re
 from compressed_tensors import CompressionFormat
-from torch.nn import Module
+
+# Mapping from standard PyTorch/Transformers class names to vLLM class names.
+# This is used when quantization configs reference standard class names like "Linear"
+# but vLLM uses specialized classes like "LinearBase", "ReplicatedLinear", etc.
+#
+# Note: The compressed-tensors library already has a built-in special case for
+# LinearBase → Linear in its _match_class function. This mapping documents that
+# behavior and provides a place to add additional vLLM-specific mappings if needed.
+#
+# For example, if a config uses "Embedding" as a target, we could add:
+#   "Embedding": "VocabParallelEmbedding"
+VLLM_CLASS_NAME_MAPPING: dict[str, str] = {
+    "Linear": "LinearBase",  # Already handled by compressed-tensors library
+}
 
 
 def is_activation_quantization_format(format: str) -> bool:
@@ -17,200 +26,3 @@ def is_activation_quantization_format(format: str) -> bool:
         CompressionFormat.nvfp4_pack_quantized.value,
     ]
     return format in _ACTIVATION_QUANTIZATION_FORMATS
-
-
-def should_ignore_layer(
-    layer_name: str | None,
-    ignore: Iterable[str] = tuple(),
-    fused_mapping: Mapping[str, list[str]] = MappingProxyType({}),
-) -> bool:
-    if layer_name is None:
-        return False
-
-    # layer_name = model.layers.0.self_attn.qkv_proj
-    # proj_name = qkv_proj
-    proj_name = layer_name.split(".")[-1]
-
-    # Fused layers like gate_up_proj or qkv_proj will not be fused
-    # in the safetensors checkpoint. So, we convert the name
-    # from the fused version to unfused + check to make sure that
-    # each shard of the fused layer has the same scheme.
-    if proj_name in fused_mapping and layer_name not in ignore:
-        shard_proj_names = fused_mapping[proj_name]
-
-        # Convert fused_name --> [shard_names]
-        shard_names = [
-            layer_name.replace(proj_name, shard_proj_name)
-            for shard_proj_name in shard_proj_names
-        ]
-
-        # Layer should be ignored if shards are ignored.
-        should_ignore_layer = None
-        for shard_name in shard_names:
-            should_ignore_shard = check_equal_or_regex_match(
-                layer_name=shard_name, targets=ignore
-            )
-
-            # If shard_idx=0, set layer ignore to match shard.
-            if should_ignore_layer is None:
-                should_ignore_layer = should_ignore_shard
-
-            # If shard_idx=1+ confirm scheme matches prior shards.
-            elif should_ignore_shard != should_ignore_layer:
-                raise ValueError(
-                    f"Found a different quantization schemes for "
-                    f"{shard_proj_names} in {layer_name}. vLLM "
-                    "requires all to use the same scheme."
-                )
-
-    # Unfused layers like down_proj and o_proj will match
-    # the safetensors checkpoint already.
-    else:
-        should_ignore_layer = check_equal_or_regex_match(
-            layer_name=layer_name, targets=ignore
-        )
-
-    assert should_ignore_layer is not None
-    return should_ignore_layer
-
-
-def check_equal_or_regex_match(layer_name: str, targets: Iterable[str]) -> bool:
-    """
-    Checks whether a layer_name is exactly equal or a regex match for
-    if target starts with 're:' to any target in list.
-    """
-    return any(_is_equal_or_regex_match(layer_name, target) for target in targets)
-
-
-def find_matched_target(
-    layer_name: str | None,
-    module: Module,
-    targets: Iterable[str],
-    fused_mapping: Mapping[str, list[str]] = MappingProxyType({}),
-) -> str:
-    """
-    Helper function to look up which "target" in the compressed-tensors
-    config that a layer corresponds to.
-
-    Recall that a compressed-tensors configs has a concept of
-    config_groups, where each layer can be quantized with a different
-    scheme.
-
-    targets in each config_group will be a list of either layer names
-    (or regexes corresponding to layer names) or names of torch Modules.
-
-    First, we try to match the layer_name with a target
-    Second, we try to match the module's name with a target
-    Third, we try to map the layer_name to a list of fused module names.
-        *All* component module names must match in order for a match to be
-        successful. A successful match returns the first component target
-
-    :param layer_name: layer name
-    :param module: torch.nn.Module
-    :param targets: list of targets to match the layer against
-    :param fused_mapping: map from fused layer names to its components
-    :param fused_strategy: either "all" or "any". If using "all", fused
-        layers match if "all" of its components match
-    """
-
-    if layer_name is None:
-        layer_name = ""
-
-    matched_target = (
-        _find_first_match(layer_name, targets)
-        or _find_first_match(module.__class__.__name__, targets, True)
-        or _match_fused_layer(layer_name, targets, fused_mapping)
-    )
-
-    if matched_target is None:
-        raise ValueError(
-            f"Unable to find matching target for {layer_name} in the "
-            "compressed-tensors config."
-        )
-
-    return matched_target
-
-
-def _find_first_match(
-    value: str, targets: Iterable[str], check_contains: bool = False
-) -> str | None:
-    """
-    Returns first element of target that matches value either
-    exactly or as a regex after 're:'. If check_contains is set to True,
-    additionally checks if the target string is contained within the value.
-
-    :param value: string to compare the list of targets against
-    :param targets: list of targets to match the layer against
-    :param check_contains: whether or not to do a substring match
-    """
-
-    for target in targets:
-        if _is_equal_or_regex_match(value, target, check_contains=check_contains):
-            return target
-    return None
-
-
-def _is_equal_or_regex_match(
-    value: str, target: str, check_contains: bool = False
-) -> bool:
-    """
-    Checks whether a value is exactly equal or a regex match for target
-    if target starts with 're:'. If check_contains is set to True,
-    additionally checks if the target string is contained within the value.
-    """
-
-    if target.startswith("re:"):
-        pattern = target[3:]
-        if re.match(pattern, value):
-            return True
-    elif check_contains:
-        if target.lower() in value.lower():
-            return True
-    elif target == value:
-        return True
-    return False
-
-
-def _match_fused_layer(
-    layer_name: str,
-    target_layers: Iterable[str],
-    fused_mapping: Mapping[str, list[str]],
-) -> str | None:
-    """
-    Match a fused layer name to its corresponding individual layer in
-    target_layers. Returns first value in fused_mapping which matches targets
-
-    Implements an "all" matching strategy where a fused layer matches iff
-    "all" of its components match
-
-    :param layer_name: layer name
-    :param target_layers: list of targets to match the layer against
-    :param fused_mapping: map from fused layer names to its components
-
-    Examples:
-        layer_name = "model.layers.0.self_attn.qkv_proj"
-        target_layers = ["model.layers.0.self_attn.q_proj",
-                        "model.layers.0.self_attn.k_proj",
-                        "model.layers.0.self_attn.v_proj"]
-    """
-    # find layer_name in mapping
-    fused = next((key for key in fused_mapping if layer_name.endswith(key)), None)
-    if fused is None:
-        return None
-
-    # expand path of unfused components
-    unfused_paths = [
-        layer_name.replace(fused, unfused) for unfused in fused_mapping[fused]
-    ]
-
-    # for each unfused component, find a match in targets
-    unfused_matches: list[str | None] = []
-    for unfused in unfused_paths:
-        for target in target_layers:
-            if _is_equal_or_regex_match(unfused, target):
-                unfused_matches.append(target)
-                break
-        else:
-            unfused_matches.append(None)
-
-    return unfused_matches[0] if all(unfused_matches) else None


### PR DESCRIPTION
## Purpose ##
* Use matching utils provided by Compressed Tensors in order to better guarantee identical matching
* Support ignoring module types in quantization config ignore list

## Prerequisites ##
* https://github.com/vllm-project/vllm/pull/22486