### PR TITLE
feat: enable vLLM inference for pruned Qwen3 models

### DIFF
--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -186,16 +186,16 @@ class Qwen3DecoderLayer(nn.Module):
         else:
             attn_type = AttentionType.ENCODER_ONLY
 
-        layer_idx =int(prefix.split(".")[-1])
-        layer_head_num = getattr(config, 'layer_head_num', None)
-        layer_inter_size = getattr(config, 'layer_inter_size', None)
+        layer_idx = extract_layer_index(prefix)
+        layer_head_num = getattr(config, "layer_head_num", None)
+        layer_inter_size = getattr(config, "layer_inter_size", None)
 
-        if layer_head_num:
+        if layer_head_num is not None:
             self.layer_heads = config.layer_head_num[layer_idx]
         else:
             self.layer_heads = config.num_attention_heads
 
-        if layer_inter_size:
+        if layer_inter_size is not None:
             self.layer_inter_size = config.layer_inter_size[layer_idx]
         else:
             self.layer_inter_size = config.intermediate_size

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -164,7 +164,6 @@ class Qwen3DecoderLayer(nn.Module):
     def __init__(
         self,
         config: Qwen3Config,
-        layer_idx: int,
         cache_config: Optional[CacheConfig] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
@@ -187,7 +186,7 @@ class Qwen3DecoderLayer(nn.Module):
         else:
             attn_type = AttentionType.ENCODER_ONLY
 
-        self.layer_idx = layer_idx
+        layer_idx =int(prefix.split(".")[-1])
         layer_head_num = getattr(config, 'layer_head_num', None)
         layer_inter_size = getattr(config, 'layer_inter_size', None)
 


### PR DESCRIPTION
## Purpose

This PR enables models with structured pruning to be loaded correctly. The model configuration files after structured pruning will be modified, as the layer_head_num and layer_inter_size parameters may vary across different layers of the network. When the vllm library loads the configuration file, it must now map these parameters layer-by-layer. This PR specifically adjusts the Qwen3 configuration loading logic in Transformers to ensure compatibility with models that have undergone structured pruning. 

The configuration file for the pruned model is as follows:
```
{
  "architectures": [
    "Qwen3ForCausalLM"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 151643,
  "eos_token_id": 151645,
  "head_dim": 128,
  "hidden_act": "silu",
  "hidden_size": 5120,
  "initializer_range": 0.02,
  "intermediate_size": 25600,
  "layer_head_num": [
    64,
    64,
    64,
    64,
    64,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    56,
    64,
    64,
    64,
    64,
    64
  ],
  "layer_inter_size": [
    25600,
    25600,
    25600,
    25600,
    25600,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    24832,
    25600,
    25600,
    25600,
    25600,
    25600
  ],
  "max_position_embeddings": 40960,
  "max_window_layers": 64,
  "model_type": "qwen3",
  "num_attention_heads": 64,
  "num_hidden_layers": 64,
  "num_key_value_heads": 8,
  "rms_norm_eps": 1e-06,
  "rope_scaling": null,
  "rope_theta": 1000000,
  "sliding_window": null,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.52.4",
  "use_cache": true,
  "use_sliding_window": false,
  "vocab_size": 151936
}
```
## Test Plan

1. Verify that the model after structured pruning can be loaded correctly by the vllm library.
2. Confirm that unpruned models can still be loaded normally by the Transformers library.


## Test Result

Both the structured-pruned model and the unpruned model can be loaded normally.

