### PR TITLE
[Performance] Remove redundant clone() calls in cutlass_mla

### DIFF
--- a/vllm/v1/attention/backends/mla/cutlass_mla.py
+++ b/vllm/v1/attention/backends/mla/cutlass_mla.py
@@ -210,9 +210,14 @@ class CutlassMLAImpl(MLACommonImpl[MLACommonMetadata]):
             sm_scale,
             num_kv_splits,
         )
-        returned_lse = lse[:, :H].contiguous(
-        ) if self.need_to_return_lse_for_decode else lse
-        return out[:, :H].contiguous(), returned_lse
+
+        if H < MAX_HEADS:
+            # Extract the subsets of the outputs
+            returned_lse = lse[:, :H].contiguous(
+            ) if self.need_to_return_lse_for_decode else lse
+            out = out[:, :H]
+
+        return out, returned_lse
 
     def _sm100_forward_decode(
         self,

--- a/vllm/v1/attention/backends/mla/cutlass_mla.py
+++ b/vllm/v1/attention/backends/mla/cutlass_mla.py
@@ -228,11 +228,6 @@ class CutlassMLAImpl(MLACommonImpl[MLACommonMetadata]):
         self._workspace.ensure_size(attn_metadata, self._num_kv_splits)
 
         # Run MLA
-        # Clone q_nope and q_pe to make sure strides computation is correct.
-        # TODO: Check if we really need it
-        q_nope = q_nope.clone()
-        q_pe = q_pe.clone()
-
         o, lse = self._sm100_cutlass_mla_decode(
             q_nope,
             q_pe,


### PR DESCRIPTION
This PR removes 2 redundant clone() calls in pre-attn cutlass MLA python code (that we found in the profiling work). This PR is step 1 (_"Remove unnecessary copies from Cutlass MLA"_) from this meta fusion issue (https://github.com/vllm-project/vllm/issues/24629):  For DeekSeekR1 on 8xB200 GPUs batch size 32, this improves decode perf by 2.4% from 19.15ms TPO to 18.7ms.

Verified that correctness is preserved via manual check and also lm_eval on GSM8K.
Command used: lm_eval --model vllm --model_args pretrained=deepseek-ai/DeepSeek-R1-0528,tensor_parallel_size=8 --tasks gsm8k --num_fewshot 5 --batch_size auto

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9568|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9538|±  |0.0058|

