### PR TITLE
Mark prompt logprobs as incompatible with prompt embeds at API level

### DIFF
--- a/tests/entrypoints/openai/test_completion_with_prompt_embeds.py
+++ b/tests/entrypoints/openai/test_completion_with_prompt_embeds.py
@@ -228,3 +228,20 @@ async def test_completions_with_logprobs_and_prompt_embeds(
             assert max(logprobs_arg,
                        1) <= len(top_logprobs) <= logprobs_arg + 1
         assert len(logprobs.tokens) == 5
+
+
+@pytest.mark.asyncio
+async def test_prompt_logprobs_raises_error(
+        client_with_prompt_embeds: openai.AsyncOpenAI):
+    with pytest.raises(BadRequestError, match="not compatible"):
+        encoded_embeds = create_dummy_embeds()
+        await client_with_prompt_embeds.completions.create(
+            model=MODEL_NAME,
+            prompt="",
+            max_tokens=5,
+            temperature=0.0,
+            extra_body={
+                "prompt_embeds": encoded_embeds,
+                "prompt_logprobs": True
+            },
+        )

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -671,10 +671,13 @@ class LLMEngine:
             arrival_time = time.time()
 
         if (isinstance(prompt, dict)
-                and prompt.get("prompt_embeds", None) is not None
-                and not prompt.get("prompt_token_ids", None)):
-            seq_len = prompt["prompt_embeds"].shape[0]
-            prompt["prompt_token_ids"] = [0] * seq_len
+                and prompt.get("prompt_embeds", None) is not None):
+            if not prompt.get("prompt_token_ids", None):
+                seq_len = prompt["prompt_embeds"].shape[0]
+                prompt["prompt_token_ids"] = [0] * seq_len
+            if params.prompt_logprobs is not None:
+                raise ValueError(
+                    "prompt_logprobs is not compatible with prompt embeds.")
 
         processed_inputs = self.input_preprocessor.preprocess(
             prompt,

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -112,6 +112,11 @@ class OpenAIServingCompletion(OpenAIServing):
             return self.create_error_response(
                 "Echo is unsupported with prompt embeds.")
 
+        if (request.prompt_logprobs is not None
+                and request.prompt_embeds is not None):
+            return self.create_error_response(
+                "prompt_logprobs is not compatible with prompt embeds.")
+
         request_id = (
             f"cmpl-"
             f"{self._base_request_id(raw_request, request.request_id)}")


### PR DESCRIPTION
## Purpose

The implementation of Prompt Logprobs is incompatible with Prompt Embeds in both the existing v0 engine and in #24278. In that PR is was requested by @DarkLight1337 to block requests with both prompt embeds and prompt logprobs at the API level. 

This PR has changes originally in #24278, but since these fixes apply to both engines, and aren't strictly related to enabling prompt embedding support in the v1 engine, I figured it would be a good idea to split it into a separate PR for easier review and to reduce the diff in #24278.

## Test Plan

Updated unit test with prompt embeds to explicitly ban requests that have both prompt embeds and prompt logprobs.

## Test Result

New tests pass locally. Pending CI, it should be good to go. The full CI of the original PR #24278 never failed related to these changes.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

