### PR TITLE
[LoRA]: Add LoRA support to Mistral's Voxtral models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -765,7 +765,7 @@ Speech2Text models trained specifically for Automatic Speech Recognition.
 | Architecture | Models | Example HF Models | [LoRA](../features/lora.md) | [PP](../serving/parallelism_scaling.md) | [V1](gh-issue:8779) |
 |--------------|--------|-------------------|----------------------|---------------------------|---------------------|
 | `WhisperForConditionalGeneration` | Whisper | `openai/whisper-small`, `openai/whisper-large-v3-turbo`, etc. | | | |
-| `VoxtralForConditionalGeneration` | Voxtral (Mistral format) | `mistralai/Voxtral-Mini-3B-2507`, `mistralai/Voxtral-Small-24B-2507`, etc. | | ✅︎ | ✅︎ |
+| `VoxtralForConditionalGeneration` | Voxtral (Mistral format) | `mistralai/Voxtral-Mini-3B-2507`, `mistralai/Voxtral-Small-24B-2507`, etc. | ✅︎ | ✅︎ | ✅︎ |
 
 ### Pooling Models
 

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -318,6 +318,11 @@ class VoxtralForConditionalGeneration(nn.Module, SupportsMultiModal,
                                       SupportsTranscription):
     supported_languages = ISO639_1_SUPPORTED_LANGS
 
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"]
+    }
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.tokenizer = cached_tokenizer_from_config(vllm_config.model_config)


### PR DESCRIPTION
Add LoRA support to Mistral's Voxtral models (`mistralai/Voxtral-Mini-3B-2507` & `mistralai/Voxtral-Small-24B-2507`), scoped strictly to the language model components.

### Changes
- [x]  Implement `SupportsLoRA` interface on `VoxtralForConditionalGeneration`
- [x] Add `get_mm_mapping()` method to filter LoRA modules:
>   - `language_model`: Text generation component (LoRA-enabled)
>   - `connector`: `audio_language_adapter` 
>   - `tower_model`: `whisper_encoder` (excluded from LoRA)

- [x] Update `docs/models/supported_models.md` to mark Voxtral as LoRA-supported (✅︎)

Closes #24516 