### PR TITLE
Change log level from info to debug for IOProcessor

### DIFF
--- a/vllm/plugins/io_processors/__init__.py
+++ b/vllm/plugins/io_processors/__init__.py
@@ -33,7 +33,7 @@ def get_io_processor(
         model_plugin = config_plugin
 
     if model_plugin is None:
-        logger.info("No IOProcessor plugins requested by the model")
+        logger.debug("No IOProcessor plugins requested by the model")
         return None
 
     logger.debug("IOProcessor plugin to be loaded %s", model_plugin)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Remove this no-op log that print every time on startup now
```
(EngineCore_DP0 pid=1814976) INFO 09-16 22:06:03 [core.py:214] init engine (profile, create kv cache, warmup model) took 42.20 seconds
INFO 09-16 22:06:04 [llm.py:295] Supported_tasks: ['generate']
INFO 09-16 22:06:04 [__init__.py:36] No IOProcessor plugins requested by the model
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

