### PR TITLE
[sleep mode] save memory for on-the-fly quantization

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -226,8 +226,8 @@ class CuMemAllocator:
             unmap_and_release(handle)
 
         logger.info(
-            "CuMemAllocator: sleep freed %s GiB memory in total, of which"
-            "%s GiB is backed up in CPU and the rest %s GiB is discarded"
+            "CuMemAllocator: sleep freed %.2f GiB memory in total, of which "
+            "%.2f GiB is backed up in CPU and the rest %.2f GiB is discarded "
             "directly.", total_bytes / 1024**3, backup_bytes / 1024**3,
             (total_bytes - backup_bytes) / 1024**3)
 

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -285,7 +285,7 @@ class CuMemAllocator:
             allocations = data[0].snapshot()
             for allocation in allocations:
                 if allocation["allocated_size"] == 0:
-                    handle = self._python_free_callback(allocation["ptr"])
+                    handle = self._python_free_callback(allocation["address"])
                     unmap_and_release(handle)
             self.current_tag = old_tag
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Solves https://github.com/vllm-project/vllm/issues/19855

## Test Plan

```python
import gc

import torch
from vllm import LLM
from vllm.utils import GiB_bytes


def print_current_mem_usage(tag):
    gc.collect()
    torch.cuda.empty_cache()
    free_bytes, total = torch.cuda.mem_get_info()
    print(f"[mem_usage] {tag} | current used: {(total - free_bytes) / GiB_bytes}")


def test_fp8_sleep():
    model_path = "Qwen/Qwen2.5-7B-Instruct"

    model = LLM(
        model=model_path,
        dtype="bfloat16",
        gpu_memory_utilization=0.8,
        trust_remote_code=True,
        enable_sleep_mode=True,
        quantization="fp8",
    )

    print_current_mem_usage("before sleep")
    model.sleep()
    print_current_mem_usage("after sleep")
    model.wake_up(["weights"])
    print_current_mem_usage("after wakeup weights")


if __name__ == "__main__":
    test_fp8_sleep()
```

Run the code, and the memory taken with quantization is close to 9 GiB, showing the benefit of online quantization.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

