### PR TITLE
[Core][MultiModalHasher] Don't convert memoryviews to bytes during hashing

### DIFF
--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -23,22 +23,21 @@ class MultiModalHasher:
     def serialize_item(cls, obj: object) -> Iterable[Union[bytes, memoryview]]:
         # Simple cases
         if isinstance(obj, (bytes, memoryview)):
-            yield obj
-        elif isinstance(obj, str):
-            yield obj.encode("utf-8")
-        elif isinstance(obj, (int, float)):
-            yield np.array(obj).tobytes()
+            return (obj, )
+        if isinstance(obj, str):
+            return (obj.encode("utf-8"), )
+        if isinstance(obj, (int, float)):
+            return (np.array(obj).tobytes(), )
 
-        elif isinstance(obj, Image.Image):
+        if isinstance(obj, Image.Image):
             exif = obj.getexif()
             if Image.ExifTags.Base.ImageID in exif and isinstance(
                     exif[Image.ExifTags.Base.ImageID], uuid.UUID):
                 # If the image has exif ImageID tag, use that
-                yield exif[Image.ExifTags.Base.ImageID].bytes
-            else:
-                yield from cls.iter_item_to_bytes(
-                    "image", np.asarray(convert_image_mode(obj, "RGBA")))
-        elif isinstance(obj, torch.Tensor):
+                return (exif[Image.ExifTags.Base.ImageID].bytes, )
+            return cls.iter_item_to_bytes(
+                "image", np.asarray(convert_image_mode(obj, "RGBA")))
+        if isinstance(obj, torch.Tensor):
             tensor_obj: torch.Tensor = obj.cpu()
             tensor_dtype = tensor_obj.dtype
             tensor_shape = tensor_obj.shape
@@ -50,29 +49,27 @@ class MultiModalHasher:
                 tensor_obj = tensor_obj.view(
                     (tensor_obj.numel(), )).view(torch.uint8)
 
-                yield from cls.iter_item_to_bytes(
+                return cls.iter_item_to_bytes(
                     "tensor", {
                         "original_dtype": str(tensor_dtype),
                         "original_shape": tuple(tensor_shape),
                         "data": tensor_obj.numpy(),
                     })
-            else:
-                yield from cls.iter_item_to_bytes("tensor", tensor_obj.numpy())
-        elif isinstance(obj, np.ndarray):
+            return cls.iter_item_to_bytes("tensor", tensor_obj.numpy())
+        if isinstance(obj, np.ndarray):
             # If the array is non-contiguous, we need to copy it first
             arr_data = obj.view(
                 np.uint8).data if obj.flags.c_contiguous else obj.tobytes()
-            yield from cls.iter_item_to_bytes("ndarray", {
+            return cls.iter_item_to_bytes("ndarray", {
                 "dtype": obj.dtype.str,
                 "shape": obj.shape,
                 "data": arr_data,
             })
-        else:
-            logger.warning(
-                "No serialization method found for %s. "
-                "Falling back to pickle.", type(obj))
+        logger.warning(
+            "No serialization method found for %s. "
+            "Falling back to pickle.", type(obj))
 
-            yield pickle.dumps(obj)
+        return (pickle.dumps(obj), )
 
     @classmethod
     def iter_item_to_bytes(


### PR DESCRIPTION
## Purpose

As mentioned in #22044 hashing large multimodal input can be inefficient. #19484 removed a data copy of numpy arrays by relying on memory views for c-contiguous data.

`blake3` already accepts uint8 buffers so this PR removes the need to convert everything back to bytes in `item_to_bytes`
https://github.com/vllm-project/vllm/blob/5bcc153d7bf69ef34bc5788a33f60f1792cf2861/vllm/multimodal/hasher.py#L81

Implementation wise `serialize_item` now yields either `bytes` or a `memoryview` which `blake3` directly consumes.

## Test Plan

Correctness should be covered by the existing hasher tests on CI.

The performance can be measured using:
```python
import numpy as np
from vllm.multimodal.hasher import MultiModalHasher

np.random.seed(42)
data = np.random.randn(3840, 2160, 4)

%timeit MultiModalHasher.hash_kwargs(data=data)
```

## Test Result

For a 4k image this speeds up hashing by ~30%. This is not massive, but for a lot of multimodal input this might become noticeably.

```shell
# main
168 ms ± 892 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# This PR
120 ms ± 1.09 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
