### PR TITLE
Document multi-proc method selection for profiling

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -73,7 +73,7 @@ apt install nsight-systems-cli
 
 ### Example commands and usage
 
-When profiling with `nsys`, it is advisable to set the environment variable `VLLM_WORKER_MULTIPROC_METHOD=spawn`. The default is to use the `fork` method instead of `spawn`, which is [generally not recommended](https://forums.developer.nvidia.com/t/cuda8-0-bug-child-process-forked-after-cuinit-get-cuda-error-not-initialized-on-cuinit/45764).
+When profiling with `nsys`, it is advisable to set the environment variable `VLLM_WORKER_MULTIPROC_METHOD=spawn`. The default is to use the `fork` method instead of `spawn`. More information on the topic can be found in the [Nsight Systems release notes](https://docs.nvidia.com/nsight-systems/ReleaseNotes/index.html#general-issues).
 
 #### Offline Inference
 

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -73,6 +73,8 @@ apt install nsight-systems-cli
 
 ### Example commands and usage
 
+When profiling with `nsys`, it is advisable to set the environment variable `VLLM_WORKER_MULTIPROC_METHOD=spawn`. The default is to use the `fork` method instead of `spawn`, which is [generally not recommended](https://forums.developer.nvidia.com/t/cuda8-0-bug-child-process-forked-after-cuinit-get-cuda-error-not-initialized-on-cuinit/45764).
+
 #### Offline Inference
 
 For basic usage, you can just append `nsys profile -o report.nsys-rep --trace-fork-before-exec=true --cuda-graph-trace=node` before any existing script you would run for offline inference.


### PR DESCRIPTION
I have faced some challenges when attempting to profile vLLM with nsys, mostly:

- Empty profiles
- Partially empty profiles
- Crashes on engine initialization

It seems that selecting `spawn` as the multi-processing method instead of `fork` resolves most of them. This PR adds the corresponding documentation in the profiling guide.