### PR TITLE
[Misc] Enable V1 FP16 inference on pre-Ampere GPUs

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1432,17 +1432,6 @@ class EngineArgs:
                                recommend_to_remove=True)
             return False
 
-        # Triton v3.3 has f16 conversion regression issue on Turing and Volta,
-        # which broke fp16 inference
-        # see: https://github.com/triton-lang/triton/issues/6698
-        if (current_platform.is_cuda()
-                and not current_platform.has_device_capability(80)
-                and model_config.dtype == torch.float16):
-            _raise_or_fallback(
-                feature_name="Compute Capability < 8.0 with FP16",
-                recommend_to_remove=False)
-            return False
-
         if self.kv_cache_dtype != "auto":
             supported = current_platform.is_kv_cache_dtype_supported(
                 self.kv_cache_dtype, model_config)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- After #20358, we upgraded Triton to 3.4.0, which have fixed the issue that broke pre-Ampere FP16 calculation, so we can fully enable V1 on Volta and Turing now.

## Test Plan
```
python examples/offline_inference/basic/basic.py
```

## Test Result
Have confirmed on T4 machine:
```
(EngineCore_0 pid=1333) INFO 09-01 05:34:08 [core.py:75] Initializing a V1 LLM engine (v0.10.1rc2.dev405+g8c742a66d) with config: model='facebook/opt-125m', speculative_config=None, tokenizer='facebook/opt-125m', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=facebook/opt-125m, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":3,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output","vllm.mamba_mixer2","vllm.mamba_mixer","vllm.short_conv","vllm.linear_attention"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"cudagraph_mode":1,"use_cudagraph":true,"cudagraph_num_of_warmups":1,"cudagraph_capture_sizes":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"pass_config":{},"max_capture_size":512,"local_cache_dir":null}
(EngineCore_0 pid=1333) ERROR 09-01 05:34:11 [fa_utils.py:57] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
[W901 05:34:22.565738035 socket.cpp:200] [c10d] The hostname of the client socket cannot be retrieved. err=-3
[W901 05:34:32.576528242 socket.cpp:200] [c10d] The hostname of the client socket cannot be retrieved. err=-3
[W901 05:34:32.577286626 ProcessGroupNCCL.cpp:981] Warning: TORCH_NCCL_AVOID_RECORD_STREAMS is the default now, this environment variable is thus deprecated. (function operator())
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_0 pid=1333) INFO 09-01 05:34:32 [parallel_state.py:1134] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_0 pid=1333) WARNING 09-01 05:34:32 [topk_topp_sampler.py:69] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
(EngineCore_0 pid=1333) INFO 09-01 05:34:32 [gpu_model_runner.py:1926] Starting to load model facebook/opt-125m...
(EngineCore_0 pid=1333) INFO 09-01 05:34:32 [gpu_model_runner.py:1958] Loading model from scratch...
(EngineCore_0 pid=1333) INFO 09-01 05:34:32 [cuda.py:334] Using FlexAttention backend on V1 engine.
(EngineCore_0 pid=1333) INFO 09-01 05:34:33 [weight_utils.py:304] Using model weights format ['*.safetensors', '*.bin', '*.pt']
pytorch_model.bin: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 251M/251M [00:01<00:00, 196MB/s]
(EngineCore_0 pid=1333) INFO 09-01 05:34:34 [weight_utils.py:325] Time spent downloading weights for facebook/opt-125m: 1.631956 seconds
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.39it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.39it/s]
(EngineCore_0 pid=1333) 
(EngineCore_0 pid=1333) INFO 09-01 05:34:35 [default_loader.py:267] Loading weights took 0.30 seconds
(EngineCore_0 pid=1333) INFO 09-01 05:34:35 [gpu_model_runner.py:1980] Model loading took 0.2389 GiB and 2.342473 seconds
(EngineCore_0 pid=1333) INFO 09-01 05:34:38 [backends.py:538] Using cache directory: /root/.cache/vllm/torch_compile_cache/d4f9f3287c/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_0 pid=1333) INFO 09-01 05:34:38 [backends.py:549] Dynamo bytecode transform time: 2.61 s
(EngineCore_0 pid=1333) INFO 09-01 05:34:41 [backends.py:194] Cache the graph for dynamic shape for later use
(EngineCore_0 pid=1333) [rank0]:W0901 05:34:42.399000 1333 torch/_inductor/utils.py:1436] [0/0] Not enough SMs to use max_autotune_gemm mode
(EngineCore_0 pid=1333) INFO 09-01 05:34:47 [backends.py:215] Compiling a graph for dynamic shape takes 9.14 s
(EngineCore_0 pid=1333) INFO 09-01 05:34:48 [monitor.py:34] torch.compile takes 11.75 s in total
(EngineCore_0 pid=1333) INFO 09-01 05:34:49 [gpu_worker.py:276] Available KV cache memory: 12.54 GiB
(EngineCore_0 pid=1333) INFO 09-01 05:34:49 [kv_cache_utils.py:849] GPU KV cache size: 365,200 tokens
(EngineCore_0 pid=1333) INFO 09-01 05:34:49 [kv_cache_utils.py:853] Maximum concurrency for 2,048 tokens per request: 178.32x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|████████████████████████████████████████████████████████████████████████████████| 67/67 [00:01<00:00, 46.10it/s]
(EngineCore_0 pid=1333) INFO 09-01 05:34:51 [gpu_model_runner.py:2681] Graph capturing finished in 2 secs, took 0.21 GiB
(EngineCore_0 pid=1333) INFO 09-01 05:34:51 [core.py:217] init engine (profile, create kv cache, warmup model) took 16.03 seconds
INFO 09-01 05:34:52 [llm.py:283] Supported_tasks: ['generate']
Adding requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 781.03it/s]
Processed prompts:  25%|████████████▊                                      | 1/4 [00:16<00:49, 16.44s/it, est. speed input: 0.36 toks/s, output: 0.97 toks/s]Processed prompts: 100%|███████████████████████████████████████████████████| 4/4 [00:16<00:00,  4.12s/it, est. speed input: 1.58 toks/s, output: 3.89 toks/s]

Generated Outputs:
------------------------------------------------------------
Prompt:    'Hello, my name is'
Output:    ' Joel, I am a 4yo, I am very naughty, and I like'
------------------------------------------------------------
Prompt:    'The president of the United States is'
Output:    ' reportedly holding back from issuing a statement about the Ukraine crisis after he called the International'
------------------------------------------------------------
Prompt:    'The capital of France is'
Output:    ' the capital of the French colony of Ireland.\nLaws of France are not'
------------------------------------------------------------
Prompt:    'The future of AI is'
Output:    " in the hands of the vast majority of people - you've probably seen it already"
------------------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

