### PR TITLE
[gpt-oss]Support lazy init mcp session

### DIFF
--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -9,6 +9,7 @@ from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Union
 
 from openai.types.responses.tool import Mcp
+from openai.types.responses.tool import Tool as OAITool
 from openai_harmony import Author, Message, Role, StreamState, TextContent
 
 from vllm import envs
@@ -153,7 +154,7 @@ class HarmonyContext(ConversationContext):
         available_tools: list[str],
         tool_server: ToolServer | None,
         request_id: str,
-        tools: list[Tool],
+        tools: list[OAITool],
     ):
         self._messages = messages
         self.finish_reason: str | None = None

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -7,7 +7,6 @@ import time
 import uuid
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
-from contextlib import AsyncExitStack
 from copy import copy
 from http import HTTPStatus
 from typing import Final
@@ -349,11 +348,6 @@ class OpenAIServingResponses(OpenAIServing):
                     else await self._get_trace_headers(raw_request.headers)
                 )
 
-                mcp_tools = {
-                    tool.server_label: tool
-                    for tool in request.tools
-                    if tool.type == "mcp"
-                }
                 context: ConversationContext
                 if self.use_harmony:
                     if request.stream:
@@ -362,7 +356,7 @@ class OpenAIServingResponses(OpenAIServing):
                             available_tools,
                             self.tool_server,
                             request.request_id,
-                            mcp_tools,
+                            request.tools,
                         )
                     else:
                         context = HarmonyContext(
@@ -370,7 +364,7 @@ class OpenAIServingResponses(OpenAIServing):
                             available_tools,
                             self.tool_server,
                             request.request_id,
-                            mcp_tools,
+                            request.tools,
                         )
                 else:
                     context = SimpleContext()

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -349,15 +349,28 @@ class OpenAIServingResponses(OpenAIServing):
                     else await self._get_trace_headers(raw_request.headers)
                 )
 
+                mcp_tools = {
+                    tool.server_label: tool
+                    for tool in request.tools
+                    if tool.type == "mcp"
+                }
                 context: ConversationContext
                 if self.use_harmony:
                     if request.stream:
                         context = StreamingHarmonyContext(
-                            messages, available_tools, self.tool_server
+                            messages,
+                            available_tools,
+                            self.tool_server,
+                            request.request_id,
+                            mcp_tools,
                         )
                     else:
                         context = HarmonyContext(
-                            messages, available_tools, self.tool_server
+                            messages,
+                            available_tools,
+                            self.tool_server,
+                            request.request_id,
+                            mcp_tools,
                         )
                 else:
                     context = SimpleContext()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -215,6 +215,7 @@ if TYPE_CHECKING:
     VLLM_NCCL_INCLUDE_PATH: str | None = None
     VLLM_USE_FBGEMM: bool = False
     VLLM_GC_DEBUG: str = ""
+    VLLM_LAZY_INIT_TOOL_SESSIONS: bool = True
 
 
 def get_default_cache_root():
@@ -1403,6 +1404,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # - VLLM_GC_DEBUG='{"top_objects":5}': enable GC debugger with
     #                                      top 5 collected objects
     "VLLM_GC_DEBUG": lambda: os.getenv("VLLM_GC_DEBUG", ""),
+    # If set to 1, delay the initialization of MCP sessions until they are
+    # actually needed. This can help reduce the startup time of vLLM in
+    # environments where MCP sessions are not immediately needed. By default,
+    # this is enabled (1).
+    "VLLM_LAZY_INIT_TOOL_SESSIONS": lambda: bool(
+        int(os.getenv("VLLM_LAZY_INIT_TOOL_SESSIONS", "1"))
+    ),
 }
 
 # --8<-- [end:env-vars-definition]


### PR DESCRIPTION

## Purpose

Currently, we initialize all MCP sessions that specified by user request before generation process no matter whether tools are actually being used.
This PR suggests implementing lazy initialization for MCP sessions. The major change is to initialize sessions with tool server only before the tool is called.

## Test Plan
With a python MCP tool server, test 2 requests with tool of `code_interpreter` type with background mode using responses API. One request do not use tool while another request use python tool.

We expect that the first request will not create any MCP session with tool server, while the second request will create session with tool server a period time after create background task for request handling.


```
import subprocess
import sys
from fastmcp import FastMCP

# Create FastMCP server instance
mcp = FastMCP("python")

@mcp.tool()
def python(code: str) -> str:
    """
    Execute Python code and return the output.

    Args:
        code: Python code to execute

    Returns:
        The output from executing the Python code
    """
    try:
        # Execute the Python code and capture output
        result = subprocess.run(
            [sys.executable, "-c", code],
            capture_output=True,
            text=True,
            timeout=30  # 30 second timeout for safety
        )

        if result.returncode == 0:
            return result.stdout if result.stdout else "Code executed successfully with no output"
        else:
            return f"Error: {result.stderr}"

    except subprocess.TimeoutExpired:
        return "Error: Code execution timed out (30 seconds)"
    except Exception as e:
        return f"Error: {str(e)}"

if __name__ == "__main__":
    # Run with SSE transport
    mcp.run(transport="sse", port=9999)
```


```
VLLM_ENABLE_RESPONSES_API_STORE=1 vllm serve /home/models/gpt-oss-20b -dp 8 --enable-expert-parallel --enforce-eager --tool-server 127.0.0.1:9999
```

```
import asyncio, time
import openai

MODEL = "/home/models/gpt-oss-20b"
client = openai.AsyncOpenAI(api_key="my_key", base_url="http://127.0.0.1:8000/v1")

async def main_background_lazy_init_mcp():
    inputs = [
        "tell me a story about a cat in 20 words",
        "Multiply 64548*15151 using python code interpreter."
    ]

    for input in inputs:
        print("="*36)
        print("="*36)
        print(input)
        print("="*36)
        response = await client.responses.create(
            model=MODEL,
            input=input,
            tools=[{
                "type": "code_interpreter",
                "container": {
                    "type": "auto"
                }
            }],
            stream=False,
            background=True,
        )

        print(f"{response=}")
        print("+"*36)
        retries = 0
        max_retries = 30
        while retries < max_retries:
            response = await client.responses.retrieve(response.id)
            print(f"{response=}")
            if response.status == "completed":
                break
            time.sleep(1)
            retries += 1

if __name__ == "__main__":
    asyncio.run(main_background_lazy_init_mcp())
```

## Test Result
mcp server log
```
# python mock_mcp_server.py 


╭─ FastMCP 2.0 ──────────────────────────────────────────────────────────────╮
│                                                                            │
│        _ __ ___ ______           __  __  _____________    ____    ____     │
│       _ __ ___ / ____/___ ______/ /_/  |/  / ____/ __ \  |___ \  / __ \    │
│      _ __ ___ / /_  / __ `/ ___/ __/ /|_/ / /   / /_/ /  ___/ / / / / /    │
│     _ __ ___ / __/ / /_/ (__  ) /_/ /  / / /___/ ____/  /  __/_/ /_/ /     │
│    _ __ ___ /_/    \__,_/____/\__/_/  /_/\____/_/      /_____(_)____/      │
│                                                                            │
│                                                                            │
│                                                                            │
│    🖥️  Server name:     python                                              │
│    📦 Transport:       SSE                                                 │
│    🔗 Server URL:      http://127.0.0.1:9999/sse                           │
│                                                                            │
│    📚 Docs:            https://gofastmcp.com                               │
│    🚀 Deploy:          https://fastmcp.cloud                               │
│                                                                            │
│    🏎️  FastMCP version: 2.11.3                                              │
│    🤝 MCP version:     1.13.1                                              │
│                                                                            │
╰────────────────────────────────────────────────────────────────────────────╯


[09/08/25 08:57:40] INFO     Starting MCP server 'python' with transport 'sse' on http://127.0.0.1:9999/sse                                                                    server.py:1522
/home/wuhang/.venv/lib/python3.12/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
  warnings.warn(  # deprecated in 14.0 - 2024-11-09
/home/wuhang/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
  from websockets.server import WebSocketServerProtocol
INFO:     Started server process [3876463]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:9999 (Press CTRL+C to quit)
INFO:     127.0.0.1:38216 - "GET /sse HTTP/1.1" 200 OK
INFO:     127.0.0.1:38224 - "POST /messages/?session_id=3eef3774ccb74a0a9231ec89fcfcd740 HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:38224 - "POST /messages/?session_id=3eef3774ccb74a0a9231ec89fcfcd740 HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:38224 - "POST /messages/?session_id=3eef3774ccb74a0a9231ec89fcfcd740 HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:38224 - "POST /messages/?session_id=3eef3774ccb74a0a9231ec89fcfcd740 HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:38224 - "POST /messages/?session_id=3eef3774ccb74a0a9231ec89fcfcd740 HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:38224 - "POST /messages/?session_id=3eef3774ccb74a0a9231ec89fcfcd740 HTTP/1.1" 202 Accepted
```

client log
```
# python openai_responses_client.py 
====================================
====================================
tell me a story about a cat in 20 words
====================================
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
++++++++++++++++++++++++++++++++++++
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_e1d66c73a1ab4cbda09b42114a78cc38', created_at=1757321872.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[ResponseReasoningItem(id='rs_82079fb4036246d082a328d4c427e348', summary=[], type='reasoning', content=[Content(text='The user asks: "tell me a story about a cat in 20 words". So presumably a short story of exactly 20 words. We need to output it. Keep exactly 20 words. The content: a cat story. Provide 20 words. Let\'s craft. Count.\n\nWe need 20 words. Let\'s craft: "Milo, a shy tuxedo cat, discovered hidden garden. He chased butterflies, befriended shy hedgehog, and returned home triumphant."\n\nCount words:\n\nMilo(1), a(2), shy(3), tuxedo(4), cat,(5), discovered(6), hidden(7), garden.(8) He(9) chased(10), butterflies,(11) befriended(12), shy(13), hedgehog,(14) and(15) returned(16) home(17) triumphant.(18)\n\nThat\'s 18 words. Need 2 more words. Add "in" "moonlight" maybe after home. Let\'s rephrase: "Milo,..." but currently 18 words. Let\'s add "under" and "moonlight" as words: "Milo, a shy tuxedo cat, discovered hidden garden. He chased butterflies, befriended shy hedgehog, and returned home triumphant under moonlight." Count again.\n\nMilo(1)\na(2)\nshy(3)\ntuxedo(4)\ncat,(5)\ndiscovered(6)\nhidden(7)\ngarden.(8)\nHe(9)\nchased(10)\nbutterflies,(11)\nbefriended(12)\nshy(13)\nhedgehog,(14)\nand(15)\nreturned(16)\nhome(17)\ntriumphant(18)\nunder(19)\nmoonlight(20).\n\nYes 20. Good. That seems fine. User asked for story about a cat in 20 words. Provide output.', type='reasoning_text')], encrypted_content=None, status=None), ResponseOutputMessage(id='msg_d6404d23fef74a78add9cf01a4f95d1f', content=[ResponseOutputText(annotations=[], text='Milo, a shy tuxedo cat, discovered hidden garden. He chased butterflies, befriended shy hedgehog, and returned home triumphant under moonlight.', type='output_text', logprobs=None)], role='assistant', status='completed', type='message')], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130928, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='completed', text=None, top_logprobs=None, truncation='disabled', usage=ResponseUsage(input_tokens=144, input_tokens_details=InputTokensDetails(cached_tokens=128), output_tokens=434, output_tokens_details=OutputTokensDetails(reasoning_tokens=391, tool_output_tokens=0), total_tokens=578), user=None)
====================================
====================================
Multiply 64548*15151 using python code interpreter.
====================================
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
++++++++++++++++++++++++++++++++++++
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130927, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='queued', text=None, top_logprobs=None, truncation='disabled', usage=None, user=None)
response=Response(id='resp_9ddfe579778149ce85d6045a544a5554', created_at=1757321893.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='/home/models/gpt-oss-20b', object='response', output=[ResponseReasoningItem(id='rs_bf4b873e5cb740cd9baa95b5703d1f3e', summary=[], type='reasoning', content=[Content(text='We need to multiply 64548 * 15151 using python. Compute.', type='reasoning_text')], encrypted_content=None, status=None), ResponseReasoningItem(id='rs_d67410f92f0f430fb853ca5fa35dbe1c', summary=[], type='reasoning', content=[Content(text='64548 * 15151', type='reasoning_text')], encrypted_content=None, status=None), ResponseReasoningItem(id='rs_5479d468175146ce82ea94ad67ec1cb9', summary=[], type='reasoning', content=[Content(text="We need to provide the result. Let's compute manually? Use python.", type='reasoning_text')], encrypted_content=None, status=None), ResponseReasoningItem(id='rs_8a1321c1d27f47409f3189bca8a480c6', summary=[], type='reasoning', content=[Content(text='64548 * 15151', type='reasoning_text')], encrypted_content=None, status=None), ResponseReasoningItem(id='rs_74bb57d2afe54bba8b0df23073ee4df4', summary=[], type='reasoning', content=[Content(text="It didn't output. I forgot to print. Let's do it.", type='reasoning_text')], encrypted_content=None, status=None), ResponseReasoningItem(id='rs_f2e8f9eba09549fca5114c2e8b81c7db', summary=[], type='reasoning', content=[Content(text='print(64548 * 15151)', type='reasoning_text')], encrypted_content=None, status=None), ResponseReasoningItem(id='rs_09f44cf3bbfc4bc297b98a3c0e1cb737', summary=[], type='reasoning', content=[Content(text='Therefore answer is 977,966,748. Provide the result.', type='reasoning_text')], encrypted_content=None, status=None), ResponseOutputMessage(id='msg_95e69c0aa9d24c519b484df6d3d3b29f', content=[ResponseOutputText(annotations=[], text='The product of\u202f64548\u202fand\u202f15151\u202fis:\n\n\\[\n64548 \\times 15151 = 977\\,966\\,748\n\\]', type='output_text', logprobs=None)], role='assistant', status='completed', type='message')], parallel_tool_calls=True, temperature=1.0, tool_choice='auto', tools=[CodeInterpreter(container=CodeInterpreterContainerCodeInterpreterToolAuto(type='auto', file_ids=None), type='code_interpreter')], top_p=1.0, background=True, max_output_tokens=130768, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='completed', text=None, top_logprobs=None, truncation='disabled', usage=ResponseUsage(input_tokens=902, input_tokens_details=InputTokensDetails(cached_tokens=656), output_tokens=165, output_tokens_details=OutputTokensDetails(reasoning_tokens=85, tool_output_tokens=51), total_tokens=1067), user=None)
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

