### PR TITLE
feat: spec decode with draft models

### DIFF
--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -54,7 +54,7 @@ def parse_args():
         "--method",
         type=str,
         default="eagle",
-        choices=["ngram", "eagle", "eagle3", "mtp"],
+        choices=["ngram", "eagle", "eagle3", "mtp", "draft_model"],
     )
     parser.add_argument("--num-spec-tokens", type=int, default=2)
     parser.add_argument("--prompt-lookup-max", type=int, default=5)
@@ -70,7 +70,11 @@ def parse_args():
     parser.add_argument("--output-len", type=int, default=256)
     parser.add_argument("--model-dir", type=str, default=None)
     parser.add_argument("--eagle-dir", type=str, default=None)
+    parser.add_argument("--draft-model", type=str, default=None)
     parser.add_argument("--custom-mm-prompts", action="store_true")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    parser.add_argument("--disable-padded-drafter-batch", action="store_true")
+    parser.add_argument("--max-num-seqs", type=int, default=None)
     return parser.parse_args()
 
 
@@ -111,6 +115,7 @@ def main(args):
             "method": args.method,
             "model": eagle_dir,
             "num_speculative_tokens": args.num_spec_tokens,
+            "disable_padded_drafter_batch": args.disable_padded_drafter_batch,
         }
     elif args.method == "ngram":
         speculative_config = {
@@ -118,6 +123,15 @@ def main(args):
             "num_speculative_tokens": args.num_spec_tokens,
             "prompt_lookup_max": args.prompt_lookup_max,
             "prompt_lookup_min": args.prompt_lookup_min,
+        }
+    elif args.method == "draft_model":
+        assert args.draft_model is not None and args.draft_model != ""
+        speculative_config = {
+            "method": args.method,
+            "model": args.draft_model,
+            "num_speculative_tokens": args.num_spec_tokens,
+            "enforce_eager": args.enforce_eager,
+            "max_model_len": args.max_model_len,
         }
     elif args.method == "mtp":
         speculative_config = {
@@ -133,12 +147,13 @@ def main(args):
         tensor_parallel_size=args.tp,
         enable_chunked_prefill=args.enable_chunked_prefill,
         enforce_eager=args.enforce_eager,
-        gpu_memory_utilization=0.9,
+        gpu_memory_utilization=args.gpu_memory_utilization,
         speculative_config=speculative_config,
         disable_log_stats=False,
         max_model_len=args.max_model_len,
         limit_mm_per_prompt={"image": 5},
         disable_chunked_mm_input=True,
+        max_num_seqs=args.max_num_seqs,
     )
 
     sampling_params = SamplingParams(temperature=args.temp, max_tokens=args.output_len)

--- a/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
@@ -4,13 +4,13 @@ import asyncio
 import copy
 import logging
 import os
-import re
 import socket
 import threading
 import uuid
 
 import aiohttp
 import msgpack
+import regex as re
 import zmq
 from quart import Quart, make_response, request
 

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import random
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -10,23 +11,29 @@ from tests.utils import get_attn_backend_list_based_on_platform, large_gpu_mark
 from vllm import LLM, SamplingParams
 from vllm.assets.base import VLLM_S3_BUCKET_URL
 from vllm.assets.image import VLM_IMAGES_DIR
+from vllm.config.vllm import VllmConfig
 from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.engine.arg_utils import EngineArgs
 from vllm.platforms import current_platform
+from vllm.v1.metrics.reader import Metric
+from vllm.v1.spec_decode.draft_model import (
+    create_vllm_config_for_draft_model,
+    merge_toks_kernel,
+)
 
 MTP_SIMILARITY_RATE = 0.8
 
 
 def _skip_if_insufficient_gpus_for_tp(tp_size: int):
     """Skip test if available GPUs < tp_size on ROCm."""
-    if current_platform.is_rocm():
-        available_gpus = torch.cuda.device_count()
-        if available_gpus < tp_size:
-            pytest.skip(
-                f"Test requires {tp_size} GPUs, but only {available_gpus} available"
-            )
+    available_gpus = torch.cuda.device_count()
+    if available_gpus < tp_size:
+        pytest.skip(
+            f"Test requires {tp_size} GPUs, but only {available_gpus} available"
+        )
 
 
-def get_test_prompts(mm_enabled: bool):
+def get_test_prompts(mm_enabled: bool, quiet: bool = False):
     prompt_types = ["repeat", "sentence"]
     if mm_enabled:
         prompt_types.append("mm")
@@ -35,7 +42,9 @@ def get_test_prompts(mm_enabled: bool):
 
     random.seed(0)
     random_prompt_type_choices = random.choices(prompt_types, k=num_prompts)
-    print(f"Prompt types: {random_prompt_type_choices}")
+
+    if not quiet:
+        print(f"Prompt types: {random_prompt_type_choices}")
 
     # Generate a mixed batch of prompts, some of which can be easily
     # predicted by n-gram matching and some which likely cannot.
@@ -77,7 +86,15 @@ def get_test_prompts(mm_enabled: bool):
 
 @pytest.fixture
 def sampling_config():
+    return greedy_sampling()
+
+
+def greedy_sampling() -> SamplingParams:
     return SamplingParams(temperature=0, max_tokens=10, ignore_eos=False)
+
+
+def stochastic_sampling() -> SamplingParams:
+    return SamplingParams(temperature=1.0, max_tokens=10, ignore_eos=False)
 
 
 @pytest.fixture
@@ -583,3 +600,242 @@ def test_mtp_correctness(
         del spec_llm
         torch.cuda.empty_cache()
         cleanup_dist_env_and_memory()
+
+
+@dataclass
+class ArgsTest:
+    target_model: str
+    draft_model: str
+    sampling_config: SamplingParams
+    num_speculative_tokens: int
+    expected_acceptance_rate: float
+    expected_acceptance_len: float
+    # Defaults
+    target_tensor_parallel_size: int = 1
+    draft_tensor_parallel_size: int = 1
+    max_model_len: int = 1024
+    gpu_memory_utilization: float = 0.5
+
+
+cases = [
+    # Same model for draft and target, greedy sampling.
+    ArgsTest(
+        target_model="Qwen/Qwen3-0.6B",
+        draft_model="Qwen/Qwen3-0.6B",
+        sampling_config=greedy_sampling(),
+        num_speculative_tokens=3,  # K
+        expected_acceptance_len=3 + 1,  # K + 1
+        expected_acceptance_rate=1.0,
+    ),
+    # Smaller draft model, stochastic sampling.
+    ArgsTest(
+        target_model="Qwen/Qwen3-1.7B",
+        draft_model="Qwen/Qwen3-0.6B",
+        sampling_config=stochastic_sampling(),
+        num_speculative_tokens=3,
+        expected_acceptance_len=2.8 + 1,
+        expected_acceptance_rate=0.9,
+    ),
+]
+
+
+@pytest.mark.parametrize("args", cases)
+@pytest.mark.parametrize("enforce_eager", [True, False])
+def test_draft_model_correctness(args: ArgsTest, enforce_eager: bool):
+    assert_draft_model_correctness(args, enforce_eager)
+
+
+@pytest.mark.parametrize(
+    "models",
+    [
+        # target_model,         draft_model
+        ("Qwen/Qwen3-1.7B-FP8", "Qwen/Qwen3-0.6B"),  # target quantized
+        ("Qwen/Qwen3-1.7B", "Qwen/Qwen3-0.6B-FP8"),  # draft quantized
+    ],
+    ids=["target_quantized", "draft_quantized"],
+)
+@pytest.mark.parametrize("enforce_eager", [True, False])
+def test_draft_model_quantization(models: tuple[str, str], enforce_eager: bool):
+    tgt_model, draft_model = models
+    sd_case = ArgsTest(
+        target_model=tgt_model,
+        draft_model=draft_model,
+        **some_high_acceptance_metrics(),
+    )
+    assert_draft_model_correctness(sd_case, enforce_eager)
+
+
+def test_draft_model_tensor_parallelism():
+    """Ensure spec decode works when running with TP > 1."""
+    _skip_if_insufficient_gpus_for_tp(2)
+    sd_case = ArgsTest(
+        target_model="Qwen/Qwen3-1.7B",
+        target_tensor_parallel_size=2,
+        draft_model="Qwen/Qwen3-0.6B",
+        draft_tensor_parallel_size=2,
+        **some_high_acceptance_metrics(),
+    )
+    assert_draft_model_correctness(sd_case, enforce_eager=False)
+
+
+def test_draft_model_engine_args_tensor_parallelism():
+    """Ensure the vllm_config for the draft model is created correctly,
+    and independently of the target model (quantization, TP, etc.)"""
+    _skip_if_insufficient_gpus_for_tp(2)
+
+    engine_args = EngineArgs(
+        model="Qwen/Qwen3-1.7B-FP8",  # <<< tgt quantized
+        tensor_parallel_size=2,
+        speculative_config={
+            "model": "Qwen/Qwen3-0.6B",  # <<< draft not quantized
+            "method": "draft_model",
+            "num_speculative_tokens": 3,
+            "draft_tensor_parallel_size": 1,  # <<< valid arg name
+        },
+    )
+    tgt_vllm_config: VllmConfig = engine_args.create_engine_config()
+    assert tgt_vllm_config.parallel_config.tensor_parallel_size == 2
+    assert tgt_vllm_config.quant_config.get_name() == "fp8"
+
+    draft_vllm_config: VllmConfig = create_vllm_config_for_draft_model(tgt_vllm_config)
+    assert draft_vllm_config.parallel_config.tensor_parallel_size == 1
+    assert draft_vllm_config.quant_config is None
+
+
+def test_draft_model_engine_args_rejects_invalid_tp_argname():
+    """The user should pass "draft_tensor_parallel_size" rather than
+    "tensor_parallel_size". We enforce this with validation."""
+
+    engine_args = EngineArgs(
+        model="Qwen/Qwen3-1.7B",
+        tensor_parallel_size=1,
+        speculative_config={
+            "model": "Qwen/Qwen3-0.6B",
+            "method": "draft_model",
+            "num_speculative_tokens": 3,
+            "tensor_parallel_size": 1,  # <<< invalid arg name
+        },
+    )
+    with pytest.raises(ValueError):
+        engine_args.create_engine_config()
+
+
+def assert_draft_model_correctness(args: ArgsTest, enforce_eager: bool):
+    """Compare the outputs using and not using speculative decoding.
+    In the greedy decoding case, the outputs must match EXACTLY."""
+    test_prompts = get_test_prompts(mm_enabled=False, quiet=True)
+
+    spec_llm = LLM(
+        model=args.target_model,
+        speculative_config={
+            "model": args.draft_model,
+            "method": "draft_model",
+            "num_speculative_tokens": args.num_speculative_tokens,
+            "max_model_len": args.max_model_len,
+            "enforce_eager": enforce_eager,
+            "draft_tensor_parallel_size": args.draft_tensor_parallel_size,
+            "max_num_seqs": 100,  # limit cudagraph capture runtime
+        },
+        max_model_len=args.max_model_len,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        tensor_parallel_size=args.target_tensor_parallel_size,
+        enforce_eager=enforce_eager,
+        disable_log_stats=False,  # enables get_metrics()
+    )
+    # we don't check the outputs, only check the metrics
+    spec_llm.chat(test_prompts, args.sampling_config)
+    metrics = spec_llm.get_metrics()
+
+    acceptance_rate: float = compute_acceptance_rate(metrics)
+    acceptance_len: float = compute_acceptance_len(metrics)
+    del spec_llm  # CLEANUP
+    torch.cuda.empty_cache()
+    cleanup_dist_env_and_memory()
+
+    assert acceptance_rate >= args.expected_acceptance_rate
+    assert acceptance_len >= args.expected_acceptance_len
+
+    print(
+        f"spec-decode: target={args.target_model}, draft={args.draft_model}, "
+        f"temperature={args.sampling_config.temperature:.2f}, "
+        f"acceptance_rate={acceptance_rate:.2f}, "
+        f"acceptance_len={acceptance_len:.2f}, "
+    )
+
+
+def some_high_acceptance_metrics() -> dict:
+    return {
+        "sampling_config": greedy_sampling(),
+        "num_speculative_tokens": 3,
+        "expected_acceptance_len": 2.95 + 1,
+        "expected_acceptance_rate": 0.95,
+    }
+
+
+def test_merge_toks_kernel():
+    device = "cuda"
+    merged_len = 5 + 2  # len(target_toks) = 5, batch_size = 2
+    merged = torch.full((merged_len,), -100, device=device)  # -100 is arbitrary
+    is_rejected_tok = torch.full((merged_len,), True, device=device)
+    grid = (2,)
+    merge_toks_kernel[grid](
+        target_toks_ptr=torch.tensor([0, 1, 2, 0, 1], device=device),
+        next_toks_ptr=torch.tensor([3, 2], device=device),
+        query_start_locs_ptr=torch.tensor([0, 3], device=device),
+        query_end_locs_ptr=torch.tensor([2, 4], device=device),
+        out_ptr_merged_toks=merged,
+        out_ptr_is_rejected_tok=is_rejected_tok,
+        target_toks_size=5,
+        rejected_tok_fill=-1,
+    )
+    expected_merged = torch.tensor([0, 1, 2, 3, 0, 1, 2], device=device)
+    assert torch.allclose(merged, expected_merged)
+
+    expected_rejected_toks = torch.tensor([False] * merged_len, device=device)
+    assert torch.allclose(is_rejected_tok, expected_rejected_toks)
+
+
+def test_merge_toks_kernel_with_rejected_tokens():
+    device = "cuda"
+    merged_size = 9 + 2  # len(target_toks) = 9, batch_size = 2
+    merged = torch.full((merged_size,), -100, device=device)
+    is_rejected_tok = torch.full((merged_size,), True, device=device)
+    grid = (2,)
+    merge_toks_kernel[grid](
+        #                                       rejected tokens
+        #                                       ↓   ↓   ↓         ↓
+        target_toks_ptr=torch.tensor([0, 1, 2, 13, 14, 15, 0, 1, 22], device=device),
+        next_toks_ptr=torch.tensor([3, 2], device=device),
+        query_start_locs_ptr=torch.tensor([0, 6], device=device),
+        query_end_locs_ptr=torch.tensor([2, 7], device=device),
+        out_ptr_merged_toks=merged,
+        out_ptr_is_rejected_tok=is_rejected_tok,
+        target_toks_size=9,
+        rejected_tok_fill=-1,
+    )
+    expected_merged = torch.tensor([0, 1, 2, 3, -1, -1, -1, 0, 1, 2, -1], device=device)
+    assert torch.allclose(merged, expected_merged)
+
+    expected_rejected_toks = torch.tensor(
+        [False, False, False, False, True, True, True, False, False, False, True],
+        device=device,
+    )
+    assert torch.allclose(is_rejected_tok, expected_rejected_toks)
+
+
+def compute_acceptance_rate(metrics: list[Metric]) -> float:
+    name2metric = {metric.name: metric for metric in metrics}
+    n_draft_toks = name2metric["vllm:spec_decode_num_draft_tokens"].value  # type: ignore
+    if n_draft_toks == 0:
+        return float("nan")
+    n_accepted_toks = name2metric["vllm:spec_decode_num_accepted_tokens"].value  # type: ignore
+    return n_accepted_toks / n_draft_toks
+
+
+def compute_acceptance_len(metrics: list[Metric]) -> float:
+    name2metric = {metric.name: metric for metric in metrics}
+    n_drafts = name2metric["vllm:spec_decode_num_drafts"].value  # type: ignore
+    n_accepted_toks = name2metric["vllm:spec_decode_num_accepted_tokens"].value  # type: ignore
+    if n_drafts == 0:
+        return 1
+    return 1 + (n_accepted_toks / n_drafts)

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -767,8 +767,8 @@ def some_high_acceptance_metrics() -> dict:
     return {
         "sampling_config": greedy_sampling(),
         "num_speculative_tokens": 3,
-        "expected_acceptance_len": 2.95 + 1,
-        "expected_acceptance_rate": 0.95,
+        "expected_acceptance_len": 2.90 + 1,
+        "expected_acceptance_rate": 0.90,
     }
 
 

--- a/tests/v1/worker/test_utils.py
+++ b/tests/v1/worker/test_utils.py
@@ -57,23 +57,23 @@ def test_bind_kv_cache_non_attention(default_vllm_config):
     assert runner_kv_caches[1] is kv_cache["model.layers.28.attn"]
 
 
-def test_bind_kv_cache_draft_model():
-    from vllm.attention import Attention
+def test_bind_kv_cache_draft_model(default_vllm_config):
+    from vllm.attention.layer import Attention
 
+    layer_names = [
+        "model.layers.0.attn",
+        "model.layers.1.attn",
+        "draft_model.layers.0.attn",
+        "draft_model.layers.1.attn",
+    ]
     ctx = {
-        "model.layers.0.attn": Attention(32, 128, 0.1),
-        "model.layers.1.attn": Attention(32, 128, 0.1),
-        "draft_model.layers.0.attn": Attention(32, 128, 0.1),
-        "draft_model.layers.1.attn": Attention(32, 128, 0.1),
+        layer_name: Attention(32, 128, 0.1, prefix=layer_name)
+        for layer_name in layer_names
     }
-    kv_cache = {
-        "model.layers.0.attn": torch.zeros((1,)),
-        "model.layers.1.attn": torch.zeros((1,)),
-        "draft_model.layers.0.attn": torch.zeros((1,)),
-        "draft_model.layers.1.attn": torch.zeros((1,)),
-    }
+    kv_cache = {layer_name: torch.zeros((1,)) for layer_name in layer_names}
     runner_kv_caches: list[torch.Tensor] = []
     bind_kv_cache(kv_cache, ctx, runner_kv_caches)
+
     assert ctx["model.layers.0.attn"].kv_cache[0] is kv_cache["model.layers.0.attn"]
     assert ctx["model.layers.1.attn"].kv_cache[0] is kv_cache["model.layers.1.attn"]
     assert (

--- a/tests/v1/worker/test_utils.py
+++ b/tests/v1/worker/test_utils.py
@@ -55,3 +55,38 @@ def test_bind_kv_cache_non_attention(default_vllm_config):
 
     assert runner_kv_caches[0] is kv_cache["model.layers.20.attn"]
     assert runner_kv_caches[1] is kv_cache["model.layers.28.attn"]
+
+
+def test_bind_kv_cache_draft_model():
+    from vllm.attention import Attention
+
+    ctx = {
+        "model.layers.0.attn": Attention(32, 128, 0.1),
+        "model.layers.1.attn": Attention(32, 128, 0.1),
+        "draft_model.layers.0.attn": Attention(32, 128, 0.1),
+        "draft_model.layers.1.attn": Attention(32, 128, 0.1),
+    }
+    kv_cache = {
+        "model.layers.0.attn": torch.zeros((1,)),
+        "model.layers.1.attn": torch.zeros((1,)),
+        "draft_model.layers.0.attn": torch.zeros((1,)),
+        "draft_model.layers.1.attn": torch.zeros((1,)),
+    }
+    runner_kv_caches: list[torch.Tensor] = []
+    bind_kv_cache(kv_cache, ctx, runner_kv_caches)
+    assert ctx["model.layers.0.attn"].kv_cache[0] is kv_cache["model.layers.0.attn"]
+    assert ctx["model.layers.1.attn"].kv_cache[0] is kv_cache["model.layers.1.attn"]
+    assert (
+        ctx["draft_model.layers.0.attn"].kv_cache[0]
+        is kv_cache["draft_model.layers.0.attn"]
+    )
+    assert (
+        ctx["draft_model.layers.1.attn"].kv_cache[0]
+        is kv_cache["draft_model.layers.1.attn"]
+    )
+
+    # caches are ordered by layer_index, interleaving target and draft model
+    assert runner_kv_caches[0] is kv_cache["model.layers.0.attn"]
+    assert runner_kv_caches[1] is kv_cache["draft_model.layers.0.attn"]
+    assert runner_kv_caches[2] is kv_cache["model.layers.1.attn"]
+    assert runner_kv_caches[3] is kv_cache["draft_model.layers.1.attn"]

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2593,17 +2593,10 @@ class InstructCoderDataset(HuggingFaceDataset):
         request_id_prefix: str = "",
         no_oversample: bool = False,
         **kwargs,
-    ) -> list:
+    ) -> list[SampleRequest]:
         output_len = output_len if output_len is not None else self.DEFAULT_OUTPUT_LEN
         sampled_requests = []
-        for i, item in enumerate(self.data):
-            if len(sampled_requests) >= num_requests:
-                break
-            prompt = (
-                f"{item['input']}\n\n{item['instruction']} Just output "
-                "the code, do not include any explanation."
-            )
-
+        for i, prompt in enumerate(self.sample_prompts(n=num_requests)):
             # apply template
             if not skip_chat_template:
                 prompt = tokenizer.apply_chat_template(
@@ -2625,6 +2618,14 @@ class InstructCoderDataset(HuggingFaceDataset):
             sampled_requests, num_requests, request_id_prefix, no_oversample
         )
         return sampled_requests
+
+    def sample_prompts(self, n: int) -> Iterator[str]:
+        for item in self.data.take(n):
+            prompt = (
+                f"{item['input']}\n\n{item['instruction']} Just output "
+                "the code, do not include any explanation."
+            )
+            yield prompt
 
 
 # -----------------------------------------------------------------------------

--- a/vllm/benchmarks/lib/ready_checker.py
+++ b/vllm/benchmarks/lib/ready_checker.py
@@ -8,7 +8,11 @@ import time
 import aiohttp
 from tqdm.asyncio import tqdm
 
+from vllm.logger import init_logger
+
 from .endpoint_request_func import RequestFunc, RequestFuncInput, RequestFuncOutput
+
+logger = init_logger(__name__)
 
 
 async def wait_for_endpoint(
@@ -61,6 +65,8 @@ async def wait_for_endpoint(
                 if output.success:
                     pbar.close()
                     return output
+                else:
+                    logger.warning("Endpoint is not ready. Error='%s'", output.error)
             except aiohttp.ClientConnectorError:
                 pass
 

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -3,6 +3,7 @@
 
 import os
 from collections.abc import Callable
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -709,3 +710,6 @@ class ParallelConfig:
             )
 
         return self
+
+    def replace(self, **kwargs) -> Self:
+        return replace(self, **kwargs)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -400,8 +400,10 @@ class SpeculativeConfig:
                             "one layer. Might need some code changes "
                             "to support multiple layers."
                         )
-                else:
-                    self.method = "draft_model"
+                elif self.method != "draft_model":
+                    raise NotImplementedError(
+                        f"Unsupported speculative method: '{self.method}'"
+                    )
 
                 # Replace hf_config for EAGLE draft_model
                 if self.method in ("eagle", "eagle3"):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -400,7 +400,9 @@ class SpeculativeConfig:
                             "one layer. Might need some code changes "
                             "to support multiple layers."
                         )
-                elif self.method != "draft_model":
+                elif self.method == "draft_model":
+                    pass
+                else:
                     raise NotImplementedError(
                         f"Unsupported speculative method: '{self.method}'"
                     )

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -77,6 +77,9 @@ class SpeculativeConfig:
     draft_tensor_parallel_size: int | None = Field(default=None, ge=1)
     """The degree of the tensor parallelism for the draft model. Can only be 1
     or the same as the target model's tensor parallel size."""
+    tensor_parallel_size: int | None = None
+    """Users should pass "draft_tensor_parallel_size". This parameter's purpose is to
+    warn users when they mistakenly provide the wrong argument."""
 
     # Draft model configuration
     quantization: me_quant.QuantizationMethods | None = None
@@ -399,12 +402,6 @@ class SpeculativeConfig:
                         )
                 else:
                     self.method = "draft_model"
-                    raise NotImplementedError(
-                        "Speculative decoding with draft model is not "
-                        "supported yet. Please consider using other "
-                        "speculative decoding methods such as ngram, medusa, "
-                        "eagle, or mtp."
-                    )
 
                 # Replace hf_config for EAGLE draft_model
                 if self.method in ("eagle", "eagle3"):
@@ -631,6 +628,12 @@ class SpeculativeConfig:
 
     @model_validator(mode="after")
     def _verify_args(self) -> Self:
+        if self.tensor_parallel_size is not None:
+            raise ValueError(
+                "'tensor_parallel_size' is not a valid argument in the "
+                "speculative_config. Please pass 'draft_tensor_parallel_size' instead."
+            )
+
         if self.num_speculative_tokens is None:
             raise ValueError(
                 "num_speculative_tokens must be provided with "
@@ -669,11 +672,31 @@ class SpeculativeConfig:
                 f"Eagle3 is only supported for {eagle3_target_supported} models. "  # noqa: E501
                 f"Got {self.target_model_config.hf_text_config.model_type=}"
             )
-
+        self.verify_equal_vocab_size_if_draft_model()
         return self
+
+    def verify_equal_vocab_size_if_draft_model(self):
+        if (
+            self.method == "draft_model"
+            and self.target_model_config is not None
+            and self.draft_model_config is not None
+        ):
+            target_vocab_size = self.target_model_config.get_vocab_size()
+            draft_vocab_size = self.draft_model_config.get_vocab_size()
+            if target_vocab_size != draft_vocab_size:
+                raise ValueError(
+                    f"Target and draft model should have the same vocabulary size. "
+                    f"Target model vocab_size={target_vocab_size}. "
+                    f"Draft model vocab_size={draft_vocab_size}. "
+                    f"Using models with different tokenizers can cause out-of-bounds "
+                    f"errors during speculative decoding."
+                )
 
     def use_eagle(self) -> bool:
         return self.method in ("eagle", "eagle3", "mtp")
+
+    def uses_draft_model(self) -> bool:
+        return self.method == "draft_model"
 
     def __repr__(self) -> str:
         method = self.method

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1214,19 +1214,17 @@ class VllmConfig:
         compilation_config = self.compilation_config
         computed_compile_ranges_split_points = []
 
-        # The upper bound of the compile ranges is the max_num_batched_tokens
-        # extended by the number of potential speculative tokens.
+        # The upper bound of the compile ranges is the max_num_batched_tokens.
+        # For speculative decoding with draft model, the compile range must be extended
+        # by 1 for each sequence.
         compile_range_end = self.scheduler_config.max_num_batched_tokens
         if compile_range_end is not None:
             do_extend: bool = (
                 self.speculative_config is not None
-                and self.speculative_config.num_speculative_tokens is not None
+                and self.speculative_config.uses_draft_model()
             )
             if do_extend:
-                compile_range_end += (
-                    self.scheduler_config.max_num_seqs
-                    * self.speculative_config.num_speculative_tokens
-                )
+                compile_range_end += self.scheduler_config.max_num_seqs
 
             computed_compile_ranges_split_points.append(compile_range_end)
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1316,6 +1316,14 @@ class VllmConfig:
         path = self.compilation_config.debug_dump_path / append_path
         return path
 
+    def replace(self, **kwargs):
+        """
+        Replace attributes of the config, and 'recompute' the config.
+        dataclass.replace() calls __init__() and __post_init__(), source:
+        https://docs.python.org/3/library/dataclasses.html#dataclasses.replace
+        """
+        return replace(self, **kwargs)
+
     def __str__(self):
         return (
             f"model={self.model_config.model!r}, "

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1215,8 +1215,19 @@ class VllmConfig:
         computed_compile_ranges_split_points = []
 
         # The upper bound of the compile ranges is the max_num_batched_tokens
+        # extended by the number of potential speculative tokens.
         max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
         if max_num_batched_tokens is not None:
+            do_extend: bool = (
+                self.speculative_config is not None
+                and self.speculative_config.num_speculative_tokens is not None
+            )
+            if do_extend:
+                max_num_batched_tokens += (
+                    self.scheduler_config.max_num_seqs
+                    * self.speculative_config.num_speculative_tokens
+                )
+
             computed_compile_ranges_split_points.append(max_num_batched_tokens)
 
         # Add the compile ranges for flashinfer

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1776,21 +1776,6 @@ class EngineArgs:
         ):
             _raise_unsupported_error(feature_name="Concurrent Partial Prefill")
 
-        # N-gram, Medusa, and Eagle are supported for speculative decoding.
-        if self.speculative_config is not None:
-            # speculative_config could still be a dict at this point
-            if isinstance(self.speculative_config, dict):
-                method = self.speculative_config.get("method", None)
-            else:
-                method = self.speculative_config.method
-
-            if method == "draft_model":
-                raise NotImplementedError(
-                    "Draft model speculative decoding is not supported yet. "
-                    "Please consider using other speculative decoding methods "
-                    "such as ngram, medusa, eagle, or mtp."
-                )
-
         if self.pipeline_parallel_size > 1:
             supports_pp = getattr(
                 self.distributed_executor_backend, "supports_pp", False

--- a/vllm/model_executor/model_loader/__init__.py
+++ b/vllm/model_executor/model_loader/__init__.py
@@ -124,12 +124,17 @@ def get_model_loader(load_config: LoadConfig) -> BaseModelLoader:
 
 
 def get_model(
-    *, vllm_config: VllmConfig, model_config: ModelConfig | None = None
+    *,
+    vllm_config: VllmConfig,
+    model_config: ModelConfig | None = None,
+    prefix: str = "",
 ) -> nn.Module:
     loader = get_model_loader(vllm_config.load_config)
     if model_config is None:
         model_config = vllm_config.model_config
-    return loader.load_model(vllm_config=vllm_config, model_config=model_config)
+    return loader.load_model(
+        vllm_config=vllm_config, model_config=model_config, prefix=prefix
+    )
 
 
 __all__ = [

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -36,7 +36,7 @@ class BaseModelLoader(ABC):
         raise NotImplementedError
 
     def load_model(
-        self, vllm_config: VllmConfig, model_config: ModelConfig
+        self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""
     ) -> nn.Module:
         """Load a model with the given configurations."""
         device_config = vllm_config.device_config
@@ -48,7 +48,7 @@ class BaseModelLoader(ABC):
         with set_default_torch_dtype(model_config.dtype):
             with target_device:
                 model = initialize_model(
-                    vllm_config=vllm_config, model_config=model_config
+                    vllm_config=vllm_config, model_config=model_config, prefix=prefix
                 )
 
             log_model_inspection(model)

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -335,7 +335,7 @@ class GGUFModelLoader(BaseModelLoader):
         )
 
     def load_model(
-        self, vllm_config: VllmConfig, model_config: ModelConfig
+        self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""
     ) -> nn.Module:
         device_config = vllm_config.device_config
         local_model_path = self._prepare_weights(model_config)
@@ -364,7 +364,7 @@ class GGUFModelLoader(BaseModelLoader):
         target_device = torch.device(device_config.device)
         with set_default_torch_dtype(model_config.dtype):
             with target_device:
-                model = initialize_model(vllm_config=vllm_config)
+                model = initialize_model(vllm_config=vllm_config, prefix=prefix)
             self.load_weights(model, model_config)
 
             process_weights_after_loading(model, model_config, target_device)

--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -68,6 +68,7 @@ class TensorizerLoader(BaseModelLoader):
     def _load_model_serialized_cpu(
         self,
         vllm_config: VllmConfig,
+        prefix: str = "",
     ) -> nn.Module:
         """Load a serialized model with tensorizer to the CPU.
 
@@ -80,7 +81,7 @@ class TensorizerLoader(BaseModelLoader):
         model_config = vllm_config.model_config
         with set_default_torch_dtype(model_config.dtype):
             with torch.device(device_config.device):
-                model = initialize_model(vllm_config=vllm_config)
+                model = initialize_model(vllm_config=vllm_config, prefix=prefix)
 
             model.load_weights(self._get_weights_iterator())
         return model.eval()
@@ -112,7 +113,7 @@ class TensorizerLoader(BaseModelLoader):
             model.load_weights(self._get_weights_iterator())
 
     def load_model(
-        self, vllm_config: VllmConfig, model_config: ModelConfig
+        self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""
     ) -> nn.Module:
         parallel_config = vllm_config.parallel_config
         self._verify_config(model_config, parallel_config)
@@ -134,7 +135,7 @@ class TensorizerLoader(BaseModelLoader):
                     )
             self.load_weights(model, model_config)
             return model
-        return self._load_model_serialized_cpu(vllm_config=vllm_config)
+        return self._load_model_serialized_cpu(vllm_config=vllm_config, prefix=prefix)
 
     @staticmethod
     def save_model(

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar, get_args
 
@@ -328,6 +328,16 @@ class CommonAttentionMetadata:
     _num_computed_tokens_cpu: torch.Tensor | None = None
 
     _num_computed_tokens_cache: torch.Tensor | None = None
+
+    def batch_size(self) -> int:
+        return self.seq_lens.shape[0]
+
+    def naive_query_lens(self) -> torch.Tensor:
+        """Naive because it assumes that query ends where the next query starts."""
+        return self.query_start_loc[1:] - self.query_start_loc[:-1]
+
+    def replace(self, **kwargs) -> "CommonAttentionMetadata":
+        return replace(self, **kwargs)
 
     @property
     @deprecated(

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -818,3 +818,35 @@ def get_dcp_local_seq_lens(
     )
     dcp_local_seq_lens = base + remainder
     return dcp_local_seq_lens.squeeze(1)
+
+
+def extend_all_queries_by_1(
+    common_attn_metadata: CommonAttentionMetadata,
+    arange: torch.Tensor,
+    new_slot_mapping: torch.Tensor,
+) -> CommonAttentionMetadata:
+    """
+    Creates a new CommonAttentionMetadata with all query lengths increased by 1.
+    Also all seq lens are increased by 1.
+    This is useful e.g. in speculative decoding with draft models, where we
+    extend each sequence by 1 token.
+    The slot mapping is computed externally, as it requires more information.
+    """
+    cad = common_attn_metadata
+    # query start loc must be increased by [+0, +1, +2, ..., +batch_size]
+    new_query_start_loc = cad.query_start_loc + arange[: len(cad.query_start_loc)]
+    new_query_start_loc_cpu = cad.query_start_loc_cpu + torch.arange(
+        len(cad.query_start_loc_cpu)
+    )
+    new_cad = cad.replace(
+        query_start_loc=new_query_start_loc,
+        query_start_loc_cpu=new_query_start_loc_cpu,
+        seq_lens=cad.seq_lens + 1,
+        # each request is extended by 1 token -> batch_size tokens are added
+        num_actual_tokens=cad.num_actual_tokens + cad.batch_size(),
+        # All query lens increase by 1, so max query len increases by 1
+        max_query_len=cad.max_query_len + 1,
+        max_seq_len=cad.max_seq_len + 1,
+        slot_mapping=new_slot_mapping,
+    )
+    return new_cad

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -836,7 +836,7 @@ def extend_all_queries_by_1(
     # query start loc must be increased by [+0, +1, +2, ..., +batch_size]
     new_query_start_loc = cad.query_start_loc + arange[: len(cad.query_start_loc)]
     new_query_start_loc_cpu = cad.query_start_loc_cpu + torch.arange(
-        len(cad.query_start_loc_cpu)
+        len(cad.query_start_loc_cpu), dtype=torch.int32
     )
     new_cad = cad.replace(
         query_start_loc=new_query_start_loc,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -208,6 +208,8 @@ class Scheduler(SchedulerInterface):
             if speculative_config.use_eagle():
                 self.use_eagle = True
                 self.num_lookahead_tokens = self.num_spec_tokens
+            if speculative_config.uses_draft_model():
+                self.num_lookahead_tokens = self.num_spec_tokens
 
         # Create the KV cache manager.
         self.kv_cache_manager = KVCacheManager(

--- a/vllm/v1/spec_decode/draft_model.py
+++ b/vllm/v1/spec_decode/draft_model.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any
+
+import torch
+
+from vllm.attention.layer import Attention
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config.speculative import SpeculativeConfig
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader import get_model
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import (
+    CommonAttentionMetadata,
+    extend_all_queries_by_1,
+)
+from vllm.v1.spec_decode.eagle import PADDING_SLOT_ID, SpecDecodeBaseProposer
+
+logger = init_logger(__name__)
+
+
+class DraftModelProposer(SpecDecodeBaseProposer):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            device=device,
+            pass_hidden_states_to_model=False,
+            runner=runner,
+        )
+        self._raise_if_multimodal()
+        self._raise_if_mrope()
+        self._raise_if_padded_drafter_batch_disabled()
+        self._raise_if_vocab_size_mismatch()
+        self._raise_if_draft_tp_mismatch()
+
+    def _block_size(self) -> int:
+        builder = self._get_attention_metadata_builder()
+        return builder.kv_cache_spec.block_size
+
+    def _raise_if_multimodal(self):
+        if self.supports_mm_inputs:
+            raise NotImplementedError(
+                "Speculative Decoding with draft models "
+                "does not support multimodal models yet"
+            )
+
+    def _raise_if_mrope(self):
+        if self.draft_model_config.uses_mrope:
+            raise NotImplementedError(
+                "Speculative Decoding with draft models does not support M-RoPE yet"
+            )
+
+    def _raise_if_padded_drafter_batch_disabled(self):
+        if self.vllm_config.speculative_config.disable_padded_drafter_batch:
+            raise NotImplementedError(
+                "Speculative Decoding with draft models only supports "
+                "padded drafter batch. Please don't pass --disable-padded-drafter-batch"
+                " in the speculative_config."
+            )
+
+    def _raise_if_vocab_size_mismatch(self):
+        self.vllm_config.speculative_config.verify_equal_vocab_size_if_draft_model()
+
+    def _raise_if_draft_tp_mismatch(self):
+        # Note(Tomas Ruiz) If we run the target model with TP > 1 and
+        # the draft model with TP = 1, then the different TP ranks collide.
+        # Specifically when all ranks compile the draft model on rank 0
+        # (because TP=1), then the torch compile cache is overwritten and corrupted.
+        # We need a mechanism like this: https://github.com/vllm-project/vllm/pull/5414
+        # To prevent this error, we assert that both TP sizes must be the same.
+        spec_cfg: SpeculativeConfig = self.vllm_config.speculative_config
+        tgt_tp = spec_cfg.target_parallel_config.tensor_parallel_size
+        draft_tp = spec_cfg.draft_parallel_config.tensor_parallel_size
+        if draft_tp != tgt_tp:
+            raise ValueError(
+                f"Currently, 'draft_tensor_parallel_size' and 'tensor_parallel_size' "
+                f"must be the same. Got {draft_tp} and {tgt_tp}. "
+                "Please pass 'draft_tensor_parallel_size' in the speculative_config."
+            )
+
+    def set_inputs_first_pass(
+        self,
+        target_token_ids: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        last_token_indices: torch.Tensor | None,
+        cad: CommonAttentionMetadata,
+        num_rejected_tokens_gpu: torch.Tensor | None,
+    ) -> tuple[int, torch.Tensor, CommonAttentionMetadata]:
+        batch_size = cad.batch_size()
+        grid = (batch_size,)
+        start_locs = cad.query_start_loc[:-1]
+        end_locs = cad.query_start_loc[1:] - 1
+        if num_rejected_tokens_gpu is not None:
+            end_locs -= num_rejected_tokens_gpu
+
+        num_tokens = target_token_ids.shape[0] + batch_size
+        is_rejected_tok = torch.empty(
+            (num_tokens,), device=self.input_ids.device, dtype=torch.bool
+        )
+        merge_toks_kernel[grid](
+            target_toks_ptr=target_token_ids,
+            next_toks_ptr=next_token_ids,
+            query_start_locs_ptr=start_locs,
+            query_end_locs_ptr=end_locs,
+            out_ptr_merged_toks=self.input_ids,
+            out_ptr_is_rejected_tok=is_rejected_tok,
+            target_toks_size=target_token_ids.shape[0],
+            # passing a negative rejected_tok_fill value will raise an error
+            # when the value is used to index into embeddings.
+            # Therefore, we pass a valid integer, e.g. 0.
+            rejected_tok_fill=0,
+        )
+        merge_toks_kernel[grid](
+            target_toks_ptr=target_positions,
+            next_toks_ptr=target_positions[end_locs] + 1,
+            query_start_locs_ptr=start_locs,
+            query_end_locs_ptr=end_locs,
+            out_ptr_merged_toks=self.positions,
+            out_ptr_is_rejected_tok=is_rejected_tok,
+            target_toks_size=target_positions.shape[0],
+            rejected_tok_fill=0,
+        )
+
+        # recompute slot mapping
+        new_slot_mapping = compute_new_slot_mapping(
+            cad=cad,
+            new_positions=self.positions[:num_tokens],
+            is_rejected_token_mask=is_rejected_tok,
+            block_size=self._block_size(),
+            max_model_len=self.max_model_len,
+        )
+        # update common_attn_metadata
+        new_cad: CommonAttentionMetadata = extend_all_queries_by_1(
+            cad,
+            arange=self.arange,
+            new_slot_mapping=new_slot_mapping,
+        )
+
+        new_last_token_indices = new_cad.query_start_loc[1:] - 1
+        if num_rejected_tokens_gpu is not None:
+            new_last_token_indices -= num_rejected_tokens_gpu
+
+        return num_tokens, new_last_token_indices, new_cad
+
+    def load_model(self, target_model: Any) -> None:
+        """Takes target_model to satisfy the type checker."""
+
+        # This must be computed before loading the draft model
+        # because that mutates the forward_context of the vllm_config
+        target_attn_layer_names = set(
+            get_layers_from_vllm_config(self.vllm_config, Attention).keys()
+        )
+
+        from vllm.compilation.backends import set_model_tag
+
+        draft_vllm_config: VllmConfig = create_vllm_config_for_draft_model(
+            target_model_vllm_config=self.vllm_config
+        )
+        logger.info(
+            "Starting to load draft model %s. TP=%d, rank=%d",
+            draft_vllm_config.model_config.model,
+            draft_vllm_config.parallel_config.tensor_parallel_size,
+            draft_vllm_config.parallel_config.rank,
+        )
+        with set_model_tag("draft_model"):
+            self.model = get_model(vllm_config=draft_vllm_config, prefix="draft_model")
+
+        # This must be computed after loading the draft model
+        # because that mutates the forward_context of the vllm_config
+        draft_attn_layer_names = (
+            get_layers_from_vllm_config(self.vllm_config, Attention).keys()
+            - target_attn_layer_names
+        )
+        self.attn_layer_names = list(draft_attn_layer_names)
+
+
+def create_vllm_config_for_draft_model(
+    target_model_vllm_config: VllmConfig,
+) -> VllmConfig:
+    """The vllm_config is configured for the target model, e.g.
+    its quant_config and parallel_config. But the draft model is potentially
+    quantized differently, and has potentially different tensor_parallel_size.
+    This function creates a new vllm_config configured for the draft model.
+    The vllm_config is useful when loading the draft model with get_model().
+    """
+    old = target_model_vllm_config
+    new_parallel_config = old.speculative_config.draft_parallel_config.replace(
+        rank=old.parallel_config.rank
+    )
+    new: VllmConfig = old.replace(
+        quant_config=None,  # quant_config is recomputed in __init__()
+        model_config=old.speculative_config.draft_model_config,
+        parallel_config=new_parallel_config,
+    )
+    return new
+
+
+def compute_new_slot_mapping(
+    cad: CommonAttentionMetadata,
+    new_positions: torch.Tensor,
+    is_rejected_token_mask: torch.Tensor,
+    block_size: int,
+    max_model_len: int,
+):
+    batch_size, n_blocks_per_req = cad.block_table_tensor.shape
+    req_indices = torch.arange(batch_size, device=cad.query_start_loc.device)
+    req_indices = torch.repeat_interleave(
+        req_indices, cad.naive_query_lens() + 1, output_size=len(new_positions)
+    )
+    # Clamp the positions to prevent an out-of-bounds error when indexing
+    # into block_table_tensor.
+    clamped_positions = torch.clamp(new_positions, max=max_model_len - 1)
+    block_table_indices = (
+        req_indices * n_blocks_per_req + clamped_positions // block_size
+    )
+    block_nums = cad.block_table_tensor.view(-1)[block_table_indices]
+    block_offsets = clamped_positions % block_size
+    new_slot_mapping = block_nums * block_size + block_offsets
+    # Mask out the position ids that exceed the max model length.
+    exceeds_max_model_len = new_positions >= max_model_len
+    new_slot_mapping.masked_fill_(exceeds_max_model_len, PADDING_SLOT_ID)
+    # Mask out rejected tokens to prevent saves to the KV cache.
+    new_slot_mapping.masked_fill_(is_rejected_token_mask, PADDING_SLOT_ID)
+    return new_slot_mapping
+
+
+@triton.jit
+def merge_toks_kernel(
+    target_toks_ptr,
+    next_toks_ptr,
+    query_start_locs_ptr,
+    query_end_locs_ptr,
+    out_ptr_merged_toks,
+    out_ptr_is_rejected_tok,
+    target_toks_size,
+    rejected_tok_fill,
+):
+    """
+    Merges the `target_toks_ptr` and the `next_toks_ptr` into a new tensor
+    called `out_ptr_merged_toks`. Rejected tokens are those after the
+    `query_end_locs_ptr` and before the next `query_start_locs_ptr`. Fills the
+    rejected tokens positions with the value `rejected_tok_fill`. Also fills a mask
+    of the rejected tokens in `out_ptr_is_rejected_tok`.
+    """
+    pid = tl.program_id(0)
+    start_loc = tl.load(query_start_locs_ptr + pid)
+    is_last_program = pid == tl.num_programs(0) - 1
+    if is_last_program:
+        next_start_loc = target_toks_size.to(tl.int32)
+    else:
+        next_start_loc = tl.load(query_start_locs_ptr + pid + 1).to(tl.int32)
+
+    end_loc = tl.load(query_end_locs_ptr + pid)
+    new_val = tl.load(next_toks_ptr + pid)
+    for i in range(start_loc, next_start_loc + 1):
+        if i <= end_loc:  # copy existing tokens
+            old_val = tl.load(target_toks_ptr + i)
+            tl.store(out_ptr_merged_toks + pid + i, old_val)
+            tl.store(out_ptr_is_rejected_tok + pid + i, False)
+        elif i == end_loc + 1:  # copy bonus token
+            tl.store(out_ptr_merged_toks + pid + i, new_val)
+            tl.store(out_ptr_is_rejected_tok + pid + i, False)
+        else:  # fill rejected tokens
+            tl.store(out_ptr_merged_toks + pid + i, rejected_tok_fill)
+            tl.store(out_ptr_is_rejected_tok + pid + i, True)

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -352,8 +352,8 @@ def bind_kv_cache(
                 pass
             else:
                 raise NotImplementedError
-        layer_name = layer_names[0]
-        runner_kv_caches.append(kv_caches[layer_name])
+        for layer_name in layer_names:
+            runner_kv_caches.append(kv_caches[layer_name])
 
     # Bind kv_caches to forward context
     for layer_name, kv_cache in kv_caches.items():


### PR DESCRIPTION
## Purpose
Enabling draft models for speculative decoding (SD).
E.g. `Qwen3-1.7B` as draft model and `Qwen3-32B` as target model.
This type of SD requires no special trained heads (like EAGLE, or Medusa).

Example usage:
```shell
vllm serve \
    --model=Qwen/Qwen3-4B \
    --speculative-config '{"model": "Qwen/Qwen3-0.6B", "method": "draft_model", "num_speculative_tokens": 3, "max-model-len": 2000, "disable_padded_drafter_batch": true}' \
    --max-model-len 2000
```
Get a generation:

```shell
curl -X POST http://localhost:8000/v1/completions \
    -H "Content-Type: application/json" \
    -d '{"prompt": "Capital of France", "max_tokens": 16}'
```
## Status
* The acceptance rates in greedy decoding are great for Qwen3 models (see corresponding section).
* Using SD with Qwen3 has higher throughput (TPOT) than not using SD.

## Acceptance Length
As suggested by @ekagra-ranjan, I benchmarked acceptance length (AL) with the command below:
```shell
VLLM_USE_V1=1 python3 examples/offline_inference/spec_decode.py \
    --model-dir Qwen/Qwen3-32B \
    --draft-model Qwen/Qwen3-1.7B \
    --method draft_model \
    --num_spec_tokens 3 \
    --dataset-name hf \
    --dataset-path philschmid/mt-bench \
    --num_prompts 100 \
    --temp 1.0 \
    --gpu-memory-utilization 0.9
```

The AL values within the Qwen3 family seem good, both with temperatures of 0.0 (greedy) and 1.0.
As a sanity check, I benchmarked LLama-3.2-1B as both target and draft, which had almost perfect AL (3.97/4), suggesting its working as intended.
I have not run the default model `meta-llama/Llama-3.1-8B-Instruct`, because I didn't find a good draft model for it, but feel free to suggest one and I can run the benchmarks.


Temperature t=0:
| Target | Draft | K | Temperature | AL |
|---|---|---|---|---|
| Qwen3-32B | Qwen3-1.7B | 3 | 0.0 | 2.79 |
| Qwen3-32B | Qwen3-1.7B | 4 | 0.0 | 3.12 |
| Llama-3.2-1B | Llama-3.2-1B | 3 | 0.0 | 3.97 |

Temperature t=1.0:
| Target | Draft | K | Temperature | AL |
|---|---|---|---|---|
| Qwen3-32B | Qwen3-1.7B | 3 | 1.0 | 2.61 |
| Qwen3-32B | Qwen3-1.7B | 4 | 1.0 | 2.85 |
| Llama-3.2-1B | Llama-3.2-1B | 3 | 1.0 | 2.82 |

Using t=1.0, the AL metric degrades. However, spec-decode with probabilities is not yet implemented, needed for lossless rejection sampling. This is being addressed atm: https://github.com/vllm-project/vllm/pull/20459. After that PR is merged, the AL for non-greedy spec-decode should improve.

All scripts and logs used for the benchmarks can be found in [this Google Drive](https://drive.google.com/drive/folders/1mFgeIVUI16VMlXJe8jm2TImY0lYKSQLC?usp=drive_link).

## Online Throughput Metrics

I measured online throughput metrics using the commands below. Hardware was an RTX PRO 6000 96GB. After making sure the draft model also uses CUDA graph, SD has higher throughput than not using SD. See tables below.

```shell
VLLM_USE_V1=1 vllm serve Qwen/Qwen3-32B \
  --max-model-len 20000 \
  --disable-uvicorn-access-log

# or 

VLLM_USE_V1=1 vllm serve Qwen/Qwen3-32B \
  --speculative_config '{"method": "draft_model", "model": "Qwen/Qwen3-1.7B", "num_speculative_tokens": 3, "max_model_len": 20000, "disable_padded_drafter_batch": true}' \
  --max-model-len 20000 \
  --disable-uvicorn-access-log

nohup vllm bench serve \
  --model Qwen/Qwen3-32B \
  --dataset-name hf \
  --dataset-path philschmid/mt-bench \
  --num-prompts 80 \
  --max-concurrency (100|1) \
  --temperature 0.0 \
  --top-p 1.0 2>&1 > results/qwen3-32b-t0-run1.out &
```

* The tables show shorter runtime and higher throughput for SD (both in batch size 1 and 100). 
* Using SD the TPOT is 50% shorter (better) in batch size 1, and 26% to 33% shorter in batch size 100. The reason is the higher throughput of the draft model.
* Using SD the TTFT and ITL are higher (worse), because tokens are produced in batches by the spec-decoding. Nevertheless, total runtimes are shorter overall when using SD.

The metrics (lower is better) are:
* TTFT: Time-to-first-token
* TPOT: Time-per-output-token
* ITL: Inter-token-latency

<details>
<summary>Batch Size = 1</summary>
For Temperature = 0.0:

| Target | Draft | Runtime |  TTFT | TPOT | ITL |
|---|---|---|---|---|---|
| Qwen3-32B | - | 943s | 69.14ms | 46.06ms | 45.88ms |
| Qwen3-32B | Qwen3-1.7B | 466s | 76.77ms | 22.62ms | 62.44ms |

Using SD runtimes and TPOT are shorter by ~50%.
</details>

<details>
<summary>Batch Size = 100</summary>
For Temperature = 0.0:

| Target | Draft | Runtime |  TTFT | TPOT | ITL |
|---|---|---|---|---|---|
| Qwen3-32B | - | 16.88s | 262.59ms | 65.09ms | 64.84ms |
| Qwen3-32B | Qwen3-1.7B | 13.04s | 284.45ms | 43.70ms | 121.48ms |

For Temperature = 1.0:

| Target | Draft | Runtime |  TTFT | TPOT | ITL |
|---|---|---|---|---|---|
| Qwen3-32B | - | 16.83s | 230.04ms | 64.95ms | 64.70ms |
| Qwen3-32B | Qwen3-1.7B | 14.84s | 272.51ms | 48.00ms | 122.27ms |
</details>

This scenario with batch size 100 is a more realistic inference case.
Using SD runtimes and TPOT are shorter.
### Profiling

This section was removed, since using CUDA graphs on the draft model significantly improved its speed.

<details>
<summary>Profiling script</summary>
I used the command below to profile the generation process and identify that the draft model was running too slow before.

```shell
export VLLM_USE_V1=1
export VLLM_TORCH_PROFILER_DIR=./profiles/
export CUDA_LAUNCH_BLOCKING=1

vllm bench throughput \
    --model=Qwen/Qwen3-32B \
    --speculative-config '{"model": "Qwen/Qwen3-1.7B", "method": "draft_model", "num_speculative_tokens": 3, "max_model_len": 2048}' \
    --dataset-name=hf \
    --dataset-path=likaixin/InstructCoder \
    --max-num-seqs=100 \
    --num-prompts=10 \
    --input-len=1000 \
    --output-len=10 \
    --max-model-len=2048 \
    --gpu-memory-utilization=0.95 \
    --profile
```
Note: The command uses the `--profile` flag, which I introduce in this PR: https://github.com/vllm-project/vllm/pull/24575
</details>

## Test Plan
The added unit test check the correctness metrics. To run it:
```shell
cd tests/v1/e2e/
pytest test_spec_decode.py -k test_draft_model_correctness
```

<details>

<summary>EAGLE testing</summary>

I tested that the EAGLE implementation stays unaffected the command below

```shell
VLLM_USE_V1=1 python3 examples/offline_inference/spec_decode.py \
    --model-dir meta-llama/Llama-3.1-8B-Instruct \
    --eagle-dir yuhuili/EAGLE3-LLaMA3.1-Instruct-8B \
    --method eagle3 \
    --num_spec_tokens 7 \
    --dataset-name hf \
    --dataset-path philschmid/mt-bench \
    --num_prompts 80 \
    --temp 0.0 \
    --gpu-memory-utilization 0.9
```
The results are in line with previous measurements like https://github.com/vllm-project/vllm/pull/17504#issuecomment-2845707371

```shell
total_num_output_tokens: 16990
num_drafts: 4816
num_draft_tokens: 33712
num_accepted_tokens: 12208
mean acceptance length: 3.53
--------------------------------------------------
acceptance at token 0: 0.74
acceptance at token 1: 0.54
acceptance at token 2: 0.41
acceptance at token 3: 0.31
acceptance at token 4: 0.23
acceptance at token 5: 0.17
acceptance at token 6: 0.13
```

</details>


## Follow-up Optimizations
* Include the tokens in `next_token_ids` together with `target_token_ids` in the first forward pass of the draft model. This reduces the number of forward passes needed in each drafting phase by one, speeding up drafting.

# Qwen3 Metrics 
Note: The code for the visualizations below can be found in this gist: https://gist.github.com/tomasruizt/81aa1dee4fed88bfad2fe746c3f66739

I compare Qwen3-32B against Qwen3-32B with Qwen3-1.7B as drafter model, on a single H100 GPU (TP=1).
The benchmarks show (left to right)
* An increase in Total Token Throughput with 1 to 100 concurrent requests (so larger batch sizes).
* A decrease Benchmark Duration
* Increases in Total Token Throughput of almost 2x

<img width="31%" alt="image" src="https://github.com/user-attachments/assets/6316dc9e-488d-4170-877b-4207baee0db5" />

<img width="31%" alt="image" src="https://github.com/user-attachments/assets/b6a93069-f573-4764-9f96-084e84881a18" />

<img width="31%" alt="image" src="https://github.com/user-attachments/assets/572b97a8-d2b0-463c-9583-c4a555595c6d" />

Broken down we find:
* A steep improvement (reduction) of Time Per Output Token (TPOT)
* Higher Inter-Token-Latency (ITL), because tokens are generated and verified in batches
* Equivalent Time-To-First-Token (TTFT) except in high batch sizes.

<img width="93%" alt="image" src="https://github.com/user-attachments/assets/28a60a9c-90ad-4e29-855b-71b317546070" />

# Llama3 Multi-GPU Metrics
I benchmarked `meta-llama/Meta-Llama-3-70B`, with `meta-llama/Llama-3.2-1B` as a draft model on 4 x H100 GPUs (TP=4). The goal was to measure the effect of tensor parallelism on throughput, since the small draft model is also running on the same level of tensor parallelism as the target model.  I found an acceleration in this setup only up to bsz=32, and a slowdown for bsz=64. This setup shows that using TP > 1 degrades the acceleration of draft_model. Presumably, because of the inter-GPU communication overhead for the draft model. In a follow-up PR this should be optimized.

[serving-script.sh](https://github.com/user-attachments/files/23006446/serving-script.sh)
[benchmark-script.sh](https://github.com/user-attachments/files/23006447/benchmark-script.sh)

<img width="31%" alt="image" src="https://github.com/user-attachments/assets/f125d957-fe17-4995-aba6-b8a3990ce4c6" />
<img width="31%" alt="image" src="https://github.com/user-attachments/assets/6488414f-a119-4e2b-90a1-0dbb5ad661fa" />
<img width="31%" alt="image" src="https://github.com/user-attachments/assets/4f2c4dcd-4751-478e-9b3e-bfcce21aa6f4" />

The TPOT metric improves in general, showing similar results to Qwen3.

<img width="93%" alt="image" src="https://github.com/user-attachments/assets/19789f11-4f73-41ba-a33b-c0ecf6196c99" />

# EAGLE3 Metrics (Reference)
Below are benchmark values using method="eagle3", with target model `meta-llama/Llama-3.3-70B-Instruct` and draft model `yuhuili/EAGLE3-LLaMA3.3-Instruct-70B` on 4 x H100 GPUs (TP=4). Eagle achieves over 2x acceleration in batch_size=1. In contrast to draft_model, the eagle drafter is running with `tensor_parallelism = 1`.

[serve-script.sh](https://github.com/user-attachments/files/23017732/serve-script.sh)
[bench-script.sh](https://github.com/user-attachments/files/23017733/bench-script.sh)

<img width="31%" alt="image" src="https://github.com/user-attachments/assets/eabe9097-511e-42ab-9cfd-d14755fba842" />
<img width="31%" alt="image" src="https://github.com/user-attachments/assets/b4d996e6-b193-463f-a9c0-eaf95b2321d0" />
<img width="31%" alt="image" src="https://github.com/user-attachments/assets/e4aec257-5d6f-4abb-91a8-29b7e7e0484d" />

<img width="93%" alt="image" src="https://github.com/user-attachments/assets/9f48750f-3753-4de3-95f5-c384f05708dc" />

---

> [!NOTE]
> Introduces draft-model-based speculative decoding and wires it across configs, runtime, and tests.
> 
> - Adds `DraftModelProposer` with Triton `merge_toks_kernel`, `extend_all_queries_by_1`, and padded-batch path; integrates with `gpu_model_runner`, scheduler lookahead, and K/V cache binding (interleaving target/draft layers)
> - New config capabilities/validation: `SpeculativeConfig.uses_draft_model()`, vocab-size check, explicit `draft_tensor_parallel_size` (rejects `tensor_parallel_size`), per-draft `ParallelConfig` creation, `disable_logprobs`, and `num_lookahead_slots`; `ParallelConfig.replace()` and `VllmConfig.replace()` helpers
> - Model loading updated to accept `prefix` and separate draft `VllmConfig`; enforce TP constraints and isolate quantization between target/draft
> - Metrics helpers to compute acceptance rate/length; ready checker logs when endpoint isn’t ready
> - Example script adds `--method draft_model`, `--draft-model`, GPU mem utilization, and max seqs; passes new speculative fields
> - Extensive tests: correctness/quantization/TP for draft-model SD, engine-args validation, KV cache binding with draft layers, and kernel unit tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9641ad89c71712b35ab9fdc05777ead16818b56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Enables speculative decoding using a separate draft model and integrates it across configuration, runtime, and tests.
> 
> - New `DraftModelProposer` with Triton `merge_toks_kernel` and query-extension path; integrates with `gpu_model_runner`, scheduler lookahead, padded-batch path, and interleaved K/V cache binding
> - Config updates: `SpeculativeConfig.uses_draft_model()`, vocab-size validation, explicit `draft_tensor_parallel_size` (rejects `tensor_parallel_size`), draft `ParallelConfig` creation, and TP constraints; add `ParallelConfig.replace()` and `VllmConfig.replace()`
> - Model loading supports draft-specific `VllmConfig` and `prefix` to namespace modules; isolates draft quantization/TP from target
> - Attention utils: `extend_all_queries_by_1`, `CommonAttentionMetadata` helpers; scheduler now sets lookahead for draft-model SD
> - Metrics helpers to compute acceptance rate/length; ready-checker logs when endpoint isn’t ready
> - Example `spec_decode.py` adds `--method draft_model`, `--draft-model`, GPU mem/max seqs flags; forwards new speculative fields
> - Tests: correctness/quantization/TP for draft-model SD, engine-args validation, KV cache binding for draft layers, and kernel unit tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d708778513f8b3cceb3f93ce6e08c77661c14bce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces draft-model-based speculative decoding and wires it across config, runtime, and tests.
> 
> - New `DraftModelProposer` with Triton `merge_toks_kernel` and query-extension (`extend_all_queries_by_1`); integrates with scheduler lookahead and `gpu_model_runner` (padded-batch path, GPU tokens) and validates KV cache grouping
> - Config: add `uses_draft_model()`, vocab-size check, explicit `draft_tensor_parallel_size` (rejects `tensor_parallel_size`), per-draft `ParallelConfig`/`VllmConfig` via `create_vllm_config_for_draft_model`, and `replace()` helpers for `ParallelConfig`/`VllmConfig`
> - Model loading supports draft-specific configs and `prefix` to namespace modules across loaders (base, GGUF, tensorizer)
> - Worker/utils: bind K/V caches interleaving target and draft layers; scheduler sets `num_lookahead_tokens` for draft-model SD
> - Bench/UX: ready-checker warns when endpoint not ready; example script adds `--method draft_model`, `--draft-model`, memory/max-seqs flags
> - Metrics: helpers to compute acceptance rate/length
> - Tests: correctness/quantization/TP for draft-model SD, engine-arg validation, KV-cache binding, and kernel unit tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ee3a595a1dade9e062f90b55e14010983553aeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
