### PR TITLE
Add data_parallel_size to VllmConfig string representation

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -3891,6 +3891,7 @@ class VllmConfig:
             f"load_format={self.load_config.load_format}, "
             f"tensor_parallel_size={self.parallel_config.tensor_parallel_size}, "  # noqa
             f"pipeline_parallel_size={self.parallel_config.pipeline_parallel_size}, "  # noqa
+            f"data_parallel_size={self.parallel_config.data_parallel_size}, "  # noqa
             f"disable_custom_all_reduce={self.parallel_config.disable_custom_all_reduce}, "  # noqa
             f"quantization={self.model_config.quantization}, "
             f"enforce_eager={self.model_config.enforce_eager}, "


### PR DESCRIPTION
Summary:
Add `data_parallel_size` to the VllmConfig's `__str__` method to ensure this parallel configuration field is visible in string serialization.

**Context:**
The VllmConfig class has a custom `__str__` method that selectively shows configuration fields. Currently it only includes 3 fields from ParallelConfig: `tensor_parallel_size`, `pipeline_parallel_size`, and `disable_custom_all_reduce`.

**Problem:**
The `data_parallel_size` field was missing from the string representation, which means it wouldn't appear in outputs like the `/server_info` endpoint response that uses `str(vllm_config)`. This makes it difficult for external tools to discover the data parallel configuration.

**Solution:**
Added `data_parallel_size={self.parallel_config.data_parallel_size}` to the string representation, positioned logically between `pipeline_parallel_size` and `disable_custom_all_reduce`.

**Impact:**
- Improves visibility of parallel configuration in string outputs
- Maintains consistency with other parallel config fields already shown
- No functional changes to vLLM behavior, only adds information to string representation
- Enables better observability and integration with external tools

Test Plan:
**Manual Testing:**
1. Start vLLM server with different data parallel configurations
2. Check that `data_parallel_size` appears correctly in string outputs
3. Verify existing functionality remains unchanged

**Example output:**
```
# Before: tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False
# After:  tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=4, disable_custom_all_reduce=False
```

Rollback Plan:

Differential Revision: D81755925


