### PR TITLE
[Core] Exposing engine sleep & wake_up state as prometheus metrics

### DIFF
--- a/tests/entrypoints/openai/test_sleep.py
+++ b/tests/entrypoints/openai/test_sleep.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import requests
+from prometheus_client.parser import text_string_to_metric_families
 
 from ...utils import RemoteOpenAIServer
 
@@ -31,11 +32,27 @@ def test_sleep_mode():
         assert response.status_code == 200
         assert response.json().get("is_sleeping") is True
 
+        # check sleep metrics
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        awake, weights_offloaded, discard_all = _get_sleep_metrics_from_api(response)
+        assert awake == 0
+        assert weights_offloaded == 1
+        assert discard_all == 0
+
         response = requests.post(remote_server.url_for("wake_up"))
         assert response.status_code == 200
         response = requests.get(remote_server.url_for("is_sleeping"))
         assert response.status_code == 200
         assert response.json().get("is_sleeping") is False
+
+        # check sleep metrics
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        awake, weights_offloaded, discard_all = _get_sleep_metrics_from_api(response)
+        assert awake == 1
+        assert weights_offloaded == 0
+        assert discard_all == 0
 
         # test wake up with tags
         response = requests.post(remote_server.url_for("sleep"), params={"level": "1"})
@@ -59,3 +76,35 @@ def test_sleep_mode():
         response = requests.get(remote_server.url_for("is_sleeping"))
         assert response.status_code == 200
         assert response.json().get("is_sleeping") is False
+
+        # check sleep metrics
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        awake, weights_offloaded, discard_all = _get_sleep_metrics_from_api(response)
+        assert awake == 1
+        assert weights_offloaded == 0
+        assert discard_all == 0
+
+
+def _get_sleep_metrics_from_api(response: requests.Response):
+    """Return (awake, weights_offloaded, discard_all)"""
+
+    awake, weights_offloaded, discard_all = None, None, None
+
+    for family in text_string_to_metric_families(response.text):
+        if family.name == "vllm:engine_sleep_state":
+            for sample in family.samples:
+                if sample.name == "vllm:engine_sleep_state":
+                    for label_name, label_value in sample.labels.items():
+                        if label_value == "awake":
+                            awake = sample.value
+                        elif label_value == "weights_offloaded":
+                            weights_offloaded = sample.value
+                        elif label_value == "discard_all":
+                            discard_all = sample.value
+
+    assert awake is not None
+    assert weights_offloaded is not None
+    assert discard_all is not None
+
+    return awake, weights_offloaded, discard_all

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -689,8 +689,14 @@ class AsyncLLM(EngineClient):
         await self.reset_prefix_cache()
         await self.engine_core.sleep_async(level)
 
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(1, level)
+
     async def wake_up(self, tags: list[str] | None = None) -> None:
         await self.engine_core.wake_up_async(tags)
+
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(0, 0)
 
     async def is_sleeping(self) -> bool:
         return await self.engine_core.is_sleeping_async()

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -332,8 +332,14 @@ class LLMEngine:
     def sleep(self, level: int = 1):
         self.engine_core.sleep(level)
 
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(1, level)
+
     def wake_up(self, tags: list[str] | None = None):
         self.engine_core.wake_up(tags)
+
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(0, 0)
 
     def is_sleeping(self) -> bool:
         return self.engine_core.is_sleeping()


### PR DESCRIPTION


This PR exposes an engine sleep and wake_up mode as Prometheus metrics.  More details are documented as https://github.com/vllm-project/vllm/issues/24175 .


## Purpose

FIX https://github.com/vllm-project/vllm/issues/24175

## Test Plan

Test script provided. 

## Test Result

Assumption: there is an local vLLM engine listening on port 8000

1. Put an engine to sleep and then scrape the metrics endpoint: :

```
$ curl -X POST http://localhost:8000/sleep
$ curl http://localhost:8000/metrics
```

Expected output (snapshot of the target metric):

```
# HELP vllm:engine_sleep_state Engine sleep state. 1 means engine sleeping and 0 means engine awake.
# TYPE vllm:engine_sleep_state gauge
vllm:engine_sleep_state{engine="0",model_name="facebook/opt-125m"} 1.0
# HELP vllm:engine_sleep_level Engine sleep level. Level 0 means engine is awake; Level 1 means model weights offload to CPU memory and discard the kv cache;level 2 means model weights and the kv cache are both discarded.
# TYPE vllm:engine_sleep_level gauge
vllm:engine_sleep_level{engine="0",model_name="facebook/opt-125m"} 1.0
```

2. Wake_up an engine to sleep and then scrape the metrics endpoint:

```
$ curl -X POST http://localhost:8000/wake_up
$ curl http://localhost:8000/metrics
```

Expected output (snapshot of the target metric):

```
# HELP vllm:engine_sleep_state Engine sleep state. 1 means engine sleeping and 0 means engine awake.
# TYPE vllm:engine_sleep_state gauge
vllm:engine_sleep_state{engine="0",model_name="facebook/opt-125m"} 0.0
# HELP vllm:engine_sleep_level Engine sleep level. Level 0 means engine is awake; Level 1 means model weights offload to CPU memory and discard the kv cache;level 2 means model weights and the kv cache are both discarded.
# TYPE vllm:engine_sleep_level gauge
vllm:engine_sleep_level{engine="0",model_name="facebook/opt-125m"} 0.0
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

