### PR TITLE
[Platform] import activation_quant_fusion for CUDA only

### DIFF
--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -8,13 +8,13 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 if current_platform.is_cuda_alike():
+    from .activation_quant_fusion import ActivationQuantFusionPass
     from .fusion import FusionPass
     from .fusion_attn import AttnFusionPass
 
 if current_platform.is_cuda():
     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
 
-from .activation_quant_fusion import ActivationQuantFusionPass
 from .fix_functionalization import FixFunctionalizationPass
 from .inductor_pass import CustomGraphPass, InductorPass, get_pass_context
 from .noop_elimination import NoOpEliminationPass


### PR DESCRIPTION
## Purpose
The commit https://github.com/vllm-project/vllm/pull/23671 add the custom init logic like `SILU_MUL_OP = torch.ops._C.silu_and_mul.default`. But it doesn't work on the platform which doesn't support custom ops. It will raise error when setup vLLM.
```
AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul'
```

This PR let  activation_quant_fusion be imported only for CUDA case

## Test Plan

This is a change for custom platform. No need for new test. and all test should not break. vLLM Ascend e2e test will be happy after this change.

## Test Result

Custom platform works well then.

