### PR TITLE
[V1] add generate optional in health api

### DIFF
--- a/tests/entrypoints/openai/test_health.py
+++ b/tests/entrypoints/openai/test_health.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import threading
+import time
+from http import HTTPStatus
+
+import pytest
+import requests
+
+from tests.utils import RemoteOpenAIServer
+
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+
+
+@pytest.fixture(scope="class")
+def server():
+    args = [
+        "--enforce-eager", "--max-model-len", "100",
+        "--gpu-memory-utilization", "0.8"
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+class TestHealth:
+
+    def test_health_basic(self, server: RemoteOpenAIServer):
+        """Test basic health check endpoint."""
+        response = requests.get(server.url_for("health"))
+        assert response.status_code == HTTPStatus.OK
+
+    def test_health_with_generate(self, server: RemoteOpenAIServer):
+        """Test health check with generate parameter."""
+        response = requests.get(server.url_for("health"),
+                                params={"generate": "true"})
+        assert response.status_code == HTTPStatus.OK
+
+    def test_health_with_running_query(self, server: RemoteOpenAIServer):
+        generation_errors: list[Exception] = []
+        start_event = threading.Event()
+        done_event = threading.Event()
+
+        def _run_generate() -> None:
+            try:
+                client = server.get_client()
+                start_event.set()
+                client.completions.create(
+                    model=MODEL_NAME,
+                    prompt="Ping health endpoint",
+                    max_tokens=50,
+                    temperature=0.0,
+                )
+            except Exception as e:
+                generation_errors.append(e)
+            finally:
+                done_event.set()
+
+        generate_thread = threading.Thread(target=_run_generate, daemon=True)
+        generate_thread.start()
+
+        time.sleep(1)  # Ensure the generation has started
+        response = requests.get(server.url_for("health"),
+                                params={"generate": "true"})
+        assert response.status_code == HTTPStatus.OK
+
+        assert start_event.wait(
+            timeout=10), "Generation thread failed to start"
+        assert done_event.wait(timeout=300), "Generation thread did not finish"
+        generate_thread.join(timeout=0)
+        if generation_errors:
+            raise generation_errors[0]

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -64,7 +64,7 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
-    def minimal_generation(self) -> str:
+    async def minimal_generation(self) -> str:
         """Generate outputs for a minimal spec prompt"""
         ...
 

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -64,6 +64,11 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    def minimal_generation(self) -> str:
+        """Generate outputs for a minimal spec prompt"""
+        ...
+
+    @abstractmethod
     def encode(
         self,
         prompt: PromptType,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -109,8 +109,6 @@ from vllm.entrypoints.utils import (
 )
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
-from vllm.transformers_utils.config import (
-    maybe_register_config_serialize_by_value)
 from vllm.transformers_utils.tokenizer import MistralTokenizer
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import (
@@ -118,8 +116,6 @@ from vllm.utils import (
     FlexibleArgumentParser,
     decorate_logs,
     is_valid_ipv6_address,
-    get_open_zmq_ipc_path,
-    random_uuid, 
     set_ulimit,
 )
 from vllm.v1.engine.exceptions import EngineDeadError

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -31,7 +31,7 @@ from vllm.transformers_utils.tokenizer import AnyTokenizer, init_tokenizer_from_
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import Device, as_list, cdiv
 from vllm.utils.async_utils import cancel_task_threadsafe
-from vllm.utils.func import deprecate_kwargs
+from vllm.utils.func import deprecate_kwargs,random_uuid
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
@@ -772,6 +772,18 @@ class AsyncLLM(EngineClient):
                 engine_idxs=list(range(new_data_parallel_size)),
                 custom_stat_loggers=None,
             )
+
+    async def minimal_generation(self) -> str:
+        prompt = "Hi"
+        sampling_params = SamplingParams(temperature=0, max_tokens=2)
+        request_id = random_uuid()
+        result_text = ""
+        async for output in self.generate(prompt, sampling_params, request_id):
+            for completion in output.outputs:
+                result_text = completion.text
+            if output.finished:
+                break
+        return result_text
 
     @property
     def is_running(self) -> bool:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -774,10 +774,14 @@ class AsyncLLM(EngineClient):
             )
 
     async def minimal_generation(self) -> str:
-        prompt = "Hi"
+        prompt = "Ping"
         sampling_params = SamplingParams(temperature=0, max_tokens=2)
         request_id = random_uuid()
         result_text = ""
+        count = await self.engine_core.get_request_count()
+        num_running_reqs, num_waiting_reqs = count[0], count[1]
+        if num_running_reqs > 0 or num_waiting_reqs > 0:
+            return result_text
         async for output in self.generate(prompt, sampling_params, request_id):
             for completion in output.outputs:
                 result_text = completion.text

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -29,9 +29,9 @@ from vllm.tracing import init_tracer
 from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
 from vllm.transformers_utils.tokenizer import AnyTokenizer, init_tokenizer_from_configs
 from vllm.usage.usage_lib import UsageContext
-from vllm.utils import Device, as_list, cdiv
+from vllm.utils import Device, as_list, cdiv, random_uuid
 from vllm.utils.async_utils import cancel_task_threadsafe
-from vllm.utils.func import deprecate_kwargs,random_uuid
+from vllm.utils.func import deprecate_kwargs
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -499,6 +499,9 @@ class EngineCore:
             self.structured_output_manager.grammar_init(req)
         return req, request.current_wave
 
+    def get_request_count(self) -> tuple[int, int]:
+        return self.scheduler.get_request_counts()
+
 
 class EngineCoreProc(EngineCore):
     """ZMQ-wrapper for running EngineCore in background process."""

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -249,6 +249,9 @@ class EngineCoreClient(ABC):
     ) -> list[_R]:
         raise NotImplementedError
 
+    async def get_request_count(self) -> tuple[int, int]:
+        raise NotImplementedError
+
 
 class InprocClient(EngineCoreClient):
     """
@@ -330,6 +333,9 @@ class InprocClient(EngineCoreClient):
 
     def dp_engines_running(self) -> bool:
         return False
+
+    async def get_request_count(self) -> tuple[int, int]:
+        return self.engine_core.get_request_count()
 
 
 @dataclass
@@ -791,6 +797,9 @@ class SyncMPClient(MPClient):
     ) -> None:
         self.call_utility("save_sharded_state", path, pattern, max_size)
 
+    async def get_request_count(self) -> tuple[int, int]:
+        return self.call_utility("get_request_count")
+
 
 class AsyncMPClient(MPClient):
     """Asyncio-compatible client for multi-proc EngineCore."""
@@ -996,6 +1005,9 @@ class AsyncMPClient(MPClient):
         return await self.call_utility_async(
             "collective_rpc", method, timeout, args, kwargs
         )
+
+    async def get_request_count(self) -> tuple[int, int]:
+        return await self.call_utility_async("get_request_count")
 
 
 class DPAsyncMPClient(AsyncMPClient):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

FIX https://github.com/vllm-project/vllm/issues/24207

Add a optional generate param to `/health?generate=true` api, can to generate a max_tokens is 2.

## Test Plan

If EngineCore progress crash, this api can response 500 http status code.

<img width="1654" height="480" alt="image" src="https://github.com/user-attachments/assets/47748992-5deb-4e5c-bf57-8f630fcc30c3" />


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

