### PR TITLE
[Bugfix] Fix  hidden_size for multimodal classification model

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -257,7 +257,7 @@ def as_seq_cls_model(cls: _T) -> _T:
     from vllm.model_executor.models.interfaces import SupportsCrossEncoding
     from vllm.sequence import IntermediateTensors
 
-    from .utils import maybe_prefix
+    from .utils import get_model_hidden_size, maybe_prefix
 
     class ModelForSequenceClassification(_create_pooling_model_cls(cls),
                                          SupportsCrossEncoding):
@@ -265,9 +265,10 @@ def as_seq_cls_model(cls: _T) -> _T:
         def _init_pooler(self, vllm_config: "VllmConfig", prefix: str = ""):
             config = vllm_config.model_config.hf_config
             quant_config = vllm_config.quant_config
+            hidden_size = get_model_hidden_size(config)
 
             self.score = ReplicatedLinear(
-                config.hidden_size,
+                hidden_size,
                 config.num_labels,
                 bias=False,
                 params_dtype=torch.float32,

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -766,7 +766,6 @@ def fast_topk(values: torch.Tensor, topk: int,
 def get_model_hidden_size(hf_config: PretrainedConfig) -> int:
     if hasattr(hf_config, "hidden_size"):
         return hf_config.hidden_size
-    elif hasattr(hf_config, "text_config"):
-        return hf_config.text_config.hidden_size
     else:
-        raise ValueError("Cannot determine hidden_size from the given config.")
+        config = hf_config.get_text_config()
+        return config.hidden_size

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -766,6 +766,5 @@ def fast_topk(values: torch.Tensor, topk: int,
 def get_model_hidden_size(hf_config: PretrainedConfig) -> int:
     if hasattr(hf_config, "hidden_size"):
         return hf_config.hidden_size
-    else:
-        config = hf_config.get_text_config()
-        return config.hidden_size
+    text_config = hf_config.get_text_config()
+    return text_config.hidden_size

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -761,3 +761,12 @@ def fast_topk(values: torch.Tensor, topk: int,
     else:
         # Use topk for efficiency with larger k values
         return torch.topk(values, topk, dim=dim)
+
+
+def get_model_hidden_size(hf_config: PretrainedConfig) -> int:
+    if hasattr(hf_config, "hidden_size"):
+        return hf_config.hidden_size
+    elif hasattr(hf_config, "text_config"):
+        return hf_config.text_config.hidden_size
+    else:
+        raise ValueError("Cannot determine hidden_size from the given config.")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Since some models (e.g., [Idefics3](https://huggingface.co/HuggingFaceM4/Idefics3-8B-Llama3/blob/main/config.json#L41)) have `hidden_size` in text_config, whereas others (e.g., [qwen2vl](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct/blob/main/config.json#L14)) have it directly in config, therefore we add a function to check this
## Test Plan
```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

from argparse import Namespace

from vllm import LLM, EngineArgs
from vllm.utils import FlexibleArgumentParser


def parse_args():
    parser = FlexibleArgumentParser()
    parser = EngineArgs.add_cli_args(parser)
    # Set example specific arguments
    parser.set_defaults(
        model="HuggingFaceM4/Idefics3-8B-Llama3",
        task="classify",
        load_format="dummy",
        enforce_eager=True,
    )
    return parser.parse_args()


def main(args: Namespace):
    # Sample prompts.
    prompts = [
        "Hello, my name is",
        "The president of the United States is",
        "The capital of France is",
        "The future of AI is",
    ]

    # Create an LLM.
    # You should pass runner="pooling" for classification models
    llm = LLM(**vars(args))

    # Generate logits. The output is a list of ClassificationRequestOutputs.
    outputs = llm.classify(prompts)

    # Print the outputs.
    print("\nGenerated Outputs:\n" + "-" * 60)
    for prompt, output in zip(prompts, outputs):
        probs = output.outputs.probs
        probs_trimmed = (str(probs[:16])[:-1] + ", ...]") if len(probs) > 16 else probs
        print(
            f"Prompt: {prompt!r} \n"
            f"Class Probabilities: {probs_trimmed} (size={len(probs)})"
        )
        print("-" * 60)


if __name__ == "__main__":
    args = parse_args()
    main(args)

```
## Test Result

The above script should pass correctly, rather than raise the following error:

```text
AttributeError: 'Idefics3Config' object has no attribute 'hidden_size'
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

