### PR TITLE
[Bugfix] when nixl port by bind, process cannot stop

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3536,3 +3536,22 @@ def set_env_var(key, value):
             del os.environ[key]
         else:
             os.environ[key] = old
+
+
+def is_port_available(host: str = "127.0.0.1", port: int = 8000) -> bool:
+    """Checks if a port is available for binding on the given host."""
+    try:
+        address_family = socket.AF_INET
+        if is_valid_ipv6_address(host):
+            address_family = socket.AF_INET6
+        with socket.socket(address_family, socket.SOCK_STREAM) as sock:
+            sock.bind((host, port))
+            return True
+    except OSError as e:
+        logger.error("Port %s:%s is already in " \
+        "use or cannot be bound: %s", host, port, e)
+        return False
+    except Exception as e:
+        logger.error("An unexpected error occurred " \
+        "while checking port %s:%s: %s", host, port, e)
+        return False


### PR DESCRIPTION

## Purpose

## Test Plan

Current nixi default bind port is `5557`, if this port having bind,  this thread exec `_nixl_handshake_listener`  method faild, but process canot auto stop.

So we should in use before, to check this port whether by bind.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

