### PR TITLE
[Benchmark] Allow arbitrary headers to be passed to benchmarked endpoints

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -68,6 +68,7 @@ class RequestFuncInput:
     model: str
     model_name: Optional[str] = None
     logprobs: Optional[int] = None
+    extra_headers: Optional[dict] = None
     extra_body: Optional[dict] = None
     multi_modal_content: Optional[Union[dict, list[dict]]] = None
     ignore_eos: bool = False
@@ -129,6 +130,8 @@ async def async_request_openai_completions(
     headers = {
         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"
     }
+    if request_func_input.extra_headers:
+        headers |= request_func_input.extra_headers
     if request_func_input.request_id:
         headers["x-request-id"] = request_func_input.request_id
 
@@ -258,6 +261,8 @@ async def async_request_openai_chat_completions(
         "Content-Type": "application/json",
         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
     }
+    if request_func_input.extra_headers:
+        headers |= request_func_input.extra_headers
     if request_func_input.request_id:
         headers["x-request-id"] = request_func_input.request_id
 
@@ -364,6 +369,8 @@ async def async_request_openai_audio(
     headers = {
         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
     }
+    if request_func_input.extra_headers:
+        headers |= request_func_input.extra_headers
     if request_func_input.request_id:
         headers["x-request-id"] = request_func_input.request_id
 


### PR DESCRIPTION
## Purpose

Some vLLM implementations or environments may wrap the vLLM engine in a custom server or use an intercepting proxy that provides other behavior, such as a sidecar that provides P/D disaggregation. Allow the benchmark script to be parameterized with additional headers for those test environments.

Values passed as `--header` will override environment variables or constants such as the OPENAI_API_KEY Authorization header or default Content-Type. Other arguments such as request id handling should override `--header` values.

## Test Plan

Manual test

## Test Result

```
# Test with no headers
$ vllm bench serve --base-url http://vllm-deepseek-r1-ep-0.vllm-deepseek-r1-ep.default:8000 --model deepseek-ai/DeepSeek-R1 --dataset-name random --seed 15111512 --ignore-eos --random-input-len 1 --random-output-len 100 --max-concurrency 32 --num-prompts 96
...
all succeed

# Test with header sent that causes a 400 bad request
vllm bench serve --base-url http://vllm-deepseek-r1-ep-0.vllm-deepseek-r1-ep.default:8000 --model deepseek-ai/DeepSeek-R1 --dataset-name random --seed 15111512 --ignore-eos --random-input-len 1 --random-output-len 100 --max-concurrency 1 --num-prompts 1 --header content-type=application/xml --ready-check-timeout-sec=10
...
ValueError: Initial test run failed - Please make sure benchmark arguments are correctly specified. Error: Bad Request
```