### PR TITLE
[KVConnector][P/D] Add kv connector metrics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -77,10 +77,7 @@ class KVConnectorMetadata(ABC):  # noqa: B024
     Abstract Metadata used to communicate between the
     Scheduler KVConnector and Worker KVConnector.
     """
-
     pass
-
-
 
 
 class KVConnectorBase_V1(ABC):
@@ -251,6 +248,14 @@ class KVConnectorBase_V1(ABC):
             call to this method (this call or a prior one).
         """
         return None, None
+
+    def shutdown(self):
+        """
+        Shutdown the connector. This is called when the worker process
+        is shutting down to ensure that all the async operations are
+        completed and the connector is cleaned up properly.
+        """
+        return None
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/connector_metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/connector_metrics.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2024, vLLM Contributors
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Connector metrics for KV transfer operations."""
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from .base import KVConnectorStats
+
+
+@dataclass 
+class TimestampedStats:
+    """KVConnectorStats with timestamp for rolling window tracking."""
+    stats: KVConnectorStats
+    timestamp: float
+
+
+@dataclass
+class MetricAggregation:
+    """Aggregated statistics for a single metric."""
+    avg: float = 0.0
+    p50: float = 0.0
+    p90: float = 0.0
+    p99: float = 0.0
+
+
+@dataclass
+class AggregatedKVConnectorStats:
+    """Aggregated connector stats over a rolling time window with percentiles."""
+    stats_count: int = 0
+    metrics: Dict[str, MetricAggregation] = field(default_factory=dict)
+
+
+class KVConnectorMetrics:
+    """Aggregates KVConnectorStats using a rolling time window.
+    
+    This class maintains a rolling window of KVConnectorStats and continuously
+    removes samples older than the specified time interval.
+    """
+    
+    def __init__(self, time_interval_seconds: float = 60.0):
+        """Initialize the metrics aggregator.
+        
+        Args:
+            time_interval_seconds: Time interval for the rolling window (default: 60 seconds)
+        """
+        self.time_interval = time_interval_seconds
+        
+        # Rolling window of timestamped stats
+        self.rolling_stats: deque[TimestampedStats] = deque()
+    
+    def observe(self, stats: KVConnectorStats) -> None:
+        """Observe new connector stats and add to the rolling window.
+        
+        Args:
+            stats: KVConnectorStats instance to observe and add to metrics
+        """
+        current_time = time.time()
+        
+        # Remove old samples outside the time interval
+        self._cleanup_old_samples(current_time)
+        
+        # Add new timestamped stats
+        timestamped_stats = TimestampedStats(stats=stats, timestamp=current_time)
+        self.rolling_stats.append(timestamped_stats)
+    
+    def _cleanup_old_samples(self, current_time: float) -> None:
+        """Remove samples older than the time interval."""
+        cutoff_time = current_time - self.time_interval
+        
+        # Remove old stats from rolling window
+        while self.rolling_stats and self.rolling_stats[0].timestamp < cutoff_time:
+            self.rolling_stats.popleft()
+    
+    def get_current_aggregated_stats(self) -> Optional[AggregatedKVConnectorStats]:
+        """Get aggregated stats for the current rolling window."""
+        current_time = time.time()
+        self._cleanup_old_samples(current_time)
+        
+        if not self.rolling_stats:
+            return None
+        
+        # Aggregate metrics from all stats samples
+        aggregated_metrics = self._calculate_metric_aggregations()
+        
+        return AggregatedKVConnectorStats(
+            stats_count=len(self.rolling_stats),
+            metrics=aggregated_metrics
+        )
+    
+    def _calculate_metric_aggregations(self) -> Dict[str, MetricAggregation]:
+        """Calculate avg, p50, p90, p99 for each metric across all samples."""
+        if not self.rolling_stats:
+            return {}
+        
+        # Collect all metric keys from all samples
+        all_metric_keys = set()
+        for sample in self.rolling_stats:
+            all_metric_keys.update(sample.stats.keys())
+        
+        aggregated_metrics = {}
+        
+        # For each metric, collect all values and calculate percentiles
+        for metric_key in all_metric_keys:
+            values = []
+            for sample in self.rolling_stats:
+                # Get the value for this metric, use 0 as default if metric doesn't exist in this sample
+                metric_value = sample.stats.get(metric_key, 0)
+                values.append(metric_value)
+            
+            # Sort values for percentile calculation
+            values.sort()
+            n = len(values)
+            
+            # Calculate aggregations
+            avg = sum(values) / n if values else 0.0
+            p50 = self._calculate_percentile(values, 50)
+            p90 = self._calculate_percentile(values, 90)
+            p99 = self._calculate_percentile(values, 99)
+            
+            aggregated_metrics[metric_key] = MetricAggregation(
+                avg=avg,
+                p50=p50,
+                p90=p90,
+                p99=p99
+            )
+        
+        return aggregated_metrics
+    
+    def _calculate_percentile(self, sorted_values: list[int], percentile: int) -> float:
+        """Calculate the specified percentile from sorted values."""
+        if not sorted_values:
+            return 0.0
+        
+        n = len(sorted_values)
+        if n == 1:
+            return float(sorted_values[0])
+        
+        # Use linear interpolation method
+        index = (percentile / 100.0) * (n - 1)
+        lower_index = int(index)
+        upper_index = min(lower_index + 1, n - 1)
+        
+        if lower_index == upper_index:
+            return float(sorted_values[lower_index])
+        
+        # Linear interpolation
+        weight = index - lower_index
+        return float(sorted_values[lower_index] * (1 - weight) + sorted_values[upper_index] * weight)
+    
+    def reset(self) -> None:
+        """Reset all metrics and clear the rolling window."""
+        self.rolling_stats.clear()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -100,6 +100,15 @@ class Scheduler(SchedulerInterface):
 
         self.block_size = self.cache_config.block_size
 
+        self.dcp_world_size = \
+            vllm_config.parallel_config.decode_context_parallel_size
+        # Note(hc): The scheduler’s block_size must be multiplied
+        # by dcp_world_size, since block hashes are computed on the
+        # original full token sequence at a granularity of
+        # original_block_size × dcp_world_size.
+        if self.dcp_world_size > 1:
+            self.block_size *= self.dcp_world_size
+
         # req_id -> Request
         self.requests: dict[str, Request] = {}
         # Scheduling policy
@@ -161,6 +170,7 @@ class Scheduler(SchedulerInterface):
             use_eagle=self.use_eagle,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
+            dcp_world_size=self.dcp_world_size,
         )
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
 
@@ -1197,6 +1207,8 @@ class Scheduler(SchedulerInterface):
     def shutdown(self) -> None:
         if self.kv_event_publisher:
             self.kv_event_publisher.shutdown()
+        if self.connector is not None:
+            self.connector.shutdown()
 
     ########################################################################
     # KV Connector Related Methods

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -100,15 +100,6 @@ class Scheduler(SchedulerInterface):
 
         self.block_size = self.cache_config.block_size
 
-        self.dcp_world_size = \
-            vllm_config.parallel_config.decode_context_parallel_size
-        # Note(hc): The scheduler’s block_size must be multiplied
-        # by dcp_world_size, since block hashes are computed on the
-        # original full token sequence at a granularity of
-        # original_block_size × dcp_world_size.
-        if self.dcp_world_size > 1:
-            self.block_size *= self.dcp_world_size
-
         # req_id -> Request
         self.requests: dict[str, Request] = {}
         # Scheduling policy
@@ -170,7 +161,6 @@ class Scheduler(SchedulerInterface):
             use_eagle=self.use_eagle,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
-            dcp_world_size=self.dcp_world_size,
         )
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
 
@@ -1186,6 +1176,7 @@ class Scheduler(SchedulerInterface):
             spec_decoding_stats=spec_decoding_stats,
             num_corrupted_reqs=sum(req.is_output_corrupted
                                    for req in self.running),
+            kv_connector_stats=None if self.connector is None else self.connector.get_kv_connector_stats()
         )
 
     def make_spec_decoding_stats(
@@ -1206,8 +1197,6 @@ class Scheduler(SchedulerInterface):
     def shutdown(self) -> None:
         if self.kv_event_publisher:
             self.kv_event_publisher.shutdown()
-        if self.connector is not None:
-            self.connector.shutdown()
 
     ########################################################################
     # KV Connector Related Methods

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -669,6 +669,7 @@ class StatLoggerManager:
         engine_idxs: Optional[list[int]] = None,
         custom_stat_loggers: Optional[list[StatLoggerFactory]] = None,
         enable_default_loggers: bool = True,
+        client_count: int = 1,
     ):
         self.engine_idxs = engine_idxs if engine_idxs else [0]
 
@@ -677,7 +678,12 @@ class StatLoggerManager:
             factories.extend(custom_stat_loggers)
 
         if enable_default_loggers and logger.isEnabledFor(logging.INFO):
-            factories.append(LoggingStatLogger)
+            if client_count > 1:
+                logger.warning(
+                    "AsyncLLM created with api_server_count more than 1; "
+                    "disabling stats logging to avoid incomplete stats.")
+            else:
+                factories.append(LoggingStatLogger)
 
         # engine_idx: StatLogger
         self.per_engine_logger_dict: dict[int, list[StatLoggerBase]] = {}

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorStats
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
 if TYPE_CHECKING:
@@ -45,6 +46,8 @@ class SchedulerStats:
     spec_decoding_stats: Optional[SpecDecodingStats] = None
 
     num_corrupted_reqs: int = 0
+
+    kv_connector_stats: Optional[KVConnectorStats] = None
 
 
 @dataclass


### PR DESCRIPTION
## Purpose

Purpose of this PR is to allow KV connector to expose a flexible KVConnectorStats, currently defined as dictionary from string to int, and adding a metric aggregator to aggregate metrics with a time window.

Meta internal stack find it very useful to expose these metrics from kv connector to scheduler, then to outer loggers, otherwise we have no insights into what's happening at connector level right now.

Example usage could be:
- If we have CPU KV cache as connector, we need to expose the latency
- For P/D architecture, we also need to expose component level latency and errors

## Test Plan

The individual kv connector needs to set_connector_stats(), and it will be shown in the Engine stats

## Test Result

E.g. we are able to get 

INFO 09-12 14:39:31 [loggers.py:150] Engine 000 KV Connector Metrics: 4714 samples
INFO 09-12 14:39:31 [loggers.py:153]   loaded_tokens - avg: 0.00, p50: 0.00, p90: 0.00, p99: 0.00
INFO 09-12 14:39:31 [loggers.py:153]   load_kv_ms - avg: 0.00, p50: 0.00, p90: 0.00, p99: 0.00
INFO 09-12 14:39:31 [loggers.py:153]   save_kv_ms - avg: 18.45, p50: 17.00, p90: 20.00, p99: 20.00
INFO 09-12 14:39:31 [loggers.py:153]   saved_tokens - avg: 16.00, p50: 16.00, p90: 16.00, p99: 16.00

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

