### PR TITLE
[Model] Remove unnecessary CUDA sync of GLM-4.1V image and video preprocess

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -1480,6 +1480,7 @@ class Glm4vForConditionalGeneration(nn.Module, SupportsMultiModal,
             self, video_input: Glm4vVideoInputs) -> tuple[torch.Tensor, ...]:
         grid_thw = video_input["video_grid_thw"]
         assert grid_thw.ndim == 2
+        grid_thw_list = grid_thw.tolist()
 
         if video_input["type"] == "video_embeds":
             video_embeds = video_input["video_embeds"].type(self.visual.dtype)
@@ -1496,8 +1497,9 @@ class Glm4vForConditionalGeneration(nn.Module, SupportsMultiModal,
                                            grid_thw=grid_thw.tolist())
         # Split concatenated embeddings for each video item.
         merge_size = self.visual.spatial_merge_size
-        sizes = grid_thw.prod(-1) // merge_size // merge_size
-        return video_embeds.split(sizes.tolist())
+        sizes = (torch.tensor(grid_thw_list, dtype=torch.long).prod(-1) //
+                 (merge_size * merge_size)).tolist()
+        return video_embeds.split(sizes)
 
     def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
         mm_input_by_modality = {}


### PR DESCRIPTION
This PR removes unnecessary CUDA sync in `_process_image_input` and `_process_video_input` of `vllm/model_executor/models/glm4_1v.py` by utilising `grid_thw_list`.

Related PR #22792
Related issue #23884 