### PR TITLE
[ROCm][Bugfix] Fix the case where there's bias

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -179,7 +179,7 @@ def rocm_per_tensor_w8a8_scaled_mm_impl(qinput: torch.Tensor,
                                         bias: torch.Tensor) -> torch.Tensor:
     from vllm.platforms.rocm import on_mi3xx
     if envs.VLLM_ROCM_USE_SKINNY_GEMM and on_mi3xx(
-    ) and qinput.shape[0] == 1 and qinput.shape[1] % 16 == 0:
+    ) and qinput.shape[0] == 1 and qinput.shape[1] % 16 == 0 and bias is None:
         output = ops.wvSplitKQ(weight.t(), qinput, out_dtype, scale_a, scale_b,
                                current_platform.get_cu_count())
     else:


### PR DESCRIPTION
## Purpose
Fix for skinny gemms (wvSplitk} being called when there's bias, which is not supported

## Test Plan
New unit test