### PR TITLE
[bug fix] disable memory pool to release unused `bf16` weights

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -23,13 +23,13 @@ from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
+from vllm.model_executor.layers.quantization.utils.disable_mem_pool import (
+    disable_mem_pool)
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     apply_flashinfer_per_tensor_scale_fp8, rotate_flashinfer_fp8_moe_weights,
     swap_w13_to_w31)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     get_col_major_tma_aligned_tensor, requant_weight_ue8m0_inplace)
-from vllm.model_executor.layers.quantization.utils.disable_mem_pool import (
-    disable_mem_pool)
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
     apply_fp8_marlin_linear, prepare_fp8_layer_for_marlin,
     prepare_moe_fp8_layer_for_marlin)
@@ -278,23 +278,22 @@ class Fp8LinearMethod(LinearMethodBase):
         weight_dtype = (torch.float8_e4m3fn
                         if self.quant_config.is_checkpoint_fp8_serialized else
                         params_dtype)
-        
+
         # WEIGHTS
         # if not fp8_serialized, quantization will be performed in `process_weights_after_loading`
-        # and the parameter created here will not be used, disable mem pool to avoid 
+        # and the parameter created here will not be used, disable mem pool to avoid
         # memory release failure, when setting `enable_sleep_mode=True`. The issue is
-        # first reported in https://github.com/vllm-project/vllm/issues/19855, together with 
-        # the solutions used here. 
+        # first reported in https://github.com/vllm-project/vllm/issues/19855, together with
+        # the solutions used here.
         with disable_mem_pool(
-            disable=not self.quant_config.is_checkpoint_fp8_serialized
-        ):
+                disable=not self.quant_config.is_checkpoint_fp8_serialized):
             weight = ModelWeightParameter(data=torch.empty(
                 output_size_per_partition,
                 input_size_per_partition,
                 dtype=weight_dtype),
-                                        input_dim=1,
-                                        output_dim=0,
-                                        weight_loader=weight_loader)
+                                            input_dim=1,
+                                            output_dim=0,
+                                            weight_loader=weight_loader)
             layer.register_parameter("weight", weight)
 
         # If checkpoint is serialized fp8, load them.
@@ -587,20 +586,19 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     f"weight quantization block_k = {block_k}.")
 
         # WEIGHTS
-        # if not fp8_serialized, quantization will be performed in `process_weights_after_loading`
-        # and the parameter created here will not be used, disable mem pool to avoid 
+        # if not fp8_serialized, quantization will be performed in `process_weights_after_loading
+        # and the parameter created here will not be used, disable mem pool to avoid
         # memory release failure, when setting `enable_sleep_mode=True`. The issue is
-        # first reported in https://github.com/vllm-project/vllm/issues/19855, together with 
-        # the solutions used here. 
+        # first reported in https://github.com/vllm-project/vllm/issues/19855, together with
+        # the solutions used here.
         with disable_mem_pool(
-            disable=not self.quant_config.is_checkpoint_fp8_serialized
-        ):
+                disable=not self.quant_config.is_checkpoint_fp8_serialized):
             w13_weight = torch.nn.Parameter(torch.empty(
                 num_experts,
                 2 * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype),
-                                            requires_grad=False)
+                                                requires_grad=False)
             layer.register_parameter("w13_weight", w13_weight)
             set_weight_attrs(w13_weight, extra_weight_attrs)
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -291,9 +291,9 @@ class Fp8LinearMethod(LinearMethodBase):
                 output_size_per_partition,
                 input_size_per_partition,
                 dtype=weight_dtype),
-                                            input_dim=1,
-                                            output_dim=0,
-                                            weight_loader=weight_loader)
+                                          input_dim=1,
+                                          output_dim=0,
+                                          weight_loader=weight_loader)
             layer.register_parameter("weight", weight)
 
         # If checkpoint is serialized fp8, load them.
@@ -598,7 +598,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 2 * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype),
-                                                requires_grad=False)
+                                            requires_grad=False)
             layer.register_parameter("w13_weight", w13_weight)
             set_weight_attrs(w13_weight, extra_weight_attrs)
 
@@ -607,7 +607,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 hidden_size,
                 intermediate_size_per_partition,
                 dtype=params_dtype),
-                                        requires_grad=False)
+                                          requires_grad=False)
             layer.register_parameter("w2_weight", w2_weight)
             set_weight_attrs(w2_weight, extra_weight_attrs)
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -607,7 +607,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 hidden_size,
                 intermediate_size_per_partition,
                 dtype=params_dtype),
-                                          requires_grad=False)
+                                           requires_grad=False)
             layer.register_parameter("w2_weight", w2_weight)
             set_weight_attrs(w2_weight, extra_weight_attrs)
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -286,7 +286,7 @@ class Fp8LinearMethod(LinearMethodBase):
         # first reported in https://github.com/vllm-project/vllm/issues/19855, together with 
         # the solutions used here. 
         with disable_mem_pool(
-            not self.quant_config.is_checkpoint_fp8_serialized
+            disable=not self.quant_config.is_checkpoint_fp8_serialized
         ):
             weight = ModelWeightParameter(data=torch.empty(
                 output_size_per_partition,
@@ -593,7 +593,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         # first reported in https://github.com/vllm-project/vllm/issues/19855, together with 
         # the solutions used here. 
         with disable_mem_pool(
-            not self.quant_config.is_checkpoint_fp8_serialized
+            disable=not self.quant_config.is_checkpoint_fp8_serialized
         ):
             w13_weight = torch.nn.Parameter(torch.empty(
                 num_experts,

--- a/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
+++ b/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
@@ -1,0 +1,25 @@
+he memory usage after wakeup weights is close to expectation (fp8 * 7B).
+
+from vllm.device_allocator.cumem import CuMemAllocator
+from contextlib import contextmanager
+from torch.cuda.memory import MemPoolContext
+from torch._C import (
+_cuda_beginAllocateToPool,
+_cuda_endAllocateCurrentStreamToPool,
+)
+
+@contextmanager
+def disable_mem_pool(disable=False):
+    if disable and MemPoolContext.active_pool() == \
+            CuMemAllocator.get_instance().allocator_and_pools["weights"][0]:
+        pool = MemPoolContext.active_pool()
+        ctx = MemPoolContext(None)
+        device_index = torch.cuda.current_device()
+        _cuda_endAllocateCurrentStreamToPool(device_index, pool.id)
+        need_restart = True
+    try:
+        yield
+    finally:
+        if disable and need_restart:
+            _cuda_beginAllocateToPool(device_index, pool.id)
+        del ctx

--- a/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
+++ b/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
@@ -10,16 +10,20 @@ _cuda_endAllocateCurrentStreamToPool,
 
 @contextmanager
 def disable_mem_pool(disable=False):
-    if disable and MemPoolContext.active_pool() == \
-            CuMemAllocator.get_instance().allocator_and_pools["weights"][0]:
+    if disable \
+            and "weights" in CuMemAllocator.get_instance().allocator_and_pools \
+            and MemPoolContext.active_pool() == \
+                CuMemAllocator.get_instance().allocator_and_pools["weights"][0]:
         pool = MemPoolContext.active_pool()
         ctx = MemPoolContext(None)
         device_index = torch.cuda.current_device()
         _cuda_endAllocateCurrentStreamToPool(device_index, pool.id)
         need_restart = True
+    else:
+        need_restart = False
     try:
         yield
     finally:
         if disable and need_restart:
             _cuda_beginAllocateToPool(device_index, pool.id)
-        del ctx
+            del ctx

--- a/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
+++ b/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
@@ -1,5 +1,3 @@
-he memory usage after wakeup weights is close to expectation (fp8 * 7B).
-
 from vllm.device_allocator.cumem import CuMemAllocator
 from contextlib import contextmanager
 from torch.cuda.memory import MemPoolContext

--- a/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
+++ b/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
@@ -8,18 +8,20 @@ _cuda_endAllocateCurrentStreamToPool,
 
 @contextmanager
 def disable_mem_pool(disable=False):
-    if disable \
-            and "weights" in CuMemAllocator.get_instance().allocator_and_pools \
-            and MemPoolContext.active_pool() == \
-                CuMemAllocator.get_instance().allocator_and_pools["weights"][0]:
-        pool = MemPoolContext.active_pool()
-        ctx = MemPoolContext(None)
-        device_index = torch.cuda.current_device()
-        _cuda_endAllocateCurrentStreamToPool(device_index, pool.id)
-        need_restart = True
-    else:
-        need_restart = False
     try:
+        if disable \
+                and "weights" in CuMemAllocator.get_instance().allocator_and_pools \
+                and MemPoolContext.active_pool() == \
+                    CuMemAllocator.get_instance().allocator_and_pools["weights"][0]:
+            pool = MemPoolContext.active_pool()
+            ctx = MemPoolContext(None)
+            device_index = torch.cuda.current_device()
+            try:
+                _cuda_endAllocateCurrentStreamToPool(device_index, pool.id)
+            finally:
+                need_restart = True
+        else:
+            need_restart = False
         yield
     finally:
         if disable and need_restart:

--- a/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
+++ b/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
@@ -5,10 +5,14 @@
 # https://github.com/vllm-project/vllm/issues/19855
 """Utility helpers for native fp8 support in sleep_mode"""
 from contextlib import contextmanager
+
+import torch
 from torch._C import (_cuda_beginAllocateToPool,
                       _cuda_endAllocateCurrentStreamToPool)
 from torch.cuda.memory import MemPoolContext
+
 from vllm.device_allocator.cumem import CuMemAllocator
+
 
 @contextmanager
 def disable_mem_pool(disable=False):

--- a/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
+++ b/vllm/model_executor/layers/quantization/utils/disable_mem_pool.py
@@ -1,10 +1,14 @@
-from vllm.device_allocator.cumem import CuMemAllocator
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Adopted from
+# https://github.com/vllm-project/vllm/issues/19855
+"""Utility helpers for native fp8 support in sleep_mode"""
 from contextlib import contextmanager
+from torch._C import (_cuda_beginAllocateToPool,
+                      _cuda_endAllocateCurrentStreamToPool)
 from torch.cuda.memory import MemPoolContext
-from torch._C import (
-_cuda_beginAllocateToPool,
-_cuda_endAllocateCurrentStreamToPool,
-)
+from vllm.device_allocator.cumem import CuMemAllocator
 
 @contextmanager
 def disable_mem_pool(disable=False):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix the memory issue for fp8 as documented in https://github.com/vllm-project/vllm/issues/19855. the fix is also provided by https://github.com/vllm-project/vllm/issues/19855

## Test Plan

The fix has been tested in the [Flash-RL](https://github.com/yaof20/Flash-RL) project. 

## Test Result

Before applying the fix, using `fp8` in RL training leads to additional memory footprint and OOM errors in RL training. After applying the fix, we observe the OOM & additional memory footprint is gone. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

