### PR TITLE
[Perf] Freeze core engine proc heap after init

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import gc
 import os
 import queue
 import signal
@@ -535,6 +536,11 @@ class EngineCoreProc(EngineCore):
 
         self.step_fn = (self.step if self.batch_queue is None else
                         self.step_with_batch_queue)
+
+        # Mark the startup heap as static so that it's ignored by GC.
+        # Reduces pause times of oldest generation collections.
+        gc.collect()
+        gc.freeze()
 
     @contextmanager
     def _perform_handshakes(


### PR DESCRIPTION
This avoids all of the "static" objects being traversed during garbage collections of the oldest generation, which reduces the pause times when they occur.

We already do this in the API server process, but it can't harm to also do it in the process where the scheduler and kv cache manager run, since they also do frequent temporary allocations.