### PR TITLE
[Misc] Add check for dual_chunk_attention

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1304,10 +1304,10 @@ class ModelConfig:
                         self.hf_config.dual_chunk_attention_config:
                     self.hf_config.dual_chunk_attention_config[
                         "sparse_attention_enabled"] = True
-            assert (
-                envs.VLLM_ATTENTION_BACKEND == STR_DUAL_CHUNK_FLASH_ATTN_VAL
-            ), ("please set VLLM_ATTENTION_BACKEND to "
-                f"{STR_DUAL_CHUNK_FLASH_ATTN_VAL}")
+
+            if envs.VLLM_ATTENTION_BACKEND != STR_DUAL_CHUNK_FLASH_ATTN_VAL:
+                raise ValueError("please set VLLM_ATTENTION_BACKEND to "
+                                 f"{STR_DUAL_CHUNK_FLASH_ATTN_VAL}")
 
     def verify_async_output_proc(self, parallel_config, speculative_config,
                                  device_config) -> None:

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -49,7 +49,8 @@ from vllm.transformers_utils.config import (
     try_get_tokenizer_config, uses_mrope)
 from vllm.transformers_utils.s3_utils import S3Model
 from vllm.transformers_utils.utils import is_s3, maybe_model_redirect
-from vllm.utils import (DEFAULT_MAX_NUM_BATCHED_TOKENS, LayerBlockType,
+from vllm.utils import (DEFAULT_MAX_NUM_BATCHED_TOKENS,
+                        STR_DUAL_CHUNK_FLASH_ATTN_VAL, LayerBlockType,
                         LazyLoader, common_broadcastable_dtype, random_uuid)
 
 if TYPE_CHECKING:
@@ -1303,6 +1304,10 @@ class ModelConfig:
                         self.hf_config.dual_chunk_attention_config:
                     self.hf_config.dual_chunk_attention_config[
                         "sparse_attention_enabled"] = True
+            assert (
+                envs.VLLM_ATTENTION_BACKEND == STR_DUAL_CHUNK_FLASH_ATTN_VAL
+            ), ("please set VLLM_ATTENTION_BACKEND to "
+                f"{STR_DUAL_CHUNK_FLASH_ATTN_VAL}")
 
     def verify_async_output_proc(self, parallel_config, speculative_config,
                                  device_config) -> None:


### PR DESCRIPTION
## Purpose
FIX https://github.com/vllm-project/vllm/issues/24048
Add an early validation check for the `DUAL_CHUNK_FLASH_ATTN` environment variable when using the `Qwen2.5-14B-Instruct-1M model`. This preemptive check should trigger a clear error on startup rather than allowing the code to fail later and obscurely within the attention module.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

