### PR TITLE
[Bugfix] Fix crash when calling sleep in data parallel mode 

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -203,8 +203,11 @@ class MultiprocExecutor(Executor):
         return self.kv_output_aggregator.aggregate(outputs, self.output_rank)
 
     def execute_dummy_batch(self) -> None:
-        self.collective_rpc("execute_dummy_batch",
-                            unique_reply_rank=self.output_rank)
+        if self.is_sleeping:
+            logger.debug("Engine is currently sleeping, skipping dummy batch execution.")
+        else:
+            self.collective_rpc("execute_dummy_batch",
+                                unique_reply_rank=self.output_rank)
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         # OPTIMIZATION: Get output only from a single worker (output_rank)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
In data parallel mode, the engine would crash if it went to sleep after handling a few requests. This PR fixes the issue.
Fixes #24879 
## Test Plan
### TEST1:
1. run vllm server
```bash
VLLM_SERVER_DEV_MODE=1 vllm serve ~/huggingface/Qwen2-1.5B-Instruct  --enable-sleep-mode --gpu-memory-utilization 0.7 -dp 2 --port 8199 --served-model-name Qwen2-1.5B-Instruct
```

2. test rollout and sleep
```python
import requests
from openai import OpenAI

port = 8199

def chat():
    openai_api_key = "EMPTY"
    openai_api_base = f"http://localhost:{port}/v1"
    client = OpenAI(
        api_key=openai_api_key,
        base_url=openai_api_base,
    )
    models = client.models.list()
    model_name = models.data[0].id
    completion = client.completions.create(model=model_name,
                                        prompt="San Francisco is a")
    print("Completion result:", completion)
    return completion

def model_sleep():
    requests.post(f'http://localhost:{port}/sleep?level=1')

if __name__ == "__main__":
   resp = chat()
   model_sleep()
```
### TEST2:
1. run common sleep test
```bash
pytest tests/entrypoints/openai/test_sleep.py
```
## Test Result
No crash occurred

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

