### PR TITLE
[Metrics] Add finer-grained buckets for request_latency to support faster/embedding models

### DIFF
--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -137,8 +137,9 @@ class Metrics:
         # Request stats
         #   Latency
         request_latency_buckets = [
-            0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
-            40.0, 50.0, 60.0, 120.0, 240.0, 480.0, 960.0, 1920.0, 7680.0
+            0.05, 0.10, 0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0,
+            20.0, 30.0, 40.0, 50.0, 60.0, 120.0, 240.0, 480.0, 960.0, 1920.0,
+            7680.0
         ]
         self.histogram_e2e_time_request = self._histogram_cls(
             name="vllm:e2e_request_latency_seconds",

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -400,8 +400,9 @@ class PrometheusStatLogger(StatLoggerBase):
             histogram_inter_token_latency, engine_indexes, model_name)
 
         request_latency_buckets = [
-            0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
-            40.0, 50.0, 60.0, 120.0, 240.0, 480.0, 960.0, 1920.0, 7680.0
+            0.05, 0.10, 0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0,
+            20.0, 30.0, 40.0, 50.0, 60.0, 120.0, 240.0, 480.0, 960.0, 1920.0,
+            7680.0
         ]
         histogram_e2e_time_request = self._histogram_cls(
             name="vllm:e2e_request_latency_seconds",


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
The `request_latency_buckets` histogram currently starts at 300ms, which
is too coarse to capture the latency distribution of faster/embedding
models that typically have much faster e2e latencies (e.g., ~50ms).

This PR adds two additional buckets [0.05, 0.10] at the beginning of the
`request_latency_buckets`. While this does increase the cardinality of the
exposed metrics, maybe it's a reasonable trade-off?

The change affects all request latency histograms:
- vllm:e2e_request_latency_seconds
- vllm:request_queue_time_seconds
- vllm:request_inference_time_seconds
- vllm:request_prefill_time_seconds
- vllm:request_decode_time_seconds

## Test Plan
Manual testing by going to http://localhost:8080/metrics

## Test Result
The `le="0.05"` and `le="0.1"` now get emitted:
```
...
vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.05",model_name="{MODEL_NAME}"} 18.0
vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.1",model_name="{MODEL_NAME}"} 18.0
vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.3",model_name="{MODEL_NAME}"} 19.0
vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.5",model_name="{MODEL_NAME}"} 21.0
vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.8",model_name="{MODEL_NAME}"} 21.0
...
vllm:request_queue_time_seconds_bucket{engine="0",le="0.05",model_name="{MODEL_NAME}"} 21.0
vllm:request_queue_time_seconds_bucket{engine="0",le="0.1",model_name="{MODEL_NAME}"} 21.0
vllm:request_queue_time_seconds_bucket{engine="0",le="0.3",model_name="{MODEL_NAME}"} 21.0
vllm:request_queue_time_seconds_bucket{engine="0",le="0.5",model_name="{MODEL_NAME}"} 21.0
...
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>