### PR TITLE
Optimize detokenizer performance for long-generation sequences

### DIFF
--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -139,7 +139,7 @@ class Detokenizer:
         logprobs = seq.output_logprobs[-1]
         if logprobs:
             # previous_tokens = all_input_ids[:-1]
-            # all_input_ids[:-1] introduces an expensive copy overhead 
+            # all_input_ids[:-1] introduces an expensive copy overhead
             # in long-generation scenarios.
             for token_id, sample_logprob in logprobs.items():
                 # If the token was generated this iteration,
@@ -150,13 +150,15 @@ class Detokenizer:
 
                 if (sample_logprob.decoded_token is None
                         and token_id != VLLM_INVALID_TOKEN_ID):
-                    
+
                     if len(all_input_ids) > 0:
                         all_input_ids[-1] = token_id
                         all_input_ids_with_logprob = all_input_ids
                     else:
-                        all_input_ids_with_logprob = all_input_ids[:-1] + [token_id]
-                    
+                        all_input_ids_with_logprob = all_input_ids[:-1] + [
+                            token_id
+                        ]
+
                     (_, new_text, _, _) = detokenize_incrementally(
                         tokenizer=tokenizer,
                         all_input_ids=all_input_ids_with_logprob,

--- a/vllm/transformers_utils/detokenizer_utils.py
+++ b/vllm/transformers_utils/detokenizer_utils.py
@@ -190,7 +190,7 @@ def detokenize_incrementally(
             skip_special_tokens=skip_special_tokens,
             spaces_between_special_tokens=spaces_between_special_tokens,
         )
-    
+
     for _ in range(len(new_tokens)):
         prev_tokens.pop()
 


### PR DESCRIPTION
## Env Info

- Python: 3.11.11
- CUDA: 12.8
- GPU: NVIDIA L20
- PyTorch: 2.7.0+cu126

## Purpose

When using vLLM for long text generation, especially when the sequence length reaches the 10k token scale, we observe a significant increase in CPU overhead between consecutive execute_model calls.

To reproduce this issue, run benchmark_serving.py with the following command:

```shell
python benchmarks/benchmark_serving.py \
  --backend vllm \
  --model deepseek-ai/DeepSeek-R1-Distill-Qwen-14B \
  --endpoint /v1/completions \
  --dataset-name random \
  --random-input-len 256 \
  --random-output-len 65536 \
  --num-prompts 10 \
  --max-concurrency 10 \
  --ignore-eos
```

Using `nsys` to profile the timeline at around 60k generated tokens, the results show a clear increase in CPU latency — reaching **8.9 ms** (Figure 1). In contrast, at a sequence length of ~4k tokens, the same operation takes only **4.6 ms** (Figure 2).

Figure 1: 
<img width="1942" height="1490" alt="image" src="https://github.com/user-attachments/assets/d30e67fc-575c-403d-9d4b-6cbcae674e89" />

Figure 2: 
<img width="2866" height="1458" alt="image" src="https://github.com/user-attachments/assets/10ef0d39-6889-46ac-8f5c-daff4b0fa224" />

Further profiling of the traceback during this period reveals multiple functions related to the `detokenizer` consuming a significant portion of CPU time.

<img width="1266" height="1560" alt="image" src="https://github.com/user-attachments/assets/1a86823b-fc7b-42cb-87a9-33a106e7dbc3" />

## Proposed Optimization

After analyzing the source code, I identified two key performance bottlenecks in the detokenizer:

1. In `vllm/transformers_utils/detokenizer.py`:

```python
previous_tokens = all_input_ids[:-1]
```
When all_input_ids is very long, this slicing operation involves an increasingly expensive copy, contributing to growing latency.

2. In `vllm/transformers_utils/detokenizer_utils.py`:

```python
output_tokens = prev_tokens + new_tokens
```
List concatenation creates a new list and copies all elements each time, leading to O(n) overhead that grows with sequence length.

After applying these optimizations, profiling with `nsys` shows that the detokenization latency is reduced to **2.9 ms** and remains stable regardless of sequence length.

<img width="688" height="729" alt="image" src="https://github.com/user-attachments/assets/f986ebfb-1ad3-4285-a509-842376ebadde" />

The improvement eliminates the growing CPU overhead during long generation, resulting in smoother and more scalable performance. And in more detail:

Original:
<img width="944" height="756" alt="image" src="https://github.com/user-attachments/assets/9feb24b5-ca66-40b7-ac5a-4bd2dbe7d31b" />

Optimized:
<img width="898" height="750" alt="image" src="https://github.com/user-attachments/assets/46ed0130-3fc9-4820-971c-f842d422957c" />

**Looking forward to any feedback or review comments. Thank you!**

