### PR TITLE
[Bugfix] add masking logits using vocab size to prevent OverflowError while detokenization

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -218,8 +218,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
             if tokenizer is not None and self.vocab_size > len(tokenizer):
                 logger.warning(
-                    f"Model vocab size({self.vocab_size}) > "
-                    f"Tokenizer vocab size({len(tokenizer)})!")
+                    "Model vocab size > Tokenizer vocab size!")
                 self.vocab_size = len(tokenizer)
 
         # Sampler

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -215,11 +215,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             tokenizer_name=model_config.tokenizer,
             trust_remote_code=model_config.trust_remote_code,
         )
-        if tokenizer != None and self.vocab_size > tokenizer.vocab_size:
+        if tokenizer is not None and self.vocab_size > len(tokenizer):
             logger.warning(
                 f"Model vocab size({self.vocab_size}) > "
-                f"Tokenizer vocab size({tokenizer.vocab_size})!")
-            self.vocab_size = tokenizer.vocab_size
+                f"Tokenizer vocab size({len(tokenizer)})!")
+            self.vocab_size = len(tokenizer)
 
         # Sampler
         self.sampler = Sampler(logprobs_mode=self.model_config.logprobs_mode)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -212,10 +212,15 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Get valid vocab size
         self.vocab_size = self.model_config.get_vocab_size()
         if not self.is_pooling_model:
-            tokenizer = get_tokenizer(
-                tokenizer_name=model_config.tokenizer,
-                trust_remote_code=model_config.trust_remote_code,
-            )
+            tokenizer = None
+            try:
+                tokenizer = get_tokenizer(
+                    tokenizer_name=model_config.tokenizer,
+                    trust_remote_code=model_config.trust_remote_code,
+                )
+            except Exception:
+                logger.warning("Failed to get tokenizer")
+
             if tokenizer is not None and self.vocab_size > len(tokenizer):
                 logger.warning("Model vocab size > Tokenizer vocab size!")
                 self.vocab_size = len(tokenizer)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -210,8 +210,8 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             model_config)
 
         # Get valid vocab size
+        self.vocab_size = self.model_config.get_vocab_size()
         if not self.is_pooling_model:
-            self.vocab_size = self.model_config.get_vocab_size()
             tokenizer = get_tokenizer(
                 tokenizer_name=model_config.tokenizer,
                 trust_remote_code=model_config.trust_remote_code,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1982,7 +1982,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if not self.is_pooling_model:
                 logits = self.apply_vocab_size(self.vocab_size, logits)
 
-
         with record_function_or_nullcontext("Sample"):
             sampler_output = self._sample(logits, spec_decode_metadata)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR is to fix the issue: https://github.com/vllm-project/vllm/issues/24211

This error occurs when the generated token ID is not present in the vocabulary.
To investigate why this issue occurs, I checked the lm_head dimension and vocabulary size of DeepSeek-R1.
In config.json, vocab_size is set to 129280,
but in tokenizer_config.json, the largest token ID is 118814.
I know the model was trained only on datasets with token IDs ≤ 118814, and IDs ≥ 118815 would never be generated via greedy decoding.
However, there appears to be space for extra tokens in lm_head, and while the probability is very low, it seems tokens that shouldn't be generated during sampling are occasionally produced.

So I added the logic applying masking logits to ensure next token ID is less then min(model vocab_size, tokenizer's vocab_size)

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

