### PR TITLE
Use hidden_size_per_head as head_size fallback

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1423,6 +1423,10 @@ class ModelConfig:
         if getattr(self.hf_text_config, "head_dim", None) is not None:
             return self.hf_text_config.head_dim
 
+        # NOTE: Some models (such as PLaMo2.1) use `hidden_size_per_head`
+        if getattr(self.hf_text_config, "hidden_size_per_head", None) is not None:
+            return self.hf_text_config.hidden_size_per_head
+
         # FIXME(woosuk): This may not be true for all models.
         return (self.hf_text_config.hidden_size //
                 self.hf_text_config.num_attention_heads)

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1424,7 +1424,8 @@ class ModelConfig:
             return self.hf_text_config.head_dim
 
         # NOTE: Some models (such as PLaMo2.1) use `hidden_size_per_head`
-        if getattr(self.hf_text_config, "hidden_size_per_head", None) is not None:
+        if getattr(self.hf_text_config, "hidden_size_per_head",
+                   None) is not None:
             return self.hf_text_config.hidden_size_per_head
 
         # FIXME(woosuk): This may not be true for all models.


### PR DESCRIPTION
<!-- markdownlint-disable -->
Some models (such as PLaMo2.1) use `hidden_size_per_head` as `head_size`. Additionally, the `hidden_size_per_head` is not equal `hidden_size // num_attention_heads`. This PR ensures the correct `head_size` is returned for these models.

For PLaMo2.1, this led to a crash due to the wrong KV cache page size being calculated.

Fixes #24204.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

