### PR TITLE
[Bugfix] Catch and log invalid token ids in detokenizer

### DIFF
--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -233,6 +233,11 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
     def _protected_step(self, next_token_id: int) -> Optional[str]:
         try:
             token = self.stream.step(self.tokenizer, next_token_id)
+        except OverflowError:
+            # Handle rare observed overflow, still to be diagnosed.
+            # See https://github.com/vllm-project/vllm/issues/21951.
+            logger.exception("Encountered invalid token id: %d", next_token_id)
+            token = None
         except Exception as e:
             if not str(e).startswith(INVALID_PREFIX_ERR_MSG):
                 raise e


### PR DESCRIPTION
There is a token overflow issue with quantized models that happens occasionally: https://github.com/vllm-project/vllm/issues/21951

The exact cause is not yet clear and it appears to be difficult to reproduce.

This change just insulates against the error, skipping the problem token but still logging the exception. It also prints the token id in question (suspected to be negative) which should help with further diagnosis.