### PR TITLE
Issue 19007 Individual GuidedDecodingParams for each prompt in prompts

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1431,7 +1431,11 @@ class LLM:
             if isinstance(sp, SamplingParams):
                 # We only care about the final output
                 sp.output_kind = RequestOutputKind.FINAL_ONLY
-        if isinstance(params.guided_decoding, list):
+        if not isinstance(params, Sequence) and isinstance(params.guided_decoding, list):
+            if len(params.guided_decoding) != len(prompts):
+                raise ValueError(
+                    "The number of guided decoding parameters must be the same "
+                    "as the number of prompts.")
             guided_options_list = params.guided_decoding
 
         # Add requests to the engine.

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1425,10 +1425,14 @@ class LLM:
             raise ValueError("The lengths of prompts and lora_request "
                              "must be the same.")
 
+        guided_options_list = None
+        
         for sp in params if isinstance(params, Sequence) else (params, ):
             if isinstance(sp, SamplingParams):
                 # We only care about the final output
                 sp.output_kind = RequestOutputKind.FINAL_ONLY
+        if isinstance(params.guided_decoding, list):
+            guided_options_list = params.guided_decoding
 
         # Add requests to the engine.
         it = prompts
@@ -1441,6 +1445,9 @@ class LLM:
         for i, prompt in enumerate(it):
 
             param = params[i] if isinstance(params, Sequence) else params
+            if guided_options_list is not None:
+                # We can dynamically change the guided decoding options for each prompt
+                params.exchange_decoding_params(guided_options_list[i])
 
             tokenization_kwargs: dict[str, Any] = {}
             _validate_truncation_size(model_config.max_model_len,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -195,7 +195,7 @@ class SamplingParams(
     _all_stop_token_ids: set[int] = msgspec.field(default_factory=set)
 
     # Fields used to construct logits processors
-    guided_decoding: Optional[GuidedDecodingParams] = None
+    guided_decoding: Optional[Union[GuidedDecodingParams, list[GuidedDecodingParams]]] = None
     """If provided, the engine will construct a guided decoding logits
     processor from these parameters."""
     logit_bias: Optional[dict[int, float]] = None
@@ -245,7 +245,7 @@ class SamplingParams(
                                                    msgspec.Meta(
                                                        ge=-1)]] = None,
         output_kind: RequestOutputKind = RequestOutputKind.CUMULATIVE,
-        guided_decoding: Optional[GuidedDecodingParams] = None,
+        guided_decoding: Optional[Union[GuidedDecodingParams, list[GuidedDecodingParams]]] = None,
         logit_bias: Optional[Union[dict[int, float], dict[str, float]]] = None,
         allowed_token_ids: Optional[list[int]] = None,
         extra_args: Optional[dict[str, Any]] = None,
@@ -516,6 +516,9 @@ class SamplingParams(
     def bad_words_token_ids(self) -> Optional[list[list[int]]]:
         # For internal use only. Backward compatibility not guaranteed
         return self._bad_words_token_ids
+
+    def exchange_decoding_params(self, guided_options):
+        self.guided_decoding = guided_options
 
     def clone(self) -> "SamplingParams":
         """Deep copy, but maybe not the LogitsProcessor objects.


### PR DESCRIPTION

## Purpose

This commit introduces the ability to provide individual guided decoding parameters for each prompt in a batch.  
Why is this important? **Named Entity Recognition (NER)**.  
Currently, it is not possible to combine batched prediction with prompt-specific grammar definitions.  
For NER, however, this functionality is essential.

## Test Plan

```py
from vllm import LLM, SamplingParams
from vllm.sampling_params import GuidedDecodingParams

llm = LLM(
    model="google/gemma-3-270m-it",
    dtype=torch.bfloat16,
    trust_remote_code=True,
    quantization="bitsandbytes",
    max_model_len=2048,
    max_num_seqs=32,
    guided_decoding_disable_any_whitespace=True,
    guided_decoding_backend="xgrammar",
)

guided_decoding_params = [GuidedDecodingParams(regex=r"(positive|negative)"), 
                           GuidedDecodingParams(regex=r"(good|bad)"), 
                           GuidedDecodingParams(regex=r"(nice|aweful)")]

sampling_params = SamplingParams(guided_decoding=guided_decoding_params)
outputs = llm.generate(
    prompts=["Classify this sentiment: vLLM is wonderful!", "Classify this sentiment: vLLM is terrible!", "Classify this sentiment: vLLM is good!"],
    sampling_params=sampling_params,
)
```

## Test Result

Outputs for the example above would be:

```
positive
bad
nice
```

Individual `GuidedDecodingParams` is used for each prompt now. However `guided_decoding` **can still be a single Object**!

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

