### PR TITLE
Fix writing benchmark results with tuple keys

### DIFF
--- a/vllm/benchmarks/lib/utils.py
+++ b/vllm/benchmarks/lib/utils.py
@@ -55,7 +55,9 @@ class InfEncoder(json.JSONEncoder):
     def clear_inf(self, o: Any):
         if isinstance(o, dict):
             return {
-                str(k) if isinstance(k, tuple) else k: self.clear_inf(v)
+                str(k)
+                if not isinstance(k, (str, int, float, bool, type(None)))
+                else k: self.clear_inf(v)
                 for k, v in o.items()
             }
         elif isinstance(o, list):
@@ -75,5 +77,4 @@ def write_to_json(filename: str, records: list) -> None:
             f,
             cls=InfEncoder,
             default=lambda o: f"<{type(o).__name__} is not JSON serializable>",
-            skipkeys=True,
         )

--- a/vllm/benchmarks/lib/utils.py
+++ b/vllm/benchmarks/lib/utils.py
@@ -54,7 +54,10 @@ class InfEncoder(json.JSONEncoder):
 
     def clear_inf(self, o: Any):
         if isinstance(o, dict):
-            return {k: self.clear_inf(v) for k, v in o.items()}
+            return {
+                str(k) if isinstance(k, tuple) else k: self.clear_inf(v)
+                for k, v in o.items()
+            }
         elif isinstance(o, list):
             return [self.clear_inf(v) for v in o]
         elif isinstance(o, float) and math.isinf(o):
@@ -72,4 +75,5 @@ def write_to_json(filename: str, records: list) -> None:
             f,
             cls=InfEncoder,
             default=lambda o: f"<{type(o).__name__} is not JSON serializable>",
+            skipkeys=True,
         )


### PR DESCRIPTION
## Purpose

https://github.com/vllm-project/vllm/pull/23119 introduced a new dataset parameter `--random-mm-bucket-config` which is default to a dictionary with a tuple key, i.e. `{(256, 256, 1): 0.7, (720, 1280, 1): 0.3}`.  The problem here is that `json.dump` doesn't like this type.  So, a bunch of benchmark runs are failing with `TypeError: keys must be str, int, float, bool or None, not tuple` error, for example https://github.com/pytorch/pytorch-integration-testing/actions/runs/17208394287/job/48814081180#step:16:1634.  The benchmark jobs keep track of the all benchmark arguments in its JSON results.

This PR fixes this error by converting the tuple to string before passing the benchmark results dictionary to `json.dump`.

## Test Plan

Run a benchmark with the change in this PR

cc @h-brenoskuk @ywang96 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results