### PR TITLE
[CI] Fix tensorizer test assertion

### DIFF
--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -164,8 +164,7 @@ def test_load_without_tensorizer_load_format(vllm_runner, capfd, model_ref):
     except RuntimeError:
         out, err = capfd.readouterr()
         combined_output = out + err
-        assert ("ValueError: Model loader extra config "
-                "is not supported for load "
+        assert ("ValueError: Unexpected extra config keys for load "
                 "format auto") in combined_output
     finally:
         del model
@@ -185,7 +184,7 @@ def test_raise_value_error_on_invalid_load_format(vllm_runner, capfd,
         out, err = capfd.readouterr()
 
         combined_output = out + err
-        assert ("ValueError: Model loader extra config is not supported "
+        assert ("ValueError: Unexpected extra config keys "
                 "for load format safetensors") in combined_output
     finally:
         del model

--- a/tests/tensorizer_loader/test_tensorizer.py
+++ b/tests/tensorizer_loader/test_tensorizer.py
@@ -161,6 +161,7 @@ def test_load_without_tensorizer_load_format(vllm_runner, capfd, model_ref):
         model = vllm_runner(
             model_ref,
             model_loader_extra_config=TensorizerConfig(tensorizer_uri="test"))
+        pytest.fail("Expected RuntimeError for extra config keys")
     except RuntimeError:
         out, err = capfd.readouterr()
         combined_output = out + err
@@ -180,6 +181,7 @@ def test_raise_value_error_on_invalid_load_format(vllm_runner, capfd,
             model_ref,
             load_format="safetensors",
             model_loader_extra_config=TensorizerConfig(tensorizer_uri="test"))
+        pytest.fail("Expected RuntimeError for extra config keys")
     except RuntimeError:
         out, err = capfd.readouterr()
 


### PR DESCRIPTION
## Purpose
Fix failing test_tensorizer tests due to #23928. #23928 changed an error message, that is asserted in test_tensorizer, to disambiguate a specific ValueError.