### PR TITLE
[Bug] Fix gpt-oss missing tool content

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -241,6 +241,11 @@ def parse_chat_input(chat_msg) -> list[Message]:
     tool_calls = chat_msg.get("tool_calls")
     if role == "assistant" and tool_calls:
         msgs: list[Message] = []
+        content = chat_msg.get("content") or ""
+        analysis_msg = Message.from_role_and_content(Role.ASSISTANT, content)
+        analysis_msg = analysis_msg.with_channel("analysis")
+        msgs.append(analysis_msg)
+
         for call in tool_calls:
             func = call.get("function", {})
             name = func.get("name", "")
@@ -265,9 +270,13 @@ def parse_chat_input(chat_msg) -> list[Message]:
                 if isinstance(item, dict) and item.get("type") == "text"
             )
 
-        msg = Message.from_author_and_content(
-            Author.new(Role.TOOL, f"functions.{name}"), content
-        ).with_channel("commentary")
+        msg = (
+            Message.from_author_and_content(
+                Author.new(Role.TOOL, f"functions.{name}"), content
+            )
+            .with_channel("commentary")
+            .with_recipient("assistant")
+        )
         return [msg]
 
     # Default: user/assistant/system messages with content


### PR DESCRIPTION
## Purpose
This PR requires the following PRs to be merged first: https://github.com/vllm-project/vllm/pull/24768 and the harmony lib PR (https://github.com/openai/harmony/pull/76).

The changes include adding 'with_recipient' and the Assistant's 'analysis' content.
Without adding this content, there was an issue where the gpt-oss model had a higher probability of outputting abnormal tokens when calling tools.

## Test Plan
[gpt-oss_test.py](https://github.com/user-attachments/files/22359291/gpt-oss_test.py)
[messages.txt](https://github.com/user-attachments/files/22359292/messages.txt)

Run python3 gpt-oss_test.py about 10 times.

## Test Result 
(before)
<img width="1239" height="225" alt="image" src="https://github.com/user-attachments/assets/3e1f91d6-7275-43cf-804f-040d490c79fa" />

(after applying the harmony lib changes)
<img width="2135" height="123" alt="image" src="https://github.com/user-attachments/assets/b3b88b2c-1283-42d2-8a54-e544a7ef4540" />

