### PR TITLE
[KV sharing] Re-land Gemma3n model changes from #22628

### DIFF
--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -23,9 +23,11 @@ from torch import nn
 from transformers.models.gemma3n.configuration_gemma3n import Gemma3nTextConfig
 
 from vllm.attention import Attention
+from vllm.compilation.backends import set_model_tag
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import (_ACTIVATION_REGISTRY,
                                                    GeluAndMul,
@@ -45,6 +47,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader, maybe_remap_kv_scale_name)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
+from vllm.v1.attention.backends.utils import KVSharingFastPrefillMetadata
 
 from .interfaces import SupportsQuant
 from .utils import (AutoWeightsLoader, extract_layer_index,
@@ -533,7 +536,178 @@ class Gemma3nDecoderLayer(nn.Module):
         return corrected_predictions
 
 
-@support_torch_compile
+# This enables torch.compile if --kv-sharing-fast-prefill passed
+@support_torch_compile(enable_if=lambda vllm_config: vllm_config.cache_config.
+                       kv_sharing_fast_prefill)
+class Gemma3nSelfDecoder(nn.Module):
+    """
+    Includes altup embedding and self decoder layers
+    """
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        decoder_layers: list[Gemma3nDecoderLayer],
+        layer_idx_start: int,
+        per_layer_model_projection: ColumnParallelLinear,
+        embed_scale_per_layer: torch.Tensor,
+        embed_tokens_per_layer: VocabParallelEmbedding,
+        per_layer_projection_norm: RMSNorm,
+        per_layer_input_scale: torch.Tensor,
+        altup_projections: nn.ModuleList,
+        eps: torch.Tensor,
+        embed_tokens: VocabParallelEmbedding,
+        embed_scale: torch.Tensor,
+    ):
+        super().__init__()
+        self.decoder_layers = decoder_layers
+        self.layer_idx_start = layer_idx_start
+        self.per_layer_model_projection = per_layer_model_projection
+        self.config = vllm_config.model_config.hf_config
+        self.embed_scale_per_layer = embed_scale_per_layer
+        self.embed_tokens_per_layer = embed_tokens_per_layer
+        self.per_layer_projection_norm = per_layer_projection_norm
+        self.per_layer_input_scale = per_layer_input_scale
+        self.altup_projections = altup_projections
+        self.eps = eps
+        self.embed_tokens = embed_tokens
+        self.embed_scale = embed_scale
+
+    def get_per_layer_input_embeddings(
+            self, input_ids: torch.Tensor) -> torch.Tensor:
+        # Deal with the fact that vocab_size_per_layer_input < vocab_size
+        # which causes us to have some out of vocab tokens by setting
+        # those token ids to 0. This matches the HF implementation.
+        per_layer_inputs_mask = torch.logical_and(
+            input_ids >= 0, input_ids < self.config.vocab_size_per_layer_input)
+        per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids,
+                                              torch.zeros_like(input_ids))
+        return self.embed_tokens_per_layer(
+            per_layer_inputs_tokens) * self.embed_scale_per_layer
+
+    def get_per_layer_inputs(
+        self,
+        hidden_states_0: torch.Tensor,
+        per_layer_inputs: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        per_layer_projection = self.per_layer_model_projection(hidden_states_0)
+        per_layer_projection = per_layer_projection.reshape(
+            *hidden_states_0.shape[:-1],
+            self.config.num_hidden_layers,
+            self.config.hidden_size_per_layer_input,
+        )
+        per_layer_projection = self.per_layer_projection_norm(
+            per_layer_projection)
+        if per_layer_inputs is not None:
+            # Profiling run does not compute per_layer_inputs
+            per_layer_inputs = per_layer_projection + per_layer_inputs
+            per_layer_inputs *= self.per_layer_input_scale
+        else:
+            per_layer_inputs = per_layer_projection
+        return per_layer_inputs
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids) * self.embed_scale
+
+    def altup_embed(self, hidden_states_0: torch.Tensor) -> torch.Tensor:
+        # Altup embed.
+        hidden_states = [hidden_states_0] * self.config.altup_num_inputs
+        target_magnitude = torch.mean(hidden_states_0**2, dim=-1,
+                                      keepdim=True)**0.5
+        for i in range(1, self.config.altup_num_inputs):
+            hidden_states[i] = self.altup_projections[i - 1](hidden_states[i])
+            new_magnitude = torch.mean(hidden_states[i]**2,
+                                       dim=-1,
+                                       keepdim=True)**0.5
+            hidden_states[i] *= target_magnitude / torch.maximum(
+                new_magnitude, self.eps)
+        hidden_states = torch.stack(hidden_states, dim=-1)
+        return hidden_states
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        per_layer_inputs: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if inputs_embeds is not None:
+            hidden_states_0 = inputs_embeds
+        else:
+            hidden_states_0 = self.get_input_embeddings(input_ids)
+
+        adjusted_per_layer_inputs = self.get_per_layer_inputs(
+            hidden_states_0, per_layer_inputs)
+        hidden_states = self.altup_embed(hidden_states_0)
+
+        # [altnum_inputs, num_tokens, hidden_size]
+        hidden_states = hidden_states.permute(2, 0, 1)
+
+        for idx, layer in enumerate(self.decoder_layers):
+            layer_idx = idx + self.layer_idx_start
+            # [altup_num_inputs, num_tokens, hidden_size]
+            hidden_states = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                per_layer_input=adjusted_per_layer_inputs[:, layer_idx, :],
+                **kwargs,
+            )
+
+        # [num_tokens, hidden_size, altnum_inputs]
+        hidden_states = hidden_states.permute(1, 2, 0)
+
+        return hidden_states, adjusted_per_layer_inputs
+
+
+# This enables torch.compile if --kv-sharing-fast-prefill passed
+@support_torch_compile(enable_if=lambda vllm_config: vllm_config.cache_config.
+                       kv_sharing_fast_prefill)
+class Gemma3nCrossDecoder(nn.Module):
+    """
+    Cross-decoder layers
+    """
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        decoder_layers: list[Gemma3nDecoderLayer],
+        layer_idx_start: int,
+    ):
+        super().__init__()
+        self.decoder_layers = decoder_layers
+        self.layer_idx_start = layer_idx_start
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        per_layer_inputs: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        # [altnum_inputs, num_tokens, hidden_size]
+        hidden_states = hidden_states.permute(2, 0, 1)
+        for idx, layer in enumerate(self.decoder_layers):
+            layer_idx = idx + self.layer_idx_start
+            # [altup_num_inputs, num_tokens, hidden_size]
+            hidden_states = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                per_layer_input=per_layer_inputs[:, layer_idx, :],
+                **kwargs,
+            )
+        # [num_tokens, hidden_size, altnum_inputs]
+        hidden_states = hidden_states.permute(1, 2, 0)
+        return hidden_states
+
+
+# This disables torch.compile if --kv-sharing-fast-prefill passed
+@support_torch_compile(enable_if=lambda vllm_config: not vllm_config.
+                       cache_config.kv_sharing_fast_prefill)
 class Gemma3nTextModel(nn.Module, SupportsQuant):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -543,7 +717,6 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
-
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
@@ -613,95 +786,211 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
             lambda prefix: Gemma3nDecoderLayer(
                 config, cache_config, quant_config, prefix=prefix),
             prefix=f"{prefix}.layers")
+
+        self.eps = torch.tensor(torch.finfo().min)
+
+        first_kv_shared_layer_idx = (config.num_hidden_layers -
+                                     config.num_kv_shared_layers)
+        # Layer idx 0-19 are self-decoder layers in You Only Cache Once (YOCO)
+        with set_model_tag("self_decoder"):
+            self.self_decoder = Gemma3nSelfDecoder(
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.self_decoder",
+                decoder_layers=self.layers[:first_kv_shared_layer_idx],
+                layer_idx_start=0,
+                per_layer_model_projection=self.per_layer_model_projection,
+                embed_scale_per_layer=self.embed_scale_per_layer,
+                embed_tokens_per_layer=self.embed_tokens_per_layer,
+                per_layer_projection_norm=self.per_layer_projection_norm,
+                per_layer_input_scale=self.per_layer_input_scale,
+                altup_projections=self.altup_projections,
+                eps=self.eps,
+                embed_tokens=self.embed_tokens,
+                embed_scale=self.embed_scale,
+            )
+        # Layer idx 20-30 are cross-decoder layers in YOCO
+        with set_model_tag("cross_decoder"):
+            self.cross_decoder = Gemma3nCrossDecoder(
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.cross_decoder",
+                decoder_layers=self.layers[first_kv_shared_layer_idx:],
+                layer_idx_start=first_kv_shared_layer_idx,
+            )
+
         self.norm = RMSNorm(
             config.hidden_size,
             eps=config.rms_norm_eps,
         )
-        self.eps = torch.tensor(torch.finfo().min)
+
+        self.fast_prefill_enabled = cache_config.kv_sharing_fast_prefill
+
+        if self.fast_prefill_enabled:
+            # Allocate static buffers for CUDAGraph
+            # TODO(sarckk): Extract this functionality to interface
+            max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+            device = next(self.parameters()).device
+            self.positions = torch.zeros(max_num_tokens,
+                                         dtype=torch.int64,
+                                         device=device)
+            self.hidden_states = torch.zeros(
+                (max_num_tokens, config.hidden_size,
+                 self.config.altup_num_inputs),
+                dtype=self.embed_tokens.weight.dtype,
+                device=device,
+            )
+            self.per_layer_inputs = torch.zeros(
+                (max_num_tokens, self.config.num_hidden_layers,
+                 self.config.hidden_size_per_layer_input),
+                dtype=self.embed_tokens.weight.dtype,
+                device=device,
+            )
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.embed_tokens(input_ids) * self.embed_scale
+        return self.self_decoder.get_input_embeddings(input_ids)
 
-    def get_per_layer_input_embeddings(
-            self, input_ids: torch.Tensor) -> torch.Tensor:
-        # Deal with the fact that vocab_size_per_layer_input < vocab_size
-        # which causes us to have some out of vocab tokens by setting
-        # those token ids to 0. This matches the HF implementation.
-        per_layer_inputs_mask = torch.logical_and(
-            input_ids >= 0, input_ids < self.config.vocab_size_per_layer_input)
-        per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids,
-                                              torch.zeros_like(input_ids))
-        return self.embed_tokens_per_layer(
-            per_layer_inputs_tokens) * self.embed_scale_per_layer
+    def fast_prefill_forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        per_layer_inputs: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        logits_indices_padded, num_logits_indices = None, None
+        attn_metadata = get_forward_context().attn_metadata
+
+        # attn_metadata is None during dummy runs
+        if (self.fast_prefill_enabled and attn_metadata is not None):
+            assert isinstance(attn_metadata, dict)
+            # Last layer is a KV sharing layer
+            layer_attn_metadata = attn_metadata[
+                self.layers[-1].self_attn.attn.layer_name]
+            if (isinstance(layer_attn_metadata, KVSharingFastPrefillMetadata)):
+                logits_indices_padded = (
+                    layer_attn_metadata.logits_indices_padded)
+                num_logits_indices = layer_attn_metadata.num_logits_indices
+
+        # Copy inputs for cudagraph
+        batch_size = positions.size(0)
+        self.positions[:batch_size].copy_(positions)
+        self_decoder_hidden_states, per_layer_inputs_adjusted = \
+            self.self_decoder(
+                input_ids=input_ids,
+                positions=self.positions[:batch_size],
+                inputs_embeds=inputs_embeds,
+                per_layer_inputs=per_layer_inputs,
+                **kwargs,
+            )
+
+        if logits_indices_padded is None:
+            logits_indices_padded = torch.arange(
+                positions.size(0),
+                dtype=positions.dtype,
+                device=positions.device,
+            )
+
+        # NOTE(sarckk): There is currently a bug caused by
+        # vLLM converting output of last piecewise CUDA graph
+        # to weakref, causing memory to be prematurely freed
+        # when there are multiple compilation units
+        # Keep .clone() until fix in
+        # https://github.com/vllm-project/vllm/pull/22282
+        hidden_states = self_decoder_hidden_states.clone()
+
+        # Copy inputs for cudagraph
+        num_padded_logits_indices = logits_indices_padded.size(0)
+        self.positions[:num_padded_logits_indices].copy_(
+            positions[logits_indices_padded])
+        self.hidden_states[:num_padded_logits_indices].copy_(
+            self_decoder_hidden_states[logits_indices_padded])
+        self.per_layer_inputs[:num_padded_logits_indices].copy_(
+            per_layer_inputs_adjusted[logits_indices_padded])
+        cross_decoder_hidden_states = self.cross_decoder(
+            positions=self.positions[:num_padded_logits_indices],
+            hidden_states=self.hidden_states[:num_padded_logits_indices],
+            per_layer_inputs=self.per_layer_inputs[:num_padded_logits_indices],
+            **kwargs,
+        )
+
+        if num_logits_indices is not None:
+            assert num_logits_indices > 0
+            # Merge cross-decoder and self-decoder hidden states
+            hidden_states[logits_indices_padded[:num_logits_indices]] = (
+                cross_decoder_hidden_states[:num_logits_indices])
+        else:
+            hidden_states = cross_decoder_hidden_states
+
+        return hidden_states
+
+    def normal_forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        per_layer_inputs: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        hidden_states, per_layer_inputs = self.self_decoder(
+            input_ids=input_ids,
+            positions=positions,
+            inputs_embeds=inputs_embeds,
+            per_layer_inputs=per_layer_inputs,
+            **kwargs,
+        )
+        hidden_states = self.cross_decoder(
+            positions=positions,
+            hidden_states=hidden_states,
+            per_layer_inputs=per_layer_inputs,
+            **kwargs,
+        )
+        return hidden_states
+
+    def altup_unembed(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        # Altup unembed.
+        target_magnitude = torch.mean(hidden_states[..., 0]**2,
+                                      dim=-1,
+                                      keepdim=True)**0.5
+        for i in range(1, self.config.altup_num_inputs):
+            hidden_states[..., i] = self.altup_unembed_projections[i - 1](
+                hidden_states[..., i])
+            new_magnitude = torch.mean(hidden_states[..., i]**2,
+                                       dim=-1,
+                                       keepdim=True)**0.5
+            hidden_states[..., i] *= target_magnitude / torch.maximum(
+                new_magnitude, self.eps)
+        # [num_tokens,hidden_size, altup_num_inputs] -> [num_tokens,hidden_size]
+        hidden_states = torch.mean(hidden_states, dim=-1)
+        return hidden_states
 
     def forward(
         self,
         input_ids: Optional[torch.Tensor],
         positions: torch.Tensor,
-        per_layer_inputs: torch.Tensor,
+        per_layer_inputs: Optional[torch.Tensor] = None,
         intermediate_tensors: Optional[IntermediateTensors] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[torch.Tensor, IntermediateTensors]:
-        if inputs_embeds is not None:
-            hidden_states_0 = inputs_embeds
-        else:
-            hidden_states_0 = self.get_input_embeddings(input_ids)
-
-        per_layer_projection = self.per_layer_model_projection(hidden_states_0)
-        per_layer_projection = per_layer_projection.reshape(
-            *hidden_states_0.shape[:-1],
-            self.config.num_hidden_layers,
-            self.config.hidden_size_per_layer_input,
-        )
-        per_layer_projection = self.per_layer_projection_norm(
-            per_layer_projection)
-
-        if per_layer_inputs is not None:
-            # Profiling run does not compute per_layer_inputs
-            per_layer_inputs = per_layer_projection + per_layer_inputs
-            per_layer_inputs *= self.per_layer_input_scale
-        else:
-            per_layer_inputs = per_layer_projection
-
-        # Altup embed.
-        hidden_states = [hidden_states_0] * self.config.altup_num_inputs
-        target_magnitude = torch.mean(hidden_states_0**2, dim=-1,
-                                      keepdim=True)**0.5
-        for i in range(1, self.config.altup_num_inputs):
-            hidden_states[i] = self.altup_projections[i - 1](hidden_states[i])
-            new_magnitude = torch.mean(hidden_states[i]**2,
-                                       dim=-1,
-                                       keepdim=True)**0.5
-            hidden_states[i] *= target_magnitude / torch.maximum(
-                new_magnitude, self.eps)
-        hidden_states = torch.stack(hidden_states, dim=0)
-
-        # Transformer blocks.
-        for layer_idx, layer in enumerate(self.layers):
-            # [altup_num_inputs, num_tokens, hidden_size]
-            hidden_states = layer(
-                positions=positions,
-                hidden_states=hidden_states,
-                per_layer_input=per_layer_inputs[:, layer_idx, :],
+        if self.fast_prefill_enabled:
+            hidden_states = self.fast_prefill_forward(
+                input_ids,
+                positions,
+                inputs_embeds,
+                per_layer_inputs,
                 **kwargs,
             )
-
-        # Altup unembed.
-        target_magnitude = torch.mean(hidden_states[0]**2,
-                                      dim=-1,
-                                      keepdim=True)**0.5
-        for i in range(1, self.config.altup_num_inputs):
-            hidden_states[i] = self.altup_unembed_projections[i - 1](
-                hidden_states[i])
-            new_magnitude = torch.mean(hidden_states[i]**2,
-                                       dim=-1,
-                                       keepdim=True)**0.5
-            hidden_states[i] *= target_magnitude / torch.maximum(
-                new_magnitude, self.eps)
-        # [altup_num_inputs,num_tokens,hidden_size] -> [num_tokens,hidden_size]
-        hidden_states = torch.mean(hidden_states, dim=0)
-
+        else:
+            hidden_states = self.normal_forward(
+                input_ids,
+                positions,
+                inputs_embeds,
+                per_layer_inputs,
+                **kwargs,
+            )
+        hidden_states = self.altup_unembed(hidden_states)
         return self.norm(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str,

--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -23,7 +23,6 @@ from torch import nn
 from transformers.models.gemma3n.configuration_gemma3n import Gemma3nTextConfig
 
 from vllm.attention import Attention
-from vllm.compilation.backends import set_model_tag
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
@@ -791,6 +790,11 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
 
         first_kv_shared_layer_idx = (config.num_hidden_layers -
                                      config.num_kv_shared_layers)
+
+        # NOTE(sarckk): importing this top level seems to cause issues
+        # during running of tests.
+        from vllm.compilation.backends import set_model_tag
+
         # Layer idx 0-19 are self-decoder layers in You Only Cache Once (YOCO)
         with set_model_tag("self_decoder"):
             self.self_decoder = Gemma3nSelfDecoder(

--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -54,6 +54,8 @@ from .utils import (AutoWeightsLoader, extract_layer_index,
 
 logger = init_logger(__name__)
 
+EPS = torch.tensor(torch.finfo().min)
+
 
 class Gemma3nAltUp(nn.Module):
     """Alternating updates (Altup)
@@ -550,29 +552,78 @@ class Gemma3nSelfDecoder(nn.Module):
         prefix: str = "",
         decoder_layers: list[Gemma3nDecoderLayer],
         layer_idx_start: int,
-        per_layer_model_projection: ColumnParallelLinear,
-        embed_scale_per_layer: torch.Tensor,
-        embed_tokens_per_layer: VocabParallelEmbedding,
-        per_layer_projection_norm: RMSNorm,
-        per_layer_input_scale: torch.Tensor,
-        altup_projections: nn.ModuleList,
-        eps: torch.Tensor,
-        embed_tokens: VocabParallelEmbedding,
-        embed_scale: torch.Tensor,
     ):
         super().__init__()
         self.decoder_layers = decoder_layers
         self.layer_idx_start = layer_idx_start
-        self.per_layer_model_projection = per_layer_model_projection
-        self.config = vllm_config.model_config.hf_config
-        self.embed_scale_per_layer = embed_scale_per_layer
-        self.embed_tokens_per_layer = embed_tokens_per_layer
-        self.per_layer_projection_norm = per_layer_projection_norm
-        self.per_layer_input_scale = per_layer_input_scale
-        self.altup_projections = altup_projections
-        self.eps = eps
-        self.embed_tokens = embed_tokens
-        self.embed_scale = embed_scale
+
+        config = vllm_config.model_config.hf_config
+        self.config = config
+        quant_config = vllm_config.quant_config
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
+        )
+        self.embed_scale = torch.tensor(
+            config.hidden_size**0.5,
+            dtype=self.embed_tokens.weight.dtype,
+        )
+        # Additional per-layer embeddings (PLE)
+        self.embed_tokens_per_layer = VocabParallelEmbedding(
+            config.vocab_size_per_layer_input,
+            config.num_hidden_layers * config.hidden_size_per_layer_input,
+            quant_config=quant_config,
+            prefix=f"{prefix}.per_layer_embed_tokens",
+        )
+        self.embed_scale_per_layer = torch.tensor(
+            config.hidden_size_per_layer_input**0.5,
+            dtype=self.embed_tokens.weight.dtype,
+        )
+        self.per_layer_model_projection = ColumnParallelLinear(
+            config.hidden_size,
+            config.num_hidden_layers * config.hidden_size_per_layer_input,
+            bias=False,
+            gather_output=True,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.per_layer_model_projection",
+        )
+        self.per_layer_projection_norm = RMSNorm(
+            hidden_size=config.hidden_size_per_layer_input,
+            eps=config.rms_norm_eps,
+        )
+        self.per_layer_input_scale = torch.rsqrt(torch.tensor(2.0)).to(
+            self.embed_tokens.weight.dtype)
+        self.per_layer_projection_scale = torch.tensor(
+            config.hidden_size**0.5,
+            dtype=self.embed_tokens.weight.dtype,
+        )
+        self.altup_projections = nn.ModuleList([
+            ColumnParallelLinear(
+                config.hidden_size,
+                config.hidden_size,
+                bias=False,
+                gather_output=True,
+                return_bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.altup_projections.{idx-1}",
+            ) for idx in range(1, self.config.altup_num_inputs)
+        ])
+
+    def get_per_layer_input_embeddings(
+            self, input_ids: torch.Tensor) -> torch.Tensor:
+        # Deal with the fact that vocab_size_per_layer_input < vocab_size
+        # which causes us to have some out of vocab tokens by setting
+        # those token ids to 0. This matches the HF implementation.
+        per_layer_inputs_mask = torch.logical_and(
+            input_ids >= 0, input_ids < self.config.vocab_size_per_layer_input)
+        per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids,
+                                              torch.zeros_like(input_ids))
+        return self.embed_tokens_per_layer(
+            per_layer_inputs_tokens) * self.embed_scale_per_layer
 
     def get_per_layer_inputs(
         self,
@@ -609,7 +660,7 @@ class Gemma3nSelfDecoder(nn.Module):
                                        dim=-1,
                                        keepdim=True)**0.5
             hidden_states[i] *= target_magnitude / torch.maximum(
-                new_magnitude, self.eps)
+                new_magnitude, EPS)
         hidden_states = torch.stack(hidden_states, dim=-1)
         return hidden_states
 
@@ -704,57 +755,7 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
-        self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size,
-            config.hidden_size,
-            quant_config=quant_config,
-            prefix=f"{prefix}.embed_tokens",
-        )
-        self.embed_scale = torch.tensor(
-            config.hidden_size**0.5,
-            dtype=self.embed_tokens.weight.dtype,
-        )
-        # Additional per-layer embeddings (PLE)
-        self.embed_tokens_per_layer = VocabParallelEmbedding(
-            config.vocab_size_per_layer_input,
-            config.num_hidden_layers * config.hidden_size_per_layer_input,
-            quant_config=quant_config,
-            prefix=f"{prefix}.per_layer_embed_tokens",
-        )
-        self.embed_scale_per_layer = torch.tensor(
-            config.hidden_size_per_layer_input**0.5,
-            dtype=self.embed_tokens.weight.dtype,
-        )
-        self.per_layer_model_projection = ColumnParallelLinear(
-            config.hidden_size,
-            config.num_hidden_layers * config.hidden_size_per_layer_input,
-            bias=False,
-            gather_output=True,
-            return_bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.per_layer_model_projection",
-        )
-        self.per_layer_projection_norm = RMSNorm(
-            hidden_size=config.hidden_size_per_layer_input,
-            eps=config.rms_norm_eps,
-        )
-        self.per_layer_input_scale = torch.rsqrt(torch.tensor(2.0)).to(
-            self.embed_tokens.weight.dtype)
-        self.per_layer_projection_scale = torch.tensor(
-            config.hidden_size**0.5,
-            dtype=self.embed_tokens.weight.dtype,
-        )
-        self.altup_projections = nn.ModuleList([
-            ColumnParallelLinear(
-                config.hidden_size,
-                config.hidden_size,
-                bias=False,
-                gather_output=True,
-                return_bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.altup_projections.{idx-1}",
-            ) for idx in range(1, self.config.altup_num_inputs)
-        ])
+
         self.altup_unembed_projections = nn.ModuleList([
             ColumnParallelLinear(
                 config.hidden_size,
@@ -767,14 +768,12 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
             ) for idx in range(1, self.config.altup_num_inputs)
         ])
 
-        # Transformer blocks.
+        # Allocate config.num_kv_shared_layers layers for self-decoder
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
             lambda prefix: Gemma3nDecoderLayer(
                 config, cache_config, quant_config, prefix=prefix),
             prefix=f"{prefix}.layers")
-
-        self.eps = torch.tensor(torch.finfo().min)
 
         first_kv_shared_layer_idx = (config.num_hidden_layers -
                                      config.num_kv_shared_layers)
@@ -790,15 +789,6 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
                 prefix=f"{prefix}.self_decoder",
                 decoder_layers=self.layers[:first_kv_shared_layer_idx],
                 layer_idx_start=0,
-                per_layer_model_projection=self.per_layer_model_projection,
-                embed_scale_per_layer=self.embed_scale_per_layer,
-                embed_tokens_per_layer=self.embed_tokens_per_layer,
-                per_layer_projection_norm=self.per_layer_projection_norm,
-                per_layer_input_scale=self.per_layer_input_scale,
-                altup_projections=self.altup_projections,
-                eps=self.eps,
-                embed_tokens=self.embed_tokens,
-                embed_scale=self.embed_scale,
             )
         # Layer idx 20-30 are cross-decoder layers in YOCO
         with set_model_tag("cross_decoder"):
@@ -837,17 +827,13 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
                 device=device,
             )
 
+    @property
+    def embed_tokens(self):
+        return self.self_decoder.embed_tokens
+
     def get_per_layer_input_embeddings(
             self, input_ids: torch.Tensor) -> torch.Tensor:
-        # Deal with the fact that vocab_size_per_layer_input < vocab_size
-        # which causes us to have some out of vocab tokens by setting
-        # those token ids to 0. This matches the HF implementation.
-        per_layer_inputs_mask = torch.logical_and(
-            input_ids >= 0, input_ids < self.config.vocab_size_per_layer_input)
-        per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids,
-                                              torch.zeros_like(input_ids))
-        return self.embed_tokens_per_layer(
-            per_layer_inputs_tokens) * self.embed_scale_per_layer
+        return self.self_decoder.get_per_layer_input_embeddings(input_ids)
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.self_decoder.get_input_embeddings(input_ids)
@@ -964,7 +950,7 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
                                        dim=-1,
                                        keepdim=True)**0.5
             hidden_states[..., i] *= target_magnitude / torch.maximum(
-                new_magnitude, self.eps)
+                new_magnitude, EPS)
         # [num_tokens,hidden_size, altup_num_inputs] -> [num_tokens,hidden_size]
         hidden_states = torch.mean(hidden_states, dim=-1)
         return hidden_states
@@ -1010,6 +996,13 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
+            # decoder layer weights, altup_unembed_projections and rmsnorm
+            # are initialized in text model, others are in self decoder
+            if (not name.startswith('layers')
+                    and not name.startswith('altup_unembed_projections')
+                    and not name.startswith('norm')):
+                name = f"self_decoder.{name}"
+
             if (self.quant_config is not None and
                 (scale_name := self.quant_config.get_cache_scale(name))):
                 # Loading kv cache scales for compressed-tensors quantization

--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -638,7 +638,7 @@ class Gemma3nForConditionalGeneration(nn.Module, SupportsMultiModal,
         # NOTE (NickLucche) Each pass needs tokens to compute PLE so we cache
         # them here, as the model  forward has only access to the input_embeds.
         if input_ids is not None:
-            per_layer_inputs = self.language_model.model.get_per_layer_input_embeddings(
+            per_layer_inputs = self.language_model.model.self_decoder.get_per_layer_input_embeddings(
                 input_ids)
             per_layer_inputs = per_layer_inputs.reshape(
                 -1, self.config.text_config.num_hidden_layers,

--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -638,7 +638,7 @@ class Gemma3nForConditionalGeneration(nn.Module, SupportsMultiModal,
         # NOTE (NickLucche) Each pass needs tokens to compute PLE so we cache
         # them here, as the model  forward has only access to the input_embeds.
         if input_ids is not None:
-            per_layer_inputs = self.language_model.model.self_decoder.get_per_layer_input_embeddings(
+            per_layer_inputs = self.language_model.model.get_per_layer_input_embeddings(
                 input_ids)
             per_layer_inputs = per_layer_inputs.reshape(
                 -1, self.config.text_config.num_hidden_layers,


### PR DESCRIPTION
## Purpose

Re-land changes reverted in https://github.com/vllm-project/vllm/pull/23897, addressing CI test failures that caused the revert.

The only perf overhead should be from the extra `.permute()` calls before and after decoder layer forwards in self-decoder and cross-decoder. These permutes are required to ensure that output `hidden_states` has shape `[num_tokens, hidden_size, altnum_inputs`.

Also addresses one of the follow ups from https://github.com/vllm-project/vllm/pull/22628, to initialize model weights in self-decoder where possible.

## Test Plan

run previously failing tests:
```
pytest tests/models/multimodal/processing/test_tensor_schema.py::test_model_tensor_schema -s 
pytest tests/models/test_initialization.py::test_can_initialize_small_subset -s
```

run gsm8k:
```
VLLM_DISABLE_COMPILE_CACHE=1 vllm serve google/gemma-3n-E2B-it --disable-log-requests -tp 1

lm_eval --model local-completions --tasks gsm8k \
    --model_args model=google/gemma-3n-E2B-it,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=200 --batch_size auto --apply_chat_template --fewshot_as_multiturn
```

chartqa:
```
lm_eval --model local-chat-completions --tasks chartqa --model_args model=google/gemma-3n-E2B-it,base_url=http://localhost:8000/v1/chat/completions --apply_chat_template --limit 100
```

perf benchmark:
```
VLLM_DISABLE_COMPILE_CACHE=1 python -m vllm.entrypoints.openai.api_server --model google/gemma-3n-E2B-it --disable-log-requests -tp 1 --port 8000 --no-enable-prefix-caching --max-num-seqs 1 --max-model-len=32768 --max_num_batched_token=8192 --kv-sharing-fast-prefill

vllm bench serve --backend vllm --ignore-eos --model google/gemma-3n-E2B-it --dataset-name random --max-concurrency 1 --request-rate inf --num-prompts 64 --random-input-len 8192 --random-output-len 20 --port 8000
```

MM offline inference, run with temp=0.0:
```
python examples/offline_inference/vision_language.py --model-type gemma3n
```

## Test Result

tests pass locally, check CI passes too.

### chartqa

on this PR, without `--kv-sharing-fast-prefill`:
```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value|   |Stderr|
|-------|------:|------|-----:|-----------------|---|----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  | 0.63|±  |0.0485|
|       |       |none  |     0|exact_match      |↑  | 0.47|±  |0.0502|
|       |       |none  |     0|relaxed_accuracy |↑  | 0.62|±  |0.0488|
```

on this PR, with `--kv-sharing-fast-prefill`:

```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value|   |Stderr|
|-------|------:|------|-----:|-----------------|---|----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  | 0.62|±  |0.0488|
|       |       |none  |     0|exact_match      |↑  | 0.45|±  |0.0500|
|       |       |none  |     0|relaxed_accuracy |↑  | 0.62|±  |0.0488|
```

base, before this PR:
```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value|   |Stderr|
|-------|------:|------|-----:|-----------------|---|----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  | 0.62|±  |0.0488|
|       |       |none  |     0|exact_match      |↑  | 0.44|±  |0.0499|
|       |       |none  |     0|relaxed_accuracy |↑  | 0.62|±  |0.0488|
```


### gsm8k

on this PR, without `--kv-sharing-fast-prefill`:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7020|±  |0.0126|
|     |       |strict-match    |     5|exact_match|↑  |0.5474|±  |0.0137|
```

on this PR, with `--kv-sharing-fast-prefill`:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7066|±  |0.0125|
|     |       |strict-match    |     5|exact_match|↑  |0.5489|±  |0.0137|
```

base, before this PR:
```
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7005|±  |0.0126|
|     |       |strict-match    |     5|exact_match|↑  |0.5489|±  |0.0137|
```

### perf

on this PR, without `--kv-sharing-fast-prefill`:
```
============ Serving Benchmark Result ============
Successful requests:                     64        
Maximum request concurrency:             1         
Benchmark duration (s):                  17.43     
Total input tokens:                      523510    
Total generated tokens:                  1280      
Request throughput (req/s):              3.67      
Output token throughput (tok/s):         73.42     
Peak output token throughput (tok/s):    80.00     
Peak concurrent requests:                5.00      
Total Token throughput (tok/s):          30100.15  
---------------Time to First Token----------------
Mean TTFT (ms):                          146.01    
Median TTFT (ms):                        148.08    
P99 TTFT (ms):                           151.35    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.64      
Median TPOT (ms):                        6.64      
P99 TPOT (ms):                           6.72      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.64      
Median ITL (ms):                         6.63      
P99 ITL (ms):                            7.36      
==================================================
```

on this PR, with `--kv-sharing-fast-prefill` (24% TTFT improvement, at cost of slight TTIT overhead)
```
============ Serving Benchmark Result ============
Successful requests:                     64        
Maximum request concurrency:             1         
Benchmark duration (s):                  15.61     
Total input tokens:                      523510    
Total generated tokens:                  1280      
Request throughput (req/s):              4.10      
Output token throughput (tok/s):         81.98     
Peak output token throughput (tok/s):    83.00     
Peak concurrent requests:                6.00      
Total Token throughput (tok/s):          33611.15  
---------------Time to First Token----------------
Mean TTFT (ms):                          112.77    
Median TTFT (ms):                        114.75    
P99 TTFT (ms):                           117.96    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.89      
Median TPOT (ms):                        6.88      
P99 TPOT (ms):                           7.07      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.89      
Median ITL (ms):                         6.89      
P99 ITL (ms):                            7.67      
==================================================
```

base, before this PR:
```
============ Serving Benchmark Result ============
Successful requests:                     64        
Maximum request concurrency:             1         
Benchmark duration (s):                  17.36     
Total input tokens:                      523510    
Total generated tokens:                  1280      
Request throughput (req/s):              3.69      
Output token throughput (tok/s):         73.72     
Peak output token throughput (tok/s):    80.00     
Peak concurrent requests:                5.00      
Total Token throughput (tok/s):          30225.57  
---------------Time to First Token----------------
Mean TTFT (ms):                          145.10    
Median TTFT (ms):                        147.17    
P99 TTFT (ms):                           148.64    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.63      
Median TPOT (ms):                        6.62      
P99 TPOT (ms):                           6.75      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.63      
Median ITL (ms):                         6.61      
P99 ITL (ms):                            7.36      
==================================================
```

### MM offline inference

on base, before this PR:

```
--------------------------------------------------
The image shows a view looking up through the branches of cherry blossom trees towards the Tokyo Skytree. 

Here's a breakdown of the content:

* **Cherry Blossoms:** The foreground is dominated by delicate pink and white cherry blossom flowers, creating a soft and dreamy atmosphere. The branches are full of
--------------------------------------------------
The image shows a view looking up through the branches of cherry blossom trees towards the Tokyo Skytree. 

Here's a breakdown of the content:

* **Cherry Blossoms:** The foreground is dominated by delicate pink and white cherry blossom flowers, creating a soft and dreamy atmosphere. The branches are full of
--------------------------------------------------
The image shows a view looking up through the branches of cherry blossom trees towards the Tokyo Skytree. 

Here's a breakdown of the content:

* **Cherry Blossoms:** The foreground is dominated by delicate pink and white cherry blossom flowers, creating a soft and dreamy atmosphere. The branches are full of
--------------------------------------------------
The image shows a view looking up through the branches of cherry blossom trees towards the Tokyo Skytree. 

Here's a breakdown of the content:

* **Cherry Blossoms:** The foreground is dominated by delicate pink and white cherry blossom flowers, creating a soft and dreamy atmosphere. The branches are full of
--------------------------------------------------
```

Same content after this PR with and without flag.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
