### PR TITLE
add(v1): RequestStatesStats to RequestOutput

### DIFF
--- a/tests/entrypoints/llm/test_generate.py
+++ b/tests/entrypoints/llm/test_generate.py
@@ -86,3 +86,16 @@ def test_max_model_len():
         # It can be less if generation finishes due to other reasons (e.g., EOS)
         # before reaching the absolute model length limit.
         assert num_total_tokens <= max_model_len
+
+
+def test_log_stats():
+    llm = LLM(
+        model=MODEL_NAME,
+        disable_log_stats=False,
+        gpu_memory_utilization=0.10,
+        enforce_eager=True,  # reduce test time
+    )
+    outputs = llm.generate(PROMPTS, sampling_params=None)
+
+    # disable_log_stats is False, every output should have metrics
+    assert all(output.metrics is not None for output in outputs)

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -14,6 +14,7 @@ from vllm.logprobs import PromptLogprobs, SampleLogprobs
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalPlaceholderDict
 from vllm.sequence import RequestMetrics
+from vllm.v1.metrics.stats import RequestStateStats
 
 logger = init_logger(__name__)
 
@@ -108,7 +109,7 @@ class RequestOutput:
         prompt_logprobs: Optional[PromptLogprobs],
         outputs: list[CompletionOutput],
         finished: bool,
-        metrics: Optional[RequestMetrics] = None,
+        metrics: Optional[Union[RequestMetrics, RequestStateStats]] = None,
         lora_request: Optional[LoRARequest] = None,
         encoder_prompt: Optional[str] = None,
         encoder_prompt_token_ids: Optional[list[int]] = None,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -257,6 +257,7 @@ class RequestState:
             finished=finished,
             kv_transfer_params=kv_transfer_params,
             num_cached_tokens=self.num_cached_tokens,
+            metrics=self.stats
         )
 
     def _new_completion_output(

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -248,17 +248,15 @@ class RequestState:
         if prompt_token_ids is None and self.prompt_embeds is not None:
             prompt_token_ids = [0] * len(self.prompt_embeds)
 
-        return RequestOutput(
-            request_id=request_id,
-            prompt=self.prompt,
-            prompt_token_ids=prompt_token_ids,
-            prompt_logprobs=prompt_logprobs,
-            outputs=cast(list[CompletionOutput], outputs),
-            finished=finished,
-            kv_transfer_params=kv_transfer_params,
-            num_cached_tokens=self.num_cached_tokens,
-            metrics=self.stats
-        )
+        return RequestOutput(request_id=request_id,
+                             prompt=self.prompt,
+                             prompt_token_ids=prompt_token_ids,
+                             prompt_logprobs=prompt_logprobs,
+                             outputs=cast(list[CompletionOutput], outputs),
+                             finished=finished,
+                             kv_transfer_params=kv_transfer_params,
+                             num_cached_tokens=self.num_cached_tokens,
+                             metrics=self.stats)
 
     def _new_completion_output(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Extends [#12644](https://github.com/vllm-project/vllm/pull/12644) by adding `RequestStateStats` to `RequestOutput`, and fixes [#15394](https://github.com/vllm-project/vllm/issues/15394).

There is already an existing PR [#16739](https://github.com/vllm-project/vllm/pull/16739) addressing the same issue, but it does not check whether `log_stats` is set to `True`, which leads to errors when it is `False`. However, the idea of changing `arrival_time` to use `time.monotonic` for consistency with other stats is worth considering.

## Test Plan
Run code below
```
import os
os.environ["VLLM_USE_V1"] = "1"

from vllm import LLM, SamplingParams

llm = LLM(
    model="meta-llama/Llama-3.2-1B",
    disable_log_stats=False,
)

print(llm.generate(
    ["Hello, my name is",], 
    SamplingParams(temperature=0.0)
))
```

## Test Result

Code above prints
```
[RequestOutput(request_id=0, prompt='Hello, my name is', prompt_token_ids=[128000, 9906, 11, 856, 836, 374], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' Kelsey and I am a 2018 graduate of the University of Wisconsin-M', token_ids=[735, 93567, 323, 358, 1097, 264, 220, 679, 23, 19560, 315, 279, 3907, 315, 21073, 5364], cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=RequestStateStats(num_generation_tokens=16, arrival_time=1758006699.5359383, queued_ts=8349051.40606402, scheduled_ts=8349051.406091422, first_token_ts=8349051.414080893, last_token_ts=8349051.486865659, first_token_latency=0.012720346450805664), lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

