### PR TITLE
[Model, Core] Support Granite Speech & LoRA for STT

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -758,6 +758,7 @@ Speech2Text models trained specifically for Automatic Speech Recognition.
 | `WhisperForConditionalGeneration` | Whisper | `openai/whisper-small`, `openai/whisper-large-v3-turbo`, etc. | | |
 | `VoxtralForConditionalGeneration` | Voxtral (Mistral format) | `mistralai/Voxtral-Mini-3B-2507`, `mistralai/Voxtral-Small-24B-2507`, etc. | ✅︎ | ✅︎ |
 | `Gemma3nForConditionalGeneration` | Gemma3n | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it`, etc. | | |
+| `GraniteSpeechForConditionalGeneration` | Granite Speech | `ibm-granite/granite-speech-3.3-2b`, `ibm-granite/granite-speech-3.3-8b`, etc. | ✅︎ | ✅︎ |
 
 ### Pooling Models
 

--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -79,6 +79,8 @@ async def test_basic_audio_with_lora(mary_had_lamb):
         f"{lora_model_name}={model_name}",
         "--max-model-len",
         "2048",
+        "--max-num-seqs",
+        "1",
     ]
 
     # Based on https://github.com/openai/openai-cookbook/blob/main/examples/Whisper_prompting_guide.ipynb.

--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -91,10 +91,11 @@ async def test_basic_audio_with_lora(mary_had_lamb):
             file=mary_had_lamb,
             language="en",
             response_format="text",
-            temperature=0.0)
+            temperature=0.0,
+        )
     out = json.loads(transcription)
-    out_text = out['text']
-    out_usage = out['usage']
+    out_text = out["text"]
+    out_usage = out["usage"]
     assert "mary had a little lamb" in out_text
     assert out_usage["seconds"] == 16, out_usage["seconds"]
 

--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -66,6 +66,38 @@ async def test_basic_audio(mary_had_lamb, model_name):
 
 
 @pytest.mark.asyncio
+async def test_basic_audio_with_lora(mary_had_lamb):
+    """Ensure STT requests can pass LoRA requests through to generate."""
+    model_name = "ibm-granite/granite-speech-3.3-2b"
+    lora_model_name = "speech"
+    server_args = [
+        "--enforce-eager",
+        "--enable-lora",
+        "--max-lora-rank",
+        "64",
+        "--lora-modules",
+        f"{lora_model_name}={model_name}",
+        "--max-model-len",
+        "2048",
+    ]
+
+    # Based on https://github.com/openai/openai-cookbook/blob/main/examples/Whisper_prompting_guide.ipynb.
+    with RemoteOpenAIServer(model_name, server_args) as remote_server:
+        client = remote_server.get_async_client()
+        transcription = await client.audio.transcriptions.create(
+            model=lora_model_name,
+            file=mary_had_lamb,
+            language="en",
+            response_format="text",
+            temperature=0.0)
+        out = json.loads(transcription)
+        out_text = out['text']
+        out_usage = out['usage']
+        assert "mary had a little lamb" in out_text
+        assert out_usage["seconds"] == 16, out_usage["seconds"]
+
+
+@pytest.mark.asyncio
 async def test_basic_audio_gemma(foscolo):
     # Gemma accuracy on some of the audio samples we use is particularly bad,
     # hence we use a different one here. WER is evaluated separately.

--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -67,7 +67,7 @@ async def test_basic_audio(mary_had_lamb, model_name):
 
 @pytest.mark.asyncio
 async def test_basic_audio_with_lora(mary_had_lamb):
-    """Ensure STT requests can pass LoRA requests through to generate."""
+    """Ensure STT (transcribe) requests can pass LoRA through to generate."""
     model_name = "ibm-granite/granite-speech-3.3-2b"
     lora_model_name = "speech"
     server_args = [
@@ -90,11 +90,11 @@ async def test_basic_audio_with_lora(mary_had_lamb):
             language="en",
             response_format="text",
             temperature=0.0)
-        out = json.loads(transcription)
-        out_text = out['text']
-        out_usage = out['usage']
-        assert "mary had a little lamb" in out_text
-        assert out_usage["seconds"] == 16, out_usage["seconds"]
+    out = json.loads(transcription)
+    out_text = out['text']
+    out_usage = out['usage']
+    assert "mary had a little lamb" in out_text
+    assert out_usage["seconds"] == 16, out_usage["seconds"]
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_translation_validation.py
+++ b/tests/entrypoints/openai/test_translation_validation.py
@@ -78,6 +78,8 @@ async def test_basic_audio_with_lora(mary_had_lamb):
         f"{lora_model_name}={model_name}",
         "--max-model-len",
         "2048",
+        "--max-num-seqs",
+        "1",
     ]
 
     # Based on https://github.com/openai/openai-cookbook/blob/main/examples/Whisper_prompting_guide.ipynb.

--- a/tests/entrypoints/openai/test_translation_validation.py
+++ b/tests/entrypoints/openai/test_translation_validation.py
@@ -48,25 +48,11 @@ async def test_non_asr_model(foscolo):
         assert err["message"] == "The model does not support Translations API"
 
 
-# NOTE: (NickLucche) the large-v3-turbo model was not trained on translation!
-@pytest.mark.asyncio
-async def test_basic_audio(foscolo, client_and_model):
-    client, model_name = client_and_model
-    translation = await client.audio.translations.create(
-        model=model_name,
-        file=foscolo,
-        response_format="text",
-        # TODO remove `language="it"` once language detection is implemented
-        extra_body=dict(language="it", to_language="en"),
-        temperature=0.0,
-    )
-    out = json.loads(translation)["text"].strip().lower()
-    assert "greek sea" in out
-
-
 @pytest.mark.asyncio
 async def test_basic_audio_with_lora(mary_had_lamb):
     """Ensure STT (translate) requests can pass LoRA through to generate."""
+    # NOTE - careful to call this test before the module scoped server
+    # fixture, otherwise it'll OOMkill the CI
     model_name = "ibm-granite/granite-speech-3.3-2b"
     lora_model_name = "speech"
     server_args = [
@@ -94,6 +80,22 @@ async def test_basic_audio_with_lora(mary_had_lamb):
         )
     out = json.loads(translation)["text"].strip().lower()
     assert "mary tenía un pequeño cordero" in out
+
+
+# NOTE: (NickLucche) the large-v3-turbo model was not trained on translation!
+@pytest.mark.asyncio
+async def test_basic_audio(foscolo, client_and_model):
+    client, model_name = client_and_model
+    translation = await client.audio.translations.create(
+        model=model_name,
+        file=foscolo,
+        response_format="text",
+        # TODO remove `language="it"` once language detection is implemented
+        extra_body=dict(language="it", to_language="en"),
+        temperature=0.0,
+    )
+    out = json.loads(translation)["text"].strip().lower()
+    assert "greek sea" in out
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_translation_validation.py
+++ b/tests/entrypoints/openai/test_translation_validation.py
@@ -65,6 +65,35 @@ async def test_basic_audio(foscolo, client_and_model):
 
 
 @pytest.mark.asyncio
+async def test_basic_audio_with_lora(mary_had_lamb):
+    """Ensure STT (translate) requests can pass LoRA through to generate."""
+    model_name = "ibm-granite/granite-speech-3.3-2b"
+    lora_model_name = "speech"
+    server_args = [
+        "--enforce-eager",
+        "--enable-lora",
+        "--max-lora-rank",
+        "64",
+        "--lora-modules",
+        f"{lora_model_name}={model_name}",
+        "--max-model-len",
+        "2048",
+    ]
+
+    # Based on https://github.com/openai/openai-cookbook/blob/main/examples/Whisper_prompting_guide.ipynb.
+    with RemoteOpenAIServer(model_name, server_args) as remote_server:
+        client = remote_server.get_async_client()
+        translation = await client.audio.translations.create(
+            model=lora_model_name,
+            file=mary_had_lamb,
+            extra_body=dict(language="en", to_language="es"),
+            response_format="text",
+            temperature=0.0)
+    out = json.loads(translation)['text'].strip().lower()
+    assert "mary tenía un pequeño cordero" in out
+
+
+@pytest.mark.asyncio
 async def test_audio_prompt(foscolo, client_and_model):
     client, model_name = client_and_model
     # Condition whisper on starting text

--- a/tests/entrypoints/openai/test_translation_validation.py
+++ b/tests/entrypoints/openai/test_translation_validation.py
@@ -90,8 +90,9 @@ async def test_basic_audio_with_lora(mary_had_lamb):
             file=mary_had_lamb,
             extra_body=dict(language="en", to_language="es"),
             response_format="text",
-            temperature=0.0)
-    out = json.loads(translation)['text'].strip().lower()
+            temperature=0.0,
+        )
+    out = json.loads(translation)["text"].strip().lower()
     assert "mary tenía un pequeño cordero" in out
 
 

--- a/vllm/entrypoints/openai/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text.py
@@ -193,7 +193,8 @@ class OpenAISpeechToText(OpenAIServing):
                 # It will not display special tokens like <|startoftranscript|>
                 request.prompt,
                 params=sampling_params,
-                lora_request=lora_request)
+                lora_request=lora_request,
+            )
 
             list_result_generator = [
                 self.engine_client.generate(
@@ -201,7 +202,8 @@ class OpenAISpeechToText(OpenAIServing):
                     sampling_params,
                     request_id,
                     lora_request=lora_request,
-                ) for prompt in prompts
+                )
+                for prompt in prompts
             ]
         except ValueError as e:
             # TODO: Use a vllm-specific Validation Error

--- a/vllm/entrypoints/openai/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text.py
@@ -167,8 +167,9 @@ class OpenAISpeechToText(OpenAIServing):
         if raw_request:
             raw_request.state.request_metadata = request_metadata
 
-        lora_request = self._maybe_get_adapters(request)
         try:
+            lora_request = self._maybe_get_adapters(request)
+
             prompts, duration_s = await self._preprocess_speech_to_text(
                 request=request,
                 audio_data=audio_data,

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -26,16 +26,19 @@
 
 import math
 from collections.abc import Iterable, Mapping
-from typing import Annotated
+from typing import Annotated, Optional, Union, cast
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import nn
 from transformers import BatchFeature, PretrainedConfig
 
-from vllm.config import CacheConfig, VllmConfig
-from vllm.config.multimodal import BaseDummyOptions
-from vllm.model_executor.layers.linear import ColumnParallelLinear, RowParallelLinear
+from vllm.config import (CacheConfig, ModelConfig, SpeechToTextConfig,
+                         VllmConfig)
+from vllm.inputs.data import PromptType
+from vllm.model_executor.layers.linear import (ColumnParallelLinear,
+                                               RowParallelLinear)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -57,16 +60,27 @@ from vllm.multimodal.processing import (
 )
 from vllm.multimodal.profiling import BaseDummyInputsBuilder
 from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.processor import cached_get_processor
+from vllm.transformers_utils.tokenizer import cached_get_tokenizer
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .blip2 import Blip2QFormerModel
-from .interfaces import (
-    MultiModalEmbeddings,
-    SupportsLoRA,
-    SupportsMultiModal,
-    SupportsPP,
-)
-from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
+from .interfaces import (MultiModalEmbeddings, SupportsLoRA,
+                         SupportsMultiModal, SupportsPP, SupportsTranscription)
+from .utils import (AutoWeightsLoader, embed_multimodal,
+                    init_vllm_registered_model, maybe_prefix)
+
+# NOTE lang support is based on what is written here:
+# https://huggingface.co/ibm-granite/granite-speech-3.3-2b
+# Though this may vary from model to model, and also many langs
+# work pretty well with zero shot.
+ISO639_1_SUPPORTED_LANGS = {
+    "en": "English",
+    "fr": "French",
+    "de": "German",
+    "pt": "Portuguese",
+    "es": "Spanish",
+}
 
 
 ### Audio Input
@@ -545,8 +559,10 @@ class GraniteSpeechForConditionalGeneration(
     SupportsMultiModal,
     SupportsPP,
     SupportsLoRA,
+    SupportsTranscription,
 ):
     merge_by_field_config = True
+    supported_languages = ISO639_1_SUPPORTED_LANGS
 
     packed_modules_mapping = {
         "qkv_proj": [
@@ -816,3 +832,63 @@ class GraniteSpeechForConditionalGeneration(
             connector="projector",
             tower_model="encoder",
         )
+
+    ### Support for speech-to-text Transcription
+    @classmethod
+    def get_generation_prompt(cls, audio: np.ndarray,
+                              model_config: ModelConfig,
+                              stt_config: SpeechToTextConfig,
+                              language: Optional[str], task_type: str,
+                              request_prompt: str) -> PromptType:
+        """Get the generation prompt to be used for transcription requests."""
+        # Audio placeholders don't use an index, so value doesn't matter
+        audio_tok = cls.get_placeholder_str("audio", 0)
+        user_prompt = f"{audio_tok}can you transcribe the speech into a written format?"  # noqa: E501
+
+        tokenizer = cached_get_tokenizer(model_config.model)
+        chat = [dict(role="user", content=user_prompt)]
+        prompt = tokenizer.apply_chat_template(
+            chat,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+        prompt_token_ids = tokenizer.encode(prompt)
+        prompt = {
+            "prompt_token_ids": prompt_token_ids,
+            "multi_modal_data": {
+                "audio": audio
+            }
+        }
+        return cast(PromptType, prompt)
+
+    # Adapted from https://github.com/huggingface/transformers/blob/v4.56.0/src/transformers/models/granite_speech/feature_extraction_granite_speech.py#L122 # noqa: E501
+    @classmethod
+    def get_num_audio_tokens(cls, audio_duration_s: float,
+                             stt_config: SpeechToTextConfig,
+                             model_config: ModelConfig) -> Optional[int]:
+        """Get the number of audio tokens for an audio duration in sec."""
+        processor = cached_get_processor(model_config.model)
+        hop_length = processor.audio_processor.melspec_kwargs["hop_length"]
+        proj_win_size = processor.audio_processor.projector_window_size
+        ds_rate = processor.audio_processor.projector_downsample_rate
+        effective_window_size = proj_win_size // ds_rate
+
+        raw_length = audio_duration_s * stt_config.sample_rate
+
+        # mel sequence length computation
+        mel_length = raw_length // hop_length + 1
+        # encoder frame takes two mel features
+        encoder_length = mel_length // 2
+        nblocks = math.ceil(encoder_length / proj_win_size)
+        # projector output length
+        return nblocks * effective_window_size
+
+    @classmethod
+    def get_speech_to_text_config(cls, model_config: ModelConfig,
+                                  task_type: str) -> SpeechToTextConfig:
+        """Get the stt config for this model."""
+        # Default settings are reasonable for this model and we don't currently
+        # expose this information in the model configs, but this may change in
+        # the future
+        return SpeechToTextConfig()

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -850,10 +850,10 @@ class GraniteSpeechForConditionalGeneration(
             full_lang_name_to = cls.supported_languages.get(
                 to_language, to_language)
             user_prompt = f"{audio_tok}translate the speech to {full_lang_name_to}"  # noqa: E501
-        elif task_type == "translate":
+        elif task_type == "transcribe":
             user_prompt = f"{audio_tok}can you transcribe the speech into a written format?"  # noqa: E501
         else:
-            raise ValueError(f"Unsupported task type {user_prompt}")
+            raise ValueError(f"Unsupported task type {task_type}")
 
         tokenizer = cached_get_tokenizer(model_config.model)
         chat = [dict(role="user", content=user_prompt)]


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR adds compatibility with transcriptions / translations for granite speech! It also passes the LoRA request through to the underlying generate calls, which is needed for this model since granite speech always should have its colocated LoRA active when processing audio.

## Test Plan
I added a test to the entrypoint for transcriptions for checking this model w/ LoRA active (which also should suffice for translations since they're both using the same STT component where the lora is passed).

Can also be validated with the following:

Start server
```bash
python3 -m vllm.entrypoints.openai.api_server \
    --model ibm-granite/granite-speech-3.3-2b \
    --max-model-len 2048 \
    --enable-lora  \
    --lora-modules speech=ibm-granite/granite-speech-3.3-2b \
    --enforce-eager \
    --max-lora-rank 64
```

Example client for transcribe:
```python
# SPDX-License-Identifier: Apache-2.0
import asyncio
import json

import httpx
from openai import OpenAI

from vllm.assets.audio import AudioAsset

mary_had_lamb = AudioAsset('mary_had_lamb').get_local_path()
winning_call = AudioAsset('winning_call').get_local_path()
lora_model_name = "speech"

# Modify OpenAI's API key and API base to use vLLM's API server.
openai_api_key = "token-abc123"
openai_api_base = "http://localhost:8000/v1"
client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)


def sync_openai():
    with open(str(mary_had_lamb), "rb") as f:
        transcription = client.audio.transcriptions.create(
            file=f,
            model=lora_model_name, ### <<<< should NOT be the base model name
            language="en",
            response_format="json",
            temperature=0.0)
        print("transcription result:", transcription)


sync_openai()

# OpenAI Transcription API client does not support streaming.
async def stream_openai_response():
    data = {
        "language": "en",
        "stream": True,
        "model": lora_model_name, ### <<<< should NOT be the base model name
        "temperature": 0,
    }
    url = openai_api_base + "/audio/transcriptions"
    print("transcription result:", end=' ')
    async with httpx.AsyncClient() as client:
        with open(str(mary_had_lamb), "rb") as f:
            async with client.stream('POST', url, files={'file': f},
                                     data=data) as response:
                async for line in response.aiter_lines():
                    # Each line is a JSON object prefixed with 'data: '
                    if line:
                        if line.startswith('data: '):
                            line = line[len('data: '):]
                        # Last chunk, stream ends
                        if line.strip() == '[DONE]':
                            break
                        # Parse the JSON response
                        chunk = json.loads(line)
                        # Extract and print the content
                        content = chunk['choices'][0].get('delta',
                                                          {}).get('content')
                        print(content, end='')


# Run the asynchronous function
asyncio.run(stream_openai_response())
```

Example client for translate:
```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
import asyncio
import json

import httpx
from openai import OpenAI

from vllm.assets.audio import AudioAsset
lora_model_name = "speech"

def sync_openai(audio_path: str, client: OpenAI):
    with open(audio_path, "rb") as f:
        translation = client.audio.translations.create(
            file=f,
            model=lora_model_name,
            response_format="json",
            temperature=0.0,
            # Additional params not provided by OpenAI API.
            extra_body=dict(
                language="en",
                to_language="es",
                seed=4419,
                repetition_penalty=1.3,
            ),
        )
        print("translation result:", translation.text)


async def stream_openai_response(audio_path: str, base_url: str, api_key: str):
    data = {
        "language":"en",
        "to_language":"es",
        "stream": True,
        "model": lora_model_name,
    }
    url = base_url + "/audio/translations"
    headers = {"Authorization": f"Bearer {api_key}"}
    print("translation result:", end=" ")
    # OpenAI translation API client does not support streaming.
    async with httpx.AsyncClient() as client:
        with open(audio_path, "rb") as f:
            async with client.stream(
                "POST", url, files={"file": f}, data=data, headers=headers
            ) as response:
                async for line in response.aiter_lines():
                    # Each line is a JSON object prefixed with 'data: '
                    if line:
                        if line.startswith("data: "):
                            line = line[len("data: ") :]
                        # Last chunk, stream ends
                        if line.strip() == "[DONE]":
                            break
                        # Parse the JSON response
                        chunk = json.loads(line)
                        # Extract and print the content
                        content = chunk["choices"][0].get("delta", {}).get("content")
                        print(content, end="")


def main():
    mary_had_lamb = AudioAsset('mary_had_lamb').get_local_path()


    # Modify OpenAI's API key and API base to use vLLM's API server.
    openai_api_key = "EMPTY"
    openai_api_key = "token-abc123"

    openai_api_base = "http://localhost:8000/v1"
    client = OpenAI(
        api_key=openai_api_key,
        base_url=openai_api_base,
    )
    sync_openai(mary_had_lamb, client)
    # Run the asynchronous function
    asyncio.run(stream_openai_response(mary_had_lamb, openai_api_base, openai_api_key))


if __name__ == "__main__":
    main()
```

## Test Result
Test should pass, and for the respective snippets above we should get the following:

Transcription result produces:
```
transcription result: Transcription(text='the first words i spoke in the original phonograph a little piece of practical poetry mary had a little lamb it smelt like white as snow and everywhere that mary went the lamb was sure to go', logprobs=None, usage=UsageDuration(seconds=16.0, type='duration'))
transcription result: the first words i spoke in the original phonograph a little piece of practical poetry mary had a little lamb it smelt like white as snow and everywhere that mary went the lamb was sure to go
```

Translation result produces (note that this is maty had a little lamb -> Spanish since this model doesn't officially support Italian):
```
translation result: las primeras palabras que hablé en el original son un poco de poesía práctica: mary tenía un pequeño cordero, que brillaba como la nieve, y dondequiera que mary fue, el cordero seguía a ella.
translation result: las primeras palabras que hablé en el original son un poco de poesía práctica: mary tenía un pequeño cordero, que brillaba como la nieve, y dondequiera que mary fue, el cordero seguía a ella.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

