### PR TITLE
[Model] [gpt-oss] fix gpt-oss pp support

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -668,9 +668,8 @@ class GptOssForCausalLM(nn.Module, SupportsPP):
                 positions: torch.Tensor,
                 intermediate_tensors: Optional[IntermediateTensors] = None,
                 inputs_embeds: Optional[torch.Tensor] = None) -> torch.Tensor:
-        assert intermediate_tensors is None
-        assert inputs_embeds is None
-        return self.model(input_ids, positions)
+        return self.model(input_ids, positions, intermediate_tensors,
+                          inputs_embeds)
 
     def compute_logits(self, hidden_states: torch.Tensor,
                        sampling_metadata: SamplingMetadata) -> torch.Tensor:


### PR DESCRIPTION
## Purpose
when _dummy_run in pp mode, it will trigger assertion fail
```
(VllmWorker PP0 pid=2421081) INFO 08-28 16:45:31 [default_loader.py:267] Loading weights took 1.47 seconds
(VllmWorker PP0 pid=2421081) WARNING 08-28 16:45:31 [marlin_utils_fp4.py:196] Your GPU does not have native support for FP4 computation but FP4 quantization is being used. Weight-only FP4 compression will be used leveraging the Marlin kernel. This may degrade performance for compute-heavy workloads.
(VllmWorker PP1 pid=2421082) INFO 08-28 16:45:31 [default_loader.py:267] Loading weights took 1.60 seconds
(VllmWorker PP1 pid=2421082) WARNING 08-28 16:45:31 [marlin_utils_fp4.py:196] Your GPU does not have native support for FP4 computation but FP4 quantization is being used. Weight-only FP4 compression will be used leveraging the Marlin kernel. This may degrade performance for compute-heavy workloads.
(VllmWorker PP0 pid=2421081) INFO 08-28 16:45:32 [gpu_model_runner.py:1986] Model loading took 7.9493 GiB and 1.784890 seconds
(VllmWorker PP1 pid=2421082) INFO 08-28 16:45:32 [gpu_model_runner.py:1986] Model loading took 7.9493 GiB and 1.940350 seconds
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602] WorkerProc hit an exception.
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602] Traceback (most recent call last):
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/executor/multiproc_executor.py", line 597, in worker_busy_loop
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     output = func(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]              ^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return func(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/worker/gpu_worker.py", line 244, in determine_available_memory
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     self.model_runner.profile_run()
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/worker/gpu_model_runner.py", line 2599, in profile_run
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     = self._dummy_run(self.max_num_tokens, is_profile=True)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return func(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/worker/gpu_model_runner.py", line 2376, in _dummy_run
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     outputs = self.model(
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]               ^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return self._call_impl(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return forward_call(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/model_executor/models/gpt_oss.py", line 671, in forward
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     assert intermediate_tensors is None
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602] AssertionError
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602] Traceback (most recent call last):
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/executor/multiproc_executor.py", line 597, in worker_busy_loop
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     output = func(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]              ^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return func(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/worker/gpu_worker.py", line 244, in determine_available_memory
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     self.model_runner.profile_run()
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/worker/gpu_model_runner.py", line 2599, in profile_run
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     = self._dummy_run(self.max_num_tokens, is_profile=True)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return func(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/v1/worker/gpu_model_runner.py", line 2376, in _dummy_run
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     outputs = self.model(
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]               ^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return self._call_impl(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     return forward_call(*args, **kwargs)
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]   File "/home/zjy/code/vllm-src/vllm/model_executor/models/gpt_oss.py", line 671, in forward
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]     assert intermediate_tensors is None
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker PP1 pid=2421082) ERROR 08-28 16:45:32 [multiproc_executor.py:602] AssertionError
```
## Test Plan
```
vllm serve /data/datasets/models-hf/gpt-oss-20b --served-model-name "gpt-oss-20b" -pp 2

curl http://localhost:8000/v1/completions \
                    -H "Content-Type: application/json" \
                    -d '{
                    "model": "gpt-oss-20b",
                    "prompt": "The future of artificial intelligence is",
                    "max_tokens": 100,
                    "temperature": 0.8,
                    "top_p": 0.9,
                    "stop": ["\n", "###"],
                    "echo": false
                }'
```
## Test Result
```
{"id":"cmpl-0f1e40b63d5c47ab843327ff252e8186","object":"text_completion","created":1756371188,"model":"gpt-oss-20b","choices":[{"index":0,"text":" a topic of much debate and speculation, and it is difficult to predict exactly how AI will evolve in the coming years. However, it is clear that AI has the potential to bring many benefits to society, such as improved healthcare, more efficient transportation, and better decision-making. At the same time, there are also concerns about the potential negative impacts of AI, such as job displacement and the potential for AI to be used for malicious purposes. In order to ensure that the benefits of AI are realized while","logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":6,"total_tokens":106,"completion_tokens":100,"prompt_tokens_details":null},"kv_transfer_params":null}
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

