### PR TITLE
The downloaded tags directory is missing a `.git` folder, which is ca…

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -97,14 +97,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -r requirements/build.txt
 
 COPY . .
-RUN --mount=type=bind,source=.git,target=.git \
-    if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh ; fi
+RUN if [ "$GIT_REPO_CHECK" != 0 ] && [ -d ".git" ]; then bash tools/check_repo.sh ; fi
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/workspace/vllm/.deps,sharing=locked \
-    --mount=type=bind,source=.git,target=.git \
-    VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel 
+    VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel
 
 ######################### TEST DEPS #########################
 FROM base AS vllm-test-deps


### PR DESCRIPTION
…using the Docker build to fail.

The downloaded tags directory is missing a `.git` folder, which is causing the Docker build to fail.

```
 => => resolve docker.io/library/ubuntu:22.04@sha256:f154feaf13b51d16e2b4b5575d69abc808da40c4b80e3a5055aaa4bcc5099d5b                                                                         0.0s
 => => sha256:f154feaf13b51d16e2b4b5575d69abc808da40c4b80e3a5055aaa4bcc5099d5b 1.42kB / 1.42kB                                                                                                0.0s
 => => sha256:3c3de9608507804525ff4303874525760ea36d62606e8105f515adaa761b80cb 529B / 529B                                                                                                    0.0s
 => => sha256:9d28ccdc1fc782ec635c98e55ff68b05e6de1df2c7fcbbb4385f023368eec716 1.46kB / 1.46kB                                                                                                0.0s
 => => sha256:aee1767db0dd7da5c30ffaef2282976fe8730cdb0a7b1ecda17cd3c85374fa57 11.18MB / 29.89MB                                                                                              0.3s
 => [internal] load build context                                                                                                                                                             0.3s
 => => transferring context: 31.93MB                                                                                                                                                          0.3s
 => CACHED [base-common 2/6] WORKDIR /workspace/                                                                                                                                              0.0s
 => CACHED [base-common 3/6] RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list &&     sed -i 's/security.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list    0.0s
 => CACHED [base-common 4/6] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update -y     && apt-get inst  0.0s
 => CACHED [base-common 5/6] RUN uv venv --python 3.12 --seed /opt/venv                                                                                                                       0.0s
 => CACHED [base-common 6/6] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=bind,src=requirements/common.txt,target=requirements/common.txt     --mount=type=bind,src=requir  0.0s
 => CACHED [base 1/1] RUN echo 'ulimit -c 0' >> ~/.bashrc                                                                                                                                     0.0s
 => CACHED [vllm-build 1/5] WORKDIR /workspace/vllm                                                                                                                                           0.0s
 => CACHED [vllm-build 2/5] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=bind,src=requirements/cpu-build.txt,target=requirements/build.txt     uv pip install -r requireme  0.0s
 => CACHED [vllm-build 3/5] COPY . .                                                                                                                                                          0.0s
 => ERROR [vllm-build 4/5] RUN --mount=type=bind,source=.git,target=.git     if [ "0" != 0 ]; then bash tools/check_repo.sh ; fi                                                              0.0s
 => ERROR [vllm-build 5/5] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=cache,target=/root/.cache/ccache     --mount=type=cache,target=/workspace/vllm/.deps,sharing=locke  0.0s
------
 > [vllm-build 4/5] RUN --mount=type=bind,source=.git,target=.git     if [ "0" != 0 ]; then bash tools/check_repo.sh ; fi:
------
------
 > [vllm-build 5/5] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=cache,target=/root/.cache/ccache     --mount=type=cache,target=/workspace/vllm/.deps,sharing=locked     --mount=type=bind,source=.git,target=.git     VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel:
------
Dockerfile.cpu:112
--------------------
 111 |     
 112 | >>> RUN --mount=type=cache,target=/root/.cache/uv \
 113 | >>>     --mount=type=cache,target=/root/.cache/ccache \
 114 | >>>     --mount=type=cache,target=/workspace/vllm/.deps,sharing=locked \
 115 | >>>     --mount=type=bind,source=.git,target=.git \
 116 | >>>     VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel 
 117 |     
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 6ad9886c-23a0-4542-84a3-faa00ca709fd::0azcq2otn1ddzr40lm9k7e6jy: "/.git": not found
```

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

