### PR TITLE
[Bugfix] Dtype error with sequence classification model and lora.

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -338,7 +338,7 @@ def as_seq_cls_model(cls: _T) -> _T:
             })
 
         def _classifier(self, x: torch.Tensor):
-            x, _ = self.score(x.float())
+            x, _ = self.score(x)
             return x
 
         def forward(

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -307,7 +307,6 @@ def as_seq_cls_model(cls: _T) -> _T:
                 hidden_size,
                 config.num_labels,
                 bias=False,
-                params_dtype=torch.float32,
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "score"),
             )


### PR DESCRIPTION
## Error

When running  `examples/offline_inference/basic/classify.py` with lora (by adding these to the engine args)
```
enable_lora=True,
max_loras=1,
```
The following error occurs
```
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/v1/worker/gpu_model_runner.py", line 2625, in profile_run
[rank0]:     output = self._dummy_pooler_run(hidden_states)
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/v1/worker/gpu_model_runner.py", line 2559, in _dummy_pooler_run
[rank0]:     output = self._dummy_pooler_run_task(hidden_states, task)
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/v1/worker/gpu_model_runner.py", line 2538, in _dummy_pooler_run_task
[rank0]:     return model.pooler(hidden_states=hidden_states_list,
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/model_executor/layers/pooler.py", line 743, in forward
[rank0]:     group_output: PoolerOutput = pooler(
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/model_executor/layers/pooler.py", line 683, in forward
[rank0]:     pooled_data = self.classifier(torch.stack(pooled_data))
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/model_executor/models/adapters.py", line 238, in _classifier
[rank0]:     x, _ = self.score(x.float())
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/lora/layers.py", line 1018, in forward
[rank0]:     output_parallel = self.apply(input_parallel)
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/lora/layers.py", line 501, in apply
[rank0]:     torch.Tensor] = self.punica_wrapper.add_lora_linear(
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/lora/punica_wrapper/punica_gpu.py", line 222, in add_lora_linear
[rank0]:     self.add_shrink(
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/lora/punica_wrapper/punica_gpu.py", line 84, in add_shrink
[rank0]:     lora_shrink(
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/_ops.py", line 1158, in __call__
[rank0]:     return self._op(*args, **(kwargs or {}))
[rank0]:   File "/home/ubuntu/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home/ubuntu/lorax-vllm/vllm/lora/ops/triton_ops/lora_shrink_op.py", line 139, in _lora_shrink
[rank0]:     assert inputs.dtype == lora_a_weights[0].dtype
[rank0]: AssertionError
```
What's important to note is that:
1) This happens during the dummy forward pass.
2) Only happens with lora enabled
3) Happens when the classifier head (`self.score`) is applied. 

## Reason

The issue is that `self.score` is initialized with `params_dtype=torch.float32`. 

Normally, the `set_default_torch_dtype` is used to correctly set the dtype for parameters in a model. In `base_loader.py` this is called like 
```
with set_default_torch_dtype(model_config.dtype):
     # Initialize model
     ...
```
and the result should be all the params are in the correct, and same dtype.

However, for sequence classification models the head weights are in `float32` because this is set in its init.

## Solution

Do not provide a fixed default dtype to `self.score` init. Also, don't cast `x` as `x.float()`. 

## Test Plan
Run `classify.py` example with lora enabled and changes.

## Test Result
Successfully does forward pass and outputs probabilities:
```
Processed prompts: 100%|████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  3.35it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]

Generated Outputs:
------------------------------------------------------------
Prompt: 'Hello, my name is' 
Class Probabilities: [0.270751953125, 0.7294921875] (size=2)
------------------------------------------------------------
Prompt: 'The president of the United States is' 
Class Probabilities: [0.0026416778564453125, 0.99755859375] (size=2)
------------------------------------------------------------
Prompt: 'The capital of France is' 
Class Probabilities: [0.002178192138671875, 0.998046875] (size=2)
------------------------------------------------------------
Prompt: 'The future of AI is' 
Class Probabilities: [0.034332275390625, 0.9658203125] (size=2)
------------------------------------------------------------
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

