### PR TITLE
[Bugfix] Fix unable to run encoder model when disable_hybrid_kv_cache_manager is true

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -754,10 +754,13 @@ def is_kv_cache_type_uniform(kv_cache_spec: dict[str, KVCacheSpec]) -> bool:
         True if all layers have the same type, False otherwise.
     """
 
+    if not kv_cache_spec:
+        # Encoder-only models do not have KV cache, kv_cache_type can be
+        # regarded as uniform.
+        return True
     try:
         kv_cache_spec_values = list(kv_cache_spec.values())
-        if kv_cache_spec_values:
-            _ = kv_cache_spec_values[0].merge(kv_cache_spec_values)
+        _ = kv_cache_spec_values[0].merge(kv_cache_spec_values)
     except AssertionError:
         return False
     return True

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -756,7 +756,8 @@ def is_kv_cache_type_uniform(kv_cache_spec: dict[str, KVCacheSpec]) -> bool:
 
     try:
         kv_cache_spec_values = list(kv_cache_spec.values())
-        _ = kv_cache_spec_values[0].merge(kv_cache_spec_values)
+        if kv_cache_spec_values:
+            _ = kv_cache_spec_values[0].merge(kv_cache_spec_values)
     except AssertionError:
         return False
     return True


### PR DESCRIPTION
In GPU devices, when running the encoder model, the `kv_cache_spec` is processed at https://github.com/vllm-project/vllm/blob/feaf202e93a18228cd34ae2e6698aece83a15e87/vllm/v1/worker/gpu_model_runner.py#L3497-L3500 and its return value is an empty dictionary. This causes the `kv_cache_spec_one_worker` variable at https://github.com/vllm-project/vllm/blob/feaf202e93a18228cd34ae2e6698aece83a15e87/vllm/v1/engine/core.py#L192-L197 to be empty. The `get_kv_cache_config` function uses the `unify_hybrid_kv_cache_specs` method to check the type consistency of the `kv_cache_spec` list. However, in the function at https://github.com/vllm-project/vllm/blob/feaf202e93a18228cd34ae2e6698aece83a15e87/vllm/v1/core/kv_cache_utils.py#L747-L765
there is no empty check for the value of kv_cache_spec, which leads to the IndexError reported in #24407. This PR fixes the error by adding a empty check.

> Additionally, I discovered that when running encoder models, the `GPUModelRunner.initialize_kv_cache` method reassigns the spec of `kv_cache_config.kv_cache_groups` to `EncoderOnlyAttentionSpec` https://github.com/vllm-project/vllm/blob/feaf202e93a18228cd34ae2e6698aece83a15e87/vllm/v1/worker/gpu_model_runner.py#L3416-L3441
An alternative fix might be to add the encoder model's `kv_cache_spec` as `EncoderOnlyAttentionSpec` in the `GPUModelRunner.get_kv_cache_spec` method, thereby avoiding returning an empty dict.

## Purpose
resolve #24407

## Test Plan
```python
from argparse import Namespace

from vllm import LLM, EngineArgs
from vllm.utils import FlexibleArgumentParser


def parse_args():
    parser = FlexibleArgumentParser()
    parser = EngineArgs.add_cli_args(parser)
    # Set example specific arguments
    parser.set_defaults(
        model="BAAI/bge-reranker-v2-m3", task="score", enforce_eager=True, disable_hybrid_kv_cache_manager=True
    )
    return parser.parse_args()


def main(args: Namespace):
    # Sample prompts.
    text_1 = "What is your favourite fruit?"
    texts_2 = [
        "Banana.",
        "Apple.",
    ]

    # Create an LLM.
    # You should pass task="score" for cross-encoder models
    llm = LLM(**vars(args))

    # Generate scores. The output is a list of ScoringRequestOutputs.
    outputs = llm.score(text_1, texts_2)

    # Print the outputs.
    print("\nGenerated Outputs:\n" + "-" * 60)
    for text_2, output in zip(texts_2, outputs):
        score = output.outputs.score
        print(f"Pair: {[text_1, text_2]!r} \nScore: {score}")
        print("-" * 60)


if __name__ == "__main__":
    args = parse_args()
    main(args)
```
Observe: No crash, valid scores returned.

## Test Result
Before: Server crashes with IndexError in is_kv_cache_type_uniform.
After: No crash, rerank results returned successfully.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

