### PR TITLE
[Frontend] Skip `stop` in reasoning content

### DIFF
--- a/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
+++ b/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from ...utils import RemoteOpenAIServer
 
 # a reasoning and tool calling model
-MODEL_NAME = "/home/jovyan/qwen3-8b"
+MODEL_NAME = "Qwen/QwQ-32B"
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
+++ b/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from ...utils import RemoteOpenAIServer
 
 # a reasoning and tool calling model
-MODEL_NAME = "Qwen/QwQ-32B"
+MODEL_NAME = "/home/jovyan/qwen3-8b"
 
 
 @pytest.fixture(scope="module")
@@ -140,7 +140,9 @@ async def test_chat_full_of_tool_and_reasoning(client: openai.AsyncOpenAI):
     assert tool_calls.choices[0].message.tool_calls[0].function.name == FUNC_NAME
     assert tool_calls.choices[0].message.tool_calls[0].function.arguments == FUNC_ARGS
 
+@pytest.mark.asyncio
 async def test_stop_str_with_reasoning(client: openai.AsyncOpenAI):
+    # check that the response is correctly stopped at "9.8"
     response = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=[{
@@ -153,3 +155,16 @@ async def test_stop_str_with_reasoning(client: openai.AsyncOpenAI):
 
     assert response.choices[0].message.reasoning_content.find("9.8") != -1
     assert response.choices[0].message.content.find("9.8") == -1
+
+    # check no stop string
+    response = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[{
+            "role": "user",
+            "content": "9.11 and 9.8, which is greater?"
+        }],
+        temperature=1.0,
+    )
+    assert response.choices[0].message.reasoning_content.find("9.8") != -1
+    # check that the response is not stopped at "9.8"
+    assert response.choices[0].message.content.find("9.8") != -1

--- a/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
+++ b/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
@@ -139,3 +139,13 @@ async def test_chat_full_of_tool_and_reasoning(client: openai.AsyncOpenAI):
     assert len(tool_calls.choices[0].message.reasoning_content) > 0
     assert tool_calls.choices[0].message.tool_calls[0].function.name == FUNC_NAME
     assert tool_calls.choices[0].message.tool_calls[0].function.arguments == FUNC_ARGS
+
+async def test_stop_str_with_reasoning(client: openai.AsyncOpenAI):
+    response = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "9.11 and 9.8, which is greater?"}],
+        stop="9.8",
+    )
+
+    assert response.choices[0].message.reasoning_content.find("9.8") != -1
+    assert response.choices[0].message.content.find("9.8") == -1

--- a/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
+++ b/tests/entrypoints/openai/test_chat_with_tool_reasoning.py
@@ -143,7 +143,11 @@ async def test_chat_full_of_tool_and_reasoning(client: openai.AsyncOpenAI):
 async def test_stop_str_with_reasoning(client: openai.AsyncOpenAI):
     response = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[{"role": "user", "content": "9.11 and 9.8, which is greater?"}],
+        messages=[{
+            "role": "user",
+            "content": "9.11 and 9.8, which is greater?"
+        }],
+        temperature=1.0,
         stop="9.8",
     )
 

--- a/tests/v1/engine/test_fast_incdec_prefix_err.py
+++ b/tests/v1/engine/test_fast_incdec_prefix_err.py
@@ -3,6 +3,7 @@
 
 from transformers import AutoTokenizer
 
+from vllm.config import VllmConfig
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.detokenizer import IncrementalDetokenizer
@@ -21,7 +22,7 @@ def test_fast_inc_detok_invalid_utf8_err_case():
     https://gist.github.com/fpaupier/0ed1375bd7633c5be6c894b1c7ac1be3.
     """
     tokenizer = AutoTokenizer.from_pretrained("google/gemma-3-1b-it")
-
+    vllm_config = VllmConfig()
     # Create a test request
     prompt_token_ids = [107, 4606, 236787, 107]
     params = SamplingParams(skip_special_tokens=True)
@@ -38,7 +39,8 @@ def test_fast_inc_detok_invalid_utf8_err_case():
         data_parallel_rank=None,
     )
 
-    detokenizer = IncrementalDetokenizer.from_new_request(tokenizer, request)
+    detokenizer = IncrementalDetokenizer.from_new_request(
+        vllm_config, tokenizer, request)
 
     assert detokenizer.__class__.__name__ == "FastIncrementalDetokenizer", (
         "Should use FastIncrementalDetokenizer by default"

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -15,6 +15,7 @@ from tests.v1.engine.utils import (
     MockEngineCore,
 )
 from vllm import PoolingParams
+from vllm.config import VllmConfig, StructuredOutputsConfig
 from vllm.config import DecodingConfig, VllmConfig
 from vllm.logprobs import PromptLogprobs, SampleLogprobs
 from vllm.outputs import CompletionOutput, RequestOutput
@@ -46,7 +47,8 @@ def _ref_convert_id_to_token(
     [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
 def test_incremental_detokenization(request_output_kind: RequestOutputKind,
                                     dummy_test_vectors):
-    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    vllm_config = VllmConfig(
+        structured_outputs_config=StructuredOutputsConfig())
     output_processor = OutputProcessor(vllm_config=vllm_config,
                                        tokenizer=dummy_test_vectors.tokenizer,
                                        log_stats=False)
@@ -421,7 +423,8 @@ def test_logprobs_processor(request_output_kind: RequestOutputKind,
                             num_sample_logprobs: Optional[int],
                             num_prompt_logprobs: Optional[int],
                             dummy_test_vectors):
-    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    vllm_config = VllmConfig(
+        structured_outputs_config=StructuredOutputsConfig())
     output_processor = OutputProcessor(vllm_config=vllm_config,
                                        tokenizer=dummy_test_vectors.tokenizer,
                                        log_stats=False)
@@ -595,7 +598,8 @@ def test_stop_token(
         dummy_test_vectors.tokenizer.eos_token_id if is_eos_test else None
     )  # '<|end_of_text|>'
     stop_token_ids = [128009] if not is_eos_test else None  # '<|eot_id|>'
-    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    vllm_config = VllmConfig(
+        structured_outputs_config=StructuredOutputsConfig())
     output_processor = OutputProcessor(vllm_config=vllm_config,
                                        tokenizer=dummy_test_vectors.tokenizer,
                                        log_stats=False)
@@ -706,7 +710,8 @@ def test_stop_token(
                          [None, NUM_SAMPLE_LOGPROBS_UNDER_TEST])
 def test_stop_string(include_stop_str_in_output: bool,
                      num_sample_logprobs: Optional[int], dummy_test_vectors):
-    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    vllm_config = VllmConfig(
+        structured_outputs_config=StructuredOutputsConfig())
     output_processor = OutputProcessor(vllm_config=vllm_config,
                                        tokenizer=dummy_test_vectors.tokenizer,
                                        log_stats=False)
@@ -837,7 +842,8 @@ def test_stop_string(include_stop_str_in_output: bool,
 
 
 def test_iteration_stats(dummy_test_vectors):
-    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    vllm_config = VllmConfig(
+        structured_outputs_config=StructuredOutputsConfig())
     output_processor = OutputProcessor(vllm_config=vllm_config,
                                        tokenizer=dummy_test_vectors.tokenizer,
                                        log_stats=True)

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -15,6 +15,7 @@ from tests.v1.engine.utils import (
     MockEngineCore,
 )
 from vllm import PoolingParams
+from vllm.config import DecodingConfig, VllmConfig
 from vllm.logprobs import PromptLogprobs, SampleLogprobs
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
@@ -41,13 +42,16 @@ def _ref_convert_id_to_token(
 
 
 @pytest.mark.parametrize(
-    "request_output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY]
-)
-def test_incremental_detokenization(
-    request_output_kind: RequestOutputKind, dummy_test_vectors
-):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
-    engine_core = MockEngineCore(tokens_list=dummy_test_vectors.generation_tokens)
+    "request_output_kind",
+    [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
+def test_incremental_detokenization(request_output_kind: RequestOutputKind,
+                                    dummy_test_vectors):
+    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    output_processor = OutputProcessor(vllm_config=vllm_config,
+                                       tokenizer=dummy_test_vectors.tokenizer,
+                                       log_stats=False)
+    engine_core = MockEngineCore(
+        tokens_list=dummy_test_vectors.generation_tokens)
 
     # Make N requests.
     requests = [
@@ -407,17 +411,20 @@ def _validate_logprobs(
 
 
 @pytest.mark.parametrize(
-    "request_output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY]
-)
-@pytest.mark.parametrize("num_sample_logprobs", [None, NUM_SAMPLE_LOGPROBS_UNDER_TEST])
-@pytest.mark.parametrize("num_prompt_logprobs", [None, NUM_PROMPT_LOGPROBS_UNDER_TEST])
-def test_logprobs_processor(
-    request_output_kind: RequestOutputKind,
-    num_sample_logprobs: Optional[int],
-    num_prompt_logprobs: Optional[int],
-    dummy_test_vectors,
-):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    "request_output_kind",
+    [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
+@pytest.mark.parametrize("num_sample_logprobs",
+                         [None, NUM_SAMPLE_LOGPROBS_UNDER_TEST])
+@pytest.mark.parametrize("num_prompt_logprobs",
+                         [None, NUM_PROMPT_LOGPROBS_UNDER_TEST])
+def test_logprobs_processor(request_output_kind: RequestOutputKind,
+                            num_sample_logprobs: Optional[int],
+                            num_prompt_logprobs: Optional[int],
+                            dummy_test_vectors):
+    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    output_processor = OutputProcessor(vllm_config=vllm_config,
+                                       tokenizer=dummy_test_vectors.tokenizer,
+                                       log_stats=False)
     engine_core = MockEngineCore(
         tokens_list=dummy_test_vectors.generation_tokens,
         generated_logprobs_raw=None
@@ -588,8 +595,10 @@ def test_stop_token(
         dummy_test_vectors.tokenizer.eos_token_id if is_eos_test else None
     )  # '<|end_of_text|>'
     stop_token_ids = [128009] if not is_eos_test else None  # '<|eot_id|>'
-
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    output_processor = OutputProcessor(vllm_config=vllm_config,
+                                       tokenizer=dummy_test_vectors.tokenizer,
+                                       log_stats=False)
     # Dummy engine core outputs, with control tokens suffixed to test stops
     suffix_token = [eos_token_id] if is_eos_test else stop_token_ids
     assert suffix_token is not None and isinstance(suffix_token[0], int)
@@ -693,13 +702,14 @@ def test_stop_token(
 
 
 @pytest.mark.parametrize("include_stop_str_in_output", [True, False])
-@pytest.mark.parametrize("num_sample_logprobs", [None, NUM_SAMPLE_LOGPROBS_UNDER_TEST])
-def test_stop_string(
-    include_stop_str_in_output: bool,
-    num_sample_logprobs: Optional[int],
-    dummy_test_vectors,
-):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+@pytest.mark.parametrize("num_sample_logprobs",
+                         [None, NUM_SAMPLE_LOGPROBS_UNDER_TEST])
+def test_stop_string(include_stop_str_in_output: bool,
+                     num_sample_logprobs: Optional[int], dummy_test_vectors):
+    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    output_processor = OutputProcessor(vllm_config=vllm_config,
+                                       tokenizer=dummy_test_vectors.tokenizer,
+                                       log_stats=False)
     engine_core = MockEngineCore(
         tokens_list=dummy_test_vectors.generation_tokens,
         generated_logprobs_raw=dummy_test_vectors.generation_logprobs
@@ -827,7 +837,10 @@ def test_stop_string(
 
 
 def test_iteration_stats(dummy_test_vectors):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=True)
+    vllm_config = VllmConfig(decoding_config=DecodingConfig())
+    output_processor = OutputProcessor(vllm_config=vllm_config,
+                                       tokenizer=dummy_test_vectors.tokenizer,
+                                       log_stats=True)
     engine_core = MockEngineCore(dummy_test_vectors.generation_tokens)
     engine_core_timestamp = time.monotonic()
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -116,9 +116,9 @@ class AsyncLLM(EngineClient):
         )
 
         # OutputProcessor (converts EngineCoreOutputs --> RequestOutput).
-        self.output_processor = OutputProcessor(
-            self.tokenizer, log_stats=self.log_stats
-        )
+        self.output_processor = OutputProcessor(self.vllm_config,
+                                                self.tokenizer,
+                                                log_stats=self.log_stats)
         if self.observability_config.otlp_traces_endpoint is not None:
             tracer = init_tracer(
                 "vllm.llm_engine", self.observability_config.otlp_traces_endpoint

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -95,9 +95,9 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         # Generation data
         self.output_text = ""
         self.reasoning_parser: Optional[ReasoningParser] = None
-        if vllm_config.decoding_config.reasoning_backend:
+        if vllm_config.structured_outputs_config.reasoning_parser:
             reasoning_parser = ReasoningParserManager.get_reasoning_parser(
-                vllm_config.decoding_config.reasoning_backend)
+                vllm_config.structured_outputs_config.reasoning_parser)
             self.reasoning_parser = reasoning_parser(tokenizer)
 
     def update(self, new_token_ids: list[int], stop_terminated: bool) -> Optional[str]:

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -359,7 +359,7 @@ class StopChecker:
             # Reasoning not ended => do not check stop strings.
             if not self.reasoning_ended:
                 self.reasoning_ended = rp.is_reasoning_end(token_ids)
-            if self.reasoning_parser and not self.reasoning_ended:
+            if not self.reasoning_ended:
                 return None
 
         for stop_str in stop:

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -10,7 +10,6 @@ from tokenizers.decoders import DecodeStream
 from transformers import PreTrainedTokenizerFast
 
 from vllm.config import VllmConfig
-from vllm.engine.output_processor.stop_checker import StopChecker
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.transformers_utils.detokenizer_utils import (

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -58,7 +58,7 @@ class IncrementalDetokenizer:
 
         if tokenizer is None:
             # No tokenizer => skipping detokenization.
-            return IncrementalDetokenizer(vllm_config=vllm_config)
+            return IncrementalDetokenizer()
 
         if USE_FAST_DETOKENIZER and isinstance(tokenizer, PreTrainedTokenizerFast):
             # Fast tokenizer => use tokenizers library DecodeStream.

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -137,8 +137,8 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
 
         # 2) Evaluate stop strings.
         stop_string = None
-        if self.reasoning_parser and not self.reasoning_parser.is_reasoning_end(
-                input_ids=self.token_ids):
+        if self.stop and self.reasoning_parser and \
+            not self.reasoning_parser.is_reasoning_end(input_ids=self.token_ids):
             return stop_string
         if self.stop and len(self.output_token_ids) > self.min_tokens:
             stop = check_stop_strings(

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -359,8 +359,8 @@ class StopChecker:
             # Reasoning not ended => do not check stop strings.
             if not self.reasoning_ended:
                 self.reasoning_ended = rp.is_reasoning_end(token_ids)
-                if not self.reasoning_ended:
-                    return None
+            if self.reasoning_parser and not self.reasoning_ended:
+                return None
 
         for stop_str in stop:
             stop_string_len = len(stop_str)

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -138,10 +138,9 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         # 2) Evaluate stop strings.
         stop_string = None
         if self.stop and len(self.output_token_ids) > self.min_tokens:
-            if (rp := self.reasoning_parser) and not rp.is_reasoning_end(
-                    self.token_ids):
-                return None
             stop = check_stop_strings(
+                token_ids=self.token_ids,
+                reasoning_parser=self.reasoning_parser,
                 output_text=self.output_text,
                 new_char_count=len(self.output_text) - stop_check_offset,
                 stop=self.stop,
@@ -334,10 +333,12 @@ class SlowIncrementalDetokenizer(BaseIncrementalDetokenizer):
 
 
 def check_stop_strings(
+    token_ids: list[int],
     output_text: str,
     new_char_count: int,
     stop: list[str],
     include_in_output: bool,
+    reasoning_parser: Optional[ReasoningParser] = None,
 ) -> Optional[tuple[str, int]]:
     """Check if any stop strings are matched and truncate sequence
     output text accordingly.
@@ -348,6 +349,8 @@ def check_stop_strings(
     length to which output_text should be truncated, or -1 for no
     truncation.
     """
+    if (rp := reasoning_parser) and not rp.is_reasoning_end(token_ids):
+        return None
     if not new_char_count or not stop:
         return None
 

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -138,7 +138,7 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         # 2) Evaluate stop strings.
         stop_string = None
         if self.stop and self.reasoning_parser and \
-            not self.reasoning_parser.is_reasoning_end(input_ids=self.token_ids):
+            not self.reasoning_parser.is_reasoning_end(self.token_ids):
             return stop_string
         if self.stop and len(self.output_token_ids) > self.min_tokens:
             stop = check_stop_strings(

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -108,9 +108,9 @@ class LLMEngine:
         )
 
         # OutputProcessor (convert EngineCoreOutputs --> RequestOutput).
-        self.output_processor = OutputProcessor(
-            self.tokenizer, log_stats=self.log_stats
-        )
+        self.output_processor = OutputProcessor(vllm_config=self.vllm_config,
+                                                tokenizer=self.tokenizer,
+                                                log_stats=self.log_stats)
         if self.observability_config.otlp_traces_endpoint is not None:
             tracer = init_tracer(
                 "vllm.llm_engine", self.observability_config.otlp_traces_endpoint


### PR DESCRIPTION

## Purpose
When the `stop=""` parameter is set, it causes the reasoning phase to stop when encountering a `stop` token, which interrupts the process and prevents the user from seeing any `content`.
## Test Plan
``` python
from openai import OpenAI

# Modify OpenAI's API key and API base to use vLLM's API server.
openai_api_key = "EMPTY"
openai_api_base = "http://localhost:8000/v1"

client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)

models = client.models.list()
model = models.data[0].id

# Round 1
messages = [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
response = client.chat.completions.create(
    model=model,
    messages=messages,
    stop="9.8",
)

reasoning_content = response.choices[0].message.reasoning_content
content = response.choices[0].message.content

print("reasoning_content for Round 1:", reasoning_content)
print("-" * 80)
print("content for Round 1:", content)

```
## Test Result
```
reasoning_content for Round 1: 
Okay, so I need to figure out whether 9.11 is greater than 9.8 or not. Let me start by recalling how to compare decimal numbers. I think the general rule is to look at the digits from left to right and compare them one by one. 

First, both numbers are in the ones place. Let me write them down to visualize better:

9.11 and 9.8
...
...
...
So, in conclusion, 9.8 is greater than 9.11.

--------------------------------------------------------------------------------
content for Round 1: 

To determine which number is greater between **9.11** and **

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

