### PR TITLE
[ci] breaks down V1 Test into 3 groups of approx 30 minutes runtime

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -234,7 +234,7 @@ steps:
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization
 
-- label: Test e2e + v1/engine
+- label: Test e2e + engine
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -234,7 +234,7 @@ steps:
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization
 
-- label: V1 Test v1/e2e
+- label: V1 Test e2e
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -244,7 +244,7 @@ steps:
     # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
     - pytest -v -s v1/e2e
 
-- label: V1 Test v1/entrypoints
+- label: V1 Test entrypoints
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -252,7 +252,7 @@ steps:
   commands:
     - pytest -v -s v1/entrypoints
 
-- label: V1 Test (others)
+- label: V1 Test others
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -234,7 +234,25 @@ steps:
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization
 
-- label: V1 Test
+- label: V1 Test v1/e2e
+  mirror_hardwares: [amdexperimental]
+  source_file_dependencies:
+    - vllm/
+    - tests/v1
+  commands:
+    # TODO: accuracy does not match, whether setting
+    # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
+    - pytest -v -s v1/e2e
+
+- label: V1 Test v1/entrypoints
+  mirror_hardwares: [amdexperimental]
+  source_file_dependencies:
+    - vllm/
+    - tests/v1
+  commands:
+    - pytest -v -s v1/entrypoints
+
+- label: V1 Test (others)
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -243,7 +261,6 @@ steps:
     # split the test to avoid interference
     - pytest -v -s v1/core
     - pytest -v -s v1/engine
-    - pytest -v -s v1/entrypoints
     - pytest -v -s v1/executor
     - pytest -v -s v1/sample
     - pytest -v -s v1/logits_processors
@@ -256,9 +273,6 @@ steps:
     - pytest -v -s v1/test_utils.py
     - pytest -v -s v1/test_oracle.py
     - pytest -v -s v1/test_metrics_reader.py
-    # TODO: accuracy does not match, whether setting
-    # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
-    - pytest -v -s v1/e2e
     # Integration test for streaming correctness (requires special branch).
     - pip install -U git+https://github.com/robertgshaw2-redhat/lm-evaluation-harness.git@streaming-api
     - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -234,7 +234,7 @@ steps:
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization
 
-- label: V1 Test e2e
+- label: Test e2e + v1/engine
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -243,8 +243,9 @@ steps:
     # TODO: accuracy does not match, whether setting
     # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
     - pytest -v -s v1/e2e
+    - pytest -v -s v1/engine
 
-- label: V1 Test entrypoints
+- label: Test entrypoints
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -252,7 +253,7 @@ steps:
   commands:
     - pytest -v -s v1/entrypoints
 
-- label: V1 Test others
+- label: Test others
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -260,7 +261,6 @@ steps:
   commands:
     # split the test to avoid interference
     - pytest -v -s v1/core
-    - pytest -v -s v1/engine
     - pytest -v -s v1/executor
     - pytest -v -s v1/sample
     - pytest -v -s v1/logits_processors

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -234,7 +234,7 @@ steps:
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization
 
-- label: Test V1 e2e + engine
+- label: V1 Test e2e + engine
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -245,7 +245,7 @@ steps:
     - pytest -v -s v1/e2e
     - pytest -v -s v1/engine
 
-- label: Test V1 entrypoints
+- label: V1 Test entrypoints
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -253,7 +253,7 @@ steps:
   commands:
     - pytest -v -s v1/entrypoints
 
-- label: Test V1 others
+- label: V1 Test others
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -234,7 +234,7 @@ steps:
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization
 
-- label: Test e2e + engine
+- label: Test V1 e2e + engine
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -245,7 +245,7 @@ steps:
     - pytest -v -s v1/e2e
     - pytest -v -s v1/engine
 
-- label: Test entrypoints
+- label: Test V1 entrypoints
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/
@@ -253,7 +253,7 @@ steps:
   commands:
     - pytest -v -s v1/entrypoints
 
-- label: Test others
+- label: Test V1 others
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/


### PR DESCRIPTION
This PR is part of the CI sprint initiative, with the goal of reduce CI latency for tests.

This is following the first step from https://github.com/vllm-project/vllm/issues/23668

It breaks down 'V1 Tests' in 3 groups, this is based on the analysis of the wallclock for test runs:
```
[2025-08-27T02:20:48Z] + pytest -v -s v1/core - 00:03 
[2025-08-27T02:23:19Z] + pytest -v -s v1/engine - 00:13
[2025-08-27T02:36:32Z] + pytest -v -s v1/entrypoints - 00:36
[2025-08-27T03:04:35Z] + pytest -v -s v1/executor - 00:02
[2025-08-27T03:06:21Z] + pytest -v -s v1/sample - 00:07
[2025-08-27T03:13:35Z] + pytest -v -s v1/logits_processors - 00:05
[2025-08-27T03:18:39Z] + pytest -v -s v1/worker - 00:01
[2025-08-27T03:19:29Z] + pytest -v -s v1/structured_output - 00:00
[2025-08-27T03:19:44Z] + pytest -v -s v1/spec_decode - 00:08
[2025-08-27T03:27:46Z] + pytest -v -s v1/kv_connector/unit - 00:04
[2025-08-27T03:31:17Z] + pytest -v -s v1/metrics - 00:01
[2025-08-27T03:32:25Z] + pytest -v -s v1/test_serial_utils.py - 00:00
[2025-08-27T03:32:39Z] + pytest -v -s v1/test_utils.py - 00:00
[2025-08-27T03:32:56Z] + pytest -v -s v1/test_oracle.py - 00:03
[2025-08-27T03:35:06Z] + pytest -v -s v1/test_metrics_reader.py - 00:00
# TODO: accuracy does not match, whether setting
# VLLM_USE_FLASHINFER_SAMPLER or not on H100.
[2025-08-27T03:35:20Z] + pytest -v -s v1/e2e - 00:20
# Integration test for streaming correctness (requires special branch).
[2025-08-27T03:55:34Z] + pip install -U git+https://github.com/robertgshaw2-redhat/lm-evaluation-harness.git@streaming-api - 00:06
[2025-08-27T03:55:48Z] + pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
[2025-08-27T04:01:13Z] 33m=============================== warnings summary ===============================
```

as a important note, there are 3 outliers: 
* `v1/e2e - 00:20`
* `v1/entrypoints - 00:36`
* `v1/engine - 00:13`

it seems the most efficient approach would be breaking into the following groups:
* 1) `v1/e2e - 00:20`
* 2) `v1/entrypoints - 00:36`
* 3) ...everything else
