### PR TITLE
[Core] Use KVCacheBlock as much as possible instead of dict[block_id, KVCacheBlock]

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -47,16 +47,15 @@ def test_chunked_local_attention_possible_cached_prefix():
             BlockHash(str(i).encode()) for i in range(len(block_is_cached))
         ]
 
-        block_pool.cached_block_hash_to_block.clear()
+        block_pool.cached_block_hash_to_block._cache.clear()
 
         # Mock the block pool with the cached blocks
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[
-                    make_block_hash_with_group_id(block_hash, 0)] = {
-                        i: block_pool.blocks[i + 10],
-                    }
+                block_pool.cached_block_hash_to_block.insert(
+                    make_block_hash_with_group_id(block_hash, 0),
+                    block_pool.blocks[i + 10])
 
         computed_blocks = manager.find_longest_cache_hit(
             block_hashes=block_hash_list,
@@ -112,16 +111,15 @@ def test_sliding_window_possible_cached_prefix():
             BlockHash(str(i).encode()) for i in range(len(block_is_cached))
         ]
 
-        block_pool.cached_block_hash_to_block.clear()
+        block_pool.cached_block_hash_to_block._cache.clear()
 
         # Mock the block pool with the cached blocks
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[
-                    make_block_hash_with_group_id(block_hash, 0)] = {
-                        i: block_pool.blocks[i + 10],
-                    }
+                block_pool.cached_block_hash_to_block.insert(
+                    make_block_hash_with_group_id(block_hash, 0),
+                    block_pool.blocks[i + 10])
 
         computed_blocks = manager.find_longest_cache_hit(
             block_hashes=block_hash_list,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -86,6 +86,11 @@ class BlockHashToBlockMap:
         if blocks is None:
             # block_hash not found in the cache
             return None
+        # TODO(Jialin): If key is found, block_id should always present
+        # in blocks. We currently keep the original behaviour for safety.
+        #
+        # Will add block_id == blocks.block_id assertion and
+        # use del blocks[block_id] instead as followup.
         if isinstance(blocks, KVCacheBlock):
             if blocks.block_id == block_id:
                 return blocks

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -86,23 +86,21 @@ class BlockHashToBlockMap:
         if blocks is None:
             # block_hash not found in the cache
             return None
-        elif isinstance(blocks, KVCacheBlock):
+        if isinstance(blocks, KVCacheBlock):
             if blocks.block_id == block_id:
                 return blocks
-            else:
-                # If the single block ID doesn't match, we should put the
-                # block back (it should happen rarely)
-                self._cache[key] = blocks
-                return None
-        elif isinstance(blocks, dict):
+            # If the single block ID doesn't match, we should put the
+            # block back (it should happen rarely)
+            self._cache[key] = blocks
+            return None
+        if isinstance(blocks, dict):
             # Try to pop block_id from the block dict, and if dict still
             # contain blocks, put back to the cache.
             block = blocks.pop(block_id, None)
             if len(blocks) > 0:
                 self._cache[key] = blocks
             return block
-        else:
-            self._unexpected_blocks_type(blocks)
+        self._unexpected_blocks_type(blocks)
         return None
 
     def __len__(self) -> int:

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections import defaultdict
 from collections.abc import Iterable
-from typing import Optional
+from typing import Any, Optional, Union
 
 from vllm.distributed.kv_events import (MEDIUM_GPU, AllBlocksCleared,
                                         BlockRemoved, BlockStored,
@@ -17,6 +16,95 @@ from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+class BlockLookupCache:
+    """
+    Cache of blocks that are used for prefix caching.
+    """
+
+    def __init__(self):
+        # {block_hash: KVCacheBlocks}.
+        # - Mostly block_hash maps to a single KVCacheBlock, and KVCacheBlocks
+        #   would simply be a KVCacheBlock.
+        # - Otherwise, KVCacheBlocks is a dict from {block_id: KVCacheBlock}
+        #
+        # NOTE: The union type is introduced in order to reduce GC costs from
+        # the inner dict.
+        #
+        # A cached block is a full block with a block hash that can be used
+        # for prefix caching.
+        # The cached block may be used by running requests or in the
+        # free_block_queue that could potentially be evicted.
+        # NOTE: We currently don't de-duplicate the blocks in the cache,
+        # meaning that if a block becomes full and is cached, we don't check
+        # if there is already an identical block in the cache. This is because
+        # we want to make sure the allocated block IDs won't change so that
+        # block tables are append-only.
+        self._cache: dict[BlockHashWithGroupId,
+                          Union[KVCacheBlock, dict[int, KVCacheBlock]]] = {}
+
+    def get_one_block(self,
+                      key: BlockHashWithGroupId) -> Optional[KVCacheBlock]:
+        """
+        Gets any block with the given block hash key.
+        """
+        blocks = self._cache.get(key)
+        if blocks is None:
+            return None
+        if type(blocks) is KVCacheBlock:
+            return blocks
+        if type(blocks) is dict:
+            return next(iter(blocks.values()))
+        self._unexpected_blocks_type(blocks)
+        return None
+
+    def insert(self, key: BlockHashWithGroupId, block: KVCacheBlock) -> None:
+        """
+        Inserts the KVCacheBlock to the cache
+        """
+        blocks = self._cache.get(key)
+        if blocks is None:
+            # When key is not found, attach a single block to the key
+            self._cache[key] = block
+        elif type(blocks) is KVCacheBlock:
+            # If there's a block with the same key, merge the original block
+            # and the new block into a dict
+            self._cache[key] = {blocks.block_id: blocks, block.block_id: block}
+        elif type(blocks) is dict:
+            # If it's already a dict, simply insert the block
+            blocks[block.block_id] = block
+        else:
+            self._unexpected_blocks_type(blocks)
+
+    def check_block_hash_and_pop_block(self, key: BlockHashWithGroupId,
+                                       block_id: int) -> bool:
+        """
+        Checks if block_hash exists and pop block_id from the cache
+        """
+        blocks = self._cache.get(key)
+        if blocks is None:
+            # block_hash not found in the cache
+            return False
+        elif type(blocks) is KVCacheBlock:
+            # If the single block ID matched the given one, directly
+            # remove the whole cached block hash entry
+            if blocks.block_id == block_id:
+                self._cache.pop(key)
+        elif type(blocks) is dict:
+            # Try to pop block_id from the block dict, and if dict became empty,
+            # remove the whole cached block hash entry
+            blocks.pop(block_id, None)
+            if len(blocks) == 0:
+                self._cache.pop(key)
+        else:
+            self._unexpected_blocks_type(blocks)
+        return True
+
+    def _unexpected_blocks_type(self, blocks: Any) -> None:
+        raise AssertionError(
+            "This should never happened, kv cache blocks should either be "
+            f"None, KVCacheBlock or dict. But it's {type(blocks)}")
 
 
 class BlockPool:
@@ -51,17 +139,8 @@ class BlockPool:
         # enabled).
         self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
 
-        # {block_hash: {block ID: block}}. A cached block is
-        # a full block with a block hash that can be used for prefix caching.
-        # The cached block may be used by running requests or in the
-        # free_block_queue that could potentially be evicted.
-        # NOTE: We currently don't de-duplicate the blocks in the cache,
-        # meaning that if a block becomes full and is cached, we don't check
-        # if there is already an identical block in the cache. This is because
-        # we want to make sure the allocated block IDs won't change so that
-        # block tables are append-only.
-        self.cached_block_hash_to_block: dict[BlockHashWithGroupId, dict[
-            int, KVCacheBlock]] = defaultdict(dict)
+        # Cache for block lookup
+        self.cached_block_hash_to_block: BlockLookupCache = BlockLookupCache()
 
         # To represent a placeholder block with block_id=0.
         # The ref_cnt of null_block is not maintained, needs special care to
@@ -90,12 +169,11 @@ class BlockPool:
         for group_id in kv_cache_group_ids:
             block_hash_with_group_id = make_block_hash_with_group_id(
                 block_hash, group_id)
-            cached_blocks_one_group = self.cached_block_hash_to_block.get(
+            block = self.cached_block_hash_to_block.get_one_block(
                 block_hash_with_group_id)
-            if not cached_blocks_one_group:
+            if not block:
                 return None
-            first_block = next(iter(cached_blocks_one_group.values()))
-            cached_blocks.append(first_block)
+            cached_blocks.append(block)
         return cached_blocks
 
     def cache_full_blocks(
@@ -140,10 +218,8 @@ class BlockPool:
             block_hash_with_group_id = make_block_hash_with_group_id(
                 block_hash, kv_cache_group_id)
             blk.block_hash = block_hash_with_group_id
-            self.cached_block_hash_to_block[block_hash_with_group_id][
-                blk.block_id] = blk
-            if new_hashes is not None:
-                new_hashes.append(maybe_convert_block_hash(block_hash))
+            self.cached_block_hash_to_block.insert(block_hash_with_group_id,
+                                                   blk)
 
         if self.enable_kv_cache_events:
             if num_cached_blocks == 0:
@@ -211,15 +287,14 @@ class BlockPool:
         if block_hash is None:
             # The block doesn't have hash, eviction is not needed
             return False
-        blocks_by_id = self.cached_block_hash_to_block.get(block_hash)
-        if blocks_by_id is None:
+
+        if not self.cached_block_hash_to_block.check_block_hash_and_pop_block(
+                block_hash, block.block_id):
             # block_hash not found in cached_block_hash_to_block,
             # eviction is not needed
             return False
+
         block.reset_hash()
-        blocks_by_id.pop(block.block_id, None)
-        if len(blocks_by_id) == 0:
-            del self.cached_block_hash_to_block[block_hash]
 
         if self.enable_kv_cache_events:
             # FIXME (Chen): Not sure whether we should return `hash_value`
@@ -283,7 +358,7 @@ class BlockPool:
             return False
 
         # Remove all hashes so that no new blocks will hit.
-        self.cached_block_hash_to_block = defaultdict(dict)
+        self.cached_block_hash_to_block = BlockLookupCache()
 
         # Remove all hashes from all blocks.
         for block in self.blocks:


### PR DESCRIPTION
## Purpose
dict[block_id, KVCacheBlock] is the currently the top GC objects, however, most of the time, each BlockHashWithGroupId simply map to a single KVCacheBlock. So we replace dict[block_id, KVCacheBlock] with Union[KVCacheBlock, dict[block_id, KVCacheBlock]] in block cache, and use KVCacheBlock as much as possible to reduce the GC overhead.

## Test Plan & Test Result
Patch https://github.com/vllm-project/vllm/pull/24829 locally with a breakdown analysis, we could see that the GC cost is left shifted as expected.

### E2E Metrics
Model: facebook/opt-125m
Prefill-heavy work: prefill 2000 decode 48
Decode-heavy work: prefill 48 decode 2000
max-concurrency: 

|Request-Rate|Before|After|
|Prefill-heavy|212.98|217.40 (**+2%**)|
|Decode-heavy|13.89|14.10 (**+1.5%**)|

### facebook/opt-125m decode heavy workload: prefill 48 decode 2000
GC cost reduced by 17% (per histogram of GC elapsed time)
<img width="1053" height="799" alt="Screenshot 2025-09-14 at 6 43 17 AM" src="https://github.com/user-attachments/assets/e0190d7a-4eeb-479e-9100-d787d180ef08" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

