### PR TITLE
[Bugfix] add cache model when from object storage get model

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     VLLM_XLA_USE_SPMD: bool = False
     VLLM_WORKER_MULTIPROC_METHOD: Literal["fork", "spawn"] = "fork"
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
+    VLLM_ASSETS_CACHE_MODEL_CLEAN: bool = False
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
     VLLM_VIDEO_FETCH_TIMEOUT: int = 30
     VLLM_AUDIO_FETCH_TIMEOUT: int = 10
@@ -698,6 +699,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
             "VLLM_ASSETS_CACHE",
             os.path.join(get_default_cache_root(), "vllm", "assets"),
         )),
+
+    # If the env var is set, we will clean model file in
+    # this path $VLLM_ASSETS_CACHE/model_streamer/$model_name
+    "VLLM_ASSETS_CACHE_MODEL_CLEAN":
+    lambda: bool(int(os.getenv("VLLM_ASSETS_CACHE_MODEL_CLEAN", "0"))),
 
     # Timeout for fetching images when serving multimodal models
     # Default is 5 seconds

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -70,9 +70,6 @@ class ObjectStorageModel:
         os.makedirs(dir_name)
         self.dir = dir_name
 
-    def __del__(self):
-        self._close()
-
     def _close(self) -> None:
         if os.path.exists(self.dir):
             shutil.rmtree(self.dir)

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -5,7 +5,6 @@ import hashlib
 import os
 import shutil
 import signal
-from pathlib import Path
 from typing import Optional
 
 from vllm import envs
@@ -60,17 +59,19 @@ class ObjectStorageModel:
     """
 
     def __init__(self, url: str) -> None:
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            existing_handler = signal.getsignal(sig)
-            signal.signal(sig, self._close_by_signal(existing_handler))
+        if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN:
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                existing_handler = signal.getsignal(sig)
+                signal.signal(sig, self._close_by_signal(existing_handler))
 
         dir_name = os.path.join(
-            tempfile.gettempdir(),
+            get_cache_dir(), "model_streamer",
             hashlib.sha256(str(url).encode()).hexdigest()[:8])
         if os.path.exists(dir_name):
             shutil.rmtree(dir_name)
         os.makedirs(dir_name)
         self.dir = dir_name
+        logger.debug("Init object storage, model cache path is: %s", dir_name)
 
     def _close(self) -> None:
         if os.path.exists(self.dir):

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -5,9 +5,11 @@ import hashlib
 import os
 import shutil
 import signal
-import tempfile
+from pathlib import Path
 from typing import Optional
 
+from vllm import envs
+from vllm.assets.base import get_cache_dir
 from vllm.logger import init_logger
 from vllm.utils import PlaceholderModule
 


### PR DESCRIPTION

## Purpose

Issue: https://github.com/vllm-project/vllm/issues/24758

## Test Plan

```

import os


os.environ['AWS_ACCESS_KEY_ID'] = "yslOIiswW3I4QX9QEiIY"
os.environ['AWS_SECRET_ACCESS_KEY'] = "oVNoExWNrWJd4TUstoYjyCybtbFchPxKGUKGM54H"
os.environ['AWS_ENDPOINT_URL']= "http://xxxxx"

from  vllm import SamplingParams, LLM, AsyncEngineArgs, AsyncLLMEngine
tests = ["hello what is your name?"]
llm = LLM(model="s3://model/Qwen/Qwen3-0.6B", load_format="runai_streamer",
                       tensor_parallel_size=1, max_model_len=20000)

outputs = llm.generate(tests)

print(outputs)
```

## Test Result

Server can success running.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

