### PR TITLE
[WIP] implement overlap of prepare_input during execute_model

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -159,6 +159,12 @@ class SchedulerConfig:
     structured outputs, speculative decoding, and pipeline parallelism.
     """
 
+    async_execute_model: bool = False
+    """EXPERIMENTAL: If set to True, perform async model execution.
+    This may help reduce the CPU overheads, leading to better latency
+    and throughput. Moreover, this rely on async scheduling.
+    """
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -246,6 +252,10 @@ class SchedulerConfig:
         if self.async_scheduling:
             self.scheduler_cls = (
                 "vllm.v1.core.sched.async_scheduler.AsyncScheduler")
+
+        if self.async_execute_model:
+            assert self.async_scheduling, (
+                "async_execute_model requires async_scheduling to be True.")
 
     @model_validator(mode='after')
     def _verify_args(self) -> Self:

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -38,8 +38,15 @@ USE_SCHED_YIELD = ((sys.version_info[:3] >= (3, 11, 1))
                        and sys.version_info[2] >= 8))
 
 
-def sched_yield():
-    if USE_SCHED_YIELD:
+def sched_yield(sleep_time: Optional[float] = None):
+    # when we set more than one threads in Worker Process,
+    # os.sched_yield() and time.sleep(0) both set the thread to ready state,
+    # but the cpu may reschedule it immediately,
+    # so we add a small sleep time to make sure the thread is set to blocked state,
+    # and the cpu can schedule other threads.
+    if sleep_time is not None:
+        time.sleep(sleep_time)
+    elif USE_SCHED_YIELD:
         os.sched_yield()
     else:
         time.sleep(0)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -445,6 +445,8 @@ class EngineArgs:
 
     async_scheduling: bool = SchedulerConfig.async_scheduling
 
+    async_execute_model: bool = SchedulerConfig.async_execute_model
+
     kv_sharing_fast_prefill: bool = \
         CacheConfig.kv_sharing_fast_prefill
 
@@ -864,6 +866,9 @@ class EngineArgs:
         scheduler_group.add_argument("--async-scheduling",
                                      **scheduler_kwargs["async_scheduling"])
 
+        scheduler_group.add_argument("--async-execute-model",
+                                     **scheduler_kwargs["async_execute_model"])
+
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)
         vllm_group = parser.add_argument_group(
@@ -1253,6 +1258,12 @@ class EngineArgs:
             if self.pipeline_parallel_size > 1:
                 raise ValueError("Async scheduling is not supported with "
                                  "pipeline-parallel-size > 1.")
+
+        if self.async_execute_model:
+            # TODO(Ronald1995): Support async execute model with ray.
+            if self.distributed_executor_backend != "mp":
+                raise ValueError("Async execute model is only supported with "
+                                 "mp-based distributed executor backend.")
 
             # Currently, async scheduling does not support speculative decoding.
             # TODO(woosuk): Support it.

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -121,7 +121,7 @@ class RejectionSampler(nn.Module):
         Returns:
             A list of lists of token IDs.
         """
-        output_token_ids_np = output_token_ids.cpu().numpy()
+        output_token_ids_np = output_token_ids.numpy()
         # Create mask for valid tokens.
         valid_mask = ((output_token_ids_np != PLACEHOLDER_TOKEN_ID) &
                       (output_token_ids_np < vocab_size))


### PR DESCRIPTION

## Purpose
in `execute_model`, it has update_states and prepare_inputs opearations, this PR aims to use multithread to overlap the update_states and prepare_input into gpu to cpu copy operations of sample_token_ids.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

