### PR TITLE
[bugfix] fix returned chunk too large bug

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -50,7 +50,7 @@ class RequestFuncOutput:
     error: str = ""
 
 
-async def iter_lines(response, encoding="utf-8"):
+async def iter_chunks(response, encoding="utf-8"):
     buffer = ""
     async for chunk in response.content.iter_any():
         text = chunk.decode(encoding, errors="ignore")
@@ -102,7 +102,7 @@ async def async_request_tgi(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in iter_lines(response):
+                    async for chunk_bytes in iter_chunks(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
@@ -176,7 +176,7 @@ async def async_request_trt_llm(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in iter_lines(response):
+                    async for chunk_bytes in iter_chunks(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
@@ -322,7 +322,7 @@ async def async_request_openai_completions(
             ) as response:
                 if response.status == 200:
                     first_chunk_received = False
-                    async for chunk_bytes in iter_lines(response):
+                    async for chunk_bytes in iter_chunks(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
@@ -436,7 +436,7 @@ async def async_request_openai_chat_completions(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in iter_lines(response):
+                    async for chunk_bytes in iter_chunks(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
@@ -549,7 +549,7 @@ async def async_request_openai_audio(
                     url=api_url, data=form, headers=headers
                 ) as response:
                     if response.status == 200:
-                        async for chunk_bytes in iter_lines(response):
+                        async for chunk_bytes in iter_chunks(response):
                             chunk_bytes = chunk_bytes.strip()
                             if not chunk_bytes:
                                 continue

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -50,6 +50,18 @@ class RequestFuncOutput:
     error: str = ""
 
 
+async def iter_lines(response, encoding="utf-8"):
+    buffer = ""
+    async for chunk in response.content.iter_any():
+        text = chunk.decode(encoding, errors="ignore")
+        buffer += text
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
+            yield line
+    if buffer:
+        yield buffer
+
+
 async def async_request_tgi(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm] = None,
@@ -90,11 +102,10 @@ async def async_request_tgi(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in response.content:
+                    async for chunk_bytes in iter_lines(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
-                        chunk_bytes = chunk_bytes.decode("utf-8")
 
                         # NOTE: Sometimes TGI returns a ping response without
                         # any data, we should skip it.
@@ -165,12 +176,12 @@ async def async_request_trt_llm(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in response.content:
+                    async for chunk_bytes in iter_lines(response.content):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
 
-                        chunk = chunk_bytes.decode("utf-8").removeprefix("data:")
+                        chunk = chunk_bytes.removeprefix("data:")
 
                         data = json.loads(chunk)
                         output.generated_text += data["text_output"]
@@ -311,12 +322,12 @@ async def async_request_openai_completions(
             ) as response:
                 if response.status == 200:
                     first_chunk_received = False
-                    async for chunk_bytes in response.content:
+                    async for chunk_bytes in iter_lines(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
 
-                        chunk = chunk_bytes.decode("utf-8").removeprefix("data: ")
+                        chunk = chunk_bytes.removeprefix("data: ")
                         if chunk != "[DONE]":
                             data = json.loads(chunk)
 
@@ -425,11 +436,10 @@ async def async_request_openai_chat_completions(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in response.content:
+                    async for chunk_bytes in iter_lines(response.content):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
-                        chunk_bytes = chunk_bytes.decode("utf-8")
                         # NOTE: SSE comments (often used as pings) start with a colon.
                         # These are not JSON data payload and should be skipped.
                         if chunk_bytes.startswith(":"):
@@ -539,12 +549,12 @@ async def async_request_openai_audio(
                     url=api_url, data=form, headers=headers
                 ) as response:
                     if response.status == 200:
-                        async for chunk_bytes in response.content:
+                        async for chunk_bytes in iter_lines(response):
                             chunk_bytes = chunk_bytes.strip()
                             if not chunk_bytes:
                                 continue
 
-                            chunk = chunk_bytes.decode("utf-8").removeprefix("data: ")
+                            chunk = chunk_bytes.removeprefix("data: ")
                             if chunk != "[DONE]":
                                 timestamp = time.perf_counter()
                                 data = json.loads(chunk)

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -176,7 +176,7 @@ async def async_request_trt_llm(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in iter_lines(response.content):
+                    async for chunk_bytes in iter_lines(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
@@ -436,7 +436,7 @@ async def async_request_openai_chat_completions(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    async for chunk_bytes in iter_lines(response.content):
+                    async for chunk_bytes in iter_lines(response):
                         chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue


### PR DESCRIPTION
## Purpose

When the returned value is too large the benchmark will fail. This patch can solve this problem: using iter_any to avoid this problem.

<img width="927" height="567" alt="截屏2025-09-04 14 58 40" src="https://github.com/user-attachments/assets/64ee66ce-8e1c-4f80-a707-a1ff4fb6240e" />

after applying this patch, everything goes well:
<img width="909" height="117" alt="截屏2025-09-04 14 59 49" src="https://github.com/user-attachments/assets/a28b62d4-ad32-4843-a6ee-dc154e9052c2" />


## Test Plan
```bash

export model_name="Qwen3-0.6B" 
python3 -m vllm.entrypoints.openai.api_server   --port 13913  --served-model-name=base_model \
--tokenizer-mode=auto --load-format=auto --max-num-batched-tokens=2048 \
--max-model-len=1680 --max-num-seqs=32 --block-size=16 \
--gpu-memory-utilization=0.8  --trust-remote-code \
--dtype=bfloat16  --model ${model_name}   \
--no-enable-prefix-caching --disable-custom-all-reduce  



python3 benchmark_serving.py \
    --dataset-name "random" \
    --base-url http://10.38.244.193:13913/ \
    --endpoint v1/completions \
    --served_model_name "base_model" \
    --model "/mnt/user/qibaoyuan/Qwen3-0.6B" \
    --num-prompts 500 --max-concurrency 4 --random-input-len 128 --random-output-len 64

```


## Test Result
To ensure compatibility, I compare the results under both conditions based on Qwen3-0.6B, showing similar benchmark results.

**with our patch:**
<img width="691" height="487" alt="截屏2025-09-09 10 05 27" src="https://github.com/user-attachments/assets/aefb6e76-1ea0-4863-9afc-b10d023d307f" />

**without our patch:**
<img width="606" height="500" alt="截屏2025-09-09 10 05 46" src="https://github.com/user-attachments/assets/bdfdfcb3-7152-4b02-976e-c992529fa10a" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

