### PR TITLE
Optimize triton unified attention performance for sliding window attention

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -83,7 +83,7 @@ def ref_paged_attn(
 @pytest.mark.parametrize("num_heads", NUM_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
 @pytest.mark.parametrize("block_size", BLOCK_SIZES)
-@pytest.mark.parametrize("sliding_window", [None, 256])
+@pytest.mark.parametrize("sliding_window", [None, 64, 128, 256])
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("soft_cap", [None, 50.0])
 @pytest.mark.parametrize("num_blocks", NUM_BLOCKS)

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -184,8 +184,30 @@ def kernel_unified_attention_2d(
     # this prefix can be skipped)
     num_tiles = cdiv_fn(max_seq_prefix_len, TILE_SIZE)
 
-    # iterate through tiles
-    for j in range(0, num_tiles):
+    # ---- Sliding-window tile pruning --------------------
+    # Default: keep previous global behavior
+    tile_start = 0
+    tile_end = num_tiles
+    if SLIDING_WINDOW > 0:
+        # Query rows covered by this Q-block
+        qpos_lo = q_block_local_idx * BLOCK_Q
+        qpos_hi = tl.minimum(
+            qpos_lo + (BLOCK_M - 1) // num_queries_per_kv,
+            cur_batch_query_len - 1,
+        )
+        # For sliding window, each query position q can only attend to
+        # keys in the range [q_abs - SLIDING_WINDOW + 1, q_abs]
+        # where q_abs = context_len + q
+        # The union of allowed key positions for this Q-block is:
+        # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
+        first_allowed_key = context_len + qpos_lo - SLIDING_WINDOW + 1
+        last_allowed_key = context_len + qpos_hi
+        # Convert to tile indices and clamp
+        tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
+        tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
+
+    # iterate through tiles (now limited to the sliding window range)
+    for j in range(tile_start, tile_end):
         seq_offset = j * TILE_SIZE + offs_t
         tile_mask = seq_offset < max_seq_prefix_len
 


### PR DESCRIPTION
Summary:
Optimize kernel_unified_attention_2d attention performance for sliding window attention by pruning unused tiles  

Before this change, GPT-OSS + triton attention backend was spending equal amount of time between global and local attention due to attn score still calculated by masked out sequences
<img width="1556" height="303" alt="gpt-oss-before" src="https://github.com/user-attachments/assets/951c0cc6-3cd3-4431-97a8-5d8c5a83c044" />


After this change, sliding window attention become much cheaper
<img width="2824" height="346" alt="gpt-oss-after" src="https://github.com/user-attachments/assets/01b89583-66a1-49cb-ad10-7b041f89dd54" />


Test Plan:
GPT-OSS 120b eval with this change
```
Writing report to /tmp/aime25_gpt-oss-120b-medium_temp1.0_20250906_171957.html
{'chars': 2580.5666666666666, 'chars:std': 1246.4907456090032, 'score': 0.875, 'score:std': 0.33071891388307384}
Writing results to /tmp/aime25_gpt-oss-120b-medium_temp1.0_20250906_171957.json
Writing all results to /tmp/aime25_gpt-oss-120b-medium_temp1.0_20250906_171957_allresults.json
[{'eval_name': 'aime25', 'model_name': 'gpt-oss-120b-medium_temp1.0_20250906_171957', 'metric': 0.875}]
```

Unit tests pass
```
pytest -v tests/kernels/attention/test_triton_unified_attention.py

==================================================================================================================== warnings summary ====================================================================================================================
../uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305
  /home/qizixi/uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================= 64 passed, 64 skipped, 1 warning in 53.32s =======================================================================================================
```

Rollback Plan:

Differential Revision: D81865757


