### PR TITLE
[BugFix] Fix routed_scaling_factor double mul for dots1 and glm4 MoE models

### DIFF
--- a/vllm/model_executor/models/dots1.py
+++ b/vllm/model_executor/models/dots1.py
@@ -137,7 +137,8 @@ class Dots1MoE(nn.Module):
             topk_group=config.topk_group,
             prefix=f"{prefix}.experts",
             scoring_func=config.scoring_func,
-            routed_scaling_factor=self.routed_scaling_factor,
+            # we do scaling outside, set factor to 1.0 to avoid double mul
+            routed_scaling_factor=1.0,
             e_score_correction_bias=self.gate.e_score_correction_bias)
 
         if config.n_shared_experts is not None:

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -159,7 +159,8 @@ class Glm4MoE(nn.Module):
             topk_group=config.topk_group,
             prefix=f"{prefix}.experts",
             scoring_func="sigmoid",
-            routed_scaling_factor=self.routed_scaling_factor,
+            # we do scaling outside, set factor to 1.0 to avoid double mul
+            routed_scaling_factor=1.0,
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts)


### PR DESCRIPTION
## Purpose
Deepseek fix landed in https://github.com/vllm-project/vllm/pull/24119. This is the same fix for Dots1 and GLM4 moe models as they both have double mult issue:

https://github.com/vllm-project/vllm/blob/98aee612aa13155badc2747bd51b378d6e515958/vllm/model_executor/models/dots1.py#L163

https://github.com/vllm-project/vllm/blob/98aee612aa13155badc2747bd51b378d6e515958/vllm/model_executor/models/glm4_moe.py#L189


## Test Plan
gsm8k
```
lm_eval --model vllm --model_args pretrained=rednote-hilab/dots.vlm1.inst,tensor_parallel_size=8,max_model_len=32768,gpu_memory_utilization=0.9,enforce_eager=True --tasks gsm8k --batch_size auto
```

## Test Result

Unable to test glm4 due to hang (https://github.com/vllm-project/vllm/issues/24133)

### dots1

Before:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.0144|±  |0.0033|
|     |       |strict-match    |     5|exact_match|↑  |0.0000|±  |0.0000|
```

After PR:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8400|±  |0.0101|
|     |       |strict-match    |     5|exact_match|↑  |0.7513|±  |0.0119|
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

