### PR TITLE
[Bugfix] support from s3 load model

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -854,10 +854,7 @@ class ModelConfig:
         if is_s3(model):
             s3_model = get_s3()
             s3_model.pull_files(model,
-                                allow_pattern=[
-                                    "*.model", "*.py", "*.json", "*.pt",
-                                    "*.safetensors", "*.bin", "*.tensors"
-                                ])
+                                allow_pattern=["*.model", "*.py", "*.json"])
             self.model_weights = model
             self.model = s3_model.get_model_path(model)
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1053,9 +1053,10 @@ class EngineArgs:
             SpeculatorsConfig)
 
         if self.speculative_config is None:
-            hf_config = get_config(self.hf_config_path or self.model,
-                                   self.trust_remote_code, self.revision,
-                                   self.code_revision, self.config_format)
+            hf_config = get_config(
+                self.hf_config_path or target_model_config.model,
+                self.trust_remote_code, self.revision, self.code_revision,
+                self.config_format)
 
             # if loading a SpeculatorsConfig, load the speculative_config
             # details from the config directly

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -938,6 +938,9 @@ def get_model_path(model: Union[str, Path], revision: Optional[str] = None):
     if os.path.exists(model):
         return model
     assert huggingface_hub.constants.HF_HUB_OFFLINE
+    if isinstance(model, str) and is_s3(model):
+        logger.warning("When from s3 load model, cannot use HF_HUB_OFFLINE")
+        return model
     common_kwargs = {
         "local_files_only": huggingface_hub.constants.HF_HUB_OFFLINE,
         "revision": revision,

--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -175,7 +175,8 @@ class S3Model:
         os.makedirs(local_dir, exist_ok=True)
         if os.path.exists(destination_file):
             return destination_file
-        self.s3.download_file(bucket_name, file_name, destination_file)
+        self.s3.download_file(bucket_name, os.path.join(base_dir, file_name),
+                              destination_file)
         return destination_file
 
     def get_model_path(self, repo_id: str):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix: https://github.com/vllm-project/vllm/issues/23236

When model save s3 store, from s3 load and start.

## Test Plan

1. start a minio, create a bucket, e.g: `models`
2. upload all model file
3.  start vllm
```
export AWS_ENDPOINT_URL=http://172.30.40.185:31181
export AWS_ACCESS_KEY_ID=abc
export AWS_SECRET_ACCESS_KEY=abc
$ vllm serve s3://models/Qwen/Qwen3-0.6B
```

## Test Result

Can success running vllm serve, and send this http requeset.
```
curl -X POST "http://localhost:8000/v1/chat/completions" \
	-H "Content-Type: application/json" \
	--data '{
		"model": "s3://models/Qwen/Qwen3-0.6B",
		"messages": [
			{
				"role": "user",
				"content": "What is the capital of France?"
			}
		]
	}'
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

