### PR TITLE
[Bugfix] Fix silu_mul+quant fusion test

### DIFF
--- a/tests/compile/test_silu_mul_quant_fusion.py
+++ b/tests/compile/test_silu_mul_quant_fusion.py
@@ -118,7 +118,8 @@ def test_fusion_silu_and_mul_quant(num_tokens, hidden_size, model_class,
     fusion_pass = ActivationQuantFusionPass(config)
 
     backend = TestBackend(NoOpEliminationPass(config), fusion_pass)
-    model = model_class(hidden_size, cuda_force_torch)
+    model = model_class(hidden_size=hidden_size,
+                        cuda_force_torch=cuda_force_torch)
 
     # First dimension dynamic
     x = torch.rand(num_tokens, hidden_size * 2)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#23725 broke the silu_mul + quant unit test, we have to use named arguments here.
```
>       model = model_class(hidden_size, cuda_force_torch)
E       TypeError: TestSiluMulNvfp4QuantModel.__init__() takes 2 positional arguments but 3 were given
tests/compile/test_silu_mul_quant_fusion.py:121: TypeError
```

## Test Plan && Test Result
`tests/compile/test_silu_mul_quant_fusion.py`
```
======= 3 passed, 1 skipped, 5 warnings in 3.94s ====
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

