### PR TITLE
[Log] Use Debug Once for DeepGEMM E8M0 When not Enabled

### DIFF
--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -36,7 +36,7 @@ def is_deep_gemm_e8m0_used() -> bool:
     "E8M0 scale on a Hopper or Blackwell-class GPU.
     """
     if not is_deep_gemm_supported():
-        logger.info_once(
+        logger.debug_once(
             "DeepGEMM E8M0 disabled: DeepGEMM not supported on this system.")
         return False
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Thanks to @mgoin for suggesting this update.

We don't need to show this log when DeepGEMM is not enabled or not supported.
