### PR TITLE
[MISC]Metrics changed time_per_output_token to inter_token_latency and added time_per_output_token

### DIFF
--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -377,16 +377,16 @@ class PrometheusStatLogger(StatLoggerBase):
         self.histogram_time_to_first_token = make_per_engine(
             histogram_time_to_first_token, engine_indexes, model_name)
 
-        histogram_time_per_output_token = self._histogram_cls(
-            name="vllm:time_per_output_token_seconds",
-            documentation="Histogram of time per output token in seconds.",
+        histogram_inter_token_latency = self._histogram_cls(
+            name="vllm:inter_token_latency_seconds",
+            documentation="Histogram of inter token latency in seconds.",
             buckets=[
                 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75,
                 1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 40.0, 80.0
             ],
             labelnames=labelnames)
-        self.histogram_time_per_output_token = make_per_engine(
-            histogram_time_per_output_token, engine_indexes, model_name)
+        self.histogram_inter_token_latency = make_per_engine(
+            histogram_inter_token_latency, engine_indexes, model_name)
 
         request_latency_buckets = [
             0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
@@ -435,6 +435,17 @@ class PrometheusStatLogger(StatLoggerBase):
             labelnames=labelnames)
         self.histogram_decode_time_request = make_per_engine(
             histogram_decode_time_request, engine_indexes, model_name)
+        
+        histogram_time_per_output_token = self._histogram_cls(
+            name="vllm:time_per_output_token",
+            documentation="Histogram of time per output token in seconds.",
+            buckets=[
+                0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75,
+                1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 40.0, 80.0
+            ],
+            labelnames=labelnames)
+        self.histogram_time_per_output_token = make_per_engine(
+            histogram_time_per_output_token, engine_indexes, model_name)
 
         #
         # LoRA metrics
@@ -537,8 +548,8 @@ class PrometheusStatLogger(StatLoggerBase):
             self.histogram_n_request[engine_idx].observe(n_param)
         for ttft in iteration_stats.time_to_first_tokens_iter:
             self.histogram_time_to_first_token[engine_idx].observe(ttft)
-        for tpot in iteration_stats.time_per_output_tokens_iter:
-            self.histogram_time_per_output_token[engine_idx].observe(tpot)
+        for itl in iteration_stats.inter_token_latency_iter:
+            self.histogram_inter_token_latency[engine_idx].observe(itl)
 
         for finished_request in iteration_stats.finished_requests:
             self.counter_request_success[
@@ -553,6 +564,8 @@ class PrometheusStatLogger(StatLoggerBase):
                 finished_request.inference_time)
             self.histogram_decode_time_request[engine_idx].observe(
                 finished_request.decode_time)
+            self.histogram_time_per_output_token[engine_idx].observe(
+                finished_request.time_per_output_token)
             self.histogram_num_prompt_tokens_request[engine_idx].observe(
                 finished_request.num_prompt_tokens)
             self.histogram_num_generation_tokens_request[engine_idx].observe(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -437,7 +437,7 @@ class PrometheusStatLogger(StatLoggerBase):
             histogram_decode_time_request, engine_indexes, model_name)
         
         histogram_time_per_output_token = self._histogram_cls(
-            name="vllm:time_per_output_token",
+            name="vllm:time_per_output_token_seconds",
             documentation="Histogram of time per output token in seconds.",
             buckets=[
                 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75,

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -130,7 +130,7 @@ class IterationStats:
             req_stats.first_token_ts = engine_core_timestamp
         else:
             itl = engine_core_timestamp - req_stats.last_token_ts
-            self.inter_token_latency.append(itl)
+            self.inter_token_latency_iter.append(itl)
 
         req_stats.last_token_ts = engine_core_timestamp
 
@@ -176,8 +176,8 @@ class IterationStats:
 
         # time_per_output_token is calculated as 
         # decode_time / decode_token_nums
-        time_per_output_token = (decode_time / (num_prompt_tokens - 1)
-                                 if num_prompt_tokens - 1 > 0 else 0)
+        time_per_output_token = (decode_time / (req_stats.num_generation_tokens - 1)
+                                 if req_stats.num_generation_tokens - 1 > 0 else 0)
 
         finished_req = \
             FinishedRequestStats(finish_reason=finish_reason,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The time per output token (tpot) in metrics is now calculated as the latency between two adjacent tokens. This calculation is more accurately calculated using inter_token_latency (itl).
The time per output token should now be calculated as decode_time / num_decode_tokens, which is more accurate.
This difference is also reflected in benchmark/benchmark_serving.py, where itl is calculated using the same method as the current tpot in metrics.
The purpose of this PR is to change the current time per output token to inter_token_latency and add time per output token.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

