### PR TITLE
[Feature][Quantization] Support Quark for mixed-precision quantized model

### DIFF
--- a/tests/quantization/test_mixed_precision.py
+++ b/tests/quantization/test_mixed_precision.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test quark-quantized mixed precision models. Specifically,
+- mixed precision schemes of {MXFP4, FP8}
+- (private) models include:
+    - amd/Llama-2-70b-chat-hf-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8
+    - amd/Mixtral-8x7B-Instruct-v0.1-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8
+
+Run `pytest tests/quantization/test_mixed_precision.py`.
+
+"""
+
+from dataclasses import dataclass
+import huggingface_hub
+import importlib
+import importlib.metadata
+import lm_eval
+import os
+from packaging import version
+import pytest
+import torch
+from typing import List
+
+
+QUARK_MXFP4_AVAILABLE = importlib.util.find_spec(
+    "quark") is not None and version.parse(
+        importlib.metadata.version("amd-quark")) >= version.parse('0.8.99')
+
+try:
+    huggingface_hub.list_repo_refs(
+        "amd/Mixtral-8x7B-Instruct-v0.1-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8")
+    HF_HUB_AMD_ORG_ACCESS = True
+except huggingface_hub.errors.RepositoryNotFoundError:
+    HF_HUB_AMD_ORG_ACCESS = False
+
+
+@pytest.fixture(scope="function", autouse=True)
+def use_v0_only(monkeypatch):
+    """
+    This module relies on V0 internals, so set VLLM_USE_V1=0.
+    """
+    monkeypatch.setenv('VLLM_USE_V1', '0')
+
+
+
+@dataclass
+class ModelCase:
+    model_id: str
+    tp: int
+
+
+@dataclass
+class EvaluationConfig:
+    model_name: str
+    excepted_value: float
+
+    def get_model_args(self) -> str:
+        return (
+            f"pretrained={self.model_name},"
+            "tensor_parallel_size=4,dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=False"
+        )
+
+
+ACCURACY_CONFIGS = [
+    # Private model.
+    EvaluationConfig(
+        model_name="amd/Llama-2-70b-chat-hf-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8",
+        excepted_value=0.53),
+    EvaluationConfig(
+        model_name="amd/Mixtral-8x7B-Instruct-v0.1-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8",
+        excepted_value=0.60),
+]
+TASKS = ["arc_challenge"]
+
+
+@pytest.mark.parametrize("config", ACCURACY_CONFIGS)
+@pytest.mark.parametrize("task", TASKS)
+@pytest.mark.skipif(not QUARK_MXFP4_AVAILABLE,
+                    reason="amd-quark>=0.9 is not available")
+@pytest.mark.skipif(
+    not HF_HUB_AMD_ORG_ACCESS,
+    reason="Read access to huggingface.co/amd is required for this test.")
+def test_mixed_precision_model_accuracies(config: EvaluationConfig, task: str):
+
+    rtol = 0.05
+
+    os.environ["VLLM_USE_TRITON_FLASH_ATTN"] = "0"
+    os.environ["VLLM_QUARK_EMU_MEM_OPT"] = "1"
+
+    results = lm_eval.simple_evaluate(
+        model="vllm",
+        model_args=config.get_model_args(),
+        tasks=task,
+        batch_size="auto"
+    )
+
+    EXPECTED_VALUE = config.excepted_value
+    measured_value = results["results"][task]["acc"]
+    assert (measured_value - rtol < EXPECTED_VALUE
+            and measured_value + rtol > EXPECTED_VALUE
+            ), f"Expected: {EXPECTED_VALUE} |  Measured: {measured_value}"
+
+    del os.environ["VLLM_USE_TRITON_FLASH_ATTN"]
+    del os.environ["VLLM_QUARK_EMU_MEM_OPT"]
+

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -173,7 +173,8 @@ def _mxfp4_quantize(
     block_shape: Optional[list[int]] = None,
 ) -> tuple[torch.Tensor, None]:
     assert block_shape is None
-    VLLM_QUARK_EMU_MEM_OPT = (os.environ.get("VLLM_QUARK_EMU_MEM_OPT", "0") == "1")
+    VLLM_QUARK_EMU_MEM_OPT = (os.environ.get("VLLM_QUARK_EMU_MEM_OPT",
+                                             "0") == "1")
     if not current_platform.supports_mx() or VLLM_QUARK_EMU_MEM_OPT:
         A = quant_dequant_mxfp4(A)
     else:

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
 from math import prod
 from typing import Optional, Union
 
@@ -171,7 +173,8 @@ def _mxfp4_quantize(
     block_shape: Optional[list[int]] = None,
 ) -> tuple[torch.Tensor, None]:
     assert block_shape is None
-    if not current_platform.supports_mx():
+    VLLM_QUARK_EMU_MEM_OPT = (os.environ.get("VLLM_QUARK_EMU_MEM_OPT", "0") == "1")
+    if not current_platform.supports_mx() or VLLM_QUARK_EMU_MEM_OPT:
         A = quant_dequant_mxfp4(A)
     else:
         raise NotImplementedError()

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -102,7 +102,9 @@ class QuarkConfig(QuantizationConfig):
             layer_quant_set = set(layer_quant_names)
 
             if not (kv_cache_set.issubset(layer_quant_set) or \
-                any(fnmatch.fnmatchcase(layer_quant, pat) for layer_quant in list(layer_quant_set) for pat in list(kv_cache_set))):
+                any(fnmatch.fnmatchcase(layer_quant, pat) \
+                    for layer_quant in list(layer_quant_set) \
+                        for pat in list(kv_cache_set))):
                 raise ValueError("The Quark quantized model has the "
                                  "kv_cache_group parameter setting, "
                                  "but no kv_cache quantization settings "
@@ -117,11 +119,14 @@ class QuarkConfig(QuantizationConfig):
                 while None in q_configs:
                     q_configs.remove(None)
                 for name, quant_cfg in layer_quant_config.items():
-                    if any(fnmatch.fnmatchcase(name, kv_pattern) for kv_pattern in kv_cache_group):
+                    if any(
+                            fnmatch.fnmatchcase(name, kv_pattern)
+                            for kv_pattern in kv_cache_group):
                         q_configs.append(quant_cfg)
 
             if not all(
-                    deep_compare(q_config["output_tensors"], q_configs[0]["output_tensors"])
+                    deep_compare(q_config["output_tensors"], q_configs[0]
+                                 ["output_tensors"])
                     for q_config in q_configs):
                 raise ValueError(
                     "The quantization method used for kv_cache should "
@@ -262,7 +267,7 @@ class QuarkConfig(QuantizationConfig):
 
     def _find_matched_config(self, layer_name: str,
                              module: torch.nn.Module) -> dict[str, Any]:
-        
+
         proj_name = layer_name.split(".")[-1]
         if proj_name in self.packed_modules_mapping:
             shard_proj_names = self.packed_modules_mapping[proj_name]
@@ -290,7 +295,8 @@ class QuarkConfig(QuantizationConfig):
             layer_quant_configs = list()
             for name_pattern in layer_quant_config:
                 if layer_name in name_pattern:
-                    layer_quant_configs.append(layer_quant_config[name_pattern])
+                    layer_quant_configs.append(
+                        layer_quant_config[name_pattern])
                     return layer_quant_configs[0]
 
             layer_type = cast(str, type(module))

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -112,17 +112,11 @@ class QuarkConfig(QuantizationConfig):
                                  "configuration.")
 
             q_configs = [
-                cast(dict[str, Any], layer_quant_config.get(name))
-                for name in kv_cache_group
+                quant_cfg for name, quant_cfg in layer_quant_config.items()
+                if any(
+                    fnmatch.fnmatchcase(name, pattern)
+                    for pattern in kv_cache_group)
             ]
-            if None in q_configs:
-                while None in q_configs:
-                    q_configs.remove(None)
-                for name, quant_cfg in layer_quant_config.items():
-                    if any(
-                            fnmatch.fnmatchcase(name, kv_pattern)
-                            for kv_pattern in kv_cache_group):
-                        q_configs.append(quant_cfg)
 
             if not all(
                     deep_compare(q_config["output_tensors"], q_configs[0]


### PR DESCRIPTION
## Purpose
This PR aims to support _**layerwise**_ mixed-precision quantization model inference, extending from quantized models in single scheme such as MXFP4, FP8 (aka PTQ models).

Here, the layerwise mixed-precision configuration for a given model is searched and then quantized by amd-quark. Specifically, in this PR, we focus on mixed scheme of {MXFP4, FP8}. FP8 here denotes for FP8 per-tensor scheme.

With the mixed-precision quantized model, one could achieve an optimal balance between accuracy and hardware metrics.
To demonstrate the benefits of mixed-precision model in the PR, we show the model accuracies on several commonly used tasks only using Quark emulation kernel for MXFP4 and triton kernel for FP8.

## Test Plan
Test on
1. Dense model: [amd/Llama-2-70b-chat-hf-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8](https://huggingface.co/amd/Llama-2-70b-chat-hf-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8)
2. MoE model: [amd/Mixtral-8x7B-Instruct-v0.1-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8](https://huggingface.co/amd/Mixtral-8x7B-Instruct-v0.1-Auto-Mixed-Precision-Weight-And-Activation-Mixed-MXFP4-FP8PT-KVFP8)

## Test Result
Coming soon.

## List of TODO items
- [x] Layerwise mixed-precision quantization scheme of {MXFP4, FP8} (exactly this PR aims for)
- [ ] benchmark hardware metrics
- [ ] further support Unquantized Linear and/or MoE layer(s) into mixed-precision scheme, i.e., {MXFP4, FP8, BF16/FP16}
- [ ] further support MXFP6 scheme for mixed-precision quantization, i.e., {MXFP4, MXFP6, FP8, BF16/FP16}
