### PR TITLE
[feat] preserve metadata for quantized model weight reload

### DIFF
--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -133,14 +133,14 @@ def process_weights_after_loading(model: nn.Module, model_config: ModelConfig,
     recorded_loader = {k: dict() for k in recorded_loader_keys}
     for name, p in model.named_parameters():
         for key in recorded_loader_keys:
-            if hasattr(p, k):
-                attr = getattr(p, k)
+            if hasattr(p, key):
+                attr = getattr(p, key)
                 if not callable(attr):
-                    recorded_loader[k][name] = attr 
+                    recorded_loader[key][name] = attr 
                 elif p is attr.__self__:
-                    recorded_loader[k][name] = attr.__func__ 
+                    recorded_loader[key][name] = attr.__func__ 
                 else:
-                    recorded_loader[k][name] = attr 
+                    recorded_loader[key][name] = attr 
     model.recorded_loader = recorded_loader
     
     for _, module in model.named_modules():

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -108,8 +108,8 @@ def support_quantized_model_reload(func):
                 # put the value of the newly created tensor to the original tensor 
                 for name, p in self.named_parameters():
                     
-                    if name in updated_params 
-                            or (name.endswith('_scale') and name[:-6] in updated_params):
+                    if name in updated_params \
+                            or (name.endswith('weight_scale') and name[:-6] in updated_params):
                         trided_data = torch.as_strided(
                             p.data, 
                             original_param_dict[name].shape, 

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -46,7 +46,7 @@ from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
 from vllm.model_executor.model_loader.weight_utils import (
-    default_weight_loader, maybe_remap_kv_scale_name)
+    default_weight_loader, maybe_remap_kv_scale_name, support_quantized_model_reload)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import is_interleaved
@@ -373,6 +373,7 @@ class Qwen2Model(nn.Module):
 
         return hidden_states
 
+    @support_quantized_model_reload
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [


### PR DESCRIPTION

## Purpose
for quantization, usually the original weight tensor would be replaced by a new tensor. In the process, many attributes are lost, e.g., weight loader. Additionally, for native `fp8` quantization, it would have additional dtype and shape mismatch. 

## Test Plan
this implementation should work for more models, and is adopted from flash-rl. The current implementation could be buggy and this only serves as an initial PR. 

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

