### PR TITLE
[Core][MultiModalHasher] Hash images without converting image mode

### DIFF
--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -37,6 +37,8 @@ class MultiModalHasher:
             data = {"mode": obj.mode, "data": np.asarray(obj)}
             if obj.palette is not None:
                 data["palette"] = obj.palette.palette
+                if obj.palette.rawmode is not None:
+                    data["palette_rawmode"] = obj.palette.rawmode
             return cls.iter_item_to_bytes("image", data)
         if isinstance(obj, torch.Tensor):
             tensor_obj: torch.Tensor = obj.cpu()

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -12,7 +12,6 @@ from blake3 import blake3
 from PIL import Image
 
 from vllm.logger import init_logger
-from vllm.multimodal.image import convert_image_mode
 
 logger = init_logger(__name__)
 
@@ -35,8 +34,10 @@ class MultiModalHasher:
                     exif[Image.ExifTags.Base.ImageID], uuid.UUID):
                 # If the image has exif ImageID tag, use that
                 return (exif[Image.ExifTags.Base.ImageID].bytes, )
-            return cls.iter_item_to_bytes(
-                "image", np.asarray(convert_image_mode(obj, "RGBA")))
+            data = {"mode": obj.mode, "data": np.asarray(obj)}
+            if obj.palette is not None:
+                data["palette"] = obj.palette.palette
+            return cls.iter_item_to_bytes("image", data)
         if isinstance(obj, torch.Tensor):
             tensor_obj: torch.Tensor = obj.cpu()
             tensor_dtype = tensor_obj.dtype


### PR DESCRIPTION
## Purpose

This PR hashes mode, palette and data of images separately which prevents the need for converting all images to RGBA. See https://github.com/vllm-project/vllm/pull/24925#discussion_r2350397896

## Test Plan

Correctness should be covered by the existing hasher tests on CI.

The performance can be measured using:

```python
import numpy as np
from PIL import Image
from vllm.multimodal.hasher import MultiModalHasher

np.random.seed(42)
data = np.random.randint(0, 255, size=(3840, 2160, 3), dtype=np.uint8)
data = Image.fromarray(data)

%timeit MultiModalHasher.hash_kwargs(data=data)
```

## Test Result

For a 4k PIL image this speeds up hashing by ~35%. This is not massive, but might add up in cases with lots of multimodal input.

```shell
# main
25.1 ms ± 124 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# This PR
16.3 ms ± 74.6 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
