### PR TITLE
[Docs] Update instructions for how to using existing torch binary

### DIFF
--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -165,8 +165,18 @@ There are scenarios where the PyTorch dependency cannot be easily installed with
 - Building vLLM with PyTorch nightly or a custom PyTorch build.
 - Building vLLM with aarch64 and CUDA (GH200), where the PyTorch wheels are not available on PyPI. Currently, only the PyTorch nightly has wheels for aarch64 with CUDA. You can run `uv pip install --index-url https://download.pytorch.org/whl/nightly/cu128 torch torchvision torchaudio` to [install PyTorch nightly](https://pytorch.org/get-started/locally/) and then build vLLM on top of it.
 
-To build vLLM using an existing PyTorch installation, it is recommended to use `uv`, because it has [a unique mechanism](https://docs.astral.sh/uv/concepts/projects/config/#disabling-build-isolation) for disabling build isolation for specific packages and vLLM leverages this mechanism to specify `torch` as the package to disable build isolation.
+To build vLLM using an existing PyTorch installation:
+```bash
+# install PyTorch first, either from PyPI or from source
+git clone https://github.com/vllm-project/vllm.git
+cd vllm
+python use_existing_torch.py
+uv pip install -r requirements/build.txt
+uv pip install --no-build-isolation -e .
+```
 
+Alternatively: if you are exclusively using `uv` to create and manage virtual environments, it has [a unique mechanism](https://docs.astral.sh/uv/concepts/projects/config/#disabling-build-isolation)
+for disabling build isolation for specific packages. vLLM can leverage this mechanism to specify `torch` as the package to disable build isolation for:
 ```bash
 # install PyTorch first, either from PyPI or from source
 git clone https://github.com/vllm-project/vllm.git
@@ -174,6 +184,7 @@ cd vllm
 # pip install -e . does not work directly, only uv can do this
 uv pip install -e .
 ```
+
 
 ##### Use the local cutlass for compilation
 

--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -166,6 +166,7 @@ There are scenarios where the PyTorch dependency cannot be easily installed with
 - Building vLLM with aarch64 and CUDA (GH200), where the PyTorch wheels are not available on PyPI. Currently, only the PyTorch nightly has wheels for aarch64 with CUDA. You can run `uv pip install --index-url https://download.pytorch.org/whl/nightly/cu128 torch torchvision torchaudio` to [install PyTorch nightly](https://pytorch.org/get-started/locally/) and then build vLLM on top of it.
 
 To build vLLM using an existing PyTorch installation:
+
 ```bash
 # install PyTorch first, either from PyPI or from source
 git clone https://github.com/vllm-project/vllm.git
@@ -177,6 +178,7 @@ uv pip install --no-build-isolation -e .
 
 Alternatively: if you are exclusively using `uv` to create and manage virtual environments, it has [a unique mechanism](https://docs.astral.sh/uv/concepts/projects/config/#disabling-build-isolation)
 for disabling build isolation for specific packages. vLLM can leverage this mechanism to specify `torch` as the package to disable build isolation for:
+
 ```bash
 # install PyTorch first, either from PyPI or from source
 git clone https://github.com/vllm-project/vllm.git
@@ -184,7 +186,6 @@ cd vllm
 # pip install -e . does not work directly, only uv can do this
 uv pip install -e .
 ```
-
 
 ##### Use the local cutlass for compilation
 


### PR DESCRIPTION
The uv approach seems to only work when you exclusively use uv to manage your virtual environments (we have reports of it not working with conda envs).

This PR is a followup to https://github.com/vllm-project/vllm/pull/24729 and https://github.com/vllm-project/vllm/pull/24303
