### PR TITLE
[Perf] Improve default fused moe configs by analyzing tuned configs

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
+++ b/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Analyze MoE config files to extract patterns for better defaults."""
+
+import json
+import os
+from collections import defaultdict
+
+import numpy as np
+
+
+def parse_all_configs():
+    """Parse all config files and extract data."""
+    configs_dir = os.path.dirname(os.path.abspath(__file__))
+
+    configs_data = []
+
+    for filename in os.listdir(configs_dir):
+        if not filename.endswith('.json') or filename == 'README.json':
+            continue
+
+        # Parse filename
+        name = filename[:-5]  # remove .json
+        parts = name.split(',')
+
+        config_info = {}
+        for part in parts:
+            if part.startswith('E='):
+                config_info['E'] = int(part[2:])
+            elif part.startswith('N='):
+                config_info['N'] = int(part[2:])
+            elif part.startswith('device_name='):
+                config_info['device'] = part[12:]
+            elif part.startswith('dtype='):
+                config_info['dtype'] = part[6:]
+
+        if 'E' not in config_info or 'N' not in config_info:
+            continue
+
+        config_info['filename'] = filename
+
+        # Load the config file
+        try:
+            with open(os.path.join(configs_dir, filename)) as f:
+                config_data = json.load(f)
+
+            config_info['batch_configs'] = {}
+            for batch_size, batch_config in config_data.items():
+                config_info['batch_configs'][int(batch_size)] = batch_config
+
+            configs_data.append(config_info)
+
+        except Exception as e:
+            print(f"Error loading {filename}: {e}")
+            continue
+
+    return configs_data
+
+
+def analyze_patterns(configs_data):
+    """Analyze patterns in the config data."""
+
+    print("=== MoE Config Analysis (All Vendors) ===\n")
+
+    # Group by dtype
+    by_dtype = defaultdict(list)
+    for config in configs_data:
+        dtype = config.get('dtype', 'unquantized')
+        by_dtype[dtype].append(config)
+
+    print("Configs by dtype:")
+    for dtype, configs in by_dtype.items():
+        print(f"  {dtype}: {len(configs)} configs")
+    print()
+
+    # Group by device families
+    device_families = defaultdict(list)
+    for config in configs_data:
+        device = config.get('device', 'Unknown')
+        if 'H100' in device:
+            family = 'H100'
+        elif 'A100' in device:
+            family = 'A100'
+        elif 'H200' in device:
+            family = 'H200'
+        elif 'H20' in device:
+            family = 'H20'
+        elif 'A800' in device:
+            family = 'A800'
+        elif 'MI300' in device:
+            family = 'MI300'
+        elif 'MI325' in device:
+            family = 'MI325'
+        elif 'AMD' in device:
+            family = 'AMD_Other'
+        else:
+            family = 'Other'
+        device_families[family].append(config)
+
+    print("Configs by device family:")
+    for family, configs in device_families.items():
+        print(f"  {family}: {len(configs)} configs")
+    print()
+
+    # Analyze patterns for each dtype
+    for dtype, configs in by_dtype.items():
+        print(f"\n=== Analysis for {dtype} ===")
+        analyze_dtype_patterns(configs, dtype)
+
+
+def analyze_dtype_patterns(configs: list[dict], dtype: str):
+    """Analyze patterns for a specific dtype."""
+
+    # Collect all batch configs across all E/N combinations
+    all_batch_configs = []
+    E_values = set()
+    N_values = set()
+
+    for config in configs:
+        E_values.add(config['E'])
+        N_values.add(config['N'])
+
+        for batch_size, batch_config in config['batch_configs'].items():
+            entry = {
+                'E': config['E'],
+                'N': config['N'],
+                'device': config['device'],
+                'batch_size': batch_size,
+                **batch_config
+            }
+            all_batch_configs.append(entry)
+
+    print(f"Expert counts (E): {sorted(E_values)}")
+    print(f"Hidden dims (N): {sorted(N_values)}")
+    print(f"Total batch configs: {len(all_batch_configs)}")
+
+    # Analyze block size patterns
+    analyze_block_sizes(all_batch_configs)
+
+    # Analyze warp and stage patterns
+    analyze_warp_stage_patterns(all_batch_configs)
+
+    # Analyze trends by E and N
+    analyze_E_N_trends(all_batch_configs)
+
+
+def analyze_block_sizes(configs):
+    """Analyze block size patterns."""
+    print("\n--- Block Size Analysis ---")
+
+    block_m_values = [c['BLOCK_SIZE_M'] for c in configs]
+    block_n_values = [c['BLOCK_SIZE_N'] for c in configs]
+    block_k_values = [c['BLOCK_SIZE_K'] for c in configs]
+
+    print(
+        f"BLOCK_SIZE_M: min={min(block_m_values)}, max={max(block_m_values)}, "
+        f"most_common={max(set(block_m_values), key=block_m_values.count)}")
+    print(
+        f"BLOCK_SIZE_N: min={min(block_n_values)}, max={max(block_n_values)}, "
+        f"most_common={max(set(block_n_values), key=block_n_values.count)}")
+    print(
+        f"BLOCK_SIZE_K: min={min(block_k_values)}, max={max(block_k_values)}, "
+        f"most_common={max(set(block_k_values), key=block_k_values.count)}")
+
+    # Look at combinations
+    combinations = defaultdict(int)
+    for c in configs:
+        combo = (c['BLOCK_SIZE_M'], c['BLOCK_SIZE_N'], c['BLOCK_SIZE_K'])
+        combinations[combo] += 1
+
+    print("\nMost common (M,N,K) combinations:")
+    for combo, count in sorted(combinations.items(),
+                               key=lambda x: x[1],
+                               reverse=True)[:10]:
+        print(f"  {combo}: {count} times")
+
+
+def analyze_warp_stage_patterns(configs):
+    """Analyze warp and stage patterns."""
+    print("\n--- Warp/Stage Analysis ---")
+
+    warp_values = [c['num_warps'] for c in configs]
+    stage_values = [c['num_stages'] for c in configs]
+    group_m_values = [c['GROUP_SIZE_M'] for c in configs]
+
+    print(f"num_warps: min={min(warp_values)}, max={max(warp_values)}, "
+          f"most_common={max(set(warp_values), key=warp_values.count)}")
+    print(f"num_stages: min={min(stage_values)}, max={max(stage_values)}, "
+          f"most_common={max(set(stage_values), key=stage_values.count)}")
+    print(
+        f"GROUP_SIZE_M: min={min(group_m_values)}, max={max(group_m_values)}, "
+        f"most_common={max(set(group_m_values), key=group_m_values.count)}")
+
+
+def analyze_E_N_trends(configs):
+    """Analyze trends based on E and N values."""
+    print("\n--- E/N Trend Analysis ---")
+
+    # Group by E ranges
+    E_ranges = {
+        'small_E': [c for c in configs if c['E'] <= 8],
+        'medium_E': [c for c in configs if 8 < c['E'] <= 64],
+        'large_E': [c for c in configs if c['E'] > 64]
+    }
+
+    # Group by N ranges
+    N_ranges = {
+        'small_N': [c for c in configs if c['N'] <= 1024],
+        'medium_N': [c for c in configs if 1024 < c['N'] <= 4096],
+        'large_N': [c for c in configs if c['N'] > 4096]
+    }
+
+    print("Trends by Expert Count (E):")
+    for range_name, range_configs in E_ranges.items():
+        if not range_configs:
+            continue
+        print(f"\n  {range_name} (n={len(range_configs)}):")
+        analyze_range_stats(range_configs)
+
+    print("\nTrends by Hidden Dim (N):")
+    for range_name, range_configs in N_ranges.items():
+        if not range_configs:
+            continue
+        print(f"\n  {range_name} (n={len(range_configs)}):")
+        analyze_range_stats(range_configs)
+
+    # Batch size trends
+    print("\nTrends by Batch Size:")
+    batch_ranges = {
+        'tiny_batch': [c for c in configs if c['batch_size'] <= 8],
+        'small_batch': [c for c in configs if 8 < c['batch_size'] <= 64],
+        'medium_batch': [c for c in configs if 64 < c['batch_size'] <= 512],
+        'large_batch': [c for c in configs if c['batch_size'] > 512]
+    }
+
+    for range_name, range_configs in batch_ranges.items():
+        if not range_configs:
+            continue
+        print(f"\n  {range_name} (n={len(range_configs)}):")
+        analyze_range_stats(range_configs)
+
+
+def analyze_range_stats(configs):
+    """Analyze stats for a range of configs."""
+    if not configs:
+        return
+
+    # Collect values for analysis
+    block_m_vals = [c['BLOCK_SIZE_M'] for c in configs]
+    block_n_vals = [c['BLOCK_SIZE_N'] for c in configs]
+    block_k_vals = [c['BLOCK_SIZE_K'] for c in configs]
+    warps_vals = [c['num_warps'] for c in configs]
+    stages_vals = [c['num_stages'] for c in configs]
+    group_m_vals = [c['GROUP_SIZE_M'] for c in configs]
+
+    def analyze_distribution(values, name):
+        """Analyze distribution of values."""
+        if not values:
+            return
+
+        # Basic stats
+        avg = np.mean(values)
+        std = np.std(values)
+        median = np.median(values)
+
+        # Mode (most common)
+        from collections import Counter
+        counter = Counter(values)
+        mode = counter.most_common(1)[0][0]
+        mode_count = counter.most_common(1)[0][1]
+        mode_pct = (mode_count / len(values)) * 100
+
+        # Top 3 most common values
+        top3 = counter.most_common(3)
+
+        print(f"    {name}:")
+        print(f"      avg={avg:.1f} ± {std:.1f}, median={median:.1f}")
+        print(f"      mode={mode} ({mode_pct:.1f}% of configs)")
+        print(f"      top3: {[f'{val}({cnt})' for val, cnt in top3]}")
+
+    analyze_distribution(block_m_vals, "BLOCK_SIZE_M")
+    analyze_distribution(block_n_vals, "BLOCK_SIZE_N")
+    analyze_distribution(block_k_vals, "BLOCK_SIZE_K")
+    analyze_distribution(warps_vals, "num_warps")
+    analyze_distribution(stages_vals, "num_stages")
+    analyze_distribution(group_m_vals, "GROUP_SIZE_M")
+
+
+if __name__ == "__main__":
+    configs_data = parse_all_configs()
+    print(f"Loaded {len(configs_data)} config files")
+    analyze_patterns(configs_data)

--- a/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
+++ b/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
@@ -148,6 +148,9 @@ def analyze_dtype_patterns(configs: list[dict], dtype: str):
 def analyze_block_sizes(configs):
     """Analyze block size patterns."""
     print("\n--- Block Size Analysis ---")
+    if not configs:
+        print("  No batch configs to analyze for block sizes.")
+        return
 
     block_m_values = [c['BLOCK_SIZE_M'] for c in configs]
     block_n_values = [c['BLOCK_SIZE_N'] for c in configs]

--- a/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
+++ b/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
@@ -6,6 +6,7 @@
 import json
 import os
 from collections import defaultdict
+from typing import Any
 
 import numpy as np
 
@@ -24,7 +25,7 @@ def parse_all_configs():
         name = filename[:-5]  # remove .json
         parts = name.split(',')
 
-        config_info: dict[str, any] = {}
+        config_info: dict[str, Any] = {}
         for part in parts:
             if part.startswith('E='):
                 config_info['E'] = int(part[2:])

--- a/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
+++ b/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
@@ -24,7 +24,7 @@ def parse_all_configs():
         name = filename[:-5]  # remove .json
         parts = name.split(',')
 
-        config_info = {}
+        config_info: dict[str, any] = {}
         for part in parts:
             if part.startswith('E='):
                 config_info['E'] = int(part[2:])
@@ -164,7 +164,7 @@ def analyze_block_sizes(configs):
         f"most_common={max(set(block_k_values), key=block_k_values.count)}")
 
     # Look at combinations
-    combinations = defaultdict(int)
+    combinations: dict[tuple[int, int, int], int] = defaultdict(int)
     for c in configs:
         combo = (c['BLOCK_SIZE_M'], c['BLOCK_SIZE_N'], c['BLOCK_SIZE_K'])
         combinations[combo] += 1

--- a/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
+++ b/vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
@@ -182,6 +182,9 @@ def analyze_block_sizes(configs):
 def analyze_warp_stage_patterns(configs):
     """Analyze warp and stage patterns."""
     print("\n--- Warp/Stage Analysis ---")
+    if not configs:
+        print("  No batch configs to analyze for warp/stage patterns.")
+        return
 
     warp_values = [c['num_warps'] for c in configs]
     stage_values = [c['num_stages'] for c in configs]

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -803,16 +803,45 @@ def get_default_config(
     dtype: Optional[str],
     block_shape: Optional[list[int]] = None,
 ) -> dict[str, int]:
+    """
+    Default config based on analysis of 200+ existing configs.
+    Performed on 9/11/25 using: 
+        python vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
+    
+    Key findings:
+    - Most common overall block sizes: 
+        BLOCK_SIZE_M=16 (50%+), BLOCK_SIZE_N=128 (40%+), BLOCK_SIZE_K=64/128
+    - num_warps=4 in 70%+ of configs across all dtypes
+    - num_stages=3 or 4 most common depending on dtype
+    - GROUP_SIZE_M=1 most common (50%+ across categories)
+    - Different dtypes (fp8_w8a8, int8_w8a16) have distinct optimal patterns
+    """
+
     if dtype == "fp8_w8a8" and block_shape is not None:
         # Block-wise quant: BLOCK_SIZE_N must be divisible by block_shape[0]
         # BLOCK_SIZE_K must be divisible by block_shape[1]
         # num_stages=3 can cause triton.runtime.errors.OutOfResources
         # on ROCm, set it to 2 instead.
+
+        # Batch size dependent BLOCK_SIZE_M and GROUP_SIZE_M based on FP8 data
+        if M <= 16:
+            # Small batch: 69% use BLOCK_SIZE_M=16, GROUP_SIZE_M=1 preferred
+            block_m = 16
+            group_m = 1
+        elif M <= 256:
+            # Medium batch: more BLOCK_SIZE_M=64 usage, GROUP_SIZE_M=1 common
+            block_m = 64
+            group_m = 1
+        else:
+            # Large batch: BLOCK_SIZE_M=64/128, GROUP_SIZE_M can be larger
+            block_m = 64
+            group_m = 16
+
         config = {
-            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_M": block_m,
             "BLOCK_SIZE_N": block_shape[0],
             "BLOCK_SIZE_K": block_shape[1],
-            "GROUP_SIZE_M": 32,
+            "GROUP_SIZE_M": group_m,
             "num_warps": 4,
             "num_stages": 3 if not current_platform.is_rocm() else 2,
         }
@@ -831,20 +860,84 @@ def get_default_config(
             config = {"BLOCK_SIZE_M": 32, "GROUP_SIZE_M": 1}
         else:
             config = {"BLOCK_SIZE_M": 64, "GROUP_SIZE_M": 1}
-    elif M <= E:
-        config = {
-            "BLOCK_SIZE_M": 16,
-            "BLOCK_SIZE_N": 32,
-            "BLOCK_SIZE_K": 64,
-            "GROUP_SIZE_M": 1,
-        }
     else:
+        # Data-driven heuristics based on analysis of 204 configs
+
+        # BLOCK_SIZE_M: Strong batch size correlation
+        # Analysis shows: tiny_batch(≤8): 96% use 16, small_batch: 69-89% use 16
+        if M <= 8:
+            block_m = 16  # 96% of tiny batch configs use 16
+        elif M <= 64:
+            block_m = 16  # 69-89% of small batch configs use 16
+        elif M <= 512:
+            # Medium batch: more variation, but 16 still most common
+            if dtype == "fp8_w8a8":
+                block_m = 64  # FP8 prefers 64 for medium batches
+            elif E > 64:
+                block_m = 16  # Large E prefers smaller blocks
+            else:
+                block_m = 64
+        else:
+            # Large batch: 128 becomes more common
+            block_m = 128
+
+        # BLOCK_SIZE_N: Hidden dimension and dtype correlation
+        # 128 is mode across all categories (37-57% of configs)
+        if N <= 1024:
+            # Small N: analysis shows preference for 64-128
+            block_n = 64 if M <= 8 else 128
+        elif N <= 4096:
+            block_n = 128  # 128 dominates medium N range
+        else:
+            # Large N: 128 still preferred, 256 for very large batches
+            block_n = 256 if M >= 512 else 128
+
+        # BLOCK_SIZE_K: Dtype and batch size dependent
+        if dtype == "fp8_w8a8":
+            # FP8 shows strong preference for 128 (57-66% of configs)
+            block_k = 128
+        elif dtype == "int8_w8a16":
+            # INT8_W8A16 has unique pattern: tiny batches prefer 256
+            if M <= 8:
+                block_k = 256  # 67% of tiny batch configs
+            elif M <= 64:
+                block_k = 128
+            else:
+                block_k = 64
+        else:
+            # Unquantized: 64 is mode (50-75% depending on category)
+            block_k = 128 if M <= 8 else 64
+
+        # num_warps: Consistently 4 across all analyses (70-80% of configs)
+        num_warps = 4
+
+        # num_stages: Dtype dependent
+        if dtype in ["fp8_w8a8", "int8_w8a16", "int8_w8a8"]:
+            num_stages = 3  # FP8/INT8 analysis shows 3 is most common
+        else:
+            # Unquantized: 4 and 2 are equally common, use 3 as compromise
+            # Analysis shows tiny batches prefer 4, larger batches prefer 3
+            num_stages = 4 if M <= 16 else 3
+
+        # GROUP_SIZE_M: Data shows 1=52%, 16=19%, 32=12%
+        # Large batches show significant usage of 16 (31% for M>512)
+        if M <= 64:
+            group_m = 1  # Small batches strongly prefer 1 (62%)
+        elif M <= 512:
+            group_m = 16 if E <= 64 else 1  # Medium batches, 16 is common
+        else:
+            # Large batches: 1=37%, 16=31%, 32=15% - use 16 as good compromise
+            group_m = 16
+
         config = {
-            "BLOCK_SIZE_M": 64,
-            "BLOCK_SIZE_N": 64,
-            "BLOCK_SIZE_K": 32,
-            "GROUP_SIZE_M": 8,
+            "BLOCK_SIZE_M": block_m,
+            "BLOCK_SIZE_N": block_n,
+            "BLOCK_SIZE_K": block_k,
+            "GROUP_SIZE_M": group_m,
+            "num_warps": num_warps,
+            "num_stages": num_stages,
         }
+
     return config
 
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -823,7 +823,6 @@ def get_default_config(
         # num_stages=3 can cause triton.runtime.errors.OutOfResources
         # on ROCm, set it to 2 instead.
 
-        # Batch size dependent BLOCK_SIZE_M and GROUP_SIZE_M based on FP8 data
         if M <= 16:
             # Small batch: 69% use BLOCK_SIZE_M=16, GROUP_SIZE_M=1 preferred
             block_m = 16
@@ -861,8 +860,6 @@ def get_default_config(
         else:
             config = {"BLOCK_SIZE_M": 64, "GROUP_SIZE_M": 1}
     else:
-        # Data-driven heuristics based on analysis of 204 configs
-
         # BLOCK_SIZE_M: Strong batch size correlation
         # Analysis shows: tiny_batch(≤8): 96% use 16, small_batch: 69-89% use 16
         if M <= 8:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

With the help of Claude, I took a look at the statistics of the 200+ configs we have for fused moe and came away with some recommendations. Haven't validated them e2e yet, but from smoke tests it seems faster.

The main improvement seems to be from just including defaults for `'num_warps': 4, 'num_stages': 3`, which were omitted before except for block fp8.

### Benchmarks on H100

Mixtral BF16
```
python benchmarks/kernels/benchmark_moe.py --model=mistralai/Mixtral-8x7B-Instruct-v0.1 -tp=2

# Tuned Config
(BenchmarkWorker pid=3339388) INFO 09-12 01:05:21 [fused_moe.py:720] Using configuration from /home/mgoin/code/vllm/vllm/model_executor/layers/fused_moe/configs/E=8,N=7168,device_name=NVIDIA_H100_80GB_HBM3.json for MoE layer.
Batch size: 1, Kernel time: 144.03 us
Batch size: 2, Kernel time: 229.28 us
Batch size: 4, Kernel time: 351.10 us
Batch size: 8, Kernel time: 434.98 us
Batch size: 16, Kernel time: 471.49 us
Batch size: 24, Kernel time: 478.27 us
Batch size: 32, Kernel time: 487.35 us
Batch size: 48, Kernel time: 487.85 us
Batch size: 64, Kernel time: 483.14 us
Batch size: 96, Kernel time: 494.42 us
Batch size: 128, Kernel time: 491.39 us
Batch size: 256, Kernel time: 536.77 us
Batch size: 512, Kernel time: 662.33 us
Batch size: 1024, Kernel time: 833.72 us
Batch size: 1536, Kernel time: 1122.93 us
Batch size: 2048, Kernel time: 1426.73 us
Batch size: 3072, Kernel time: 1999.02 us
Batch size: 4096, Kernel time: 2613.12 us

# Main Default
Batch size: 1, Kernel time: 151.56 us
Batch size: 2, Kernel time: 253.26 us
Batch size: 4, Kernel time: 354.48 us
Batch size: 8, Kernel time: 433.38 us
Batch size: 16, Kernel time: 634.05 us
Batch size: 24, Kernel time: 619.83 us
Batch size: 32, Kernel time: 625.04 us
Batch size: 48, Kernel time: 654.93 us
Batch size: 64, Kernel time: 645.96 us
Batch size: 96, Kernel time: 664.05 us
Batch size: 128, Kernel time: 681.72 us
Batch size: 256, Kernel time: 872.23 us
Batch size: 512, Kernel time: 1123.58 us
Batch size: 1024, Kernel time: 1845.98 us
Batch size: 1536, Kernel time: 2648.33 us
Batch size: 2048, Kernel time: 3415.64 us
Batch size: 3072, Kernel time: 5038.12 us
Batch size: 4096, Kernel time: 6595.58 us

# PR Default
Batch size: 1, Kernel time: 143.52 us
Batch size: 2, Kernel time: 232.60 us
Batch size: 4, Kernel time: 354.45 us
Batch size: 8, Kernel time: 441.44 us
Batch size: 16, Kernel time: 502.77 us
Batch size: 24, Kernel time: 511.23 us
Batch size: 32, Kernel time: 512.27 us
Batch size: 48, Kernel time: 519.52 us
Batch size: 64, Kernel time: 572.61 us
Batch size: 96, Kernel time: 508.80 us
Batch size: 128, Kernel time: 513.73 us
Batch size: 256, Kernel time: 539.29 us
Batch size: 512, Kernel time: 746.29 us
Batch size: 1024, Kernel time: 883.60 us
Batch size: 1536, Kernel time: 1148.06 us
Batch size: 2048, Kernel time: 1435.83 us
Batch size: 3072, Kernel time: 2023.13 us
Batch size: 4096, Kernel time: 2597.61 us
```


Qwen3 MoE BF16
```
python benchmarks/kernels/benchmark_moe.py --model=Qwen/Qwen3-30B-A3B -tp=1

# Main Default
Batch size: 1, Kernel time: 52.29 us
Batch size: 2, Kernel time: 74.83 us
Batch size: 4, Kernel time: 121.40 us
Batch size: 8, Kernel time: 188.22 us
Batch size: 16, Kernel time: 277.91 us
Batch size: 24, Kernel time: 337.50 us
Batch size: 32, Kernel time: 367.86 us
Batch size: 48, Kernel time: 407.03 us
Batch size: 64, Kernel time: 414.02 us
Batch size: 96, Kernel time: 424.88 us
Batch size: 128, Kernel time: 430.53 us
Batch size: 256, Kernel time: 547.07 us
Batch size: 512, Kernel time: 634.68 us
Batch size: 1024, Kernel time: 754.72 us
Batch size: 1536, Kernel time: 837.02 us
Batch size: 2048, Kernel time: 992.01 us
Batch size: 3072, Kernel time: 1332.06 us
Batch size: 4096, Kernel time: 1696.40 us

# PR Default
Batch size: 1, Kernel time: 52.35 us
Batch size: 2, Kernel time: 77.73 us
Batch size: 4, Kernel time: 119.14 us
Batch size: 8, Kernel time: 188.24 us
Batch size: 16, Kernel time: 280.65 us
Batch size: 24, Kernel time: 341.52 us
Batch size: 32, Kernel time: 381.03 us
Batch size: 48, Kernel time: 414.23 us
Batch size: 64, Kernel time: 420.20 us
Batch size: 96, Kernel time: 430.50 us
Batch size: 128, Kernel time: 434.91 us
Batch size: 256, Kernel time: 469.38 us
Batch size: 512, Kernel time: 546.70 us
Batch size: 1024, Kernel time: 534.09 us
Batch size: 1536, Kernel time: 601.91 us
Batch size: 2048, Kernel time: 701.57 us
Batch size: 3072, Kernel time: 829.49 us
Batch size: 4096, Kernel time: 1024.92 us
```

Qwen3 MoE FP8
```
python benchmarks/kernels/benchmark_moe.py --model=Qwen/Qwen3-30B-A3B -tp=1 --dtype=fp8_w8a8

# Main
Batch size: 1, Kernel time: 44.54 us
Batch size: 2, Kernel time: 59.94 us
Batch size: 4, Kernel time: 90.46 us
Batch size: 8, Kernel time: 129.77 us
Batch size: 16, Kernel time: 185.40 us
Batch size: 24, Kernel time: 215.99 us
Batch size: 32, Kernel time: 238.37 us
Batch size: 48, Kernel time: 257.83 us
Batch size: 64, Kernel time: 262.73 us
Batch size: 96, Kernel time: 270.98 us
Batch size: 128, Kernel time: 273.72 us
Batch size: 256, Kernel time: 355.49 us
Batch size: 512, Kernel time: 391.86 us
Batch size: 1024, Kernel time: 536.33 us
Batch size: 1536, Kernel time: 727.31 us
Batch size: 2048, Kernel time: 911.64 us
Batch size: 3072, Kernel time: 1279.17 us
Batch size: 4096, Kernel time: 1647.57 us

# PR
Batch size: 1, Kernel time: 40.44 us
Batch size: 2, Kernel time: 56.15 us
Batch size: 4, Kernel time: 78.10 us
Batch size: 8, Kernel time: 118.64 us
Batch size: 16, Kernel time: 164.64 us
Batch size: 24, Kernel time: 193.48 us
Batch size: 32, Kernel time: 210.07 us
Batch size: 48, Kernel time: 230.59 us
Batch size: 64, Kernel time: 237.26 us
Batch size: 96, Kernel time: 244.33 us
Batch size: 128, Kernel time: 247.67 us
Batch size: 256, Kernel time: 262.38 us
Batch size: 512, Kernel time: 286.24 us
Batch size: 1024, Kernel time: 354.49 us
Batch size: 1536, Kernel time: 398.70 us
Batch size: 2048, Kernel time: 472.43 us
Batch size: 3072, Kernel time: 606.13 us
Batch size: 4096, Kernel time: 751.27 us
```

DeepSeekV3 BF16
```
python benchmarks/kernels/benchmark_moe.py --model=deepseek-ai/DeepSeek-V3.1 -tp=8

# Main
Batch size: 1, Kernel time: 77.89 us
Batch size: 2, Kernel time: 123.30 us
Batch size: 4, Kernel time: 164.23 us
Batch size: 8, Kernel time: 248.83 us
Batch size: 16, Kernel time: 428.22 us
Batch size: 24, Kernel time: 541.59 us
Batch size: 32, Kernel time: 651.49 us
Batch size: 48, Kernel time: 761.50 us
Batch size: 64, Kernel time: 850.43 us
Batch size: 96, Kernel time: 938.06 us
Batch size: 128, Kernel time: 969.19 us
Batch size: 256, Kernel time: 1012.41 us
Batch size: 512, Kernel time: 1319.28 us
Batch size: 1024, Kernel time: 1467.50 us
Batch size: 1536, Kernel time: 1639.19 us
Batch size: 2048, Kernel time: 2014.49 us
Batch size: 3072, Kernel time: 2598.05 us
Batch size: 4096, Kernel time: 3264.58 us

# PR
Batch size: 1, Kernel time: 66.88 us
Batch size: 2, Kernel time: 99.99 us
Batch size: 4, Kernel time: 148.07 us
Batch size: 8, Kernel time: 243.62 us
Batch size: 16, Kernel time: 413.16 us
Batch size: 24, Kernel time: 546.18 us
Batch size: 32, Kernel time: 635.38 us
Batch size: 48, Kernel time: 763.65 us
Batch size: 64, Kernel time: 859.70 us
Batch size: 96, Kernel time: 941.08 us
Batch size: 128, Kernel time: 970.69 us
Batch size: 256, Kernel time: 1006.38 us
Batch size: 512, Kernel time: 1119.63 us
Batch size: 1024, Kernel time: 1126.84 us
Batch size: 1536, Kernel time: 1184.36 us
Batch size: 2048, Kernel time: 1266.73 us
Batch size: 3072, Kernel time: 1388.82 us
Batch size: 4096, Kernel time: 1670.61 us
```

DeepSeekV3 FP8
```
python benchmarks/kernels/benchmark_moe.py --model=deepseek-ai/DeepSeek-V3.1 -tp=8 --dtype=fp8_w8a8

# Main
Batch size: 1, Kernel time: 70.37 us
Batch size: 2, Kernel time: 84.81 us
Batch size: 4, Kernel time: 109.80 us
Batch size: 8, Kernel time: 177.52 us
Batch size: 16, Kernel time: 274.24 us
Batch size: 24, Kernel time: 353.83 us
Batch size: 32, Kernel time: 400.78 us
Batch size: 48, Kernel time: 480.75 us
Batch size: 64, Kernel time: 541.81 us
Batch size: 96, Kernel time: 563.25 us
Batch size: 128, Kernel time: 580.92 us
Batch size: 256, Kernel time: 610.11 us
Batch size: 512, Kernel time: 652.35 us
Batch size: 1024, Kernel time: 728.38 us
Batch size: 1536, Kernel time: 801.37 us
Batch size: 2048, Kernel time: 1025.57 us
Batch size: 3072, Kernel time: 1336.62 us
Batch size: 4096, Kernel time: 1604.17 us

# PR
Batch size: 1, Kernel time: 64.67 us
Batch size: 2, Kernel time: 83.92 us
Batch size: 4, Kernel time: 104.69 us
Batch size: 8, Kernel time: 150.40 us
Batch size: 16, Kernel time: 233.71 us
Batch size: 24, Kernel time: 353.05 us
Batch size: 32, Kernel time: 400.59 us
Batch size: 48, Kernel time: 482.10 us
Batch size: 64, Kernel time: 527.70 us
Batch size: 96, Kernel time: 569.72 us
Batch size: 128, Kernel time: 587.93 us
Batch size: 256, Kernel time: 616.24 us
Batch size: 512, Kernel time: 650.36 us
Batch size: 1024, Kernel time: 727.57 us
Batch size: 1536, Kernel time: 803.41 us
Batch size: 2048, Kernel time: 972.73 us
Batch size: 3072, Kernel time: 1250.35 us
Batch size: 4096, Kernel time: 1532.79 us
```

Example output of the analysis script (only the first general section):
```
python vllm/model_executor/layers/fused_moe/configs/analyze_configs.py
Loaded 204 config files
=== MoE Config Analysis (All Vendors) ===

Configs by dtype:
  unquantized: 94 configs
  fp8_w8a8: 92 configs
  int8_w8a16: 13 configs
  int8_w8a8: 5 configs

Configs by device family:
  H200: 30 configs
  H20: 25 configs
  H100: 40 configs
  A100: 33 configs
  MI300: 26 configs
  MI325: 21 configs
  Other: 23 configs
  A800: 6 configs


=== Analysis for unquantized ===
Expert counts (E): [1, 8, 16, 60, 62, 64, 72, 128, 160, 256, 512]
Hidden dims (N): [64, 96, 176, 192, 256, 320, 352, 384, 512, 640, 704, 768, 896, 1024, 1280, 1344, 1408, 1792, 2048, 2560, 2688, 3072, 3584, 4096, 7168, 8192, 14336, 16384]
Total batch configs: 1747

--- Block Size Analysis ---
BLOCK_SIZE_M: min=16, max=256, most_common=16
BLOCK_SIZE_N: min=16, max=256, most_common=128
BLOCK_SIZE_K: min=32, max=256, most_common=64

Most common (M,N,K) combinations:
  (128, 128, 64): 267 times
  (16, 64, 128): 161 times
  (128, 256, 64): 154 times
  (16, 128, 128): 133 times
  (16, 64, 64): 119 times
  (16, 128, 64): 109 times
  (16, 64, 256): 106 times
  (64, 128, 64): 92 times
  (32, 128, 128): 81 times
  (16, 32, 64): 62 times

--- Warp/Stage Analysis ---
num_warps: min=1, max=16, most_common=4
num_stages: min=1, max=8, most_common=4
GROUP_SIZE_M: min=1, max=128, most_common=1
...
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

