### PR TITLE
[Bugfix] Fix _synced_weight_loader

### DIFF
--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -52,10 +52,11 @@ def set_weight_attrs(
 def _make_synced_weight_loader(original_weight_loader):
 
     def _synced_weight_loader(param, *args, **kwargs):
-        original_weight_loader(param, *args, **kwargs)
+        out = original_weight_loader(param, *args, **kwargs)
         # torch._sync doesn't support, is not needed for CPU tensors.
         if param.device != torch.device("cpu"):
             torch._sync(param)
+        return out
 
     return _synced_weight_loader
 


### PR DESCRIPTION
Fixes a bug when the vLLM expects weight loader to return output when using return_success=True


## Purpose

Fixes a bug when the vLLM expects weight loader to return output when using `return_success=True`

Example: [qwen3_moe.py](https://github.com/vllm-project/vllm/blob/feaf202e93a18228cd34ae2e6698aece83a15e87/vllm/model_executor/models/qwen3_moe.py#L540)

