### PR TITLE
Run:ai model streamer add GCS package support

### DIFF
--- a/docs/models/extensions/runai_model_streamer.md
+++ b/docs/models/extensions/runai_model_streamer.md
@@ -24,6 +24,13 @@ vllm serve s3://core-llm/Llama-3-8b \
     --load-format runai_streamer
 ```
 
+To run model from Google Cloud Storage run:
+
+```bash
+vllm serve gs://core-llm/Llama-3-8b \
+    --load-format runai_streamer
+```
+
 To run model from a S3 compatible object store run:
 
 ```bash

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -43,6 +43,6 @@ tritonclient==2.51.0
 numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
 numba == 0.61.2; python_version > '3.9'
 numpy
-runai-model-streamer[s3]==0.14.0
+runai-model-streamer[s3,gcs]==0.14.0
 fastsafetensors>=0.1.10
 pydantic>=2.10 # 2.9 leads to error on python 3.10

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -13,6 +13,6 @@ tensorizer==2.10.1
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-runai-model-streamer[s3]==0.14.0
+runai-model-streamer[s3,gcs]==0.14.0
 conch-triton-kernels==1.2.1
 timm>=1.0.17

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -51,7 +51,7 @@ tritonclient==2.51.0
 numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
 numba == 0.61.2; python_version > '3.9'
 numpy
-runai-model-streamer[s3]==0.14.0
+runai-model-streamer[s3,gcs]==0.14.0
 fastsafetensors>=0.1.10
 pydantic>=2.10 # 2.9 leads to error on python 3.10
 decord==0.6.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -251,11 +251,27 @@ gitdb==4.0.12
 gitpython==3.1.44
     # via mlflow-skinny
 google-api-core==2.24.2
-    # via opencensus
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   opencensus
 google-auth==2.40.2
     # via
     #   databricks-sdk
     #   google-api-core
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   runai-model-streamer-gcs
+google-cloud-core==2.4.3
+    # via google-cloud-storage
+google-cloud-storage==3.4.0
+    # via runai-model-streamer-gcs
+google-crc32c==1.7.1
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via google-cloud-storage
 googleapis-common-protos==1.70.0
     # via google-api-core
 graphene==3.4.3
@@ -890,6 +906,7 @@ requests==2.32.3
     #   docker
     #   evaluate
     #   google-api-core
+    #   google-cloud-storage
     #   huggingface-hub
     #   lightly
     #   lm-eval
@@ -929,6 +946,8 @@ rtree==1.4.0
     # via torchgeo
 runai-model-streamer==0.14.0
     # via -r requirements/test.in
+runai-model-streamer-gcs==0.14.0
+    # via runai-model-streamer
 runai-model-streamer-s3==0.14.0
     # via runai-model-streamer
 s3transfer==0.10.3


### PR DESCRIPTION
## Purpose
 * Install the `runai-model-streamer[gcs]` pip package by default, to enable GCS support in the nightly / published image. 

## Test Plan / Test Result
Validated locally by building docker image and running locally (see updated documentation).
