### PR TITLE
[CI] Fix broken compile tests due to unsupported SiluMul+Nvfp4Quant fusion

### DIFF
--- a/vllm/compilation/activation_quant_fusion.py
+++ b/vllm/compilation/activation_quant_fusion.py
@@ -29,8 +29,9 @@ SILU_MUL_OP = torch.ops._C.silu_and_mul.default
 FUSED_OPS: dict[QuantKey, OpOverload] = {
     kFp8StaticTensorSym: torch.ops._C.silu_and_mul_quant.default,  # noqa: E501
 }
-if current_platform.is_cuda() and hasattr(torch.ops._C,
-                                          "silu_and_mul_nvfp4_quant"):
+silu_and_mul_nvfp4_quant_supported = (current_platform.is_cuda() and hasattr(
+    torch.ops._C, "silu_and_mul_nvfp4_quant"))
+if silu_and_mul_nvfp4_quant_supported:
     FUSED_OPS[
         kNvfp4Quant] = torch.ops._C.silu_and_mul_nvfp4_quant.default  # noqa: E501
 
@@ -171,8 +172,7 @@ class ActivationQuantFusionPass(VllmInductorPass):
         pattern_silu_mul_fp8 = SiluMulFp8StaticQuantPattern()
         pattern_silu_mul_fp8.register(self.patterns)
 
-        if current_platform.is_cuda() and hasattr(torch.ops._C,
-                                                  "silu_and_mul_nvfp4_quant"):
+        if silu_and_mul_nvfp4_quant_supported:
             pattern_silu_mul_nvfp4 = SiluMulNvfp4QuantPattern()
             pattern_silu_mul_nvfp4.register(self.patterns)
 

--- a/vllm/compilation/activation_quant_fusion.py
+++ b/vllm/compilation/activation_quant_fusion.py
@@ -171,8 +171,10 @@ class ActivationQuantFusionPass(VllmInductorPass):
         pattern_silu_mul_fp8 = SiluMulFp8StaticQuantPattern()
         pattern_silu_mul_fp8.register(self.patterns)
 
-        pattern_silu_mul_nvfp4 = SiluMulNvfp4QuantPattern()
-        pattern_silu_mul_nvfp4.register(self.patterns)
+        if current_platform.is_cuda() and hasattr(torch.ops._C,
+                                                  "silu_and_mul_nvfp4_quant"):
+            pattern_silu_mul_nvfp4 = SiluMulNvfp4QuantPattern()
+            pattern_silu_mul_nvfp4.register(self.patterns)
 
     def __call__(self, graph: torch.fx.Graph):
         self.begin()


### PR DESCRIPTION
## Purpose

Fix failing tests [compile/test_pass_manager.py::test_pass_manager_uuid](https://buildkite.com/vllm/ci/builds/28885/steps/canvas?jid=0198f756-9939-483d-8550-dd8113d73cff) and [compile/test_full_graph.py::test_custom_compile_config](https://buildkite.com/vllm/ci/builds/28885/steps/canvas?jid=0198f756-993a-407f-8a04-6c785a896182).

The error is:
```
[2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/activation_quant_fusion.py", line 174, in __init__
--
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)     pattern_silu_mul_nvfp4 = SiluMulNvfp4QuantPattern()
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/activation_quant_fusion.py", line 116, in __init__
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)     super().__init__(kNvfp4Quant)
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/activation_quant_fusion.py", line 55, in __init__
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)     assert self.quant_key in FUSED_OPS, \
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176) torch._dynamo.exc.BackendCompilerFailed: backend='<vllm.compilation.backends.VllmBackend object at 0x7f27e72f50a0>' raised:
  | [2025-08-29T20:36:33Z] (EngineCore_0 pid=14176) AssertionError: unsupported fusion scheme QuantKey(u8,scale(f8e4m3fn,dynamic,GroupShape(row=1, col=16)),scale2(f32,static,per_tensor),symmetric)
```

This can happen when `hasattr(torch.ops._C, "silu_and_mul_nvfp4_quant")` is false. Only enable SiluMul+Nvfp4Quant fusion added in https://github.com/vllm-project/vllm/pull/23671 if supported.

## Test Plan
```
pytest tests/compile/test_pass_manager.py::test_pass_manager_uuid
pytest tests/compile/test_full_graph.py::test_custom_compile_config
```


## Test Result
All tests passed locally, check passes in CI as well.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>