### PR TITLE
[Misc] Make `download_weights_from_hf` more reliable

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -287,7 +287,11 @@ def download_weights_from_hf(
             file_list = fs.ls(model_name_or_path,
                               detail=False,
                               revision=revision)
-        except Exception:
+        except Exception as e:
+            logger.warning(
+                "Failed to get file list for '%s'. Trying each pattern in "
+                "allow_patterns individually until weights have been "
+                "downloaded. Error: %s", model_name_or_path, e)
             file_list = []
 
         # Use the first pattern found in the HF repo's files.

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -301,6 +301,7 @@ def download_weights_from_hf(
     # Use file lock to prevent multiple processes from
     # downloading the same model weights at the same time.
     with get_lock(model_name_or_path, cache_dir):
+        assert len(allow_patterns) > 0
         start_time = time.perf_counter()
         for allow_pattern in allow_patterns:
             hf_folder = snapshot_download(


### PR DESCRIPTION
Issue:
- Uncaught timeout errors in `HfFileSystem.ls` have been causing issues with vLLM's CI
- This method is being used to determine the file format of the weights in the HF repo and reduce the length of `allow_patterns` to 1

Fix:
- Allow this check to fail, leaving `allow_patterns` unchanged (i.e. when `load_format == "auto"` this is `["*.safetensors", "*.bin", "*.pt"]`)
- Then, check each pattern one at a time and break the loop as soon as something has been downloaded

So what happens?
- The vast majority of the time, this will behave exactly the same as before this PR
- In the event that `HfFileSystem.ls` fails, vLLM will still call `snapshot_download` for each `allow_pattern` individually
- `snapshot_download` will fall back to the local cache in the event of `HTTPError`, `ConnectionError`, `Timeout`, making this approach significantly more robust