### PR TITLE
[XPU] Fix circular import error. 

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -170,6 +170,10 @@ class XPUPlatform(Platform):
                     "only NHD layout is supported by XPU attention kernels.")
 
     @classmethod
+    def support_hybrid_kv_cache(cls) -> bool:
+        return True
+
+    @classmethod
     def is_pin_memory_available(cls):
         return True
 

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -9,7 +9,6 @@ import torch
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils import DEFAULT_MAX_NUM_BATCHED_TOKENS
-from vllm.v1.attention.backends.utils import set_kv_cache_layout
 
 from .interface import DeviceCapability, Platform, PlatformEnum, _Backend
 
@@ -164,6 +163,7 @@ class XPUPlatform(Platform):
             vllm_config.scheduler_config.max_num_batched_tokens = max(
                 vllm_config.scheduler_config.max_model_len,
                 DEFAULT_MAX_NUM_BATCHED_TOKENS)
+        from vllm.v1.attention.backends.utils import set_kv_cache_layout
 
         set_kv_cache_layout("NHD")
         logger.info("Setting VLLM_KV_CACHE_LAYOUT to 'NHD' for XPU; "


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#24745 introduce a circular import error, which will make vllm fail to start on xpu platform.
also fix a kv cache ut fail error by adding `support_hybrid_kv_cache` method. xpu should support sliding window hybrid kv natively.

## Test Plan
ut & CI

## Test Result
v1/core/test_kv_cache_utils.py could pass now.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

