### PR TITLE
[Bugfix] Add missing enable_log_outputs parameter to init_app_state function

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1748,6 +1748,7 @@ async def init_app_state(
         reasoning_parser=args.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
         enable_force_include_usage=args.enable_force_include_usage,
+        enable_log_outputs=args.enable_log_outputs,
     ) if "generate" in supported_tasks else None
     state.openai_serving_chat = OpenAIServingChat(
         engine_client,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1765,6 +1765,7 @@ async def init_app_state(
         reasoning_parser=args.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
         enable_force_include_usage=args.enable_force_include_usage,
+        enable_log_outputs=args.enable_log_outputs,
     ) if "generate" in supported_tasks else None
     state.openai_serving_completion = OpenAIServingCompletion(
         engine_client,


### PR DESCRIPTION
<!-- markdownlint-disable -->

The --enable-log-outputs feature implemented in PR #20707 was missing the connection between the CLI argument and the OpenAIServingChat constructor when using `vllm.entrypoints.openai.api_server` as your entrypoint. This PR adds the missing `enable_log_outputs=args.enable_log_outputs` parameter to make the feature functional.

## Purpose

Fix broken --enable-log-outputs functionality

## Test Plan

Run `vllm serve` with `--enable-log-outputs` flag

## Test Result

Outputs are logged:

```
(APIServer pid=16079) INFO 08-26 10:15:31 [logger.py:71] Generated response chatcmpl-f27a5a32690542b59c73d4e094c091ae: output: 'Hello there!', output_token_ids: [19556, 665, 17, 2], finish_reason: stop
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
