### PR TITLE
Fix implementation divergence for BLOOM models between vLLM and HuggingFace when using prompt embeds

### DIFF
--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import os
 from typing import Optional
 
 import pytest
@@ -99,9 +98,10 @@ AITER_MODEL_LIST = [
 @pytest.mark.parametrize("num_logprobs", [5])
 @pytest.mark.parametrize(
     "use_rocm_aiter", [True, False] if current_platform.is_rocm() else [False])
+@pytest.mark.parametrize("use_prompt_embeds", [True, False])
 def test_models(hf_runner, vllm_runner, example_prompts, model: str,
                 max_tokens: int, num_logprobs: int, use_rocm_aiter: bool,
-                monkeypatch) -> None:
+                use_prompt_embeds: bool, monkeypatch) -> None:
 
     model_info = HF_EXAMPLE_MODELS.find_hf_info(model)
     model_info.check_available_online(on_fail="skip")
@@ -118,8 +118,6 @@ def test_models(hf_runner, vllm_runner, example_prompts, model: str,
         # needed as all the models will be calling AITER kernels
         # in parts of the operators
         pytest.skip(f"Skipping '{model}' model test with AITER kernel.")
-
-    use_prompt_embeds = os.getenv("VLLM_USE_V1") == "0"
 
     with hf_runner(model) as hf_model:
         hf_outputs = hf_model.generate_greedy_logprobs_limit(

--- a/vllm/model_executor/models/bloom.py
+++ b/vllm/model_executor/models/bloom.py
@@ -257,7 +257,7 @@ class BloomModel(nn.Module):
                                                     config.hidden_size))
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.word_embeddings_layernorm(self.word_embeddings(input_ids))
+        return self.word_embeddings(input_ids)
 
     def forward(
         self,
@@ -271,6 +271,7 @@ class BloomModel(nn.Module):
                 hidden_states = inputs_embeds
             else:
                 hidden_states = self.get_input_embeddings(input_ids)
+            hidden_states = self.word_embeddings_layernorm(hidden_states)
         else:
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]


### PR DESCRIPTION

## Purpose

The HF implementation of Bloom models assumes that `inputs_embeds` do not have the word embedding layer norm pre-applied. So doing `PretrainedModel.get_input_embeddings()(token_ids)` and vLLM's `BloomModel.get_input_embeddings(token_ids)` will give different embeddings. This divergence causes downstream differences in the model forward when passing in prompt embeds.

This is the relevant portion in the HF source code: https://github.com/huggingface/transformers/blob/cf084f5b40e19b5a5f946cee75bead6d4247b071/src/transformers/models/bloom/modeling_bloom.py#L545-L562

This was not caught by the prompt embeds tests because the prompt embeds `common_models.py::test_models` test for `bigscience/bloom-560m` only ran in the v1 engine, and prompt embeds inputs were tested only if the v0 engine was active.

## Test Plan

1.  Update `common_models.py::test_models` to test with `use_prompt_embeds` as both True and False (parametrize the tests). Because since https://github.com/vllm-project/vllm/pull/17615, when needing prompt embeds support, the test will automatically fall back to the v0 engine for prompt embeds tests, until https://github.com/vllm-project/vllm/pull/24278 lands.

## Test Result

Newly updated tests failed before patching the Bloom model definition, and pass now that the Bloom definition is updated.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

