### PR TITLE
[Core] Add delayed batching

### DIFF
--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -34,6 +34,8 @@ def create_scheduler(
     num_speculative_tokens: Optional[int] = None,
     skip_tokenizer_init: bool = False,
     async_scheduling: bool = False,
+    max_delayed_iterations: int = 0,
+    max_num_delayed_tokens: int = 0,
 ) -> Union[Scheduler, AsyncScheduler]:
     '''Create scheduler under test.
 
@@ -58,6 +60,8 @@ def create_scheduler(
         disable_chunked_mm_input=disable_chunked_mm_input,
         enable_chunked_prefill=True,
         async_scheduling=async_scheduling,
+        max_delayed_iterations=max_delayed_iterations,
+        max_num_delayed_tokens=max_num_delayed_tokens,
     )
     model_config = ModelConfig(
         model=model,

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -159,6 +159,19 @@ class SchedulerConfig:
     structured outputs, speculative decoding, and pipeline parallelism.
     """
 
+    max_delayed_iterations: int = 0
+    """The maximum number of iterations that a request can be delayed even
+    when resources are available. This allows prefill phase to run on a
+    larger batch size, which may be more efficient than running each request
+    as soon as possible.
+    """
+
+    max_num_delayed_tokens: int = 0
+    """The threshold over which prefill will run without delaying.
+    Must be less than max_num_batched_tokens. See also
+    max_delayed_iterations. 
+    """
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -454,6 +454,8 @@ class EngineArgs:
     """Custom logitproc types"""
 
     async_scheduling: bool = SchedulerConfig.async_scheduling
+    max_delayed_iterations: int = SchedulerConfig.max_delayed_iterations
+    max_num_delayed_tokens: int = SchedulerConfig.max_num_delayed_tokens
 
     kv_sharing_fast_prefill: bool = \
         CacheConfig.kv_sharing_fast_prefill
@@ -872,6 +874,12 @@ class EngineArgs:
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"])
         scheduler_group.add_argument("--async-scheduling",
                                      **scheduler_kwargs["async_scheduling"])
+        scheduler_group.add_argument(
+            "--max-delayed-iterations",
+            **scheduler_kwargs["max_delayed_iterations"])
+        scheduler_group.add_argument(
+            "--max-num-delayed-tokens",
+            **scheduler_kwargs["max_num_delayed_tokens"])
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)
@@ -1339,6 +1347,8 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.
             disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
+            max_delayed_iterations=self.max_delayed_iterations,
+            max_num_delayed_tokens=self.max_num_delayed_tokens,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -219,6 +219,7 @@ class RequestStatus(enum.IntEnum):
     WAITING_FOR_REMOTE_KVS = enum.auto()
     RUNNING = enum.auto()
     PREEMPTED = enum.auto()
+    QUEUED = enum.auto()
     # Note: anything after PREEMPTED will be considered
     # as a finished status.
     FINISHED_STOPPED = enum.auto()

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -121,6 +121,10 @@ class Request:
             self.get_hash_new_full_blocks = partial(block_hasher, self)
             self.block_hashes = self.get_hash_new_full_blocks()
 
+        # Delayed iterations is number of iterations that this
+        # request has been waiting in scheduler.queued.
+        self.delayed_iterations = 0
+
     @classmethod
     def from_engine_core_request(
         cls, request: EngineCoreRequest,


### PR DESCRIPTION
## Purpose
For certain optimization passes, we cannot use piecewise cudagraphs, see https://github.com/vllm-project/vllm/issues/23261. When using those optimization passes, it's either full cudagraph or no cudagraph.

However, prefill attention doesn't support cudagraph. Therefore, prefill must run without cudagraphs, which causes a very large amount of host overhead. This PR alleviates the problem by introducing delayed batching, which waits a few iterations or until enough requests arrive before running prefill instead of running requests as they come. This results in a lower number of prefill iterations and increases overall TPS. This comes at the cost of increasing TTFT and should be considered a perf tuning knob.

For llama3 FP8 ISL=OSL=1024 concurrency=128 TP2 on B200 + Intel Xeon Platinum 8570, there is a ~4% throughput improvement.

Without delayed batching (current ToT)
```
============ Serving Benchmark Result ============
Successful requests:                     640       
Maximum request concurrency:             128       
Benchmark duration (s):                  115.40    
Total input tokens:                      595258    
Total generated tokens:                  596284    
Request throughput (req/s):              5.55      
Output token throughput (tok/s):         5166.99   
Total Token throughput (tok/s):          10325.08  
---------------Time to First Token----------------
Mean TTFT (ms):                          744.32    
Median TTFT (ms):                        161.53    
P99 TTFT (ms):                           4940.43   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          23.18     
Median TPOT (ms):                        22.04     
P99 TPOT (ms):                           35.00     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.27     
Median ITL (ms):                         15.12     
P99 ITL (ms):                            99.76     
==================================================
```

With delayed batching
```
============ Serving Benchmark Result ============
Successful requests:                     640       
Maximum request concurrency:             128       
Benchmark duration (s):                  111.15    
Total input tokens:                      595258    
Total generated tokens:                  596284    
Request throughput (req/s):              5.76      
Output token throughput (tok/s):         5364.54   
Total Token throughput (tok/s):          10719.85  
---------------Time to First Token----------------
Mean TTFT (ms):                          955.85    
Median TTFT (ms):                        377.78    
P99 TTFT (ms):                           5130.32   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.04     
Median TPOT (ms):                        20.34     
P99 TPOT (ms):                           33.86     
---------------Inter-token Latency----------------
Mean ITL (ms):                           22.12     
Median ITL (ms):                         15.07     
P99 ITL (ms):                            269.00    
==================================================
```

Higher perf increases are expected on machines with higher host overhead. Will update this PR once I have collected numbers.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

