### PR TITLE
[V1] [Hybrid] Mamba2 Automatic Prefix Caching

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1796,6 +1796,14 @@ class CacheConfig:
     mamba_page_size_padded: Optional[int] = None
     """ Optional override for mamba page size; used by hybrid mamba/attention
     models to ensure exact alignment with attention page size."""
+    mamba_block_size: Optional[int] = None
+    """Size of a contiguous cache block in number of tokens for mamba cache."""
+    mamba_cache_strategy: str = "all"
+    """Logic for mamba cache:
+    * disabled - turn of prefix caching
+    * all - keep states for all prefixes
+    * last - keep the states of the last full blocks after each request
+    """
 
     # Will be set after profiling.
     num_gpu_blocks: Optional[int] = field(default=None, init=False)

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -415,7 +415,9 @@ def causal_conv1d_fn(
         activation = "silu"
 
     args = None
-    out = torch.empty_like(x)
+    #out = torch.empty_like(x)
+    #TODO: Noticed strange behavior, maybe due to use of uninitialzed values?
+    out = torch.zeros_like(x)
     if metadata is not None:
         cu_seqlen = metadata.cu_seqlen
         nums_dict = metadata.nums_dict

--- a/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
+++ b/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
@@ -52,6 +52,7 @@ def _selective_scan_update_kernel(
     z_ptr,
     out_ptr,
     state_batch_indices_ptr,
+    dst_state_batch_indices_ptr,
     pad_slot_id,
     # Matrix dimensions
     batch,
@@ -107,11 +108,16 @@ def _selective_scan_update_kernel(
     # is taken from the state_batch_indices_ptr Otherwise, the state coordinate
     # is the same as the batch id.
     if HAS_STATE_BATCH_INDICES:
+        dst_state_batch_indices_ptr += pid_b
+        dst_state_batch_idx = tl.load(dst_state_batch_indices_ptr).to(tl.int64)
+        dst_state_ptr = state_ptr + (dst_state_batch_idx * stride_state_batch +
+                      pid_h * stride_state_head)
         state_batch_indices_ptr += pid_b
         state_batch_idx = tl.load(state_batch_indices_ptr).to(tl.int64)
         state_ptr += (state_batch_idx * stride_state_batch +
                       pid_h * stride_state_head)
     else:
+        dst_state_ptr = state_ptr + pid_b * stride_state_batch + pid_h * stride_state_head
         state_ptr += pid_b * stride_state_batch + pid_h * stride_state_head
 
     x_ptr += pid_b * stride_x_batch + pid_h * stride_x_head
@@ -130,6 +136,8 @@ def _selective_scan_update_kernel(
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
     state_ptrs = state_ptr + (offs_m[:, None] * stride_state_dim +
+                              offs_n[None, :] * stride_state_dstate)
+    dst_state_ptrs = dst_state_ptr + (offs_m[:, None] * stride_state_dim +
                               offs_n[None, :] * stride_state_dstate)
     x_ptrs = x_ptr + offs_m * stride_x_dim
     dt_ptrs = dt_ptr + offs_m * stride_dt_dim
@@ -185,7 +193,7 @@ def _selective_scan_update_kernel(
     mask = (offs_m[:, None] < dim) & (offs_n[None, :] < dstate)
     if HAS_STATE_BATCH_INDICES:
         mask &= (state_batch_idx != pad_slot_id)
-    tl.store(state_ptrs, state, mask=mask)
+    tl.store(dst_state_ptrs, state, mask=mask)
     out = tl.sum(state * C[None, :], axis=1)
     if HAS_D:
         out += x * D
@@ -205,6 +213,7 @@ def selective_state_update(state,
                            dt_bias=None,
                            dt_softplus=False,
                            state_batch_indices=None,
+                           dst_state_batch_indices=None,
                            pad_slot_id=PAD_SLOT_ID):
     """
     Argument:
@@ -264,6 +273,7 @@ def selective_state_update(state,
         assert dt_bias.shape == (nheads, dim)
     if state_batch_indices is not None:
         assert state_batch_indices.shape == (batch, )
+        assert dst_state_batch_indices.shape == (batch, )
     out = torch.empty_like(x)
     grid = lambda META: (triton.cdiv(dim, META['BLOCK_SIZE_M']), batch, nheads)
     z_strides = ((z.stride(0), z.stride(1), z.stride(2)) if z is not None else
@@ -289,6 +299,7 @@ def selective_state_update(state,
             z,
             out,
             state_batch_indices,
+            dst_state_batch_indices,
             pad_slot_id,
             batch,
             nheads,

--- a/vllm/model_executor/layers/mamba/ops/ssd_combined.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_combined.py
@@ -180,6 +180,7 @@ def mamba_chunk_scan_combined(x,
                               cu_seqlens=None,
                               dt_softplus=False,
                               dt_limit=(0.0, float("inf")),
+                              return_intermediate_states=False,
                               return_final_states=False,
                               return_varlen_states=False):
     """
@@ -222,11 +223,16 @@ def mamba_chunk_scan_combined(x,
         cu_seqlens=cu_seqlens,
         dt_softplus=dt_softplus,
         dt_limit=dt_limit)
-    if not return_varlen_states:
-        return out if not return_final_states else (out, final_states)
-    else:
+    if return_varlen_states:
         varlen_states = rest[0]
-        return (out,
-                varlen_states) if not return_final_states else (out,
-                                                                final_states,
-                                                                varlen_states)
+        if return_final_states:
+            return (out, final_states, varlen_states)
+        elif return_intermediate_states:
+            return (out, states, varlen_states)
+        else:
+            return (out, varlen_states)
+    else:
+        if return_final_states:
+            return (out, final_states)
+        else:
+            return (out, states)

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -265,12 +265,37 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
             block_size=model_config.max_model_len,
         ).page_size_bytes
 
-        # some attention backends (e.g. FA) only support setting
-        # block size to multiple of 16, so let's suggest a value
-        # that would work (note: FA is currently not compatible
-        # with mamba layers, use FlashInfer instead).
-        attn_block_size = 16 * cdiv(mamba_page_size,
-                                    16 * attn_page_size_1_token)
+        if cache_config.enable_prefix_caching:
+            # With prefix caching, select attention block size to 
+            # optimize for mamba kernel performance
+
+            # mamba SSD kernel uses a chunk_size, e.g. 256. Align the block to the kernel:
+            # use lowest multiple of 256 attention tokens that would fit mamba_page_size
+            # e.g. mamba page size of 788kB ; attn_1_token 2kB -> fits ~394 tokens
+            # then round up to a mulitple of 256 -> 512 tokens
+            # attn_block_size = 512
+            # mamba_block_size = 512 (aligned to a multiple of kernel chunk_size)
+            chunk_size = model_config.get_mamba_chunk_size()
+            attn_tokens_per_mamba_state = cdiv(mamba_page_size, attn_page_size_1_token)
+            attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
+            cache_config.mamba_block_size = attn_block_size
+
+            # This below might be redundant now:
+            if model_config.max_model_len % attn_block_size != 0:
+                # Currently HybridCacheManager uses max_model_len for Mamba block
+                # and requires it to be a multiple of attention block
+                model_config.max_model_len -= model_config.max_model_len % attn_block_size
+                print("Adjusting max_model_len to", model_config.max_model_len)
+        else:
+            # Without prefix caching, select minimum valid attention block size
+            # to minimize mamba state padding
+
+            # some attention backends (e.g. FA) only support setting
+            # block size to multiple of 16, so let's suggest a value
+            # that would work (note: FA is currently not compatible
+            # with mamba layers, use FlashInfer instead).
+            attn_block_size = 16 * cdiv(mamba_page_size,
+                                        16 * attn_page_size_1_token)            
 
         # override attention block size if either (a) the
         # user has not set it or (b) the user has set it

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -567,10 +567,6 @@ class GraniteMoeHybridForCausalLM(nn.Module, HasInnerState, SupportsLoRA,
         cache_config = vllm_config.cache_config
         lora_config = vllm_config.lora_config
         scheduler_config = vllm_config.scheduler_config
-        if cache_config.enable_prefix_caching:
-            raise RuntimeError(
-                "GraniteMoeHybrid currently does not support prefix caching")
-
         self.quant_config = vllm_config.quant_config
         self.config = config
         self.scheduler_config = scheduler_config

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -82,6 +82,7 @@ class Mamba2AttentionMetadata:
     cu_seqlen: Optional[int] = None
     batch_ptr: Optional[torch.tensor] = None
     token_chunk_offset_ptr: Optional[torch.tensor] = None
+    cache_spec: Optional[MambaSpec] = None
 
 
 class Mamba2AttentionMetadataBuilder(
@@ -116,7 +117,23 @@ class Mamba2AttentionMetadataBuilder(
         has_initial_states = None
         prep_initial_states = False
 
-        state_indices_tensor = common_attn_metadata.block_table_tensor[:, 0]
+        if self.kv_cache_spec.cache_strategy == "disabled":
+            # Always return just a single block per each request:
+            state_indices_tensor = common_attn_metadata.block_table_tensor[:, 0]
+        else:
+            # Return a tensor of shape (#requests, #blocks for longest request)
+            # filled in with cached and newly allocated blocks for each request
+            cache_block_size = self.kv_cache_spec.block_size
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+            block_table_bounds_cpu = (seq_lens_cpu + cache_block_size - 1) // cache_block_size
+            max_num_blocks = block_table_bounds_cpu.max()        
+            paged_kv_indices = common_attn_metadata.block_table_tensor[:, :max_num_blocks]
+            if self.kv_cache_spec.cache_strategy == "last":
+                # TODO: The "last" strategy is not fully implemented yet
+                # In the "last" strategy, the allocator puts 2 block in front
+                # For easiness of handling, we move them to be two last in list
+                paged_kv_indices = torch.roll(paged_kv_indices, max_num_blocks.item()-2, -1)
+            state_indices_tensor = paged_kv_indices
 
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(common_attn_metadata,
@@ -162,6 +179,7 @@ class Mamba2AttentionMetadataBuilder(
             has_initial_states=has_initial_states,
             prep_initial_states=prep_initial_states,
             chunk_size=self.chunk_size,
+            cache_spec=self.kv_cache_spec,
             seq_idx=seq_idx,
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2899,20 +2899,22 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 raise NotImplementedError(
                     "Mamba with speculative decoding is not supported yet.")
             if self.vllm_config.cache_config.enable_prefix_caching:
-                raise NotImplementedError(
-                    "Prefix caching is not supported for Mamba yet.")
-            max_model_len = self.vllm_config.model_config.max_model_len
+                mamba_block_size = self.vllm_config.cache_config.mamba_block_size
+            else:                
+                # Set block_size to max_model_len, so that mamba model will always
+                # have only one block
+                mamba_block_size = self.vllm_config.model_config.max_model_len
+                self.vllm_config.cache_config.mamba_cache_strategy = "disabled"
 
             page_size_padded = (
                 self.vllm_config.cache_config.mamba_page_size_padded)
 
-            # Set block_size to max_model_len, so that mamba model will always
-            # have only one block in the KV cache.
             for layer_name, mamba_module in mamba_layers.items():
                 kv_cache_spec[layer_name] = MambaSpec(
                     shapes=mamba_module.get_state_shape(),
                     dtype=self.kv_cache_dtype,
-                    block_size=max_model_len,
+                    block_size=mamba_block_size,
+                    cache_strategy=self.vllm_config.cache_config.mamba_cache_strategy,
                     page_size_padded=page_size_padded,
                     mamba_type=mamba_module.mamba_type)
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new </

## Purpose
This PR implements Automatic Prefix Caching (APC) for Mamba2 hybrid models.
Logic before this PR:
- Mamba2 implementation uses single cache block for the "current state" updated in-place

This PR assumes that different caching strategies might be used, currently introducing "all" and "last" strategies:
- "all" strategy - as requests arrive, allocate a number of blocks proportional to the sequence length in order to store all states at block boundaries (places where cache hits may occur), and the current state
- "last" strategy - to limit block allocations, allocate only two blocks - the last block-aligned intermediate state (to allow for cache hits), and the current state

Technical considerations:
- Current vLLM logic: Cache Manager assumes that page sizes should be equal for various attention implementations. block_size is determined as the smallest attention block size for which attention page size >= Mamba2 page size, and Mamba2 state blocks are padded.
- Additionally in this PR we introduce another condition: Due to Mamba2 kernel specifics, obtaining intermediate states efficiently during prefill is possible every mamba_chunk_size (typically 256). Thus, we assume that the block_size should be set to a multiple of 256.

Pending enhancements:
- support for multiple requests
- proper implementation of the "last" strategy (currently only "all" strategy works properly)
- tests
- verification for various other hybrid models (currently experimenting with granite-4.0-tiny)

@tdoublep @bohnstingl 

## Test Plan
```
from vllm import LLM, SamplingParams
from vllm.distributed import cleanup_dist_env_and_memory
import time
MODEL = "ibm-granite/granite-4.0-tiny-preview"
PROMPT_MULTIPLE = 310
sampling_params = SamplingParams(temperature=0.0)
prefix = ( # examples/offline_inference/prefix_caching.py
    "You are an expert school principal, skilled in effectively managing "
    "faculty and staff. Draft 10-15 questions for a potential first grade "
    "Head Teacher for my K-12, all-girls', independent school that emphasizes "
    "community, joyful discovery, and life-long learning. The candidate is "
    "coming in for a first-round panel interview for a 8th grade Math "
    "teaching role. They have 5 years of previous teaching experience "
    "as an assistant teacher at a co-ed, public school with experience "
    "in middle school math teaching. ")
prefix2 = ("Based on these information, fulfill "
            "the following paragraph: ")
prompt = PROMPT_MULTIPLE * prefix + prefix2 + "Hello, my name is"
print('Prompt length:', len(prompt))
for APC in [False, True]:
    engine = LLM(
        model=MODEL, enable_prefix_caching=APC, gpu_memory_utilization=0.4,
        enforce_eager=True, ## required for debugging
        disable_cascade_attn=True, ## not verified yet
        disable_log_stats=False, ## collect APC stats
    )
    for i in range(3):
        if i == 0:
            print('Warm-up')
        if i == 1:
            print('Measuring')
            start_time = time.time()
        outputs = engine.generate(prompt, sampling_params)
        print('APC:', APC, i, f"Generated text: {outputs[0].outputs[0].text!r}")
        for m in engine.llm_engine.get_metrics():
            if 'vllm:prefix_cache_hits' in m.name:
                print(m.name, m.value)
    print('APC:', APC, "loop took --- %s seconds ---" % (time.time() - start_time))
    del engine
    cleanup_dist_env_and_memory()
```
## Test Result

```
Warm-up
Adding requests: 100%|--------------------------------------------------------------------------------| 1/1 [00:00<00:00,  9.09it/s]
Processed prompts: 100%|-----------------------| 1/1 [00:15<00:00, 15.14s/it, est. speed input: 2438.47 toks/s, output: 1.06 toks/s]
APC: False 0 Generated text: ' NAME_1. I am an expert school principal, skilled in effectively managing'
vllm:prefix_cache_hits 0
Measuring
Adding requests: 100%|--------------------------------------------------------------------------------| 1/1 [00:00<00:00, 10.01it/s]
Processed prompts: 100%|----------------------| 1/1 [00:02<00:00,  2.43s/it, est. speed input: 15186.42 toks/s, output: 6.58 toks/s]
APC: False 1 Generated text: ' NAME_1. I am an expert school principal, skilled in effectively managing'
vllm:prefix_cache_hits 0
Adding requests: 100%|--------------------------------------------------------------------------------| 1/1 [00:00<00:00, 10.74it/s]
Processed prompts: 100%|----------------------| 1/1 [00:02<00:00,  2.53s/it, est. speed input: 14591.76 toks/s, output: 6.33 toks/s]
APC: False 2 Generated text: ' NAME_1. I am an expert school principal, skilled in effectively managing'
vllm:prefix_cache_hits 0
APC: False loop took --- 5.159611701965332 seconds ---

Warm-up
Adding requests: 100%|--------------------------------------------------------------------------------| 1/1 [00:00<00:00,  9.47it/s]
Processed prompts: 100%|-----------------------| 1/1 [00:15<00:00, 15.59s/it, est. speed input: 2367.35 toks/s, output: 1.03 toks/s]
APC: True 0 Generated text: ' NAME_1. I am an expert school principal, skilled in effectively managing'
vllm:prefix_cache_hits 0
Measuring
Adding requests: 100%|--------------------------------------------------------------------------------| 1/1 [00:00<00:00, 10.11it/s]
Processed prompts: 100%|----------------------| 1/1 [00:01<00:00,  1.65s/it, est. speed input: 22340.56 toks/s, output: 9.69 toks/s]
APC: True 1 Generated text: ' NAME_1. I am an expert school principal, skilled in effectively managing'
vllm:prefix_cache_hits 36864
Adding requests: 100%|--------------------------------------------------------------------------------| 1/1 [00:00<00:00, 10.55it/s]
Processed prompts: 100%|----------------------| 1/1 [00:01<00:00,  1.64s/it, est. speed input: 22469.11 toks/s, output: 9.74 toks/s]
APC: True 2 Generated text: ' NAME_1. I am an expert school principal, skilled in effectively managing'
vllm:prefix_cache_hits 73728
APC: True loop took --- 3.4955577850341797 seconds ---
```
