### PR TITLE
[GPT-OSS] More robust way to handle cases where channel may be None

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -250,7 +250,7 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
             type="web_search_call",
         )
         output_items.append(web_search_item)
-    elif message.channel == "analysis":
+    elif message.channel == "analysis" or (message.channel == "commentary" and recipient is None) or not message.channel:
         for content in message.content:
             reasoning_item = ResponseReasoningItem(
                 id=f"rs_{random_uuid()}",

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -250,7 +250,9 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
             type="web_search_call",
         )
         output_items.append(web_search_item)
-    elif message.channel == "analysis" or (message.channel == "commentary" and recipient is None) or not message.channel:
+    elif message.channel == "analysis" or (message.channel == "commentary"
+                                           and recipient
+                                           is None) or not message.channel:
         for content in message.content:
             reasoning_item = ResponseReasoningItem(
                 id=f"rs_{random_uuid()}",


### PR DESCRIPTION

## Purpose

In some cases, GPT OSS model can generate messages where the channel is None, in these cases we shouldn't fail the request, we should be more robust and add these to reasoning.

## Test Plan

WIP

## Test Result

WIP

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

