### PR TITLE
[BUGFIX ]'AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul_nvfp4_quant' 

### DIFF
--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -97,7 +97,8 @@ class FixFunctionalizationPass(VllmInductorPass):
                                      node,
                                      mutated_args,
                                      args=('result', 'input', 'scale'))
-            elif at_target == torch.ops._C.silu_and_mul_nvfp4_quant.default:
+            elif (hasattr(torch.ops._C, "silu_and_mul_nvfp4_quant") and
+                  at_target == torch.ops._C.silu_and_mul_nvfp4_quant.default):
                 mutated_args = {1: 'result', 2: 'result_block_scale'}
                 self.defunctionalize(graph,
                                      node,


### PR DESCRIPTION
The PR fixes the bug introduced in PR: https://github.com/vllm-project/vllm/pull/23671 and reported in https://github.com/vllm-project/vllm/issues/23916 of inference in ROCM, it only checks if the attribute exists before calling the function