### PR TITLE
[mrope][Qwen2-VL] Fix edge case where getting index of image/video token can potentially throw in default vl mrope implementation. 

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -547,12 +547,18 @@ class MRotaryEmbedding(RotaryEmbedding):
         image_index, video_index = 0, 0
         for _ in range(image_nums + video_nums):
             video_second_per_grid_t = 0.0
-            if image_token_id in input_tokens and remain_images > 0:
-                ed_image = input_tokens.index(image_token_id, st)
+            if remain_images > 0:
+                try:
+                    ed_image = input_tokens.index(image_token_id, st)
+                except ValueError:
+                    ed_image = len(input_tokens) + 1
             else:
                 ed_image = len(input_tokens) + 1
-            if video_token_id in input_tokens and remain_videos > 0:
-                ed_video = input_tokens.index(video_token_id, st)
+            if remain_videos > 0:
+                try:
+                    ed_video = input_tokens.index(video_token_id, st)
+                except ValueError:
+                    ed_video = len(input_tokens) + 1
             else:
                 ed_video = len(input_tokens) + 1
             if ed_image < ed_video:


### PR DESCRIPTION
## Purpose

In #23838, Gemini caught an edge case where checking image/video token in `input_tokens` does not guarantee `input_tokens.index(image_token_id, st)` won't throw, hence the missing try-catch block is needed. After discussion with @DarkLight1337 we want to add this check in the default vl mrope code as well. 

<img width="719" height="449" alt="image" src="https://github.com/user-attachments/assets/86455366-4911-4311-878d-c7da539ffa47" />

## Test Plan

Note that there's no meaningful perf impact since checking an item in the list is generally very fast:

```
(vllm) [huachenheli@devgpu039.dkl2 ~/github/vllm (mrope)]$ python -m timeit "99999 in range(100000)"
5000000 loops, best of 5: 84.3 nsec per loop
(vllm) [huachenheli@devgpu039.dkl2 ~/github/vllm (mrope)]$ python -m timeit "99999 in range(100000)"
5000000 loops, best of 5: 83 nsec per loop
(vllm) [huachenheli@devgpu039.dkl2 ~/github/vllm (mrope)]$ python -m timeit "99999 in range(100000)"
5000000 loops, best of 5: 84.3 nsec per loop
```

e2e benchmarks (reference only):
Without this PR:
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Benchmark duration (s):                  3.75      
Total input tokens:                      156       
Total generated tokens:                  1667      
Request throughput (req/s):              2.67      
Output token throughput (tok/s):         444.86    
Total Token throughput (tok/s):          486.49    
---------------Time to First Token----------------
Mean TTFT (ms):                          943.28    
Median TTFT (ms):                        881.49    
P99 TTFT (ms):                           1103.42   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.93     
Median TPOT (ms):                        11.91     
P99 TPOT (ms):                           13.91     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.21     
Median ITL (ms):                         14.30     
P99 ITL (ms):                            17.47     
==================================================
```

With this PR:
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Benchmark duration (s):                  3.69      
Total input tokens:                      156       
Total generated tokens:                  1642      
Request throughput (req/s):              2.71      
Output token throughput (tok/s):         445.57    
Total Token throughput (tok/s):          487.90    
---------------Time to First Token----------------
Mean TTFT (ms):                          888.17    
Median TTFT (ms):                        772.37    
P99 TTFT (ms):                           1079.04   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.35     
Median TPOT (ms):                        12.56     
P99 TPOT (ms):                           13.80     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.78     
Median ITL (ms):                         14.40     
P99 ITL (ms):                            16.96     
==================================================
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

