### PR TITLE
[Bugfix] Invalid prefix exception with the new transformers library

### DIFF
--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -234,7 +234,7 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
         try:
             token = self.stream.step(self.tokenizer, next_token_id)
         except Exception as e:
-            if str(e) != INVALID_PREFIX_ERR_MSG:
+            if INVALID_PREFIX_ERR_MSG not in str(e):
                 raise e
             # Recover from edge case where tokenizer can produce non-monotonic,
             # invalid UTF-8 output, which breaks the internal state of
@@ -243,7 +243,8 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
             logger.warning(
                 "Encountered invalid prefix detokenization error"
                 " for request %s, resetting decode stream.", self.request_id)
-            self.stream = DecodeStream(self.skip_special_tokens)
+            self.stream = DecodeStream(
+                skip_special_tokens=self.skip_special_tokens)
             token = self.stream.step(self.tokenizer, next_token_id)
         return token
 


### PR DESCRIPTION
https://github.com/vllm-project/vllm/issues/17448 fixed in #19449 has now re-appeared
Before 4.56 the exception text was simply
`Invalid prefix encountered`
With transformers library == 4.56 the error message looks like
`Exception: Invalid prefix encountered while decoding stream. Token ID: 30049, Expected prefix: '섬', Actual string: '�����ầ`
and doesn't match exactly.
To filter it out and preserve the backwards compatibility with the old one, the common pattern would be to check for whether INVALID_PREFIX_ERR_MSG is included in the new message

Also the API for DecodeStream changed from
`def __init__(self, skip_special_tokens):`
to
`def __init__(self, ids=None, skip_special_tokens=False):`
