### PR TITLE
[CI] Add ci_envs for convenient local testing

### DIFF
--- a/tests/ci_envs.py
+++ b/tests/ci_envs.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+These envs only work for a small part of the tests, fix what you need!
+"""
+
+import os
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+if TYPE_CHECKING:
+    VLLM_CI_NO_SKIP: bool = False
+    VLLM_CI_DTYPE: Optional[str] = None
+    VLLM_CI_HEAD_DTYPE: Optional[str] = None
+    VLLM_CI_HF_DTYPE: Optional[str] = None
+
+environment_variables: dict[str, Callable[[], Any]] = {
+    # A model family has many models with the same architecture.
+    # By default, a model family tests only one model.
+    # Through this flag, all models can be tested.
+    "VLLM_CI_NO_SKIP": lambda: bool(int(os.getenv("VLLM_CI_NO_SKIP", "0"))),
+    # Allow changing the dtype used by vllm in tests
+    "VLLM_CI_DTYPE": lambda: os.getenv("VLLM_CI_DTYPE", None),
+    # Allow changing the head dtype used by vllm in tests
+    "VLLM_CI_HEAD_DTYPE": lambda: os.getenv("VLLM_CI_HEAD_DTYPE", None),
+    # Allow changing the head dtype used by transformers in tests
+    "VLLM_CI_HF_DTYPE": lambda: os.getenv("VLLM_CI_HF_DTYPE", None),
+}
+
+
+def __getattr__(name: str):
+    # lazy evaluation of environment variables
+    if name in environment_variables:
+        return environment_variables[name]()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(environment_variables.keys())
+
+
+def is_set(name: str):
+    """Check if an environment variable is explicitly set."""
+    if name in environment_variables:
+        return name in os.environ
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1780,13 +1780,15 @@ class ModelConfig:
         you can use --hf-overrides '{"head_dtype": "model"}' to disable it.
         """
 
-        if self.runner_type != "pooling":
-            raise ValueError(
-                "`head_dtype` currently only supports pooling models.")
-
         head_dtype = _get_head_dtype(config=self.hf_config,
                                      dtype=self.dtype,
                                      runner_type=self.runner_type)
+
+        if self.runner_type != "pooling" and head_dtype != self.dtype:
+            logger.warning_once(
+                "`head_dtype` [%s] currently only supports pooling models."
+                "fallback to model dtype [%s].", head_dtype, self.dtype)
+            return self.dtype
 
         if head_dtype not in current_platform.supported_dtypes:
             logger.warning_once(

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1786,8 +1786,8 @@ class ModelConfig:
 
         if self.runner_type != "pooling" and head_dtype != self.dtype:
             logger.warning_once(
-                "`head_dtype` [%s] currently only supports pooling models."
-                "fallback to model dtype [%s].", head_dtype, self.dtype)
+                "`head_dtype` currently only supports pooling models."
+                "fallback to model dtype [%s].", self.dtype)
             return self.dtype
 
         if head_dtype not in current_platform.supported_dtypes:

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1775,12 +1775,14 @@ class ModelConfig:
         such as the lm_head in a generation model,
         or the score or classifier in a classification model.
 
-        The default head_dtype based on runner_type.\n
+        `head_dtype` currently only supports pooling models.\n
         - The pooling model defaults to using fp32 head,
-        you can use --hf-overrides '{"head_dtype": "model"}' to disable it.\n
-        - The generate model defaults to not using fp32 head,
-        you can use --hf-overrides '{"head_dtype": "float32"}' to enable it.
+        you can use --hf-overrides '{"head_dtype": "model"}' to disable it.
         """
+
+        if self.runner_type != "pooling":
+            return self.dtype
+
         head_dtype = _get_head_dtype(config=self.hf_config,
                                      dtype=self.dtype,
                                      runner_type=self.runner_type)

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1781,7 +1781,8 @@ class ModelConfig:
         """
 
         if self.runner_type != "pooling":
-            return self.dtype
+            raise ValueError(
+                "`head_dtype` currently only supports pooling models.")
 
         head_dtype = _get_head_dtype(config=self.hf_config,
                                      dtype=self.dtype,


### PR DESCRIPTION
## Purpose
- ci envs for convenient testing
    - VLLM_CI_NO_SKIP
    - VLLM_CI_DTYPE
    - VLLM_CI_HEAD_DTYPE
    - VLLM_CI_HF_DTYPE

e.g. testing Flex Attention, you don't need to manually modify dtype=float32 #24089
```
VLLM_CI_DTYPE=float32 pytest tests/models/language/pooling_mteb_test/test_st_projector.py::test_embed_models_mteb[model_info1] 
VLLM_CI_DTYPE=float32 pytest tests/models/language/pooling_mteb_test/test_gte.py::test_rerank_models_mteb[model_info0]
```

A model family has many models with the same architecture. By default, a model family tests only one model.
Through VLLM_CI_NO_SKIP, all models can be tested.

```
VLLM_CI_NO_SKIP=1 pytest tests/models/language/pooling_mteb_test/test_baai.py::test_embed_models_mteb[model_info1]
```

VLLM_CI_HEAD_DTYPE & VLLM_CI_HF_DTYPE #24567

```
VLLM_CI_HF_DTYPE="float32" VLLM_CI_HEAD_DTYPE="model" pytest -s -vvv tests/models/language/generation_ppl_test/test_gpt.py
```

hitchhiking
- `head_dtype` currently only supports pooling models. #24567 expected to discuss for a long time

cc @DarkLight1337 @maxdebayser

## Test Plan

keep ci green

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

