### PR TITLE
[ROCm][FEAT] Integrate AITER tgemm.

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Optional
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils import direct_register_custom_op
+
+
+def rocm_aiter_tuned_gemm_impl(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+        out_dtype: Optional[torch.dtype] = None,
+        scale_a: Optional[torch.Tensor] = None,
+        scale_b: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+    # This AITER function can be used for
+    # - BF16 and FP16 matmul
+    #   e.g. vllm/model_executor/layers/linear.py
+    # - per-tensor activations + per-tensor weights
+    #   e.g. vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+    from aiter.tuned_gemm import tgemm as aiter_tgemm
+
+    return aiter_tgemm.mm(input,
+                          weight,
+                          otype=out_dtype,
+                          scale_a=scale_a,
+                          scale_b=scale_b,
+                          bias=bias)
+
+
+def rocm_aiter_tuned_gemm_fake(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+        out_dtype: Optional[torch.dtype] = None,
+        scale_a: Optional[torch.Tensor] = None,
+        scale_b: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+    m = input.shape[0]
+    n = weight.shape[0]
+    if out_dtype is None:
+        out_dtype = input.dtype
+    return torch.empty((m, n), dtype=out_dtype, device=input.device)
+
+
+if current_platform.is_rocm():
+    direct_register_custom_op(
+        op_name="rocm_aiter_tuned_gemm",
+        op_func=rocm_aiter_tuned_gemm_impl,
+        mutates_args=[],
+        fake_impl=rocm_aiter_tuned_gemm_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
+
+
+def rocm_aiter_tuned_gemm(
+        input: torch.Tensor,  # [M, K]
+        weight: torch.Tensor,  # [N, K]
+        bias: Optional[torch.Tensor] = None,
+        out_dtype: Optional[torch.dtype] = None,
+        scale_a: Optional[torch.Tensor] = None,
+        scale_b: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+    return torch.ops.vllm.rocm_aiter_tuned_gemm(
+        input,
+        weight,
+        bias=bias,
+        out_dtype=out_dtype,
+        scale_a=scale_a,
+        scale_b=scale_b,
+    )

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -74,7 +74,7 @@ def _rocm_aiter_tuned_gemm_fake(
 _OPS_REGISTERED = False
 
 
-class AiterOps:
+class aiter_ops:
     _IS_AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
 
     @classmethod
@@ -117,4 +117,4 @@ class AiterOps:
         )
 
 
-AiterOps.register_ops_once()
+aiter_ops.register_ops_once()

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -185,6 +185,10 @@ class LinearMethodBase(QuantizeMethodBase):
 class UnquantizedLinearMethod(LinearMethodBase):
     """Linear method without quantization."""
 
+    def __init__(self):
+        super().__init__()
+        self._gemm_func = dispatch_unquantized_gemm()
+
     def create_weights(self, layer: torch.nn.Module,
                        input_size_per_partition: int,
                        output_partition_sizes: list[int], input_size: int,
@@ -224,7 +228,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
-        return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+        return self._gemm_func(x, layer.weight, bias)
 
 
 class LinearBase(CustomOp):

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -228,7 +228,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
-        return self._gemm_func(x, layer.weight, bias)
+        return self._gemm_func(layer, x, layer.weight, bias)
 
 
 class LinearBase(CustomOp):

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -336,7 +336,7 @@ class Fp8LinearOp:
 
         # AITER is only supported on ROCm and only for FP8_FNUZ
         # and at the moment are MI300 series
-        self.use_aiter_and_is_supported = (current_platform.is_rocm()
+        self.use_aiter_and_is_supported = (aiter_ops.is_aiter_supported()
                                            and envs.VLLM_ROCM_USE_AITER
                                            and envs.VLLM_ROCM_USE_AITER_LINEAR
                                            and current_platform.is_fp8_fnuz())

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -8,7 +8,7 @@ from packaging import version
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
-from vllm._aiter_ops import AiterOps
+from vllm._aiter_ops import aiter_ops
 from vllm.config import CompilationLevel, get_current_vllm_config
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -166,12 +166,12 @@ def rocm_aiter_per_tensor_w8a8_scaled_mm(qinput: torch.Tensor,
                                          input_2d: torch.Tensor,
                                          output_shape: list) -> torch.Tensor:
 
-    output = AiterOps.rocm_aiter_tuned_gemm(qinput,
-                                            weight.t(),
-                                            out_dtype=out_dtype,
-                                            scale_a=scale_a,
-                                            scale_b=scale_b,
-                                            bias=bias)
+    output = aiter_ops.rocm_aiter_tuned_gemm(qinput,
+                                             weight.t(),
+                                             out_dtype=out_dtype,
+                                             scale_a=scale_a,
+                                             scale_b=scale_b,
+                                             bias=bias)
 
     return torch.narrow(output, 0, 0, input_2d.shape[0]).view(*output_shape)
 
@@ -336,7 +336,7 @@ class Fp8LinearOp:
 
         # AITER is only supported on ROCm and only for FP8_FNUZ
         # and at the moment are MI300 series
-        self.use_aiter_and_is_supported = (AiterOps.is_linear_enabled()
+        self.use_aiter_and_is_supported = (aiter_ops.is_linear_enabled()
                                            and current_platform.is_fp8_fnuz())
 
         # Note: we pad the input because torch._scaled_mm is more performant

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -294,9 +294,10 @@ def torch_channelwise_w8a8_scaled_mm(qinput: torch.Tensor,
 
 
 def dispatch_w8a8_scaled_mm(
-        cutlass_fp8_supported: bool, use_aiter_and_is_supported: bool,
-        per_tensor_weights: bool, per_tensor_activations: bool,
-        use_per_token_if_dynamic: Optional[bool]
+    cutlass_fp8_supported: bool,
+    use_aiter_and_is_supported: bool,
+    per_tensor_weights: bool,
+    per_tensor_activations: bool,
 ) -> Callable[..., torch.Tensor]:
 
     # cutlass_scaled_mm supports per tensor/channel W and per tensor/token A

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -6,9 +6,9 @@ from typing import Callable, Optional, Union
 import torch
 from packaging import version
 
-import vllm._aiter_ops as aiter_ops
 import vllm.envs as envs
 from vllm import _custom_ops as ops
+from vllm._aiter_ops import AiterOps
 from vllm.config import CompilationLevel, get_current_vllm_config
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -166,12 +166,12 @@ def rocm_aiter_per_tensor_w8a8_scaled_mm(qinput: torch.Tensor,
                                          input_2d: torch.Tensor,
                                          output_shape: list) -> torch.Tensor:
 
-    output = aiter_ops.rocm_aiter_tuned_gemm(qinput,
-                                             weight.t(),
-                                             out_dtype=out_dtype,
-                                             scale_a=scale_a,
-                                             scale_b=scale_b,
-                                             bias=bias)
+    output = AiterOps.rocm_aiter_tuned_gemm(qinput,
+                                            weight.t(),
+                                            out_dtype=out_dtype,
+                                            scale_a=scale_a,
+                                            scale_b=scale_b,
+                                            bias=bias)
 
     return torch.narrow(output, 0, 0, input_2d.shape[0]).view(*output_shape)
 
@@ -336,9 +336,7 @@ class Fp8LinearOp:
 
         # AITER is only supported on ROCm and only for FP8_FNUZ
         # and at the moment are MI300 series
-        self.use_aiter_and_is_supported = (aiter_ops.is_aiter_supported()
-                                           and envs.VLLM_ROCM_USE_AITER
-                                           and envs.VLLM_ROCM_USE_AITER_LINEAR
+        self.use_aiter_and_is_supported = (AiterOps.is_linear_enabled()
                                            and current_platform.is_fp8_fnuz())
 
         # Note: we pad the input because torch._scaled_mm is more performant

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -5,9 +5,9 @@ from typing import Callable, Optional
 
 import torch
 
-import vllm._aiter_ops as aiter_ops
 import vllm.envs as envs
 from vllm import _custom_ops as ops
+from vllm._aiter_ops import AiterOps
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
 
@@ -163,12 +163,11 @@ def rocm_aiter_unquantized_gemm(layer: torch.nn.Module,
                                 x: torch.Tensor,
                                 weight: torch.Tensor,
                                 bias: Optional[torch.Tensor] = None):
-    return aiter_ops.rocm_aiter_tuned_gemm(x, weight, bias)
+    return AiterOps.rocm_aiter_tuned_gemm(x, weight, bias)
 
 
 def dispatch_unquantized_gemm() -> Callable[..., torch.Tensor]:
-    if (aiter_ops.is_aiter_supported() and envs.VLLM_ROCM_USE_AITER
-            and envs.VLLM_ROCM_USE_AITER_LINEAR):
+    if (AiterOps.is_linear_enabled()):
         return rocm_aiter_unquantized_gemm
     if current_platform.is_rocm():
         return rocm_unquantized_gemm

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -166,9 +166,7 @@ def rocm_aiter_unquantized_gemm(layer: torch.nn.Module,
     return aiter_ops.rocm_aiter_tuned_gemm(x, weight, bias)
 
 
-def dispatch_unquantized_gemm() -> Callable[
-    [torch.nn.Module, torch.Tensor, torch.Tensor, Optional[torch.Tensor]],
-    torch.Tensor]:
+def dispatch_unquantized_gemm() -> Callable[..., torch.Tensor]:
     if (aiter_ops.is_aiter_supported() and envs.VLLM_ROCM_USE_AITER
             and envs.VLLM_ROCM_USE_AITER_LINEAR):
         return rocm_aiter_unquantized_gemm

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -7,7 +7,7 @@ import torch
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
-from vllm._aiter_ops import AiterOps
+from vllm._aiter_ops import aiter_ops
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
 
@@ -163,11 +163,11 @@ def rocm_aiter_unquantized_gemm(layer: torch.nn.Module,
                                 x: torch.Tensor,
                                 weight: torch.Tensor,
                                 bias: Optional[torch.Tensor] = None):
-    return AiterOps.rocm_aiter_tuned_gemm(x, weight, bias)
+    return aiter_ops.rocm_aiter_tuned_gemm(x, weight, bias)
 
 
 def dispatch_unquantized_gemm() -> Callable[..., torch.Tensor]:
-    if (AiterOps.is_linear_enabled()):
+    if (aiter_ops.is_linear_enabled()):
         return rocm_aiter_unquantized_gemm
     if current_platform.is_rocm():
         return rocm_unquantized_gemm

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -116,8 +116,8 @@ def rocm_unquantized_gemm(layer: torch.nn.Module,
     from vllm.platforms.rocm import on_gfx9
     ON_MI300 = on_gfx9()
     use_skinny = envs.VLLM_ROCM_USE_SKINNY_GEMM and ON_MI300
-    use_aiter = (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_LINEAR
-                 and ON_MI300)
+    use_aiter = (aiter_ops.is_aiter_supported() and envs.VLLM_ROCM_USE_AITER
+                 and envs.VLLM_ROCM_USE_AITER_LINEAR)
 
     k = weight.shape[1]
     _use_skinny = (use_skinny and \


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR integrates aiter tgemm kernel that support bfloat16, float16, and fp8 data types, resulting in improved model performance.

This PR also introduces `_aiter_ops.py` as proposed in the [RFC here](https://github.com/vllm-project/vllm/issues/21504). The `aiter_ops` namespace provides several key benefits:

- Centralized kernel registration: Ensures that kernels from the aiter package are properly registered

- Environment availability checks: Encapsulates aiter support detection and environment compatibility validation

- Reduced code duplication: Eliminates the need for duplicate helper functions across different vLLM modules

This implementation establishes the foundation for future refactoring efforts, where existing kernels throughout the vLLM repository will be migrated to use this unified approach for better maintainability and consistency.

This PR uses [7aa65b6](https://github.com/ROCm/aiter/commit/7aa65b60138251464e2bf56acc61c82e99b74db3) commit from `aiter` repo.

Benchmark Results


### meta-llama/Llama-3.3-70B-Instruct tp2

| Metric                    | With AITER tgemm | With AITER tuned tgemm | Without AITER tgemm |
|---------------------------|:----------------:|:----------------------:|:-------------------:|
| Request Throughput (req/s)| 1.25             | 1.24                   | 1.25                |
| Output Token Thpt (tok/s) | 696.23           | 706.41                 | 701.09              |
| Total Token Thpt (tok/s)  | 1939.97          | 1944.30                | 1953.18             |
| Mean TTFT (ms)            | 457.92           | 461.52                 | 448.17              |
| Median TTFT (ms)          | 290.64           | 289.67                 | 289.39              |
| P99 TTFT (ms)             | 5261.99          | 4960.19                | 5408.76             |
| Mean TPOT (ms)            | 44.80            | 44.71                  | 45.90               |
| Median TPOT (ms)          | 44.52            | 44.10                  | 44.13               |
| P99 TPOT (ms)             | 63.25            | 70.00                  | 66.27               |
| Mean ITL (ms)             | 44.43            | 43.81                  | 44.10               |
| Median ITL (ms)           | 32.39            | 31.99                  | 32.11               |
| P99 ITL (ms)              | 260.39           | 259.57                 | 259.04              |


### amd/Llama-3.3-70B-Instruct-FP8-KV tp2

| Metric                    | With AITER tgemm | With AITER tuned tgemm | Without AITER tgemm |
|---------------------------|:----------------:|:----------------------:|:-------------------:|
| Request Throughput (req/s)| 1.77             | 1.78                   | 1.80                |
| Output Token Thpt (tok/s) | 994.62           | 980.54                 | 986.99              |
| Total Token Thpt (tok/s)  | 2763.94          | 2752.32                | 2779.85             |
| Mean TTFT (ms)            | 350.12           | 344.54                 | 337.96              |
| Median TTFT (ms)          | 215.54           | 215.35                 | 215.35              |
| P99 TTFT (ms)             | 3683.01          | 3631.55                | 3827.46             |
| Mean TPOT (ms)            | 32.93            | 33.62                  | 32.22               |
| Median TPOT (ms)          | 31.05            | 31.53                  | 31.41               |
| P99 TPOT (ms)             | 50.99            | 58.38                  | 56.30               |
| Mean ITL (ms)             | 31.03            | 31.44                  | 31.24               |
| Median ITL (ms)           | 21.97            | 22.28                  | 21.96               |
| P99 ITL (ms)              | 195.56           | 194.72                 | 195.24              |


**benchmark setting**

`
python vllm/benchmarks/benchmark_serving.py
--backend vllm
--model "$model_name"
--dataset-name random
--num-prompts 1000
--max-concurrency 32
--random-input-len 1000
--random-output-len 1000 `

**AITER tgemm tuning guide**
 
 1. Run vllm serve command with `AITER_TUNE_GEMM=1` environment flag:
    Example:

        `VLLM_USE_V1=1 \
         VLLM_ROCM_USE_AITER=1 \
         AITER_TUNE_GEMM=1 \
         vllm serve meta-llama/Llama-3.3-70B-Instruct \
         --tensor-parallel-size 2 \
         --disable-log-requests \
         --trust-remote-code \
         --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE", "cudagraph_capture_sizes": [1,2,4,8,16,24,32]}'`
    
    The above command will record the requested shapes based on cudagraph_capture_sizes into `aiter/configs/untuned_gemm.csv` in the directory where you have installed/cloned the `aiter` package/repo.

  2. Run `python3 gradlib/gradlib/gemm_tuner.py --tuned_file aiter/configs/tuned_gemm.csv  --input_file aiter/configs/untuned_gemm.csv` in the directory where `aiter` package exists.

  for more instruction, follow the [documentation here](https://github.com/ROCm/aiter/tree/main/gradlib). 


## Test Plan

Test models that are afftected by this change, using lm_eval on gsm8k dataset.

**environment setting**

Step 1: run vllm serve

`VLLM_USE_V1=1
VLLM_ROCM_USE_AITER=1
vllm serve $MODEL_NAME --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE", "cudagraph_capture_sizes": [1,2,4,8,16,24,32]}' -tp 2 --trust-remote-code --swap-space 16 --distributed-executor-backend mp`

Step 2: run lm_eval

`lm_eval --model local-completions
--tasks gsm8k
--model_args model=$MODEL_NAME,base_url=http://localhost:8000/v1/completions
--trust_remote_code
--num_fewshot 5
--batch_size 256`


## Test Results

### meta-llama/Llama-3.3-70B-Instruct tp2

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9356|±  |0.0068|
|     |       |strict-match    |     5|exact_match|↑  |0.9083|±  |0.0080|

### amd/Llama-3.3-70B-Instruct-FP8-KV tp2

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9378|±  |0.0067|
|     |       |strict-match    |     5|exact_match|↑  |0.8984|±  |0.0083|
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

