### PR TITLE
Xgrammar fixed

### DIFF
--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -250,12 +250,22 @@ def sample_requests(
             )
             input_len = len(tokenizer(prompt).input_ids)
             completion = dataset["completion"][idx]
+            output_lengths = [
+                35, 119, 109, 32, 46, 84, 86, 78, 50, 21,
+                56, 57, 43, 49, 85, 76, 49, 81, 128, 57,
+                99, 101, 45, 26, 43, 16, 43, 48, 84, 41,
+                1, 31, 45, 49, 43, 117, 65, 50, 50, 43,
+                44, 128, 89, 100, 101, 32, 43, 52, 128, 66,
+                86, 24, 44, 80, 40, 41, 76, 51, 76, 79,
+                55, 91, 48, 82, 52, 42, 6
+            ]
 
             requests.append(
                 SampleRequest(
                     prompt=prompt,
                     prompt_len=input_len,
-                    expected_output_len=args.output_len,
+                    #expected_output_len=args.output_len,
+                    expected_output_len=output_lengths[idx],
                     schema=schema,
                     structure_type=args.structure_type,
                     completion=completion,

--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -250,22 +250,12 @@ def sample_requests(
             )
             input_len = len(tokenizer(prompt).input_ids)
             completion = dataset["completion"][idx]
-            output_lengths = [
-                35, 119, 109, 32, 46, 84, 86, 78, 50, 21,
-                56, 57, 43, 49, 85, 76, 49, 81, 128, 57,
-                99, 101, 45, 26, 43, 16, 43, 48, 84, 41,
-                1, 31, 45, 49, 43, 117, 65, 50, 50, 43,
-                44, 128, 89, 100, 101, 32, 43, 52, 128, 66,
-                86, 24, 44, 80, 40, 41, 76, 51, 76, 79,
-                55, 91, 48, 82, 52, 42, 6
-            ]
-
+ 
             requests.append(
                 SampleRequest(
                     prompt=prompt,
                     prompt_len=input_len,
-                    #expected_output_len=args.output_len,
-                    expected_output_len=output_lengths[idx],
+                    expected_output_len=args.output_len,
                     schema=schema,
                     structure_type=args.structure_type,
                     completion=completion,

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -151,7 +151,7 @@ class SchedulerOutput:
     # for filling the next token bitmask
     structured_output_request_ids: dict[str, int]
     # the bitmask for the whole batch
-    grammar_bitmask: Optional[npt.NDArray[np.int32]]
+    eos_token_ids: dict[str,int]
 
     # KV Cache Connector metadata.
     kv_connector_metadata: Optional[KVConnectorMetadata] = None

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -557,7 +557,7 @@ class Scheduler(SchedulerInterface):
             req_to_new_blocks,
         )
 
-        eos_token_ids = {req.request_id: req.eos_token_id for req in self.running}
+        eos_token_ids = {req.request_id: req.eos_token_id for req in self.running if req.eos_token_id is not None}
         structured_output_request_ids = self.get_structured_output_request_ids(self.running,
                                      )
         scheduler_output = SchedulerOutput(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -447,13 +447,6 @@ class EngineCore:
 
         req = Request.from_engine_core_request(request,
                                                self.request_block_hasher)
-        if req.use_structured_output:
-            # Note on thread safety: no race condition.
-            # `grammar_init` is only invoked in input processing thread. For
-            # `structured_output_manager`, each request is independent and
-            # grammar compilation is async. Scheduler always checks grammar
-            # compilation status before scheduling request.
-            self.structured_output_manager.grammar_init(req)
         return req, request.current_wave
 
 

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass,field
 from typing import NamedTuple, Optional
 
 import torch
@@ -121,6 +121,10 @@ class DraftTokenIds:
     req_ids: list[str]
     # num_reqs x num_draft_tokens
     draft_token_ids: list[list[int]]
+
+    should_advance: dict[str, bool] = field(default_factory=dict)
+
+    spec_token_ids: dict[str, list[int]] = field(default_factory=dict)
 
 
 EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[],

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -271,8 +271,9 @@ class StructuredOutputManager:
         return True
 
     def should_advance(self, request: CachedRequestState) -> bool:
-        if request.sampling_params.guided_decoding is None:
-            return False
+        if request.sampling_params is not None :
+            if request.sampling_params.guided_decoding is None:
+                return False
 
         # To determine whether we can advance the FSM.
         # Supports thinking usage where we skip the reasoning components.

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -271,7 +271,7 @@ class StructuredOutputManager:
         return True
 
     def should_advance(self, request: CachedRequestState) -> bool:
-        if not request.sampling_params.guided_decoding:
+        if request.sampling_params.guided_decoding is None:
             return False
 
         # To determine whether we can advance the FSM.
@@ -288,7 +288,7 @@ class StructuredOutputManager:
                 return True
 
             # Check if reasoning ends in *this* step
-            all_token_ids = ConstantList(request.prompt_token_ids) + ConstantList(request.output_token_ids)
+            all_token_ids = ConstantList(request.prompt_token_ids + request.output_token_ids)
             if self.reasoner.is_reasoning_end(all_token_ids):
                 # Reasoning just ended, so we shouldn't advance til
                 # next pass

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -24,6 +24,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.utils import is_spec_decode_unsupported
 from vllm.v1.utils import copy_slice
 from vllm.v1.worker.block_table import MultiGroupBlockTable
+from vllm.v1.structured_output.request import StructuredOutputRequest
 
 
 @dataclass
@@ -46,6 +47,12 @@ class CachedRequestState:
     mrope_position_delta: Optional[int] = None
 
     lora_request: Optional[LoRARequest] = None
+
+    structured_output_request: Optional[StructuredOutputRequest] = None
+
+    requests_stop_id: int = None
+
+    stop : bool = False
 
     def __post_init__(self):
         self.num_prompt_tokens = len(self.prompt_token_ids)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -50,7 +50,7 @@ class CachedRequestState:
 
     structured_output_request: Optional[StructuredOutputRequest] = None
 
-    requests_stop_id: int = None
+    requests_stop_id: Optional[int] = None
 
     stop : bool = False
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -475,11 +475,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 lora_request=new_req_data.lora_request,
                 structured_output_request = StructuredOutputRequest(
                     sampling_params=sampling_params,),
-                requests_stop_id = scheduler_output.eos_token_ids[req_id] if scheduler_output.eos_token_ids[req_id] else None,
+                requests_stop_id = scheduler_output.eos_token_ids.get(req_id),
                 
             )
             self.requests[req_id] = req_state
-            if self.requests[req_id].sampling_params.guided_decoding:
+            if self.requests[req_id].sampling_params is not None and self.requests[req_id].sampling_params.guided_decoding is not None:
                 self.structured_output_manager.grammar_init(self.requests[req_id])
 
             # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
@@ -1761,16 +1761,18 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             count = 0
             for num_new, output_token_id in enumerate(generated_token_ids, 1):
                 last_token_id = output_token_id
-                if (not self.requests[req_id].sampling_params.ignore_eos  and 
+                if (self.requests[req_id].sampling_params is not None and 
+                    not self.requests[req_id].sampling_params.ignore_eos  and 
                    last_token_id == scheduler_output.eos_token_ids[req_id]):
                    count = num_new
                    self.requests[req_id].stop = True
                    break
             if generated_token_ids and self.structured_output_manager.should_advance(self.requests[req_id]):
-                if count > 0:
-                    self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids[:count])
-                else:
-                    self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids)
+                if self.requests[req_id].structured_output_request is not None and self.requests[req_id].structured_output_request.grammar is not None:
+                    if count > 0:
+                        self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids[:count])
+                    else:
+                        self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids)
 
         return ModelRunnerOutput(
             req_ids=self.input_batch.req_ids,
@@ -1805,10 +1807,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     if last_token_id == self.requests[req_id].requests_stop_id:
                         count = num_new
                         break
-                if count == 0 or count == len(draft_token_ids[i]):
-                    spec_token_ids[req_id] = self.requests[req_id].structured_output_request.grammar.validate_tokens(draft_token_ids[i])
-                else:
-                    spec_token_ids[req_id] = self.requests[req_id].structured_output_request.grammar.validate_tokens(draft_token_ids[i][:count])
+                if self.requests[req_id].structured_output_request is not None and self.requests[req_id].structured_output_request.grammar is not None:
+                    if count == 0 or count == len(draft_token_ids[i]):
+                        spec_token_ids[req_id] = self.requests[req_id].structured_output_request.grammar.validate_tokens(draft_token_ids[i])
+                    else:
+                        spec_token_ids[req_id] = self.requests[req_id].structured_output_request.grammar.validate_tokens(draft_token_ids[i][:count])
             else:
                 should_advance[req_id] = False
         return DraftTokenIds(req_ids, draft_token_ids, should_advance, spec_token_ids)

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -403,8 +403,9 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 lora_request=new_req_data.lora_request,
             )
 
-            if self.requests[req_id].sampling_params.guided_decoding is not None:
-                self.structured_output_manager.grammar_init(self.requests[req_id])
+            if self.requests[req_id].sampling_params is not None:
+                if self.requests[req_id].sampling_params.guided_decoding is not None:
+                    self.structured_output_manager.grammar_init(self.requests[req_id])
 
             req_ids_to_add.append(req_id)
 
@@ -1133,18 +1134,19 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             count = 0
             for num_new, output_token_id in enumerate(generated_token_ids, 1):
                 last_token_id = output_token_id
-                if (self.requests[req_id].sampling_params is not None and 
-                    not self.requests[req_id].sampling_params.ignore_eos  and 
-                   last_token_id == scheduler_output.eos_token_ids[req_id]):
-                   count = num_new
-                   self.requests[req_id].stop = True
-                   break
+                if self.requests[req_id].sampling_params is not None :
+                   if not self.requests[req_id].sampling_params.ignore_eos \
+                      and last_token_id == scheduler_output.eos_token_ids[req_id]:
+                    count = num_new
+                    self.requests[req_id].stop = True
+                    break
             if generated_token_ids and self.structured_output_manager.should_advance(self.requests[req_id]):
-                if self.requests[req_id].structured_output_request is not None and self.requests[req_id].structured_output_request.grammar is not None:
-                    if count > 0:
-                        self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids[:count])
-                    else:
-                        self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids)
+                if self.requests[req_id].structured_output_request is not None :
+                    if self.requests[req_id].structured_output_request.grammar is not None:
+                        if count > 0:
+                            self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids[:count])
+                        else:
+                            self.requests[req_id].structured_output_request.grammar.accept_tokens(req_id, generated_token_ids)
 
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids,


### PR DESCRIPTION
This PR refactors the execution of structured output generation to improve performance by hiding the overhead of grammar bitmask calculations, as proposed in the RFC.

Currently, all backend generation for StructuredRequests is managed by the StructuredOutputManager, which runs in the same process as the scheduler. The call to the grammar_bitmask function within this manager introduces blocking overhead that can impact overall latency.

This change moves the execution of the grammar_bitmask function into the gpu_runner, scheduling it to run after the main model execution. This allows the CPU-bound work of calculating the grammar bitmask to be overlapped (hidden) by the GPU computation, leading to better performance for requests using constrained grammar sampling.

To achieve this, the implementation includes:

Performing grammar state initialization when the CacheRequest is generated in the worker_runner.

Moving all related logic for speculative decoding and "reason thinking" for structured output requests into the gpu_runner.

### Test Plan

Command: python /path/vllm/benchmarks/benchmark_serving_structured_output.py --model /home/models/Qwen3-8B --dataset xgrammar_bench --num-prompts 100

Request throughput increased by ~31.5% (from 18.47 to 24.29 req/s).

Output token throughput improved by ~33.1% (from 1132.30 to 1507.32 tok/s).

Furthermore, the latency for generating subsequent tokens was reduced, with the mean Time per Output Token (TPOT) decreasing by ~21% and the mean Inter-token Latency (ITL) decreasing by ~19%.

baseline
```code
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: None
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:05<00:00, 18.47it/s]
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  5.41      
Total input tokens:                      27748     
Total generated tokens:                  6129      
Request throughput (req/s):              18.47     
Output token throughput (tok/s):         1132.30   
Total Token throughput (tok/s):          6258.62   
---------------Time to First Token----------------
Mean TTFT (ms):                          968.93    
Median TTFT (ms):                        1122.44   
P99 TTFT (ms):                           1401.09   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.58     
Median TPOT (ms):                        39.42     
P99 TPOT (ms):                           77.37     
---------------Inter-token Latency----------------
Mean ITL (ms):                           40.60     
Median ITL (ms):                         37.08     
P99 ITL (ms):                            156.27    
==================================================
correct_rate(%) 91.0 

```
opt
```code
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: None
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:04<00:00, 24.29it/s]
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  4.12      
Total input tokens:                      27748     
Total generated tokens:                  6205      
Request throughput (req/s):              24.29     
Output token throughput (tok/s):         1507.32   
Total Token throughput (tok/s):          8247.88   
---------------Time to First Token----------------
Mean TTFT (ms):                          226.07    
Median TTFT (ms):                        227.83    
P99 TTFT (ms):                           264.96    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          34.47     
Median TPOT (ms):                        34.67     
P99 TPOT (ms):                           39.40     
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.78     
Median ITL (ms):                         33.62     
P99 ITL (ms):                            44.94     
==================================================
correct_rate(%) 91.0 
```
