### PR TITLE
[Perf] Use NVIDIA hardware-accelerated instruction for float to fp8_e4m3 quantization

### DIFF
--- a/csrc/quantization/fp8/common.cuh
+++ b/csrc/quantization/fp8/common.cuh
@@ -52,7 +52,7 @@ __device__ __forceinline__ fp8_type scaled_fp8_conversion(float const val,
 #ifndef USE_ROCM
   // Use hardware cvt instruction for fp8 on nvidia
   // Currently only support fp8_type = c10::Float8_e4m3fn
-  return fp8::scaled_vec_conversion<fp8_type, float>(r, 1.0f, __NV_E4M3);
+  return fp8::vec_conversion<fp8_type, float>(r);
 #else
   // Use hardware cvt instruction for fp8 on rocm
   return fp8::cvt_c10<fp8_type>(r);

--- a/csrc/quantization/fp8/common.cuh
+++ b/csrc/quantization/fp8/common.cuh
@@ -5,7 +5,9 @@
 
 #include <cmath>
 
-#ifdef USE_ROCM
+#ifndef USE_ROCM
+  #include "nvidia/quant_utils.cuh"
+#else
   #include "amd/quant_utils.cuh"
 #endif
 
@@ -48,7 +50,9 @@ __device__ __forceinline__ fp8_type scaled_fp8_conversion(float const val,
   float r =
       fmaxf(-quant_type_max_v<fp8_type>, fminf(x, quant_type_max_v<fp8_type>));
 #ifndef USE_ROCM
-  return static_cast<fp8_type>(r);
+  // Use hardware cvt instruction for fp8 on nvidia
+  // Currently only support fp8_type = c10::Float8_e4m3fn
+  return fp8::scaled_vec_conversion<fp8_type, float>(r, 1.0f, __NV_E4M3);
 #else
   // Use hardware cvt instruction for fp8 on rocm
   return fp8::cvt_c10<fp8_type>(r);

--- a/csrc/quantization/fp8/nvidia/quant_utils.cuh
+++ b/csrc/quantization/fp8/nvidia/quant_utils.cuh
@@ -12,13 +12,26 @@ namespace vllm {
 namespace fp8 {
   #ifdef ENABLE_FP8
 
-    #if 0  // Disable the following code to reduce the binary size.
 template <typename Tout, typename Tin>
-__inline__ __device__ Tout
-vec_conversion(const Tin &x, const __nv_fp8_interpretation_t fp8_type) {
+__inline__ __device__ Tout vec_conversion(
+    const Tin& x, const __nv_fp8_interpretation_t fp8_type = __NV_E4M3) {
   return x;
 }
 
+// float -> c10::Float8_e4m3fn
+template <>
+__inline__ __device__ c10::Float8_e4m3fn
+vec_conversion<c10::Float8_e4m3fn, float>(
+    const float& a, const __nv_fp8_interpretation_t fp8_type) {
+    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return static_cast<c10::Float8_e4m3fn>(a);
+    #else
+  return c10::Float8_e4m3fn(__nv_cvt_float_to_fp8(a, __NV_SATFINITE, fp8_type),
+                            c10::Float8_e4m3fn::from_bits());
+    #endif
+}
+
+    #if 0  // Disable the following code to reduce the binary size.
 // fp8 -> half
 template <>
 __inline__ __device__ uint16_t vec_conversion<uint16_t, uint8_t>(
@@ -486,21 +499,6 @@ __inline__ __device__ uint8_t scaled_vec_conversion<uint8_t, float>(
   __nv_fp8_storage_t res =
       __nv_cvt_float_to_fp8(a / scale, __NV_SATFINITE, fp8_type);
   return (uint8_t)res;
-}
-
-// float -> c10::Float8_e4m3fn
-template <>
-__inline__ __device__ c10::Float8_e4m3fn
-scaled_vec_conversion<c10::Float8_e4m3fn, float>(
-    const float& a, const float scale,
-    const __nv_fp8_interpretation_t fp8_type) {
-    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  return static_cast<c10::Float8_e4m3fn>(a / scale);
-    #else
-  return c10::Float8_e4m3fn(
-      __nv_cvt_float_to_fp8(a / scale, __NV_SATFINITE, fp8_type),
-      c10::Float8_e4m3fn::from_bits());
-    #endif
 }
 
 // fp8x4 -> float4

--- a/csrc/quantization/fp8/nvidia/quant_utils.cuh
+++ b/csrc/quantization/fp8/nvidia/quant_utils.cuh
@@ -488,6 +488,21 @@ __inline__ __device__ uint8_t scaled_vec_conversion<uint8_t, float>(
   return (uint8_t)res;
 }
 
+// float -> c10::Float8_e4m3fn
+template <>
+__inline__ __device__ c10::Float8_e4m3fn
+scaled_vec_conversion<c10::Float8_e4m3fn, float>(
+    const float& a, const float scale,
+    const __nv_fp8_interpretation_t fp8_type) {
+    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return static_cast<c10::Float8_e4m3fn>(a / scale);
+    #else
+  return c10::Float8_e4m3fn(
+      __nv_cvt_float_to_fp8(a / scale, __NV_SATFINITE, fp8_type),
+      c10::Float8_e4m3fn::from_bits());
+    #endif
+}
+
 // fp8x4 -> float4
 template <>
 __inline__ __device__ float4 scaled_vec_conversion<float4, uint32_t>(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Use NVIDIA hardware-accelerated instruction for float to fp8_e4m3 quantization.

## Test Plan && Test Result
Unit test:
`tests/kernels/quantization/test_fp8_quant.py`
```
===== 109 passed, 1 warning in 15.71s =====
```

E2E accuracy test:
```
vllm ({'pretrained': 'nvidia/Llama-3.3-70B-Instruct-FP8', 'kv_cache_dtype': 'fp8', 'tensor_parallel_size': 1, 'max_model_len': 2048, 'trust_remote_code': True}), gen_kwargs: (temperature=0.0), limit: 500.0, num_fewshot: 5, batch_size: 200
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.940|±  |0.0106|
|     |       |strict-match    |     5|exact_match|↑  |0.904|±  |0.0132|
```

Perf test:
About 30-50% improvement per-op:
```
main:
Attn Query Quant: 3.488 μs
RMS Norm Quant: 3.392 μs
SiluMul Quant: 8.288 μs

PR:
Attn Query Quant: 2.464 μs
RMS Norm Quant: 2.336 μs
SiluMul Quant: 4.160 μs
```
~3% E2E Perf improvement for nvidia/Llama-3.3-70B-Instruct-FP8:
```
main:
Output token throughput (tok/s):         4073.02
Median TPOT (ms):                        29.65

PR:
Output token throughput (tok/s):         4182.03
Median TPOT (ms):                        28.91
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

