### PR TITLE
[Benchmark] Allow long context length serving benchmark

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -52,13 +52,18 @@ class RequestFuncOutput:
 
 async def async_request_tgi(
     request_func_input: RequestFuncInput,
+    context_len: Optional[int] = None,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
 
+    cur_context_len = request_func_input.prompt_len + request_func_input.output_len if context_len is None else context_len
+    # NOTE: we estimate bufsize increasement by taking one token as approximately 4 bytes.
+    # 2**16 : the default read_bufsize of aiohttp.ClientSession
+    read_bufsize = cur_context_len * 4 + 2**16
     async with aiohttp.ClientSession(
-        trust_env=True, timeout=AIOHTTP_TIMEOUT
+        trust_env=True, timeout=AIOHTTP_TIMEOUT, read_bufsize=read_bufsize
     ) as session:
         params = {
             "max_new_tokens": request_func_input.output_len,
@@ -133,13 +138,18 @@ async def async_request_tgi(
 
 async def async_request_trt_llm(
     request_func_input: RequestFuncInput,
+    context_len: Optional[int] = None,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
 
+    cur_context_len = request_func_input.prompt_len + request_func_input.output_len if context_len is None else context_len
+    # NOTE: we estimate bufsize increasement by taking one token as approximately 4 bytes.
+    # 2**16 : the default read_bufsize of aiohttp.ClientSession
+    read_bufsize = cur_context_len * 4 + 2**16
     async with aiohttp.ClientSession(
-        trust_env=True, timeout=AIOHTTP_TIMEOUT
+        trust_env=True, timeout=AIOHTTP_TIMEOUT, read_bufsize=read_bufsize
     ) as session:
         payload = {
             "accumulate_tokens": True,
@@ -204,6 +214,7 @@ async def async_request_trt_llm(
 
 async def async_request_deepspeed_mii(
     request_func_input: RequestFuncInput,
+    context_len: Optional[int] = None,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
@@ -211,8 +222,12 @@ async def async_request_deepspeed_mii(
         "OpenAI Completions API URL must end with 'completions' or 'profile'."
     )
 
+    cur_context_len = request_func_input.prompt_len + request_func_input.output_len if context_len is None else context_len
+    # NOTE: we estimate bufsize increasement by taking one token as approximately 4 bytes.
+    # 2**16 : the default read_bufsize of aiohttp.ClientSession
+    read_bufsize = cur_context_len * 4 + 2**16
     async with aiohttp.ClientSession(
-        trust_env=True, timeout=AIOHTTP_TIMEOUT
+        trust_env=True, timeout=AIOHTTP_TIMEOUT, read_bufsize=read_bufsize
     ) as session:
         payload = {
             "model": request_func_input.model,
@@ -267,6 +282,7 @@ async def async_request_deepspeed_mii(
 
 async def async_request_openai_completions(
     request_func_input: RequestFuncInput,
+    context_len: Optional[int] = None,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
@@ -274,8 +290,12 @@ async def async_request_openai_completions(
         "OpenAI Completions API URL must end with 'completions' or 'profile'."
     )
 
+    cur_context_len = request_func_input.prompt_len + request_func_input.output_len if context_len is None else context_len
+    # NOTE: we estimate bufsize increasement by taking one token as approximately 4 bytes.
+    # 2**16 : the default read_bufsize of aiohttp.ClientSession
+    read_bufsize = cur_context_len * 4 + 2**16
     async with aiohttp.ClientSession(
-        trust_env=True, timeout=AIOHTTP_TIMEOUT
+        trust_env=True, timeout=AIOHTTP_TIMEOUT, read_bufsize=read_bufsize
     ) as session:
         payload = {
             "model": request_func_input.model_name
@@ -367,6 +387,7 @@ async def async_request_openai_completions(
 
 async def async_request_openai_chat_completions(
     request_func_input: RequestFuncInput,
+    context_len: Optional[int] = None,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
@@ -374,8 +395,12 @@ async def async_request_openai_chat_completions(
         "OpenAI Chat Completions API URL must end with 'chat/completions'."
     )
 
+    cur_context_len = request_func_input.prompt_len + request_func_input.output_len if context_len is None else context_len
+    # NOTE: we estimate bufsize increasement by taking one token as approximately 4 bytes.
+    # 2**16 : the default read_bufsize of aiohttp.ClientSession
+    read_bufsize = cur_context_len * 4 + 2**16
     async with aiohttp.ClientSession(
-        trust_env=True, timeout=AIOHTTP_TIMEOUT
+        trust_env=True, timeout=AIOHTTP_TIMEOUT, read_bufsize=read_bufsize
     ) as session:
         content = [{"type": "text", "text": request_func_input.prompt}]
         if request_func_input.multi_modal_content:
@@ -476,6 +501,7 @@ async def async_request_openai_chat_completions(
 
 async def async_request_openai_audio(
     request_func_input: RequestFuncInput,
+    context_len: Optional[int] = None,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     # Lazy import without PlaceholderModule to avoid vllm dep.
@@ -487,8 +513,12 @@ async def async_request_openai_audio(
     )
     "or `translations`."
 
+    cur_context_len = request_func_input.prompt_len + request_func_input.output_len if context_len is None else context_len
+    # NOTE: we estimate bufsize increasement by taking one token as approximately 4 bytes.
+    # 2**16 : the default read_bufsize of aiohttp.ClientSession
+    read_bufsize = cur_context_len * 4 + 2**16
     async with aiohttp.ClientSession(
-        trust_env=True, timeout=AIOHTTP_TIMEOUT
+        trust_env=True, timeout=AIOHTTP_TIMEOUT, read_bufsize=read_bufsize
     ) as session:
         content = [{"type": "text", "text": request_func_input.prompt}]
         payload = {


### PR DESCRIPTION
## Purpose
Allow long context length serving benchmark. Currently the long context length serving benchmark will fail due to the limited read buffer size of aiohttp. This pr specifies the read buffersize of `ClientSession` according to the `prompt_len` and `output_len` of `RequestInput` as a default value, and allow users to specify it.

## Test Plan
Run `benchmark_serving.py`/ `vllm benchmark serve` successfuly with long context, e.g., 32k prompt + 1k ouput. 
w/ and w/o specifying `context-len`

## Test Result


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

