### PR TITLE
fix bad words issue when adding leading space changes token id count

### DIFF
--- a/vllm/logits_process.py
+++ b/vllm/logits_process.py
@@ -34,12 +34,8 @@ def get_bad_words_logits_processors(
             prompt_token_ids = tokenizer.encode(text=prompt,
                                                 add_special_tokens=False)
 
-            # If no space at the beginning
-            # or if prefix space produces a new word token
-            if (not add_prefix_space) or (
-                    add_prefix_space
-                    and prompt_token_ids[0] != bad_words_ids[-1][0]
-                    and len(prompt_token_ids) == len(bad_words_ids[-1])):
+            # If prefix space produces a new word token
+            if not prompt_token_ids in bad_words_ids:
                 bad_words_ids.append(prompt_token_ids)
 
     return [NoBadWordsLogitsProcessor(bad_words_ids=bad_words_ids)]

--- a/vllm/logits_process.py
+++ b/vllm/logits_process.py
@@ -34,8 +34,8 @@ def get_bad_words_logits_processors(
             prompt_token_ids = tokenizer.encode(text=prompt,
                                                 add_special_tokens=False)
 
-            # If prefix space produces a new word token
-            if not prompt_token_ids in bad_words_ids:
+            # Add the tokenized bad word if it's not already in the list.
+            if prompt_token_ids not in bad_words_ids:
                 bad_words_ids.append(prompt_token_ids)
 
     return [NoBadWordsLogitsProcessor(bad_words_ids=bad_words_ids)]


### PR DESCRIPTION
## Purpose

Fix the handling of `bad_words` when leading spaces are involved.  
Currently, the implementation checks whether adding a leading space results in the same number of token IDs. This condition is unnecessary and can lead to undesirable results.

For example, with the `deepseek-r1-distilled-32b` model:
- Adding `"described"` to `bad_words` does **not** prevent `" described"` from being generated.  
- This happens because `" described"` maps to 1 token, while `"described"` maps to 2 tokens, and the current condition filters out this case incorrectly.

**Issue reference:** [#23886](https://github.com/vllm-project/vllm/issues/23886)

## Test Plan

- Tested locally (not in this PR due to the simplicity of the logic change) that it can successfully prevent " described" from being generated when "described" is in `bad_words`

## Test Result

- With the fix, `"described"` in `bad_words` correctly blocks both `"described"` and `" described"`.  
- Verified by running sample generations with `deepseek-r1-distilled-32b`.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

