### PR TITLE
[CI] Trigger BC Linter when labels are added/removed

### DIFF
--- a/.github/workflows/bc-lint.yml
+++ b/.github/workflows/bc-lint.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   bc_lint:


### PR DESCRIPTION
## Purpose
Trigger BC Linter when labels are added/removed, so that we can use labels to make bc-linter more self served. 
https://github.com/pytorch/test-infra/wiki/BC-Linter