### PR TITLE
[BugFix][Multi Modal] Fix TensorSchema shape mismatch in Molmo

### DIFF
--- a/vllm/model_executor/models/molmo.py
+++ b/vllm/model_executor/models/molmo.py
@@ -76,8 +76,8 @@ class MolmoImageInputs(TensorSchema):
     """
     Dimensions:
         - bn: Batch size * number of images
-        - nc: Number of crops
-        - np: Number of patches (dynamic)
+        - nc: Number of crops (dynamic)
+        - np: Number of patches
         - tp: Token sequence positions
         - pd: Patch dimension
     """

--- a/vllm/model_executor/models/molmo.py
+++ b/vllm/model_executor/models/molmo.py
@@ -77,19 +77,21 @@ class MolmoImageInputs(TensorSchema):
     Dimensions:
         - bn: Batch size * number of images
         - nc: Number of crops
-        - np: Number of patches
+        - np: Number of patches (dynamic)
+        - tp: Token sequence positions
         - pd: Patch dimension
     """
     images: Annotated[Union[torch.Tensor, list[torch.Tensor]],
-                      TensorShape("bn", "nc", "np", "pd")]
+                      TensorShape("bn", "nc", "np", "pd", dynamic_dims={"nc"})]
+    # Number of crops may vary per batch and image, so pass it as a list.
 
     image_masks: Annotated[Optional[Union[torch.Tensor, list[torch.Tensor]]],
-                           TensorShape("bn", "nc", "np")]
+                           TensorShape("bn", "nc", "np", dynamic_dims={"nc"})]
 
-    feat_is_patch: Annotated[Union[torch.Tensor, list[torch.Tensor]],
-                             TensorShape("bn", "nc", "np")]
+    feat_is_patch: Annotated[
+        Union[torch.Tensor, list[torch.Tensor]],
+        TensorShape("bn", "nc", "tp", dynamic_dims={"nc"})]
     # A boolean mask indicating which image features correspond to patch tokens.
-
     num_crops: Annotated[torch.Tensor, TensorShape("bn")]
 
 


### PR DESCRIPTION
Number of crops would be dynamic in different images, so need to make it dynamic. 

Fix: https://github.com/vllm-project/vllm/issues/24544

Related: https://github.com/vllm-project/vllm/pull/22022

cc: @bbeckca @DarkLight1337 

### Test
```
python -m vllm.entrypoints.openai.api_server --model allenai/Molmo-7B-D-0924 --trust-remote-code

vllm bench serve   --backend openai-chat   --endpoint-type openai-chat   --model allenai/Molmo-7B-D-0924   --endpoint /v1/chat/completions   --dataset-name hf   --dataset-path lmarena-ai/VisionArena-Chat   --hf-split train   --hf-output-len 1   --num-prompts 10   --seed 40
```
### Result
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Benchmark duration (s):                  1.15      
Total input tokens:                      816       
Total generated tokens:                  10        
Request throughput (req/s):              8.70      
Output token throughput (tok/s):         8.70      
Total Token throughput (tok/s):          719.00    
---------------Time to First Token----------------
Mean TTFT (ms):                          695.62    
Median TTFT (ms):                        549.66    
P99 TTFT (ms):                           1132.05   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.02      
Median ITL (ms):                         0.02      
P99 ITL (ms):                            0.02      
==================================================
```