### PR TITLE
[bugfix][rocm] handle flash_attn import error gracefully when flash_attn unavailable

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -224,9 +224,12 @@ try:
     from vllm.vllm_flash_attn import flash_attn_varlen_func
     is_vllm_fa = True
 except ImportError:
-    # For rocm use upstream flash attention
-    if current_platform.is_rocm():
-        from flash_attn import flash_attn_varlen_func
+    try:
+        # For rocm use upstream flash attention
+        if current_platform.is_rocm():
+            from flash_attn import flash_attn_varlen_func
+    except ImportError:
+        flash_attn_varlen_func = None
     is_vllm_fa = False
 
 try:


### PR DESCRIPTION
## Purpose
handle flash_attn import error gracefully when flash_attn unavailable. 

Current when I run this on mi300x:
```
# run
python3 /data/users/lifans/gitrepos/vllm/examples/offline_inference/basic/basic.py
# error
	(EngineCore_0 pid=184901)     from flash_attn import flash_attn_varlen_func
	(EngineCore_0 pid=184901) ModuleNotFoundError: No module named 'flash_attn'
	Traceback (most recent call last):
```

## Test Plan & Test Result

After this PR 
```
# run
python3 /data/users/lifans/gitrepos/vllm/examples/offline_inference/basic/basic.py
# output
Generated Outputs:
------------------------------------------------------------
Prompt:    'Hello, my name is'
Output:    ' Joel, my dad is my friend and we are in a relationship. I am'
------------------------------------------------------------
Prompt:    'The president of the United States is'
Output:    ' reportedly being investigated by the FBI over the allegations that he broke campaign finance laws in'
------------------------------------------------------------
Prompt:    'The capital of France is'
Output:    ' all set to open a new gateway to the most notorious terror camps in Europe,'
------------------------------------------------------------
Prompt:    'The future of AI is'
Output:    ' in their hands. We cannot prevent the future.\nAgreed.  '
------------------------------------------------------------
```