### PR TITLE
[Metrics] Hide deprecated metrics with gpu_ prefix

### DIFF
--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -206,40 +206,46 @@ class PrometheusStatLogger(StatLoggerBase):
         #
         # GPU cache
         #
-        # Deprecated in 0.9 - Renamed as vllm:kv_cache_usage_perc
-        # TODO: in 0.10, only enable if show_hidden_metrics=True
-        gauge_gpu_cache_usage = self._gauge_cls(
-            name="vllm:gpu_cache_usage_perc",
-            documentation=(
-                "GPU KV-cache usage. 1 means 100 percent usage."
-                "DEPRECATED: Use vllm:kv_cache_usage_perc instead."),
-            multiprocess_mode="mostrecent",
-            labelnames=labelnames)
-        self.gauge_gpu_cache_usage = make_per_engine(gauge_gpu_cache_usage,
-                                                     engine_indexes,
-                                                     model_name)
+        # Deprecated in 0.9.2 - Renamed as vllm:kv_cache_usage_perc
+        # With 0.11.x you can enable with --show-hidden-metrics-for-version=0.10
+        # TODO: remove in 0.12.0
+        if self.show_hidden_metrics:
+            gauge_gpu_cache_usage = self._gauge_cls(
+                name="vllm:gpu_cache_usage_perc",
+                documentation=(
+                    "GPU KV-cache usage. 1 means 100 percent usage."
+                    "DEPRECATED: Use vllm:kv_cache_usage_perc instead."),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames)
+            self.gauge_gpu_cache_usage = make_per_engine(
+                gauge_gpu_cache_usage, engine_indexes, model_name)
 
-        # Deprecated in 0.9 - Renamed as vllm:prefix_cache_queries
-        # TODO: in 0.10, only enable if show_hidden_metrics=True
-        counter_gpu_prefix_cache_queries = self._counter_cls(
-            name="vllm:gpu_prefix_cache_queries",
-            documentation=(
-                "GPU prefix cache queries, in terms of number of queried"
-                "tokens. DEPRECATED: Use vllm:prefix_cache_queries instead."),
-            labelnames=labelnames)
-        self.counter_gpu_prefix_cache_queries = make_per_engine(
-            counter_gpu_prefix_cache_queries, engine_indexes, model_name)
+        # Deprecated in 0.9.2 - Renamed as vllm:prefix_cache_queries
+        # With 0.11.x you can enable with --show-hidden-metrics-for-version=0.10
+        # TODO: remove in 0.12.0
+        if self.show_hidden_metrics:
+            counter_gpu_prefix_cache_queries = self._counter_cls(
+                name="vllm:gpu_prefix_cache_queries",
+                documentation=(
+                    "GPU prefix cache queries, in terms of number of queried"
+                    "tokens. DEPRECATED: Use vllm:prefix_cache_queries instead."
+                ),
+                labelnames=labelnames)
+            self.counter_gpu_prefix_cache_queries = make_per_engine(
+                counter_gpu_prefix_cache_queries, engine_indexes, model_name)
 
-        # Deprecated in 0.9 - Renamed as vllm:prefix_cache_hits
-        # TODO: in 0.10, only enable if show_hidden_metrics=True
-        counter_gpu_prefix_cache_hits = self._counter_cls(
-            name="vllm:gpu_prefix_cache_hits",
-            documentation=(
-                "GPU prefix cache hits, in terms of number of cached "
-                "tokens. DEPRECATED: Use vllm:prefix_cache_hits instead."),
-            labelnames=labelnames)
-        self.counter_gpu_prefix_cache_hits = make_per_engine(
-            counter_gpu_prefix_cache_hits, engine_indexes, model_name)
+        # Deprecated in 0.9.2 - Renamed as vllm:prefix_cache_hits
+        # With 0.11.x you can enable with --show-hidden-metrics-for-version=0.10
+        # TODO: remove in 0.12.0
+        if self.show_hidden_metrics:
+            counter_gpu_prefix_cache_hits = self._counter_cls(
+                name="vllm:gpu_prefix_cache_hits",
+                documentation=(
+                    "GPU prefix cache hits, in terms of number of cached "
+                    "tokens. DEPRECATED: Use vllm:prefix_cache_hits instead."),
+                labelnames=labelnames)
+            self.counter_gpu_prefix_cache_hits = make_per_engine(
+                counter_gpu_prefix_cache_hits, engine_indexes, model_name)
 
         gauge_kv_cache_usage = self._gauge_cls(
             name="vllm:kv_cache_usage_perc",
@@ -513,15 +519,17 @@ class PrometheusStatLogger(StatLoggerBase):
             self.gauge_scheduler_waiting[engine_idx].set(
                 scheduler_stats.num_waiting_reqs)
 
-            self.gauge_gpu_cache_usage[engine_idx].set(
-                scheduler_stats.kv_cache_usage)
+            if self.show_hidden_metrics:
+                self.gauge_gpu_cache_usage[engine_idx].set(
+                    scheduler_stats.kv_cache_usage)
             self.gauge_kv_cache_usage[engine_idx].set(
                 scheduler_stats.kv_cache_usage)
 
-            self.counter_gpu_prefix_cache_queries[engine_idx].inc(
-                scheduler_stats.prefix_cache_stats.queries)
-            self.counter_gpu_prefix_cache_hits[engine_idx].inc(
-                scheduler_stats.prefix_cache_stats.hits)
+            if self.show_hidden_metrics:
+                self.counter_gpu_prefix_cache_queries[engine_idx].inc(
+                    scheduler_stats.prefix_cache_stats.queries)
+                self.counter_gpu_prefix_cache_hits[engine_idx].inc(
+                    scheduler_stats.prefix_cache_stats.hits)
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries)


### PR DESCRIPTION
In #18354, these metrics were deprecated, and the change was included in the v0.9.2 release.

We probably should only deprecate things in a v0.N.0 minor release, so let's say these were deprecated in v0.10.0.

According to https://docs.vllm.ai/en/latest/usage/metrics.html:

> Note: when metrics are deprecated in version X.Y, they are hidden in
>  version X.Y+1 but can be re-enabled using the
>  --show-hidden-metrics-for-version=X.Y escape hatch, and are then
>  removed in version X.Y+2.

The deprecated metrics should be hidden in the v0.11.0 release, but with a --show-hidden-metrics-for-version=0.10 escape hatch.

They should then be removed in the v0.12.0 release.