### PR TITLE
[Bugfix] Fix the issue that Blip2ForConditionalGeneration' object has…

### DIFF
--- a/vllm/model_executor/models/blip2.py
+++ b/vllm/model_executor/models/blip2.py
@@ -560,8 +560,8 @@ class Blip2ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors)
 
-    def _create_image_input(self,
-                            **kwargs: object) -> Optional[Blip2ImageInputs]:
+    def _parse_and_validate_image_input(
+            self, **kwargs: object) -> Optional[Blip2ImageInputs]:
         pixel_values = kwargs.pop("pixel_values", None)
         image_embeds = kwargs.pop("image_embeds", None)
 


### PR DESCRIPTION
## Purpose
Due to [commit](https://github.com/vllm-project/vllm/commit/ccf27cc4d4645a1382c7742bb6bddedb7dc50fea) ,  `_parse_and_validate_image_input` was renamed to `_create_image_input`, and this leads to error when run blip2 model, eg
```
vllm serve Salesforce/blip2-opt-6.7b   --max_model_len 2048   --max_num_seq 32
```
<img width="1262" height="309" alt="image" src="https://github.com/user-attachments/assets/8bd2314e-82b7-4a8d-9153-5e8dd638c77a" />

This pr just renames  `_create_image_input` back to `_parse_and_validate_image_input` like mostly multimodal models in vllm repo.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

