### PR TITLE
[Refactor] refactor freezing_value/cuda_event initialize outside try finally

### DIFF
--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -123,8 +123,8 @@ def _torch_cuda_wrapper():
             self.record = lambda: None
             self.synchronize = lambda: None
 
+    cuda_event = torch.cuda.Event
     try:
-        cuda_event = torch.cuda.Event
         torch.cuda.Event = _EventPlaceholder
         yield
     finally:
@@ -136,9 +136,9 @@ def _set_global_compilation_settings(config: VllmConfig):
     import torch._inductor.config
 
     inductor_config = config.compilation_config.inductor_compile_config
+    # Note: The MKLDNN and CPPGEMM backend requires freezing parameters.
+    freezing_value = torch._inductor.config.freezing
     try:
-        # Note: The MKLDNN and CPPGEMM backend requires freezing parameters.
-        freezing_value = torch._inductor.config.freezing
         if inductor_config.get("max_autotune", False):
             torch._inductor.config.freezing = True
         yield


### PR DESCRIPTION

## Purpose
refactor `freezing_value` and `cuda_event` outside try...finally by removing complaining `Local variable 'cuda_event' might be referenced before assignment `
## Test Plan
NA
## Test Result
NA
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

