### PR TITLE
[Benchmarks] Add --skip-check argument to reduce wait time

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -427,14 +427,15 @@ async def benchmark(
         timeout=aiohttp.ClientTimeout(total=6 * 60 * 60),
     )
 
+    test_prompt, test_prompt_len, test_output_len, test_mm_content = (
+        input_requests[0].prompt,
+        input_requests[0].prompt_len,
+        input_requests[0].expected_output_len,
+        input_requests[0].multi_modal_data,
+    )
     if not skip_check:
         print("Starting initial single prompt test run...")
-        test_prompt, test_prompt_len, test_output_len, test_mm_content = (
-            input_requests[0].prompt,
-            input_requests[0].prompt_len,
-            input_requests[0].expected_output_len,
-            input_requests[0].multi_modal_data,
-        )
+
 
         assert (
             test_mm_content is None


### PR DESCRIPTION
<!-- markdownlint-disable -->
When capturing a timeline with a concurrency of 50 batch, for example, the following command is used. However, this command includes an initial test run. If the `--random-output-len` set to a relatively long value, the initial test run may take a significant amount of time to complete before the 50-concurrency inference process begins. In order to reduce waiting time, a `--skip-check` argument is added to skip the initial test run.

```shell
vllm bench serve \
    --model /apdcephfs_qy2/share_303477892/lehuading/models/Qwen3-32B/ \
    --served-model-name vllm_infer_1 \
    --random-input-len 1 \
    --random-output-len 5000 \
    --num-prompts 50 \
    --max-concurrency 50 \
    --ignore-eos
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

