### PR TITLE
[Platform][Bugfix] add default mla backend for cuda

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -279,6 +279,7 @@ class CudaPlatformBase(Platform):
                 return ("vllm.v1.attention.backends.mla."
                         "triton_mla.TritonMLABackend")
         if use_v1:
+            assert not use_mla  # will not trigger
             FLASHINFER_V1 = "vllm.v1.attention.backends.flashinfer.FlashInferBackend"  # noqa: E501
             FLEX_ATTENTION_V1 = "vllm.v1.attention.backends.flex_attention.FlexAttentionBackend"  # noqa: E501
             TRITON_ATTN_VLLM_V1 = "vllm.v1.attention.backends.triton_attn.TritonAttentionBackend"  # noqa: E501

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -278,8 +278,13 @@ class CudaPlatformBase(Platform):
                 logger.info_once("Using Triton MLA backend on V1 engine.")
                 return ("vllm.v1.attention.backends.mla."
                         "triton_mla.TritonMLABackend")
+            # If this point is reached, no valid backend has been selected or found
+            if selected_backend is None:
+                raise ValueError("No valid MLA backend could be found for this configuration.")  # noqa: E501
+            else:
+                raise ValueError(f"{selected_backend.name} is not a valid backend for this configuration.")  # noqa: E501
+
         if use_v1:
-            assert not use_mla  # will not trigger
             FLASHINFER_V1 = "vllm.v1.attention.backends.flashinfer.FlashInferBackend"  # noqa: E501
             FLEX_ATTENTION_V1 = "vllm.v1.attention.backends.flex_attention.FlexAttentionBackend"  # noqa: E501
             TRITON_ATTN_VLLM_V1 = "vllm.v1.attention.backends.triton_attn.TritonAttentionBackend"  # noqa: E501


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix the bug that the mla attn_backend selection may fall to non-mla attn_backend.
I think we need to add triton mla backend as default mla attn backend for cuda.
## Test Plan
pytest -sv tests/kernels/attention/test_attention_selector.py 
## Test Result
Passed (in my local env)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

