### PR TITLE
[CI][Spec Decode] Adjust threshold for flaky ngram spec decoding test again

### DIFF
--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -117,9 +117,9 @@ def test_ngram_correctness(
                 print(f"ref_output: {ref_output.outputs[0].text}")
                 print(f"spec_output: {spec_output.outputs[0].text}")
 
-        # Heuristic: expect at least 68% of the prompts to match exactly
+        # Heuristic: expect at least 66% of the prompts to match exactly
         # Upon failure, inspect the outputs to check for inaccuracy.
-        assert matches >= int(0.68 * len(ref_outputs))
+        assert matches >= int(0.66 * len(ref_outputs))
         del spec_llm
         torch.cuda.empty_cache()
         cleanup_dist_env_and_memory()


### PR DESCRIPTION
`tests/v1/e2e/test_spec_decode.py::test_ngram_correctness` is still flaky after https://github.com/vllm-project/vllm/pull/24528

Example failures at main: 
https://buildkite.com/vllm/ci/builds/30544#01993eac-288c-4699-af07-f991b95918c0,
https://buildkite.com/vllm/ci/builds/30529#01993e6c-3c5f-4de7-a7b2-cdd4ca680d6d,
https://buildkite.com/vllm/ci/builds/30507#01993dac-fe3a-4f99-b106-97c65b59a783,
https://buildkite.com/vllm/ci/builds/30434#01993aeb-c38f-4277-b736-f740bf4e548a

I ran it locally multiple times (>5) and the least number I have seen was 66. 

Related: https://github.com/vllm-project/vllm/issues/24314

CC: @njhill @markmc @ekagra-ranjan @WoosukKwon @LiuXiaoxuanPKU 