### PR TITLE
[Docs] add the parallel sampling usage in LLMEngine and AsyncLLM

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -107,11 +107,12 @@ class SamplingParams(
 
     n: int = 1
     """Number of outputs to return for the given prompt request.
-    Note that `LLMEngine` or `AsyncLLM` stream outputs by default.
-    When `n > 1`, all `n` outputs are generated and streamed
-    per request. But only the last output for the request may be printed
-    depending on the setup. To see all `n` outputs upon completion,
-    use `RequestOutputKind.FINAL_ONLY`."""
+
+    NOTE:
+        `AsyncLLM` streams outputs by default. When `n > 1`, all `n` outputs
+        are generated and streamed cumulatively per request. To see all `n`
+        outputs upon completion, use `output_kind=RequestOutputKind.FINAL_ONLY`
+        in `SamplingParams`."""
     best_of: Optional[int] = None
     """Number of output sequences that are generated from the prompt. From
     these `best_of` sequences, the top `n` sequences are returned. `best_of`

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -106,7 +106,12 @@ class SamplingParams(
     """
 
     n: int = 1
-    """Number of output sequences to return for the given prompt."""
+    """Number of outputs to return for the given prompt request.
+    Note that `LLMEngine` or `AsyncLLM` generates sequences in streaming
+    by default. Thus, when n > 1 they generate the expected number of
+    final outputs, but only the last for the request may be printed 
+    depending on the setup. This is normal in streaming. Or use 
+    `RequestOutputKind.FINAL_ONLY` to avoid it."""
     best_of: Optional[int] = None
     """Number of output sequences that are generated from the prompt. From
     these `best_of` sequences, the top `n` sequences are returned. `best_of`

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -107,11 +107,11 @@ class SamplingParams(
 
     n: int = 1
     """Number of outputs to return for the given prompt request.
-    Note that `LLMEngine` or `AsyncLLM` generates sequences in streaming
-    by default. Thus, when n > 1 they generate the expected number of
-    final outputs, but only the last for the request may be printed 
-    depending on the setup. This is normal in streaming. Or use 
-    `RequestOutputKind.FINAL_ONLY` to avoid it."""
+    Note that `LLMEngine` or `AsyncLLM` stream outputs by default.
+    When `n > 1`, all `n` outputs are generated and streamed
+    per request. But only the last output for the request may be printed
+    depending on the setup. To see all `n` outputs upon completion,
+    use `RequestOutputKind.FINAL_ONLY`."""
     best_of: Optional[int] = None
     """Number of output sequences that are generated from the prompt. From
     these `best_of` sequences, the top `n` sequences are returned. `best_of`


### PR DESCRIPTION
## Purpose
The recent issue (#24029) shows users' confusion about parallel sampling in `LLMEngine` and `AsyncLLM`. The gist of the confusion is that users expect features to behave as in the class `LLM`, but the difference is `LLM` uses `FINAL_ONLY` by default, whereas `LLMEngine` or `AsyncLLM` uses `CUMULATIVE` by default to support streaming. I've added documentation to clarify this distinction.

I couldn't find a better place for the doc. if one exists, I'll update it there.

@njhill @hmellor 


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

