### PR TITLE
[rocm] enable torchao quantization for rocm

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -171,7 +171,7 @@ class RocmPlatform(Platform):
 
     supported_quantization: list[str] = [
         "awq", "gptq", "fp8", "compressed-tensors", "fbgemm_fp8", "gguf",
-        "quark", "ptpc_fp8", "mxfp4", "petit_nvfp4"
+        "quark", "ptpc_fp8", "mxfp4", "petit_nvfp4", "torchao"
     ]
 
     @classmethod


### PR DESCRIPTION
## Purpose

torchao quantization works for rocm now after this PR: https://github.com/pytorch/ao/pull/2883, so enable it for rocm. 

## Test Plan & Test Result

### Environment
- Torch 
```
torch                             2.9.0.dev20250906+rocm6.4
torchao                           0.14.0.dev20250906+rocm6.4
torchaudio                        2.8.0.dev20250906+rocm6.4
torchvision                       0.24.0.dev20250906+rocm6.4
```
- Hardware: MI300X

### lm_eval

#### With torchao fp8
```
# Run
HIP_VISIBLE_DEVICES=7 lm_eval \
  --model vllm \
  --model_args pretrained=/home/lifans/hf_models/meta-llama/Llama-3.1-8B-Instruct-float8dq,max_model_len=4096 \
  --tasks gsm8k \
  --batch_size auto

# Memory
(EngineCore_0 pid=1391249) INFO 09-07 13:14:23 [gpu_model_runner.py:2235] Model loading took 10.8145 GiB and 6.196072 seconds

# Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7794|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7589|±  |0.0118|
```
#### Baseline
```
# Run
HIP_VISIBLE_DEVICES=7 lm_eval \
  --model vllm \
  --model_args pretrained=/home/lifans/hf_models/meta-llama/Llama-3.1-8B-Instruct,max_model_len=4096 \
  --tasks gsm8k \
  --batch_size auto

# Memory
(EngineCore_0 pid=1965276) INFO 09-07 13:32:45 [gpu_model_runner.py:2235] Model loading took 15.0508 GiB and 10.106234 seconds

# Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7809|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7589|±  |0.0118|
```

### Quantization Script

```
import os
from torchao.quantization import (
    Float8DynamicActivationFloat8WeightConfig,
)
from torchao.quantization.granularity import PerRow
from transformers import AutoModelForCausalLM, AutoTokenizer, TorchAoConfig

SAVE = os.environ.get("SAVE", "1")

quant_config = Float8DynamicActivationFloat8WeightConfig(granularity=PerRow())
# or float8 weight only quantization
# quant_config = Float8WeightOnlyConfig()
quantization_config = TorchAoConfig(quant_type=quant_config)

model_id="/home/lifans/hf_models/meta-llama/Llama-3.1-8B-Instruct"

# Load and quantize the model
quantized_model = AutoModelForCausalLM.from_pretrained(
    model_id,
    torch_dtype="auto",
    device_map="auto",
    quantization_config=quantization_config,
)

tokenizer = AutoTokenizer.from_pretrained(model_id)
input_text = "What are we having for dinner?"
input_ids = tokenizer(input_text, return_tensors="pt").to(quantized_model.device)

# auto-compile the quantized model with `cache_implementation="static"` to get speed up
output = quantized_model.generate(
    **input_ids, max_new_tokens=20, cache_implementation="static"
)

if SAVE == "1":
    postfix = "float8dq"
    save_to = f"{model_id}-{postfix}"
    quantized_model.save_pretrained(save_to, safe_serialization=False)
    tokenizer.save_pretrained(save_to)
```