### PR TITLE
[Core][Multimodal] Cache `supports_kw`

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -2082,6 +2082,7 @@ async def _run_task_with_lock(task: Callable, lock: asyncio.Lock, *args,
         return await task(*args, **kwargs)
 
 
+@lru_cache
 def supports_kw(
     callable: Callable[..., object],
     kw_name: str,


### PR DESCRIPTION
`supports_kw` is surprisingly slow due to `inspect.signature`.
<img width="809" height="452" alt="Screenshot 2025-09-12 at 19 38 55" src="https://github.com/user-attachments/assets/a49531fc-53b1-4d1a-893d-27f04419bc0b" />

Since it's called multiple times on every request (every time `get_hf_processor` is called) I think it makes sense to cache it. Let me know if this could lead to problems.
