### PR TITLE
Add deprecation warning for lora_extra_vocab_size

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -2438,9 +2438,9 @@ class LoRAConfig:
     `max_loras`."""
     lora_dtype: Union[torch.dtype, LoRADType] = "auto"
     """Data type for LoRA. If auto, will default to base model dtype."""
-    lora_extra_vocab_size: int = 256
-    """Maximum size of extra vocabulary that can be present in a LoRA adapter
-    (added to the base model vocabulary)."""
+    lora_extra_vocab_size: int = 0
+    """(Deprecating) Maximum size of extra vocabulary that can be present in a 
+    LoRA adapter. Set to 0 to disable. Will be removed in a future release."""
     lora_vocab_padding_size: ClassVar[int] = current_platform\
         .get_lora_vocab_padding_size()
 
@@ -2482,10 +2482,19 @@ class LoRAConfig:
         return hash_str
 
     def __post_init__(self):
+        # Deprecation warning for lora_extra_vocab_size
+        if self.lora_extra_vocab_size != 0:
+            logger.warning(
+                "`lora_extra_vocab_size` is deprecated and will be removed "
+                "in a future release. Additional vocabulary support for "
+                "LoRA adapters is being phased out."
+            )
+        
         # Setting the maximum rank to 512 should be able to satisfy the vast
         # majority of applications.
         possible_max_ranks = (8, 16, 32, 64, 128, 256, 320, 512)
-        possible_lora_extra_vocab_size = (256, 512)
+        # Include 0 to allow users to disable the deprecated feature
+        possible_lora_extra_vocab_size = (0, 256, 512)
         if self.max_lora_rank not in possible_max_ranks:
             raise ValueError(
                 f"max_lora_rank ({self.max_lora_rank}) must be one of "

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -2438,9 +2438,9 @@ class LoRAConfig:
     `max_loras`."""
     lora_dtype: Union[torch.dtype, LoRADType] = "auto"
     """Data type for LoRA. If auto, will default to base model dtype."""
-    lora_extra_vocab_size: int = 0
+    lora_extra_vocab_size: int = 256
     """(Deprecated) Maximum size of extra vocabulary that can be present in a 
-    LoRA adapter. Set to 0 to disable. Will be removed in v0.12.0."""
+    LoRA adapter. Will be removed in v0.12.0."""
     lora_vocab_padding_size: ClassVar[int] = current_platform\
         .get_lora_vocab_padding_size()
 
@@ -2483,18 +2483,15 @@ class LoRAConfig:
 
     def __post_init__(self):
         # Deprecation warning for lora_extra_vocab_size
-        if self.lora_extra_vocab_size != 0:
-            logger.warning(
-                "`lora_extra_vocab_size` is deprecated and will be removed "
-                "in v0.12.0. Additional vocabulary support for "
-                "LoRA adapters is being phased out."
-            )
-        
+        logger.warning(
+            "`lora_extra_vocab_size` is deprecated and will be removed "
+            "in v0.12.0. Additional vocabulary support for "
+            "LoRA adapters is being phased out.")
+
         # Setting the maximum rank to 512 should be able to satisfy the vast
         # majority of applications.
         possible_max_ranks = (8, 16, 32, 64, 128, 256, 320, 512)
-        # Include 0 to allow users to disable the deprecated feature
-        possible_lora_extra_vocab_size = (0, 256, 512)
+        possible_lora_extra_vocab_size = (256, 512)
         if self.max_lora_rank not in possible_max_ranks:
             raise ValueError(
                 f"max_lora_rank ({self.max_lora_rank}) must be one of "

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -2439,8 +2439,8 @@ class LoRAConfig:
     lora_dtype: Union[torch.dtype, LoRADType] = "auto"
     """Data type for LoRA. If auto, will default to base model dtype."""
     lora_extra_vocab_size: int = 0
-    """(Deprecating) Maximum size of extra vocabulary that can be present in a 
-    LoRA adapter. Set to 0 to disable. Will be removed in a future release."""
+    """(Deprecated) Maximum size of extra vocabulary that can be present in a 
+    LoRA adapter. Set to 0 to disable. Will be removed in v0.12.0."""
     lora_vocab_padding_size: ClassVar[int] = current_platform\
         .get_lora_vocab_padding_size()
 
@@ -2486,7 +2486,7 @@ class LoRAConfig:
         if self.lora_extra_vocab_size != 0:
             logger.warning(
                 "`lora_extra_vocab_size` is deprecated and will be removed "
-                "in a future release. Additional vocabulary support for "
+                "in v0.12.0. Additional vocabulary support for "
                 "LoRA adapters is being phased out."
             )
         


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Add deprecation warning for `lora_extra_vocab_size` parameter as suggested in PR #23540. This is a gentler approach than immediate removal, giving users time to adapt their code.

Related to: #23474

## Test Plan

Test that the deprecation warning appears when using LoRA with non-zero `lora_extra_vocab_size`:

```python
from vllm.config import LoRAConfig
config = LoRAConfig()
config = LoRAConfig(lora_extra_vocab_size=256)
```

## Test Result

```
>>> from vllm.config import LoRAConfig
INFO 08-26 16:37:46 [__init__.py:241] Automatically detected platform cuda.
>>> config = LoRAConfig()
WARNING 08-26 16:38:01 [__init__.py:2502] `lora_extra_vocab_size` is deprecated and will be removed in a future release. Additional vocabulary support for LoRA adapters is being phased out.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

