### PR TITLE
fix(chat): prevent GLM-4.5V infinite repetition with n > 1 completions

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -774,6 +774,11 @@ class LLM:
         )
         _chat_template_kwargs.update(chat_template_kwargs or {})
 
+        # NOTE: Prevent infinite repetition in thinking models
+        # Remove enable_thinking=False to avoid dummy thinking tokens
+        if (_chat_template_kwargs.get('enable_thinking') is False):
+            _chat_template_kwargs.pop('enable_thinking', None)
+
         prompts: list[Union[TokensPrompt, TextPrompt]] = []
 
         for msgs in list_of_messages:

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -882,6 +882,11 @@ class OpenAIServing:
         )
         _chat_template_kwargs.update(chat_template_kwargs or {})
 
+        # NOTE: Prevent infinite repetition in thinking models
+        # Remove enable_thinking=False to avoid dummy thinking tokens
+        if (_chat_template_kwargs.get('enable_thinking') is False):
+            _chat_template_kwargs.pop('enable_thinking', None)
+
         request_prompt: Union[str, list[int]]
 
         if tokenizer is None:


### PR DESCRIPTION
Remove enable_thinking=False parameter to prevent dummy <think></think> tokens that cause infinite loops in GLM-4.5V when generating multiple completions. Unified fix logic across harmony and standard paths.

FIX #23438
FIX #23251