### PR TITLE
Allow loading of cpatonn/InternVL3_5-14B-AWQ-4bit

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -63,7 +63,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         sparsity_ignore_list: list[str],
         kv_cache_scheme: Optional[dict[str, Any]] = None,
         config: Optional[dict[str, Any]] = None,
-        transform_config: Optional[TransformConfig] = None,
+        transform_config: Optional[dict] = None,
     ):
         super().__init__()
         self.ignore = ignore
@@ -75,7 +75,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.sparsity_ignore_list = sparsity_ignore_list
         self.config = config
 
-        if transform_config is not None:
+        if transform_config is not None and transform_config:
             self.transform_config = TransformConfig.model_validate(
                 transform_config)
         else:


### PR DESCRIPTION
## Purpose

Allow loading of https://huggingface.co/cpatonn/InternVL3_5-14B-AWQ-4bit. Without this patch, we get a Pydantic validation error like this:

```text
  (APIServer pid=2029616) Traceback (most recent call last):
  (APIServer pid=2029616)   File "<frozen runpy>", line 198, in _run_module_as_main
  (APIServer pid=2029616)   File "<frozen runpy>", line 88, in _run_code
  (APIServer pid=2029616)   File "/home/jeff/local_clones/github.com/vllm-project/vllm/vllm/entrypoints/openai/api_server.py", line 1996, in <module>
  (APIServer pid=2029616)     uvloop.run(run_server(args))
  (APIServer pid=2029616)   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/uvloop/__init__.py", line 109, in run
  (APIServer pid=2029616)     return __asyncio.run(
  (APIServer pid=2029616)            ^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "/usr/lib/python3.12/asyncio/runners.py", line 195, in run
  (APIServer pid=2029616)     return runner.run(main)
  (APIServer pid=2029616)            ^^^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
  (APIServer pid=2029616)     return self._loop.run_until_complete(task)
  (APIServer pid=2029616)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  (APIServer pid=2029616)   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/uvloop/__init__.py", line 61, in wrapper
  (APIServer pid=2029616)     return await main
  (APIServer pid=2029616)            ^^^^^^^^^^
  (APIServer pid=2029616)   File "/home/jeff/local_clones/github.com/vllm-project/vllm/vllm/entrypoints/openai/api_server.py", line 1926, in run_server
  (APIServer pid=2029616)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
  (APIServer pid=2029616)   File "/home/jeff/local_clones/github.com/vllm-project/vllm/vllm/entrypoints/openai/api_server.py", line 1946, in 
  run_server_worker
  (APIServer pid=2029616)     async with build_async_engine_client(
  (APIServer pid=2029616)                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
  (APIServer pid=2029616)     return await anext(self.gen)
  (APIServer pid=2029616)            ^^^^^^^^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "/home/jeff/local_clones/github.com/vllm-project/vllm/vllm/entrypoints/openai/api_server.py", line 178, in 
  build_async_engine_client
  (APIServer pid=2029616)     async with build_async_engine_client_from_engine_args(
  (APIServer pid=2029616)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
  (APIServer pid=2029616)     return await anext(self.gen)
  (APIServer pid=2029616)            ^^^^^^^^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "/home/jeff/local_clones/github.com/vllm-project/vllm/vllm/entrypoints/openai/api_server.py", line 204, in 
  build_async_engine_client_from_engine_args
  (APIServer pid=2029616)     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
  (APIServer pid=2029616)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  (APIServer pid=2029616)   File "/home/jeff/local_clones/github.com/vllm-project/vllm/vllm/engine/arg_utils.py", line 1382, in create_engine_config
  (APIServer pid=2029616)     config = VllmConfig(
  (APIServer pid=2029616)              ^^^^^^^^^^^
  (APIServer pid=2029616)   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 123, in __init__
  (APIServer pid=2029616)     s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  (APIServer pid=2029616) pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
  (APIServer pid=2029616) config_groups
  (APIServer pid=2029616)   Field required [type=missing, input_value={}, input_type=dict]
  (APIServer pid=2029616)     For further information visit https://errors.pydantic.dev/2.11/v/missing

```

## Test Plan

Try loading cpatonn/InternVL3_5-14B-AWQ-4bit, observe it working and not hitting the Pydantic validation failure.

## Test Result

Loads successfully.
