### PR TITLE
[Bug] Fix Cutlass Scaled MM Compilation Error

### DIFF
--- a/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm100_fp8_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm100_fp8_dispatch.cuh
@@ -172,24 +172,22 @@ void cutlass_gemm_caller_blockwise(torch::Tensor& out, torch::Tensor const& a,
   auto b_scales_ptr = static_cast<ElementBlockScale const*>(b_scales.data_ptr());
 
   typename GemmKernel::MainloopArguments mainloop_args{};
+  mainloop_args.layout_SFA = layout_SFA;
+  mainloop_args.layout_SFB = layout_SFB;
   if (swap_ab) {
     mainloop_args.ptr_A = b_ptr;
     mainloop_args.dA = b_stride;
     mainloop_args.ptr_B = a_ptr;
     mainloop_args.dB = a_stride;
     mainloop_args.ptr_SFA = b_scales_ptr;
-    mainloop_args.layout_SFA = layout_SFA;
     mainloop_args.ptr_SFB = a_scales_ptr;
-    mainloop_args.layout_SFB = layout_SFB;
   } else {
     mainloop_args.ptr_A = a_ptr;
     mainloop_args.dA = a_stride;
     mainloop_args.ptr_B = b_ptr;
     mainloop_args.dB = b_stride;
     mainloop_args.ptr_SFA = a_scales_ptr;
-    mainloop_args.layout_SFA = layout_SFA;
     mainloop_args.ptr_SFB = b_scales_ptr;
-    mainloop_args.layout_SFB = layout_SFB;
   }
   auto prob_shape = swap_ab ? cute::make_shape(n, m, k, 1) : cute::make_shape(m, n, k, 1);
 

--- a/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm100_fp8_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm100_fp8_dispatch.cuh
@@ -146,6 +146,7 @@ void cutlass_gemm_caller_blockwise(torch::Tensor& out, torch::Tensor const& a,
 
   using ElementAB = typename Gemm::ElementAB;
   using ElementD = typename Gemm::ElementD;
+  using ElementBlockScale = typename Gemm::ElementBlockScale;
 
   int32_t m = a.size(0), n = b.size(1), k = a.size(1);
 

--- a/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm120_fp8_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm120_fp8_dispatch.cuh
@@ -143,17 +143,20 @@ void cutlass_gemm_caller_blockwise(torch::Tensor& out, torch::Tensor const& a,
   LayoutSFB layout_SFB = 
       ScaleConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
 
-  auto a_ptr = static_cast<ElementAB*>(a.data_ptr());
-  auto b_ptr = static_cast<ElementAB*>(b.data_ptr());
-  auto a_scales_ptr = static_cast<float*>(a_scales.data_ptr());
-  auto b_scales_ptr = static_cast<float*>(b_scales.data_ptr());
+  auto a_ptr = static_cast<ElementAB const*>(a.data_ptr());
+  auto b_ptr = static_cast<ElementAB const*>(b.data_ptr());
+  auto a_scales_ptr = static_cast<ElementBlockScale const*>(a_scales.data_ptr());
+  auto b_scales_ptr = static_cast<ElementBlockScale const*>(b_scales.data_ptr());
 
-  auto mainloop_args = [&](){
-    return typename GemmKernel::MainloopArguments{
-        a_ptr,        a_stride,   b_ptr,        b_stride,
-        a_scales_ptr, layout_SFA, b_scales_ptr, layout_SFB
-    };
-  }();
+  typename GemmKernel::MainloopArguments mainloop_args{};
+  mainloop_args.ptr_A = a_ptr;
+  mainloop_args.dA = a_stride;
+  mainloop_args.ptr_B = b_ptr;
+  mainloop_args.dB = b_stride;
+  mainloop_args.ptr_SFA = a_scales_ptr;
+  mainloop_args.layout_SFA = layout_SFA;
+  mainloop_args.ptr_SFB = b_scales_ptr;
+  mainloop_args.layout_SFB = layout_SFB;
   auto prob_shape = cute::make_shape(m, n, k, 1);
 
   auto c_ptr = static_cast<ElementD*>(out.data_ptr());

--- a/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm120_fp8_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm120_fp8_dispatch.cuh
@@ -125,6 +125,7 @@ void cutlass_gemm_caller_blockwise(torch::Tensor& out, torch::Tensor const& a,
 
   using ElementAB = typename Gemm::ElementAB;
   using ElementD = typename Gemm::ElementD;
+  using ElementBlockScale = typename Gemm::ElementBlockScale;
 
   int32_t m = a.size(0), n = b.size(1), k = a.size(1);
 

--- a/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm90_fp8_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm90_fp8_dispatch.cuh
@@ -115,6 +115,7 @@ void cutlass_gemm_caller_blockwise(torch::Tensor& out, torch::Tensor const& a,
 
   using ElementAB = typename Gemm::ElementAB;
   using ElementD = typename Gemm::ElementD;
+  using ElementBlockScale = typename Gemm::ElementBlockScale;
 
   int32_t m = a.size(0), n = b.size(1), k = a.size(1);
 
@@ -135,17 +136,20 @@ void cutlass_gemm_caller_blockwise(torch::Tensor& out, torch::Tensor const& a,
   LayoutSFB layout_SFB = 
       ScaleConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
 
-  auto a_ptr = static_cast<ElementAB*>(a.data_ptr());
-  auto b_ptr = static_cast<ElementAB*>(b.data_ptr());
-  auto a_scales_ptr = static_cast<float*>(a_scales.data_ptr());
-  auto b_scales_ptr = static_cast<float*>(b_scales.data_ptr());
+  auto a_ptr = static_cast<ElementAB const*>(a.data_ptr());
+  auto b_ptr = static_cast<ElementAB const*>(b.data_ptr());
+  auto a_scales_ptr = static_cast<ElementBlockScale const*>(a_scales.data_ptr());
+  auto b_scales_ptr = static_cast<ElementBlockScale const*>(b_scales.data_ptr());
 
-  auto mainloop_args = [&](){
-    return typename GemmKernel::MainloopArguments{
-        a_ptr,        a_stride,   b_ptr,        b_stride,
-        a_scales_ptr, layout_SFA, b_scales_ptr, layout_SFB
-    };
-  }();
+  typename GemmKernel::MainloopArguments mainloop_args{};
+  mainloop_args.ptr_A = a_ptr;
+  mainloop_args.dA = a_stride;
+  mainloop_args.ptr_B = b_ptr;
+  mainloop_args.dB = b_stride;
+  mainloop_args.ptr_SFA = a_scales_ptr;
+  mainloop_args.layout_SFA = layout_SFA;
+  mainloop_args.ptr_SFB = b_scales_ptr;
+  mainloop_args.layout_SFB = layout_SFB;
   auto prob_shape = cute::make_shape(m, n, k, 1);
 
   auto c_ptr = static_cast<ElementD*>(out.data_ptr());


### PR DESCRIPTION

## Purpose


```bash
/home/wentao/vllm/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm90_fp8_dispatch.cuh(147): error: a value of type "const ElementBlockScale *" cannot be used to initialize an entity of type "uint32_t" (aka "unsigned int")
          a_scales_ptr, layout_SFA, b_scales_ptr, layout_SFB
          ^
          detected during:
            instantiation of "void vllm::cutlass_gemm_caller_blockwise<Gemm>(at::Tensor &, const at::Tensor &, const at::Tensor &, const at::Tensor &, const at::Tensor &) [with Gemm=vllm::cutlass_3x_gemm_fp8_blockwise<cutlass::half_t, 1, 128, 128, cute::tuple<cute::_128, cute::_128, cute::_128>, cute::tuple<cute::_1, cute::_2, cute::_1>, cutlass::epilogue::TmaWarpSpecializedCooperative, cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8BlockScaledAccum>]" at line 170
            instantiation of "void vllm::cutlass_gemm_blockwise_sm90_fp8_dispatch<OutType>(at::Tensor &, const at::Tensor &, const at::Tensor &, const at::Tensor &, const at::Tensor &) [with OutType=cutlass::half_t]" at line 19 of /home/wentao/vllm/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm90_fp8.cu
8 errors detected in the compilation of "/home/wentao/vllm/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm90_fp8.cu".
ninja: build stopped: subcommand failed.
```

## Test

Now:

```bash
(wentao) wentao@H100-GPU17:~/vllm$ cmake --build --preset release --target install
[2/3] Install the project...
-- Install configuration: "Release"
-- Up-to-date: /home/wentao/vllm/vllm/cumem_allocator.abi3.so
-- Installing: /home/wentao/vllm/vllm/_C.abi3.so
-- Set non-toolchain portion of runtime path of "/home/wentao/vllm/vllm/_C.abi3.so" to ""
-- Up-to-date: /home/wentao/vllm/vllm/_moe_C.abi3.so
-- Up-to-date: /home/wentao/vllm/vllm/_flashmla_C.abi3.so
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/_vllm_fa2_C.abi3.so
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/_vllm_fa3_C.abi3.so
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops/triton
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops/triton/rotary.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops/triton/__init__.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/layers
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/layers/rotary.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/layers/__init__.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/__init__.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops/triton
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops/triton/rotary.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/ops/triton/__init__.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/layers
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/layers/rotary.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/layers/__init__.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
-- Up-to-date: /home/wentao/vllm/vllm/vllm_flash_attn/__init__.py
```
