### PR TITLE
fix type of sampling rate for encode_base64

### DIFF
--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -106,7 +106,7 @@ class AudioMediaIO(MediaIO[tuple[npt.NDArray, float]]):
     def load_file(self, filepath: Path) -> tuple[npt.NDArray, float]:
         return librosa.load(filepath, sr=None)
 
-    def encode_base64(self, media: tuple[npt.NDArray, float]) -> str:
+    def encode_base64(self, media: tuple[npt.NDArray, int]) -> str:
         audio, sr = media
 
         with BytesIO() as buffer:

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -310,7 +310,7 @@ class MediaConnector:
 
 def encode_audio_base64(
     audio: np.ndarray,
-    sampling_rate: float,
+    sampling_rate: int,
 ) -> str:
     """Encode audio as base64."""
     audio_io = AudioMediaIO()


### PR DESCRIPTION
## Purpose
fix encode_base64 media.sr type, from float to int
in soundfile, samplerate is int

https://github.com/bastibe/python-soundfile/blob/5069b8cb828eb2bb26aba0620e1f7ea2ae37f189/soundfile.py#L329
```
def write(file: FileDescriptorOrPath, data: AudioData, samplerate: int, 
          subtype: Optional[str] = None, endian: Optional[str] = None, 
          format: Optional[str] = None, closefd: bool = True, 
          compression_level: Optional[float] = None, 
          bitrate_mode: Optional[str] = None) -> None: 
```
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

