### PR TITLE
[Bugfix] Does not support modify head dtype when Lora is enabled temporarily

### DIFF
--- a/tests/models/language/pooling/test_classification_with_lora.py
+++ b/tests/models/language/pooling/test_classification_with_lora.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["jason9693/Qwen2.5-1.5B-apeach"],
+)
+def test_models(
+    hf_runner,
+    vllm_runner,
+    example_prompts,
+    model: str,
+) -> None:
+
+    with vllm_runner(model, max_model_len=512, enable_lora=True) as vllm_model:
+        model_config = vllm_model.llm.llm_engine.model_config
+        head_dtype = model_config.head_dtype
+        dtype = model_config.dtype
+        assert head_dtype == dtype

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -2656,12 +2656,6 @@ class VllmConfig:
         if self.lora_config is not None:
             self.lora_config.verify_with_cache_config(self.cache_config)
             self.lora_config.verify_with_model_config(self.model_config)
-            if self.model_config._head_dtype != self.model_config.dtype:
-                self.model_config._head_dtype = self.model_config.dtype
-                logger.warning_once(
-                    "Does not support [%s] head dtype when Lora is enabled, "
-                    "fallback to model dtype [%s].",
-                    self.model_config._head_dtype, self.model_config.dtype)
 
         if self.quant_config is None and self.model_config is not None:
             self.quant_config = VllmConfig._get_quantization_config(

--- a/vllm/config/lora.py
+++ b/vllm/config/lora.py
@@ -130,3 +130,9 @@ class LoRAConfig:
             self.lora_dtype = model_config.dtype
         elif isinstance(self.lora_dtype, str):
             self.lora_dtype = getattr(torch, self.lora_dtype)
+        if model_config._head_dtype != model_config.dtype:
+            model_config._head_dtype = model_config.dtype
+            logger.warning_once(
+                "Does not support [%s] head dtype when Lora is enabled, "
+                "fallback to model dtype [%s].", model_config._head_dtype,
+                model_config.dtype)


### PR DESCRIPTION

## Purpose

Does not support set head dtype when Lora is enabled

cc @jeejeelee

## Test Plan

tests/models/language/pooling/test_classification_with_lora.py

## Test Result

pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

