### PR TITLE
[CI] make all multi-gpu weight loading tests run nightly

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -794,6 +794,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/tests"
   num_gpus: 2
+  optional: true
   source_file_dependencies:
   - vllm/
   - tests/weight_loading


### PR DESCRIPTION
cc @njhill 
## Purpose
Reduce CI time by deferring multi-gpu weightloading tests to nightly. First part of https://github.com/vllm-project/vllm/issues/23669

## Test Plan
n/a

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

