### PR TITLE
[BugFix][AMD][Deepseek] fix a dtype mismatch error for deepseek running on AMD

### DIFF
--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -279,7 +279,7 @@ def rocm_aiter_grouped_topk(
     if e_score_correction_bias is not None:
         torch.ops.vllm.rocm_aiter_biased_grouped_topk(
             gating_output,
-            e_score_correction_bias,
+            e_score_correction_bias.to(gating_output.dtype),
             topk_weights,
             topk_ids,
             num_expert_group,
@@ -409,15 +409,15 @@ def shuffle_weights(
     *tensors: torch.Tensor, layout: tuple[int, int] = (16, 16)
 ) -> tuple[torch.Tensor, ...]:
     """
-    Applies shuffle_weight function from AITER to each 
+    Applies shuffle_weight function from AITER to each
     input tensor and returns them.
-    
+
     Rearranges (shuffles) the input tensor/s
     into a specified block layout for optimized computation.
 
     Args:
         *tensors: Variable number of torch.Tensor objects.
-        layout: A pair of integers specifying the 
+        layout: A pair of integers specifying the
         block sizes used to divide the tensors during shuffling.
         Default is (16, 16).
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Commit [fdeb3da](https://github.com/vllm-project/vllm/commit/fdeb3dac132c9ef92d981dd811529e6496781b07) turns the dtype of e_score_correction_bias to float32. 
This works fine in H100 because the dtype was [converted](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fused_moe/fused_moe.py#L1041) before executing `grouped_topk`. 
However, there's no such dtype conversion in AMD based grouped_topk, so we will hit a type check error:
`gating_output.dtype() == correction_bias.dtype()`, because the default dtype for gating_output is bfloat16.

This PR fixes this issue by converting the dtype of correction_bias to gating_output's dtype.

## Test Plan
Ran deepseek V3 on AMD machine.

## Test Result
### Before
Worker failed during start and raise 
```
RuntimeError: gating_output.dtype() == correction_bias.dtype()

```

### After
Worker created successfully

### Perf
Success rate:        100.00%
QPS:                 0.67
Avg latency:         5.759s
Avg TTFT (client):   673.22ms
P50 TTFT (client):   629.28ms
P99 TTFT (client):   2037.26ms
Avg TTIT (client):   0.87ms
P50 TTIT (client):   0.87ms
P99 TTIT (client):   1.11ms
Avg TTFT (server):   694.07ms
Avg TTIT (server):   49.93ms
Avg prefill len:     5825.60 tokens
P50 prefill len:     5829.00 tokens
P99 prefill len:     5882.00 tokens
Avg decode len:      5825.60 tokens
P50 decode len:      5829.00 tokens
P99 decode len:      5829.00 tokens

### Accuracy

Evaluation results on task gsm8k.8_shot.1_gen: em: 0.980000 | f1: 0.980000 | em_maj1@1: 0.980000 | f1_maj1@1: 0.980000

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

