### PR TITLE
[CI/Build] Ci abort on first failure

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -35,7 +35,7 @@ steps:
   # if this test fails, it means the nightly torch version is not compatible with some
   # of the dependencies. Please check the error message and add the package to whitelist
   # in /vllm/tools/generate_nightly_torch_test.py
-  soft_fail: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - requirements/nightly_torch_test.txt
   commands:
@@ -43,6 +43,7 @@ steps:
 
 - label: Async Engine, Inputs, Utils, Worker Test # 24min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/mq_llm_engine
@@ -65,6 +66,7 @@ steps:
 
 - label: Python-only Installation Test
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - tests/standalone_tests/python_only_compile.sh
   - setup.py
@@ -75,6 +77,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   fast_check: true
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/basic_correctness/test_basic_correctness
@@ -91,6 +94,7 @@ steps:
 - label: Core Test # 10min
   mirror_hardwares: [amdexperimental]
   fast_check: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/core
   - vllm/distributed
@@ -103,6 +107,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   fast_check: true
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/llm
@@ -120,6 +125,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   fast_check: true
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/openai
@@ -134,6 +140,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/tests"
   num_gpus: 4
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/distributed/
   - vllm/core/
@@ -175,6 +182,7 @@ steps:
 
 - label: EPLB Algorithm Test
   working_dir: "/vllm-workspace/tests"
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/distributed/eplb
   - tests/distributed/test_eplb_algo.py
@@ -184,6 +192,7 @@ steps:
 - label: EPLB Execution Test # 5min
   working_dir: "/vllm-workspace/tests"
   num_gpus: 4
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/distributed/eplb
   - tests/distributed/test_eplb_execute.py
@@ -193,6 +202,7 @@ steps:
 - label: Metrics, Tracing Test # 10min
   mirror_hardwares: [amdexperimental]
   num_gpus: 2
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/metrics
@@ -211,6 +221,7 @@ steps:
 
 - label: Regression Test # 5min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/test_regression
@@ -221,6 +232,7 @@ steps:
 
 - label: Engine Test # 10min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/engine
@@ -236,6 +248,7 @@ steps:
 
 - label: V1 Test
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
     - vllm/
     - tests/v1
@@ -266,6 +279,7 @@ steps:
 - label: Examples Test # 25min
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/examples"
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/entrypoints
   - examples/
@@ -290,6 +304,7 @@ steps:
 
 - label: Platform Tests (CUDA)
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/cuda
@@ -298,6 +313,7 @@ steps:
 
 - label: Samplers Test # 36min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/model_executor/layers
   - vllm/sampling_metadata.py
@@ -309,6 +325,7 @@ steps:
 
 - label: LoRA Test %N # 15min each
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/lora
   - tests/lora
@@ -318,6 +335,7 @@ steps:
 - label: PyTorch Compilation Unit Tests
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
     - vllm/
     - tests/compile
@@ -334,6 +352,7 @@ steps:
 - label: PyTorch Fullgraph Smoke Test # 9min
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/compile
@@ -348,6 +367,7 @@ steps:
 - label: PyTorch Fullgraph Test # 18min
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/compile
@@ -356,6 +376,7 @@ steps:
 
 - label: Kernels Core Operation Test
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/
   - tests/kernels/core
@@ -364,6 +385,7 @@ steps:
 
 - label: Kernels Attention Test %N
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/attention/
   - vllm/attention
@@ -375,6 +397,7 @@ steps:
 
 - label: Kernels Quantization Test %N
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/quantization/
   - vllm/model_executor/layers/quantization
@@ -385,6 +408,7 @@ steps:
 
 - label: Kernels MoE Test %N
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/quantization/cutlass_w8a8/moe/
   - csrc/moe/
@@ -397,6 +421,7 @@ steps:
 
 - label: Kernels Mamba Test
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/mamba/
   - tests/kernels/mamba
@@ -405,6 +430,7 @@ steps:
 
 - label: Tensorizer Test # 11min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/model_executor/model_loader
   - tests/tensorizer_loader
@@ -417,6 +443,7 @@ steps:
 
 - label: Model Executor Test
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/model_executor
   - tests/model_executor
@@ -428,6 +455,7 @@ steps:
 - label: Benchmarks # 9min
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/.buildkite"
+  cancel_on_build_failing: true
   source_file_dependencies:
   - benchmarks/
   commands:
@@ -435,6 +463,7 @@ steps:
 
 - label: Benchmarks CLI Test # 10min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/benchmarks/
@@ -443,6 +472,7 @@ steps:
 
 - label: Quantization Test
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization
@@ -455,6 +485,7 @@ steps:
 
 - label: LM Eval Small Models # 53min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization
@@ -463,6 +494,7 @@ steps:
 
 - label: OpenAI API correctness
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/
   - vllm/entrypoints/openai/
@@ -472,6 +504,7 @@ steps:
 
 - label: Encoder Decoder tests # 5min
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/encoder_decoder
@@ -481,6 +514,7 @@ steps:
 - label: OpenAI-Compatible Tool Use # 20 min
   mirror_hardwares: [amdexperimental]
   fast_check: false
+  cancel_on_build_failing: true
   source_file_dependencies:
     - vllm/
     - tests/tool_use
@@ -494,6 +528,7 @@ steps:
 - label: Basic Models Test # 24min
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models
@@ -507,6 +542,7 @@ steps:
 - label: Language Models Test (Standard)
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/language
@@ -517,6 +553,7 @@ steps:
 - label: Language Models Test (Hybrid) # 35 min
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/language/generation
@@ -530,6 +567,7 @@ steps:
 - label: Language Models Test (Extended Generation) # 1hr20min
   mirror_hardwares: [amdexperimental]
   optional: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/language/generation
@@ -541,6 +579,7 @@ steps:
 - label: Language Models Test (Extended Pooling)  # 36min
   mirror_hardwares: [amdexperimental]
   optional: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/language/pooling
@@ -548,6 +587,7 @@ steps:
     - pytest -v -s models/language/pooling -m 'not core_model'
 
 - label: Multi-Modal Processor Test
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -559,6 +599,7 @@ steps:
 - label: Multi-Modal Models Test (Standard)
   mirror_hardwares: [amdexperimental]
   torch_nightly: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -571,6 +612,7 @@ steps:
 - label: Multi-Modal Models Test (Extended) 1
   mirror_hardwares: [amdexperimental]
   optional: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -581,6 +623,7 @@ steps:
 - label: Multi-Modal Models Test (Extended) 2
   mirror_hardwares: [amdexperimental]
   optional: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -591,6 +634,7 @@ steps:
 - label: Multi-Modal Models Test (Extended) 3
   mirror_hardwares: [amdexperimental]
   optional: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -600,6 +644,7 @@ steps:
 
 - label: Quantized Models Test
   mirror_hardwares: [amdexperimental]
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/model_executor/layers/quantization
   - tests/models/quantization
@@ -610,6 +655,7 @@ steps:
 - label: Custom Models Test
   mirror_hardwares: [amdexperimental]
   optional: true
+  cancel_on_build_failing: true
   commands:
     - echo 'Testing custom models...'
     # PR authors can temporarily add commands below to test individual models
@@ -619,6 +665,7 @@ steps:
 - label: Transformers Nightly Models Test
   working_dir: "/vllm-workspace/"
   optional: true
+  cancel_on_build_failing: true
   commands:
     - pip install --upgrade git+https://github.com/huggingface/transformers
     - pytest -v -s tests/models/test_initialization.py
@@ -632,6 +679,7 @@ steps:
   working_dir: "/vllm-workspace/"
   gpu: b200
   # optional: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/quantization/fp4/
   - csrc/attention/mla/
@@ -671,6 +719,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/tests"
   num_gpus: 2
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/distributed
   - tests/distributed
@@ -683,6 +732,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   num_gpus: 2
   num_nodes: 2
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/distributed/
   - vllm/engine/
@@ -706,6 +756,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/tests"
   num_gpus: 2
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/distributed/
   - vllm/engine/
@@ -746,6 +797,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/tests"
   num_gpus: 2
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/plugins/
   - tests/plugins/
@@ -767,6 +819,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/tests"
   num_gpus: 4
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/distributed/
   - vllm/engine/
@@ -780,6 +833,7 @@ steps:
 - label: LoRA TP Test (Distributed)
   mirror_hardwares: [amdexperimental]
   num_gpus: 4
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/lora
   - tests/lora
@@ -798,6 +852,7 @@ steps:
   mirror_hardwares: [amdexperimental]
   working_dir: "/vllm-workspace/tests"
   num_gpus: 2
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/weight_loading
@@ -810,6 +865,7 @@ steps:
   num_gpus: 2
   gpu: a100
   optional: true
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   - tests/weight_loading
@@ -824,6 +880,7 @@ steps:
   gpu: a100
   optional: true
   num_gpus: 4
+  cancel_on_build_failing: true
   source_file_dependencies:
   - vllm/
   commands:
@@ -839,6 +896,7 @@ steps:
   optional: true
   num_gpus: 4
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  cancel_on_build_failing: true
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization
@@ -850,5 +908,6 @@ steps:
   gpu: h200
   optional: true
   num_gpus: 2
+  cancel_on_build_failing: true
   commands:
     - CUDA_VISIBLE_DEVICES=1,2 VLLM_ALL2ALL_BACKEND=deepep_high_throughput VLLM_USE_DEEP_GEMM=1 VLLM_LOGGING_LEVEL=DEBUG python3 /vllm-workspace/examples/offline_inference/data_parallel.py --model Qwen/Qwen1.5-MoE-A2.7B --tp-size=1  --dp-size=2 --max-model-len 2048


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
According to this issue #23453 , we need to abort the CI on first failure as it will free up valuable resources (re-run would be needed regardless). 

To automatically cancel any remaining jobs as soon as any job in the build fails (except jobs marked as soft_fail), I added the `cancel_on_build_failing: true` attribute to the command steps. When a job fails, the build enters a failing state. Any jobs still running that have `cancel_on_build_failing: true` are automatically canceled. Once all running jobs have been cancelled, the build is marked as failed due to the initial job failure.

Check official buildkite documentation here: https://buildkite.com/docs/pipelines/configure/step-types/command-step#fast-fail-running-jobs

## Test Plan
Opening the PR will kick off the test-pipeline. The first failure should abort the entire pipeline and build should be marked as failed due to the initial job failure

## Test Result
TBD - have to let the pipeline run first

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

