### PR TITLE
[Docs] Improve organisation of API Reference nav

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -48,7 +48,7 @@ nav:
     - Design Documents: design
   - API Reference:
     - api/README.md
-    - api/vllm/*
+    - api/vllm
   - CLI Reference: cli
   - Community:
     - community/*


### PR DESCRIPTION
After https://github.com/tlambert03/mkdocs-api-autonav/pull/25 deep APIs with long names became readable.

This PR moves the API reference headings 1 level down.

Before:

```
h1 - API Reference
h2 - submodule
h3 - subsubmodule
...
```

After:

```
h1 - API Reference
h2 - vllm
h3 - submodule
h4 - subsubmodule
...
```

This results in much nicer rendering of the navigation sidebar on https://docs.vllm.ai/en/latest/api/index.html