### PR TITLE
[Feature]support xPyD reconnect

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -504,8 +504,7 @@ class P2pNcclEngine:
 
                 # Step 2: Prepare and send PUT command
                 with self.send_stream:
-                    tensor = self.extract_kv_from_layer(item.is_mla, item.tensor,
-                                                        item.slot_mapping)
+                    tensor = item.tensor
                 data = {
                     "cmd": "PUT",
                     "tensor_id": item.tensor_id,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -409,10 +409,11 @@ class P2pNcclEngine:
                     # The sender's timeout will handle this.
                     tensor = None
                     logger.warning(
-                        "🔴[PUT] Recv Tensor failed after sending OK, %s👈%s, "
-                        "error:%s. Cleaning up connection.", 
-                        self.zmq_address, remote_address,
-                        str(e))
+                        "🔴[PUT] Recv Tensor failed after sending OK, %s👈%s. "
+                        "Cleaning up connection.",
+                        self.zmq_address,
+                        remote_address,
+                        exc_info=e)
                     # The connection might be broken, clean it up.
                     self._cleanup_connection(remote_address)
 
@@ -448,9 +449,11 @@ class P2pNcclEngine:
                             self.send_store[tensor_id] = tensor
                             self.have_sent_tensor_id(tensor_id)
                     except Exception as e:
-                        logger.error("Failed to send tensor for GET to %s: %s."
-                                     " Cleaning up connection.",
-                                     remote_address, e)
+                        logger.error(
+                            "Failed to send tensor for GET to %s. "
+                            "Cleaning up connection.",
+                            remote_address,
+                            exc_info=e)
                         self._cleanup_connection(remote_address)
                 else:
                     data = {"ret": 1}
@@ -560,9 +563,11 @@ class P2pNcclEngine:
             except (Exception, zmq.ZMQError) as e:
                 logger.error(
                     "💥 Connection error during send_sync to %s "
-                    "(attempt %d/%d): %s. Cleaning up and retrying.",
-                    item.remote_address, attempt + 1, max_retries, e
-                )
+                    "(attempt %d/%d). Cleaning up and retrying.",
+                    item.remote_address,
+                    attempt + 1,
+                    max_retries,
+                    exc_info=e)
                 self._cleanup_connection(item.remote_address)
                 time.sleep(0.1) # Small delay before retry
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -18,8 +18,8 @@ import zmq
 from vllm.config import KVTransferConfig
 from vllm.distributed.device_communicators.pynccl_wrapper import (
     NCCLLibrary, buffer_type, cudaStream_t, ncclComm_t, ncclDataTypeEnum)
-from vllm.distributed.kv_transfer.kv_connector.v1.p2p.tensor_memory_pool \
-    import TensorMemoryPool
+from vllm.distributed.kv_transfer.kv_connector.v1.p2p.tensor_memory_pool import (  # noqa: E501
+    TensorMemoryPool)
 from vllm.utils import current_stream, get_ip
 
 logger = logging.getLogger(__name__)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -187,7 +187,7 @@ class P2pNcclEngine:
                 sock.setsockopt(zmq.LINGER, 0)
                 sock.close()
             except Exception as e:
-                logger.debug("Error closing stale ZMQ socket: %s", e)
+                logger.exception("Error closing stale ZMQ socket: %s", e)
 
 
     def create_connect(self, remote_address: typing.Optional[str] = None):
@@ -408,7 +408,7 @@ class P2pNcclEngine:
                     # we might not be able to reply.
                     # The sender's timeout will handle this.
                     tensor = None
-                    logger.warning(
+                    logger.error(
                         "🔴[PUT] Recv Tensor failed after sending OK, %s👈%s. "
                         "Cleaning up connection.",
                         self.zmq_address,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -18,8 +18,8 @@ import zmq
 from vllm.config import KVTransferConfig
 from vllm.distributed.device_communicators.pynccl_wrapper import (
     NCCLLibrary, buffer_type, cudaStream_t, ncclComm_t, ncclDataTypeEnum)
-from vllm.distributed.kv_transfer.kv_connector.v1.p2p.tensor_memory_pool import (
-    TensorMemoryPool)
+from vllm.distributed.kv_transfer.kv_connector.v1.p2p.tensor_memory_pool \
+    import TensorMemoryPool
 from vllm.utils import current_stream, get_ip
 
 logger = logging.getLogger(__name__)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -175,7 +175,8 @@ class P2pNcclEngine:
             remote_address
         )
         if remote_address in self.comms:
-            # Note: ncclCommDestroy is ideally called, but the peer process is likely gone.
+            # Note: ncclCommDestroy is ideally called, 
+            # but the peer process is likely gone.
             # Simply removing the handle is the primary step.
             del self.comms[remote_address]
         
@@ -372,7 +373,7 @@ class P2pNcclEngine:
                         "Requesting re-initialization.",
                         remote_address
                     )
-                    # Respond with code '2' to signal the sender to re-initialize.
+                    # Respond with code '2' to tell the sender to re-init.
                     self.router_socket.send_multipart([
                         remote_address_bytes, b"2"])
                     continue


### PR DESCRIPTION
Purpose
This PR introduces a robust reconnection mechanism for the xPyD distributed service to enhance its fault tolerance and high availability.

Previously, if any server instance (worker) in the xPyD cluster restarted due to a crash or planned maintenance, the connection from the master/client would be permanently lost. This would disrupt the entire service, causing subsequent inference requests to fail or hang indefinitely, requiring a full-service restart to recover.

With this change, the system now implements an automatic reconnection logic. When a connection to a worker is lost, the system will periodically attempt to re-establish the link. This allows a restarted worker to seamlessly rejoin the cluster and resume its role. This ensures that the inference service can automatically recover from individual worker failures, significantly improving the overall reliability and operational robustness.