### PR TITLE
[Bugfix] Update import path for bc_linter_include

### DIFF
--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
-from vllm import bc_linter_include
+from vllm._bc_linter import bc_linter_include
 
 if TYPE_CHECKING:
     import numpy as np


### PR DESCRIPTION
## Purpose

Resolves an `ImportError` that occurs when loading certain models due to a fragile top-level import within the model inspection subprocess. The exact error is:

```
ImportError: cannot import name 'bc_linter_include' from 'vllm' (unknown location)
```

This PR fixes the issue by updating the import path in `vllm/v1/core/sched/output.py` to be more direct and robust.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

