### PR TITLE
[kernel] Add stride checks for rms_norm kernels

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -1,6 +1,7 @@
 #include "type_convert.cuh"
 #include "dispatch_utils.h"
 #include "cub_helpers.h"
+#include "utils.h"
 
 #include <torch/cuda.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -348,6 +349,7 @@ void rms_norm(torch::Tensor& out,     // [..., hidden_size]
               double epsilon) {
   TORCH_CHECK(out.is_contiguous());
   TORCH_CHECK(input.stride(-1) == 1);
+  TORCH_CHECK(is_contiguous_except_last_dim(input));
   TORCH_CHECK(weight.is_contiguous());
 
   int hidden_size = input.size(-1);
@@ -380,6 +382,8 @@ void fused_add_rms_norm(torch::Tensor& input,     // [..., hidden_size]
                         torch::Tensor& weight,    // [hidden_size]
                         double epsilon) {
   TORCH_CHECK(residual.is_contiguous());
+  TORCH_CHECK(input.stride(-1) == 1);
+  TORCH_CHECK(is_contiguous_except_last_dim(input));
   TORCH_CHECK(weight.is_contiguous());
   int hidden_size = input.size(-1);
   int64_t input_stride = input.stride(-2);

--- a/csrc/layernorm_quant_kernels.cu
+++ b/csrc/layernorm_quant_kernels.cu
@@ -9,6 +9,7 @@
 #include "quantization/fp8/common.cuh"
 #include "dispatch_utils.h"
 #include "cub_helpers.h"
+#include "utils.h"
 
 #include <torch/cuda.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -170,6 +171,8 @@ void rms_norm_static_fp8_quant(torch::Tensor& out,     // [..., hidden_size]
                                torch::Tensor& scale,   // [1]
                                double epsilon) {
   TORCH_CHECK(out.is_contiguous());
+  TORCH_CHECK(input.stride(-1) == 1);
+  TORCH_CHECK(is_contiguous_except_last_dim(input));
   int hidden_size = input.size(-1);
   int input_stride = input.stride(-2);
   int num_tokens = input.numel() / hidden_size;
@@ -214,6 +217,8 @@ void fused_add_rms_norm_static_fp8_quant(
     torch::Tensor& scale,     // [1]
     double epsilon) {
   TORCH_CHECK(out.is_contiguous());
+  TORCH_CHECK(input.stride(-1) == 1);
+  TORCH_CHECK(is_contiguous_except_last_dim(input));
   TORCH_CHECK(residual.is_contiguous());
   int hidden_size = input.size(-1);
   int input_stride = input.stride(-2);

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <torch/all.h>
+
+//! Check if the tensor is contiguous except for the last dimension.
+//!
+//! \param tensor The tensor to check.
+//! \return True if the tensor is contiguous except for the last dimension.
+inline bool is_contiguous_except_last_dim(const torch::Tensor& tensor) {
+  // If the tensor has 2 or fewer dimensions, it is contiguous.
+  size_t ndim = tensor.ndimension();
+  if (ndim <= 2) {
+    return true;
+  }
+
+  // Check if the tensor is contiguous except for the last dimension.
+  auto strides = tensor.strides();
+  auto sizes = tensor.sizes();
+  for (size_t i = 0; i < ndim - 2; ++i) {
+    if (strides[i] != sizes[i + 1] * strides[i + 1]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -5,176 +5,261 @@ import pytest
 import torch
 
 from tests.kernels.quant_utils import FP8_DTYPE
-from tests.kernels.utils import opcheck
+from tests.kernels.utils import create_strided_tensor, opcheck
 from vllm.model_executor.layers.layernorm import PolyNorm, RMSNorm
 from vllm.platforms import current_platform
 
-DTYPES = [torch.half, torch.bfloat16, torch.float]
-NUM_TOKENS = [7, 83, 4096]  # Arbitrary values for testing
-HIDDEN_SIZES = [8, 768, 769, 770, 771, 5120, 5124, 5125, 5126, 8192,
-                8199]  # Arbitrary values for testing
+# Tuple of (size, strides)
+TENSOR_SIZES_STRIDES = [
+    # Normal tensor layouts
+    ((7, 8), (8, 1)),
+    ((7, 768), (768, 1)),
+    ((7, 769), (769, 1)),
+    ((7, 5120), (5120, 1)),
+    ((7, 5125), (5125, 1)),
+    ((7, 5126), (5126, 1)),
+    ((7, 8192), (8192, 1)),
+    ((7, 8199), (8199, 1)),
+    ((83, 8), (8, 1)),
+    ((83, 768), (768, 1)),
+    ((83, 769), (769, 1)),
+    ((83, 5120), (5120, 1)),
+    ((83, 5125), (5125, 1)),
+    ((83, 5126), (5126, 1)),
+    ((83, 8192), (8192, 1)),
+    ((83, 8199), (8199, 1)),
+    ((4096, 8), (8, 1)),
+    ((4096, 768), (768, 1)),
+    ((4096, 769), (769, 1)),
+    ((4096, 5120), (5120, 1)),
+    ((4096, 5125), (5125, 1)),
+    ((4096, 5126), (5126, 1)),
+    ((4096, 8192), (8192, 1)),
+    ((4096, 8199), (8199, 1)),
+
+    # Strided tensor layouts
+    ((7, 8), (15, 1)),
+    ((7, 768), (1536, 1)),
+    ((7, 769), (769, 1)),
+    ((7, 5120), (5121, 1)),
+    ((7, 5125), (5128, 1)),
+    ((7, 5126), (8192, 1)),
+    ((7, 8192), (16384, 1)),
+    ((7, 8199), (16789, 1)),
+    ((83, 8), (23, 1)),
+    ((83, 768), (2304, 1)),
+    ((83, 769), (2555, 1)),
+    ((83, 5120), (5122, 1)),
+    ((83, 5125), (5127, 1)),
+    ((83, 5126), (8194, 1)),
+    ((83, 8192), (10000, 1)),
+    ((83, 8199), (10001, 1)),
+    ((4096, 8), (9, 1)),
+    ((4096, 768), (769, 1)),
+    ((4096, 769), (770, 1)),
+    ((4096, 5120), (5122, 1)),
+    ((4096, 5125), (5130, 1)),
+    ((4096, 5126), (5130, 1)),
+    ((4096, 8192), (9000, 1)),
+    ((4096, 8199), (9001, 1)),
+
+    # Multiple num_tokens dimensions
+    ((7, 8, 8), (64, 8, 1)),
+    ((7, 8, 8), (128, 16, 1)),
+    ((12, 7, 768), (5607, 801, 1)),
+    ((2, 3, 6, 769), (13860, 4620, 770, 1)),
+
+    # Unsupported: last stride is not 1
+    ((7, 8), (1, 8)),
+    ((7, 768), (1, 8)),
+    ((2, 3, 6, 769), (2, 3076, 9228, 4)),
+
+    # Unsupported: multiple non-contiguous num_tokens dimensions
+    ((7, 8, 8), (8, 64, 1)),
+    ((7, 8, 8), (160, 16, 1)),
+    ((12, 7, 768), (8010, 801, 1)),
+    ((2, 3, 6, 769), (2310, 770, 9240, 1)),
+]
+# Whether to add residual to the input.
 ADD_RESIDUAL = [False, True]
+# Input and residual dtype.
+DTYPES = [torch.half, torch.bfloat16, torch.float]
+# Tuple of (quant_dtype, quant_scale)
+QUANT_DTYPE_AND_SCALE = [
+    (None, None),
+    (FP8_DTYPE, 1.0),
+    (FP8_DTYPE, 0.01),
+    (FP8_DTYPE, 10.0),
+]
 SEEDS = [0]
 CUDA_DEVICES = [
     f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)
 ]
 
 
-@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
-@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("tensor_sizes_strides", TENSOR_SIZES_STRIDES)
 @pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
 @pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("quant_dtype_and_scale", QUANT_DTYPE_AND_SCALE)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
-@pytest.mark.parametrize("strided_input", [False, True])
 @torch.inference_mode()
 def test_rms_norm(
-    num_tokens: int,
-    hidden_size: int,
+    tensor_sizes_strides: tuple[tuple[int, ...], tuple[int, ...]],
     add_residual: bool,
     dtype: torch.dtype,
+    quant_dtype_and_scale: tuple[torch.dtype, float],
     seed: int,
     device: str,
-    strided_input: bool,
 ) -> None:
+
+    # Validate tensor_sizes_strides.
+    tensor_size, tensor_stride = tensor_sizes_strides
+    assert len(tensor_size) == len(tensor_stride), \
+        f"Invalid tensor_sizes_strides: {tensor_sizes_strides}"
+    hidden_size = tensor_size[-1]
+
+    # Validate quant_dtype.
+    quant_dtype, quant_scale = quant_dtype_and_scale
+    assert quant_dtype is None or quant_dtype is FP8_DTYPE, \
+        f"Invalid quant_dtype: {quant_dtype}"
+
+    # Set up the inputs.
     current_platform.seed_everything(seed)
     torch.set_default_device(device)
     layer = RMSNorm(hidden_size).to(dtype=dtype)
     layer.weight.data.normal_(mean=1.0, std=0.1)
+    weight = layer.weight.data
     scale = 1 / (2 * hidden_size)
-    last_dim = 2 * hidden_size if strided_input else hidden_size
-    x = torch.randn(num_tokens, last_dim, dtype=dtype)
-    x = x[..., :hidden_size]
-    assert x.is_contiguous() != strided_input
+    x = create_strided_tensor(tensor_size, tensor_stride, dtype).normal_()
     x *= scale
-    residual = torch.randn_like(x) * scale if add_residual else None
+    residual = torch.randn_like(x).contiguous() * scale \
+        if add_residual else None
 
     # NOTE(woosuk): The reference implementation should be executed first
     # because the custom kernel is in-place.
     ref_out = layer.forward_native(x, residual)
-    out = layer(x, residual)
+    if add_residual:
+        ref_out, ref_residual = ref_out[0], ref_out[1]
+    if quant_dtype is FP8_DTYPE:
+        # static_scaled_fp8_quant only supports contiguous input.
+        ref_out = ref_out.contiguous()
+        ref_out_quant = torch.empty_like(ref_out, dtype=FP8_DTYPE)
+        quant_scale_t = torch.tensor(quant_scale, dtype=torch.float32)
+        torch.ops._C.static_scaled_fp8_quant(ref_out_quant, ref_out,
+                                             quant_scale_t)
+        ref_out = ref_out_quant
+
+    # Check whether the custom kernel supports the given tensor layout.
+    is_supported = True
+    # If last stride is not 1, not supported.
+    if tensor_stride[-1] != 1:
+        is_supported = False
+    # If multiple num_tokens dimensions with non-contiguous strides, not
+    # supported.
+    for i in range(len(tensor_size) - 2):
+        if tensor_stride[i] != tensor_size[i + 1] * tensor_stride[i + 1]:
+            is_supported = False
+            break
+
+    # Run the custom kernel and make sure it raises an error if the tensor
+    # layout is not supported.
+    try:
+        if quant_dtype is FP8_DTYPE:
+            out = torch.empty_like(x, dtype=FP8_DTYPE).contiguous()
+            if add_residual:
+                torch.ops._C.fused_add_rms_norm_static_fp8_quant(
+                    out, x, residual, weight, quant_scale_t, 1e-6)
+            else:
+                torch.ops._C.rms_norm_static_fp8_quant(out, x, weight,
+                                                       quant_scale_t, 1e-6)
+        else:
+            out = layer.forward_cuda(x, residual)
+            if add_residual:
+                out, residual = out[0], out[1]
+    except RuntimeError as e:
+        if not is_supported:
+            return
+        raise e
+
+    if not is_supported:
+        raise RuntimeError("Custom kernel does not support the given tensor "
+                           "layout but did not raise an error.")
+
     # NOTE(woosuk): LayerNorm operators (including RMS) typically have larger
     # numerical errors than other operators because they involve reductions.
     # Therefore, we use a larger tolerance.
+    rtol_out = 2e-1 if quant_dtype is FP8_DTYPE else 1e-2
+    torch.testing.assert_close(out.to(dtype=torch.float32),
+                               ref_out.to(dtype=torch.float32),
+                               atol=1e-2,
+                               rtol=rtol_out)
     if add_residual:
-        torch.testing.assert_close(out[0], ref_out[0], atol=1e-2, rtol=1e-2)
-        torch.testing.assert_close(out[1], ref_out[1], atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(residual,
+                                   ref_residual,
+                                   atol=1e-2,
+                                   rtol=1e-2)
+
+    # Op checks
+    if quant_dtype is FP8_DTYPE:
+        if add_residual:
+            opcheck(torch.ops._C.fused_add_rms_norm_static_fp8_quant,
+                    (out, x, residual, weight, quant_scale_t,
+                     layer.variance_epsilon))
+        else:
+            opcheck(torch.ops._C.rms_norm_static_fp8_quant,
+                    (out, x, weight, quant_scale_t, layer.variance_epsilon))
     else:
-        torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
-
-    if residual is not None:
-        opcheck(torch.ops._C.fused_add_rms_norm,
-                (x, residual, layer.weight.data, layer.variance_epsilon))
-    else:
-        opcheck(torch.ops._C.rms_norm,
-                (out, x, layer.weight.data, layer.variance_epsilon))
+        if add_residual:
+            opcheck(torch.ops._C.fused_add_rms_norm,
+                    (x, residual, weight, layer.variance_epsilon))
+        else:
+            opcheck(torch.ops._C.rms_norm,
+                    (out, x, weight, layer.variance_epsilon))
 
 
-@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
-@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("tensor_sizes_strides", TENSOR_SIZES_STRIDES)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @torch.inference_mode()
 def test_poly_norm(
-    num_tokens: int,
-    hidden_size: int,
+    tensor_sizes_strides: tuple[tuple[int, ...], tuple[int, ...]],
     dtype: torch.dtype,
     seed: int,
     device: str,
 ) -> None:
+    # Validate tensor_sizes_strides.
+    tensor_size, tensor_stride = tensor_sizes_strides
+    assert len(tensor_size) == len(tensor_stride), \
+        f"Invalid tensor_sizes_strides: {tensor_sizes_strides}"
+    hidden_size = tensor_size[-1]
+
     current_platform.seed_everything(seed)
     torch.set_default_device(device)
     layer = PolyNorm().to(dtype=dtype)
     layer.weight.data.normal_(mean=1.0, std=0.1)
     layer.bias.data.normal_(mean=1.0, std=0.1)
     scale = 1 / (2 * hidden_size)
-    x = torch.randn(num_tokens, hidden_size, dtype=dtype)
+    x = create_strided_tensor(tensor_size, tensor_stride, dtype).normal_()
     x *= scale
 
     ref_out = layer.forward_native(x)
     out = layer(x)
     torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
 
-    opcheck(
-        torch.ops._C.poly_norm,
-        (out, x, layer.weight.data, layer.bias.data, layer.variance_epsilon))
+    # PolyNorm does not support strided tensor layouts, so we make sure that it
+    # raises an error.
+    is_supported = x.is_contiguous()
+    try:
+        opcheck(torch.ops._C.poly_norm,
+                (out, x, layer.weight.data, layer.bias.data,
+                 layer.variance_epsilon))
+    except Exception as e:
+        if not is_supported:
+            return
+        raise e
 
-
-@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
-@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
-@pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
-@pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("quant_scale", [1.0, 0.01, 10.0])
-@pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.parametrize("device", CUDA_DEVICES)
-@pytest.mark.parametrize("strided_input", [False, True])
-def test_fused_rms_norm_quant(
-    num_tokens: int,
-    hidden_size: int,
-    add_residual: bool,
-    dtype: torch.dtype,
-    quant_scale: float,
-    seed: int,
-    device: str,
-    strided_input: bool,
-) -> None:
-    current_platform.seed_everything(seed)
-    torch.set_default_device(device)
-
-    weight = torch.empty(hidden_size, dtype=dtype).normal_(mean=1.0, std=0.1)
-    scale = 1 / (2 * hidden_size)
-    last_dim = 2 * hidden_size if strided_input else hidden_size
-    x_base = torch.randn(num_tokens, last_dim, dtype=dtype)
-    x = x_base[..., :hidden_size]
-    assert x.is_contiguous() != strided_input
-
-    x *= scale
-    if add_residual:
-        residual = torch.randn_like(x) * scale
-        residual_fused = residual.clone()
-    else:
-        residual = residual_fused = None
-
-    out_norm = torch.empty_like(x)
-    out_quant = torch.empty_like(x, dtype=FP8_DTYPE)
-    out_quant_fused = torch.empty_like(out_quant)
-
-    quant_scale_t = torch.tensor(quant_scale, dtype=torch.float32)
-
-    if add_residual:
-        torch.ops._C.fused_add_rms_norm_static_fp8_quant(
-            out_quant_fused, x, residual_fused, weight, quant_scale_t, 1e-6)
-
-        # Unfused kernel is in-place so it goes second
-        # Also use a separate clone of x to avoid modifying the input
-        x_unfused_base = x_base.clone()
-        x_unfused = x_unfused_base[..., :hidden_size]
-        assert x_unfused.is_contiguous() != strided_input
-        torch.ops._C.fused_add_rms_norm(x_unfused, residual, weight, 1e-6)
-        torch.ops._C.static_scaled_fp8_quant(out_quant, x_unfused.contiguous(),
-                                             quant_scale_t)
-
-        torch.cuda.synchronize()
-        torch.testing.assert_close(residual_fused,
-                                   residual,
-                                   atol=1e-2,
-                                   rtol=1e-2)
-        opcheck(
-            torch.ops._C.fused_add_rms_norm_static_fp8_quant,
-            (out_quant_fused, x, residual_fused, weight, quant_scale_t, 1e-6))
-    else:
-        torch.ops._C.rms_norm_static_fp8_quant(out_quant_fused, x, weight,
-                                               quant_scale_t, 1e-6)
-
-        torch.ops._C.rms_norm(out_norm, x, weight, 1e-6)
-        torch.ops._C.static_scaled_fp8_quant(out_quant, out_norm,
-                                             quant_scale_t)
-
-        opcheck(torch.ops._C.rms_norm_static_fp8_quant,
-                (out_quant_fused, x, weight, quant_scale_t, 1e-6))
-
-    torch.testing.assert_close(out_quant.to(dtype=torch.float32),
-                               out_quant_fused.to(dtype=torch.float32),
-                               atol=1e-3,
-                               rtol=1e-3)
+    if not is_supported:
+        raise RuntimeError("Custom kernel does not support the strided tensor "
+                           "but did not raise an error.")

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -261,9 +261,7 @@ def rotary_embedding(
 # layer norm ops
 def rms_norm(out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor,
              epsilon: float) -> None:
-    # TODO: Remove this contiguous call when the kernel is updated to support non-contiguous input
-    input_contiguous = input.contiguous()
-    torch.ops._C.rms_norm(out, input_contiguous, weight, epsilon)
+    torch.ops._C.rms_norm(out, input, weight, epsilon)
 
 
 def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -20,7 +20,9 @@ def is_rocm_aiter_rmsnorm_enabled() -> bool:
 def rms_norm(x: torch.Tensor, weight: torch.Tensor,
              variance_epsilon: float) -> torch.Tensor:
     from vllm import _custom_ops as ops
-    out = torch.empty_like(x)
+
+    # x may not be contiguous but out must be contiguous
+    out = torch.empty_like(x).contiguous()
     ops.rms_norm(
         out,
         x,
@@ -46,7 +48,9 @@ def fused_add_rms_norm(
 def poly_norm(x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor,
               variance_epsilon: float) -> torch.Tensor:
     from vllm import _custom_ops as ops
-    out = torch.empty_like(x)
+
+    # x may not be contiguous but out must be contiguous
+    out = torch.empty_like(x).contiguous()
     ops.poly_norm(
         out,
         x,

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -144,12 +144,10 @@ class Qwen3Attention(nn.Module):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         # Add qk-norm
-        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim,
-                           self.head_dim)
+        q_by_head = q.reshape(-1, self.head_dim)
         q_by_head = self.q_norm(q_by_head)
         q = q_by_head.view(q.shape)
-        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim,
-                           self.head_dim)
+        k_by_head = k.reshape(-1, self.head_dim)
         k_by_head = self.k_norm(k_by_head)
         k = k_by_head.view(k.shape)
         q, k = self.rotary_emb(positions, q, k)


### PR DESCRIPTION
## Purpose

This is a follow-up PR from #22701

Currently, the rms_norm kernels (including the ones with fused ResidualAdd and/or FP8-Quant) supported partially strided tensors, with the following restrictions:

- The stride of the last dimension (hidden_size) must be 1.
- The num_tokens dimensions (if more than 1) must be contiguous.

Previously, we did not check these in the custom op implementation. That caused silent corruptions and cuda illegal memory access if users passed in tensors not supported by the kernels.

This PR adds such checks to ensure that when this situation happens, it fails loudly with corresponding error messages.

The unit test (test_layernorm.py) is also updated to add such "negative" (i.e. unsupported) test cases and make sure the custom ops raise an error when users pass in unsupported tensors.

This PR also fuses the rms_norm tests with rms_norm+quant tests since the two are very similar and have duplicated code.

## Test Plan

```
python3 -m pytest --capture=no tests/kernels/core/test_layernorm.py -k test_rms_norm
```

Running on H200 GPU.

## Test Result

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/scratch.pohanh_sw/vllm
configfile: pyproject.toml
plugins: subtests-0.14.1, rerunfailures-14.0, buildkite-test-collector-0.1.9, mock-3.14.0, asyncio-0.24.0, shard-0.1.2, forked-1.6.0, anyio-4.6.2.post1, timeout-2.3.1, hypothesis-6.131.0, schemathesis-3.39.15, hydra-core-1.3.2
asyncio: mode=Mode.STRICT, default_loop_scope=None
WARNING 09-04 09:00:02 [interface.py:534] Current platform cuda does not have '_pytestfixturefunction' attribute.
WARNING 09-04 09:00:02 [interface.py:534] Current platform cuda does not have '__test__' attribute.
WARNING 09-04 09:00:02 [interface.py:534] Current platform cuda does not have '__bases__' attribute.
WARNING 09-04 09:00:02 [interface.py:534] Current platform cuda does not have '__test__' attribute.
WARNING 09-04 09:00:02 [interface.py:534] Current platform cuda does not have '_schemathesis_test' attribute.
collected 1416 items
Running 1416 items in this shard

tests/kernels/core/test_layernorm.py WARNING 09-04 09:00:02 [__init__.py:3998] Current vLLM config is not set.
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
================= 1416 passed, 1 warning in 441.46s (0:07:21) ==================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

