### PR TITLE
[Bugfix] Fix broken deepseek fp8 TP weights loading

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -262,7 +262,7 @@ class LinearBase(CustomOp):
         self.tp_size = (get_tensor_model_parallel_world_size()
                         if not disable_tp else 1)
 
-    def __post_init__(self):
+    def update_param_tp_status(self):
         for param in self.parameters():
             if isinstance(param, BasevLLMParameter):
                 param.tp_rank = self.tp_rank
@@ -459,6 +459,7 @@ class ColumnParallelLinear(LinearBase):
             })
         else:
             self.register_parameter("bias", None)
+        self.update_param_tp_status()
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
 
@@ -1250,6 +1251,7 @@ class RowParallelLinear(LinearBase):
             })
         else:
             self.register_parameter("bias", None)
+        self.update_param_tp_status()
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
         input_dim = getattr(param, "input_dim", None)

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -270,7 +270,8 @@ class Fp8LinearMethod(LinearMethodBase):
         layer.weight_block_size = None
 
         if self.block_quant:
-            tp_size = get_tensor_model_parallel_world_size()
+            tp_size = getattr(layer, "tp_size",
+                              get_tensor_model_parallel_world_size())
             assert self.quant_config.weight_block_size is not None
             layer.weight_block_size = self.quant_config.weight_block_size
             block_n, block_k = (


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix https://github.com/vllm-project/vllm/pull/23024#issuecomment-3261563873
- Manually update parameter's `tp_size` and `tp_rank` through `self.update_param_tp_status()`
(I just realized that `__post_init__` is never called for `nn.Module` because it's not a dataclass. My bad. 😅)

Also cc @minosfuture, can you check if this PR also fixed the issue on your side? Thanks!

## Test Plan
```
vllm serve Isotr0py/DeepSeek-V3-0324-tiny -tp 2 --enforce-eager --trust-remote-code
```

## Test Result
Verified on dummy tiny Deepseek-v3 FP8 checkpoint with 1 MLA layer.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

