### PR TITLE
[BugFix] Fix async core engine client finalizer

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -347,8 +347,9 @@ class BackgroundResources:
 
         if isinstance(self.output_socket, zmq.asyncio.Socket):
             # Async case.
-            loop = self.output_socket._get_loop()
-            asyncio.get_running_loop()
+            loop = self.output_queue_task._loop \
+                if self.output_queue_task else None
+
             sockets = (self.output_socket, self.input_socket,
                        self.first_req_send_socket, self.first_req_rcv_socket,
                        self.stats_update_socket)
@@ -359,11 +360,12 @@ class BackgroundResources:
                 close_sockets(sockets)
                 for task in tasks:
                     if task is not None and not task.done():
-                        task.cancel()
+                        with contextlib.suppress(Exception):
+                            task.cancel()
 
             if in_loop(loop):
                 close_sockets_and_tasks()
-            elif not loop.is_closed():
+            elif loop and not loop.is_closed():
                 loop.call_soon_threadsafe(close_sockets_and_tasks)
             else:
                 # Loop has been closed, try to clean up directly.


### PR DESCRIPTION
This fixes a bug where the asyncio event loop isn't properly obtained in the async engine client shutdown/finalizer logic.

```
(APIServer pid=769888)   File "/home/name/vllm_serve/.venv/lib/python3.12/site-packages/zmq/asyncio.py", line 116, in _default_loop
(APIServer pid=769888)     return asyncio.get_event_loop()
(APIServer pid=769888)            ^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=769888)   File "/usr/lib/python3.12/asyncio/events.py", line 702, in get_event_loop
(APIServer pid=769888)     raise RuntimeError('There is no current event loop in thread %r.'
(APIServer pid=769888) RuntimeError: There is no current event loop in thread 'MPClientEngineMonitor'
```

Fixes https://github.com/vllm-project/vllm/issues/24230.
Fixes https://github.com/vllm-project/vllm/issues/24305.