### PR TITLE
[Kernels][Nvidia] AOT compilation workflow [1/n]

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -394,6 +394,7 @@ steps:
     - pytest -v -s compile/test_async_tp.py
     - pytest -v -s compile/test_fusion_all_reduce.py
     - pytest -v -s compile/test_decorator.py
+    - pytest -v -s compile/test_aot_compile.py
 
 - label: PyTorch Fullgraph Smoke Test # 15min
   timeout_in_minutes: 30

--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import (CompilationConfig, CompilationLevel, VllmConfig,
+                         set_current_vllm_config)
+from vllm.forward_context import set_forward_context
+
+
+class MyMod(torch.nn.Module):
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    def forward(self, x: torch.Tensor):
+        for _ in range(3000):
+            x = x + x.shape[0]
+        return x
+
+
+def make_vllm_config() -> VllmConfig:
+    return VllmConfig(compilation_config=CompilationConfig(
+        level=CompilationLevel.PIECEWISE, ))
+
+
+@contextmanager
+def use_vllm_config(vllm_config: VllmConfig):
+    with set_forward_context(
+        {}, vllm_config), set_current_vllm_config(vllm_config):
+        yield
+
+
+def test_no_eval_frame(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        mod = MyMod()
+        args = (torch.randn(10, 10), )
+        expected = mod(*args)
+        CompiledMod = support_torch_compile(MyMod)
+
+        vllm_config = make_vllm_config()
+        m.setenv("VLLM_USE_AOT_COMPILE", "0")
+        try:
+            with use_vllm_config(vllm_config), torch.compiler.set_stance(
+                    "fail_on_recompile"):
+                CompiledMod(vllm_config=vllm_config)(*args)
+        except RuntimeError as e:
+            assert "Detected recompile" in str(e)
+        else:
+            raise AssertionError("Expected exception to be raised")
+
+        m.setenv("VLLM_USE_AOT_COMPILE", "1")
+        torch._dynamo.reset()
+        with use_vllm_config(vllm_config), torch.compiler.set_stance(
+                "fail_on_recompile"):
+            ret = CompiledMod(vllm_config=vllm_config)(*args)
+            assert torch.allclose(ret, expected)

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -389,6 +389,35 @@ def set_model_tag(tag: str):
         model_tag = old_tag
 
 
+try:
+    from torch._dynamo.aot_compile import SerializableCallable
+except ImportError:
+    SerializableCallable = object
+
+assert isinstance(SerializableCallable, type)
+
+
+class VllmCompiledFunction(SerializableCallable):
+
+    def __init__(self, graph_module, example_inputs, vllm_config,
+                 optimized_call):
+        self.graph_module = graph_module
+        self.example_inputs = example_inputs
+        self.vllm_config = vllm_config
+        self.optimized_call = optimized_call
+
+    def __call__(self, *args, **kwargs):
+        return self.optimized_call(*args, **kwargs)
+
+    @classmethod
+    def serialize_compile_artifacts(cls, compiled_fn):
+        raise NotImplementedError("serialization not implemented")
+
+    @classmethod
+    def deserialize_compile_artifacts(cls, data):
+        raise NotImplementedError("deserialization not implemented")
+
+
 class VllmBackend:
     """The compilation backend for `torch.compile` with vLLM.
     It is used for compilation level of `CompilationLevel.PIECEWISE`,
@@ -596,7 +625,8 @@ class VllmBackend:
 
         if self.compilation_config.cudagraph_mode == CUDAGraphMode.NONE or \
             not self.compilation_config.cudagraph_copy_inputs:
-            return self.split_gm
+            return VllmCompiledFunction(graph, example_inputs, vllm_config,
+                                        self.split_gm)
 
         # if we need to copy input buffers for cudagraph
         from torch._guards import detect_fake_mode
@@ -638,4 +668,5 @@ class VllmBackend:
                 list_args[index] = static_tensor
             return self.split_gm(*list_args)
 
-        return copy_and_call
+        return VllmCompiledFunction(graph, example_inputs, vllm_config,
+                                    copy_and_call)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -386,6 +386,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_USE_STANDALONE_COMPILE":
     lambda: os.environ.get("VLLM_USE_STANDALONE_COMPILE", "1") == "1",
 
+    # Feature flag to enable/disable AOT compilation. This will ensure
+    # compilation is done in warmup phase and the compilation will be
+    # reused in subsequent calls.
+    "VLLM_USE_AOT_COMPILE":
+    lambda: os.environ.get("VLLM_USE_AOT_COMPILE", "0") == "1",
+
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK":


### PR DESCRIPTION
Addressing RFC: https://github.com/vllm-project/vllm/issues/20402

## Purpose
This PR adds an option VLLM_USE_AOT_COMPILE which will switch the torch compile workflow to AOT compilation. From user perspective, there should be no behavior differences. 

Internally, when VLLM_USE_AOT_COMPILE is enabled, we will call aot precompile api `torch.compile().aot_compile()` while the model is in warmup phase in compile. This should be the first step for vllm to adopt a completely aot style workflow. 

**NOTE**: As in this particular PR, we focus on adding the scaffolding code to call aot_compile at the right place. The result of aot compile is only stored in memory and we haven't added the code to save/load aot compiled function yet (which will be introduced in the next PR). 

Since we don't need to save the compile artifacts, we don't need to implement save/load function for backend as well (which will also be introduced in the next PR).
 
## Test Plan
pytest tests/compile/test_aot_compile.py
## Test Result
```
===================================================================== test session starts ======================================================================
platform linux -- Python 3.12.11, pytest-7.3.2, pluggy-1.6.0
rootdir: /data/users/zhxchen17/vllm
configfile: pyproject.toml
plugins: xdoctest-1.1.0, hypothesis-5.35.1, xdist-3.3.1, subtests-0.13.1, rerunfailures-14.0, flakefinder-1.1.0, cpp-2.3.0, anyio-4.9.0
collected 1 item                                                                                                                                               

tests/compile/test_aot_compile.py .                                                                                                                      [100%]

====================================================================== 1 passed in 8.84s ====================================================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

