### PR TITLE
[Benchmarks] Throw usage error when using dataset-name random and dataset-path together

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -11,6 +11,7 @@ generation. Supported dataset types include:
   - HuggingFace
   - VisionArena
 """
+import argparse
 import ast
 import base64
 import io
@@ -1019,6 +1020,25 @@ class ShareGPTDataset(BenchmarkDataset):
         return samples
 
 
+class _ValidateDatasetArgs(argparse.Action):
+    """Argparse action to validate dataset name and path compatibility."""
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        
+        # Get current values of both dataset_name and dataset_path
+        dataset_name = getattr(namespace, 'dataset_name', 'random')
+        dataset_path = getattr(namespace, 'dataset_path', None)
+        
+        # Validate the combination
+        if dataset_name == "random" and dataset_path is not None:
+            parser.error(
+                "Cannot use 'random' dataset with --dataset-path. "
+                "Please specify the appropriate --dataset-name (e.g., "
+                "'sharegpt', 'custom', 'sonnet') for your dataset file: "
+                f"{dataset_path}"
+            )
+
+
 def add_dataset_parser(parser: FlexibleArgumentParser):
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument(
@@ -1031,6 +1051,7 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         "--dataset-name",
         type=str,
         default="random",
+        action=_ValidateDatasetArgs,
         choices=[
             "sharegpt", "burstgpt", "sonnet", "random", "random-mm", "hf", 
             "custom", "prefix_repetition", "spec_bench"
@@ -1046,6 +1067,7 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         "--dataset-path",
         type=str,
         default=None,
+        action=_ValidateDatasetArgs,
         help="Path to the sharegpt/sonnet dataset. "
         "Or the huggingface dataset ID if using HF dataset.",
     )
@@ -1332,14 +1354,6 @@ def get_samples(args, tokenizer) -> list[SampleRequest]:
 
     if not hasattr(args, "request_id_prefix"):
         args.request_id_prefix = ""
-
-    # Validate that random dataset is not used with dataset_path
-    if args.dataset_name == "random" and args.dataset_path is not None:
-        raise ValueError(
-            "Cannot use 'random' dataset with --dataset-path. "
-            "Please specify the appropriate --dataset-name (e.g., 'sharegpt', "
-            f"'custom', 'sonnet') for your dataset file: {args.dataset_path}"
-        )
 
     if args.dataset_name == "custom":
         dataset = CustomDataset(dataset_path=args.dataset_path)

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -1333,6 +1333,14 @@ def get_samples(args, tokenizer) -> list[SampleRequest]:
     if not hasattr(args, "request_id_prefix"):
         args.request_id_prefix = ""
 
+    # Validate that random dataset is not used with dataset_path
+    if args.dataset_name == "random" and args.dataset_path is not None:
+        raise ValueError(
+            "Cannot use 'random' dataset with --dataset-path. "
+            "Please specify the appropriate --dataset-name (e.g., 'sharegpt', "
+            f"'custom', 'sonnet') for your dataset file: {args.dataset_path}"
+        )
+
     if args.dataset_name == "custom":
         dataset = CustomDataset(dataset_path=args.dataset_path)
         input_requests = dataset.sample(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
There's some confusion https://github.com/vllm-project/vllm/issues/24684 that default behavior for `vllm bench serve` is incorrect. This is due to `vllm bench serve` uses random by default and it does not throw any errors when using provide a shardgpt dataset path lol.

## Test Plan
```
# only specify dataset path
vllm bench serve --model meta-llama/Llama-3.1-8B-Instruct --percentile-metrics ttft,tpot,itl,e2el --dataset-path /models/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json --max-concurrency 64 --num-prompts 640 --ignore-eos --sharegpt-output-len 512
# specify dataset path first, then dataset name
vllm bench serve --model meta-llama/Llama-3.1-8B-Instruct --percentile-metrics ttft,tpot,itl,e2el --dataset-path /models/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json --dataset-name random --max-concurrency 64 --num-prompts 640 --ignore-eos --sharegpt-output-len 512
# specify dataset name first, then dataset path
vllm bench serve --model meta-llama/Llama-3.1-8B-Instruct --dataset-name random --percentile-metrics ttft,tpot,itl,e2el --dataset-path /models/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json --max-concurrency 64 --num-prompts 640 --ignore-eos --sharegpt-output-len 512
```
## Test Result
all throw the following error:
```
usage: vllm bench serve [options]
vllm bench <bench_type> [options] serve: error: Cannot use 'random' dataset with --dataset-path. Please specify the appropriate --dataset-name (e.g., 'sharegpt', 'custom', 'sonnet') for your dataset file: /models/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

