### PR TITLE
Consolidate rendering parameters into RenderConfig dataclass

### DIFF
--- a/vllm/entrypoints/openai/serving_classification.py
+++ b/vllm/entrypoints/openai/serving_classification.py
@@ -20,6 +20,7 @@ from vllm.entrypoints.openai.serving_engine import (ClassificationServeContext,
                                                     OpenAIServing,
                                                     ServeContext)
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels
+from vllm.entrypoints.renderer import RenderConfig
 from vllm.logger import init_logger
 from vllm.outputs import ClassificationOutput, PoolingRequestOutput
 from vllm.pooling_params import PoolingParams
@@ -57,8 +58,7 @@ class ClassificationMixin(OpenAIServing):
             renderer = self._get_renderer(ctx.tokenizer)
             ctx.engine_prompts = await renderer.render_prompt(
                 prompt_or_prompts=ctx.request.input,
-                max_length=self.max_model_len,
-                truncate_prompt_tokens=ctx.request.truncate_prompt_tokens)
+                config=self._build_render_config(ctx.request))
 
             return None
 
@@ -113,6 +113,13 @@ class ClassificationMixin(OpenAIServing):
             data=items,
             usage=usage,
         )
+
+    def _build_render_config(self,
+                             request: ClassificationRequest) -> RenderConfig:
+        return RenderConfig(
+            max_length=self.max_model_len,
+            truncate_prompt_tokens=request.truncate_prompt_tokens,
+            add_special_tokens=request.add_special_tokens)
 
 
 class ServingClassification(ClassificationMixin):

--- a/vllm/entrypoints/openai/serving_classification.py
+++ b/vllm/entrypoints/openai/serving_classification.py
@@ -118,8 +118,7 @@ class ClassificationMixin(OpenAIServing):
                              request: ClassificationRequest) -> RenderConfig:
         return RenderConfig(
             max_length=self.max_model_len,
-            truncate_prompt_tokens=request.truncate_prompt_tokens,
-            add_special_tokens=request.add_special_tokens)
+            truncate_prompt_tokens=request.truncate_prompt_tokens)
 
 
 class ServingClassification(ClassificationMixin):

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -58,7 +58,8 @@ from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               TranslationRequest)
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels
 from vllm.entrypoints.openai.tool_parsers import ToolParser
-from vllm.entrypoints.renderer import BaseRenderer, CompletionRenderer
+from vllm.entrypoints.renderer import (BaseRenderer, CompletionRenderer,
+                                       RenderConfig)
 # yapf: enable
 from vllm.inputs.data import PromptType
 from vllm.inputs.data import TokensPrompt as EngineTokensPrompt
@@ -247,6 +248,19 @@ class OpenAIServing:
             model_config=self.model_config,
             tokenizer=tokenizer,
             async_tokenizer_pool=self._async_tokenizer_pool)
+
+    def _build_render_config(
+        self,
+        request: Any,
+    ) -> RenderConfig:
+        """
+        Build and return a `RenderConfig` for an endpoint.
+
+        Used by the renderer to control how prompts are prepared
+        (e.g., tokenization and length handling). Endpoints should
+        implement this with logic appropriate to their request type.
+        """
+        raise NotImplementedError
 
     def _get_async_tokenizer(self, tokenizer) -> AsyncMicrobatchTokenizer:
         """

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -28,6 +28,7 @@ from vllm.entrypoints.openai.protocol import (ErrorResponse,
 # yapf: enable
 from vllm.entrypoints.openai.serving_engine import OpenAIServing
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels
+from vllm.entrypoints.renderer import RenderConfig
 from vllm.entrypoints.utils import _validate_truncation_size
 from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
@@ -149,10 +150,7 @@ class OpenAIServingPooling(OpenAIServing):
             elif isinstance(request, PoolingCompletionRequest):
                 engine_prompts = await renderer.render_prompt(
                     prompt_or_prompts=request.input,
-                    max_length=self.max_model_len,
-                    truncate_prompt_tokens=truncate_prompt_tokens,
-                    add_special_tokens=request.add_special_tokens,
-                    cache_salt=getattr(request, 'cache_salt', None),
+                    config=self._build_render_config(request),
                 )
             else:
                 raise ValueError(
@@ -270,3 +268,10 @@ class OpenAIServingPooling(OpenAIServing):
             data=items,
             usage=usage,
         )
+
+    def _build_render_config(
+            self, request: PoolingCompletionRequest) -> RenderConfig:
+        return RenderConfig(
+            max_length=self.max_model_len,
+            truncate_prompt_tokens=request.truncate_prompt_tokens,
+            add_special_tokens=request.add_special_tokens)

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -22,23 +22,24 @@ from vllm.utils import AsyncMicrobatchTokenizer
 @dataclass(frozen=True)
 class RenderConfig:
     """Configuration to control how prompts are prepared."""
-    # Maximum allowable total input token length. If provided,
-    # token inputs longer than this raise ``ValueError``.
+
     max_length: Optional[int] = None
+    """Maximum allowable total input token length. If provided,
+    token inputs longer than this raise ``ValueError``."""
 
-    # Number of tokens to keep. ``None`` means no truncation.
-    # ``0`` yields an empty list (and skips embeds).
-    # ``-1`` maps to ``model_config.max_model_len``.
     truncate_prompt_tokens: Optional[int] = None
+    """Number of tokens to keep. ``None`` means no truncation.
+    ``0`` yields an empty list (and skips embeds).
+    ``-1`` maps to ``model_config.max_model_len``."""
 
-    # Whether to add model-specific special tokens during text tokenization.
     add_special_tokens: Optional[bool] = True
+    """Whether to add model-specific special tokens during tokenization."""
 
-    # String to disambiguate prefix cache entries.
     cache_salt: Optional[str] = None
+    """String to disambiguate prefix cache entries."""
 
-    # If True, detokenize IDs back to text for inclusion in outputs.
     needs_detokenization: Optional[bool] = False
+    """If True, detokenize IDs back to text for inclusion in outputs."""
 
 
 class BaseRenderer(ABC):
@@ -71,6 +72,7 @@ class BaseRenderer(ABC):
     @abstractmethod
     async def render_prompt(
         self,
+        *,
         prompt_or_prompts: Union[str, list[str], list[int], list[list[int]]],
         config: "RenderConfig",
     ) -> list[EngineTokensPrompt]:
@@ -101,10 +103,11 @@ class BaseRenderer(ABC):
     @abstractmethod
     async def render_prompt_and_embeds(
         self,
-        config: "RenderConfig",
+        *,
         prompt_or_prompts: Optional[Union[str, list[str], list[int],
                                           list[list[int]]]] = None,
         prompt_embeds: Optional[Union[bytes, list[bytes]]] = None,
+        config: "RenderConfig",
     ) -> list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
         """
         Convert text/token and/or base64-encoded embeddings inputs into
@@ -184,6 +187,7 @@ class CompletionRenderer(BaseRenderer):
 
     async def render_prompt(
         self,
+        *,
         prompt_or_prompts: Union[str, list[str], list[int], list[list[int]]],
         config: "RenderConfig",
     ) -> list[EngineTokensPrompt]:
@@ -231,10 +235,11 @@ class CompletionRenderer(BaseRenderer):
 
     async def render_prompt_and_embeds(
         self,
-        config: "RenderConfig",
+        *,
         prompt_or_prompts: Optional[Union[str, list[str], list[int],
                                           list[list[int]]]] = None,
         prompt_embeds: Optional[Union[bytes, list[bytes]]] = None,
+        config: "RenderConfig",
     ) -> list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
         """
         Render text/token prompts and/or precomputed embedding prompts. At

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -4,6 +4,7 @@
 import asyncio
 import io
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Annotated, Optional, Union
 
 import pybase64
@@ -16,6 +17,28 @@ from vllm.inputs.data import TokensPrompt as EngineTokensPrompt
 from vllm.inputs.parse import parse_and_batch_prompt
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import AsyncMicrobatchTokenizer
+
+
+@dataclass(frozen=True)
+class RenderConfig:
+    """Configuration to control how prompts are prepared."""
+    # Maximum allowable total input token length. If provided,
+    # token inputs longer than this raise ``ValueError``.
+    max_length: Optional[int] = None
+
+    # Number of tokens to keep. ``None`` means no truncation.
+    # ``0`` yields an empty list (and skips embeds).
+    # ``-1`` maps to ``model_config.max_model_len``.
+    truncate_prompt_tokens: Optional[int] = None
+
+    # Whether to add model-specific special tokens during text tokenization.
+    add_special_tokens: Optional[bool] = True
+
+    # String to disambiguate prefix cache entries.
+    cache_salt: Optional[str] = None
+
+    # If True, detokenize IDs back to text for inclusion in outputs.
+    needs_detokenization: Optional[bool] = False
 
 
 class BaseRenderer(ABC):
@@ -49,11 +72,7 @@ class BaseRenderer(ABC):
     async def render_prompt(
         self,
         prompt_or_prompts: Union[str, list[str], list[int], list[list[int]]],
-        max_length: Optional[int] = None,
-        truncate_prompt_tokens: Optional[Annotated[int, Field(ge=-1)]] = None,
-        add_special_tokens: Optional[bool] = True,
-        cache_salt: Optional[str] = None,
-        needs_detokenization: Optional[bool] = False,
+        config: "RenderConfig",
     ) -> list[EngineTokensPrompt]:
         """
         Convert text or token inputs into engine-ready TokensPrompt objects.
@@ -68,16 +87,8 @@ class BaseRenderer(ABC):
                 - ``list[str]``: Batch of text prompts.
                 - ``list[int]``: Single pre-tokenized sequence.
                 - ``list[list[int]]``: Batch of pre-tokenized sequences.
-            max_length: Maximum allowable total input token length. If provided,
-                token inputs longer than this raise ``ValueError``.
-            truncate_prompt_tokens: Number of tokens to keep. ``None`` means no
-                truncation. ``0`` yields an empty list (and skips embeds).
-                ``-1`` maps to ``model_config.max_model_len``.
-            add_special_tokens: Whether to add model-specific special tokens
-                during text tokenization.
-            cache_salt: Optional string to disambiguate prefix cache entries.
-            needs_detokenization: If True and ``prompt_or_prompts`` is token
-                input, detokenize IDs back to text for inclusion in outputs.
+            config: Render configuration controlling how prompts are prepared
+                (e.g., tokenization and length handling). 
 
         Returns:
             list[EngineTokensPrompt]: Engine-ready token prompts.
@@ -90,18 +101,14 @@ class BaseRenderer(ABC):
     @abstractmethod
     async def render_prompt_and_embeds(
         self,
+        config: "RenderConfig",
         prompt_or_prompts: Optional[Union[str, list[str], list[int],
                                           list[list[int]]]] = None,
         prompt_embeds: Optional[Union[bytes, list[bytes]]] = None,
-        max_length: Optional[int] = None,
-        truncate_prompt_tokens: Optional[Annotated[int, Field(ge=-1)]] = None,
-        add_special_tokens: Optional[bool] = True,
-        cache_salt: Optional[str] = None,
-        needs_detokenization: Optional[bool] = False,
     ) -> list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
         """
         Convert text/token and/or base64-encoded embeddings inputs into
-        engine-ready prompt objects.
+        engine-ready prompt objects using a unified RenderConfig.
 
         At least one of ``prompt_or_prompts`` or ``prompt_embeds`` must be
         provided and non-empty. If both are omitted or empty (e.g., empty
@@ -111,15 +118,8 @@ class BaseRenderer(ABC):
             prompt_or_prompts: Text or token inputs to include.
             prompt_embeds: Base64-encoded bytes (or list thereof) containing a
                 torch-saved tensor to be used as prompt embeddings.
-            max_length: Maximum allowable total input token length. If provided,
-                inputs longer than this raise ``ValueError``.
-            truncate_prompt_tokens: Number of tokens/rows to keep from the end
-                of the sequence. ``-1`` maps to ``model_config.max_model_len``.
-            add_special_tokens: Whether to add model-specific special tokens
-                during text tokenization.
-            cache_salt: Optional string to disambiguate prefix cache entries.
-            needs_detokenization: If True and ``prompt_or_prompts`` is token
-                input, detokenize IDs back to text for inclusion in outputs.
+            config: Render configuration controlling how prompts are prepared
+                (e.g., tokenization and length handling). 
 
         Returns:
             list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
@@ -185,11 +185,7 @@ class CompletionRenderer(BaseRenderer):
     async def render_prompt(
         self,
         prompt_or_prompts: Union[str, list[str], list[int], list[list[int]]],
-        max_length: Optional[int] = None,
-        truncate_prompt_tokens: Optional[Annotated[int, Field(ge=-1)]] = None,
-        add_special_tokens: Optional[bool] = True,
-        cache_salt: Optional[str] = None,
-        needs_detokenization: Optional[bool] = False,
+        config: "RenderConfig",
     ) -> list[EngineTokensPrompt]:
         """Implementation of prompt rendering for completion-style requests.
         
@@ -197,7 +193,7 @@ class CompletionRenderer(BaseRenderer):
         for detailed parameter documentation.
         """
         truncate_prompt_tokens = self._validate_and_normalize_truncate_tokens(
-            truncate_prompt_tokens, max_length)
+            config.truncate_prompt_tokens, config.max_length)
         if truncate_prompt_tokens == 0:
             return []
 
@@ -211,16 +207,19 @@ class CompletionRenderer(BaseRenderer):
                 detokenize_task = asyncio.create_task(
                     # Note: detokenization is needed when echo is enabled,
                     # where the input token IDs are decoded back to text.
-                    self._maybe_detokenize(prompt_input["content"], max_length,
-                                           truncate_prompt_tokens, cache_salt,
-                                           needs_detokenization))
+                    self._maybe_detokenize(prompt_input["content"],
+                                           config.max_length,
+                                           truncate_prompt_tokens,
+                                           config.cache_salt,
+                                           config.needs_detokenization))
                 tasks.append(detokenize_task)
             else:
                 # Text input
                 tokenize_task = asyncio.create_task(
-                    self._tokenize(prompt_input["content"], max_length,
-                                   truncate_prompt_tokens, add_special_tokens,
-                                   cache_salt))
+                    self._tokenize(prompt_input["content"], config.max_length,
+                                   truncate_prompt_tokens,
+                                   config.add_special_tokens,
+                                   config.cache_salt))
                 tasks.append(tokenize_task)
 
         # Wait for all text tokenization to finish
@@ -232,21 +231,17 @@ class CompletionRenderer(BaseRenderer):
 
     async def render_prompt_and_embeds(
         self,
+        config: "RenderConfig",
         prompt_or_prompts: Optional[Union[str, list[str], list[int],
                                           list[list[int]]]] = None,
         prompt_embeds: Optional[Union[bytes, list[bytes]]] = None,
-        max_length: Optional[int] = None,
-        truncate_prompt_tokens: Optional[Annotated[int, Field(ge=-1)]] = None,
-        add_special_tokens: Optional[bool] = True,
-        cache_salt: Optional[str] = None,
-        needs_detokenization: Optional[bool] = False,
     ) -> list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
         """
         Render text/token prompts and/or precomputed embedding prompts. At
         least one of `prompt_or_prompts` or `prompt_embeds` must be provided.
         """
         truncate_prompt_tokens = self._validate_and_normalize_truncate_tokens(
-            truncate_prompt_tokens, max_length)
+            config.truncate_prompt_tokens, config.max_length)
         if truncate_prompt_tokens == 0:
             return []
 
@@ -255,17 +250,13 @@ class CompletionRenderer(BaseRenderer):
         if prompt_embeds is not None:
             rendered.extend(
                 self.load_prompt_embeds(prompt_embeds, truncate_prompt_tokens,
-                                        cache_salt))
+                                        config.cache_salt))
         if prompt_or_prompts is None or prompt_or_prompts == "":
             return rendered
 
         token_prompts = await self.render_prompt(
             prompt_or_prompts=prompt_or_prompts,
-            max_length=max_length,
-            truncate_prompt_tokens=truncate_prompt_tokens,
-            add_special_tokens=add_special_tokens,
-            cache_salt=cache_salt,
-            needs_detokenization=needs_detokenization,
+            config=config,
         )
         rendered.extend(token_prompts)
 


### PR DESCRIPTION
## Purpose
Refactors rendering class to use a unified RenderConfig dataclass instead of multiple individual parameters. This is a follow-up to #24405 to reduce parameter sprawl.

### Key changes
  - Adds RenderConfig dataclass to consolidate rendering parameters (max_length, truncate_prompt_tokens, add_special_tokens, cache_salt, needs_detokenization)
  - Updates all serving endpoints (completion, embedding, pooling, tokenization, classification) to use RenderConfig
  - Each endpoint implements _build_render_config() to construct appropriate configuration

## Test Plan
```
pytest tests/entrypoints/test_renderer.py
```
