### PR TITLE
[Feature][P/D]: Optimize NIXL Connector xfer Launch

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1226,7 +1226,7 @@ class NixlConnectorWorker:
         Otherwise, we use all regions.
         """
         if layer_idx is None:
-            region_ids = range(self.num_regions)
+            region_ids = np.arange(self.num_regions)
         else:
             assert layer_idx < self.num_layers
             if self.num_layers < self.num_regions:
@@ -1234,20 +1234,19 @@ class NixlConnectorWorker:
                 # the regions are organized as [K0, V0, K1, V1, ...]
                 # and we select K_i and V_i
                 assert 2 * self.num_layers == self.num_regions
-                region_ids = range(2 * layer_idx, 2 * layer_idx + 2)
+                region_ids = np.arange(2 * layer_idx, 2 * layer_idx + 2)
             else:
                 # Otherwise, we assume we have MLA and select i-th layer
                 assert self.num_layers == self.num_regions
-                region_ids = range(layer_idx, layer_idx + 1)
+                region_ids = np.arange(layer_idx, layer_idx + 1)
 
         num_blocks = self.dst_num_blocks[engine_id]
 
         # Compute the desc ids for each block.
-        descs_ids: list[int] = []
-        for reg_id in region_ids:
-            for block_id in block_ids:
-                descs_ids.append(reg_id * num_blocks + block_id)
-        return descs_ids
+        region_ids = region_ids[:, None]
+        block_ids = np.array(block_ids)[None, :]
+        descs_ids = region_ids * num_blocks + block_ids
+        return descs_ids.flatten().tolist()
 
 
 @contextlib.contextmanager

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 import msgspec
+import numpy as np
 import torch
 import zmq
 


### PR DESCRIPTION

## Purpose
issue #23780 
## Test Plan

prefill instance:
```
CUDA_VISIBLE_DEVICES=0 VLLM_NIXL_SIDE_CHANNEL_PORT=5567 vllm serve /workspace/models/qwen2.5_7B \
  --port 20001 \
  --tensor-parallel-size 1 \
  --enforce-eager \
  --block-size 16 \
  --enable-log-requests \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
```

decode instance:
```
CUDA_VISIBLE_DEVICES=1 VLLM_NIXL_SIDE_CHANNEL_PORT=5667 viztracer -o decode.json vllm serve /workspace/models/qwen2.5_7B \
  --port 20002 \
  --tensor-parallel-size 1 \
  --enforce-eager \
  --block-size 16 \
  --enable-log-requests \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
```

proxy:
```
python ./tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
      --port 40000 \
      --prefiller-port 20001 \
      --decoder-port 20002
```

```
python benchmarks/benchmark_serving.py \
    --backend vllm \
    --endpoint /v1/completions \
    --model /workspace/models/qwen2.5_7B \
    --dataset-name random \
    --random-input 800 \
    --random-output 100 \
    --num-prompts 100 \
    --request-rate 5 \
    --host localhost \
    --port 40000 \
```

## Test Result
origin:
<img width="1216" height="381" alt="image" src="https://github.com/user-attachments/assets/6afc179d-69da-4374-bbc4-5800db635cf3" />

after this pr:
<img width="1480" height="393" alt="image" src="https://github.com/user-attachments/assets/ee94b118-376e-4cea-8223-52b78071fe51" />

_get_block_descs_ids time reduced from ~2ms to ~0.05ms

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

