### PR TITLE
[Bugfix][Frontend] Fix `--enable-log-outputs` does not match the documentation

### DIFF
--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -171,8 +171,8 @@ schema. Example: `[{"type": "text", "text": "Hello world!"}]`"""
     """Enable the /get_tokenizer_info endpoint. May expose chat
     templates and other tokenizer configuration."""
     enable_log_outputs: bool = False
-    """If set to True, enable logging of model outputs (generations) 
-    in addition to the input logging that is enabled by default."""
+    """If True, log model outputs (generations).
+    Requires --enable-log-requests."""
     h11_max_incomplete_event_size: int = H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT
     """Maximum size (bytes) of an incomplete HTTP event (header or body) for
     h11 parser. Helps mitigate header abuse. Default: 4194304 (4 MB)."""
@@ -273,6 +273,9 @@ def validate_parsed_serve_args(args: argparse.Namespace):
     if args.enable_auto_tool_choice and not args.tool_call_parser:
         raise TypeError("Error: --enable-auto-tool-choice requires "
                         "--tool-call-parser")
+    if args.enable_log_outputs and not args.enable_log_requests:
+        raise TypeError("Error: --enable-log-outputs requires "
+                        "--enable-log-requests")
 
 
 def create_parser_for_docs() -> FlexibleArgumentParser:


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/24578

## Purpose

See https://github.com/vllm-project/vllm/blob/5931b7e5d9acd4fd9eb42d56086c379fa2e2014e/vllm/entrypoints/openai/cli_args.py#L175

If `--enable-log-outputs` exists, `--enable-log-requests` should be set.

## Test Plan

`vllm serve /model --enable-log-outputs`

## Test Result

```
  File "/home/jovyan/vllm/vllm/entrypoints/openai/api_server.py", line 2009, in <module>
    validate_parsed_serve_args(args)
  File "/home/jovyan/vllm/vllm/entrypoints/openai/cli_args.py", line 277, in validate_parsed_serve_args
    raise TypeError("Error: --enable-log-outputs requires "
TypeError: Error: --enable-log-outputs requires --enable-log-requests
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

