### PR TITLE
[BugFix] Fix pipeline parallel

### DIFF
--- a/vllm/executor/uniproc_executor.py
+++ b/vllm/executor/uniproc_executor.py
@@ -71,6 +71,10 @@ class UniProcExecutor(ExecutorBase):
             self.shutdown()
         return
 
+    def shutdown(self) -> None:
+        if worker := self.driver_worker:
+            worker.shutdown()
+
 
 UniProcExecutorAsync = UniProcExecutor
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2070,7 +2070,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             sampler_output = self._sample(logits, spec_decode_metadata)
 
         with record_function_or_nullcontext("Bookkeep"):
-            assert isinstance(hidden_states, torch.Tensor)
             (
                 num_nans_in_logits,
                 logprobs_lists,

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -45,7 +45,8 @@ class KVConnectorModelRunnerMixin:
 
     @staticmethod
     def ensure_kv_transfer_shutdown() -> None:
-        if has_kv_transfer_group():
+        # has_kv_transfer_group can be None during interpreter shutdown.
+        if has_kv_transfer_group and has_kv_transfer_group():
             ensure_kv_transfer_shutdown()
 
     @staticmethod


### PR DESCRIPTION
It was broken by an incorrect `assert` introduced in https://github.com/vllm-project/vllm/pull/24265. The breakage was originally obscured by the other NCCL-related 4-GPU distributed tests CI breakage.

This fixes the 4-GPU distributed CI test.

Edit: It looks like the separate pipeline parallel test was still passing, I'm not sure what the difference is but the torchrun version of it was failing due to this.