### PR TITLE
Fix weights loading for Apertus

### DIFF
--- a/vllm/model_executor/models/apertus.py
+++ b/vllm/model_executor/models/apertus.py
@@ -418,7 +418,8 @@ class ApertusModel(nn.Module):
 
         # we need to load the buffers for beta and eps (XIELU)
         for name, buffer in self.named_buffers():
-            params_dict[name] = buffer
+            if name.endswith(".beta") or name.endswith(".eps"):
+                params_dict[name] = buffer
 
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:

--- a/vllm/model_executor/models/apertus.py
+++ b/vllm/model_executor/models/apertus.py
@@ -415,6 +415,11 @@ class ApertusModel(nn.Module):
             (".qkv_proj", ".v_proj", "v"),
         ]
         params_dict = dict(self.named_parameters())
+
+        # we need to load the buffers for beta and eps (XIELU)
+        for name, buffer in self.named_buffers():
+            params_dict[name] = buffer
+
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR fixes the weight loading mechanism for the [Apertus](https://huggingface.co/swiss-ai/Apertus-8B-Instruct-2509) models. The model uses a custom [XIELU](https://arxiv.org/abs/2411.13010) activation function that needs custom parameters for each layers. These parameters need to be stored alongside the model's weights. So we need to load the buffers too.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

