### PR TITLE
[Doc]: Remove 404 hyperlinks

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -2,6 +2,6 @@
 
 vLLM's examples are split into three categories:
 
-- If you are using vLLM from within Python code, see [Offline Inference](./offline_inference)
-- If you are using vLLM from an HTTP application or client, see [Online Serving](./online_serving)
-- For examples of using some of vLLM's advanced features (e.g. LMCache or Tensorizer) which are not specific to either of the above use cases, see [Others](./others)
+- If you are using vLLM from within Python code, see the *Offline Inference* section.
+- If you are using vLLM from an HTTP application or client, see the *Online Serving* section.
+- For examples of using some of vLLM's advanced features (e.g. LMCache or Tensorizer) which are not specific to either of the above use cases, see the *Others* section.


### PR DESCRIPTION
The hyperlinks in the [examples page](https://docs.vllm.ai/en/stable/examples/index.html) lead to 404 links (listed below):

- Offline Inference: https://docs.vllm.ai/en/stable/examples/offline_inference (404)
- Online Serving: https://docs.vllm.ai/en/stable/examples/online_serving (404)
- Others: https://docs.vllm.ai/en/stable/examples/others (404)

two ways to go about this:

1. Either add a placeholder page with placeholder content until actual content is ready

(or)

2. Remove the invalid links.

This PR takes approach 2 and removes the invalid links.