### PR TITLE
[Kernel][SM100]: Enable FI FusedMoE By Default for Llama

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -135,8 +135,8 @@ if TYPE_CHECKING:
     VLLM_USE_DEEP_GEMM_E8M0_HOPPER: bool = False
     VLLM_SKIP_DEEP_GEMM_WARMUP: bool = False
     VLLM_USE_FUSED_MOE_GROUPED_TOPK: bool = True
-    VLLM_USE_FLASHINFER_MOE_FP8: bool = False
-    VLLM_USE_FLASHINFER_MOE_FP4: bool = False
+    VLLM_USE_FLASHINFER_MOE_FP8: Optional[bool] = None
+    VLLM_USE_FLASHINFER_MOE_FP4: Optional[bool] = None
     VLLM_FLASHINFER_MOE_BACKEND: str = "throughput"
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -983,11 +983,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
 
     # Allow use of FlashInfer MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP8":
-    lambda: bool(int(os.getenv("VLLM_USE_FLASHINFER_MOE_FP8", "0"))),
+    lambda: bool(int(os.environ["VLLM_USE_FLASHINFER_MOE_FP8"]))
+    if "VLLM_USE_FLASHINFER_MOE_FP8" in os.environ else None,
 
     # Allow use of FlashInfer CUTLASS kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP4":
-    lambda: bool(int(os.getenv("VLLM_USE_FLASHINFER_MOE_FP4", "0"))),
+    lambda: bool(int(os.environ["VLLM_USE_FLASHINFER_MOE_FP4"]))
+    if "VLLM_USE_FLASHINFER_MOE_FP4" in os.environ else None,
 
     # If set to 1, use the FlashInfer
     # MXFP8 (activation) x MXFP4 (weight) MoE backend.

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -403,7 +403,8 @@ class FusedMoEConfig:
         """
         return (self.quant_config is not None
                 and self.quant_config.quant_dtype == "nvfp4"
-                and envs.VLLM_USE_FLASHINFER_MOE_FP4
+                and (envs.VLLM_USE_FLASHINFER_MOE_FP4
+                     or envs.VLLM_USE_FLASHINFER_MOE_FP4 is not None)
                 and has_flashinfer_cutlass_fused_moe()
                 and envs.VLLM_FLASHINFER_MOE_BACKEND == "throughput")
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -404,7 +404,7 @@ class FusedMoEConfig:
         return (self.quant_config is not None
                 and self.quant_config.quant_dtype == "nvfp4"
                 and (envs.VLLM_USE_FLASHINFER_MOE_FP4
-                     or envs.VLLM_USE_FLASHINFER_MOE_FP4 is not None)
+                     or envs.VLLM_USE_FLASHINFER_MOE_FP4 is None)
                 and has_flashinfer_cutlass_fused_moe()
                 and envs.VLLM_FLASHINFER_MOE_BACKEND == "throughput")
 

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -24,7 +24,8 @@ __all__ = [
 
 def is_flashinfer_fp4_cutlass_moe_available() -> bool:
     """Return ``True`` when FlashInfer CUTLASS NV-FP4 kernels can be used."""
-    return (envs.VLLM_USE_FLASHINFER_MOE_FP4
+    return ((envs.VLLM_USE_FLASHINFER_MOE_FP4
+             or envs.VLLM_USE_FLASHINFER_MOE_FP4 is not None)
             and has_flashinfer_cutlass_fused_moe()
             and current_platform.is_cuda()
             and current_platform.is_device_capability(100))

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -25,7 +25,7 @@ __all__ = [
 def is_flashinfer_fp4_cutlass_moe_available() -> bool:
     """Return ``True`` when FlashInfer CUTLASS NV-FP4 kernels can be used."""
     return ((envs.VLLM_USE_FLASHINFER_MOE_FP4
-             or envs.VLLM_USE_FLASHINFER_MOE_FP4 is not None)
+             or envs.VLLM_USE_FLASHINFER_MOE_FP4 is None)
             and has_flashinfer_cutlass_fused_moe()
             and current_platform.is_cuda()
             and current_platform.is_device_capability(100))


### PR DESCRIPTION
## Purpose
This PR will enable flashinfer FusedMoE by default for `llama4` when running on SM100, for `fp8` or `modelopt` quantizations.
This PR will also fix https://github.com/vllm-project/vllm/issues/24109 , by picking `cutlass` backend only for `llama4`

## Test Plan
- Run llama4 `modelopt` and `fp8` quantizations and verify that FusedMoE kernels are used by default.
- Verify https://github.com/vllm-project/vllm/issues/24109 is fixed.

## Test Result