### PR TITLE
Add user agent to HTTP calls initiated with requests globally

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from huggingface_hub import snapshot_download
 from PIL import Image
+from requests import utils as request_utils
 from transformers import (AutoConfig, AutoModelForCausalLM, AutoTokenizer,
                           BatchEncoding, BatchFeature)
 from transformers.models.auto.auto_factory import _BaseAutoModelClass
@@ -1218,3 +1219,14 @@ def cli_config_file():
 def cli_config_file_with_model():
     """Return the path to the CLI config file with model."""
     return os.path.join(_TEST_DIR, "config", "test_config_with_model.yaml")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_user_agent():
+    """
+    Set user agent in conformance with wikimedia policy
+    to avoid 403 errors (see https://w.wiki/4wJS)
+    """
+
+    request_utils.default_user_agent = \
+            lambda: 'vLLM tests (https://github.com/vllm-project/vllm)'


### PR DESCRIPTION
Wikimedia is now blocking requests which don't have a User agent set. This affects all CI tests that download images and other media from wikimedia such as `entrypoints/openai/test_vision.py::test_single_chat_session_image[https://upload.wikimedia.org/wikipedia/commons/0/0b/RGBA_comp.png-microsoft/Phi-3.5-vision-instruct]`

The error shows up in the CI logs as 

```
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x7f2f60538c20>
```

Because the response is actually the text below with a 403 status instead of an image byte stream:

```
'Please set a user-agent and respect our robot policy https://w.wiki/4wJS. See also T400119.\n'
```

This PR sets the User Agent globally identifying the agent as the vLLM tests and adding contect information.