### PR TITLE
[CI/Build] Skip prompt embeddings tests on V1-only CPU backend

### DIFF
--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -119,6 +119,12 @@ def test_models(hf_runner, vllm_runner, example_prompts, model: str,
         # in parts of the operators
         pytest.skip(f"Skipping '{model}' model test with AITER kernel.")
 
+    # Note: can be removed when
+    # https://github.com/vllm-project/vllm/pull/24278 finished
+    if current_platform.is_cpu() and use_prompt_embeds:
+        pytest.skip("Skipping use_prompt_embeds=True with "
+                    "V1-only CPU backend.")
+
     with hf_runner(model) as hf_model:
         hf_outputs = hf_model.generate_greedy_logprobs_limit(
             example_prompts, max_tokens, num_logprobs)


### PR DESCRIPTION
## Purpose

- For now prompt embeddings fallbacks to V0, which has been deprecated on CPU backend. Skip related tests temporarily, which can be recovered after #24278 merged

## Test Plan

CI tests

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

