### PR TITLE
[build] fix tag_regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -520,7 +520,12 @@ def get_gaudi_sw_version():
 
 
 def get_vllm_version() -> str:
-    version = get_version(write_to="vllm/_version.py")
+    version = get_version(
+        write_to="vllm/_version.py",
+        # allow 3 minor versions (by default, only 2)
+        tag_regex=re.compile(
+            r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,3}[^\+]*)(?:\+.*)?$"
+        ))
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 
     if _no_device():


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The default regex can only recognize 2 minor versions, while we can have 3. this leads to problems that we cannot generate `0.10.1.2` in nightly wheel, so people cannot download the wheel directly using `pip` .

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

