### PR TITLE
[Frontend] Add OpenAI Harmony integration for responses API

### DIFF
--- a/tests/entrypoints/openai/test_response_api_harmony_input_output.py
+++ b/tests/entrypoints/openai/test_response_api_harmony_input_output.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import httpx
+import pytest
+import pytest_asyncio
+from openai import OpenAI
+
+from ...utils import RemoteOpenAIServer
+
+MODEL_NAME = "openai/gpt-oss-20b"
+
+
+@pytest.fixture(scope="module")
+def monkeypatch_module():
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
+
+@pytest.fixture(scope="module")
+def server(monkeypatch_module: pytest.MonkeyPatch):
+    args = ["--enforce-eager", "--tool-server", "demo"]
+
+    with monkeypatch_module.context() as m:
+        m.setenv("VLLM_ENABLE_RESPONSES_API_STORE", "1")
+        m.setenv("VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT", "1")
+        with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+            yield remote_server
+
+
+@pytest_asyncio.fixture
+async def client(server):
+    async with server.get_async_client() as async_client:
+        yield async_client
+
+
+async def send_harmony_request(server, data: dict) -> dict:
+    """Helper function to send requests with harmony messages using HTTP."""
+    async with httpx.AsyncClient(timeout=120.0) as http_client:
+        response = await http_client.post(
+            f"{server.url_root}/v1/responses",
+            json=data,
+            headers={"Authorization": f"Bearer {server.DUMMY_API_KEY}"})
+        response.raise_for_status()
+        return response.json()
+
+
+class HarmonyResponse:
+    """Helper class to make HTTP response look like OpenAI client response."""
+
+    def __init__(self, data: dict):
+        self.status = data["status"]
+        self.input_harmony_messages = data.get("input_harmony_messages", [])
+        self.output_harmony_messages = data.get("output_harmony_messages", [])
+        self.id = data.get("id")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_message_deserialization(client: OpenAI, model_name: str,
+                                               server):
+    """Test that harmony messages can be properly deserialized from JSON."""
+
+    # Create some harmony messages manually (as they would come from a client)
+    previous_harmony_messages = [{
+        "role":
+        "user",
+        "content": [{
+            "type": "text",
+            "text": "What is the capital of France?"
+        }],
+        "channel":
+        None,
+        "recipient":
+        None,
+        "content_type":
+        None
+    }, {
+        "role":
+        "assistant",
+        "content": [{
+            "type": "text",
+            "text": "The capital of France is Paris."
+        }],
+        "channel":
+        None,
+        "recipient":
+        None,
+        "content_type":
+        None
+    }]
+
+    # Use direct HTTP request since OpenAI client doesn't support custom params
+    response_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "Tell me more about that city.",
+            "instructions": "Use the previous conversation context.",
+            "previous_response_harmony_messages": previous_harmony_messages
+        })
+
+    response = HarmonyResponse(response_json)
+
+    assert response is not None
+    assert response.status == "completed"
+
+    # Verify the response includes both the previous and new messages
+    all_messages = (response.input_harmony_messages +
+                    response.output_harmony_messages)
+
+    # Verify that all messages have proper serialization
+    all_messages = (response.input_harmony_messages +
+                    response.output_harmony_messages)
+    for msg in all_messages:
+        assert "role" in msg
+        assert "content" in msg
+        assert isinstance(msg["content"], list)
+
+        # Ensure content is not empty objects
+        for content_item in msg["content"]:
+            assert isinstance(content_item, dict)
+            assert len(content_item) > 0  # Should not be empty {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_message_round_trip(client: OpenAI, model_name: str,
+                                          server):
+    """Test full round-trip: get harmony messages from response, send back."""
+
+    # First request using standard OpenAI client
+    response1 = await client.responses.create(
+        model=model_name,
+        input="What is 2 + 2?",
+        instructions="Provide a simple answer.")
+
+    assert response1 is not None
+    assert response1.status == "completed"
+
+    # Extract harmony messages from first response
+    first_input_messages = response1.input_harmony_messages
+    first_output_messages = response1.output_harmony_messages
+
+    # Combine all messages from first conversation
+    all_first_messages = first_input_messages + first_output_messages
+
+    # Second request using harmony messages from first response - use HTTP
+    response2_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "Now what is 3 + 3?",
+            "instructions": "Continue the math conversation.",
+            "previous_response_harmony_messages": all_first_messages
+        })
+
+    response2 = HarmonyResponse(response2_json)
+
+    assert response2 is not None
+    assert response2.status == "completed"
+
+    # Verify that second response contains more messages (original + new)
+    second_input_messages = response2.input_harmony_messages
+    second_output_messages = response2.output_harmony_messages
+
+    # Should have at least the messages from the first conversation plus new
+    assert len(second_input_messages) > len(first_input_messages)
+
+    # Verify all messages in the full conversation have proper content
+    all_second_messages = second_input_messages + second_output_messages
+    text_message_count = 0
+
+    for msg in all_second_messages:
+        assert "role" in msg
+        assert "content" in msg
+
+        for content_item in msg["content"]:
+            if content_item.get("type") == "text":
+                assert "text" in content_item
+                assert len(content_item["text"].strip()) > 0
+                text_message_count += 1
+
+    # Should have at least some text messages in the conversation
+    assert text_message_count > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_message_context_continuation(client: OpenAI,
+                                                    model_name: str, server):
+    """Test that harmony messages provide proper context continuation."""
+
+    # First establish context with a specific topic
+    response1_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input":
+            "I'm planning a trip to Tokyo. What's the best time to visit?",
+            "instructions": "Provide travel advice."
+        })
+
+    response1 = HarmonyResponse(response1_json)
+    assert response1.status == "completed"
+
+    # Get all messages from the first conversation
+    all_messages = (response1.input_harmony_messages +
+                    response1.output_harmony_messages)
+
+    # Continue the conversation with a follow-up question
+    response2_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "What about food recommendations for that city?",
+            "instructions": "Continue helping with travel planning.",
+            "previous_response_harmony_messages": all_messages
+        })
+
+    response2 = HarmonyResponse(response2_json)
+    assert response2.status == "completed"
+
+    # Verify context is maintained - should have more messages now
+    assert len(response2.input_harmony_messages) > len(
+        response1.input_harmony_messages)
+
+    # The conversation should contain references to the original topic
+    all_content = []
+    for msg in (response2.input_harmony_messages +
+                response2.output_harmony_messages):
+        for content_item in msg["content"]:
+            if content_item.get("type") == "text" and "text" in content_item:
+                all_content.append(content_item["text"].lower())
+
+    # Should contain references to the original context (Tokyo/trip)
+    conversation_text = " ".join(all_content)
+    assert ("tokyo" in conversation_text or "trip" in conversation_text
+            or "travel" in conversation_text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_message_empty_list(client: OpenAI, model_name: str,
+                                          server):
+    """Test that empty harmony messages list works properly."""
+
+    response_json = await send_harmony_request(
+        server,
+        {
+            "model": model_name,
+            "input": "What's 5 + 5?",
+            "instructions": "Answer the math question.",
+            "previous_response_harmony_messages": []  # Empty list
+        })
+
+    response = HarmonyResponse(response_json)
+    assert response.status == "completed"
+    assert len(response.input_harmony_messages) > 0
+    assert len(response.output_harmony_messages) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_message_none_parameter(client: OpenAI, model_name: str,
+                                              server):
+    """Test that None harmony messages parameter works (same as omitting)."""
+
+    response_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "What's 7 + 8?",
+            "instructions": "Answer the math question.",
+            "previous_response_harmony_messages": None
+        })
+
+    response = HarmonyResponse(response_json)
+    assert response.status == "completed"
+    assert len(response.input_harmony_messages) > 0
+    assert len(response.output_harmony_messages) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_message_validation_error(client: OpenAI,
+                                                model_name: str, server):
+    """Test that malformed harmony messages produce validation errors."""
+
+    # Test with invalid harmony message structure
+    invalid_harmony_messages = [{
+        "role": "user",
+        # Missing required "content" field
+        "channel": None,
+        "recipient": None,
+        "content_type": None
+    }]
+
+    async with httpx.AsyncClient(timeout=120.0) as http_client:
+        response = await http_client.post(
+            f"{server.url_root}/v1/responses",
+            json={
+                "model": model_name,
+                "input": "Hello",
+                "previous_response_harmony_messages": invalid_harmony_messages
+            },
+            headers={"Authorization": f"Bearer {server.DUMMY_API_KEY}"})
+
+        # Should get an error (4xx or 5xx status code due to missing content)
+        assert response.status_code >= 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_message_chain_conversation(client: OpenAI,
+                                                  model_name: str, server):
+    """Test chaining multiple requests with harmony messages."""
+
+    # Start a conversation
+    response1_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "My favorite color is blue.",
+            "instructions": "Remember this information."
+        })
+
+    response1 = HarmonyResponse(response1_json)
+    assert response1.status == "completed"
+
+    # Continue with context from first response
+    messages_after_1 = (response1.input_harmony_messages +
+                        response1.output_harmony_messages)
+
+    response2_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "What's my favorite color?",
+            "instructions": "Use the previous context.",
+            "previous_response_harmony_messages": messages_after_1
+        })
+
+    response2 = HarmonyResponse(response2_json)
+    assert response2.status == "completed"
+
+    # Continue with context from second response
+    messages_after_2 = (response2.input_harmony_messages +
+                        response2.output_harmony_messages)
+
+    response3_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "What about my favorite number? It's 42.",
+            "instructions": "Remember this new information too.",
+            "previous_response_harmony_messages": messages_after_2
+        })
+
+    response3 = HarmonyResponse(response3_json)
+    assert response3.status == "completed"
+
+    # Final request should have context from all previous messages
+    messages_after_3 = (response3.input_harmony_messages +
+                        response3.output_harmony_messages)
+
+    response4_json = await send_harmony_request(
+        server, {
+            "model": model_name,
+            "input": "What are my favorite color and number?",
+            "instructions": "Recall both pieces of information.",
+            "previous_response_harmony_messages": messages_after_3
+        })
+
+    response4 = HarmonyResponse(response4_json)
+    assert response4.status == "completed"
+
+    # Verify the conversation has grown with each interaction
+    assert len(response4.input_harmony_messages) > len(
+        response3.input_harmony_messages)
+    assert len(response3.input_harmony_messages) > len(
+        response2.input_harmony_messages)
+    assert len(response2.input_harmony_messages) > len(
+        response1.input_harmony_messages)

--- a/tests/entrypoints/openai/test_response_api_harmony_input_output.py
+++ b/tests/entrypoints/openai/test_response_api_harmony_input_output.py
@@ -93,7 +93,7 @@ class ResponsesApiResponse:
 async def test_harmony_message_deserialization(client: OpenAI, model_name: str,
                                                server):
     """Test that harmony messages can be properly deserialized from JSON."""
-    
+
     # Create some harmony messages manually (as they would come from a client)
     previous_harmony_messages = [{
         "role":
@@ -138,12 +138,10 @@ async def test_harmony_message_deserialization(client: OpenAI, model_name: str,
     assert response.status == "completed"
 
     # Verify the response includes both the previous and new messages
-    all_messages = (response.input_messages +
-                    response.output_messages)
+    all_messages = (response.input_messages + response.output_messages)
 
     # Verify that all messages have proper serialization
-    all_messages = (response.input_messages +
-                    response.output_messages)
+    all_messages = (response.input_messages + response.output_messages)
     for msg in all_messages:
         assert "role" in msg
         assert "content" in msg
@@ -242,8 +240,7 @@ async def test_harmony_message_context_continuation(client: OpenAI,
     assert response1.status == "completed"
 
     # Get all messages from the first conversation
-    all_messages = (response1.input_messages +
-                    response1.output_messages)
+    all_messages = (response1.input_messages + response1.output_messages)
 
     # Continue the conversation with a follow-up question
     response2_json = await send_responses_request(
@@ -260,13 +257,11 @@ async def test_harmony_message_context_continuation(client: OpenAI,
     assert response2.status == "completed"
 
     # Verify context is maintained - should have more messages now
-    assert len(response2.input_messages) > len(
-        response1.input_messages)
+    assert len(response2.input_messages) > len(response1.input_messages)
 
     # The conversation should contain references to the original topic
     all_content = []
-    for msg in (response2.input_messages +
-                response2.output_messages):
+    for msg in (response2.input_messages + response2.output_messages):
         for content_item in msg["content"]:
             if content_item.get("type") == "text" and "text" in content_item:
                 all_content.append(content_item["text"].lower())
@@ -323,7 +318,7 @@ async def test_harmony_message_none_parameter(client: OpenAI, model_name: str,
 async def test_tools_presence_across_requests(client: OpenAI, model_name: str,
                                               server):
     """Test that tools are properly handled when present in first request but not second."""
-    
+
     # First request with tools defined
     response1_json = await send_responses_request(
         server, {
@@ -348,7 +343,8 @@ async def test_tools_presence_across_requests(client: OpenAI, model_name: str,
 
     # Second request with NO tools defined, but using messages from first request
     response2_json = await send_responses_request(
-        server, {
+        server,
+        {
             "model": model_name,
             "input": "What was that calculation result again?",
             "instructions": "Use the previous conversation context.",
@@ -367,11 +363,11 @@ async def test_tools_presence_across_requests(client: OpenAI, model_name: str,
     for msg in response2.input_messages:
         assert "role" in msg
         assert "content" in msg
-        
+
         # Check that there are no tool-related keys in the message structure
         assert "tools" not in msg
         assert "tool_calls" not in msg
-        
+
         # Check content items don't contain tool definitions
         if isinstance(msg["content"], list):
             for content_item in msg["content"]:
@@ -389,13 +385,14 @@ async def test_tools_presence_across_requests(client: OpenAI, model_name: str,
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_tools_introduction_in_second_request(client: OpenAI, 
-                                                   model_name: str, server):
+async def test_tools_introduction_in_second_request(client: OpenAI,
+                                                    model_name: str, server):
     """Test introducing tools in second request when first had none."""
-    
+
     # First request with NO tools
     response1_json = await send_responses_request(
-        server, {
+        server,
+        {
             "model": model_name,
             "input": "I need to do a calculation later: 42 + 58.",
             "instructions": "Just acknowledge the request for now.",
@@ -415,8 +412,10 @@ async def test_tools_introduction_in_second_request(client: OpenAI,
     response2_json = await send_responses_request(
         server, {
             "model": model_name,
-            "input": "Now please calculate that addition I mentioned using the python tool.",
-            "instructions": "Use the previous conversation context and perform the calculation.",
+            "input":
+            "Now please calculate that addition I mentioned using the python tool.",
+            "instructions":
+            "Use the previous conversation context and perform the calculation.",
             "previous_response_messages": all_messages_1,
             "tools": [{
                 "type": "code_interpreter",
@@ -440,17 +439,21 @@ async def test_tools_introduction_in_second_request(client: OpenAI,
             for content_item in msg["content"]:
                 content_type = content_item.get("type", "")
                 # Look for tool-related content types
-                if content_type in ["tool_call", "tool_result", "code_interpreter"]:
+                if content_type in [
+                        "tool_call", "tool_result", "code_interpreter"
+                ]:
                     has_tool_call = True
                     tool_evidence.append(f"Found {content_type}")
                     break
                 # Also check for text content that indicates code execution
                 elif (content_type == "text" and "text" in content_item):
                     text_content = content_item["text"].lower()
-                    if any(keyword in text_content for keyword in 
-                           ["python", "execute", "calculate", "42", "58", "100"]):
+                    if any(
+                            keyword in text_content for keyword in
+                        ["python", "execute", "calculate", "42", "58", "100"]):
                         has_tool_call = True
-                        tool_evidence.append(f"Found calculation evidence in text")
+                        tool_evidence.append(
+                            "Found calculation evidence in text")
                         break
         if has_tool_call:
             break
@@ -466,21 +469,28 @@ async def test_tools_introduction_in_second_request(client: OpenAI,
     for msg in response2.input_messages + response2.output_messages:
         if "content" in msg and isinstance(msg["content"], list):
             for content_item in msg["content"]:
-                if content_item.get("type") == "text" and "text" in content_item:
+                if content_item.get(
+                        "type") == "text" and "text" in content_item:
                     all_content.append(content_item["text"].lower())
-    
+
     conversation_text = " ".join(all_content)
     # Should contain references to the calculation mentioned in first request
-    calculation_refs = [kw for kw in ["42", "58", "calculation", "addition"] if kw in conversation_text]
-    
-    assert len(calculation_refs) > 0, f"Expected calculation references, found: {calculation_refs}"
+    calculation_refs = [
+        kw for kw in ["42", "58", "calculation", "addition"]
+        if kw in conversation_text
+    ]
+
+    assert len(
+        calculation_refs
+    ) > 0, f"Expected calculation references, found: {calculation_refs}"
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_code_interpreter_tool_structure(client: OpenAI, model_name: str, server):
+async def test_code_interpreter_tool_structure(client: OpenAI, model_name: str,
+                                               server):
     """Test code_interpreter tool has correct structure and appears in output_messages with analysis channel."""
-    
+
     # Request that should trigger code_interpreter tool usage
     response_json = await send_responses_request(
         server, {
@@ -506,19 +516,19 @@ async def test_code_interpreter_tool_structure(client: OpenAI, model_name: str, 
         if isinstance(item, dict) and item.get("type") == "tool_call":
             has_tool_call_in_output = True
             break
-    
+
     # Tool calls should NOT appear in response.output
     assert not has_tool_call_in_output, "Tool calls should not appear in response.output"
 
     # Find code_interpreter tool calls in output_messages
     code_interpreter_calls = []
     analysis_channel_messages = []
-    
+
     for msg in response.output_messages:
         # Check for analysis channel
         if msg.get("channel") == "analysis":
             analysis_channel_messages.append(msg)
-        
+
         # Look for code_interpreter tool calls in message content
         if "content" in msg and isinstance(msg["content"], list):
             for content_item in msg["content"]:
@@ -529,27 +539,30 @@ async def test_code_interpreter_tool_structure(client: OpenAI, model_name: str, 
                         code_interpreter_calls.append(content_item)
 
     # For now, just verify we have analysis channel messages (tool calls may vary by implementation)
-    assert len(analysis_channel_messages) > 0, "Expected messages with channel='analysis'"
+    assert len(analysis_channel_messages
+               ) > 0, "Expected messages with channel='analysis'"
 
     # Validate structure of code_interpreter tool calls if they exist
     for i, tool_call_item in enumerate(code_interpreter_calls):
         assert tool_call_item["type"] == "tool_call"
         tool_call = tool_call_item["tool_call"]
-        
+
         # Verify it's a code_interpreter type
         assert tool_call["type"] == "code_interpreter"
-        
+
         # Should have required fields for code_interpreter
         assert "id" in tool_call
         assert "code_interpreter" in tool_call
-        
+
         code_interpreter = tool_call["code_interpreter"]
         assert "input" in code_interpreter  # Should have code input
-        
+
         # The code should be related to factorial calculation
         code_input = code_interpreter["input"].lower()
-        factorial_keywords = [kw for kw in ["factorial", "5", "*", "math"] if kw in code_input]
-        
+        factorial_keywords = [
+            kw for kw in ["factorial", "5", "*", "math"] if kw in code_input
+        ]
+
         assert len(factorial_keywords) > 0, \
             f"Code should be related to factorial calculation, got: {code_input}"
 
@@ -580,8 +593,7 @@ async def test_harmony_message_chain_conversation(client: OpenAI,
     assert response1.status == "completed"
 
     # Continue with context from first response
-    messages_after_1 = (response1.input_messages +
-                        response1.output_messages)
+    messages_after_1 = (response1.input_messages + response1.output_messages)
 
     response2_json = await send_responses_request(
         server, {
@@ -596,8 +608,7 @@ async def test_harmony_message_chain_conversation(client: OpenAI,
     assert response2.status == "completed"
 
     # Continue with context from second response
-    messages_after_2 = (response2.input_messages +
-                        response2.output_messages)
+    messages_after_2 = (response2.input_messages + response2.output_messages)
 
     response3_json = await send_responses_request(
         server, {
@@ -612,8 +623,7 @@ async def test_harmony_message_chain_conversation(client: OpenAI,
     assert response3.status == "completed"
 
     # Final request should have context from all previous messages
-    messages_after_3 = (response3.input_messages +
-                        response3.output_messages)
+    messages_after_3 = (response3.input_messages + response3.output_messages)
 
     response4_json = await send_responses_request(
         server, {
@@ -628,12 +638,9 @@ async def test_harmony_message_chain_conversation(client: OpenAI,
     assert response4.status == "completed"
 
     # Verify the conversation has grown with each interaction
-    assert len(response4.input_messages) > len(
-        response3.input_messages)
-    assert len(response3.input_messages) > len(
-        response2.input_messages)
-    assert len(response2.input_messages) > len(
-        response1.input_messages)
+    assert len(response4.input_messages) > len(response3.input_messages)
+    assert len(response3.input_messages) > len(response2.input_messages)
+    assert len(response2.input_messages) > len(response1.input_messages)
 
 
 @pytest.mark.asyncio
@@ -663,8 +670,7 @@ async def test_harmony_message_with_python_tool(client: OpenAI,
     assert len(response1.output_messages) > 0
 
     # Look for tool usage in the messages
-    all_messages_1 = (response1.input_messages +
-                      response1.output_messages)
+    all_messages_1 = (response1.input_messages + response1.output_messages)
 
     # Check if any message contains tool calls or tool results
     has_tool_content = False
@@ -701,12 +707,10 @@ async def test_harmony_message_with_python_tool(client: OpenAI,
     assert response2.status == "completed"
 
     # Verify second response has more messages than first (accumulated context)
-    assert len(response2.input_messages) > len(
-        response1.input_messages)
+    assert len(response2.input_messages) > len(response1.input_messages)
 
     # Verify all messages maintain proper structure
-    all_messages_2 = (response2.input_messages +
-                      response2.output_messages)
+    all_messages_2 = (response2.input_messages + response2.output_messages)
 
     for msg in all_messages_2:
         assert "role" in msg
@@ -723,25 +727,29 @@ async def test_harmony_message_with_python_tool(client: OpenAI,
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_harmony_library_input_messages(client: OpenAI, model_name: str, server):
+async def test_harmony_library_input_messages(client: OpenAI, model_name: str,
+                                              server):
     """Test using harmony library to create messages and send via previous_response_messages for single-turn conversations."""
-    
+
     # Create harmony messages using the library
     user_message = Message.from_role_and_content(
-        Role.USER, 
-        "Hello! Can you help me understand how Python functions work?"
-    )
-    
+        Role.USER,
+        "Hello! Can you help me understand how Python functions work?")
+
     # Convert to dict format for API using helper function
     harmony_messages = [harmony_message_to_dict(user_message)]
-      
+
     # Send request with harmony messages in previous_response_messages and current input
     response_json = await send_responses_request(
-        server, {
+        server,
+        {
             "model": model_name,
-            "input": "Can you explain more about Python functions?",  # Non-empty input field
-            "previous_response_messages": harmony_messages,  # Using previous_response_messages to provide context
-            "instructions": "Provide a helpful explanation about Python functions.",
+            "input":
+            "Can you explain more about Python functions?",  # Non-empty input field
+            "previous_response_messages":
+            harmony_messages,  # Using previous_response_messages to provide context
+            "instructions":
+            "Provide a helpful explanation about Python functions.",
             "enable_response_messages": True
         })
 
@@ -751,68 +759,64 @@ async def test_harmony_library_input_messages(client: OpenAI, model_name: str, s
     # Verify the harmony message was processed correctly
     assert len(response.input_messages) > 0
     assert len(response.output_messages) > 0
-    
+
     # Check that our original harmony message is in the input_messages
     found_original_message = False
     for msg in response.input_messages:
-        if (msg.get("role") == "user" and 
-            "content" in msg and 
-            isinstance(msg["content"], list)):
+        if (msg.get("role") == "user" and "content" in msg
+                and isinstance(msg["content"], list)):
             for content_item in msg["content"]:
-                if (content_item.get("type") == "text" and 
-                    "python functions" in content_item.get("text", "").lower()):
+                if (content_item.get("type") == "text" and "python functions"
+                        in content_item.get("text", "").lower()):
                     found_original_message = True
                     break
         if found_original_message:
             break
-    
+
     assert found_original_message, "Original harmony message should be preserved in input_messages"
-    
+
     # Verify response contains relevant content about Python functions
     response_text = ""
     for msg in response.output_messages:
         if "content" in msg and isinstance(msg["content"], list):
             for content_item in msg["content"]:
-                if content_item.get("type") == "text" and "text" in content_item:
+                if content_item.get(
+                        "type") == "text" and "text" in content_item:
                     response_text += content_item["text"].lower()
-    
-    python_keywords_found = [kw for kw in ["function", "python", "def", "return"] 
-                            if kw in response_text]
-    
-    assert len(python_keywords_found) > 0, "Response should contain Python function information"
+
+    python_keywords_found = [
+        kw for kw in ["function", "python", "def", "return"]
+        if kw in response_text
+    ]
+
+    assert len(python_keywords_found
+               ) > 0, "Response should contain Python function information"
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_harmony_library_multi_message_input(client: OpenAI, model_name: str, server):
+async def test_harmony_library_multi_message_input(client: OpenAI,
+                                                   model_name: str, server):
     """Test using harmony library to create multiple messages via input_messages."""
-    
+
     # Create a conversation using harmony library
-    user_msg1 = Message.from_role_and_content(
-        Role.USER, 
-        "What's the capital of Japan?"
-    )
-    
+    user_msg1 = Message.from_role_and_content(Role.USER,
+                                              "What's the capital of Japan?")
+
     assistant_msg1 = Message.from_role_and_content(
-        Role.ASSISTANT, 
-        "The capital of Japan is Tokyo."
-    )
-    
+        Role.ASSISTANT, "The capital of Japan is Tokyo.")
+
     user_msg2 = Message.from_role_and_content(
-        Role.USER, 
-        "What's the population of that city?"
-    )
-    
+        Role.USER, "What's the population of that city?")
+
     # Convert to dict format for API using helper function
-    harmony_messages = harmony_messages_to_dicts([
-        user_msg1,
-        assistant_msg1,
-        user_msg2
-    ])
-    
+    harmony_messages = harmony_messages_to_dicts(
+        [user_msg1, assistant_msg1, user_msg2])
+
     # Send request with multiple harmony messages
     response_json = await send_responses_request(
-        server, {
+        server,
+        {
             "model": model_name,
             "input": "",  # Empty input field
             "previous_response_messages": harmony_messages,
@@ -825,21 +829,25 @@ async def test_harmony_library_multi_message_input(client: OpenAI, model_name: s
 
     # Verify all original messages are preserved
     assert len(response.input_messages) >= len(harmony_messages)
-    
+
     # Check that conversation context is maintained
     response_text = ""
     for msg in response.output_messages:
         if "content" in msg and isinstance(msg["content"], list):
             for content_item in msg["content"]:
-                if content_item.get("type") == "text" and "text" in content_item:
+                if content_item.get(
+                        "type") == "text" and "text" in content_item:
                     response_text += content_item["text"].lower()
-    
+
     # Should reference Tokyo or population in the response
-    context_keywords = [kw for kw in ["tokyo", "population", "million", "people", "city"] 
-                       if kw in response_text]
-    
-    assert len(context_keywords) > 0, "Response should maintain conversation context"
-    
+    context_keywords = [
+        kw for kw in ["tokyo", "population", "million", "people", "city"]
+        if kw in response_text
+    ]
+
+    assert len(
+        context_keywords) > 0, "Response should maintain conversation context"
+
     # Verify message structure integrity
     for msg in response.input_messages:
         assert "role" in msg

--- a/tests/entrypoints/openai/test_response_api_harmony_input_output.py
+++ b/tests/entrypoints/openai/test_response_api_harmony_input_output.py
@@ -5,10 +5,185 @@ import httpx
 import pytest
 import pytest_asyncio
 from openai import OpenAI
+from openai_harmony import Message, Role, TextContent
 
 from ...utils import RemoteOpenAIServer
 
 MODEL_NAME = "openai/gpt-oss-20b"
+
+
+def print_conversation(messages: list, title: str = "Conversation", show_all_fields: bool = False):
+    """
+    Pretty print a conversation with colors and formatting.
+    
+    Args:
+        messages: List of harmony message dicts
+        title: Title to display above the conversation
+        show_all_fields: Whether to show channel, recipient, content_type fields
+    """
+    # ANSI color codes
+    COLORS = {
+        'user': '\033[94m',      # Blue
+        'assistant': '\033[92m', # Green  
+        'system': '\033[93m',    # Yellow
+        'developer': '\033[95m', # Magenta
+        'tool': '\033[96m',      # Cyan
+        'reset': '\033[0m',      # Reset
+        'bold': '\033[1m',       # Bold
+        'dim': '\033[2m',        # Dim
+        'header': '\033[97m\033[44m',  # White on blue background
+    }
+    
+    def get_role_color(role: str) -> str:
+        return COLORS.get(role.lower(), '\033[97m')  # Default to white
+    
+    def truncate_text(text: str, max_length: int = 100) -> str:
+        if len(text) <= max_length:
+            return text
+        return text[:max_length-3] + "..."
+    
+    # Print header
+    print(f"\n{COLORS['header']} {title} {COLORS['reset']}")
+    print("=" * (len(title) + 2))
+    
+    if not messages:
+        print(f"{COLORS['dim']}  No messages to display{COLORS['reset']}")
+        return
+    
+    for i, msg in enumerate(messages):
+        role = msg.get('role', 'unknown')
+        role_color = get_role_color(role)
+        
+        # Message header with role
+        print(f"\n{COLORS['bold']}{i+1:2d}.{COLORS['reset']} {role_color}{role.upper()}{COLORS['reset']}", end="")
+        
+        # Show additional fields if requested
+        if show_all_fields:
+            extras = []
+            if msg.get('channel'):
+                extras.append(f"channel={msg['channel']}")
+            if msg.get('recipient'):
+                extras.append(f"recipient={msg['recipient']}")
+            if msg.get('content_type'):
+                extras.append(f"type={msg['content_type']}")
+            if msg.get('name'):
+                extras.append(f"name={msg['name']}")
+                
+            if extras:
+                print(f" {COLORS['dim']}({', '.join(extras)}){COLORS['reset']}", end="")
+        
+        print()  # New line after header
+        
+        # Process content
+        content = msg.get('content', [])
+        if isinstance(content, str):
+            # Handle simple string content
+            print(f"    💬 {content}")
+        elif isinstance(content, list):
+            for j, content_item in enumerate(content):
+                if isinstance(content_item, dict):
+                    content_type = content_item.get('type', 'unknown')
+                    
+                    if content_type == 'text':
+                        text = content_item.get('text', '')
+                        print(f"    💬 {text}")
+                        
+                    elif content_type == 'tool_call':
+                        tool_call = content_item.get('tool_call', {})
+                        tool_type = tool_call.get('type', 'unknown')
+                        tool_id = tool_call.get('id', 'no-id')[:8]  # Show first 8 chars of ID
+                        print(f"    🔧 {COLORS['dim']}TOOL_CALL{COLORS['reset']} {tool_type} (id: {tool_id})")
+                        
+                        # Show tool-specific details
+                        if tool_type == 'code_interpreter':
+                            code_input = tool_call.get('code_interpreter', {}).get('input', '')
+                            if code_input:
+                                preview = truncate_text(code_input.replace('\n', ' '), 80)
+                                print(f"        💻 {COLORS['dim']}{preview}{COLORS['reset']}")
+                        elif tool_type == 'function':
+                            func_name = tool_call.get('function', {}).get('name', 'unknown')
+                            print(f"        ⚡ Function: {func_name}")
+                            
+                    elif content_type == 'tool_result':
+                        tool_result = content_item.get('tool_result', {})
+                        tool_id = tool_result.get('tool_call_id', 'no-id')[:8]
+                        print(f"    📊 {COLORS['dim']}TOOL_RESULT{COLORS['reset']} (id: {tool_id})")
+                        
+                        # Show result content if available
+                        if 'content' in tool_result:
+                            result_content = str(tool_result['content'])
+                            preview = truncate_text(result_content.replace('\n', ' '), 80)
+                            print(f"        📈 {COLORS['dim']}{preview}{COLORS['reset']}")
+                            
+                    elif content_type == 'system_content':
+                        print(f"    🔧 SYSTEM_CONTENT")
+                        
+                    elif content_type == 'developer_content':
+                        instructions = content_item.get('instructions', '')
+                        if instructions:
+                            preview = truncate_text(instructions, 80)
+                            print(f"    👨‍💻 DEVELOPER: {preview}")
+                        else:
+                            print(f"    👨‍💻 DEVELOPER_CONTENT")
+                            
+                    else:
+                        # Unknown content type, show what we can
+                        print(f"    ❓ {content_type.upper()}: {truncate_text(str(content_item), 80)}")
+                else:
+                    print(f"    ❓ {truncate_text(str(content_item), 80)}")
+        else:
+            print(f"    ❓ {COLORS['dim']}Unknown content format{COLORS['reset']}")
+    
+    print()  # Extra line at end
+
+
+def print_response_summary(response, title: str = "Response Summary"):
+    """Print a summary of the response with key metrics."""
+    COLORS = {
+        'header': '\033[97m\033[44m',  # White on blue background
+        'reset': '\033[0m',
+        'green': '\033[92m',
+        'blue': '\033[94m',
+        'yellow': '\033[93m',
+        'dim': '\033[2m',
+    }
+    
+    print(f"\n{COLORS['header']} {title} {COLORS['reset']}")
+    print("-" * (len(title) + 2))
+    
+    print(f"📊 Status: {COLORS['green']}{response.status}{COLORS['reset']}")
+    print(f"📥 Input messages: {COLORS['blue']}{len(response.input_messages)}{COLORS['reset']}")
+    print(f"📤 Output messages: {COLORS['blue']}{len(response.output_messages)}{COLORS['reset']}")
+    
+    # Count channels in output messages
+    channels = {}
+    tool_calls = 0
+    tool_results = 0
+    
+    for msg in response.output_messages:
+        channel = msg.get('channel')
+        if channel:
+            channels[channel] = channels.get(channel, 0) + 1
+            
+        # Count tool calls and results
+        if 'content' in msg and isinstance(msg['content'], list):
+            for content_item in msg['content']:
+                if isinstance(content_item, dict):
+                    if content_item.get('type') == 'tool_call':
+                        tool_calls += 1
+                    elif content_item.get('type') == 'tool_result':
+                        tool_results += 1
+    
+    if channels:
+        print(f"📡 Channels: {COLORS['yellow']}{', '.join(f'{ch}({ct})' for ch, ct in channels.items())}{COLORS['reset']}")
+    
+    if tool_calls > 0:
+        print(f"🔧 Tool calls: {COLORS['yellow']}{tool_calls}{COLORS['reset']}")
+    
+    if tool_results > 0:
+        print(f"📊 Tool results: {COLORS['yellow']}{tool_results}{COLORS['reset']}")
+    
+    print()
 
 
 @pytest.fixture(scope="module")
@@ -24,8 +199,6 @@ def server(monkeypatch_module: pytest.MonkeyPatch):
     args = ["--enforce-eager", "--tool-server", "demo"]
 
     with monkeypatch_module.context() as m:
-        m.setenv("VLLM_ENABLE_RESPONSES_API_STORE", "1")
-        m.setenv("VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT", "1")
         with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
             yield remote_server
 
@@ -36,8 +209,8 @@ async def client(server):
         yield async_client
 
 
-async def send_harmony_request(server, data: dict) -> dict:
-    """Helper function to send requests with harmony messages using HTTP."""
+async def send_responses_request(server, data: dict) -> dict:
+    """Helper function to send requests using HTTP."""
     async with httpx.AsyncClient(timeout=120.0) as http_client:
         response = await http_client.post(
             f"{server.url_root}/v1/responses",
@@ -48,13 +221,13 @@ async def send_harmony_request(server, data: dict) -> dict:
         return response.json()
 
 
-class HarmonyResponse:
+class ResponsesApiResponse:
     """Helper class to make HTTP response look like OpenAI client response."""
 
     def __init__(self, data: dict):
         self.status = data["status"]
-        self.input_harmony_messages = data.get("input_harmony_messages", [])
-        self.output_harmony_messages = data.get("output_harmony_messages", [])
+        self.input_messages = data.get("input_messages", [])
+        self.output_messages = data.get("output_messages", [])
         self.id = data.get("id")
 
 
@@ -63,6 +236,13 @@ class HarmonyResponse:
 async def test_harmony_message_deserialization(client: OpenAI, model_name: str,
                                                server):
     """Test that harmony messages can be properly deserialized from JSON."""
+    
+    print("\n" + "="*80)
+    print("🧪 TEST: Harmony Message Deserialization")
+    print("="*80)
+    print("📋 Purpose: Test that harmony messages can be properly deserialized from JSON")
+    print("📥 Input: Previous conversation about France + follow-up question")
+    print("📤 Expected: Messages properly deserialized with correct structure")
 
     # Create some harmony messages manually (as they would come from a client)
     previous_harmony_messages = [{
@@ -93,27 +273,37 @@ async def test_harmony_message_deserialization(client: OpenAI, model_name: str,
         None
     }]
 
+    print(f"📨 Sending request with {len(previous_harmony_messages)} previous messages")
+    print(f"💬 New input: 'Tell me more about that city.'")
+
     # Use direct HTTP request since OpenAI client doesn't support custom params
-    response_json = await send_harmony_request(
+    response_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "Tell me more about that city.",
             "instructions": "Use the previous conversation context.",
-            "previous_response_harmony_messages": previous_harmony_messages
+            "previous_response_messages": previous_harmony_messages,
+            "enable_response_messages": True
         })
 
-    response = HarmonyResponse(response_json)
+    response = ResponsesApiResponse(response_json)
 
     assert response is not None
     assert response.status == "completed"
+    
+    print(f"✅ Response status: {response.status}")
 
     # Verify the response includes both the previous and new messages
-    all_messages = (response.input_harmony_messages +
-                    response.output_harmony_messages)
+    all_messages = (response.input_messages +
+                    response.output_messages)
+
+    print(f"📊 Total messages in response: {len(all_messages)}")
+    print(f"   - Input messages: {len(response.input_messages)}")
+    print(f"   - Output messages: {len(response.output_messages)}")
 
     # Verify that all messages have proper serialization
-    all_messages = (response.input_harmony_messages +
-                    response.output_harmony_messages)
+    all_messages = (response.input_messages +
+                    response.output_messages)
     for msg in all_messages:
         assert "role" in msg
         assert "content" in msg
@@ -123,6 +313,9 @@ async def test_harmony_message_deserialization(client: OpenAI, model_name: str,
         for content_item in msg["content"]:
             assert isinstance(content_item, dict)
             assert len(content_item) > 0  # Should not be empty {}
+    
+    print("✅ All messages have proper structure (role, content, non-empty objects)")
+    print("🎉 Test PASSED: Messages deserialized correctly!")
 
 
 @pytest.mark.asyncio
@@ -131,39 +324,44 @@ async def test_harmony_message_round_trip(client: OpenAI, model_name: str,
                                           server):
     """Test full round-trip: get harmony messages from response, send back."""
 
-    # First request using standard OpenAI client
-    response1 = await client.responses.create(
-        model=model_name,
-        input="What is 2 + 2?",
-        instructions="Provide a simple answer.")
+    # First request using HTTP since we need enable_response_messages
+    response1_json = await send_responses_request(
+        server, {
+            "model": model_name,
+            "input": "What is 2 + 2?",
+            "instructions": "Provide a simple answer.",
+            "enable_response_messages": True
+        })
 
+    response1 = ResponsesApiResponse(response1_json)
     assert response1 is not None
     assert response1.status == "completed"
 
     # Extract harmony messages from first response
-    first_input_messages = response1.input_harmony_messages
-    first_output_messages = response1.output_harmony_messages
+    first_input_messages = response1.input_messages
+    first_output_messages = response1.output_messages
 
     # Combine all messages from first conversation
     all_first_messages = first_input_messages + first_output_messages
 
     # Second request using harmony messages from first response - use HTTP
-    response2_json = await send_harmony_request(
+    response2_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "Now what is 3 + 3?",
             "instructions": "Continue the math conversation.",
-            "previous_response_harmony_messages": all_first_messages
+            "previous_response_messages": all_first_messages,
+            "enable_response_messages": True
         })
 
-    response2 = HarmonyResponse(response2_json)
+    response2 = ResponsesApiResponse(response2_json)
 
     assert response2 is not None
     assert response2.status == "completed"
 
     # Verify that second response contains more messages (original + new)
-    second_input_messages = response2.input_harmony_messages
-    second_output_messages = response2.output_harmony_messages
+    second_input_messages = response2.input_messages
+    second_output_messages = response2.output_messages
 
     # Should have at least the messages from the first conversation plus new
     assert len(second_input_messages) > len(first_input_messages)
@@ -193,41 +391,43 @@ async def test_harmony_message_context_continuation(client: OpenAI,
     """Test that harmony messages provide proper context continuation."""
 
     # First establish context with a specific topic
-    response1_json = await send_harmony_request(
+    response1_json = await send_responses_request(
         server, {
             "model": model_name,
             "input":
             "I'm planning a trip to Tokyo. What's the best time to visit?",
-            "instructions": "Provide travel advice."
+            "instructions": "Provide travel advice.",
+            "enable_response_messages": True
         })
 
-    response1 = HarmonyResponse(response1_json)
+    response1 = ResponsesApiResponse(response1_json)
     assert response1.status == "completed"
 
     # Get all messages from the first conversation
-    all_messages = (response1.input_harmony_messages +
-                    response1.output_harmony_messages)
+    all_messages = (response1.input_messages +
+                    response1.output_messages)
 
     # Continue the conversation with a follow-up question
-    response2_json = await send_harmony_request(
+    response2_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "What about food recommendations for that city?",
             "instructions": "Continue helping with travel planning.",
-            "previous_response_harmony_messages": all_messages
+            "previous_response_messages": all_messages,
+            "enable_response_messages": True
         })
 
-    response2 = HarmonyResponse(response2_json)
+    response2 = ResponsesApiResponse(response2_json)
     assert response2.status == "completed"
 
     # Verify context is maintained - should have more messages now
-    assert len(response2.input_harmony_messages) > len(
-        response1.input_harmony_messages)
+    assert len(response2.input_messages) > len(
+        response1.input_messages)
 
     # The conversation should contain references to the original topic
     all_content = []
-    for msg in (response2.input_harmony_messages +
-                response2.output_harmony_messages):
+    for msg in (response2.input_messages +
+                response2.output_messages):
         for content_item in msg["content"]:
             if content_item.get("type") == "text" and "text" in content_item:
                 all_content.append(content_item["text"].lower())
@@ -244,19 +444,20 @@ async def test_harmony_message_empty_list(client: OpenAI, model_name: str,
                                           server):
     """Test that empty harmony messages list works properly."""
 
-    response_json = await send_harmony_request(
+    response_json = await send_responses_request(
         server,
         {
             "model": model_name,
             "input": "What's 5 + 5?",
             "instructions": "Answer the math question.",
-            "previous_response_harmony_messages": []  # Empty list
+            "previous_response_messages": [],  # Empty list
+            "enable_response_messages": True
         })
 
-    response = HarmonyResponse(response_json)
+    response = ResponsesApiResponse(response_json)
     assert response.status == "completed"
-    assert len(response.input_harmony_messages) > 0
-    assert len(response.output_harmony_messages) > 0
+    assert len(response.input_messages) > 0
+    assert len(response.output_messages) > 0
 
 
 @pytest.mark.asyncio
@@ -265,47 +466,349 @@ async def test_harmony_message_none_parameter(client: OpenAI, model_name: str,
                                               server):
     """Test that None harmony messages parameter works (same as omitting)."""
 
-    response_json = await send_harmony_request(
+    response_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "What's 7 + 8?",
             "instructions": "Answer the math question.",
-            "previous_response_harmony_messages": None
+            "previous_response_messages": None,
+            "enable_response_messages": True
         })
 
-    response = HarmonyResponse(response_json)
+    response = ResponsesApiResponse(response_json)
     assert response.status == "completed"
-    assert len(response.input_harmony_messages) > 0
-    assert len(response.output_harmony_messages) > 0
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_harmony_message_validation_error(client: OpenAI,
-                                                model_name: str, server):
-    """Test that malformed harmony messages produce validation errors."""
+async def test_tools_presence_across_requests(client: OpenAI, model_name: str,
+                                              server):
+    """Test that tools are properly handled when present in first request but not second."""
+    
+    print("\n" + "="*80)
+    print("🧪 TEST: Tools Presence Across Requests")
+    print("="*80)
+    print("📋 Purpose: Test tools in first request, no tools in second request")
+    print("📥 Input: First request WITH tools → Second request WITHOUT tools")
+    print("📤 Expected: Second request input_messages have no tool definitions")
+    
+    # First request with tools defined
+    print("📨 STEP 1: Sending request WITH code_interpreter tool")
+    print("💬 Input: 'Calculate 25 + 17 using Python.'")
+    
+    response1_json = await send_responses_request(
+        server, {
+            "model": model_name,
+            "input": "Calculate 25 + 17 using Python.",
+            "tools": [{
+                "type": "code_interpreter",
+                "container": {
+                    "type": "auto"
+                }
+            }],
+            "enable_response_messages": True
+        })
 
-    # Test with invalid harmony message structure
-    invalid_harmony_messages = [{
-        "role": "user",
-        # Missing required "content" field
-        "channel": None,
-        "recipient": None,
-        "content_type": None
-    }]
+    response1 = ResponsesApiResponse(response1_json)
+    assert response1.status == "completed"
+    assert len(response1.input_messages) > 0
+    assert len(response1.output_messages) > 0
 
-    async with httpx.AsyncClient(timeout=120.0) as http_client:
-        response = await http_client.post(
-            f"{server.url_root}/v1/responses",
-            json={
-                "model": model_name,
-                "input": "Hello",
-                "previous_response_harmony_messages": invalid_harmony_messages
-            },
-            headers={"Authorization": f"Bearer {server.DUMMY_API_KEY}"})
+    print(f"✅ First response status: {response1.status}")
+    print(f"📊 First response messages: {len(response1.input_messages)} input, {len(response1.output_messages)} output")
 
-        # Should get an error (4xx or 5xx status code due to missing content)
-        assert response.status_code >= 400
+    # Get all messages from first response
+    all_messages_1 = response1.input_messages + response1.output_messages
+
+    # Second request with NO tools defined, but using messages from first request
+    print("📨 STEP 2: Sending request WITHOUT tools (using previous messages)")
+    print("💬 Input: 'What was that calculation result again?'")
+    
+    response2_json = await send_responses_request(
+        server, {
+            "model": model_name,
+            "input": "What was that calculation result again?",
+            "instructions": "Use the previous conversation context.",
+            "previous_response_messages": all_messages_1,
+            # Note: explicitly NOT including tools here
+            "enable_response_messages": True
+        })
+
+    response2 = ResponsesApiResponse(response2_json)
+    assert response2.status == "completed"
+    assert len(response2.input_messages) > 0
+    assert len(response2.output_messages) > 0
+
+    print(f"✅ Second response status: {response2.status}")
+    print(f"📊 Second response messages: {len(response2.input_messages)} input, {len(response2.output_messages)} output")
+
+    # Validate that input_messages from second response do not contain tool definitions
+    tool_definitions_found = 0
+    for msg in response2.input_messages:
+        assert "role" in msg
+        assert "content" in msg
+        
+        # Check that there are no tool-related keys in the message structure
+        assert "tools" not in msg
+        assert "tool_calls" not in msg
+        
+        # Check content items don't contain tool definitions
+        if isinstance(msg["content"], list):
+            for content_item in msg["content"]:
+                # Tool definitions should not be present in content
+                if content_item.get("type") == "tool_definition":
+                    tool_definitions_found += 1
+                # But tool_call and tool_result types may still be present from previous conversation
+                # We're specifically checking that new tool definitions aren't added
+
+    print(f"🔍 Validation: Found {tool_definitions_found} tool definitions in second request input")
+    assert tool_definitions_found == 0, "No tool definitions should be in second request input"
+
+    # Verify the second response has more messages (accumulated context)
+    assert len(response2.input_messages) > len(response1.input_messages)
+    
+    print("✅ Context accumulated properly (more messages in second response)")
+    print("🎉 Test PASSED: Tools correctly removed from second request!")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_tools_introduction_in_second_request(client: OpenAI, 
+                                                   model_name: str, server):
+    """Test introducing tools in second request when first had none."""
+    
+    print("\n" + "="*80)
+    print("🧪 TEST: Tools Introduction in Second Request")
+    print("="*80)
+    print("📋 Purpose: Test NO tools in first request, tools in second request")
+    print("📥 Input: First request WITHOUT tools → Second request WITH tools")
+    print("📤 Expected: Tool calls appear in second response output")
+    
+    # First request with NO tools
+    print("📨 STEP 1: Sending request WITHOUT tools")
+    print("💬 Input: 'I need to do a calculation later: 42 + 58.'")
+    
+    response1_json = await send_responses_request(
+        server, {
+            "model": model_name,
+            "input": "I need to do a calculation later: 42 + 58.",
+            "instructions": "Just acknowledge the request for now.",
+            # Note: explicitly NOT including tools here
+            "enable_response_messages": True
+        })
+
+    response1 = ResponsesApiResponse(response1_json)
+    assert response1.status == "completed"
+    assert len(response1.input_messages) > 0
+    assert len(response1.output_messages) > 0
+
+    print(f"✅ First response status: {response1.status}")
+    print(f"📊 First response messages: {len(response1.input_messages)} input, {len(response1.output_messages)} output")
+
+    # Get all messages from first response
+    all_messages_1 = response1.input_messages + response1.output_messages
+
+    # Second request WITH tools defined, using messages from first request
+    print("📨 STEP 2: Sending request WITH code_interpreter tool (using previous messages)")
+    print("💬 Input: 'Now please calculate that addition I mentioned using Python.'")
+    
+    response2_json = await send_responses_request(
+        server, {
+            "model": model_name,
+            "input": "Now please calculate that addition I mentioned using the python tool.",
+            "instructions": "Use the previous conversation context and perform the calculation.",
+            "previous_response_messages": all_messages_1,
+            "tools": [{
+                "type": "code_interpreter",
+                "container": {
+                    "type": "auto"
+                }
+            }],
+            "enable_response_messages": True
+        })
+
+    response2 = ResponsesApiResponse(response2_json)
+    assert response2.status == "completed"
+    assert len(response2.input_messages) > 0
+    assert len(response2.output_messages) > 0
+
+    print_response_summary(response2, "Tool Introduction Response")
+    
+    # Display conversations visually
+    print_conversation(all_messages_1, "📨 First Request (No Tools)")
+    print_conversation(response2.input_messages, "📥 Second Request Input (With Tool Context)")
+    print_conversation(response2.output_messages, "📤 Second Request Output (With Tools)", show_all_fields=True)
+
+    # Check for tool calls or tool results in the output messages
+    has_tool_call = False
+    tool_evidence = []
+    for msg in response2.output_messages:
+        if "content" in msg and isinstance(msg["content"], list):
+            for content_item in msg["content"]:
+                content_type = content_item.get("type", "")
+                # Look for tool-related content types
+                if content_type in ["tool_call", "tool_result", "code_interpreter"]:
+                    has_tool_call = True
+                    tool_evidence.append(f"Found {content_type}")
+                    break
+                # Also check for text content that indicates code execution
+                elif (content_type == "text" and "text" in content_item):
+                    text_content = content_item["text"].lower()
+                    if any(keyword in text_content for keyword in 
+                           ["python", "execute", "calculate", "42", "58", "100"]):
+                        has_tool_call = True
+                        tool_evidence.append(f"Found calculation evidence in text")
+                        break
+        if has_tool_call:
+            break
+
+    print(f"🔍 Tool evidence found: {tool_evidence}")
+
+    # Verify that tool functionality was engaged
+    assert has_tool_call, "Expected tool call or calculation evidence in output messages"
+
+    # Verify the second response has more messages (accumulated context)
+    assert len(response2.input_messages) > len(response1.input_messages)
+
+    # Verify conversation continuity - should reference the original calculation
+    all_content = []
+    for msg in response2.input_messages + response2.output_messages:
+        if "content" in msg and isinstance(msg["content"], list):
+            for content_item in msg["content"]:
+                if content_item.get("type") == "text" and "text" in content_item:
+                    all_content.append(content_item["text"].lower())
+    
+    conversation_text = " ".join(all_content)
+    # Should contain references to the calculation mentioned in first request
+    calculation_refs = [kw for kw in ["42", "58", "calculation", "addition"] if kw in conversation_text]
+    
+    print(f"🔍 Calculation references found: {calculation_refs}")
+    assert len(calculation_refs) > 0, f"Expected calculation references, found: {calculation_refs}"
+    
+    print("✅ Tool functionality engaged and conversation continuity maintained")
+    print("🎉 Test PASSED: Tools successfully introduced in second request!")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_code_interpreter_tool_structure(client: OpenAI, model_name: str, server):
+    """Test code_interpreter tool has correct structure and appears in output_messages with analysis channel."""
+    
+    print("\n" + "="*80)
+    print("🧪 TEST: Code Interpreter Tool Structure")
+    print("="*80)
+    print("📋 Purpose: Test code_interpreter tool structure and channel='analysis'")
+    print("📥 Input: Factorial calculation request with code_interpreter tool")
+    print("📤 Expected: Tool calls in output_messages (not response.output), analysis channel")
+    
+    # Request that should trigger code_interpreter tool usage
+    print("📨 Sending request with code_interpreter tool")
+    print("💬 Input: 'Calculate the factorial of 5 using Python code.'")
+    
+    response_json = await send_responses_request(
+        server, {
+            "model": model_name,
+            "input": "Calculate the factorial of 5 using Python code.",
+            "tools": [{
+                "type": "code_interpreter",
+                "container": {
+                    "type": "auto"
+                }
+            }],
+            "enable_response_messages": True
+        })
+
+    response = ResponsesApiResponse(response_json)
+    assert response.status == "completed"
+    assert len(response.output_messages) > 0
+
+    print(f"✅ Response status: {response.status}")
+    print(f"📊 Output messages: {len(response.output_messages)}")
+
+    # Check that response.output doesn't contain tool calls (they should be in output_messages)
+    response_output = response_json.get("output", [])
+    has_tool_call_in_output = False
+    for item in response_output:
+        if isinstance(item, dict) and item.get("type") == "tool_call":
+            has_tool_call_in_output = True
+            break
+    
+    print(f"🔍 Tool calls in response.output: {has_tool_call_in_output}")
+    
+    # Tool calls should NOT appear in response.output
+    assert not has_tool_call_in_output, "Tool calls should not appear in response.output"
+
+    # Find code_interpreter tool calls in output_messages
+    code_interpreter_calls = []
+    analysis_channel_messages = []
+    
+    for msg in response.output_messages:
+        # Check for analysis channel
+        if msg.get("channel") == "analysis":
+            analysis_channel_messages.append(msg)
+        
+        # Look for code_interpreter tool calls in message content
+        if "content" in msg and isinstance(msg["content"], list):
+            for content_item in msg["content"]:
+                if content_item.get("type") == "tool_call":
+                    # Check if it's a code_interpreter tool call
+                    tool_call = content_item.get("tool_call", {})
+                    if tool_call.get("type") == "code_interpreter":
+                        code_interpreter_calls.append(content_item)
+
+    print(f"🔍 Code interpreter tool calls found: {len(code_interpreter_calls)}")
+    print(f"🔍 Analysis channel messages found: {len(analysis_channel_messages)}")
+
+    # For now, just verify we have analysis channel messages (tool calls may vary by implementation)
+    assert len(analysis_channel_messages) > 0, "Expected messages with channel='analysis'"
+
+    # Validate structure of code_interpreter tool calls if they exist
+    for i, tool_call_item in enumerate(code_interpreter_calls):
+        print(f"📋 Validating tool call #{i+1}")
+        
+        assert tool_call_item["type"] == "tool_call"
+        tool_call = tool_call_item["tool_call"]
+        
+        # Verify it's a code_interpreter type
+        assert tool_call["type"] == "code_interpreter"
+        print(f"   ✅ Type: {tool_call['type']}")
+        
+        # Should have required fields for code_interpreter
+        assert "id" in tool_call
+        assert "code_interpreter" in tool_call
+        print(f"   ✅ Has required fields: id, code_interpreter")
+        
+        code_interpreter = tool_call["code_interpreter"]
+        assert "input" in code_interpreter  # Should have code input
+        
+        # The code should be related to factorial calculation
+        code_input = code_interpreter["input"].lower()
+        factorial_keywords = [kw for kw in ["factorial", "5", "*", "math"] if kw in code_input]
+        
+        print(f"   💻 Code input: {code_interpreter['input'][:50]}...")
+        print(f"   🔍 Factorial keywords found: {factorial_keywords}")
+        
+        assert len(factorial_keywords) > 0, \
+            f"Code should be related to factorial calculation, got: {code_input}"
+
+    # Verify analysis channel messages have proper structure
+    for i, msg in enumerate(analysis_channel_messages):
+        print(f"📋 Validating analysis message #{i+1}")
+        
+        assert msg["channel"] == "analysis"
+        assert "role" in msg
+        assert "content" in msg
+        assert isinstance(msg["content"], list)
+        
+        print(f"   ✅ Channel: {msg['channel']}, Role: {msg['role']}")
+        print(f"   ✅ Content items: {len(msg['content'])}")
+
+    print("✅ All validations passed!")
+    print("   - Tool calls NOT in response.output ✓")
+    print("   - Tool calls in output_messages ✓") 
+    print("   - Analysis channel messages present ✓")
+    print("   - Proper code_interpreter structure ✓")
+    print("🎉 Test PASSED: Code interpreter tool structure validated!")
 
 
 @pytest.mark.asyncio
@@ -315,68 +818,72 @@ async def test_harmony_message_chain_conversation(client: OpenAI,
     """Test chaining multiple requests with harmony messages."""
 
     # Start a conversation
-    response1_json = await send_harmony_request(
+    response1_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "My favorite color is blue.",
-            "instructions": "Remember this information."
+            "instructions": "Remember this information.",
+            "enable_response_messages": True
         })
 
-    response1 = HarmonyResponse(response1_json)
+    response1 = ResponsesApiResponse(response1_json)
     assert response1.status == "completed"
 
     # Continue with context from first response
-    messages_after_1 = (response1.input_harmony_messages +
-                        response1.output_harmony_messages)
+    messages_after_1 = (response1.input_messages +
+                        response1.output_messages)
 
-    response2_json = await send_harmony_request(
+    response2_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "What's my favorite color?",
             "instructions": "Use the previous context.",
-            "previous_response_harmony_messages": messages_after_1
+            "previous_response_messages": messages_after_1,
+            "enable_response_messages": True
         })
 
-    response2 = HarmonyResponse(response2_json)
+    response2 = ResponsesApiResponse(response2_json)
     assert response2.status == "completed"
 
     # Continue with context from second response
-    messages_after_2 = (response2.input_harmony_messages +
-                        response2.output_harmony_messages)
+    messages_after_2 = (response2.input_messages +
+                        response2.output_messages)
 
-    response3_json = await send_harmony_request(
+    response3_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "What about my favorite number? It's 42.",
             "instructions": "Remember this new information too.",
-            "previous_response_harmony_messages": messages_after_2
+            "previous_response_messages": messages_after_2,
+            "enable_response_messages": True
         })
 
-    response3 = HarmonyResponse(response3_json)
+    response3 = ResponsesApiResponse(response3_json)
     assert response3.status == "completed"
 
     # Final request should have context from all previous messages
-    messages_after_3 = (response3.input_harmony_messages +
-                        response3.output_harmony_messages)
+    messages_after_3 = (response3.input_messages +
+                        response3.output_messages)
 
-    response4_json = await send_harmony_request(
+    response4_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "What are my favorite color and number?",
             "instructions": "Recall both pieces of information.",
-            "previous_response_harmony_messages": messages_after_3
+            "previous_response_messages": messages_after_3,
+            "enable_response_messages": True
         })
 
-    response4 = HarmonyResponse(response4_json)
+    response4 = ResponsesApiResponse(response4_json)
     assert response4.status == "completed"
 
     # Verify the conversation has grown with each interaction
-    assert len(response4.input_harmony_messages) > len(
-        response3.input_harmony_messages)
-    assert len(response3.input_harmony_messages) > len(
-        response2.input_harmony_messages)
-    assert len(response2.input_harmony_messages) > len(
-        response1.input_harmony_messages)
+    assert len(response4.input_messages) > len(
+        response3.input_messages)
+    assert len(response3.input_messages) > len(
+        response2.input_messages)
+    assert len(response2.input_messages) > len(
+        response1.input_messages)
 
 
 @pytest.mark.asyncio
@@ -385,7 +892,7 @@ async def test_harmony_message_with_python_tool(client: OpenAI,
                                                 model_name: str, server):
     """Test harmony messages with Python tool usage and context preservation."""
     # First request that should trigger Python tool usage using proper tool spec
-    response1_json = await send_harmony_request(
+    response1_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "Calculate the square root of 144 using Python code.",
@@ -394,19 +901,20 @@ async def test_harmony_message_with_python_tool(client: OpenAI,
                 "container": {
                     "type": "auto"
                 }
-            }]
+            }],
+            "enable_response_messages": True
         })
 
-    response1 = HarmonyResponse(response1_json)
+    response1 = ResponsesApiResponse(response1_json)
     assert response1.status == "completed"
 
     # Verify we have harmony messages from the first response
-    assert len(response1.input_harmony_messages) > 0
-    assert len(response1.output_harmony_messages) > 0
+    assert len(response1.input_messages) > 0
+    assert len(response1.output_messages) > 0
 
     # Look for tool usage in the messages
-    all_messages_1 = (response1.input_harmony_messages +
-                      response1.output_harmony_messages)
+    all_messages_1 = (response1.input_messages +
+                      response1.output_messages)
 
     # Check if any message contains tool calls or tool results
     has_tool_content = False
@@ -424,30 +932,31 @@ async def test_harmony_message_with_python_tool(client: OpenAI,
             break
 
     # Continue conversation with tool context
-    response2_json = await send_harmony_request(
+    response2_json = await send_responses_request(
         server, {
             "model": model_name,
             "input": "Now calculate the square of that result.",
             "instructions": "Use the result from the previous calculation.",
-            "previous_response_harmony_messages": all_messages_1,
+            "previous_response_messages": all_messages_1,
             "tools": [{
                 "type": "code_interpreter",
                 "container": {
                     "type": "auto"
                 }
-            }]
+            }],
+            "enable_response_messages": True
         })
 
-    response2 = HarmonyResponse(response2_json)
+    response2 = ResponsesApiResponse(response2_json)
     assert response2.status == "completed"
 
     # Verify second response has more messages than first (accumulated context)
-    assert len(response2.input_harmony_messages) > len(
-        response1.input_harmony_messages)
+    assert len(response2.input_messages) > len(
+        response1.input_messages)
 
     # Verify all messages maintain proper structure
-    all_messages_2 = (response2.input_harmony_messages +
-                      response2.output_harmony_messages)
+    all_messages_2 = (response2.input_messages +
+                      response2.output_messages)
 
     for msg in all_messages_2:
         assert "role" in msg
@@ -464,255 +973,188 @@ async def test_harmony_message_with_python_tool(client: OpenAI,
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_harmony_tools_serialization_chaining(client: OpenAI,
-                                                    model_name: str, server):
-    """Test that tools in system/developer content are properly serialized
-    and deserialized when chaining requests."""
-    # Create harmony messages with system content containing tools
-    system_content_with_tools = {
-        "role":
-        "system",
-        "content": [{
-            "type": "system_content",
-            "model_identity":
-            "You are a helpful AI assistant with access to tools.",
-            "reasoning_effort": "Medium",
-            "knowledge_cutoff": "2024-06",
-            "tools": {
-                "python": {
-                    "name":
-                    "python",
-                    "description":
-                    "Execute Python code",
-                    "tools": [{
-                        "name": "execute_python",
-                        "description": "Execute Python code in a sandbox",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string",
-                                    "description": "Python code to execute"
-                                }
-                            },
-                            "required": ["code"]
-                        }
-                    }]
-                },
-                "browser": {
-                    "name":
-                    "browser",
-                    "description":
-                    "Browse the web",
-                    "tools": [{
-                        "name": "search_web",
-                        "description": "Search the web for information",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "query": {
-                                    "type": "string",
-                                    "description": "Search query"
-                                }
-                            },
-                            "required": ["query"]
-                        }
-                    }]
-                }
-            }
-        }]
-    }
-
-    # Developer content with tools
-    developer_content_with_tools = {
-        "role":
-        "developer",
-        "content": [{
-            "type": "developer_content",
-            "instructions": "Use the available tools to help the user.",
-            "tools": {
-                "functions": {
-                    "name":
-                    "functions",
-                    "description":
-                    "Custom functions available to the assistant",
-                    "tools": [{
-                        "name": "calculate_area",
-                        "description": "Calculate area of geometric shapes",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "shape": {
-                                    "type": "string",
-                                    "enum":
-                                    ["circle", "rectangle", "triangle"]
-                                },
-                                "dimensions": {
-                                    "type": "object",
-                                    "description": "Shape-specific dimensions"
-                                }
-                            },
-                            "required": ["shape", "dimensions"]
-                        }
-                    }]
-                }
-            }
-        }]
-    }
-
-    # First request with harmony messages containing tools
-    initial_harmony_messages = [
-        system_content_with_tools, developer_content_with_tools, {
-            "role":
-            "user",
-            "content": [{
-                "type":
-                "text",
-                "text":
-                "I need to calculate the area of a circle with radius 5."
-            }]
-        }
-    ]
-
-    response1_json = await send_harmony_request(
+async def test_harmony_library_input_messages(client: OpenAI, model_name: str, server):
+    """Test using harmony library to create messages and send via input_messages instead of input."""
+    
+    print("\n" + "="*80)
+    print("🧪 TEST: Harmony Library Input Messages")
+    print("="*80)
+    print("📋 Purpose: Use harmony library to create messages, send via input_messages")
+    print("📥 Input: Empty 'input' field, populated 'input_messages' with harmony messages")
+    print("📤 Expected: Server processes harmony messages correctly without 'input'")
+    
+    # Create harmony messages using the library
+    user_message = Message.from_role_and_content(
+        Role.USER, 
+        "Hello! Can you help me understand how Python functions work?"
+    )
+    
+    print("📨 Creating harmony messages using library:")
+    print(f"   - Message role: {user_message.author.role}")
+    print(f"   - Message content type: {type(user_message.content[0])}")
+    print(f"   - Message text: '{user_message.content[0].text[:50]}...'")
+    
+    # Convert to dict format for API
+    harmony_messages = [user_message.to_dict()]
+    
+    print(f"📨 Sending request with harmony input_messages (empty input)")
+    print(f"   - input: '' (empty)")
+    print(f"   - input_messages: {len(harmony_messages)} harmony messages")
+    
+    # Send request with harmony messages in input_messages and empty input
+    response_json = await send_responses_request(
         server, {
             "model": model_name,
-            "input": "Please help me with this calculation.",
-            "instructions": "Use the available tools as needed.",
-            "previous_response_harmony_messages": initial_harmony_messages
+            "input": "",  # Empty input field
+            "input_messages": harmony_messages,  # Using input_messages instead
+            "instructions": "Provide a helpful explanation about Python functions.",
+            "enable_response_messages": True
         })
 
-    response1 = HarmonyResponse(response1_json)
-    assert response1.status == "completed"
+    response = ResponsesApiResponse(response_json)
+    assert response.status == "completed"
+    
+    print_response_summary(response, "Single Harmony Message Response")
+    
+    # Display the conversation visually
+    print_conversation(harmony_messages, "📨 Original Harmony Input")
+    print_conversation(response.input_messages, "📥 Server Input Messages")
+    print_conversation(response.output_messages, "📤 Server Output Messages", show_all_fields=True)
 
-    # Extract harmony messages from first response
-    all_messages_1 = (response1.input_harmony_messages +
-                      response1.output_harmony_messages)
-
-    # Verify tools are preserved in system content
-    system_tools_found = False
-    developer_tools_found = False
-
-    for msg in all_messages_1:
-        if msg.get("role") == "system" and "content" in msg:
+    # Verify the harmony message was processed correctly
+    assert len(response.input_messages) > 0
+    assert len(response.output_messages) > 0
+    
+    # Check that our original harmony message is in the input_messages
+    found_original_message = False
+    for msg in response.input_messages:
+        if (msg.get("role") == "user" and 
+            "content" in msg and 
+            isinstance(msg["content"], list)):
             for content_item in msg["content"]:
-                if (content_item.get("type") == "system_content"
-                        and "tools" in content_item):
-                    tools = content_item["tools"]
-                    assert isinstance(tools, dict)
-                    # Verify python and browser tools are present
-                    if "python" in tools and "browser" in tools:
-                        system_tools_found = True
-                        # Verify structure is intact
-                        python_tool = tools["python"]
-                        assert isinstance(python_tool, dict)
-                        assert python_tool.get("name") == "python"
-                        assert "tools" in python_tool
-                        assert len(python_tool["tools"]) > 0
-
-        if msg.get("role") == "developer" and "content" in msg:
-            for content_item in msg["content"]:
-                if (content_item.get("type") == "developer_content"
-                        and "tools" in content_item):
-                    tools = content_item["tools"]
-                    assert isinstance(tools, dict)
-                    # Verify functions tool is present
-                    if "functions" in tools:
-                        developer_tools_found = True
-                        functions_tool = tools["functions"]
-                        assert isinstance(functions_tool, dict)
-                        assert functions_tool.get("name") == "functions"
-                        assert "tools" in functions_tool
-                        assert len(functions_tool["tools"]) > 0
-
-    # At least one should be found (tools are preserved)
-    assert system_tools_found or developer_tools_found, (
-        "Tools should be preserved in serialized harmony messages")
-
-    # Second request using messages from first response (should maintain tools)
-    response2_json = await send_harmony_request(
-        server, {
-            "model": model_name,
-            "input":
-            "Now calculate the area of a rectangle with width 3 and height 4.",
-            "instructions": "Continue using the available tools.",
-            "previous_response_harmony_messages": all_messages_1
-        })
-
-    response2 = HarmonyResponse(response2_json)
-    assert response2.status == "completed"
-
-    # Extract harmony messages from second response
-    all_messages_2 = (response2.input_harmony_messages +
-                      response2.output_harmony_messages)
-
-    # Verify tools are still preserved after second round-trip
-    system_tools_found_2 = False
-    developer_tools_found_2 = False
-
-    for msg in all_messages_2:
-        if msg.get("role") == "system" and "content" in msg:
-            for content_item in msg["content"]:
-                if (content_item.get("type") == "system_content"
-                        and "tools" in content_item):
-                    tools = content_item["tools"]
-                    if isinstance(tools, dict) and "python" in tools:
-                        system_tools_found_2 = True
-
-        if msg.get("role") == "developer" and "content" in msg:
-            for content_item in msg["content"]:
-                if (content_item.get("type") == "developer_content"
-                        and "tools" in content_item):
-                    tools = content_item["tools"]
-                    if isinstance(tools, dict) and "functions" in tools:
-                        developer_tools_found_2 = True
-
-    # Tools should still be preserved after chaining
-    assert system_tools_found_2 or developer_tools_found_2, (
-        "Tools should be preserved after chaining requests")
-
-    # Third request - test longer chain to ensure robustness
-    response3_json = await send_harmony_request(
-        server, {
-            "model":
-            model_name,
-            "input": ("Finally, calculate the area of a triangle with "
-                      "base 6 and height 8."),
-            "instructions":
-            "Use the calculation tools for this final request.",
-            "previous_response_harmony_messages":
-            all_messages_2
-        })
-
-    response3 = HarmonyResponse(response3_json)
-    assert response3.status == "completed"
-
-    # Verify conversation has grown and tools are maintained
-    all_messages_3 = (response3.input_harmony_messages +
-                      response3.output_harmony_messages)
-
-    assert len(all_messages_3) > len(all_messages_2) > len(all_messages_1)
-
-    # Final verification that tools are still intact
-    final_tools_found = False
-    for msg in all_messages_3:
+                if (content_item.get("type") == "text" and 
+                    "python functions" in content_item.get("text", "").lower()):
+                    found_original_message = True
+                    break
+        if found_original_message:
+            break
+    
+    print(f"🔍 Original harmony message found in input_messages: {found_original_message}")
+    assert found_original_message, "Original harmony message should be preserved in input_messages"
+    
+    # Verify response contains relevant content about Python functions
+    response_text = ""
+    for msg in response.output_messages:
         if "content" in msg and isinstance(msg["content"], list):
             for content_item in msg["content"]:
-                if (content_item.get("type")
-                        in ["system_content", "developer_content"]
-                        and "tools" in content_item):
-                    tools = content_item["tools"]
-                    if isinstance(tools, dict) and len(tools) > 0:
-                        final_tools_found = True
-                        # Verify at least one tool has proper structure
-                        for tool_name, tool_config in tools.items():
-                            assert isinstance(tool_config, dict)
-                            assert "name" in tool_config
-                            assert tool_config["name"] == tool_name
-                            break
-                        break
-        if final_tools_found:
-            break
+                if content_item.get("type") == "text" and "text" in content_item:
+                    response_text += content_item["text"].lower()
+    
+    python_keywords_found = [kw for kw in ["function", "python", "def", "return"] 
+                            if kw in response_text]
+    
+    print(f"🔍 Python-related keywords in response: {python_keywords_found}")
+    assert len(python_keywords_found) > 0, "Response should contain Python function information"
+    
+    print("✅ All validations passed!")
+    print("   - Empty input field processed correctly ✓")
+    print("   - Harmony input_messages processed ✓")
+    print("   - Original message preserved ✓")
+    print("   - Relevant response generated ✓")
+    print("🎉 Test PASSED: Harmony library messages work via input_messages!")
 
-    assert final_tools_found, (
-        "Tools should be preserved through the entire chain")
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_harmony_library_multi_message_input(client: OpenAI, model_name: str, server):
+    """Test using harmony library to create multiple messages via input_messages."""
+    
+    print("\n" + "="*80)
+    print("🧪 TEST: Harmony Library Multi-Message Input")
+    print("="*80)
+    print("📋 Purpose: Send multiple harmony messages via input_messages (conversation)")
+    print("📥 Input: Empty 'input', multiple harmony messages in input_messages")
+    print("📤 Expected: Multi-turn conversation processed correctly")
+    
+    # Create a conversation using harmony library
+    user_msg1 = Message.from_role_and_content(
+        Role.USER, 
+        "What's the capital of Japan?"
+    )
+    
+    assistant_msg1 = Message.from_role_and_content(
+        Role.ASSISTANT, 
+        "The capital of Japan is Tokyo."
+    )
+    
+    user_msg2 = Message.from_role_and_content(
+        Role.USER, 
+        "What's the population of that city?"
+    )
+    
+    print("📨 Creating multi-message conversation using harmony library:")
+    print(f"   - User message 1: '{user_msg1.content[0].text}'")
+    print(f"   - Assistant message 1: '{assistant_msg1.content[0].text}'")
+    print(f"   - User message 2: '{user_msg2.content[0].text}'")
+    
+    # Convert to dict format for API
+    harmony_messages = [
+        user_msg1.to_dict(),
+        assistant_msg1.to_dict(),
+        user_msg2.to_dict()
+    ]
+    
+    print(f"📨 Sending request with {len(harmony_messages)} harmony input_messages")
+    
+    # Send request with multiple harmony messages
+    response_json = await send_responses_request(
+        server, {
+            "model": model_name,
+            "input": "",  # Empty input field
+            "input_messages": harmony_messages,
+            "instructions": "Continue the conversation about Tokyo.",
+            "enable_response_messages": True
+        })
+
+    response = ResponsesApiResponse(response_json)
+    assert response.status == "completed"
+    
+    print_response_summary(response, "Multi-Message Harmony Response")
+    
+    # Display the conversations visually
+    print_conversation(harmony_messages, "📨 Original Multi-Message Harmony Input")
+    print_conversation(response.input_messages, "📥 Server Input Messages")  
+    print_conversation(response.output_messages, "📤 Server Output Messages", show_all_fields=True)
+
+    # Verify all original messages are preserved
+    assert len(response.input_messages) >= len(harmony_messages)
+    
+    # Check that conversation context is maintained
+    response_text = ""
+    for msg in response.output_messages:
+        if "content" in msg and isinstance(msg["content"], list):
+            for content_item in msg["content"]:
+                if content_item.get("type") == "text" and "text" in content_item:
+                    response_text += content_item["text"].lower()
+    
+    # Should reference Tokyo or population in the response
+    context_keywords = [kw for kw in ["tokyo", "population", "million", "people", "city"] 
+                       if kw in response_text]
+    
+    print(f"🔍 Context keywords found in response: {context_keywords}")
+    assert len(context_keywords) > 0, "Response should maintain conversation context"
+    
+    # Verify message structure integrity
+    for msg in response.input_messages:
+        assert "role" in msg
+        assert "content" in msg
+        assert isinstance(msg["content"], list)
+        for content_item in msg["content"]:
+            assert isinstance(content_item, dict)
+            assert len(content_item) > 0
+    
+    print("✅ All validations passed!")
+    print("   - Multiple harmony messages processed ✓")
+    print("   - Conversation context maintained ✓")
+    print("   - Message structure preserved ✓")
+    print("🎉 Test PASSED: Multi-message harmony input works correctly!")

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -254,6 +254,25 @@ ChatCompletionMessageParam = Union[
     OpenAIHarmonyMessage,
 ]
 
+def chat_completion_message_param_to_dict(
+    param: ChatCompletionMessageParam
+) -> dict[str, Any]:
+    if isinstance(param, OpenAIHarmonyMessage):
+        out = param.to_dict()
+        out["type"] = "harmony"
+        return out
+    elif isinstance(param, dict):
+        return dict(param)
+    else:
+        raise ValueError(f"Unknown message param type: {type(param)}")
+
+def chat_completion_message_param_from_dict(
+    param: dict[str, Any]
+) -> ChatCompletionMessageParam:
+    if param.get("type", None) == "harmony":
+        return OpenAIHarmonyMessage.from_dict(param)
+    else:
+        return cast(ChatCompletionMessageParam, param)
 
 # TODO: Make fields ReadOnly once mypy supports it
 class ConversationMessage(TypedDict, total=False):

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -101,6 +101,7 @@ class HarmonyContext(ConversationContext):
         available_tools: list[str],
     ):
         self._messages = messages
+        self.input_messages = messages.copy()
         self.available_tools = available_tools
         self._tool_sessions: dict[str, Union[ClientSession, Tool]] = {}
 

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -111,7 +111,6 @@ def get_developer_message(
 def get_user_message(content: str) -> Message:
     return Message.from_role_and_content(Role.USER, content)
 
-
 def parse_response_input(
     response_msg: ResponseInputOutputItem,
     prev_responses: list[Union[ResponseOutputItem, ResponseReasoningItem]]
@@ -213,7 +212,7 @@ def render_for_completion(messages: list[Message]) -> list[int]:
     return token_ids
 
 
-def parse_output_message(message: Message) -> list[ResponseOutputItem]:
+def convert_harmony_message_to_output_item(message: Message) -> list[ResponseOutputItem]:
     """
     Parse a Harmony message into a list of output response items.
     """
@@ -315,7 +314,7 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
     return output_items
 
 
-def parse_remaining_state(
+def parse_remaining_state_into_output_items(
         parser: StreamableParser) -> list[ResponseOutputItem]:
     if not parser.current_content:
         return []

--- a/vllm/entrypoints/openai/logprobs_utils.py
+++ b/vllm/entrypoints/openai/logprobs_utils.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Utility functions for converting vLLM logprobs to OpenAI formats."""
+
+from collections.abc import Sequence
+from typing import Optional
+
+from openai.types.responses.response_output_text import (Logprob,
+                                                         LogprobTopLogprob)
+from openai.types.responses import response_text_delta_event
+
+from vllm.logprobs import Logprob as SampleLogprob
+from vllm.logprobs import SampleLogprobs
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+
+
+def _topk_logprobs(logprobs: dict[int, SampleLogprob], top_logprobs: int,
+                   tokenizer: AnyTokenizer) -> list[LogprobTopLogprob]:
+    """Returns the top-k logprobs from the logprobs dictionary."""
+    out = []
+    for i, (token_id, _logprob) in enumerate(logprobs.items()):
+        if i >= top_logprobs:
+            break
+        text = _logprob.decoded_token if _logprob.decoded_token \
+            is not None else tokenizer.decode([token_id])
+        out.append(
+            LogprobTopLogprob(
+                token=text,
+                logprob=max(_logprob.logprob, -9999.0),
+                bytes=list(text.encode("utf-8", errors="replace")),
+            ))
+    return out
+
+
+def create_stream_response_logprobs(
+        token_ids: Sequence[int],
+        logprobs: Optional[SampleLogprobs],
+        tokenizer: AnyTokenizer,
+        top_logprobs: Optional[int] = None
+) -> list[response_text_delta_event.Logprob]:
+    """Create streaming response logprobs for OpenAI Responses API."""
+    lgs = create_response_logprobs(token_ids=token_ids,
+                                   logprobs=logprobs,
+                                   tokenizer=tokenizer,
+                                   top_logprobs=top_logprobs)
+    return [
+        response_text_delta_event.Logprob(
+            token=lg.token,
+            logprob=lg.logprob,
+            top_logprobs=[
+                response_text_delta_event.LogprobTopLogprob(
+                    token=tl.token, logprob=tl.logprob)
+                for tl in lg.top_logprobs
+            ]) for lg in lgs
+    ]
+
+
+def create_response_logprobs(
+        token_ids: Sequence[int],
+        logprobs: Optional[SampleLogprobs],
+        tokenizer: AnyTokenizer,
+        top_logprobs: Optional[int] = None) -> list[Logprob]:
+    assert logprobs is not None, "logprobs must be provided"
+    assert len(token_ids) == len(logprobs), (
+        "token_ids and logprobs.token_ids must have the same length")
+    out = []
+    for i, token_id in enumerate(token_ids):
+        logprob = logprobs[i]
+        token_logprob = logprob[token_id]
+        text = token_logprob.decoded_token if token_logprob.decoded_token \
+            is not None else tokenizer.decode([token_id])
+        out.append(
+            Logprob(
+                token=text,
+                logprob=max(token_logprob.logprob, -9999.0),
+                bytes=list(text.encode("utf-8", errors="replace")),
+                top_logprobs=_topk_logprobs(logprob,
+                                            top_logprobs=top_logprobs,
+                                            tokenizer=tokenizer)
+                if top_logprobs else [],
+            ))
+    return out

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -168,6 +168,7 @@ if TYPE_CHECKING:
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = False
     VLLM_TUNED_CONFIG_FOLDER: Optional[str] = None
     VLLM_DISABLE_PAD_FOR_CUDAGRAPH: bool = False
+    VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
 
 
@@ -1201,6 +1202,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_TUNED_CONFIG_FOLDER":
     lambda: os.getenv("VLLM_TUNED_CONFIG_FOLDER", None),
 
+    # Whether to enable outputting Harmony messages on the
+    # Responses API response object
+    "VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT":
+    lambda: bool(int(
+        os.getenv("VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT",
+        "0"))),
     # Add optional custom scopes for profiling, disable to avoid overheads
     "VLLM_CUSTOM_SCOPES_FOR_PROFILING":
     lambda: bool(int(os.getenv("VLLM_CUSTOM_SCOPES_FOR_PROFILING", "0"))),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -168,7 +168,6 @@ if TYPE_CHECKING:
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = False
     VLLM_TUNED_CONFIG_FOLDER: Optional[str] = None
     VLLM_DISABLE_PAD_FOR_CUDAGRAPH: bool = False
-    VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
 
 
@@ -1202,12 +1201,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_TUNED_CONFIG_FOLDER":
     lambda: os.getenv("VLLM_TUNED_CONFIG_FOLDER", None),
 
-    # Whether to enable outputting Harmony messages on the
-    # Responses API response object
-    "VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT":
-    lambda: bool(int(
-        os.getenv("VLLM_RESPONSES_API_ENABLE_HARMONY_MESSAGES_OUTPUT",
-        "0"))),
     # Add optional custom scopes for profiling, disable to avoid overheads
     "VLLM_CUSTOM_SCOPES_FOR_PROFILING":
     lambda: bool(int(os.getenv("VLLM_CUSTOM_SCOPES_FOR_PROFILING", "0"))),


### PR DESCRIPTION
## Purpose
In order for the Responses API to have full functionality when not using the Responses Store and Messages Store, we must allow users to store the messages client side. 

In order to support this, this PR adds Harmony Messages as additional output to the Responses API, and accepts Harmony messages as input to the Responses API.

Harmony messages used as input replicates the functionality of continuing a conversation the same way the Messages Store works.

## Test Plan
Tested with Unit tests + serving locally
## Test Result
Passed
