### PR TITLE
[Multi Modal] Add FA3 in VIT

### DIFF
--- a/tests/entrypoints/openai/test_vision.py
+++ b/tests/entrypoints/openai/test_vision.py
@@ -34,7 +34,7 @@ EXPECTED_MM_BEAM_SEARCH_RES = [
     ],
     [
         "The image shows a Venn diagram with three over",
-        "The image shows a Venn diagram with three intersect",
+        "This image shows a Venn diagram with three over",
     ],
     [
         "This image displays a gradient of colors ranging from",

--- a/tests/entrypoints/openai/test_vision.py
+++ b/tests/entrypoints/openai/test_vision.py
@@ -38,7 +38,7 @@ EXPECTED_MM_BEAM_SEARCH_RES = [
     ],
     [
         "This image displays a gradient of colors ranging from",
-        "The image displays a gradient of colors ranging from",
+        "This image displays a gradient of colors forming a spectrum",
     ],
 ]
 

--- a/tests/kernels/attention/test_mha_attn.py
+++ b/tests/kernels/attention/test_mha_attn.py
@@ -54,20 +54,9 @@ def test_mha_attn_platform(device: str):
             assert attn.attn_backend == _Backend.FLASH_ATTN
 
         # Test CUDA with head_size=72 (not divisible by 32)
-        # - upstream FA available
+        # - should use xformers
         with patch("vllm.model_executor.models.vision.current_platform",
-                   CudaPlatform()), \
-             patch("transformers.utils.is_flash_attn_2_available",
-                   return_value=True):
-            attn = MultiHeadAttention(16, 72, scale=1)
-            assert attn.attn_backend == _Backend.FLASH_ATTN
-
-        # Test CUDA with head_size=72 (not divisible by 32)
-        # - upstream FA not available
-        with patch("vllm.model_executor.models.vision.current_platform",
-                   CudaPlatform()), \
-             patch("transformers.utils.is_flash_attn_2_available",
-                   return_value=False):
+                   CudaPlatform()):
             attn = MultiHeadAttention(16, 72, scale=1)
             assert attn.attn_backend == _Backend.XFORMERS
 

--- a/tests/kernels/attention/test_mha_attn.py
+++ b/tests/kernels/attention/test_mha_attn.py
@@ -36,35 +36,11 @@ def test_mha_attn_platform(device: str):
     torch.set_default_dtype(torch.float16)
 
     if device == "cpu":
-<<<<<<< HEAD
-        with patch("vllm.attention.selector.current_platform",
-                   CpuPlatform()), \
-             patch("vllm.platforms.current_platform", CpuPlatform()):
-=======
         with patch("vllm.model_executor.models.vision.current_platform",
                    CpuPlatform()):
->>>>>>> add dtype checking and fix tests
             attn = MultiHeadAttention(16, 64, scale=1)
             assert attn.attn_backend == _Backend.TORCH_SDPA_VLLM_V1
     elif device == "hip":
-<<<<<<< HEAD
-        with patch("vllm.attention.selector.current_platform",
-                   RocmPlatform()), \
-             patch("vllm.platforms.current_platform", RocmPlatform()), \
-             patch("vllm.attention.layer.current_platform", RocmPlatform()):
-            attn = MultiHeadAttention(16, 64, scale=1)
-            assert attn.attn_backend == _Backend.TORCH_SDPA
-    else:
-        with patch("vllm.attention.selector.current_platform",
-                   CudaPlatform()), \
-             patch("vllm.platforms.current_platform", CudaPlatform()):
-            attn = MultiHeadAttention(16, 64, scale=1)
-            assert attn.attn_backend == _Backend.XFORMERS
-
-        with patch("vllm.attention.selector.current_platform",
-                   CudaPlatform()), \
-             patch("vllm.platforms.current_platform", CudaPlatform()):
-=======
         with patch("vllm.model_executor.models.vision.current_platform",
                    RocmPlatform()):
             attn = MultiHeadAttention(16, 64, scale=1)
@@ -92,7 +68,6 @@ def test_mha_attn_platform(device: str):
                    CudaPlatform()), \
              patch("transformers.utils.is_flash_attn_2_available",
                    return_value=False):
->>>>>>> add dtype checking and fix tests
             attn = MultiHeadAttention(16, 72, scale=1)
             assert attn.attn_backend == _Backend.XFORMERS
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -451,7 +451,6 @@ class MultiHeadAttention(nn.Module):
                 max_seqlen_k=kv_len,
                 softmax_scale=self.scale,
             )
-            out = out.reshape(bsz, q_len, -1)
         elif self.attn_backend == _Backend.XFORMERS:
             from xformers import ops as xops
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -369,8 +369,8 @@ class MultiHeadAttention(nn.Module):
         # to upstream flash attention if available.
         # If vllm native fa is selected, we use it directly.
         use_upstream_fa = False
-        if check_upstream_fa_availability(
-                dtype) and backend != _Backend.FLASH_ATTN:
+        if backend != _Backend.FLASH_ATTN and check_upstream_fa_availability(
+                dtype):
             backend = _Backend.FLASH_ATTN
             use_upstream_fa = True
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -350,10 +350,13 @@ class MultiHeadAttention(nn.Module):
             f"divisible by num_kv_heads ({self.num_kv_heads})"
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
 
-        # dtype = torch.get_default_dtype()
+        # During model initialization, the default dtype is set as the model
+        # weight and activation dtype.
+        dtype = torch.get_default_dtype()
 
         # Determine the attention backend
-        backend, use_upstream_fa = get_vit_attn_backend(head_size=head_size)
+        backend, use_upstream_fa = get_vit_attn_backend(head_size=head_size,
+                                                        dtype=dtype)
 
         if current_platform.is_rocm():
             # currently, only torch_sdpa is supported on rocm

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -34,6 +34,7 @@ import torch.nn.functional as F
 from einops import rearrange, repeat
 from transformers import BatchFeature
 
+from vllm.attention.layer import check_upstream_fa_availability
 from vllm.config import VllmConfig
 from vllm.distributed import parallel_state
 from vllm.distributed import utils as dist_utils
@@ -170,9 +171,16 @@ class Ernie4_5_VisionAttention(nn.Module):
                                       prefix=f"{prefix}.proj")
 
         # Detect attention implementation.
-        self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
+        self.attn_backend = get_vit_attn_backend(
             head_size=self.hidden_size_per_attention_head,
             dtype=torch.get_default_dtype())
+
+        self.use_upstream_fa = False
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+            check_upstream_fa_availability(torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
+            self.use_upstream_fa = True
+
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
                 _Backend.ROCM_AITER_FA
@@ -462,8 +470,11 @@ class Ernie4_5_VisionTransformer(nn.Module):
                 ), "vit's config.hidden must be equal to config.embed_dim"
         self.ln = nn.LayerNorm(hidden_size, eps=1e-6)
 
-        self.attn_backend, _ = get_vit_attn_backend(
+        self.attn_backend = get_vit_attn_backend(
             head_size=head_dim, dtype=torch.get_default_dtype())
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+        check_upstream_fa_availability(torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -171,7 +171,8 @@ class Ernie4_5_VisionAttention(nn.Module):
 
         # Detect attention implementation.
         self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
-            head_size=self.hidden_size_per_attention_head)
+            head_size=self.hidden_size_per_attention_head,
+            dtype=torch.get_default_dtype())
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
                 _Backend.ROCM_AITER_FA
@@ -461,7 +462,8 @@ class Ernie4_5_VisionTransformer(nn.Module):
                 ), "vit's config.hidden must be equal to config.embed_dim"
         self.ln = nn.LayerNorm(hidden_size, eps=1e-6)
 
-        self.attn_backend, _ = get_vit_attn_backend(head_size=head_dim)
+        self.attn_backend, _ = get_vit_attn_backend(
+            head_size=head_dim, dtype=torch.get_default_dtype())
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -170,7 +170,8 @@ class Ernie4_5_VisionAttention(nn.Module):
                                       prefix=f"{prefix}.proj")
 
         # Detect attention implementation.
-        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
+        self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
+            head_size=self.hidden_size_per_attention_head)
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
                 _Backend.ROCM_AITER_FA
@@ -233,7 +234,10 @@ class Ernie4_5_VisionAttention(nn.Module):
             if self.attn_backend == _Backend.ROCM_AITER_FA:
                 from aiter import flash_attn_varlen_func
             else:
-                from flash_attn import flash_attn_varlen_func
+                if self.use_upstream_fa:
+                    from flash_attn import flash_attn_varlen_func
+                else:
+                    from vllm.vllm_flash_attn import flash_attn_varlen_func
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -457,7 +461,7 @@ class Ernie4_5_VisionTransformer(nn.Module):
                 ), "vit's config.hidden must be equal to config.embed_dim"
         self.ln = nn.LayerNorm(hidden_size, eps=1e-6)
 
-        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
+        self.attn_backend, _ = get_vit_attn_backend(head_size=head_dim)
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -261,7 +261,8 @@ class Glm4vVisionAttention(nn.Module):
 
         # Detect attention implementation.
         self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
-            head_size=self.hidden_size_per_attention_head)
+            head_size=self.hidden_size_per_attention_head,
+            dtype=torch.get_default_dtype())
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN,
                 _Backend.TORCH_SDPA,
@@ -719,7 +720,8 @@ class Glm4vVisionTransformer(nn.Module):
         self.post_layernorm = RMSNorm(vision_config.hidden_size,
                                       eps=vision_config.rms_norm_eps)
 
-        self.attn_backend, _ = get_vit_attn_backend(head_size=head_dim)
+        self.attn_backend, _ = get_vit_attn_backend(
+            head_size=head_dim, dtype=torch.get_default_dtype())
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -260,7 +260,8 @@ class Glm4vVisionAttention(nn.Module):
         )
 
         # Detect attention implementation.
-        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
+        self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
+            head_size=self.hidden_size_per_attention_head)
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN,
                 _Backend.TORCH_SDPA,
@@ -310,7 +311,10 @@ class Glm4vVisionAttention(nn.Module):
         if self.attn_backend == _Backend.FLASH_ATTN:
             # from vllm_flash_attn.flash_attn_interface import (
             #   flash_attn_varlen_func)
-            from flash_attn import flash_attn_varlen_func
+            if self.use_upstream_fa:
+                from flash_attn import flash_attn_varlen_func
+            else:
+                from vllm.vllm_flash_attn import flash_attn_varlen_func
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -715,7 +719,7 @@ class Glm4vVisionTransformer(nn.Module):
         self.post_layernorm = RMSNorm(vision_config.hidden_size,
                                       eps=vision_config.rms_norm_eps)
 
-        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
+        self.attn_backend, _ = get_vit_attn_backend(head_size=head_dim)
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -44,6 +44,7 @@ from transformers.models.glm4v.video_processing_glm4v import (
     Glm4vVideoProcessor)
 from transformers.video_utils import VideoMetadata
 
+from vllm.attention.layer import check_upstream_fa_availability
 from vllm.config import VllmConfig
 from vllm.distributed import (get_tensor_model_parallel_world_size,
                               parallel_state)
@@ -260,9 +261,15 @@ class Glm4vVisionAttention(nn.Module):
         )
 
         # Detect attention implementation.
-        self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
+        self.attn_backend = get_vit_attn_backend(
             head_size=self.hidden_size_per_attention_head,
             dtype=torch.get_default_dtype())
+        self.use_upstream_fa = False
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+            check_upstream_fa_availability(torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
+            self.use_upstream_fa = True
+
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN,
                 _Backend.TORCH_SDPA,
@@ -720,8 +727,11 @@ class Glm4vVisionTransformer(nn.Module):
         self.post_layernorm = RMSNorm(vision_config.hidden_size,
                                       eps=vision_config.rms_norm_eps)
 
-        self.attn_backend, _ = get_vit_attn_backend(
+        self.attn_backend = get_vit_attn_backend(
             head_size=head_dim, dtype=torch.get_default_dtype())
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+            check_upstream_fa_availability(torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/keye.py
+++ b/vllm/model_executor/models/keye.py
@@ -375,7 +375,7 @@ class KeyeSiglipAttention(nn.Module):
 
         # Detect attention implementation.
         self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
-            head_size=self.head_dim)
+            head_size=self.head_dim, dtype=torch.get_default_dtype())
         if self.attn_backend not in {_Backend.FLASH_ATTN, _Backend.XFORMERS}:
             raise RuntimeError(
                 f"Keye-VL does not support {self.attn_backend} backend now.")

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -298,7 +298,8 @@ class Qwen2_5_VisionAttention(nn.Module):
                                       disable_tp=use_data_parallel)
 
         # Detect attention implementation.
-        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
+        self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
+            head_size=self.hidden_size_per_attention_head)
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
                 _Backend.ROCM_AITER_FA
@@ -359,7 +360,10 @@ class Qwen2_5_VisionAttention(nn.Module):
             if self.attn_backend == _Backend.ROCM_AITER_FA:
                 from aiter import flash_attn_varlen_func
             else:
-                from flash_attn import flash_attn_varlen_func
+                if self.use_upstream_fa:
+                    from flash_attn import flash_attn_varlen_func
+                else:
+                    from vllm.vllm_flash_attn import flash_attn_varlen_func
 
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
@@ -628,7 +632,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
             prefix=f"{prefix}.merger",
             use_data_parallel=use_data_parallel,
         )
-        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
+        self.attn_backend, _ = get_vit_attn_backend(head_size=head_dim)
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -299,7 +299,8 @@ class Qwen2_5_VisionAttention(nn.Module):
 
         # Detect attention implementation.
         self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
-            head_size=self.hidden_size_per_attention_head)
+            head_size=self.hidden_size_per_attention_head,
+            dtype=torch.get_default_dtype())
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
                 _Backend.ROCM_AITER_FA
@@ -632,7 +633,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
             prefix=f"{prefix}.merger",
             use_data_parallel=use_data_parallel,
         )
-        self.attn_backend, _ = get_vit_attn_backend(head_size=head_dim)
+        self.attn_backend, _ = get_vit_attn_backend(
+            head_size=head_dim, dtype=torch.get_default_dtype())
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -315,7 +315,8 @@ class Qwen2VisionAttention(nn.Module):
 
         # Detect attention implementation.
         self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
-            head_size=self.hidden_size_per_attention_head)
+            head_size=self.hidden_size_per_attention_head,
+            dtype=torch.get_default_dtype())
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
                 _Backend.ROCM_AITER_FA
@@ -632,7 +633,8 @@ class Qwen2VisionTransformer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.merger",
         )
-        self.attn_backend, _ = get_vit_attn_backend(head_size=head_dim)
+        self.attn_backend, _ = get_vit_attn_backend(
+            head_size=head_dim, dtype=torch.get_default_dtype())
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -41,6 +41,7 @@ from transformers.models.qwen2_vl.image_processing_qwen2_vl import smart_resize
 from transformers.models.qwen2_vl.video_processing_qwen2_vl import (
     Qwen2VLVideoProcessor)
 
+from vllm.attention.layer import check_upstream_fa_availability
 from vllm.config import VllmConfig
 from vllm.distributed import parallel_state, tensor_model_parallel_all_gather
 from vllm.distributed import utils as dist_utils
@@ -314,9 +315,16 @@ class Qwen2VisionAttention(nn.Module):
                                       prefix=f"{prefix}.proj")
 
         # Detect attention implementation.
-        self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
+        self.attn_backend = get_vit_attn_backend(
             head_size=self.hidden_size_per_attention_head,
             dtype=torch.get_default_dtype())
+        self.use_upstream_fa = False
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+            check_upstream_fa_availability(
+                torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
+            self.use_upstream_fa = True
+
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
                 _Backend.ROCM_AITER_FA
@@ -633,8 +641,12 @@ class Qwen2VisionTransformer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.merger",
         )
-        self.attn_backend, _ = get_vit_attn_backend(
+        self.attn_backend = get_vit_attn_backend(
             head_size=head_dim, dtype=torch.get_default_dtype())
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+            check_upstream_fa_availability(
+                torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
 
     @property
     def dtype(self) -> torch.dtype:

--- a/vllm/model_executor/models/siglip2navit.py
+++ b/vllm/model_executor/models/siglip2navit.py
@@ -13,6 +13,7 @@ from torch.nn import functional as F
 from transformers import Siglip2VisionConfig
 from transformers.configuration_utils import PretrainedConfig
 
+from vllm.attention.layer import check_upstream_fa_availability
 from vllm.config import QuantizationConfig
 from vllm.distributed import divide, get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.activation import get_act_fn
@@ -236,8 +237,15 @@ class Siglip2Attention(nn.Module):
         self.use_rope = config.use_rope
 
         # Detect attention implementation.
-        self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
+        self.attn_backend = get_vit_attn_backend(
             head_size=self.head_dim, dtype=torch.get_default_dtype())
+        self.use_upstream_fa = False
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+            check_upstream_fa_availability(
+                torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
+            self.use_upstream_fa = True
+
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA,
                 _Backend.ROCM_AITER_FA

--- a/vllm/model_executor/models/siglip2navit.py
+++ b/vllm/model_executor/models/siglip2navit.py
@@ -237,7 +237,7 @@ class Siglip2Attention(nn.Module):
 
         # Detect attention implementation.
         self.attn_backend, self.use_upstream_fa = get_vit_attn_backend(
-            head_size=self.head_dim)
+            head_size=self.head_dim, dtype=torch.get_default_dtype())
         if self.attn_backend not in {
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA,
                 _Backend.ROCM_AITER_FA

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -68,7 +68,8 @@ def get_vision_encoder_info(
     raise NotImplementedError(msg)
 
 
-def get_vit_attn_backend(head_size: int) -> tuple[_Backend, bool]:
+def get_vit_attn_backend(head_size: int,
+                         dtype: torch.dtype) -> tuple[_Backend, bool]:
     """
     Get the available attention backend for Vision Transformer.
     
@@ -79,7 +80,7 @@ def get_vit_attn_backend(head_size: int) -> tuple[_Backend, bool]:
     if selected_backend is not None:
         return selected_backend, False
 
-    return current_platform.get_vit_attn_backend(head_size)
+    return current_platform.get_vit_attn_backend(head_size, dtype)
 
 
 def resolve_visual_encoder_outputs(

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -68,8 +68,7 @@ def get_vision_encoder_info(
     raise NotImplementedError(msg)
 
 
-def get_vit_attn_backend(head_size: int,
-                         dtype: torch.dtype) -> tuple[_Backend, bool]:
+def get_vit_attn_backend(head_size: int, dtype: torch.dtype) -> _Backend:
     """
     Get the available attention backend for Vision Transformer.
     
@@ -78,7 +77,7 @@ def get_vit_attn_backend(head_size: int,
     """
     selected_backend: Optional[_Backend] = get_env_variable_attn_backend()
     if selected_backend is not None:
-        return selected_backend, False
+        return selected_backend
 
     return current_platform.get_vit_attn_backend(head_size, dtype)
 

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -70,9 +70,6 @@ def get_vision_encoder_info(
 def get_vit_attn_backend(head_size: int, dtype: torch.dtype) -> _Backend:
     """
     Get the available attention backend for Vision Transformer.
-    
-    Returns:
-        Tuple of (backend, use_upstream_fa)
     """
     # Lazy import to avoid circular dependency
     from vllm.attention.selector import get_env_variable_attn_backend

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -68,17 +68,18 @@ def get_vision_encoder_info(
     raise NotImplementedError(msg)
 
 
-def get_vit_attn_backend(support_fa: bool = False) -> _Backend:
+def get_vit_attn_backend(head_size: int) -> tuple[_Backend, bool]:
     """
     Get the available attention backend for Vision Transformer.
+    
+    Returns:
+        Tuple of (backend, use_upstream_fa)
     """
-    # TODO(Isotr0py): Remove `support_fa` after support FA for all ViTs attn.
-
     selected_backend: Optional[_Backend] = get_env_variable_attn_backend()
     if selected_backend is not None:
-        return selected_backend
+        return selected_backend, False
 
-    return current_platform.get_vit_attn_backend(support_fa)
+    return current_platform.get_vit_attn_backend(head_size)
 
 
 def resolve_visual_encoder_outputs(

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -7,7 +7,6 @@ from typing import Final, Generic, Optional, Protocol, TypeVar, Union
 import torch
 from transformers import PretrainedConfig
 
-from vllm.attention.selector import get_env_variable_attn_backend
 from vllm.logger import init_logger
 from vllm.platforms import _Backend, current_platform
 
@@ -75,6 +74,9 @@ def get_vit_attn_backend(head_size: int, dtype: torch.dtype) -> _Backend:
     Returns:
         Tuple of (backend, use_upstream_fa)
     """
+    # Lazy import to avoid circular dependency
+    from vllm.attention.selector import get_env_variable_attn_backend
+
     selected_backend: Optional[_Backend] = get_env_variable_attn_backend()
     if selected_backend is not None:
         return selected_backend

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -209,7 +209,11 @@ class CudaPlatformBase(Platform):
         return torch.cuda.max_memory_allocated(device)
 
     @classmethod
-    def get_vit_attn_backend(cls, head_size: int) -> tuple[_Backend, bool]:
+    def get_vit_attn_backend(cls, head_size: int,
+                             dtype: torch.dtype) -> tuple[_Backend, bool]:
+        if dtype not in (torch.float16, torch.bfloat16):
+            return _Backend.XFORMERS, False
+
         if cls.has_device_capability(80):
             if head_size % 32 == 0:
                 # Use vllm-flash-attn

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -192,8 +192,8 @@ class Platform:
             return device_id
 
     @classmethod
-    def get_vit_attn_backend(cls, support_fa: bool = False) -> _Backend:
-        return _Backend.TORCH_SDPA
+    def get_vit_attn_backend(cls, head_size: int) -> tuple[_Backend, bool]:
+        return _Backend.TORCH_SDPA, False
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -193,8 +193,8 @@ class Platform:
 
     @classmethod
     def get_vit_attn_backend(cls, head_size: int,
-                             dtype: torch.dtype) -> tuple[_Backend, bool]:
-        return _Backend.TORCH_SDPA, False
+                             dtype: torch.dtype) -> _Backend:
+        return _Backend.TORCH_SDPA
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -192,7 +192,8 @@ class Platform:
             return device_id
 
     @classmethod
-    def get_vit_attn_backend(cls, head_size: int) -> tuple[_Backend, bool]:
+    def get_vit_attn_backend(cls, head_size: int,
+                             dtype: torch.dtype) -> tuple[_Backend, bool]:
         return _Backend.TORCH_SDPA, False
 
     @classmethod

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -176,15 +176,15 @@ class RocmPlatform(Platform):
 
     @classmethod
     def get_vit_attn_backend(cls, head_size: int,
-                             dtype: torch.dtype) -> tuple[_Backend, bool]:
+                             dtype: torch.dtype) -> _Backend:
         if (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA
                 and on_gfx9()):
             # Note: AITER FA is only supported for Qwen-VL models.
             # TODO: Add support for other VL models in their model class.
-            return _Backend.ROCM_AITER_FA, False
+            return _Backend.ROCM_AITER_FA
         if on_gfx9():
-            return _Backend.FLASH_ATTN, False
-        return _Backend.TORCH_SDPA, False
+            return _Backend.FLASH_ATTN
+        return _Backend.TORCH_SDPA
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -175,7 +175,8 @@ class RocmPlatform(Platform):
     ]
 
     @classmethod
-    def get_vit_attn_backend(cls, head_size: int) -> tuple[_Backend, bool]:
+    def get_vit_attn_backend(cls, head_size: int,
+                             dtype: torch.dtype) -> tuple[_Backend, bool]:
         if (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA
                 and on_gfx9()):
             # Note: AITER FA is only supported for Qwen-VL models.

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -175,16 +175,15 @@ class RocmPlatform(Platform):
     ]
 
     @classmethod
-    def get_vit_attn_backend(cls, support_fa: bool = False) -> _Backend:
-        if support_fa:
-            if (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA
-                    and on_gfx9()):
-                # Note: AITER FA is only supported for Qwen-VL models.
-                # TODO: Add support for other VL models in their model class.
-                return _Backend.ROCM_AITER_FA
-            if on_gfx9():
-                return _Backend.FLASH_ATTN
-        return _Backend.TORCH_SDPA
+    def get_vit_attn_backend(cls, head_size: int) -> tuple[_Backend, bool]:
+        if (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA
+                and on_gfx9()):
+            # Note: AITER FA is only supported for Qwen-VL models.
+            # TODO: Add support for other VL models in their model class.
+            return _Backend.ROCM_AITER_FA, False
+        if on_gfx9():
+            return _Backend.FLASH_ATTN, False
+        return _Backend.TORCH_SDPA, False
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

1. Enable FA3 in VIT. The original FA3 is not supported because head_dim has to be a multiple of 32 (in vllm's build). However, in the upstream FA, it could theoratically support any head_dim which is a multiple of 8. (https://github.com/Dao-AILab/flash-attention/blob/v2.8.3/csrc/flash_attn/flash_api.cpp#L605). 

vLLM's native FA does not support it because it forbids `FLASHATTENTION_DISABLE_UNEVEN_K` to padding. (http://github.com/vllm-project/flash-attention/blob/v2.6.2/setup.py#L223)

So, we use vllm's native flash attention if appliable and upstream FA as a fallback. 

Previous attempt and revert: https://github.com/vllm-project/vllm/pull/12435, https://github.com/vllm-project/vllm/pull/12355, https://github.com/vllm-project/vllm/pull/12445

2. Refactor` get_vit_attn_backend()` so that it could decide the attention backend tyoe internally. 

Related to #23880, https://github.com/vllm-project/vllm/issues/23884

cc: @ywang96 @DarkLight1337 @Isotr0py  

## Test 

```
vllm serve llava-hf/llava-onevision-qwen2-7b-ov-hf --trust-remote-code

vllm bench serve  \
	--backend openai-chat   \
	--model llava-hf/llava-onevision-qwen2-7b-ov-hf   \
	--endpoint /v1/chat/completions   \
	--dataset-name random-mm   \
	--num-prompts 100   \
	--random-prefix-len 0   \
	--random-input-len 0  \
	--random-output-len 1   \
	--random-range-ratio 0   \
	--random-mm-base-items-per-request 1   \
	--random-mm-limit-mm-per-prompt '{"image": 1, "video": 0}'   \
	--random-mm-bucket-config '{(224, 224, 1): 1.0}'   \
	--request-rate 10   \
	--ignore-eos   \
	--seed 42 \
	--endpoint-type openai-chat
```
whose head_dim is 72, not a multiple of 32. 

```
vllm serve OpenGVLab/InternVL3_5-4B --trust-remote-code

vllm bench serve  \
	--backend openai-chat   \
	--model llava-hf/llava-onevision-qwen2-7b-ov-hf   \
        ...
```
whose head_dim is 64, a multiple of 32.

```
pytest tests/kernels/attention/test_mha_attn.py -s -v 

========== 27 passed, 5 warnings in 9.86s ===================
```
