### PR TITLE
allow calc_kv_scales

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -240,9 +240,7 @@ class Attention(nn.Module, AttentionLayerBase):
         `vllm.forward_context.get_forward_context().attn_metadata`.
         """
         if self.calculate_kv_scales:
-            attn_metadata = get_forward_context().attn_metadata
-            if attn_metadata.enable_kv_scales_calculation:
-                self.calc_kv_scales(query, key, value)
+            self.calc_kv_scales(query, key, value)
         if self.use_output:
             output_shape = (output_shape
                             if output_shape is not None else query.shape)


### PR DESCRIPTION
Summary:
When running the gpt-oss, I found that there is a bug when enabling `calculate_kv_scales`:
1. The self.calc_kv_scales() should be invoked without checking `attn_metadata`
2. `attn_metadata` is avail only when full graph mode of cudagraph. If a user does not use it, there is an error(NoneType) when checking `attn_metadata.enable_kv_scales_calculation`
This PR should fix the above problem.

But we can not use torch.compile when we set `calculate_kv_scales=True`, it will complain using .item() in `def calc_kv_scales()`

Differential Revision: D81300417


