### PR TITLE
[Performance][MM] Building the inverse permutation in O(n) time in Qwen2_5_VisionTransformer

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -716,7 +716,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
         elif self.attn_backend == _Backend.XFORMERS:
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
         return max_seqlen, seqlens
-    
+
     @staticmethod
     def invert_permutation(perm: torch.Tensor) -> torch.Tensor:
         # building the inverse permutation in O(n) time

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -716,6 +716,15 @@ class Qwen2_5_VisionTransformer(nn.Module):
         elif self.attn_backend == _Backend.XFORMERS:
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
         return max_seqlen, seqlens
+    
+    @staticmethod
+    def invert_permutation(perm: torch.Tensor) -> torch.Tensor:
+        # building the inverse permutation in O(n) time
+        inv = torch.empty_like(perm)
+        inv[perm] = torch.arange(perm.numel(),
+                                 device=perm.device,
+                                 dtype=perm.dtype)
+        return inv
 
     def forward(
         self,
@@ -760,6 +769,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
 
         rotary_pos_emb = torch.cat(rotary_pos_emb)
         window_index = torch.cat(window_index)
+        # compute reverse indices
+        reverse_indices = self.invert_permutation(window_index)
         cu_window_seqlens = torch.cat(cu_window_seqlens)
         cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
         cu_seqlens = torch.cat(cu_seqlens)
@@ -813,7 +824,6 @@ class Qwen2_5_VisionTransformer(nn.Module):
 
         # adapter
         hidden_states = self.merger(hidden_states)
-        reverse_indices = torch.argsort(window_index)
         hidden_states = hidden_states[reverse_indices, :]
         return hidden_states
 


### PR DESCRIPTION
Summary:
The original code used `torch.argsort(window_index)` to restore the original sequence order, which was slow for large tensors due to its O(n log n) complexity. Since `window_index` is a permutation, we can efficiently compute its inverse mapping in O(n) time using `inv[perm] = arange(n)`. This change significantly speeds up the operation by replacing sorting with a simple indexing assignment, reducing both computational and memory overhead for large-scale vision transformer inference.

Related to: #23884
 
Reduce the permutation from 46ms to 138μs
Before:
<img width="1684" height="712" alt="829dc047930f4a538908a2859e91529f" src="https://github.com/user-attachments/assets/4ed5adc2-2613-4ccd-b6ac-8e48a0130b76" />

After:
<img width="1701" height="535" alt="38d8547e4d2a48c5a6a48c5573eee0de" src="https://github.com/user-attachments/assets/1584618e-95ec-4104-85b6-b6a8ef4b4cf9" />
<img width="2256" height="1153" alt="A6552B0C-D262-46A4-D4BC-0FAF6E78A245" src="https://github.com/user-attachments/assets/666677d1-c2ec-42ff-866e-0c699407d76c" />

 benchmark
```
python /workspace/l00807937/eagle_mm/vllm-LJH/benchmarks/benchmark_serving.py   --backend openai-chat   --endpoint /v1/chat/completions   --model /workspace/models/Qwen2.5-VL-7B-Instruct   --trust_remote_code   --port 5580   --host 127.0.0.1   --dataset-name hf    --dataset-path lmarena-ai/VisionArena-Chat   --num-prompts 100   --seed 40
```

```
Before:
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  11.43     
Total input tokens:                      5280      
Total generated tokens:                  11174     
Request throughput (req/s):              8.75      
Output token throughput (tok/s):         977.50    
Total Token throughput (tok/s):          1439.39   
---------------Time to First Token----------------
Mean TTFT (ms):                          4448.27   
Median TTFT (ms):                        4240.09   
P99 TTFT (ms):                           9020.88   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          66.89     
Median TPOT (ms):                        61.11     
P99 TPOT (ms):                           243.20    
---------------Inter-token Latency----------------
Mean ITL (ms):                           55.84     
Median ITL (ms):                         19.65     
P99 ITL (ms):                            282.39    
==================================================

After:
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  10.99     
Total input tokens:                      5280      
Total generated tokens:                  11213     
Request throughput (req/s):              9.10      

============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  10.99     
Total input tokens:                      5280      
Total generated tokens:                  11213     
Request throughput (req/s):              9.10      
Output token throughput (tok/s):         1020.56   
Total Token throughput (tok/s):          1501.12   
---------------Time to First Token----------------
Mean TTFT (ms):                          4055.25   
Median TTFT (ms):                        4037.67   
P99 TTFT (ms):                           8585.00   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          66.50     
Median TPOT (ms):                        59.92     
P99 TPOT (ms):                           246.17    
---------------Inter-token Latency----------------
Mean ITL (ms):                           55.36     
Median ITL (ms):                         20.06     
P99 ITL (ms):                            264.74    
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

