### PR TITLE
[Docs] Move feature compatibility tables to README

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -32,10 +32,7 @@ nav:
       - models/pooling_models.md
       - models/extensions
       - Hardware Supported Models: models/hardware_supported_models
-    - Features:
-      - features/compatibility_matrix.md
-      - features/*
-      - features/quantization
+    - Features: features
   - Developer Guide:
     - contributing/README.md
     - General:

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,4 +1,6 @@
-# Compatibility Matrix
+# Features
+
+## Compatibility Matrix
 
 The tables below show mutually exclusive features and the support on some hardware.
 
@@ -12,7 +14,7 @@ The symbols used have the following meanings:
 !!! note
     Check the ❌ or 🟠 with links to see tracking issue for unsupported feature/hardware combination.
 
-## Feature x Feature
+### Feature x Feature
 
 <style>
 td:not(:first-child) {
@@ -56,7 +58,7 @@ th:not(:first-child) {
 
 [](){ #feature-x-hardware }
 
-## Feature x Hardware
+### Feature x Hardware
 
 | Feature                                                   | Volta               | Turing    | Ampere    | Ada    | Hopper     | CPU                | AMD    | TPU |
 |-----------------------------------------------------------|---------------------|-----------|-----------|--------|------------|--------------------|--------|-----|


### PR DESCRIPTION
Similar to https://github.com/vllm-project/vllm/pull/23663, move the compatibility tables up a level into the README for the docs section. This:

- Creates the README that users will see when navigating to https://docs.vllm.ai/en/latest/features/index.html
- Stops the compatibility matrix apearing alongside all the actual feature pages
- Enables better rendering when navigating to https://github.com/vllm-project/vllm/tree/main/docs/features

I have already created a redirect in RTD.