### PR TITLE
[BUGFIX] GPTQ quantization compatibility for Qwen3 MOE models (AutoGPTQ and AutoRound-GPTQ)

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -37,6 +37,7 @@ class GPTQConfig(QuantizationConfig):
         desc_act: bool,
         lm_head_quantized: bool,
         dynamic: dict[str, dict[str, Union[int, bool]]],
+        autoround_version: str = "",
     ) -> None:
         # GPTQModel use `dynamic` config property to allow per module
         # quantization config so each module can be individually optimized.
@@ -74,6 +75,9 @@ class GPTQConfig(QuantizationConfig):
                 "Currently, only 2/3/4/8-bit weight quantization is "
                 f"supported for GPTQ, but got {self.weight_bits} bits.")
 
+        # used to identify GPTQ model quantized by autoround
+        self.autoround_version = autoround_version
+
     def __repr__(self) -> str:
         return (f"GPTQConfig(weight_bits={self.weight_bits}, "
                 f"group_size={self.group_size}, "
@@ -108,8 +112,10 @@ class GPTQConfig(QuantizationConfig):
         desc_act = cls.get_from_keys(config, ["desc_act"])
         lm_head_quantized = cls.get_from_keys_or(config, ["lm_head"],
                                                  default=False)
+        autoround_version = cls.get_from_keys_or(config, ["autoround_version"],
+                                                 default="")
         return cls(weight_bits, group_size, desc_act, lm_head_quantized,
-                   dynamic)
+                   dynamic, autoround_version)
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -119,6 +119,9 @@ class GPTQMarlinConfig(QuantizationConfig):
 
         self.quant_type = self.TYPE_MAP[(weight_bits, is_sym)]
 
+        # used to identify GPTQ model quantized by autoround
+        self.autoround_version = full_config.get("autoround_version", "")
+
     def __repr__(self) -> str:
         return (f"GPTQMarlinConfig(quant_type={self.quant_type}, "
                 f"group_size={self.group_size}, "

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-#
+
 # Copyright 2024 The Qwen team.
 # Copyright 2023 The vLLM team.
 # Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
@@ -46,6 +46,9 @@ from vllm.model_executor.layers.linear import (MergedColumnParallelLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.gptq import GPTQConfig
+from vllm.model_executor.layers.quantization.gptq_marlin import (
+    GPTQMarlinConfig)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
@@ -109,34 +112,28 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
+
         self.ep_group = get_ep_group().device_group
         self.ep_rank = self.ep_group.rank()
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.num_experts
+
         if self.tp_size > config.num_experts:
             raise ValueError(
                 f"Tensor parallel size {self.tp_size} is greater than "
                 f"the number of experts {config.num_experts}.")
 
-        from_autoround_gptq = False
-        if hasattr(config, "quantization_config"):
-            q_config = config.quantization_config
-            if (isinstance(q_config, dict)
-                    and q_config.get("quant_method") == "gptq"
-                    and "autoround_version" in q_config):
-                from_autoround_gptq = True
-
-        gate_quant_config = quant_config if from_autoround_gptq else None
-
         # Load balancing settings.
         vllm_config = get_current_vllm_config()
         eplb_config = vllm_config.parallel_config.eplb_config
         self.enable_eplb = enable_eplb
+
         self.n_logical_experts = self.n_routed_experts
         self.n_redundant_experts = eplb_config.num_redundant_experts
         self.n_physical_experts = (self.n_logical_experts +
                                    self.n_redundant_experts)
         self.n_local_physical_experts = self.n_physical_experts // self.ep_size
+
         self.physical_expert_start = (self.ep_rank *
                                       self.n_local_physical_experts)
         self.physical_expert_end = (self.physical_expert_start +
@@ -152,21 +149,37 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
                                 prefix=f"{prefix}.experts",
                                 enable_eplb=self.enable_eplb,
                                 num_redundant_experts=self.n_redundant_experts)
-        self.gate = ReplicatedLinear(config.hidden_size,
-                                     config.num_experts,
-                                     bias=False,
-                                     quant_config=gate_quant_config,
-                                     prefix=f"{prefix}.gate")
+
+        self.gate = ReplicatedLinear(
+            config.hidden_size,
+            config.num_experts,
+            bias=False,
+            quant_config=self._maybe_ignore_quant_config(quant_config),
+            prefix=f"{prefix}.gate")
+
+    def _maybe_ignore_quant_config(self, quant_config: QuantizationConfig):
+        # GPTQ configs do not have a list of ignored modules, however AutoGPTQ
+        # seems to avoid gate quantization while AutoRound does.
+        # See: https://huggingface.co/Qwen/Qwen3-30B-A3B-GPTQ-Int4,
+        # and https://huggingface.co/jart25/Qwen3-Coder-30B-A3B-Instruct-Int4-gptq
+        if isinstance(
+                quant_config,
+            (GPTQConfig,
+             GPTQMarlinConfig)) and not quant_config.autoround_version:
+            return None
+        return quant_config
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # NOTE: hidden_states can have either 1D or 2D shape.
         orig_shape = hidden_states.shape
         hidden_dim = hidden_states.shape[-1]
         hidden_states = hidden_states.view(-1, hidden_dim)
+
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(hidden_states=hidden_states,
                                            router_logits=router_logits)
+
         return final_hidden_states.view(orig_shape)
 
 
@@ -219,6 +232,7 @@ class Qwen3MoeAttention(nn.Module):
                                           bias=qkv_bias,
                                           quant_config=quant_config,
                                           prefix=f"{prefix}.qkv_proj")
+
         self.o_proj = RowParallelLinear(self.total_num_heads * self.head_dim,
                                         hidden_size,
                                         bias=False,
@@ -257,17 +271,16 @@ class Qwen3MoeAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-
         # Add qk-norm
         q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim,
                            self.head_dim)
         q_by_head = self.q_norm(q_by_head)
         q = q_by_head.view(q.shape)
+
         k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim,
                            self.head_dim)
         k_by_head = self.k_norm(k_by_head)
         k = k_by_head.view(k.shape)
-
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
@@ -293,7 +306,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
         dual_chunk_attention_config = getattr(config,
                                               "dual_chunk_attention_config",
                                               None)
-
         self.self_attn = Qwen3MoeAttention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
@@ -345,11 +357,11 @@ class Qwen3MoeDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.input_layernorm(
                 hidden_states, residual)
-
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
         )
+
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual)
@@ -362,11 +374,11 @@ class Qwen3MoeModel(nn.Module):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
+
         config = vllm_config.model_config.hf_config
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
         parallel_config = vllm_config.parallel_config
-
         enable_eplb = parallel_config.enable_eplb
         eplb_config = parallel_config.eplb_config
         self.num_redundant_experts = eplb_config.num_redundant_experts
@@ -374,7 +386,6 @@ class Qwen3MoeModel(nn.Module):
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.config = config
-
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
@@ -390,7 +401,6 @@ class Qwen3MoeModel(nn.Module):
             prefix=f"{prefix}.layers",
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-
         self.make_empty_intermediate_tensors = (
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))
@@ -415,16 +425,13 @@ class Qwen3MoeModel(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
-
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual)
-
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({
                 "hidden_states": hidden_states,
                 "residual": residual
             })
-
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
@@ -456,9 +463,7 @@ class Qwen3MoeModel(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
-
         expert_params_mapping = self.get_expert_mapping()
-
         for name, loaded_weight in weights:
             for (param_name, weight_name, shard_id) in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
@@ -481,7 +486,6 @@ class Qwen3MoeModel(nn.Module):
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
-
                 if name.endswith("scale"):
                     # Remapping the name of FP8 kv-scale.
                     name = maybe_remap_kv_scale_name(name, params_dict)
@@ -504,14 +508,18 @@ class Qwen3MoeModel(nn.Module):
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
                         continue
+
                     # Anyway, this is an expert weight and should not be
                     # attempted to load as other weights later
                     is_expert_weight = True
+
                     # Do not modify `name` since the loop may continue here
                     # Instead, create a new variable
                     name_mapped = name.replace(weight_name, param_name)
+
                     if is_pp_missing_parameter(name_mapped, self):
                         continue
+
                     # Skip loading extra parameters for GPTQ/modelopt models.
                     if name_mapped.endswith(
                             ignore_suffixes
@@ -539,15 +547,14 @@ class Qwen3MoeModel(nn.Module):
                         # However it's not mapped locally to this rank
                         # So we simply skip it
                         continue
+
                     # Skip loading extra parameters for GPTQ/modelopt models.
                     if name.endswith(
                             ignore_suffixes) and name not in params_dict:
                         continue
-
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name, self):
                         continue
-
                     # Remapping the name of FP8 kv-scale.
                     if name.endswith("kv_scale"):
                         remapped_kv_scale_name = name.replace(
@@ -565,7 +572,6 @@ class Qwen3MoeModel(nn.Module):
                     weight_loader = getattr(param, "weight_loader",
                                             default_weight_loader)
                     weight_loader(param, loaded_weight)
-
             loaded_params.add(name)
         return loaded_params
 
@@ -605,17 +611,21 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA,
 
         # Set MoE hyperparameters
         self.expert_weights = []
+
         self.moe_layers: list[FusedMoE] = []
         example_layer = None
         for layer in self.model.layers:
             if isinstance(layer, PPMissingLayer):
                 continue
+
             assert isinstance(layer, Qwen3MoeDecoderLayer)
             if isinstance(layer.mlp, Qwen3MoeSparseMoeBlock):
                 example_layer = layer.mlp
                 self.moe_layers.append(layer.mlp.experts)
+
         if example_layer is None:
-            raise RuntimeError("No Qwen3Moe layer found in the model.layers.")
+            raise RuntimeError("No Qwen3MoE layer found in the model.layers.")
+
         self.num_moe_layers = len(self.moe_layers)
         self.num_expert_groups = 1
         self.num_shared_experts = 0

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -684,9 +684,8 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA,
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
-        weights_list = list(weights)
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights_list)
+        return loader.load_weights(weights)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -691,7 +691,7 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA,
         try:
             loader = AutoWeightsLoader(self)
             return loader.load_weights(weights_list)
-        except Exception:
+        except KeyError:
             logger.warning("Detected quantized MoE gate layers. "
                            "Proceeding with automatic "
                            "gate layer adjustment "

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -653,9 +653,13 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA,
             return loader.load_weights(weights_list)
         except Exception:
             logger.warning("Detected quantized MoE gate layers. "
-                           "Proceeding with automatic"
-                           "gate layer adjustment"
-                           "for compatibility.")
+                           "Proceeding with automatic "
+                           "gate layer adjustment "
+                           "for compatibility. "
+                           "Please use the env variable: "
+                           "VLLM_QUANTIZATION_FROM_AUTOROUND_GPTQ=1 "
+                           "to avoid the adjustment and the WARNING: "
+                           "Current vLLM config is not set.")
             for layer in self.model.layers:
                 if isinstance(layer, PPMissingLayer):
                     continue

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -150,11 +150,11 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             config.hidden_size,
             config.num_experts,
             bias=False,
-            quant_config=self.maybe_not_quantization(quant_config),
+            quant_config=self._maybe_not_quantization(quant_config),
             prefix=f"{prefix}.gate")
 
-    def maybe_not_quantization(self,
-                               quant_config: Optional[QuantizationConfig]):
+    def _maybe_not_quantization(self,
+                                quant_config: Optional[QuantizationConfig]):
         if os.environ.get("VLLM_QUANTIZATION_FROM_AUTOROUND_GPTQ") == "1":
             return quant_config
         if isinstance(quant_config, (GPTQConfig, GPTQMarlinConfig)):

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -312,8 +312,8 @@ class Qwen3MoeDecoderLayer(nn.Module):
         mlp_only_layers = ([] if not hasattr(config, "mlp_only_layers") else
                            config.mlp_only_layers)
         if (layer_idx not in mlp_only_layers) and (
-            config.num_experts > 0 and
-                (layer_idx + 1) % config.decoder_sparse_step == 0):
+                config.num_experts > 0 and
+            (layer_idx + 1) % config.decoder_sparse_step == 0):
             self.mlp = Qwen3MoeSparseMoeBlock(config=config,
                                               quant_config=quant_config,
                                               prefix=f"{prefix}.mlp",


### PR DESCRIPTION
The following PR attempts to make the quantized MOE model chart compatible with AutoGPTQ and Autoround-GPTQ.

The PR: https://github.com/vllm-project/vllm/issues/23467 attempted to fix GPTQ quantization for Autoround-GPTQ, but it prevented AutoGPTQ models from loading, as @Isotr0py pointed out in his PR: https://github.com/vllm-project/vllm/pull/23490

In PR #23490, the method _maybe_ignore_quant_config was created.

Which: if isinstance(quant_config, (GPTQConfig, GPTQMarlinConfig)): returns None. This again breaks AutoRound-GPTQ models, since they do have quantized layer gates.

The current PR attempts to extend @Isotr0py's logic and establish an environment variable that directly sets quant_config = quant_config if VLLM_QUANTIZATION_FROM_AUTOROUND_GPTQ = 1.

A fallback system is also implemented, allowing AutoRound-GPTQs to run once the load_weights loading has failed due to the need to set the quantized layer gates and having been initially configured with quant_config = None.

The fallback log also warns of the use of: VLLM_QUANTIZATION_FROM_AUTOROUND_GPTQ = 1

To avoid entering the fallback and autotuning the gates.

I've tested both the following models:
Qwen/Qwen3-30B-A3B-GPTQ-Int4 performed using AutoGPTQ
Loading without fallback

and

jart25/Qwen3-Coder-30B-A3B-Instruct-Int8-gptq performed using Autoround-GPTQ
Loading with fallback.
It doesn't fallback if: VLLM_QUANTIZATION_FROM_AUTOROUND_GPTQ=1
And it works correctly