### PR TITLE
[Docs] vllm/benchmarks/datasets.py fix docstring param format.

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -104,9 +104,9 @@ class BenchmarkDataset(ABC):
 
         Args:
             dataset_path (Optional[str]): Path to the dataset. If None, it
-            indicates that a default or random dataset might be used.
+                indicates that a default or random dataset might be used.
             random_seed (int): Seed value for reproducible shuffling or
-            sampling. Defaults to DEFAULT_SEED.
+                sampling. Defaults to DEFAULT_SEED.
         """
         self.dataset_path = dataset_path
         # Set the random seed, ensuring that a None value is replaced with the
@@ -200,8 +200,7 @@ class BenchmarkDataset(ABC):
             tokenizer (PreTrainedTokenizerBase): The tokenizer to be used
                 for processing the dataset's text.
             num_requests (int): The number of sample requests to generate.
-            request_id_prefix (str) The prefix of request_id.
-
+            request_id_prefix (str): The prefix of request_id.
 
         Returns:
             list[SampleRequest]: A list of sample requests generated from the
@@ -224,7 +223,8 @@ class BenchmarkDataset(ABC):
             requests (List[SampleRequest]): The current list of sampled
                 requests.
             num_requests (int): The target number of requests.
-            request_id_prefix (str) The prefix of the request ids.
+            request_id_prefix (str): The prefix applied to generated request
+                identifiers.
 
         """
         if no_oversample:


### PR DESCRIPTION
## Purpose

Ensure BenchmarkDataset docstrings follow the name (type): description format so griffe stops emitting parsing warnings.

```
WARNING -  griffe: vllm/benchmarks/datasets.py:107: Failed to get 'name: description' pair from 'sampling. Defaults to DEFAULT_SEED.'
--
  | WARNING -  griffe: vllm/benchmarks/datasets.py:237: Failed to get 'name: description' pair from 'request_id_prefix (str) The prefix of the request ids.'
  | WARNING -  griffe: vllm/benchmarks/datasets.py:213: Failed to get 'name: description' pair from 'request_id_prefix (str) The prefix of request_id.'
```


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

