### PR TITLE
[BugFix] Fix the missing value for argument 'no_lora_flag_cpu' error when running benchmark_lora.py

### DIFF
--- a/benchmarks/kernels/benchmark_lora.py
+++ b/benchmarks/kernels/benchmark_lora.py
@@ -500,6 +500,11 @@ class BenchmarkTensors:
         assert len(o_shape) == 3
         assert o_shape == (num_slices, num_tokens, lora_rank)
 
+        no_lora = torch.all(self.lora_kernel_meta.token_lora_mapping == -1)
+        no_lora_flag_cpu = torch.tensor([no_lora],
+                                        dtype=torch.bool,
+                                        device='cpu')
+
         return {
             "inputs": self.input,
             "lora_a_weights": self.lora_weights_lst,
@@ -511,6 +516,7 @@ class BenchmarkTensors:
             "num_tokens_per_lora": self.lora_kernel_meta.num_tokens_per_lora,
             "lora_token_start_loc": self.lora_kernel_meta.lora_token_start_loc,
             "lora_ids": self.lora_kernel_meta.active_lora_ids,
+            "no_lora_flag_cpu": no_lora_flag_cpu,
             "scaling": 1.0,
         }
 
@@ -539,6 +545,11 @@ class BenchmarkTensors:
         assert len(o_shape) == 2
         assert o_shape == (num_tokens, hidden_size * num_slices)
 
+        no_lora = torch.all(self.lora_kernel_meta.token_lora_mapping == -1)
+        no_lora_flag_cpu = torch.tensor([no_lora],
+                                        dtype=torch.bool,
+                                        device='cpu')
+
         return {
             "inputs": self.input,
             "lora_b_weights": self.lora_weights_lst,
@@ -552,6 +563,7 @@ class BenchmarkTensors:
             "lora_ids": self.lora_kernel_meta.active_lora_ids,
             "offset_start": 0,
             "add_inputs": add_inputs,
+            "no_lora_flag_cpu": no_lora_flag_cpu,
         }
 
     def bench_fn_kwargs(


### PR DESCRIPTION
## Purpose
FIx the bug #25013 by adding the argument `no_lora_flag_cpu` when preparing the input arguments in `as_lora_shrink_kwargs` and `as_lora_expand_kwargs`.

## Test Plan
```python
python3 benchmarks/kernels/benchmark_lora.py model_bench --models meta-llama/Llama-3-8b  --arg-pool-size 32 --batch-sizes 32 --dtype torch.float16  --lora-ranks 16 --num-loras 1 4 --op-types lora_shrink lora_expand --seq-lengths 16 --sort-by-lora-id 1 --cuda-graph-nops 32 
```

## Test Result
**Output after the bug fix**
```
Namespace(cmd='model_bench', models=['meta-llama/Llama-3-8b'], tp_sizes=[1], lora_ranks=[16], dtype=torch.float16, arg_pool_size=32, cuda_graph_nops=32, num_loras=[1, 4], num_active_loras=None, sort_by_lora_id=[True], op_types=[<OpType.LORA_SHRINK: 1>, <OpType.LORA_EXPAND: 2>], seq_lengths=[16], batch_sizes=[32], expand_fn_add_inputs=[True, False], output_directory=None, test_correctness=False, func=<function run_model_bench at 0x734bc084df80>)
Model bench :
 Hidden Sizes {6144, 4096, 28672} LoRA Ranks [16]
Benchmarking 32 invocations inside a CUDA Graph
[-------------------------------------------------------------------------------------------------------------------------------- lora-torch.float16 | cugraph 32 ops ---------------------------------------------------------------------------------------------------------------------------------]
                                                                                                                 |  single-lora roofline using torch.mm (f16xf16=>f16)  |  LORA_SHRINK() (f16xf16=>f32)  |  LORA_EXPAND(add_inputs=True) (f32xf16=>f16)  |  LORA_EXPAND(add_inputs=False) (f32xf16=>f16)
1 threads: ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      {"bs": 32, "sl": 16, "m": 512, "k": 6144, "n": 16, "num_loras": 1, "sort_by_lora": true, "num_slices": 1}  |                        228.4                         |             602.9              |                                               |                                              
      {"bs": 32, "sl": 16, "m": 512, "k": 6144, "n": 16, "num_loras": 1, "sort_by_lora": true, "num_slices": 2}  |                        233.8                         |             862.0              |                                               |                                              
      {"bs": 32, "sl": 16, "m": 512, "k": 6144, "n": 16, "num_loras": 1, "sort_by_lora": true, "num_slices": 3}  |                        278.2                         |             844.9              |                                               |                                              
      {"bs": 32, "sl": 16, "m": 512, "k": 16, "n": 6144, "num_loras": 1, "sort_by_lora": true, "num_slices": 1}  |                        168.7                         |                                |                      275.8                    |                     183.5                    
      {"bs": 32, "sl": 16, "m": 512, "k": 16, "n": 6144, "num_loras": 1, "sort_by_lora": true, "num_slices": 2}  |                        242.0                         |                                |                      753.5                    |                     496.3                    
      {"bs": 32, "sl": 16, "m": 512, "k": 16, "n": 6144, "num_loras": 1, "sort_by_lora": true, "num_slices": 3}  |                        410.7                         |                                |                     1108.8                    |                     723.2                    

Times are in microseconds (us).

Note on Comparison with torch.mm : The torch.mm numbers are benchmark numbers of a simple matmul emulating the single lora case. It is provided as a roofline for comparing our LoRA Kernel implementations. It is expected that the LoRA kernels will be slower than torch.mm in cases where num_loras is big. But for small num_loras the goal should be to match the torch.mm numbers.

...
```

**Output before the bug fix**
```
Benchmarking 32 invocations inside a CUDA Graph
Traceback (most recent call last):
  File "/home/ec2-user/vllm/benchmarks/kernels/benchmark_lora.py", line 1065, in <module>
    args.func(args)
  File "/home/ec2-user/vllm/benchmarks/kernels/benchmark_lora.py", line 918, in run_model_bench
    run(args, bench_contexts)
  File "/home/ec2-user/vllm/benchmarks/kernels/benchmark_lora.py", line 793, in run
    bench_optype(
  File "/home/ec2-user/vllm/benchmarks/kernels/benchmark_lora.py", line 642, in bench_optype
    op_type.bench_fn()(**kwargs)
  File "/home/ec2-user/.local/lib/python3.9/site-packages/torch/_ops.py", line 1243, in __call__
    return self._op(*args, **kwargs)
RuntimeError: vllm::lora_shrink() is missing value for argument 'no_lora_flag_cpu'. Declaration: vllm::lora_shrink(Tensor inputs, Tensor[] lora_a_weights, Tensor(a2!) output_tensor, Tensor token_lora_mapping, Tensor token_indices_sorted_by_lora_ids, Tensor num_tokens_per_lora, Tensor lora_token_start_loc, Tensor lora_ids, Tensor no_lora_flag_cpu, float scaling) -> ()
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

