### PR TITLE
[xformers] Force to use xformers kernels

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -18,7 +18,7 @@ from vllm.v1.kv_cache_interface import FullAttentionSpec
 BACKENDS_TO_TEST = [
     _Backend.FLASH_ATTN_VLLM_V1, _Backend.FLASHINFER_VLLM_V1,
     _Backend.FLEX_ATTENTION, _Backend.TRITON_ATTN_VLLM_V1, _Backend.TREE_ATTN,
-    "FLEX_ATTENTION_SLOW"
+    _Backend.XFORMERS_VLLM_V1, "FLEX_ATTENTION_SLOW"
 ]
 
 # Remove flashinfer from the list if it's not available
@@ -299,6 +299,7 @@ def test_backend_correctness(batch_spec_name: str, model: str):
     batch_spec = BATCH_SPECS[batch_spec_name]
     vllm_config = create_vllm_config(model_name=model,
                                      max_model_len=max(batch_spec.seq_lens),
+                                     block_size=128,
                                      num_gpu_blocks=8192)
     device = torch.device("cuda:0")
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Use xformer kernels for prefill and fused prefill/decode cases. Following plans include adding context parallel with xformer backends. 
## Test Plan
pytest tests/v1/attention/test_attention_backends.py -k test_backend_correctness
```
======================================================== warnings summary =========================================================
../uv_env/vllm/lib64/python3.12/site-packages/sklearn/utils/_param_validation.py:11
  /home/qiruiyang/uv_env/vllm/lib64/python3.12/site-packages/sklearn/utils/_param_validation.py:11: UserWarning: A NumPy version >=1.22.4 and <2.3.0 is required for this version of SciPy (detected version 2.3.2)
    from scipy.sparse import csr_matrix, issparse

../uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305
  /home/qiruiyang/uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

tests/v1/attention/test_attention_backends.py::test_backend_correctness[/home/qiruiyang/models/llama3_8b_oss-small_decode]
tests/v1/attention/test_attention_backends.py::test_backend_correctness[/home/qiruiyang/models/llama3_8b_oss-small_decode]
tests/v1/attention/test_attention_backends.py::test_backend_correctness[/home/qiruiyang/models/llama3_8b_oss-small_decode]
tests/v1/attention/test_attention_backends.py::test_backend_correctness[/home/qiruiyang/models/llama3_8b_oss-small_decode]
  /home/qiruiyang/uv_env/vllm/lib64/python3.12/site-packages/triton/runtime/autotuner.py:97: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 10 passed, 6 warnings in 25.26s =================================================
```
## Test Result
Serving Benchmark Result | Before | After
-- | -- | --
Successful requests | 128 | 128
Benchmark duration (s) | 13.22 | 12.87
Total input tokens | 127731 | 127731
Total generated tokens | 38400 | 38400
Request throughput (req/s) | 9.68 | 9.95
Output token throughput (tok/s) | 2905.24 | 2983.88
Total Token throughput (tok/s) | 12569.01 | 12909.27
Time to First Token |   |  
Mean TTFT (ms) | 929.93 | 833.42
Median TTFT (ms) | 776.85 | 692.02
P99 TTFT (ms) | 2080.56 | 1852.9
Time per Output Token (excl. 1st token) |   |  
Mean TPOT (ms) | 18.87 | 18.59
Median TPOT (ms) | 19.24 | 18.93
P99 TPOT (ms) | 21.51 | 20.94
Inter-token Latency |   |  
Mean ITL (ms) | 18.87 | 18.59
Median ITL (ms) | 15.35 | 15.5
P99 ITL (ms) | 256.01 | 226.79

The updated v1 XFormers backend performs slightly better.

