### PR TITLE
[gpt-oss][Responses API] Fix the function call id format

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -273,7 +273,7 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
                     call_id=f"call_{random_id}",
                     type="function_call",
                     name=function_name,
-                    id=f"ft_{random_id}",
+                    id=f"fc_{random_id}",
                 )
                 output_items.append(response_item)
         elif recipient is not None and (recipient.startswith("python")


### PR DESCRIPTION
## Purpose

Refer to https://platform.openai.com/docs/guides/function-calling
```
    {
      "arguments": "{\"sign\":\"Aquarius\"}",
      "call_id": "call_wdzaQlITiXLNAgYToS2LX6WS",
      "name": "get_horoscope",
      "type": "function_call",
      "id": "fc_68be50e1bab881948ea46ef552a40d0f01274d71df061905",
      "status": "completed"
    }
```
Fix the function call id format
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

