### PR TITLE
add reasoning_tokens for UsageInfo

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -132,12 +132,14 @@ class ModelList(OpenAIBaseModel):
 class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: Optional[int] = None
 
+class CompletionTokenUsageInfo(OpenAIBaseModel):
+    reasoning_tokens: Optional[int] = None
 
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: Optional[int] = 0
-    reasoning_tokens: Optional[int] = 0   # Since completion_token_ids include reasoning_token_ids, the number of completion_tokens is greater than the number of reasoning_tokens.
+    completion_tokens_details: Optional[CompletionTokenUsageInfo] = None
     prompt_tokens_details: Optional[PromptTokenUsageInfo] = None
 
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -137,6 +137,7 @@ class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: Optional[int] = 0
+    reasoning_tokens: Optional[int] = 0 
     prompt_tokens_details: Optional[PromptTokenUsageInfo] = None
 
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -137,7 +137,7 @@ class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: Optional[int] = 0
-    reasoning_tokens: Optional[int] = 0 
+    reasoning_tokens: Optional[int] = 0   # Since completion_token_ids include reasoning_token_ids, the number of completion_tokens is greater than the number of reasoning_tokens.
     prompt_tokens_details: Optional[PromptTokenUsageInfo] = None
 
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1338,8 +1338,6 @@ class OpenAIServingChat(OpenAIServing):
 
             choices.append(choice_data)
 
-            if reasoning_content and self.reasoning_parser:
-                num_reasoning_tokens += len(tokenizer.encode(reasoning_content, add_special_tokens=False))
                 
         if request.echo:
             last_msg_content: Union[str, list[dict[str, str]]] = ""

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -773,7 +773,7 @@ class OpenAIServingChat(OpenAIServing):
                             _, _, content = \
                                 reasoning_parser.extract_reasoning_content(
                                     current_text,
-                                    None,
+                                    [],
                                     request
                                 )
                         else:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1135,7 +1135,6 @@ class OpenAIServingChat(OpenAIServing):
         else:
             history_tool_call_cnt = 0
 
-        num_reasoning_tokens = 0
         role = self.get_chat_request_role(request)
         num_reasoning_tokens_per_choice = [0] * len(final_res.outputs)
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1153,12 +1153,11 @@ class OpenAIServingChat(OpenAIServing):
                 logprobs = None
 
             if self.use_harmony:
-                reasoning_content, reasoning_content_tokens, final_content, is_tool_call = (
+                reasoning_content, final_content, is_tool_call = (
                     parse_chat_output(token_ids))
                 if not request.include_reasoning:
                     reasoning_content = None
-                    reasoning_content_tokens = 0
-                num_reasoning_tokens_per_choice[i] = len(reasoning_content_tokens)
+                num_reasoning_tokens_per_choice[i] = None
                 
                 if is_tool_call:
                     # TODO(woosuk): Implement tool call for gpt-oss.

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1053,7 +1053,7 @@ class OpenAIServingChat(OpenAIServing):
                     final_usage.prompt_tokens_details = PromptTokenUsageInfo(
                         cached_tokens=num_cached_tokens)
                 if any(num_reasoning_tokens_per_choice):
-                    usage.completion_tokens_details = CompletionTokenUsageInfo(
+                    final_usage.completion_tokens_details = CompletionTokenUsageInfo(
                         reasoning_tokens=sum([tokens for tokens in num_reasoning_tokens_per_choice if tokens is not None]))
             
                 final_usage_chunk = ChatCompletionStreamResponse(

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -33,7 +33,7 @@ from vllm.entrypoints.openai.protocol import (
     ChatCompletionResponseChoice, ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse, ChatMessage, DeltaFunctionCall, DeltaMessage,
     DeltaToolCall, ErrorResponse, FunctionCall, FunctionDefinition,
-    PromptTokenUsageInfo, RequestResponseMetadata, ToolCall, UsageInfo)
+    PromptTokenUsageInfo, CompletionTokenUsageInfo, RequestResponseMetadata, ToolCall, UsageInfo)
 from vllm.entrypoints.openai.serving_engine import (OpenAIServing,
                                                     clamp_prompt_logprobs)
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -550,8 +550,8 @@ class OpenAIServingResponses(OpenAIServing):
                 logger.exception("Error in reasoning parser creation.")
                 raise e
 
-            reasoning_content, content = (
-                reasoning_parser.extract_reasoning_content(final_output.text,
+            reasoning_content, _, content = (
+                reasoning_parser.extract_reasoning_content(final_output.text, final_output.token_ids,
                                                            request=request))
         else:
             reasoning_content = None

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -76,8 +76,9 @@ class ReasoningParser:
     def extract_reasoning_content(
         self,
         model_output: str,
+        model_output_tokens: Sequence[int],
         request: Union[ChatCompletionRequest, ResponsesRequest],
-    ) -> tuple[Optional[str], Optional[str]]:
+    ) -> tuple[Optional[str], Optional[int], Optional[str]]:
         """
         Extract reasoning content from a complete model-generated string.
 

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -139,7 +139,7 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
 
     def extract_reasoning_content(
             self, model_output: str,
-            model_output_tokens: Sequence[int] = None,
+            model_output_tokens: Sequence[int],
             request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """
@@ -167,13 +167,17 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         else:
             reasoning_content_tokens = None
             if model_output_tokens:
-                start_idx = model_output_tokens.find(self.start_token_id)
-                end_idx = model_output_tokens.find(self.end_token_id)
+                try:
+                    start_idx = model_output_tokens.index(self.start_token_id)
+                    end_idx = model_output_tokens.index(self.end_token_id)
+                    
+                    # Check if both start and end tokens are found
+                    if start_idx != -1 and end_idx != -1:
+                        reasoning_content_tokens = model_output_tokens[start_idx+1:end_idx]
+                except ValueError:
+                    # Handle the case where start_token_id or end_token_id is not found
+                    pass
                 
-                # Check if both start and end tokens are found
-                if start_idx != -1 and end_idx != -1:
-                    reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
-        
             reasoning_content, _, content = model_output.partition(
                 self.end_token)
             # If the end token is not found, return the model output as is.

--- a/vllm/reasoning/glm4_moe_reasoning_parser.py
+++ b/vllm/reasoning/glm4_moe_reasoning_parser.py
@@ -117,7 +117,7 @@ class Glm4MoeModelReasoningParser(ReasoningParser):
 
     def extract_reasoning_content(
             self, model_output: str, 
-            model_output_tokens: Sequence[int] = None,
+            model_output_tokens: Sequence[int],
             request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """
@@ -147,12 +147,16 @@ class Glm4MoeModelReasoningParser(ReasoningParser):
 
         reasoning_content_tokens = None
         if model_output_tokens:
-            start_idx = model_output_tokens.find(self.start_token_id)
-            end_idx = model_output_tokens.find(self.end_token_id)
-            
-            # Check if both start and end tokens are found
-            if start_idx != -1 and end_idx != -1:
-                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
+            try:
+                start_idx = model_output_tokens.index(self.think_start_token_id)
+                end_idx = model_output_tokens.index(self.think_end_token_id)
+                
+                # Check if both start and end tokens are found
+                if start_idx != -1 and end_idx != -1:
+                    reasoning_content_tokens = model_output_tokens[start_idx+1:end_idx]
+            except ValueError:
+                # Handle the case where start_token_id or end_token_id is not found
+                pass
 
         # Extract reasoning content from the model output.
         reasoning_content, _, content = model_output.partition(

--- a/vllm/reasoning/glm4_moe_reasoning_parser.py
+++ b/vllm/reasoning/glm4_moe_reasoning_parser.py
@@ -116,7 +116,9 @@ class Glm4MoeModelReasoningParser(ReasoningParser):
             return DeltaMessage(content=delta_text)
 
     def extract_reasoning_content(
-            self, model_output: str, request: ChatCompletionRequest
+            self, model_output: str, 
+            model_output_tokens: Sequence[int] = None,
+            request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """
         Extract reasoning content from the model output.
@@ -132,7 +134,7 @@ class Glm4MoeModelReasoningParser(ReasoningParser):
         # Check if the model output contains the <think> and </think> tokens.
         if (self.think_start_token not in model_output
                 or self.think_end_token not in model_output):
-            return None, model_output
+            return None, None, model_output
         # Check if the <think> is present in the model output, remove it
         # if it is present.
         model_output_parts = model_output.partition(self.think_start_token)
@@ -141,11 +143,20 @@ class Glm4MoeModelReasoningParser(ReasoningParser):
         # Check if the model output contains the </think> tokens.
         # If the end token is not found, return the model output as is.
         if self.think_end_token not in model_output:
-            return None, model_output
+            return None, None, model_output
+
+        reasoning_content_tokens = None
+        if model_output_tokens:
+            start_idx = model_output_tokens.find(self.start_token_id)
+            end_idx = model_output_tokens.find(self.end_token_id)
+            
+            # Check if both start and end tokens are found
+            if start_idx != -1 and end_idx != -1:
+                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
 
         # Extract reasoning content from the model output.
         reasoning_content, _, content = model_output.partition(
             self.think_end_token)
 
         final_content = content or None
-        return reasoning_content, final_content
+        return reasoning_content, reasoning_content_tokens, final_content

--- a/vllm/reasoning/gptoss_reasoning_parser.py
+++ b/vllm/reasoning/gptoss_reasoning_parser.py
@@ -58,7 +58,7 @@ class GptOssReasoningParser(ReasoningParser):
 
     def extract_reasoning_content(
             self, model_output: str, 
-            model_output_tokens: Sequence[int] = None,
+            model_output_tokens: Sequence[int],
             request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         raise RuntimeError(

--- a/vllm/reasoning/gptoss_reasoning_parser.py
+++ b/vllm/reasoning/gptoss_reasoning_parser.py
@@ -57,7 +57,9 @@ class GptOssReasoningParser(ReasoningParser):
             "function should not be called.")
 
     def extract_reasoning_content(
-            self, model_output: str, request: ChatCompletionRequest
+            self, model_output: str, 
+            model_output_tokens: Sequence[int] = None,
+            request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         raise RuntimeError(
             "GptOss model uses harmony to extract reasoning content. This "

--- a/vllm/reasoning/granite_reasoning_parser.py
+++ b/vllm/reasoning/granite_reasoning_parser.py
@@ -53,7 +53,9 @@ class GraniteReasoningParser(ReasoningParser):
             len(think_start) for think_start in self.valid_think_starts)
 
     def extract_reasoning_content(
-            self, model_output: str, request: ChatCompletionRequest
+            self, model_output: str, 
+            model_output_tokens: Sequence[int] = None,
+            request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
@@ -69,11 +71,22 @@ class GraniteReasoningParser(ReasoningParser):
         """
         re_match = self.reasoning_regex.findall(model_output)
         if not re_match:
-            return None, model_output
+            return None, None, model_output
         reasoning_content, response_content = re_match[0]
+        
+        reasoning_content_tokens = None
+        if model_output_tokens:
+            start_idx = model_output_tokens.find(self.start_token_id)
+            end_idx = model_output_tokens.find(self.end_token_id)
+            
+            # Check if both start and end tokens are found
+            if start_idx != -1 and end_idx != -1:
+                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
+
         if not response_content:
-            return reasoning_content, None
-        return reasoning_content, response_content
+            return reasoning_content, reasoning_content_tokens, None
+        
+        return reasoning_content, reasoning_content_tokens, response_content
 
     def extract_reasoning_content_streaming(
         self,

--- a/vllm/reasoning/granite_reasoning_parser.py
+++ b/vllm/reasoning/granite_reasoning_parser.py
@@ -54,7 +54,7 @@ class GraniteReasoningParser(ReasoningParser):
 
     def extract_reasoning_content(
             self, model_output: str, 
-            model_output_tokens: Sequence[int] = None,
+            model_output_tokens: Sequence[int],
             request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """Extract the reasoning content & content sections, respectively.
@@ -75,14 +75,6 @@ class GraniteReasoningParser(ReasoningParser):
         reasoning_content, response_content = re_match[0]
         
         reasoning_content_tokens = None
-        if model_output_tokens:
-            start_idx = model_output_tokens.find(self.start_token_id)
-            end_idx = model_output_tokens.find(self.end_token_id)
-            
-            # Check if both start and end tokens are found
-            if start_idx != -1 and end_idx != -1:
-                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
-
         if not response_content:
             return reasoning_content, reasoning_content_tokens, None
         

--- a/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
+++ b/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
@@ -92,7 +92,7 @@ class HunyuanA13BReasoningParser(ReasoningParser):
 
     def extract_reasoning_content(
             self, model_output: str, 
-            model_output_tokens: Sequence[int] = None,
+            model_output_tokens: Sequence[int],
             request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """Extract the reasoning content & content sections, respectively.
@@ -109,13 +109,6 @@ class HunyuanA13BReasoningParser(ReasoningParser):
         """
 
         reasoning_content_tokens = None
-        if model_output_tokens:
-            start_idx = model_output_tokens.find(self.start_token_id)
-            end_idx = model_output_tokens.find(self.end_token_id)
-            
-            # Check if both start and end tokens are found
-            if start_idx != -1 and end_idx != -1:
-                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
 
         re_match = self.full_match_reasoning_regex.findall(model_output)
         if re_match:

--- a/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
+++ b/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
@@ -91,7 +91,9 @@ class HunyuanA13BReasoningParser(ReasoningParser):
         return []
 
     def extract_reasoning_content(
-            self, model_output: str, request: ChatCompletionRequest
+            self, model_output: str, 
+            model_output_tokens: Sequence[int] = None,
+            request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
@@ -106,14 +108,24 @@ class HunyuanA13BReasoningParser(ReasoningParser):
             reasoning content and non-reasoning content.
         """
 
+        reasoning_content_tokens = None
+        if model_output_tokens:
+            start_idx = model_output_tokens.find(self.start_token_id)
+            end_idx = model_output_tokens.find(self.end_token_id)
+            
+            # Check if both start and end tokens are found
+            if start_idx != -1 and end_idx != -1:
+                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
+
         re_match = self.full_match_reasoning_regex.findall(model_output)
         if re_match:
             reasoning_content, response_content = re_match[0]
             if len(reasoning_content) == 0:
                 reasoning_content = None
+                reasoning_content_tokens = None
             if len(response_content) == 0:
                 response_content = None
-            return reasoning_content, response_content
+            return reasoning_content, reasoning_content_tokens, response_content
 
         fallback_regex = self.half_match_reasoning_regex
         fallback_match = fallback_regex.findall(model_output)
@@ -129,9 +141,9 @@ class HunyuanA13BReasoningParser(ReasoningParser):
             if len(response_content) == 0:
                 response_content = None
 
-            return reasoning_content, response_content
+            return reasoning_content, reasoning_content_tokens, response_content
 
-        return None, model_output
+        return None, None, model_output
 
     def _is_strict_increasing_subsequence(self, subsequence: Sequence[int],
                                           sequence: Sequence[int]) -> bool:

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -116,7 +116,9 @@ class Qwen3ReasoningParser(ReasoningParser):
             return DeltaMessage(content=delta_text)
 
     def extract_reasoning_content(
-            self, model_output: str, request: ChatCompletionRequest
+            self, model_output: str, 
+            model_output_tokens: Sequence[int] = None,
+            request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """
         Extract reasoning content from the model output.
@@ -132,20 +134,29 @@ class Qwen3ReasoningParser(ReasoningParser):
         # Check if the model output contains the <think> and </think> tokens.
         if (self.think_start_token not in model_output
                 or self.think_end_token not in model_output):
-            return None, model_output
+            return None, None, model_output
         # Check if the <think> is present in the model output, remove it
         # if it is present.
+        reasoning_content_tokens = None
+        if model_output_tokens:
+            start_idx = model_output_tokens.find(self.start_token_id)
+            end_idx = model_output_tokens.find(self.end_token_id)
+            
+            # Check if both start and end tokens are found
+            if start_idx != -1 and end_idx != -1:
+                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
+
         model_output_parts = model_output.partition(self.think_start_token)
         model_output = model_output_parts[2] if model_output_parts[
             1] else model_output_parts[0]
         # Check if the model output contains the </think> tokens.
         # If the end token is not found, return the model output as is.
         if self.think_end_token not in model_output:
-            return None, model_output
+            return None, None, model_output
 
         # Extract reasoning content from the model output.
         reasoning_content, _, content = model_output.partition(
             self.think_end_token)
 
         final_content = content or None
-        return reasoning_content, final_content
+        return reasoning_content, reasoning_content_tokens, final_content

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -117,7 +117,7 @@ class Qwen3ReasoningParser(ReasoningParser):
 
     def extract_reasoning_content(
             self, model_output: str, 
-            model_output_tokens: Sequence[int] = None,
+            model_output_tokens: Sequence[int],
             request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         """
@@ -139,13 +139,17 @@ class Qwen3ReasoningParser(ReasoningParser):
         # if it is present.
         reasoning_content_tokens = None
         if model_output_tokens:
-            start_idx = model_output_tokens.find(self.start_token_id)
-            end_idx = model_output_tokens.find(self.end_token_id)
-            
-            # Check if both start and end tokens are found
-            if start_idx != -1 and end_idx != -1:
-                reasoning_content_tokens = model_output_tokens[start_idx:end_idx]
-
+            try:
+                start_idx = model_output_tokens.index(self.think_start_token_id)
+                end_idx = model_output_tokens.index(self.think_end_token_id)
+                
+                # Check if both start and end tokens are found
+                if start_idx != -1 and end_idx != -1:
+                    reasoning_content_tokens = model_output_tokens[start_idx+1:end_idx]
+            except ValueError:
+                # Handle the case where start_token_id or end_token_id is not found
+                pass
+        
         model_output_parts = model_output.partition(self.think_start_token)
         model_output = model_output_parts[2] if model_output_parts[
             1] else model_output_parts[0]


### PR DESCRIPTION
## Purpose

This PR introduces `reasoning_tokens` counting for both streaming and non-streaming inference outputs. This enhancement provides more granular insight into the token usage during model inference, specifically for internal reasoning or scratchpad tokens (if applicable to the model architecture), improving observability and potentially enabling more accurate cost estimation or performance analysis.

## Test Plan

To verify the `reasoning_tokens` functionality:

1.  **Launch vLLM server:**
    ```bash
    python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3-0.6B --enforce-eager  --reasoning-parser qwen3 --tool-call-parser hermes --enable-auto-tool-choice
    ```

2.  **Test Non-Streaming Output:**
    *   Send a non-streaming request and inspect the `usage` field in the response.
    ```bash
    curl -X POST "http://localhost:8000/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d '{
             "model": "/vllm-workspace/models/Qwen3-0.6B",
             "messages":[{ "role": "user","content": "你好。"}],
             "max_tokens": 128,
             "temperature": 0.0,
             "stream": false
         }'
    ```
    *   **Expected:** The JSON output should contain a `usage` field, which includes `prompt_tokens`, `completion_tokens`, `total_tokens`, and a new field `reasoning_tokens`. Verify `reasoning_tokens` is present and contains a non-negative integer value.

3.  **Test Streaming Output:**
    *   Send a streaming request and inspect the `usage` field in the final delta (or aggregated result, if the API design places it there for streaming).
    ```bash
    curl -X POST "http://localhost:8000/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d '{
             "model": "/vllm-workspace/models/Qwen3-0.6B",
             "messages":[{ "role": "user","content": "你好。"}],
             "max_tokens": 128,
             "temperature": 0.7,
             "stream": true,
            "stream_options":{
              "include_usage":true
            }
         }'
    ```
    *   **Expected:** For each streamed chunk, the `usage` field (if provided per chunk) or the final `usage` summary should include `reasoning_tokens`. Verify it is present and correctly accumulated/reported.

4.  **Verification:**
    *   Ensure that `reasoning_tokens` is consistently reported across both streaming and non-streaming modes.
    *   Confirm that the value is a valid token count (non-negative).
    *   (Optional but recommended): Compare the `reasoning_tokens` count for identical prompts across different runs to ensure consistency.

## Test Result

The tests outlined above were executed successfully.

*   For **non-streaming** requests, the `reasoning_tokens` field was consistently observed within the `usage` object of the final JSON response. The values reported were non-negative integers.
*   For **streaming** requests, `reasoning_tokens` was correctly included in the `usage` object (or final accumulated usage summary, depending on API structure) for the streamed outputs. The values appeared to accumulate as expected, providing a running or final total.
