### PR TITLE
[VLM][Performance] Fast multimodal placeholder masking via vocabulary LUT buffer

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -1167,7 +1167,7 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
             else:
                 ids = self._mm_placeholder_lut.to(device=input_ids.device)
                 is_multimodal = (input_ids.unsqueeze(-1) == ids.view(
-                    1,-1)).any(dim=-1)
+                    1, -1)).any(dim=-1)
             inputs_embeds = merge_multimodal_embeddings_from_mask(
                 inputs_embeds=inputs_embeds,
                 is_multimodal=is_multimodal,

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -1166,8 +1166,8 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
                 is_multimodal = self._mm_placeholder_lut[input_ids]
             else:
                 ids = self._mm_placeholder_lut.to(device=input_ids.device)
-                is_multimodal = (
-                    input_ids.unsqueeze(-1) == ids.view(1,-1)).any(dim=-1)
+                is_multimodal = (input_ids.unsqueeze(-1) == ids.view(
+                    1,-1)).any(dim=-1)
             inputs_embeds = merge_multimodal_embeddings_from_mask(
                 inputs_embeds=inputs_embeds,
                 is_multimodal=is_multimodal,

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -404,6 +404,21 @@ def merge_multimodal_embeddings_from_map(
         placeholder_map.src].to(dtype=inputs_embeds.dtype)
     return inputs_embeds
 
+def merge_multimodal_embeddings_from_mask(
+    inputs_embeds: torch.Tensor,
+    is_multimodal: torch.Tensor,
+    multimodal_embeddings: NestedTensors,
+) -> torch.Tensor:
+    """
+    Merge multimodal embeddings using a precomputed boolean mask.
+
+    This updates inputs_embeds in place.
+    """
+    return _merge_multimodal_embeddings(
+        inputs_embeds=inputs_embeds,
+        is_multimodal=is_multimodal,
+        multimodal_embeddings=multimodal_embeddings,
+    )
 
 def _merge_multimodal_embeddings(
     inputs_embeds: torch.Tensor,

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -404,6 +404,7 @@ def merge_multimodal_embeddings_from_map(
         placeholder_map.src].to(dtype=inputs_embeds.dtype)
     return inputs_embeds
 
+
 def merge_multimodal_embeddings_from_mask(
     inputs_embeds: torch.Tensor,
     is_multimodal: torch.Tensor,
@@ -419,6 +420,7 @@ def merge_multimodal_embeddings_from_mask(
         is_multimodal=is_multimodal,
         multimodal_embeddings=multimodal_embeddings,
     )
+
 
 def _merge_multimodal_embeddings(
     inputs_embeds: torch.Tensor,


### PR DESCRIPTION
<!-- markdownlint-disable -->

Summary：
Replace torch.isin-based placeholder detection with a fast LUT. Build a boolean lookup tensor of length config.vocab_size marking multimodal placeholder token IDs and register it as a non-persistent buffer so it follows device moves but isn’t checkpointed. At runtime, create the mask via is_multimodal = lut[input_ids] (O(N) gather); if IDs may exceed vocab, fall back to broadcasted equality + any. Keep merge logic unchanged (masked_scatter_), removing the aten::isin hotspot while keeping code simple, robust, and efficient.
 
Reduce the time cost of get_input_embeddings from 47ms to 1ms
Before:
<img width="1493" height="756" alt="image" src="https://github.com/user-attachments/assets/bcea3df5-1cba-4bbb-92f0-68c31aca3b85" />

After:
<img width="1422" height="756" alt="image" src="https://github.com/user-attachments/assets/a27ac32c-d48c-440b-8fbb-4f017996be84" />

benchmark
```
vllm bench serve \
  --backend openai-chat \
  --endpoint /v1/chat/completions \
  --endpoint-type openai-chat \
  --model /workspace/models/Qwen2.5-VL-7B-Instruct \
  --trust-remote-code \
  --port 5580 \
  --host 127.0.0.1 \
  --dataset-name hf \
  --dataset-path lmarena-ai/VisionArena-Chat \
  --num-prompts 100 \
  --seed 40
```

```
Before：
============ Serving Benchmark Result ============
Successful requests:                     99        
Benchmark duration (s):                  13.24     
Total input tokens:                      9959      
Total generated tokens:                  11478     
Request throughput (req/s):              7.48      
Output token throughput (tok/s):         866.75    
Total Token throughput (tok/s):          1618.79   
---------------Time to First Token----------------
Mean TTFT (ms):                          4796.99   
Median TTFT (ms):                        3748.13   
P99 TTFT (ms):                           10748.97  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          72.34     
Median TPOT (ms):                        74.50     
P99 TPOT (ms):                           218.71    
---------------Inter-token Latency----------------
Mean ITL (ms):                           67.08     
Median ITL (ms):                         20.59     
P99 ITL (ms):                            631.23    
==================================================
After：
============ Serving Benchmark Result ============
Successful requests:                     99        
Benchmark duration (s):                  12.28     
Total input tokens:                      9959      
Total generated tokens:                  11490     
Request throughput (req/s):              8.06      
Output token throughput (tok/s):         935.31    
Total Token throughput (tok/s):          1746.00   
---------------Time to First Token----------------
Mean TTFT (ms):                          4441.68   
Median TTFT (ms):                        3989.55   
P99 TTFT (ms):                           9758.09   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          66.80     
Median TPOT (ms):                        69.00     
P99 TPOT (ms):                           232.78    
---------------Inter-token Latency----------------
Mean ITL (ms):                           61.90     
Median ITL (ms):                         20.93     
P99 ITL (ms):                            277.66    
==================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

