### PR TITLE
[Misc] Improve `s3_utils` type hints with `BaseClient`

### DIFF
--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -2,9 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import fnmatch
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from vllm.utils import PlaceholderModule
+
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
 
 try:
     import boto3
@@ -26,7 +29,7 @@ def _filter_ignore(paths: list[str], patterns: list[str]) -> list[str]:
     ]
 
 
-def glob(s3: Optional[Any] = None,
+def glob(s3: Optional["BaseClient"] = None,
          path: str = "",
          allow_pattern: Optional[list[str]] = None) -> list[str]:
     """
@@ -51,7 +54,7 @@ def glob(s3: Optional[Any] = None,
 
 
 def list_files(
-        s3: Any,
+        s3: "BaseClient",
         path: str,
         allow_pattern: Optional[list[str]] = None,
         ignore_pattern: Optional[list[str]] = None


### PR DESCRIPTION
related: https://github.com/vllm-project/vllm/pull/24791/files/1a90c7f45d95de77cd1f4fe507233a62d96e513f#r2345985241

## Summary

Improves type safety in `s3_utils.py` by replacing generic `Any` type hints with more specific `BaseClient` type hints for S3 client parameters.

## Changes Made

- Replace `s3: Optional[Any]` with `s3: Optional["BaseClient"]` in `glob()` function
- Replace `s3: Any` with `s3: "BaseClient"` in `list_files()` function
- Add `TYPE_CHECKING` guard for `botocore.client.BaseClient` import
- Remove unused `Any` import from typing

## Follow-up
This addresses feedback from PR reviewers (@hmellor, @DarkLight1337) who suggested using more specific type hints while avoiding additional runtime dependencies.