### PR TITLE
[Bugfix] Enable FP8 KV cache for FlashInfer and Triton backend on non-sm100 GPUs

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -530,6 +530,8 @@ class CudaPlatformBase(Platform):
                     supported = flash_attn_supports_fp8()
                 else:
                     supported = True
+            elif attention_backend == "FLASHINFER":
+                supported = True
         return supported
 
     @classmethod

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -532,6 +532,8 @@ class CudaPlatformBase(Platform):
                     supported = True
             elif attention_backend == "FLASHINFER":
                 supported = True
+            elif attention_backend == "TRITON_ATTN_VLLM_V1":
+                supported = cls.supports_fp8()
         return supported
 
     @classmethod

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -202,7 +202,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         else:
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
-        self.q_data_type = self.kv_cache_dtype if supports_trtllm_attention()[0] else self.model_config.dtype
+
+        if supports_trtllm_attention()[0]:
+            self.q_data_type = self.kv_cache_dtype
+        else:
+            self.q_data_type = self.model_config.dtype
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -202,7 +202,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         else:
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
-        self.q_data_type = self.kv_cache_dtype
+        self.q_data_type = self.kv_cache_dtype if supports_trtllm_attention()[0] else self.model_config.dtype
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

FlashInfer supports FP8 KV-cache on GPUs that use FA2 backend e.g. sm80, sm89, sm120. Currently I only have access to sm120 GPU so I can only confirm that it works.

Triton attention backend also support FP8.

Changes
- When attention backend is FlashInfer or Triton, `is_kv_cache_dtype_supported()` returns True
- In FlashInfer attention, only enable FP8 query when TRT-LLM attention is supported on the current GPU - see https://github.com/vllm-project/vllm/pull/23647#issuecomment-3274251481
- Triton attention is only enabled if the GPU supports FP8, because I believe the triton kernel always uses FP8 query

## Test Plan

```bash
# for FlashInfer
VLLM_ATTENTION_BACKEND=FLASHINFER vllm serve Qwen/Qwen3-4B --kv-cache-dtype fp8

# for Triton
# block size requires to be at least 32 for FP8
VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1 vllm serve Qwen/Qwen3-4B --kv-cache-dtype fp8 --block-size 32
```

```bash
curl -N http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen3-4B",
    "messages": [
      {"role": "user", "content": "Who are you"}
    ]
  }'
```

## Test Result

```
{"id":"chatcmpl-b48c5ec42e2d476d80ca8c94e695428d","object":"chat.completion","created":1757499722,"model":"Qwen/Qwen3-4B","choices":[{"index":0,"message":{"role":"assistant","content":"<think>\nOkay, the user asked, \"Who are you?\" I need to respond in a friendly and informative way. Let me start by introducing myself as Qwen, the large language model developed by Alibaba Cloud. I should mention my capabilities, like answering questions, creating content, and assisting with various tasks. It's important to highlight that I'm designed to be helpful and can adapt to different needs. Also, I should invite the user to ask questions or share what they need help with. Let me make sure the tone is approachable and not too technical. I'll check for any key points I might have missed, like the fact that I'm multilingual and can handle multiple tasks. Alright, that should cover it.\n</think>\n\nHello! I am Qwen, a large language model developed by Alibaba Cloud. I can answer questions, create content, and assist with a variety of tasks. I am designed to be helpful and can adapt to different needs. Feel free to ask me anything or let me know what you need help with!","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":11,"total_tokens":221,"completion_tokens":210,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}%
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

