### PR TITLE
[gpt-oss][Bugfix]Fix streamableparser for missing handling of certain token_ids

### DIFF
--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -238,11 +238,11 @@ class StreamingHarmonyContext(HarmonyContext):
             # (finished=True), then the next token processed will mark the
             # beginning of a new message
             self.first_tok_of_message = output.finished
-            tok = output.outputs[0].token_ids[0]
-            self.parser.process(tok)
+            for tok in output.outputs[0].token_ids:
+                self.parser.process(tok)
             self._update_num_output_tokens(output.outputs[0].token_ids)
             # Check if the current token is part of reasoning content
-            self._update_num_reasoning_tokens([tok])
+            self._update_num_reasoning_tokens(output.outputs[0].token_ids)
             self.last_tok = tok
         else:
             # Handle the case of tool output in direct message format


### PR DESCRIPTION
## Purpose
Fix streamableparser for missing handling of certain token_ids
## Test Plan

## Test Result
As shown below, I printed the content of output.outputs[0].token_ids, and it can be seen that token_ids do not always contain just one element.


```diff
diff --git a/vllm/entrypoints/context.py b/vllm/entrypoints/context.py
index e4f2e800f..b79110b49 100644
--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -238,6 +238,7 @@ class StreamingHarmonyContext(HarmonyContext):
             # (finished=True), then the next token processed will mark the
             # beginning of a new message
             self.first_tok_of_message = output.finished
+            print(f"------{output.outputs[0].token_ids=}------")
             for tok in output.outputs[0].token_ids:
                 self.parser.process(tok)
             self._update_num_output_tokens(output.outputs[0].token_ids)

```

```
(APIServer pid=42081) ------output.outputs[0].token_ids=[10128]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[4050]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[46830]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[1853]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[392]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[72782]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[11]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[10128]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[4050]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[200007]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[200006, 173781, 200005]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[12606]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[815]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[316]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[28]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[44580]------
(APIServer pid=42081) ------output.outputs[0].token_ids=[775]------

```

