### PR TITLE
[UX] Only perform FlashInfer autotuning if needed by kernels

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -17,7 +17,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.parameter import (GroupQuantScaleParameter,
                                            ModelWeightParameter,
                                            PerTensorScaleParameter)
-from vllm.utils.flashinfer import flashinfer_scaled_fp4_mm, has_flashinfer
+from vllm.utils.flashinfer import (flashinfer_scaled_fp4_mm, has_flashinfer,
+                                   register_flashinfer_kernel_autotune)
 
 logger = init_logger(__name__)
 
@@ -30,8 +31,12 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         if envs.VLLM_USE_TRTLLM_FP4_GEMM:
             assert has_flashinfer(), "TRTLLM FP4 GEMM requires FlashInfer"
             self.backend = "flashinfer-trtllm"
+            register_flashinfer_kernel_autotune(
+                reason="CompressedTensors NVFP4 dense GEMM (TRT-LLM)")
         elif has_flashinfer():
             self.backend = "flashinfer-cutlass"
+            register_flashinfer_kernel_autotune(
+                reason="CompressedTensors NVFP4 dense GEMM (CUTLASS)")
         else:
             self.backend = "cutlass"
         self.group_size = 16

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -50,7 +50,8 @@ from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.utils import has_deep_gemm
 from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used, is_deep_gemm_supported
-from vllm.utils.flashinfer import has_flashinfer_moe
+from vllm.utils.flashinfer import (has_flashinfer_moe,
+                                   register_flashinfer_kernel_autotune)
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -536,6 +537,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             logger.info_once(
                 f"Using FlashInfer {self.flashinfer_moe_backend.value} kernels"
             )
+            register_flashinfer_kernel_autotune(reason="Fp8MoEMethod")
         # For GPUs that lack FP8 hardware support, we can leverage the Marlin
         # kernel for fast weight-only FP8 quantization
         self.use_marlin = (not current_platform.has_device_capability(89)

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -43,7 +43,8 @@ from vllm.model_executor.parameter import (ModelWeightParameter,
 from vllm.scalar_type import scalar_types
 from vllm.utils import next_power_of_2
 from vllm.utils.flashinfer import (flashinfer_scaled_fp4_mm, has_flashinfer,
-                                   has_flashinfer_moe)
+                                   has_flashinfer_moe,
+                                   register_flashinfer_kernel_autotune)
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -301,6 +302,8 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
             logger.info_once(
                 f"Using FlashInfer {self.flashinfer_moe_backend.value} kernels"
             )
+            register_flashinfer_kernel_autotune(
+                reason="ModelOpt FP8 MoE (ModelOptFp8MoEMethod)")
 
     def maybe_make_prepare_finalize(
         self,
@@ -817,8 +820,12 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         if envs.VLLM_USE_TRTLLM_FP4_GEMM:
             assert has_flashinfer(), "TRTLLM FP4 GEMM requires FlashInfer"
             self.backend = "flashinfer-trtllm"
+            register_flashinfer_kernel_autotune(
+                reason="ModelOpt NVFP4 dense GEMM (TRT-LLM)")
         elif has_flashinfer():
             self.backend = "flashinfer-cutlass"
+            register_flashinfer_kernel_autotune(
+                reason="ModelOpt NVFP4 dense GEMM (CUTLASS)")
         elif cutlass_fp4_supported():
             self.backend = "cutlass"
         elif is_fp4_marlin_supported():
@@ -1032,6 +1039,8 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             logger.info_once(
                 f"Using FlashInfer {self.flashinfer_moe_backend.value} kernels"
                 " for ModelOptNvFp4FusedMoE.")
+            register_flashinfer_kernel_autotune(
+                reason="ModelOpt NVFP4 MoE (ModelOptNvFp4FusedMoE)")
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -29,7 +29,8 @@ from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.utils import (has_triton_kernels, is_torch_equal_or_newer,
                         next_power_of_2, round_up)
-from vllm.utils.flashinfer import has_flashinfer
+from vllm.utils.flashinfer import (has_flashinfer,
+                                   register_flashinfer_kernel_autotune)
 
 logger = init_logger(__name__)
 
@@ -161,6 +162,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             "No MXFP4 MoE backend (FlashInfer/Marlin/Triton) available."
             "Please check your environment and try again.")
         self._cache_permute_indices: dict[torch.Size, torch.Tensor] = {}
+
+        # If using any FlashInfer MXFP4 backend, register for autotune warmup
+        if self.mxfp4_backend in (Mxfp4Backend.SM100_FI_MXFP4_MXFP8_TRTLLM,
+                                  Mxfp4Backend.SM100_FI_MXFP4_MXFP8_CUTLASS,
+                                  Mxfp4Backend.SM100_FI_MXFP4_BF16,
+                                  Mxfp4Backend.SM90_FI_MXFP4_BF16):
+            register_flashinfer_kernel_autotune(
+                reason=f"MXFP4 MoE ({self.mxfp4_backend.name})")
 
     def create_weights(self, layer: torch.nn.Module, num_experts: int,
                        hidden_size: int, intermediate_size_per_partition: int,

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -14,7 +14,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape)
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
-from vllm.utils.flashinfer import flashinfer_scaled_fp8_mm, has_flashinfer
+from vllm.utils.flashinfer import (flashinfer_scaled_fp8_mm, has_flashinfer,
+                                   register_flashinfer_kernel_autotune)
 
 # Input scaling factors are no longer optional in _scaled_mm starting
 # from pytorch 2.5. Allocating a dummy tensor to pass as input_scale
@@ -363,6 +364,9 @@ class Fp8LinearOp:
             if has_flashinfer() and current_platform.has_device_capability(
                     100):
                 self.preferred_backend = "flashinfer"
+                # Dense GEMM will use FlashInfer; register for autotune warmup
+                register_flashinfer_kernel_autotune(
+                    reason="FP8 dense GEMM (Fp8LinearOp)")
             else:
                 self.preferred_backend = "cutlass"
         else:

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -364,7 +364,6 @@ class Fp8LinearOp:
             if has_flashinfer() and current_platform.has_device_capability(
                     100):
                 self.preferred_backend = "flashinfer"
-                # Dense GEMM will use FlashInfer; register for autotune warmup
                 register_flashinfer_kernel_autotune(
                     reason="FP8 dense GEMM (Fp8LinearOp)")
             else:

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -35,6 +35,14 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
 _AUTOTUNE_KERNELS_WILL_BE_USED: bool = False
 
 
+@functools.cache
+def has_flashinfer() -> bool:
+    """Return ``True`` if FlashInfer is available."""
+    # Use find_spec to check if the module exists without importing it
+    # This avoids potential CUDA initialization side effects
+    return importlib.util.find_spec("flashinfer") is not None
+
+
 def register_flashinfer_kernel_autotune(reason: str) -> None:
     """Mark that FlashInfer autotune-able kernels will be used.
 
@@ -51,14 +59,6 @@ def register_flashinfer_kernel_autotune(reason: str) -> None:
 def flashinfer_autotune_needed() -> bool:
     """Return True if any FlashInfer autotune-able kernel is registered."""
     return _AUTOTUNE_KERNELS_WILL_BE_USED
-
-
-@functools.cache
-def has_flashinfer() -> bool:
-    """Return ``True`` if FlashInfer is available."""
-    # Use find_spec to check if the module exists without importing it
-    # This avoids potential CUDA initialization side effects
-    return importlib.util.find_spec("flashinfer") is not None
 
 
 def _missing(*_: Any, **__: Any) -> NoReturn:

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -30,6 +30,28 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
     "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/",  # noqa: E501
 )
 
+# Global flag to indicate whether any FlashInfer autotune-able kernels
+# (e.g. MoE or dense GEMMs) are expected to be used by the current model.
+_AUTOTUNE_KERNELS_WILL_BE_USED: bool = False
+
+
+def register_flashinfer_kernel_autotune(reason: str) -> None:
+    """Mark that FlashInfer autotune-able kernels will be used.
+
+    This allows the warmup path to only run FlashInfer autotuner when
+    at least one kernel that benefits from autotuning is expected to run.
+    Safe to call multiple times.
+    """
+    global _AUTOTUNE_KERNELS_WILL_BE_USED
+    if not _AUTOTUNE_KERNELS_WILL_BE_USED:
+        _AUTOTUNE_KERNELS_WILL_BE_USED = True
+        logger.debug_once("Registered FlashInfer autotune usage: %s", reason)
+
+
+def flashinfer_autotune_needed() -> bool:
+    """Return True if any FlashInfer autotune-able kernel is registered."""
+    return _AUTOTUNE_KERNELS_WILL_BE_USED
+
 
 @functools.cache
 def has_flashinfer() -> bool:
@@ -369,4 +391,6 @@ __all__ = [
     "use_trtllm_attention",
     "flashinfer_scaled_fp4_mm",
     "flashinfer_scaled_fp8_mm",
+    "register_flashinfer_kernel_autotune",
+    "flashinfer_autotune_needed",
 ]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Before this PR, we would always run a forward pass with max_num_batched_tokens simply if FlashInfer was installed and we were on Hopper or above. This is obviously too loose and affects startup time.

Introduces a `register_flashinfer_kernel_autotune` function that we can call when we know that a FlashInfer kernel that benefits from autotuning will be used at runtime. Then we can query `flashinfer_autotune_needed` to better gate the autotuning warmup pass only when it is needed.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

