### PR TITLE
[Bugfix] fix bf16 multimodal model hash

### DIFF
--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -44,7 +44,7 @@ class MultiModalHasher:
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
             if obj.dtype == torch.bfloat16:
-                obj = obj.to(torch.float16)
+                obj = obj.to(torch.float32)
             return cls.item_to_bytes("tensor", obj.cpu().numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -45,8 +45,9 @@ class MultiModalHasher:
         if isinstance(obj, torch.Tensor):
             tensor_obj: torch.Tensor = obj.cpu()
             if tensor_obj.dtype == torch.bfloat16:
+                tensor_obj = tensor_obj.contiguous()
                 tensor_obj = tensor_obj.view(
-                    (tensor_obj.numel(), )).contiguous().view(torch.uint8)
+                    (tensor_obj.numel(), )).view(torch.uint8)
             return cls.item_to_bytes("tensor", tensor_obj.numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -43,9 +43,10 @@ class MultiModalHasher:
             return cls.item_to_bytes(
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
+            obj = obj.cpu()
             if obj.dtype == torch.bfloat16:
                 obj = obj.to(torch.float32)
-            return cls.item_to_bytes("tensor", obj.cpu().numpy())
+            return cls.item_to_bytes("tensor", obj.numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first
             arr_data = obj.data if obj.flags.c_contiguous else obj.tobytes()

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -43,10 +43,10 @@ class MultiModalHasher:
             return cls.item_to_bytes(
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
-            tensor_obj: torch.Tensor = obj.cpu().contiguous()
+            tensor_obj: torch.Tensor = obj.cpu()
             if tensor_obj.dtype == torch.bfloat16:
                 tensor_obj = tensor_obj.view(
-                    (tensor_obj.numel(), )).view(torch.uint8)
+                    (tensor_obj.numel(), )).contiguous().view(torch.uint8)
             return cls.item_to_bytes("tensor", tensor_obj.numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -45,7 +45,8 @@ class MultiModalHasher:
         if isinstance(obj, torch.Tensor):
             tensor_obj: torch.Tensor = obj.cpu()
             if tensor_obj.dtype == torch.bfloat16:
-                tensor_obj = tensor_obj.to(torch.float32)
+                tensor_obj = tensor_obj.view(
+                    (tensor_obj.numel(), )).view(torch.uint8)
             return cls.item_to_bytes("tensor", tensor_obj.numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -43,6 +43,8 @@ class MultiModalHasher:
             return cls.item_to_bytes(
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
+            if obj.dtype == torch.bfloat16:
+                obj = obj.to(torch.float16)
             return cls.item_to_bytes("tensor", obj.cpu().numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -43,7 +43,7 @@ class MultiModalHasher:
             return cls.item_to_bytes(
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
-            tensor_obj: torch.Tensor = obj.cpu()
+            tensor_obj: torch.Tensor = obj.cpu().contiguous()
             if tensor_obj.dtype == torch.bfloat16:
                 tensor_obj = tensor_obj.view(
                     (tensor_obj.numel(), )).view(torch.uint8)

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -49,10 +49,13 @@ class MultiModalHasher:
                 tensor_obj = tensor_obj.contiguous()
                 tensor_obj = tensor_obj.view(
                     (tensor_obj.numel(), )).view(torch.uint8)
-            return cls.item_to_bytes("tensor", {
-                "original_dtype": str(tensor_dtype),
-                "data": tensor_obj.numpy()
-            })
+                return cls.item_to_bytes(
+                    "tensor", {
+                        "original_dtype": str(tensor_dtype),
+                        "original_shape": tuple(tensor_obj.shape),
+                        "data": tensor_obj.numpy()
+                    })
+            return cls.item_to_bytes("tensor", tensor_obj.numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first
             arr_data = obj.data if obj.flags.c_contiguous else obj.tobytes()

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -44,11 +44,15 @@ class MultiModalHasher:
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
             tensor_obj: torch.Tensor = obj.cpu()
-            if tensor_obj.dtype == torch.bfloat16:
+            tensor_dtype = tensor_obj.dtype
+            if tensor_dtype == torch.bfloat16:
                 tensor_obj = tensor_obj.contiguous()
                 tensor_obj = tensor_obj.view(
                     (tensor_obj.numel(), )).view(torch.uint8)
-            return cls.item_to_bytes("tensor", tensor_obj.numpy())
+            return cls.item_to_bytes("tensor", {
+                "original_dtype": str(tensor_dtype),
+                "data": tensor_obj.numpy()
+            })
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first
             arr_data = obj.data if obj.flags.c_contiguous else obj.tobytes()

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -43,10 +43,10 @@ class MultiModalHasher:
             return cls.item_to_bytes(
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
-            obj: torch.Tensor = obj.cpu()
-            if obj.dtype == torch.bfloat16:
-                obj = obj.to(torch.float32)
-            return cls.item_to_bytes("tensor", obj.numpy())
+            tensor_obj: torch.Tensor = obj.cpu()
+            if tensor_obj.dtype == torch.bfloat16:
+                tensor_obj = tensor_obj.to(torch.float32)
+            return cls.item_to_bytes("tensor", tensor_obj.numpy())
         if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first
             arr_data = obj.data if obj.flags.c_contiguous else obj.tobytes()

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -43,7 +43,7 @@ class MultiModalHasher:
             return cls.item_to_bytes(
                 "image", np.asarray(convert_image_mode(obj, "RGBA")))
         if isinstance(obj, torch.Tensor):
-            obj = obj.cpu()
+            obj: torch.Tensor = obj.cpu()
             if obj.dtype == torch.bfloat16:
                 obj = obj.to(torch.float32)
             return cls.item_to_bytes("tensor", obj.numpy())


### PR DESCRIPTION
This PR fixed a bug when multimodal model and its embedding input is torch.bfloat16 tensor. Bfloat16 tensors can't be converted to numpy() directly.

