### PR TITLE
[Hardware][Apple-CPU] Disable OneDNN build for Apple Silicon

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -88,6 +88,7 @@ is_avx512_disabled(AVX512_DISABLED)
 
 if (MACOSX_FOUND AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     message(STATUS "Apple Silicon Detected")
+    set(APPLE_SILICON_FOUND TRUE)
     set(ENABLE_NUMA OFF)
     check_sysctl(hw.optional.neon ASIMD_FOUND)
     check_sysctl(hw.optional.arm.FEAT_BF16 ARM_BF16_FOUND)
@@ -189,7 +190,7 @@ else()
     set(USE_ACL OFF)
 endif()
 
-if ((AVX512_FOUND AND NOT AVX512_DISABLED) OR ASIMD_FOUND OR POWER9_FOUND OR POWER10_FOUND OR POWER11_FOUND)
+if ((AVX512_FOUND AND NOT AVX512_DISABLED) OR (ASIMD_FOUND AND NOT APPLE_SILICON_FOUND) OR POWER9_FOUND OR POWER10_FOUND OR POWER11_FOUND)
     FetchContent_Declare(
         oneDNN
         GIT_REPOSITORY https://github.com/oneapi-src/oneDNN.git


### PR DESCRIPTION
When building the CPU backend on Apple Silicon, as arm's neon is supported for apple silicon cpus, the build process currently compiles also OneDNN kernels, which significantly increases build time. However, these kernels are only used in quantization paths, which are not enabled on Apple CPUs. As a result, building OneDNN kernels on Apple Silicon provides no functional benefit but adds unnecessary overhead.

Even if quantization paths were enabled, OneDNN is build without ACL for apple silicon, making only available slow reference kernels.

Earlier today I tested a quantized model (I needed to manually modify torch_bindings as quantization methods are currently gated for apple devices) an the speed was under a 1 tokens/s for a 0.5b model. For reference, for non-quantized with the same setup (sampling, prompts, etc) I get around 60 tokens/s.