### PR TITLE
[perf]: Use in-place adds in Qwen vl

### DIFF
--- a/vllm/model_executor/models/qwen_vl.py
+++ b/vllm/model_executor/models/qwen_vl.py
@@ -242,7 +242,7 @@ class VisualAttentionBlock(nn.Module):
         x: torch.Tensor,
         attn_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        x += self.attention(self.ln_1(x), attn_mask=attn_mask)
+        x = x + self.attention(self.ln_1(x), attn_mask=attn_mask)
         x += self.mlp(self.ln_2(x))
         return x
 

--- a/vllm/model_executor/models/qwen_vl.py
+++ b/vllm/model_executor/models/qwen_vl.py
@@ -242,8 +242,8 @@ class VisualAttentionBlock(nn.Module):
         x: torch.Tensor,
         attn_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        x = x + self.attention(self.ln_1(x), attn_mask=attn_mask)
-        x = x + self.mlp(self.ln_2(x))
+        x += self.attention(self.ln_1(x), attn_mask=attn_mask)
+        x += self.mlp(self.ln_2(x))
         return x
 
 

--- a/vllm/model_executor/models/qwen_vl.py
+++ b/vllm/model_executor/models/qwen_vl.py
@@ -359,8 +359,7 @@ class VisionTransformer(nn.Module):
                       -1)  # shape = [*, width, grid ** 2]
         x = x.permute(0, 2, 1)  # shape = [*, grid ** 2, width]
 
-        x = x + get_abs_pos(self.positional_embedding, int(math.sqrt(
-            x.size(1))))
+        x += get_abs_pos(self.positional_embedding, int(math.sqrt(x.size(1))))
 
         x = self.ln_pre(x)
 


### PR DESCRIPTION
This PR changes out-of-place additions to in-place additions (+=) in the VisualAttentionBlock of the Qwen-VL model to reduce memory allocation overhead and improve performance.

Related to: https://github.com/vllm-project/vllm/issues/23884

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

command to start the model: 
```bash 
vllm serve Qwen/Qwen2-VL-7B-Instruct --max-model-len 31072
```
command to benchmark: 
```bash
vllm bench serve   --backend openai-chat   --endpoint-type openai-chat   --model Qwen/Qwen2-VL-7B-Instruct   --endpoint /v1/chat/completions   --dataset-name hf   --dataset-path lmarena-ai/VisionArena-Chat   --hf-split train   --num-prompts 1000
```

before the change

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  415.09    
Total input tokens:                      94327     
Total generated tokens:                  99090     
Request throughput (req/s):              2.41      
Output token throughput (tok/s):         238.72    
Total Token throughput (tok/s):          465.97    
---------------Time to First Token----------------
Mean TTFT (ms):                          188424.97 
Median TTFT (ms):                        177943.39 
P99 TTFT (ms):                           403871.14 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          149.13    
Median TPOT (ms):                        145.56    
P99 TPOT (ms):                           321.36    
---------------Inter-token Latency----------------
Mean ITL (ms):                           143.98    
Median ITL (ms):                         40.19     
P99 ITL (ms):                            908.31    
==================================================
```

after applying the change

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  415.48    
Total input tokens:                      94327     
Total generated tokens:                  98559     
Request throughput (req/s):              2.41      
Output token throughput (tok/s):         237.22    
Total Token throughput (tok/s):          464.25    
---------------Time to First Token----------------
Mean TTFT (ms):                          186496.52 
Median TTFT (ms):                        179024.84 
P99 TTFT (ms):                           402789.44 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          148.27    
Median TPOT (ms):                        146.81    
P99 TPOT (ms):                           284.78    
---------------Inter-token Latency----------------
Mean ITL (ms):                           145.05    
Median ITL (ms):                         40.29     
P99 ITL (ms):                            892.30    
==================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

