### PR TITLE
Add 'path' option to ImagePrompt data_format

### DIFF
--- a/tests/plugins/prithvi_io_processor_plugin/prithvi_io_processor/types.py
+++ b/tests/plugins/prithvi_io_processor_plugin/prithvi_io_processor/types.py
@@ -22,7 +22,7 @@ class DataModuleConfig(TypedDict):
 
 class ImagePrompt(BaseModel):
 
-    data_format: Literal["b64_json", "bytes", "url"]
+    data_format: Literal["b64_json", "bytes", "url", "path"]
     """
     This is the data type for the input image
     """


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR adds the `"path"` option to `data_format` in `ImagePrompt` for the `prithvi_io_processor` plugin.

Notice that the plugin already [supports](https://github.com/vllm-project/vllm/blob/087c6ffc9202599f438f1f7e0d6449020a958ac1/tests/plugins/prithvi_io_processor_plugin/prithvi_io_processor/prithvi_processor.py#L140) that option, but fails when used with a file because of the pydantic check. 


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

