### PR TITLE
[Docs] Fix an admonition important

### DIFF
--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -164,7 +164,7 @@ llm = LLM(
 )
 ```
 
-!! important
+!!! important
     Batch-level DP is not to be confused with API request-level DP
     (which is instead controlled by `data_parallel_size`).
 


### PR DESCRIPTION
Only add a `!` to adapt the MkDocs style of an `important` admonition.