### PR TITLE
[BugFix] `python collect_env.py` and `vllm collect-env` compatibility with uv venv

### DIFF
--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -489,6 +489,16 @@ def get_libc_version():
     return '-'.join(platform.libc_ver())
 
 
+def is_uv_venv():
+    if os.environ.get("UV"):
+        return True
+    pyvenv_cfg_path = os.path.join(sys.prefix, 'pyvenv.cfg')
+    if os.path.exists(pyvenv_cfg_path):
+        with open(pyvenv_cfg_path, 'r') as f:
+            return any(line.startswith('uv = ') for line in f)
+    return False
+
+
 def get_pip_packages(run_lambda, patterns=None):
     """Return `pip list` output. Note: will also find conda-installed pytorch and numpy packages."""
     if patterns is None:
@@ -504,7 +514,7 @@ def get_pip_packages(run_lambda, patterns=None):
 
         if pip_available:
             cmd = [sys.executable, '-mpip', 'list', '--format=freeze']
-        elif os.environ.get("UV") is not None:
+        elif is_uv_venv():
             print("uv is set")
             cmd = ["uv", "pip", "list", "--format=freeze"]
         else:


### PR DESCRIPTION
## Purpose

Fix: #24063

This PR fixes issues when running `python collect_env.py` and `vllm collect-env` inside a uv venv environment. The changes ensure correct environment detection and reporting, resolving errors and inconsistencies specific to uv venv setups.

## Test Plan

```
uv venv
source .venv/bin/activate
uv pip install vllm --torch-backend=auto
vllm collect-env # or python vllm/collect_env.py
```

## Test Result

After change:
```
(vllm) root@gpu-3090:~/oss/vllm# python vllm/collect_env.py
Collecting environment information...
uv is set
```
If no change, print error `Could not collect pip list output (pip or uv module not available)`, the same as #24063

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

