### PR TITLE
[kv cache] update num_free_blocks in the end

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -244,6 +244,18 @@ def test_free_kv_cache_block_queue_append_n():
     assert blocks[3].next_free_block is queue.fake_free_list_tail
     assert queue.fake_free_list_tail.prev_free_block is blocks[3]
 
+    # Create an empty FreeKVCacheBlockQueue
+    invalid_queue = FreeKVCacheBlockQueue([])
+    # set prev_free_block to None and this will cause assertation in append_n
+    invalid_queue.fake_free_list_tail.prev_free_block = None
+    with pytest.raises(AssertionError):
+        # Append 1 block
+        # fake_head->fake_tail
+        invalid_queue.append_n(blocks[0:1])
+    assert invalid_queue.num_free_blocks == 0
+    assert (invalid_queue.fake_free_list_head.next_free_block ==
+            invalid_queue.fake_free_list_tail)
+
 
 def test_free_kv_cache_block_queue_popleft_n():
     blocks = [KVCacheBlock(block_id=i) for i in range(6)]

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -370,7 +370,6 @@ class FreeKVCacheBlockQueue:
         """
         if len(blocks) == 0:
             return
-        self.num_free_blocks += len(blocks)
 
         last_block = self.fake_free_list_tail.prev_free_block
         assert last_block is not None, (
@@ -384,6 +383,8 @@ class FreeKVCacheBlockQueue:
         # Connect the last block of <blocks> to the fake tail
         last_block.next_free_block = self.fake_free_list_tail
         self.fake_free_list_tail.prev_free_block = last_block
+
+        self.num_free_blocks += len(blocks)
 
     def get_all_free_blocks(self) -> list[KVCacheBlock]:
         """Get all free blocks in the free list. Mainly used for testing.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Update `num_free_blocks` fields only after the check is ok. This can ensure that queue should not be in a inconsistent state when the check is false. For now, the `num_free_blocks` is updated but the `blocks` is not updated if assert error.
## Test Plan
Add a new ut case
## Test Result
Pass
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

