### PR TITLE
[Misc] collect flashinfer version in collect_env.py

### DIFF
--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -74,6 +74,7 @@ DEFAULT_CONDA_PATTERNS = {
     "zmq",
     "nvidia",
     "pynvml",
+    "flashinfer-python",
 }
 
 DEFAULT_PIP_PATTERNS = {
@@ -89,6 +90,7 @@ DEFAULT_PIP_PATTERNS = {
     "zmq",
     "nvidia",
     "pynvml",
+    "flashinfer-python",
 }
 
 


### PR DESCRIPTION
## Purpose
While working on repro in https://github.com/yeqcharlotte/vllm/pull/3, notice flashinfer version is not collected 😂

## Test Plan
```
python vllm/collect_env.py 
```

## Test Result
https://gist.github.com/yeqcharlotte/edbbf13b07a3e26e05ef14519641ca6e
```
...
==============================
Versions of relevant libraries
==============================
[pip3] efficientnet_pytorch==0.7.1
[pip3] flashinfer-python==0.3.1
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

