### PR TITLE
[Docs] Document the extra memory footprint overhead when using EPLB

### DIFF
--- a/docs/serving/expert_parallel_deployment.md
+++ b/docs/serving/expert_parallel_deployment.md
@@ -160,7 +160,7 @@ vllm serve Qwen/Qwen3-30B-A3B \
 
 EPLB uses redundant experts to that need to fit in GPU memory. This means that EPLB may not be a good fit for memory constrained environments or when KV cache space is at a premium.
 
-This overhead equals `NUM_MOE_LAYERS * BYTES_PER_EXPERT * (NUM_TOTAL_EXPERTS + NUM_REDUNDANT_EXPERTS) ÷ NUM_EP_RANKS`. 
+This overhead equals `NUM_MOE_LAYERS * BYTES_PER_EXPERT * (NUM_TOTAL_EXPERTS + NUM_REDUNDANT_EXPERTS) ÷ NUM_EP_RANKS`.
 For DeepSeekV3, this is approximately `2.4 GB` for one redundant expert per rank.
 
 ### Example Command

--- a/docs/serving/expert_parallel_deployment.md
+++ b/docs/serving/expert_parallel_deployment.md
@@ -156,6 +156,13 @@ vllm serve Qwen/Qwen3-30B-A3B \
 - **Default**: Each EP rank has `NUM_TOTAL_EXPERTS ÷ NUM_EP_RANKS` experts
 - **With redundancy**: Each EP rank has `(NUM_TOTAL_EXPERTS + NUM_REDUNDANT_EXPERTS) ÷ NUM_EP_RANKS` experts
 
+### Memory Footprint Overhead
+
+EPLB uses redundant experts to that need to fit in GPU memory. This means that EPLB may not be a good fit for memory constrained environments or when KV cache space is at a premium.
+
+This overhead equals `NUM_MOE_LAYERS * BYTES_PER_EXPERT * (NUM_TOTAL_EXPERTS + NUM_REDUNDANT_EXPERTS) ÷ NUM_EP_RANKS`. 
+For DeepSeekV3, this is approximately `2.4 GB` for one redundant expert per rank.
+
 ### Example Command
 
 Single node deployment with EPLB enabled:


### PR DESCRIPTION
## Purpose

Document the extra memory footprint when using EPLB, to be explicit about the tradeoffs of `num_redundant_experts`, since it's not immediately obvious that there's a tradeoff.

## Test Plan

## Test Result