### PR TITLE
[MoE] Skip Gloo all_reduce optimization

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -91,7 +91,8 @@ class DPMetadata:
                 tp_size_=parallel_config.tensor_model_parallel_size,
                 dp_size_=parallel_config.data_parallel_size,
                 vllm_parallel_config=parallel_config))
-        if (moe_parallel_config.use_forward_impl_chunked
+
+        if not (moe_parallel_config.use_forward_impl_chunked
                 and num_tokens > moe_dp_chunk_size):
             dist.all_reduce(num_tokens_tensor, group=get_dp_group().cpu_group)
         return num_tokens_tensor

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -120,12 +120,7 @@ class DPMetadata:
         # Otherwise, num_tokens_across_dp[dp_rank] should be equal to batchsize
         assert (num_tokens_across_dp is None
                 or num_tokens_across_dp[dp_rank] == batchsize)
-        # SKIP NO CHUNKING
-        # When not to skip: on a2a, when chunking with chunk>1,
-        # self.moe_parallel_config.use_pplx_kernels
-        #         or self.moe_parallel_config.use_deepep_ll_kernels
-        #         or use_flashinfer_cutlass_kernels
-        # if batchsize < VLLM_MOE_DP_CHUNK_SIZE
+
         if num_tokens_across_dp is None:
             num_tokens_across_dp = DPMetadata.num_tokens_across_dp(
                 batchsize, dp_size, dp_rank, parallel_config)

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1663,14 +1663,8 @@ class FusedMoE(CustomOp):
     def forward_impl(self, hidden_states: torch.Tensor,
                      router_logits: torch.Tensor):
         assert self.quant_method is not None
-        # Route to the chunked forward path using the FlashInfer Cutlass kernel
-        # only when data parallelism (DP) is enabled.
-        use_flashinfer_cutlass_kernels = (
-            self.dp_size > 1
-            and self.moe_config.use_flashinfer_cutlass_kernels)
-        if (self.moe_parallel_config.use_pplx_kernels
-                or self.moe_parallel_config.use_deepep_ll_kernels
-                or use_flashinfer_cutlass_kernels):
+
+        if self.moe_parallel_config.use_forward_impl_chunked:
             return self.forward_impl_chunked(hidden_states, router_logits)
 
         do_naive_dispatch_combine: bool = (

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -8,12 +8,6 @@ import torch
 import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig
-from vllm.model_executor.layers.fused_moe.config import (  # noqa: E501
-    FusedMoEParallelConfig)
-from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
-    is_flashinfer_fp4_cutlass_moe_available)
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    FlashinferMoeBackend, get_flashinfer_moe_backend)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8)
 from vllm.model_executor.layers.quantization.utils.int8_utils import (
@@ -22,8 +16,6 @@ from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
     quant_dequant_mxfp4)
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     mxfp8_quantize)
-from vllm.model_executor.layers.quantization.utils.quant_utils import (
-    cutlass_fp4_supported)
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils import cdiv
@@ -284,6 +276,15 @@ def needs_gloo_all_reduce(vllm_config: VllmConfig, num_local_tokens: int):
     """
     Checks whether a Gloo AllReduce is needed for the current MoE setup.
     """
+    # Avoid circular imports.
+    from vllm.model_executor.layers.fused_moe.config import (  # noqa: E501
+        FusedMoEParallelConfig)
+    from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (  # noqa: E501
+        is_flashinfer_fp4_cutlass_moe_available)
+    from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (  # noqa: E501
+        FlashinferMoeBackend, get_flashinfer_moe_backend)
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        cutlass_fp4_supported)
     moe_dp_chunk_size: int = envs.VLLM_MOE_DP_CHUNK_SIZE
     naive_a2a_backend: bool = envs.VLLM_ALL2ALL_BACKEND == "naive"
 


### PR DESCRIPTION
This change allows to side-step the slow `gloo:all_reduce` to get the num of tokens to each DP rank, for known cases where it is not needed, in particular when chunked fused_moe is used with number of chunks=1.

It does so by explicitely ruling out the cases where it's needed.

cc @tlrmchlsmth  