### PR TITLE
[torch.compile] Make Query Quantization Fusable

### DIFF
--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -38,6 +38,8 @@ class AttentionBackend(ABC):
     # If True, the attention layer will handle query quantization instead
     # of the backend, allowing torch.compile to fuse quantization with
     # previous operations.
+    # Needs to be worked through for all backends
+    # https://github.com/vllm-project/vllm/issues/25584
     supports_quant_query_input: bool = False
 
     @staticmethod

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -34,6 +34,12 @@ class AttentionBackend(ABC):
     # makes sure the output tensor is allocated inside the cudagraph.
     accept_output_buffer: bool = False
 
+    # Whether this backend supports receiving pre-quantized query input.
+    # If True, the attention layer will handle query quantization instead
+    # of the backend, allowing torch.compile to fuse quantization with
+    # previous operations.
+    supports_quant_query_input: bool = False
+
     @staticmethod
     @abstractmethod
     def get_name() -> str:

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -288,6 +288,7 @@ class Attention(nn.Module, AttentionLayerBase):
             # which reduces overheads during decoding.
             # Otherwise queries are quantized using custom ops
             # which causes decoding overheads
+            assert self.kv_cache_dtype in {"fp8", "fp8_e4m3"}
             query, _ = self.query_quant.forward_native(query, self._q_scale)
 
         if self.use_output:

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -22,7 +22,10 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape)
 from vllm.model_executor.models.vision import get_vit_attn_backend
 from vllm.platforms import _Backend, current_platform
 from vllm.utils import GiB_bytes, direct_register_custom_op
@@ -247,6 +250,13 @@ class Attention(nn.Module, AttentionLayerBase):
                 "This may be caused by insufficient memory to allocate "
                 "kv cache.") from e
 
+        # for attn backends supporting query quantization
+        self.query_quant = None
+        if self.kv_cache_dtype.startswith(
+                "fp8") and self.attn_backend.supports_quant_query_input:
+            self.query_quant = QuantFP8(static=True,
+                                        group_shape=GroupShape.PER_TENSOR)
+
     def forward(
         self,
         query: torch.Tensor,
@@ -270,6 +280,15 @@ class Attention(nn.Module, AttentionLayerBase):
             attn_metadata = get_forward_context().attn_metadata
             if attn_metadata.enable_kv_scales_calculation:
                 self.calc_kv_scales(query, key, value)
+
+        if self.query_quant is not None:
+            # quantizing with a simple torch operation enables
+            # torch.compile to fuse this into previous ops
+            # which reduces overheads during decoding.
+            # Otherwise queries are quantized using custom ops
+            # which causes decoding overheads
+            query, _ = self.query_quant.forward_native(query, self._q_scale)
+
         if self.use_output:
             output_shape = (output_shape
                             if output_shape is not None else query.shape)
@@ -277,22 +296,6 @@ class Attention(nn.Module, AttentionLayerBase):
                                  dtype=query.dtype,
                                  device=query.device)
             hidden_size = output_shape[-1]
-
-            if envs.VLLM_FUSE_QUERY_QUANT and self.kv_cache_dtype != "auto":
-                # quantizing with a simple torch operation enables
-                # torch.compile to fuse this into previous ops
-                # which reduces overheads during decoding.
-                # Otherwise queries are quantized using custom ops
-                # which causes decoding overheads
-                assert self._q_scale.numel() == 1
-                if self.kv_cache_dtype in ["fp8", "fp8_e4m3"]:
-                    query = (query / self._q_scale).to(torch.float8_e4m3fn)
-                elif self.kv_cache_dtype == "fp8_e5m2":
-                    query = (query / self._q_scale).to(torch.float8_e5m2)
-                else:
-                    raise NotImplementedError(
-                        "VLLM_FUSE_QUERY_QUANT only supported for fp8_e4m3 "
-                        "and fp8_e5m2")
 
             # We skip reshaping query, key and value tensors for the MLA
             # backend since these tensors have different semantics and are

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -280,7 +280,8 @@ class Attention(nn.Module, AttentionLayerBase):
             # We skip reshaping query, key and value tensors for the MLA
             # backend since these tensors have different semantics and are
             # processed differently.
-            if envs.VLLM_FUSE_QUERY_QUANT:
+            if (envs.VLLM_FUSE_QUERY_QUANT
+                    and self.kv_cache_dtype.startswith("fp8")):
                 assert self._q_scale.numel() == 1
                 query = (query / self._q_scale).to(torch.float8_e4m3fn)
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -280,6 +280,10 @@ class Attention(nn.Module, AttentionLayerBase):
             # We skip reshaping query, key and value tensors for the MLA
             # backend since these tensors have different semantics and are
             # processed differently.
+            if envs.VLLM_FUSE_QUERY_QUANT:
+                assert self._q_scale.numel() == 1
+                query = (query / self._q_scale).to(torch.float8_e4m3fn)
+
             if not self.use_mla:
                 # Reshape the query, key, and value tensors.
                 # NOTE(woosuk): We do this outside the custom op to minimize the

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -278,7 +278,7 @@ class Attention(nn.Module, AttentionLayerBase):
                                  device=query.device)
             hidden_size = output_shape[-1]
 
-            if envs.VLLM_FUSE_QUERY_QUANT:
+            if envs.VLLM_FUSE_QUERY_QUANT and self.kv_cache_dtype != "auto":
                 # quantizing with a simple torch operation enables
                 # torch.compile to fuse this into previous ops
                 # which reduces overheads during decoding.

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -281,6 +281,7 @@ class Attention(nn.Module, AttentionLayerBase):
             if attn_metadata.enable_kv_scales_calculation:
                 self.calc_kv_scales(query, key, value)
 
+        output_dtype = query.dtype
         if self.query_quant is not None:
             # quantizing with a simple torch operation enables
             # torch.compile to fuse this into previous ops
@@ -293,7 +294,7 @@ class Attention(nn.Module, AttentionLayerBase):
             output_shape = (output_shape
                             if output_shape is not None else query.shape)
             output = torch.zeros(output_shape,
-                                 dtype=query.dtype,
+                                 dtype=output_dtype,
                                  device=query.device)
             hidden_size = output_shape[-1]
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -297,7 +297,6 @@ class Attention(nn.Module, AttentionLayerBase):
                                  dtype=output_dtype,
                                  device=query.device)
             hidden_size = output_shape[-1]
-
             # We skip reshaping query, key and value tensors for the MLA
             # backend since these tensors have different semantics and are
             # processed differently.

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -289,7 +289,7 @@ class Attention(nn.Module, AttentionLayerBase):
             # Otherwise queries are quantized using custom ops
             # which causes decoding overheads
             assert self.kv_cache_dtype in {"fp8", "fp8_e4m3"}
-            query, _ = self.query_quant.forward_native(query, self._q_scale)
+            query, _ = self.query_quant(query, self._q_scale)
 
         if self.use_output:
             output_shape = (output_shape

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -160,7 +160,6 @@ if TYPE_CHECKING:
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_SLEEP_WHEN_IDLE: bool = False
-    VLLM_FUSE_QUERY_QUANT: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_KV_CACHE_LAYOUT: Optional[Literal["NHD", "HND"]] = None
@@ -1257,13 +1256,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SLEEP_WHEN_IDLE":
     lambda: bool(int(os.getenv("VLLM_SLEEP_WHEN_IDLE", "0"))),
 
-    # Quantize the query in the attention layer with a simple
-    # pytorch operation instead of a custom op in the attention backend.
-    # Then torch.compile can fuse it and reduce overhead.
-    # Only relevant for quantized attention w/ FA3
-    "VLLM_FUSE_QUERY_QUANT":
-    lambda: bool(int(os.getenv("VLLM_FUSE_QUERY_QUANT", "0"))),
-
     # Control the max chunk bytes (in MB) for the rpc message queue.
     # Object larger than this threshold will be broadcast to worker
     # processes via zmq.
@@ -1523,7 +1515,6 @@ def compute_hash() -> str:
         "VLLM_USE_CUDNN_PREFILL",
         "VLLM_USE_TRTLLM_ATTENTION",
         "VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION",
-        "VLLM_FUSE_QUERY_QUANT",
         "VLLM_ROCM_USE_AITER",
         "VLLM_ROCM_USE_AITER_PAGED_ATTN",
         "VLLM_ROCM_USE_AITER_LINEAR",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -160,6 +160,7 @@ if TYPE_CHECKING:
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_SLEEP_WHEN_IDLE: bool = False
+    VLLM_FUSE_QUERY_QUANT: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_KV_CACHE_LAYOUT: Optional[Literal["NHD", "HND"]] = None
@@ -1255,6 +1256,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # latency penalty when a request eventually comes.
     "VLLM_SLEEP_WHEN_IDLE":
     lambda: bool(int(os.getenv("VLLM_SLEEP_WHEN_IDLE", "0"))),
+
+    # Fuse query quantization into the attention layer instead of
+    # doing it in the attention backend. Then torch.compile can
+    # fuse it into previous ops and reduce overhead.
+    "VLLM_FUSE_QUERY_QUANT":
+    lambda: bool(int(os.getenv("VLLM_FUSE_QUERY_QUANT", "0"))),
 
     # Control the max chunk bytes (in MB) for the rpc message queue.
     # Object larger than this threshold will be broadcast to worker

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1257,9 +1257,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SLEEP_WHEN_IDLE":
     lambda: bool(int(os.getenv("VLLM_SLEEP_WHEN_IDLE", "0"))),
 
-    # Fuse query quantization into the attention layer instead of
-    # doing it in the attention backend. Then torch.compile can
-    # fuse it into previous ops and reduce overhead.
+    # Quantize the query in the attention layer with a simple
+    # pytorch operation instead of a custom op in the attention backend.
+    # Then torch.compile can fuse it and reduce overhead.
+    # Only relevant for quantized attention w/ FA3
     "VLLM_FUSE_QUERY_QUANT":
     lambda: bool(int(os.getenv("VLLM_FUSE_QUERY_QUANT", "0"))),
 
@@ -1522,6 +1523,7 @@ def compute_hash() -> str:
         "VLLM_USE_CUDNN_PREFILL",
         "VLLM_USE_TRTLLM_ATTENTION",
         "VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION",
+        "VLLM_FUSE_QUERY_QUANT",
         "VLLM_ROCM_USE_AITER",
         "VLLM_ROCM_USE_AITER_PAGED_ATTN",
         "VLLM_ROCM_USE_AITER_LINEAR",

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -7,7 +7,6 @@ from typing import Optional
 import numpy as np
 import torch
 
-from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionMetadata, AttentionType,
@@ -38,6 +37,7 @@ logger = init_logger(__name__)
 class FlashAttentionBackend(AttentionBackend):
 
     accept_output_buffer: bool = True
+    supports_quant_query_input: bool = True
 
     @classmethod
     def get_supported_dtypes(cls) -> list[torch.dtype]:
@@ -506,17 +506,11 @@ class FlashAttentionImpl(AttentionImpl):
             )
 
         if self.kv_cache_dtype.startswith("fp8"):
+            # queries are quantized in the attention layer
             dtype = FlashAttentionBackend.get_fp8_dtype_for_flashattn(
                 self.kv_cache_dtype)
             key_cache = key_cache.view(dtype)
             value_cache = value_cache.view(dtype)
-            if not envs.VLLM_FUSE_QUERY_QUANT:
-                num_tokens, num_heads, head_size = query.shape
-                query, _ = ops.scaled_fp8_quant(
-                    query.reshape(
-                        (num_tokens, num_heads * head_size)).contiguous(),
-                    layer._q_scale)
-                query = query.reshape((num_tokens, num_heads, head_size))
 
         if not attn_metadata.use_cascade:
             cu_seqlens_q = attn_metadata.query_start_loc

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -7,7 +7,6 @@ from typing import Optional
 import numpy as np
 import torch
 
-import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,


### PR DESCRIPTION
## Purpose
When running attention in FP8, quantizing the queries causes overhead, since this is done via a custom operation. And because it is a custom op it cannot be fused by torch compile. Profiling shows that this is a (context-lenght-independent) overhead. 

This PR moves the query quantization out of the attention backend into `attention/layer.py` and uses a simple torch implementation. Then torch compile is able to fuse it and reduce the quantization overheads.

It is currently only done for the FA backend, but the design is generalizable. Created an Issue to track https://github.com/vllm-project/vllm/issues/25584

## Test Plan
Spin up server
```
vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --kv-cache-dtype fp8 \
  --compilation-config '{"compile_sizes": [1,2,4,8], "cudagraph_capture_sizes": [1,2,4,8], "cudagraph_mode": "FULL_AND_PIECEWISE"}' \
  --no-enable-prefix-caching
```
Benchmark
```
vllm bench serve \
    --backend vllm \
    --model $model_name \
    --dataset-name sonnet \
    --dataset-path vllm/benchmarks/sonnet.txt \
    --sonnet-input-len 1000 \
    --sonnet-output-len 200 \
    --port 8000 \
    --num-prompts 20 \
    --max-concurrency 1
```

unit test covering these changes:
`pytest /efs/kuebj/kv_cache/vllm_source/tests/quantization/test_fp8.py::test_kv_cache_model_load_and_run` ✅ 

### Accuracy
To ensure there is no accidental accuracy degradation we also run
```
lm_eval \
  --model vllm \
  --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct,kv_cache_dtype=auto,tensor_parallel_size=8,enforce_eager=True \
  --tasks gsm8k \
  --batch_size 
```
with `kv_cache_dtype` in `{auto,fp8}` both on this PR and on mainline. We also run without `enforce_eager=True` for the FP8 variants

## Test Result
```
this PR:

============ Serving Benchmark Result ============
Successful requests:                     20        
Maximum request concurrency:             1         
Benchmark duration (s):                  27.16     
Total input tokens:                      18248     
Total generated tokens:                  4000      
Request throughput (req/s):              0.74      
Output token throughput (tok/s):         147.27    
Peak output token throughput (tok/s):    151.00    
Peak concurrent requests:                2.00      
Total Token throughput (tok/s):          819.09    
---------------Time to First Token----------------
Mean TTFT (ms):                          32.36     
Median TTFT (ms):                        31.82     
P99 TTFT (ms):                           37.59     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.66      
Median TPOT (ms):                        6.66      
P99 TPOT (ms):                           6.68      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.66      
Median ITL (ms):                         6.66      
P99 ITL (ms):                            6.95 



MAINLINE
============ Serving Benchmark Result ============
Successful requests:                     20        
Maximum request concurrency:             1         
Benchmark duration (s):                  27.44     
Total input tokens:                      18248     
Total generated tokens:                  4000      
Request throughput (req/s):              0.73      
Output token throughput (tok/s):         145.77    
Peak output token throughput (tok/s):    149.00    
Peak concurrent requests:                2.00      
Total Token throughput (tok/s):          810.80    
---------------Time to First Token----------------
Mean TTFT (ms):                          30.39     
Median TTFT (ms):                        30.26     
P99 TTFT (ms):                           31.77     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.74      
Median TPOT (ms):                        6.74      
P99 TPOT (ms):                           6.75      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.74      
Median ITL (ms):                         6.74      
P99 ITL (ms):                            7.01      
==================================================

```
### Accuracy on GSM8k ✅ 
The PR preserves the accuracy numbers both for FP8 and auto. That FP8 can be slightly worse than auto is expected.

Main+auto
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7801|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7597|±  |0.0118|
```
PR + auto
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7801|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7597|±  |0.0118|
```

Main+fp8 (enforce-eager)
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7559|±  |0.0118|
|     |       |strict-match    |     5|exact_match|↑  |0.7384|±  |0.0121|
```

PR+fp8 (enforce-eager)
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7559|±  |0.0118|
|     |       |strict-match    |     5|exact_match|↑  |0.7384|±  |0.0121|
```
Main+fp8 (w/ compile)
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7703|±  |0.0116|
|     |       |strict-match    |     5|exact_match|↑  |0.7460|±  |0.0120|
```


PR+fp8 (w/compile)
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7650|±  |0.0117|
|     |       |strict-match    |     5|exact_match|↑  |0.7445|±  |0.0120|
```

-----
<details>
<summary>[old description until 09/24]</summary>
## Purpose
This PR is part of a series to make FP8 attention fast for GPT-OSS, see https://github.com/vllm-project/vllm/issues/24916 for context. However, this specific PR would make quantization faster for any model using quantized Queries. 

Quantizing the queries causes overhead, since this is done via a custom operation, it cannot be fused by torch compile. Profiling shows that this is a (context-lenght-independent) overhead. This PR adds an env variable that allows to perform the query quantization via simple torch operations. When running with torch.compile enabled, this can automatically be fused into previous ops and removes the quantization overhead.

## Test Plan
Setup server via
```
export VLLM_FUSE_QUERY_QUANT=1
python -m vllm.entrypoints.openai.api_server \
    --model $MODEL_PATH \
    --tensor-parallel-size 1 \
    --max-num-seqs 1 \
    --port 8088 \
    --kv-cache-dtype "fp8" \
    --served-model-name gpt-oss-KV8-fuse-q-quant \
    --compilation-config '{"compile_sizes": [1,2,4,8], "cudagraph_capture_sizes": [1,2,4,8], "cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --no-enable-prefix-caching
```
Benchmark via 
```
model_name=gpt-oss-KV8-fuse-q-quant
vllm bench serve \
    --backend vllm \
    --model $model_name \
    --dataset-name sonnet \
    --dataset-path /home/ec2-user/gpt-oss-attn/vllm/benchmarks/sonnet.txt \
    --sonnet-input-len 25000 \
    --sonnet-output-len 200 \
    --port 8088 \
    --tokenizer openai/gpt-oss-120b \
    --num-prompts 10 \
    --max-concurrency 1
```
## Test Result
We tested with concurrency 1, TP1 on GPT-OSS for 25k and 1k inputs (`bench serve`). As intended the query quantization overheads disappear. Also profiling showed that the quantization get's fused by torch compile. We also tested the accuracy through GPQA and AIME25 via GPT-OSS repo, and find no differences between the usual noise.

| model                                            | applied optimization | input  | output | median ITL [ms] | median ttft [ms] |
|--------------------------------------------------|----------------------|--------|--------|-----------------|------------------|
| gpt-oss (full bf 16)                             |        mainline              |  25000 |    200 |            5.08 |          1252.43 |
| gpt-oss (full bf 16)                             |       mainline               |   1000 |    200 |            4.83 |            76.16 |
| kv fp8                                           |        mainline              |  25000 |    200 |            5.38 |          1211.33 |
| kv fp8                                           |       mainline               |   1000 |    200 |            5.06 |            76.36 |
| gpt-oss-KV8-fuse-q-quant                         |                    this PR |  25000 |    200 |             5.3 |          1208.56 |
| gpt-oss-KV8-fuse-q-quant                         |                    this PR |   1000 |    200 |            4.98 |            78.89 |


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

</details>