### PR TITLE
[Attention] remove decode wrapper of flashinfer

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1104,7 +1104,6 @@ def fast_plan_decode(
             head_dim,
             head_dim,
             False,  # causal
-            window_left,  # for sliding window
         )
     except Exception as e:
         raise RuntimeError(f"Error in tensor core plan: {e}") from e


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR removes the decode wrapper of the FlashInfer backend in V1 to simplify code paths and improve maintenance. As `use_tensor_cores` is always enabled for batch decode requests for better performance (https://github.com/vllm-project/vllm/blob/aae725af7cee79628e576e7b394811050f651e49/vllm/v1/attention/backends/flashinfer.py#L380), the backend kernels are always dispatched into FA2 prefill kernels in FlashInfer (https://github.com/flashinfer-ai/flashinfer/blob/2bd914460c08c3d26093165b117fb9089f857bed/flashinfer/decode.py#L1018). Thus, using either `DecodeWrapper` or `PrefillWrapper` is theoretically equivalent.

In the future, both prefill and decode could be batched and executed within a single kernel call for a unified kernel (as proposed in https://github.com/flashinfer-ai/flashinfer/pull/1137).

cc @heheda12345 for https://github.com/vllm-project/vllm/pull/24856. This PR is compatible with current stable FlashInfer.

## Test Plan

## Test Result

perf benchmark:
<img width="711" height="258" alt="image" src="https://github.com/user-attachments/assets/cf8533d7-7ede-4e01-adb0-55f0fe648e5d" />
The ~2% perf degrade potentially due to the lightly higher overhead of `plan` function of `BatchPrefillWrapper`, which should be minimal when using `fast_decode_plan` (https://github.com/vllm-project/vllm/blob/aae725af7cee79628e576e7b394811050f651e49/vllm/v1/attention/backends/flashinfer.py#L978) in cuda graph.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

