### PR TITLE
Only run `get_attr_docs` if generating help text

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -154,7 +154,8 @@ def is_online_quantization(quantization: Any) -> bool:
 
 @functools.lru_cache(maxsize=30)
 def _compute_kwargs(cls: ConfigType) -> dict[str, Any]:
-    cls_docs = get_attr_docs(cls)
+    # Save time only getting attr docs if we're generating help text
+    cls_docs = get_attr_docs(cls) if "--help" in (sys.argv) else {}
     kwargs = {}
     for field in fields(cls):
         # Get the set of possible types for the field
@@ -172,7 +173,7 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, Any]:
 
         # Get the help text for the field
         name = field.name
-        help = cls_docs[name].strip()
+        help = cls_docs.get(name, "").strip()
         # Escape % for argparse
         help = help.replace("%", "%%")
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -152,7 +152,11 @@ def is_online_quantization(quantization: Any) -> bool:
     return quantization in ["inc"]
 
 
-NEEDS_HELP = "--help" in sys.argv or sys.argv[0].endswith("mkdocs")
+NEEDS_HELP = (
+    "--help" in sys.argv  # vllm SUBCOMMAND --help
+    or "mkdocs" in sys.orig_argv[:3]  # python -m mkdocs SUBCOMMAND
+    or sys.argv[0].endswith("mkdocs")  # mkdocs SUBCOMMAND
+)
 
 
 @functools.lru_cache(maxsize=30)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -152,10 +152,13 @@ def is_online_quantization(quantization: Any) -> bool:
     return quantization in ["inc"]
 
 
+NEEDS_HELP = "--help" in sys.argv or sys.argv[0].endswith("mkdocs")
+
+
 @functools.lru_cache(maxsize=30)
 def _compute_kwargs(cls: ConfigType) -> dict[str, Any]:
     # Save time only getting attr docs if we're generating help text
-    cls_docs = get_attr_docs(cls) if "--help" in (sys.argv) else {}
+    cls_docs = get_attr_docs(cls) if NEEDS_HELP else {}
     kwargs = {}
     for field in fields(cls):
         # Get the set of possible types for the field
@@ -254,6 +257,9 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, Any]:
 
 def get_kwargs(cls: ConfigType) -> dict[str, Any]:
     """Return argparse kwargs for the given Config dataclass.
+
+    If `--help` or `mkdocs` are not present in the command line command, the
+    attribute documentation will not be included in the help output.
 
     The heavy computation is cached via functools.lru_cache, and a deep copy
     is returned so callers can mutate the dictionary without affecting the

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -153,9 +153,9 @@ def is_online_quantization(quantization: Any) -> bool:
 
 
 NEEDS_HELP = (
-    "--help" in sys.argv  # vllm SUBCOMMAND --help
-    or "mkdocs" in sys.orig_argv[:3]  # python -m mkdocs SUBCOMMAND
-    or sys.argv[0].endswith("mkdocs")  # mkdocs SUBCOMMAND
+    "--help" in (argv := sys.argv)  # vllm SUBCOMMAND --help
+    or (argv0 := argv[0]).endswith("mkdocs")  # mkdocs SUBCOMMAND
+    or argv0.endswith("mkdocs/__main__.py")  # python -m mkdocs SUBCOMMAND
 )
 
 


### PR DESCRIPTION
The docstrings for config class attributes are only actually needed if we're generating `--help` text or documentation. 

This saves 235ms on my machine by completely eliminating the cost of extracting the docstrings on start up.

---

```console
$ vllm serve --help
INFO 08-27 10:36:28 [__init__.py:241] Automatically detected platform cuda.
INFO 08-27 10:36:30 [arg_utils.py:165] Computed kwargs for FrontendArgs in 0.0038s (cumulative: 0.0038s)
INFO 08-27 10:36:30 [arg_utils.py:165] Computed kwargs for ModelConfig in 0.0383s (cumulative: 0.0421s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for LoadConfig in 0.0263s (cumulative: 0.0684s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for DecodingConfig in 0.0302s (cumulative: 0.0985s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for ParallelConfig in 0.0061s (cumulative: 0.1046s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for CacheConfig in 0.0032s (cumulative: 0.1078s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for MultiModalConfig in 0.0284s (cumulative: 0.1362s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for LoRAConfig in 0.0283s (cumulative: 0.1645s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for ObservabilityConfig in 0.0302s (cumulative: 0.1947s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for SchedulerConfig in 0.0034s (cumulative: 0.1980s)
INFO 08-27 10:36:31 [arg_utils.py:165] Computed kwargs for VllmConfig in 0.0370s (cumulative: 0.2350s)
...
```

```console
$ vllm serve 
INFO 08-27 10:36:57 [__init__.py:241] Automatically detected platform cuda.
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for FrontendArgs in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for ModelConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for LoadConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for DecodingConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for ParallelConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for CacheConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for MultiModalConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for LoRAConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for ObservabilityConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for SchedulerConfig in 0.0000s (cumulative: 0.0000s)
INFO 08-27 10:37:00 [arg_utils.py:165] Computed kwargs for VllmConfig in 0.0000s (cumulative: 0.0000s)
...
```