### PR TITLE
[Misc][gpt-oss] Add gpt-oss label to PRs that mention harmony or related to builtin tool call

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -126,6 +126,9 @@ pull_request_rules:
       - files~=^tests/.*gpt[-_]?oss.*\.py
       - files~=^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
       - files~=^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
+      - files~=^vllm/entrypoints/harmony_utils.py
+      - files~=^vllm/entrypoints/tool_server.py
+      - files~=^vllm/entrypoints/tool.py
       - title~=(?i)gpt[-_]?oss
       - title~=(?i)harmony
   actions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -125,6 +125,7 @@ pull_request_rules:
       - files~=^examples/.*gpt[-_]?oss.*\.py
       - files~=^tests/.*gpt[-_]?oss.*\.py
       - files~=^tests/entrypoints/openai/test_response_api_with_harmony.py
+      - files~=^tests/entrypoints/test_context.py
       - files~=^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
       - files~=^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
       - files~=^vllm/entrypoints/harmony_utils.py

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -124,6 +124,7 @@ pull_request_rules:
     - or:
       - files~=^examples/.*gpt[-_]?oss.*\.py
       - files~=^tests/.*gpt[-_]?oss.*\.py
+      - files~=^tests/entrypoints/openai/test_response_api_with_harmony.py
       - files~=^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
       - files~=^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
       - files~=^vllm/entrypoints/harmony_utils.py

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -127,6 +127,7 @@ pull_request_rules:
       - files~=^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
       - files~=^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
       - title~=(?i)gpt[-_]?oss
+      - title~=(?i)harmony
   actions:
     label:
       add:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -129,6 +129,7 @@ pull_request_rules:
       - files~=^vllm/entrypoints/harmony_utils.py
       - files~=^vllm/entrypoints/tool_server.py
       - files~=^vllm/entrypoints/tool.py
+      - files~=^vllm/entrypoints/context.py
       - title~=(?i)gpt[-_]?oss
       - title~=(?i)harmony
   actions:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Harmony parser and built-in tool call are only used by gpt-oss now. And some of these PRs don't mention gpt-oss. So I want to add a label to filter these PRs.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

