### PR TITLE
[rocm] update pytorch rocm from 6.3 to 6.4

### DIFF
--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r common.txt
 
---extra-index-url https://download.pytorch.org/whl/rocm6.3
+--extra-index-url https://download.pytorch.org/whl/rocm6.4
 torch==2.8.0
 torchvision==0.23.0
 torchaudio==2.8.0


### PR DESCRIPTION
## Purpose
Update pytorch rocm from 6.3 to 6.4

Initial purpose for myself: trying to test TorchAO FP8 on MI300X, and from the [doc](https://github.com/pytorch/ao/blob/6a2d9754/torchao/float8/README.md), it is tested with ROCm 6.4.

## Test Plan & Test Result
```
# MI300X
lm_eval \
  --model vllm \
  --model_args pretrained=/home/lifans/hf_models/meta-llama/Llama-3.1-8B-Instruct,max_model_len=4096 \
  --tasks gsm8k \
  --batch_size auto
```

```
# rocm 6.4
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7862|±  |0.0113|
|     |       |strict-match    |     5|exact_match|↑  |0.7619|±  |0.0117|

# rocm 6.3
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7824|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7566|±  |0.0118|
```