### PR TITLE
[Performance] implement async_scheduling in single process mode

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1260,9 +1260,6 @@ class EngineArgs:
                 self.distributed_executor_backend = "mp"
                 logger.info("Using mp-based distributed executor backend "
                             "for async scheduling.")
-            if self.distributed_executor_backend == "uni":
-                raise ValueError("Async scheduling is not supported with "
-                                 "uni-process backend.")
             if self.pipeline_parallel_size > 1:
                 raise ValueError("Async scheduling is not supported with "
                                  "pipeline-parallel-size > 1.")

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -357,6 +357,27 @@ class EngineCore:
 
         return engine_core_outputs, model_executed
 
+    def step_async_in_process(self):
+        """Make asynchronous schedule in single process."""
+        # Check for any requests remaining in the scheduler - unfinished,
+        # or finished and not yet removed from the batch.
+        if not self.scheduler.has_requests():
+            return {}, False
+        engine_core_outputs = {}
+        scheduler_output = self.scheduler.schedule()
+        model_output = self.execute_model_with_error_logging(
+            self.model_executor.execute_model,  # type: ignore
+            scheduler_output)
+        # in single process mode, the model_output may be a bool value to
+        # notify it's time to make  scheduleing of next step.
+        # so in this situation, we don't need to call update_from_output.
+        if isinstance(model_output, ModelRunnerOutput):
+            engine_core_outputs = self.scheduler.update_from_output(
+                scheduler_output, model_output)  # type: ignore
+
+        return (engine_core_outputs,
+                scheduler_output.total_num_scheduled_tokens > 0)
+
     def shutdown(self):
         self.structured_output_manager.clear_backend()
         if self.model_executor:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -138,7 +138,8 @@ class EngineCore:
         # schedule and execute batches, and is required by pipeline parallelism
         # to eliminate pipeline bubbles.
         self.batch_queue_size = self.model_executor.max_concurrent_batches
-        self.batch_queue: Optional[deque[tuple[Future[ModelRunnerOutput],
+        self.batch_queue: Optional[deque[Union[tuple[Future[ModelRunnerOutput],
+                                                     SchedulerOutput],
                                                SchedulerOutput]]] = None
         if self.batch_queue_size > 1:
             logger.info("Batch queue is enabled with size %d",
@@ -361,6 +362,7 @@ class EngineCore:
         """Make asynchronous schedule in single process."""
         # Check for any requests remaining in the scheduler - unfinished,
         # or finished and not yet removed from the batch.
+        assert self.batch_queue is not None
         if not self.scheduler.has_requests():
             return {}, False
         engine_core_outputs = {}

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -138,8 +138,7 @@ class EngineCore:
         # schedule and execute batches, and is required by pipeline parallelism
         # to eliminate pipeline bubbles.
         self.batch_queue_size = self.model_executor.max_concurrent_batches
-        self.batch_queue: Optional[deque[Union[tuple[Future[ModelRunnerOutput],
-                                                     SchedulerOutput],
+        self.batch_queue: Optional[deque[tuple[Future[ModelRunnerOutput],
                                                SchedulerOutput]]] = None
         if self.batch_queue_size > 1:
             logger.info("Batch queue is enabled with size %d",
@@ -320,8 +319,7 @@ class EngineCore:
         batch in the job queue is finished.
         3. Update the scheduler from the output.
         """
-        batch_queue: Optional[deque[tuple[Future[ModelRunnerOutput],
-                                          SchedulerOutput]]] = self.batch_queue
+        batch_queue = self.batch_queue
         assert batch_queue is not None
 
         # Try to schedule a new batch if the batch queue is not full, but
@@ -363,7 +361,7 @@ class EngineCore:
         """Make asynchronous schedule in single process."""
         # Check for any requests remaining in the scheduler - unfinished,
         # or finished and not yet removed from the batch.
-        batch_queue: Optional[deque[SchedulerOutput]] = self.batch_queue
+        batch_queue = self.batch_queue
         assert batch_queue is not None
         if not self.scheduler.has_requests():
             return {}, False
@@ -371,7 +369,7 @@ class EngineCore:
         model_output = None
         scheduler_output = self.scheduler.schedule()
         if scheduler_output.total_num_scheduled_tokens > 0:
-            batch_queue.appendleft(scheduler_output)
+            batch_queue.appendleft(scheduler_output)  # type: ignore
             model_output = self.execute_model_with_error_logging(
                 self.model_executor.execute_model,  # type: ignore
                 scheduler_output)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -243,9 +243,13 @@ class InprocClient(EngineCoreClient):
 
     def __init__(self, *args, **kwargs):
         self.engine_core = EngineCore(*args, **kwargs)
+        self.async_scehduling = self.engine_core.vllm_config.scheduler_config.async_scheduling
 
     def get_output(self) -> EngineCoreOutputs:
-        outputs, _ = self.engine_core.step()
+        if self.async_scehduling:
+            outputs, _ = self.engine_core.step_async_in_process()
+        else:
+            outputs, _ = self.engine_core.step()
         return outputs.get(0) or EngineCoreOutputs()
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -243,7 +243,7 @@ class InprocClient(EngineCoreClient):
 
     def __init__(self, *args, **kwargs):
         self.engine_core = EngineCore(*args, **kwargs)
-        self.async_scehduling = self.engine_core.vllm_config.scheduler_config.async_scheduling
+        self.async_scehduling = self.engine_core.vllm_config.scheduler_config.async_scheduling  # noqa
 
     def get_output(self) -> EngineCoreOutputs:
         if self.async_scehduling:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -8,8 +8,8 @@ from collections import defaultdict
 from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from queue import Queue
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import numpy as np
 import torch
@@ -1757,6 +1757,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         if self.output_queue is None:
             return output
+        # When using output_queue, deepcopy the req_ids and req_id_to_index
+        # incase the input_batch is modified before the output is consumed.
+        output.req_ids = deepcopy(self.input_batch.req_ids)
+        output.req_id_to_index = deepcopy(self.input_batch.req_id_to_index)
         self.output_queue.put(output)
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1762,6 +1762,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         output.req_ids = deepcopy(self.input_batch.req_ids)
         output.req_id_to_index = deepcopy(self.input_batch.req_id_to_index)
         self.output_queue.put(output)
+        return output
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         if self._draft_token_ids is None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -371,6 +371,12 @@ class Worker(WorkerBase):
         if isinstance(output, ModelRunnerOutput):
             return output
 
+        # this means use async scheduling with uni-process executor，
+        # the modeloutput will be put in the output queue,
+        # the output will be None. so we won't validate the output type here.
+        if self.output_queue is not None:
+            return output
+
         assert isinstance(output, IntermediateTensors)
         parallel_config = self.vllm_config.parallel_config
         assert parallel_config.distributed_executor_backend != (

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -5,8 +5,8 @@ import copy
 import gc
 import os
 from contextlib import AbstractContextManager, nullcontext
-from typing import TYPE_CHECKING, Any, Optional
 from queue import Queue
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 import torch.distributed

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -371,12 +371,6 @@ class Worker(WorkerBase):
         if isinstance(output, ModelRunnerOutput):
             return output
 
-        # this means use async scheduling with uni-process executor，
-        # the modeloutput will be put in the output queue,
-        # the output will be None. so we won't validate the output type here.
-        if self.output_queue is not None:
-            return output
-
         assert isinstance(output, IntermediateTensors)
         parallel_config = self.vllm_config.parallel_config
         assert parallel_config.distributed_executor_backend != (


### PR DESCRIPTION
## Purpose
async_scheduling don't support UniProcExecutor and ExecutorWithExternalLauncher, this PR aims to implement async_scheduling in single process mode.
i make a new thread to do the execute_model task, when copy sample_token_ids from device to host, it will block the new thread, so let the new thread notify main thread to make scheduling of next step, it can overlap schedule operations with the data copy operations.

## Test Plan
test script refer to：https://github.com/vllm-project/vllm-ascend/blob/main/examples/offline_external_launcher.py
In A100, we use exeternal_launcher method to initialize LLM, make configurations as:
TP=2, max_num_seqs=512,max_model_len=4096,max_tokens=512,ignore_eos=True,prm800k_500.jsonl as dataset.
## Test Result

|gbs|sync_scheduling(tps)|async_scheduling(tps)|speedup(%)|
|---|---|---|---|
|32|1014|1025|1.1%|
|64|1853|1896|2.3%|
|128|3048|3177|4.2%|
|256|4039|4258|5.4%|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

