### PR TITLE
[Core][Prefix Hash] Fix prefix hash metrics sliding window maintainance

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -138,8 +138,12 @@ class PrefixCachingMetrics:
         self.aggregated_query_total += stats.queries
         self.aggregated_query_hit += stats.hits
 
-        # Remove the oldest stats if the number of requests exceeds.
-        if self.aggregated_requests > self.max_recent_requests:
+        # Remove the oldest stats until number of requests does not exceed
+        # the limit.
+        # NOTE: We preserve the latest added stats regardless.
+        while len(
+                self.query_queue
+        ) > 1 and self.aggregated_requests > self.max_recent_requests:
             old_requests, old_queries, old_hits = self.query_queue.popleft()
             self.aggregated_requests -= old_requests
             self.aggregated_query_total -= old_queries

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -127,6 +127,11 @@ class PrefixCachingMetrics:
         if stats.reset:
             self.reset()
 
+        # DO NOT appending empty stats to avoid helpful info get kicked out
+        # due to sliding window.
+        if stats.requests == 0:
+            return
+
         # Update the metrics.
         self.query_queue.append((stats.requests, stats.queries, stats.hits))
         self.aggregated_requests += stats.requests


### PR DESCRIPTION
## Purpose
1) We should not only pop 1 stat from the left, but pop multiple stats until the requests limit is within range
2) Avoid enqueuing empty stats to simply the maintenance. When hosts are running hot, all requests might be in the waiting queue without scheduling, in that case, empty prefix hash stats might be trying to append which could mess up the hit rate (e.g. helpful info got kicked out from the sliding window).

## Test Plan
Unit test

## Test Result
N/A

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

