### PR TITLE
[Bug] Fix Layer `weight_block_size` Assertion Issue

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -449,11 +449,11 @@ class Fp8LinearMethod(LinearMethodBase):
             # Activations not quantized for marlin.
             del layer.input_scale
 
-        # On B200, if E8M0 for DeepGemm is used, we need to
+        # On Blackwell or Hopper, if E8M0 for DeepGemm is used, we need to
         # requantize the weight and input to the specific scale
         # at the same time.
-        # Only applicable to block-quantized weights.
-        if is_deep_gemm_e8m0_used() and layer.weight_block_size is not None:
+        if is_deep_gemm_e8m0_used() and self.block_quant:
+            assert layer.weight_block_size is not None
             block_sz = tuple(layer.weight_block_size)
             requant_weight_ue8m0_inplace(
                 layer.weight.data,
@@ -896,7 +896,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             del layer.w13_input_scale
             del layer.w2_input_scale
 
-        if is_deep_gemm_e8m0_used() and layer.weight_block_size is not None:
+        if is_deep_gemm_e8m0_used() and self.block_quant:
+            assert layer.weight_block_size is not None
             # Re-quantise the expert weights so their scales are UE8M0.
             block_sz = tuple(layer.weight_block_size)
             requant_weight_ue8m0_inplace(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -452,8 +452,8 @@ class Fp8LinearMethod(LinearMethodBase):
         # On B200, if E8M0 for DeepGemm is used, we need to
         # requantize the weight and input to the specific scale
         # at the same time.
-        if is_deep_gemm_e8m0_used():
-            assert layer.weight_block_size is not None
+        # Only applicable to block-quantized weights.
+        if is_deep_gemm_e8m0_used() and layer.weight_block_size is not None:
             block_sz = tuple(layer.weight_block_size)
             requant_weight_ue8m0_inplace(
                 layer.weight.data,
@@ -896,8 +896,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             del layer.w13_input_scale
             del layer.w2_input_scale
 
-        if is_deep_gemm_e8m0_used():
-            assert layer.weight_block_size is not None
+        if is_deep_gemm_e8m0_used() and layer.weight_block_size is not None:
             # Re-quantise the expert weights so their scales are UE8M0.
             block_sz = tuple(layer.weight_block_size)
             requant_weight_ue8m0_inplace(


### PR DESCRIPTION
## Purpose

`VLLM_USE_DEEP_GEMM=1 lm_eval --model vllm --model_args "pretrained=RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8,max_model_len=32768,enforce_eager=True" --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto`

Fixed the assertion issue

```bash
EngineCore_DP0 pid=3398267) Process EngineCore_DP0:
(EngineCore_DP0 pid=3398267) Traceback (most recent call last):
(EngineCore_DP0 pid=3398267)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=3398267)     self.run()
(EngineCore_DP0 pid=3398267)   File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=3398267)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/v1/engine/core.py", line 722, in run_engine_core
(EngineCore_DP0 pid=3398267)     raise e
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/v1/engine/core.py", line 709, in run_engine_core
(EngineCore_DP0 pid=3398267)     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=3398267)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/v1/engine/core.py", line 505, in __init__
(EngineCore_DP0 pid=3398267)     super().__init__(vllm_config, executor_class, log_stats,
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/v1/engine/core.py", line 82, in __init__
(EngineCore_DP0 pid=3398267)     self.model_executor = executor_class(vllm_config)
(EngineCore_DP0 pid=3398267)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/executor/executor_base.py", line 54, in __init__
(EngineCore_DP0 pid=3398267)     self._init_executor()
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/executor/uniproc_executor.py", line 49, in _init_executor
(EngineCore_DP0 pid=3398267)     self.collective_rpc("load_model")
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
(EngineCore_DP0 pid=3398267)     answer = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=3398267)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/utils/__init__.py", line 3057, in run_method
(EngineCore_DP0 pid=3398267)     return func(*args, **kwargs)
(EngineCore_DP0 pid=3398267)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/v1/worker/gpu_worker.py", line 213, in load_model
(EngineCore_DP0 pid=3398267)     self.model_runner.load_model(eep_scale_up=eep_scale_up)
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/v1/worker/gpu_model_runner.py", line 2230, in load_model
(EngineCore_DP0 pid=3398267)     self.model = model_loader.load_model(
(EngineCore_DP0 pid=3398267)                  ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/model_executor/model_loader/base_loader.py", line 51, in load_model
(EngineCore_DP0 pid=3398267)     process_weights_after_loading(model, model_config, target_device)
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/model_executor/model_loader/utils.py", line 112, in process_weights_after_loading
(EngineCore_DP0 pid=3398267)     quant_method.process_weights_after_loading(module)
(EngineCore_DP0 pid=3398267)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/model_executor/layers/quantization/fp8.py", line 456, in process_weights_after_loading
(EngineCore_DP0 pid=3398267)     assert layer.weight_block_size is not None
(EngineCore_DP0 pid=3398267)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3398267) AssertionError
```

## Test

```bash
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7491|±  |0.0119|
|     |       |strict-match    |     5|exact_match|↑  |0.7240|±  |0.0123|
```