### PR TITLE
[Bugfix] Enforce installed FlashInfer version to match optional requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 # cannot import envs directly because it depends on vllm,
 #  which is not installed yet
 envs = load_module_from_path('envs', os.path.join(ROOT_DIR, 'vllm', 'envs.py'))
+version = load_module_from_path('version',
+                                os.path.join(ROOT_DIR, 'vllm', 'version.py'))
 
 VLLM_TARGET_DEVICE = envs.VLLM_TARGET_DEVICE
 
@@ -664,7 +666,7 @@ setup(
                   "mistral_common[audio]"],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility
         # FlashInfer should be updated together with the Dockerfile
-        "flashinfer": ["flashinfer-python==0.3.0"],
+        "flashinfer": [f"flashinfer-python=={version.FLASHINFER_VERSION}"],
         # Optional deps for AMD FP4 quantization support
         "petit-kernel": ["petit-kernel"],
     },

--- a/vllm/version.py
+++ b/vllm/version.py
@@ -39,3 +39,10 @@ def _prev_minor_version():
     # In dev tree, this will return "0.-1", but that will work fine"
     assert isinstance(__version_tuple__[1], int)
     return f"{__version_tuple__[0]}.{__version_tuple__[1] - 1}"
+
+
+# Optional dependency versions
+# This should be kept in sync with:
+# - setup.py extras_require
+# - docker/Dockerfile version specifications
+FLASHINFER_VERSION = "0.3.0"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Previously there was no enforcement on the installed version of FlashInfer, just that the imported function exists. This enforcement should help guide users to install FI using the official pathway and reduce user error when FI function behavior changes.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

