### PR TITLE
[rocm] fix rocm setup.py build

### DIFF
--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -913,7 +913,6 @@ __global__ void cp_gather_cache(
   const int32_t split_end = min((split + 1) * split_slots, tot_slots);
 
   const bool is_active_split = (split_start < tot_slots);
-  const bool is_last_split = (split_end == tot_slots);
 
   if (!is_active_split) return;
 


### PR DESCRIPTION
## Purpose
I am encountering an issue that is very likely caused by this PR (https://github.com/vllm-project/vllm/pull/23791) when building on AMD MI300X.
```
# Run
python setup.py clean && python setup.py build
# Error
FAILED: [code=1] CMakeFiles/_C.dir/csrc/cache_kernels.hip.o

/data/users/lifans/gitrepos/vllm/build/temp.linux-x86_64-cpython-312/csrc/cache_kernels.hip:918:14: error: unused variable 'is_last_split' [-Werror,-Wunused-variable]
  918 |   const bool is_last_split = (split_end == tot_slots);
      |              ^~~~~~~~~~~~~
2 warnings and 1 error generated when compiling for gfx942.
```
## Test Plan & Test Result

```
# python setup.py clean && python setup.py build
The error is gone. 
```

```
# Run 
from vllm import LLM
if __name__ == "__main__":
    llm = LLM("/home/lifans/hf_models/meta-llama/Llama-3.1-8B-Instruct")
    result = llm.generate("Hello my name is")
    print(result[0].outputs[0].text)

# Output
Adding requests: 100%|█████████████████| 1/1 [00:00<00:00, 55.36it/s]
Processed prompts: 100%|█| 1/1 [00:01<00:00,  1.19s/it, est. speed in
 Helen and I am a 35 year old mother of three. I am a
```
