### PR TITLE
Invert pattern order to make sure that out_proj layers are identified

### DIFF
--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -585,11 +585,11 @@ class VoxtralForConditionalGeneration(nn.Module, SupportsMultiModal,
              r"language_model.model.layers.\1.mlp.down_proj"),
             (r"layers\.(\d+)\.feed_forward\.w3",
              r"language_model.model.layers.\1.mlp.up_proj"),
-            (r"mm_whisper_embeddings\.whisper_encoder\.transformer\.layers\.(\d+)\.attention.wo",
-             r"whisper_encoder.whisper_encoder.layers.\1.layers.self_attn.out_proj"
-             ),
             (r"mm_whisper_embeddings\.whisper_encoder\.transformer\.layers\.(\d+)\.attention.w(.*)",
              r"whisper_encoder.whisper_encoder.layers.\1.layers.self_attn.\2_proj"
+             ),
+            (r"mm_whisper_embeddings\.whisper_encoder\.transformer\.layers\.(\d+)\.attention.wo",
+             r"whisper_encoder.whisper_encoder.layers.\1.layers.self_attn.out_proj"
              ),
             (r"mm_whisper_embeddings\.whisper_encoder\.transformer\.layers\.(\d+)\.feed_forward.w(\d+)",
              r"whisper_encoder.whisper_encoder.layers.\1.layers.mlp.fc\2"),


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Fix pattern matching for quantized Voxtral model. The ordering of the pattern matching lead wo layer to be mapped to o_proj instead of out_proj.

## Test Plan
Ran a sample voice data through RedHatAI/Voxtral-Mini-3B-2507-FP8-dynamic and verified the output.

```
vllm serve  RedHatAI/Voxtral-Mini-3B-2507-FP8-dynamic --tokenizer_mode mistral --load_format mistral --config_format mistral
```

```python
from openai import OpenAI

client = OpenAI(
    api_key="EMPTY", 
    base_url="http://localhost:8000/v1"
)

messages = [
    {
        "role": "user",
        "content": [
            {
                "type": "audio_url",
                "audio_url": {
                    "url": "https://github.com/tarukumar/artifacts/raw/refs/heads/main/audio/2086-149220-0033.wav"
                },
            },
            {"type": "text", "text": "What's in this audio?"},
        ],
    }
]

chat_completion = client.chat.completions.create(
    model="RedHatAI/Voxtral-Mini-3B-2507-FP8-dynamic",
    messages=messages,
    temperature=0.0,
    max_tokens=100,
)

print("Response:", chat_completion.choices[0].message.content)
print("Finish reason:", chat_completion.choices[0].finish_reason)
print("Token usage:", chat_completion.usage)
```

## Test Result
Response: The audio discusses a painting that Phoebe finds unsettling, comparing it to an old portrait.
Finish reason: stop
Token usage: CompletionUsage(completion_tokens=19, prompt_tokens=385, total_tokens=404, completion_tokens_details=None, prompt_tokens_details=None)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

