### PR TITLE
[Bugfix] Fix Incremental Detokenization with `tokenizers == 0.22.0`

### DIFF
--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -234,7 +234,7 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
         try:
             token = self.stream.step(self.tokenizer, next_token_id)
         except Exception as e:
-            if str(e) != INVALID_PREFIX_ERR_MSG:
+            if INVALID_PREFIX_ERR_MSG not in str(e):
                 raise e
             # Recover from edge case where tokenizer can produce non-monotonic,
             # invalid UTF-8 output, which breaks the internal state of
@@ -243,7 +243,8 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
             logger.warning(
                 "Encountered invalid prefix detokenization error"
                 " for request %s, resetting decode stream.", self.request_id)
-            self.stream = DecodeStream(self.skip_special_tokens)
+            self.stream = DecodeStream(
+                skip_special_tokens=self.skip_special_tokens)
             token = self.stream.step(self.tokenizer, next_token_id)
         return token
 

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -234,7 +234,7 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
         try:
             token = self.stream.step(self.tokenizer, next_token_id)
         except Exception as e:
-            if INVALID_PREFIX_ERR_MSG not in str(e):
+            if not str(e).startswith(INVALID_PREFIX_ERR_MSG):
                 raise e
             # Recover from edge case where tokenizer can produce non-monotonic,
             # invalid UTF-8 output, which breaks the internal state of


### PR DESCRIPTION
## Purpose
This PR updates the `_protected_step` method to incorporate the [latest change](https://github.com/huggingface/tokenizers/pull/1856/files#diff-d0762643761cfb97962b098a5e39cd493c380ecb33f128672f1ab7a471ee1a72)  of `DecodeStream` in tokenizers 0.22.0 to avoid the following UT failure: 

```bash
pytest -rA tests/v1/engine/test_fast_incdec_prefix_err.py::test_fast_inc_detok_invalid_utf8_err_case
```
Error Log:
```bash
self = <vllm.v1.engine.detokenizer.FastIncrementalDetokenizer object at 0x7f0bae57d9f0>, next_token_id = 237167

    def _protected_step(self, next_token_id: int) -> Optional[str]:
        try:
>           token = self.stream.step(self.tokenizer, next_token_id)
E           Exception: Invalid prefix encountered while decoding stream. Token ID: 237167, Expected prefix: ' ', Actual string: '���»'

vllm/v1/engine/detokenizer.py:235: Exception
```
Since the latest transformers v4.56 would automatically install the latest tokenizers 0.22.0, we need to update the code logic introduced in PR https://github.com/vllm-project/vllm/pull/19449 to make it work for both tokenizers 0.21.4 and 0.22.0.

## Test Result
With the fix in this PR, `test_fast_inc_detok_invalid_utf8_err_case` can pass:
```bash
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.10.12, pytest-8.4.1, pluggy-1.6.0
rootdir: /workspace/vllm
configfile: pyproject.toml
plugins: hypothesis-6.136.6, typeguard-4.4.4, anyio-4.9.0
collected 1 item                                                                                                                                                       

tests/v1/engine/test_fast_incdec_prefix_err.py .                                                                                                                 [100%]

================================================================================ PASSES ================================================================================
______________________________________________________________ test_fast_inc_detok_invalid_utf8_err_case _______________________________________________________________
------------------------------------------------------------------------- Captured stdout call -------------------------------------------------------------------------
WARNING 09-03 16:38:16 [detokenizer.py:243] Encountered invalid prefix detokenization error for request test, resetting decode stream.
======================================================================= short test summary info ========================================================================
PASSED tests/v1/engine/test_fast_incdec_prefix_err.py::test_fast_inc_detok_invalid_utf8_err_case
========================================================================== 1 passed in 3.63s ===========================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
