### PR TITLE
[Log] Per Rank Log

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
     VLLM_LOGGING_LEVEL: str = "INFO"
     VLLM_LOGGING_PREFIX: str = ""
     VLLM_LOGGING_CONFIG_PATH: Optional[str] = None
+    VLLM_LOGS_DIR: Optional[str] = None
+    VLLM_PER_RANK_LOGS: bool = False
     VLLM_LOGITS_PROCESSOR_THREADS: Optional[int] = None
     VLLM_LOG_STATS_INTERVAL: float = 10.
     VLLM_TRACE_FUNCTION: int = 0
@@ -434,6 +436,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # if set, VLLM_LOGGING_PREFIX will be prepended to all log messages
     "VLLM_LOGGING_PREFIX":
     lambda: os.getenv("VLLM_LOGGING_PREFIX", ""),
+
+    # if set, vLLM will store logs in file
+    "VLLM_LOGS_DIR":
+    lambda: os.getenv("VLLM_LOGS_DIR", None),
+
+    # if set, vLLM will store logs for each rank in a separate file
+    "VLLM_PER_RANK_LOGS":
+    lambda: bool(int(os.getenv("VLLM_PER_RANK_LOGS", "0"))),
 
     # if set, vllm will call logits processors in a thread pool with this many
     # threads. This is useful when using custom logits processors that either

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Logging configuration for vLLM."""
+import copy
 import datetime
 import json
 import logging
@@ -166,10 +167,14 @@ def _configure_vllm_root_logger() -> None:
 def setup_per_rank_logger(rank) -> None:
     if not envs.VLLM_PER_RANK_LOGS:
         return
+    if LOG_FILE_NAME is None:
+        raise ValueError(
+            "LOG_FILE_NAME is None. "
+            "Please configure logging before setting up per-rank logger.")
     base_str = os.path.splitext(LOG_FILE_NAME)[0]
     log_file = f"{base_str}_rank_{rank}.log"
 
-    log_config = DEFAULT_LOGGING_CONFIG.copy()
+    log_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
     log_config["handlers"]["vllm_log_file"]["filename"] = log_file
     dictConfig(log_config)
 

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -175,7 +175,10 @@ def setup_per_rank_logger(rank) -> None:
     log_file = f"{base_str}_rank_{rank}.log"
 
     log_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
-    log_config["handlers"]["vllm_log_file"]["filename"] = log_file
+    if log_config["handlers"].get("vllm_log_file") is not None:
+        log_config["handlers"]["vllm_log_file"]["filename"] = log_file
+    else:
+        raise ValueError("vllm_log_file handler is not configured.")
     dictConfig(log_config)
 
 

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -176,7 +176,7 @@ def setup_per_rank_logger(rank) -> None:
 
     log_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
     try:
-        log_config["handlers"]["vllm_log_file"][
+        log_config["handlers"]["vllm_log_file"][  # type: ignore[index]
             "filename"] = log_file  # type: ignore[index]
     except KeyError as err:
         raise ValueError(

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -175,10 +175,11 @@ def setup_per_rank_logger(rank) -> None:
     log_file = f"{base_str}_rank_{rank}.log"
 
     log_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
-    if log_config["handlers"].get("vllm_log_file") is not None:
+    try:
         log_config["handlers"]["vllm_log_file"]["filename"] = log_file
-    else:
-        raise ValueError("vllm_log_file handler is not configured.")
+    except KeyError as err:
+        raise ValueError(
+            "vllm_log_file handler is not configured correctly.") from err
     dictConfig(log_config)
 
 

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -176,7 +176,8 @@ def setup_per_rank_logger(rank) -> None:
 
     log_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
     try:
-        log_config["handlers"]["vllm_log_file"]["filename"] = log_file
+        log_config["handlers"]["vllm_log_file"][
+            "filename"] = log_file  # type: ignore[index]
     except KeyError as err:
         raise ValueError(
             "vllm_log_file handler is not configured correctly.") from err

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -28,7 +28,7 @@ from vllm.distributed.device_communicators.shm_broadcast import (Handle,
 from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
 from vllm.executor.multiproc_worker_utils import (
     set_multiprocessing_worker_envs)
-from vllm.logger import init_logger
+from vllm.logger import init_logger, setup_per_rank_logger
 from vllm.utils import (decorate_logs, get_distributed_init_method,
                         get_loopback_ip, get_mp_context, get_open_port,
                         set_process_title)
@@ -507,6 +507,10 @@ class WorkerProc:
         # SystemExit exception is only raised once to allow this and worker
         # processes to terminate without error
         shutdown_requested = False
+
+        rank = kwargs.get("rank")
+        if rank is not None:
+            setup_per_rank_logger(rank)
 
         def signal_handler(signum, frame):
             nonlocal shutdown_requested


### PR DESCRIPTION
## Purpose
https://github.com/vllm-project/vllm/issues/23761

Add support for per-rank log(multiproc backend).

## Test Plan

```
VLLM_LOGS_DIR=~/vllm_log VLLM_PER_RANK_LOGS=1 vllm serve /data/datasets/models-hf/Qwen2.5-0.5B/ -tp 2
```

## Test Result

main
```
INFO 09-03 16:28:08 [__init__.py:241] Automatically detected platform cuda.
INFO 09-03 16:28:10 [api_server.py:1882] vLLM API server version 0.10.2.dev378+g4d7fe40fc.d20250829
INFO 09-03 16:28:10 [utils.py:328] non-default args: {'model_tag': '/data/datasets/models-hf/Qwen2.5-0.5B/', 'model': '/data/datasets/models-hf/Qwen2.5-0.5B/', 'tensor_parallel_size': 2}
INFO 09-03 16:28:15 [__init__.py:241] Automatically detected platform cuda.
INFO 09-03 16:28:17 [__init__.py:744] Resolved architecture: Qwen2ForCausalLM
INFO 09-03 16:28:17 [__init__.py:1773] Using max model len 32768
INFO 09-03 16:28:17 [scheduler.py:222] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 09-03 16:28:21 [__init__.py:241] Automatically detected platform cuda.
INFO 09-03 16:28:23 [core.py:648] Waiting for init message from front-end.
INFO 09-03 16:28:23 [core.py:75] Initializing a V1 LLM engine (v0.10.2.dev378+g4d7fe40fc.d20250829) with config: model='/data/datasets/models-hf/Qwen2.5-0.5B/', speculative_config=None, tokenizer='/data/datasets/models-hf/Qwen2.5-0.5B/', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=2, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=/data/datasets/models-hf/Qwen2.5-0.5B/, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":3,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output","vllm.mamba_mixer2","vllm.mamba_mixer","vllm.short_conv","vllm.linear_attention"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"cudagraph_mode":1,"use_cudagraph":true,"cudagraph_num_of_warmups":1,"cudagraph_capture_sizes":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"pass_config":{},"max_capture_size":512,"local_cache_dir":null}
WARNING 09-03 16:28:23 [multiproc_worker_utils.py:273] Reducing Torch parallelism from 120 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
INFO 09-03 16:28:23 [shm_broadcast.py:289] vLLM message queue communication handle: Handle(local_reader_ranks=[0, 1], buffer_handle=(2, 16777216, 10, 'psm_f241ca15'), local_subscribe_addr='ipc:///tmp/4d300e46-aa24-4299-b54e-47288199524b', remote_subscribe_addr=None, remote_addr_ipv6=False)
INFO 09-03 16:28:27 [__init__.py:241] Automatically detected platform cuda.
INFO 09-03 16:28:27 [__init__.py:241] Automatically detected platform cuda.
INFO 09-03 16:28:39 [kv_cache_utils.py:850] GPU KV cache size: 6,781,696 tokens
INFO 09-03 16:28:39 [kv_cache_utils.py:854] Maximum concurrency for 32,768 tokens per request: 206.96x
INFO 09-03 16:28:39 [kv_cache_utils.py:850] GPU KV cache size: 6,781,696 tokens
INFO 09-03 16:28:39 [kv_cache_utils.py:854] Maximum concurrency for 32,768 tokens per request: 206.96x
INFO 09-03 16:28:41 [core.py:217] init engine (profile, create kv cache, warmup model) took 9.28 seconds
INFO 09-03 16:28:42 [loggers.py:142] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 423856
INFO 09-03 16:28:42 [async_llm.py:166] Torch profiler disabled. AsyncLLM CPU traces will not be collected.
INFO 09-03 16:28:42 [api_server.py:1680] Supported_tasks: ['generate']
WARNING 09-03 16:28:42 [__init__.py:1673] Default sampling parameters have been overridden by the model's Hugging Face generation config recommended from the model creator. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
INFO 09-03 16:28:42 [serving_responses.py:126] Using default chat sampling params from model: {'max_tokens': 2048}
INFO 09-03 16:28:42 [serving_chat.py:137] Using default chat sampling params from model: {'max_tokens': 2048}
INFO 09-03 16:28:42 [serving_completion.py:79] Using default completion sampling params from model: {'max_tokens': 2048}
INFO 09-03 16:28:42 [api_server.py:1957] Starting vLLM API server 0 on http://0.0.0.0:8000
INFO 09-03 16:28:42 [launcher.py:36] Available routes are:
INFO 09-03 16:28:42 [launcher.py:44] Route: /openapi.json, Methods: HEAD, GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /docs, Methods: HEAD, GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /docs/oauth2-redirect, Methods: HEAD, GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /redoc, Methods: HEAD, GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /health, Methods: GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /load, Methods: GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /ping, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /ping, Methods: GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /tokenize, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /detokenize, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/models, Methods: GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /version, Methods: GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/responses, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/responses/{response_id}, Methods: GET
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/responses/{response_id}/cancel, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/chat/completions, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/completions, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/embeddings, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /pooling, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /classify, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /score, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/score, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/audio/transcriptions, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/audio/translations, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /rerank, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v1/rerank, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /v2/rerank, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /scale_elastic_ep, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /is_scaling_elastic_ep, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /invocations, Methods: POST
INFO 09-03 16:28:42 [launcher.py:44] Route: /metrics, Methods: GET
INFO 09-03 16:28:47 [launcher.py:101] Shutting down FastAPI HTTP server.
```

rank 0
```
INFO 09-03 16:28:30 [shm_broadcast.py:289] vLLM message queue communication handle: Handle(local_reader_ranks=[0], buffer_handle=(1, 10485760, 10, 'psm_ad0fc295'), local_subscribe_addr='ipc:///tmp/d0e5fc2e-4933-47d0-a403-ac53265c1324', remote_subscribe_addr=None, remote_addr_ipv6=False)
INFO 09-03 16:28:30 [__init__.py:1432] Found nccl from library libnccl.so.2
INFO 09-03 16:28:30 [pynccl.py:70] vLLM is using nccl==2.27.3
INFO 09-03 16:28:31 [custom_all_reduce.py:35] Skipping P2P check and trusting the driver's P2P report.
INFO 09-03 16:28:31 [shm_broadcast.py:289] vLLM message queue communication handle: Handle(local_reader_ranks=[1], buffer_handle=(1, 4194304, 6, 'psm_6071f478'), local_subscribe_addr='ipc:///tmp/c062e361-ae56-40ca-95f1-30785e287a1e', remote_subscribe_addr=None, remote_addr_ipv6=False)
INFO 09-03 16:28:31 [parallel_state.py:1134] rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
INFO 09-03 16:28:31 [topk_topp_sampler.py:58] Using FlashInfer for top-p & top-k sampling.
INFO 09-03 16:28:31 [gpu_model_runner.py:1932] Starting to load model /data/datasets/models-hf/Qwen2.5-0.5B/...
INFO 09-03 16:28:31 [gpu_model_runner.py:1964] Loading model from scratch...
INFO 09-03 16:28:31 [cuda.py:328] Using Flash Attention backend on V1 engine.
INFO 09-03 16:28:31 [default_loader.py:267] Loading weights took 0.12 seconds
INFO 09-03 16:28:31 [gpu_model_runner.py:1986] Model loading took 0.4643 GiB and 0.233247 seconds
INFO 09-03 16:28:35 [backends.py:538] Using cache directory: /home/zjy/.cache/vllm/torch_compile_cache/92ff14ab85/rank_0_0/backbone for vLLM's torch.compile
INFO 09-03 16:28:35 [backends.py:549] Dynamo bytecode transform time: 3.87 s
INFO 09-03 16:28:37 [backends.py:161] Directly load the compiled graph(s) for dynamic shape from the cache, took 1.130 s
INFO 09-03 16:28:38 [monitor.py:34] torch.compile takes 3.87 s in total
INFO 09-03 16:28:38 [gpu_worker.py:276] Available KV cache memory: 38.81 GiB
INFO 09-03 16:28:41 [custom_all_reduce.py:202] Registering 3283 cuda graph addresses
INFO 09-03 16:28:41 [gpu_model_runner.py:2687] Graph capturing finished in 2 secs, took 0.39 GiB
INFO 09-03 16:28:47 [multiproc_executor.py:539] Parent process exited, terminating worker
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

