### PR TITLE
chore: build release image by default

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -63,6 +63,7 @@ steps:
       DOCKER_BUILDKIT: "1"
 
   - label: "Build release image (x86)"
+    depends_on: ~
     id: build-release-image-x86
     agents:
       queue: cpu_queue_postmerge
@@ -75,6 +76,7 @@ steps:
       - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT"
 
   - label: "Build release image (arm64)"
+    depends_on: ~
     id: build-release-image-arm64
     agents:
       queue: arm64_cpu_queue_postmerge

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -62,12 +62,7 @@ steps:
     env:
       DOCKER_BUILDKIT: "1"
 
-  - block: "Build release image (x86)"
-    depends_on: ~
-    key: block-release-image-build
-
   - label: "Build release image (x86)"
-    depends_on: block-release-image-build
     id: build-release-image-x86
     agents:
       queue: cpu_queue_postmerge
@@ -80,7 +75,6 @@ steps:
       - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT"
 
   - label: "Build release image (arm64)"
-    depends_on: block-release-image-build
     id: build-release-image-arm64
     agents:
       queue: arm64_cpu_queue_postmerge


### PR DESCRIPTION
## Summary
- remove manual block gating release image builds

No tests were run.

------
https://chatgpt.com/codex/tasks/task_e_68b0a2f841808329886e4d7feb6e332c