### PR TITLE
[Docs] Fix warnings in mkdocs build (continued) 

### DIFF
--- a/vllm/multimodal/__init__.py
+++ b/vllm/multimodal/__init__.py
@@ -15,7 +15,7 @@ is used by model runners to dispatch data processing according to the target
 model.
 
 Info:
-    [mm_processing](../../../design/mm_processing.html)
+    [mm_processing](../../../design/mm_processing.md)
 """
 
 __all__ = [

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -3214,7 +3214,7 @@ def cprofile_context(save_file: Optional[str] = None):
 
     Args:
         save_file: path to save the profile result. "1" or
-          None will result in printing to stdout.
+            None will result in printing to stdout.
     """
     import cProfile
 
@@ -3271,7 +3271,7 @@ def check_use_alibi(model_config: ModelConfig) -> bool:
                       and getattr(cfg.attn_config, "alibi", False)))))
 
 
-def sha256(input) -> bytes:
+def sha256(input: Any) -> bytes:
     """Hash any picklable Python object using SHA-256.
 
     The input is serialized using pickle before hashing, which allows
@@ -3288,7 +3288,7 @@ def sha256(input) -> bytes:
     return hashlib.sha256(input_bytes).digest()
 
 
-def sha256_cbor(input) -> bytes:
+def sha256_cbor(input: Any) -> bytes:
     """
     Hash objects using CBOR serialization and SHA-256.
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1150,8 +1150,8 @@ def get_kv_cache_configs(vllm_config: VllmConfig,
     Args:
         vllm_config: The global VllmConfig
         kv_cache_specs: List of dict[layer_name, KVCacheSpec] for each worker.
-        available_memory: Memory available for KV cache in bytes for each 
-        worker.
+        available_memory: Memory available for KV cache in bytes for each
+            worker. 
 
     Returns:
         The generated KVCacheConfigs for each worker.

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -351,17 +351,17 @@ def generate_uniform_probs(
     without a seed.
 
     Args:
-        num_tokens : int
+        num_tokens: int
             Total number of tokens.
-        num_draft_tokens : List[List[int]]
+        num_draft_tokens: List[List[int]]
             Number of draft tokens per request.
-        generators : Optional[Dict[int, torch.Generator]]
+        generators: Optional[Dict[int, torch.Generator]]
             A dictionary mapping indices in the batch to
             `torch.Generator` objects.
-        device : torch.device
+        device: torch.device
             The device on which to allocate the tensor.
     Returns:
-        uniform_rand : torch.Tensor
+        uniform_rand: torch.Tensor
             A tensor of shape `(num_tokens, )` containing uniform
             random values in the range [0, 1).
     """

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1407,7 +1407,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         Args:
             scheduler_output: The scheduler output containing scheduled encoder
-              inputs.
+                inputs.
 
         Returns:
             A tuple of (mm_kwargs, req_ids_pos) where:

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -204,7 +204,8 @@ def gather_mm_placeholders(
     """
     Reconstructs the embeddings from the placeholder tokens.
 
-    This is the operation of [scatter_mm_placeholders][].
+    This is the operation of [`scatter_mm_placeholders`]
+    [vllm.v1.worker.utils.scatter_mm_placeholders].
     """
     if is_embed is None:
         return placeholders

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1819,6 +1819,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         if self.vllm_config.kv_transfer_config is None:
             return False
 
+        if model_input.attn_metadata is None:
+            return False
+
         prefill_meta = model_input.attn_metadata.prefill_metadata
 
         # check if the current run is profiling
@@ -1843,6 +1846,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         """
 
         if self.vllm_config.kv_transfer_config is None:
+            return False
+
+        if model_input.attn_metadata is None:
             return False
 
         prefill_meta = model_input.attn_metadata.prefill_metadata

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1803,7 +1803,8 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
 
         return [output]
 
-    def need_recv_kv(self, model_input, kv_caches) -> bool:
+    def need_recv_kv(self, model_input: ModelInputForGPU,
+                     kv_caches: List[torch.Tensor]) -> bool:
         """Check if we need to receive kv-cache from the other worker.
         We need to receive KV when
             1. current vLLM instance is KV cache consumer/decode vLLM instance
@@ -1828,7 +1829,8 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         return self.vllm_config.kv_transfer_config.is_kv_consumer and (
             not is_profile_run) and is_prefill_run
 
-    def need_send_kv(self, model_input, kv_caches) -> bool:
+    def need_send_kv(self, model_input: ModelInputForGPU,
+                     kv_caches: List[torch.Tensor]) -> bool:
         """Check if we need to send kv-cache to the other worker.
         We need to send KV when
             1. current vLLM instance is KV cache producer/prefill vLLM instance

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1820,7 +1820,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
             return False
 
         if model_input.attn_metadata is None:
-            return False
+            raise ValueError("model_input.attn_metadata cannot be None")
 
         prefill_meta = model_input.attn_metadata.prefill_metadata
 
@@ -1849,7 +1849,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
             return False
 
         if model_input.attn_metadata is None:
-            return False
+            raise ValueError("model_input.attn_metadata cannot be None")
 
         prefill_meta = model_input.attn_metadata.prefill_metadata
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1803,7 +1803,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
 
         return [output]
 
-    def need_recv_kv(self, model_input: ModelInputForGPU,
+    def need_recv_kv(self, model_input: ModelInputForGPUWithSamplingMetadata,
                      kv_caches: List[torch.Tensor]) -> bool:
         """Check if we need to receive kv-cache from the other worker.
         We need to receive KV when
@@ -1829,7 +1829,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         return self.vllm_config.kv_transfer_config.is_kv_consumer and (
             not is_profile_run) and is_prefill_run
 
-    def need_send_kv(self, model_input: ModelInputForGPU,
+    def need_send_kv(self, model_input: ModelInputForGPUWithSamplingMetadata,
                      kv_caches: List[torch.Tensor]) -> bool:
         """Check if we need to send kv-cache to the other worker.
         We need to send KV when


### PR DESCRIPTION
Fixes the all warnings occurred within these files during `mkdocs build`.

<details>
<summary> vllm/utils/ and vllm/worker/ - 7 warnings </summary>

```
WARNING - griffe: vllm/utils/init.py:3282: No type or annotation for parameter 'input'
WARNING - griffe: vllm/utils/init.py:3297: No type or annotation for parameter 'input'
WARNING - griffe: vllm/utils/init.py:3217: Confusing indentation for continuation line 5 in docstring, should be 4 * 2 = 8 spaces, not 6
WARNING - griffe: vllm/worker/model_runner.py:1814: No type or annotation for parameter 'model_input'
WARNING - griffe: vllm/worker/model_runner.py:1815: No type or annotation for parameter 'kv_caches'
WARNING - griffe: vllm/worker/model_runner.py:1839: No type or annotation for parameter 'model_input'
WARNING - griffe: vllm/worker/model_runner.py:1840: No type or annotation for parameter 'kv_caches'
```
</details>

<details>
<summary> 
vllm/v1/core/, vllm/v1/sample/, and vllm/v1/worker/ - 10 warnings </summary> 

```
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:353: No type or annotation for parameter 'num_tokens '
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:353: Parameter 'num_tokens ' does not appear in the function signature
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:355: Parameter 'num_draft_tokens ' does not appear in the function signature
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:355: No type or annotation for parameter 'num_draft_tokens'
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:357: Parameter 'generators ' does not appear in the function signature
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:357: No type or annotation for parameter 'generators '
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:360: Parameter 'device ' does not appear in the function signature
WARNING - griffe: vllm/v1/sample/rejection_sampler.py:360: No type or annotation for parameter 'device '
WARNING - griffe: vllm/v1/worker/gpu_model_runner.py:1357: Confusing indentation for continuation line 5 in docstring, should be 4 * 2 = 8 spaces, not 6
WARNING - mkdocs_autorefs: api/vllm/v1/worker/utils.md: from /home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/24820/vllm/v1/worker/utils.py:196: (vllm.v1.worker.utils.gather_mm_placeholders) Could not find cross-reference target 'scatter_mm_placeholders'
```
</details>

<details>
<summary> 
Documentation and other warnings - 1 warning </summary> 

```
WARNING - Doc file 'api/vllm/multimodal/index.md' contains a link '../../../design/mm_processing.html', but the target 'design/mm_processing.html' is not found among documentation files. Did you mean '../../../design/mm_processing.md'?
```

</details>

Related to: https://github.com/vllm-project/vllm/issues/25020