### PR TITLE
[Bugfix] Use mk.prepare_finalize.topk_indices_dtype() in profile_modular_kernel

### DIFF
--- a/tests/kernels/moe/modular_kernel_tools/profile_modular_kernel.py
+++ b/tests/kernels/moe/modular_kernel_tools/profile_modular_kernel.py
@@ -59,7 +59,7 @@ def profile_modular_kernel(
         "w1": rank_weights.w1,
         "w2": rank_weights.w2,
         "topk_weights": rank_tensors.topk_weights,
-        "topk_ids": rank_tensors.topk_ids,
+        "topk_ids": rank_tensors.topk_ids.to(mk.prepare_finalize.topk_indices_dtype()),
         "expert_map": rank_tensors.expert_map,
         "w1_scale": rank_weights.w1_scale,
         "w2_scale": rank_weights.w2_scale,


### PR DESCRIPTION

## Purpose
I'm experimenting with combinations of moe kernels using `profile_modular_kernel.py`, and I'm getting an error in the `DeepEP` `topk_ids` dtype.
Other code matches the dtype, but it's missing here, so I'm adding it.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
