### PR TITLE
[Bugfix][Multi Modal] Fix oom bug when using sdap attention backend i…

### DIFF
--- a/tests/models/multimodal/generation/test_moonvit_attn_backend.py
+++ b/tests/models/multimodal/generation/test_moonvit_attn_backend.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import random
+
+import pytest
+import torch
+
+from vllm.model_executor.models.moonvit import (multihead_attention,
+                                                sdpa_attention,
+                                                xformers_attention)
+
+
+def random_create_qk_cu_seqlens(tot_seqlens, batch_size, device):
+    cuts = sorted(random.sample(range(1, tot_seqlens), batch_size - 1))
+    segs = [a - b for a, b in zip(cuts + [tot_seqlens], [0] + cuts)]
+
+    # self-attention, q,k,v are the same shape
+    cu_seqlens = torch.nn.functional.pad(torch.tensor(segs).cumsum(0), (1, 0))
+    cu_seqlens = cu_seqlens.to(dtype=torch.int32, device=device)
+    return cu_seqlens, cu_seqlens
+
+
+@pytest.mark.parametrize("qkv_shape", [(65340, 16, 72)])
+@pytest.mark.parametrize("batch_size", [16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("device", ["cuda"])
+def test_moonvit_attn_backend(qkv_shape, batch_size, dtype, device):
+    q_cu_lens, k_cu_lens = random_create_qk_cu_seqlens(qkv_shape[0],
+                                                       batch_size, device)
+
+    q = torch.randn(*qkv_shape, dtype=dtype, device=device)
+    k = torch.randn(*qkv_shape, dtype=dtype, device=device)
+    v = torch.randn(*qkv_shape, dtype=dtype, device=device)
+
+    flash_attn_out = multihead_attention(q, k, v, q_cu_lens, k_cu_lens)
+    xformers_attn_out = xformers_attention(q, k, v, q_cu_lens, k_cu_lens)
+    sdpa_attn_out = sdpa_attention(q, k, v, q_cu_lens, k_cu_lens)
+
+    rtol, atol = 1e-3, 5e-3
+    torch.testing.assert_close(flash_attn_out,
+                               sdpa_attn_out,
+                               rtol=rtol,
+                               atol=atol)
+    torch.testing.assert_close(flash_attn_out,
+                               xformers_attn_out,
+                               rtol=rtol,
+                               atol=atol)


### PR DESCRIPTION
## Purpose
When using torch sdpa attention backend(without flash_attn ) in kimi-vl vit module, it will cause oom bug.

Related issue is reported https://github.com/vllm-project/vllm/issues/17835#issuecomment-2865911282

You can run the following command to reproduce the bug.
```
python examples/offline_inference/vision_language.py --model_type kimi_vl
```
<img width="1237" height="176" alt="image" src="https://github.com/user-attachments/assets/4e90d7ea-c33f-4226-88da-3accd9bde285" />

The root reason is that torch will allocate lots of memory when running packed requests. So I split the requests, and infer one by one.

I notice that this solution will be slow, any suggestions will be welcomed.

Any way, flash_attn can solve the problem :) 
## Test Plan

## Test Result
<img width="1237" height="628" alt="image" src="https://github.com/user-attachments/assets/1514fb5c-ba4b-41ca-96ad-fe3e85a5d712" />



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

