### PR TITLE
[CI]Add transformers_utils to Async Engine, Inputs, Utils, Worker Test

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -54,6 +54,7 @@ steps:
   - tests/utils_
   - tests/worker
   - tests/standalone_tests/lazy_imports.py
+  - tests/transformers_utils
   commands:
   - python3 standalone_tests/lazy_imports.py
   - pytest -v -s mq_llm_engine # MQLLMEngine
@@ -63,6 +64,7 @@ steps:
   - pytest -v -s multimodal
   - pytest -v -s utils_ # Utils
   - pytest -v -s worker # Worker
+  - pytest -v -s transformers_utils # transformers_utils
 
 - label: Python-only Installation Test # 10min
   timeout_in_minutes: 20
@@ -818,8 +820,8 @@ steps:
   # Avoid importing model tests that cause CUDA reinitialization error
   - pytest models/test_transformers.py -v -s -m 'distributed(num_gpus=2)'
   - pytest models/language -v -s -m 'distributed(num_gpus=2)'
-  - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py 
-  - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)' 
+  - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py
+  - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
   # test sequence parallel
   - pytest -v -s distributed/test_sequence_parallel.py
   # this test fails consistently.


### PR DESCRIPTION
## Purpose
Per discussion  https://github.com/vllm-project/vllm/pull/24277#discussion_r2336741283, added `tests/transformers_utils` directory to "Async Engine, Inputs, Utils, Worker Test"

## Test Plan
CI
## Test Result
In Async Engine, Inputs, Utils, Worker Test

```
  | [2025-09-11T08:21:19Z] + pytest -v -s transformers_utils
  | [2025-09-11T08:21:26Z] INFO 09-11 01:21:26 [__init__.py:216] Automatically detected platform cuda.
  | [2025-09-11T08:21:30Z] /usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
  | [2025-09-11T08:21:30Z] The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
  | [2025-09-11T08:21:30Z]
  | [2025-09-11T08:21:30Z]   warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
  | [2025-09-11T08:21:30Z] ============================= test session starts ==============================
  | [2025-09-11T08:21:30Z] platform linux -- Python 3.12.11, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
  | [2025-09-11T08:21:30Z] cachedir: .pytest_cache
  | [2025-09-11T08:21:30Z] hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
  | [2025-09-11T08:21:30Z] rootdir: /vllm-workspace
  | [2025-09-11T08:21:30Z] configfile: pyproject.toml
  | [2025-09-11T08:21:30Z] plugins: anyio-4.6.2.post1, buildkite-test-collector-0.1.9, hydra-core-1.3.2, hypothesis-6.131.0, asyncio-0.24.0, forked-1.6.0, mock-3.14.0, rerunfailures-14.0, shard-0.1.2, subtests-0.14.1, timeout-2.3.1, schemathesis-3.39.15
  | [2025-09-11T08:21:30Z] asyncio: mode=Mode.STRICT, default_loop_scope=None
  | [2025-09-11T08:21:30Z] collecting ... INFO 09-11 01:21:30 [config.py:255] Registered config parser `<class 'tests.transformers_utils.test_config_parser_registry.CustomConfigParser'>` with config format `custom_config_parser`
  | collected 2 items
  | [2025-09-11T08:21:30Z] Running 2 items in this shard: tests/transformers_utils/test_config_parser_registry.py::test_register_config_parser, tests/transformers_utils/test_config_parser_registry.py::test_invalid_config_parser
  | [2025-09-11T08:21:30Z]
  | [2025-09-11T08:21:31Z] transformers_utils/test_config_parser_registry.py::test_register_config_parser PASSED
  | [2025-09-11T08:21:31Z] transformers_utils/test_config_parser_registry.py::test_invalid_config_parser PASSED


```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

