### PR TITLE
[BUG] Exclude .pth files when pulling remote files 

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -844,7 +844,8 @@ class ModelConfig:
                 object_storage_model.pull_files(model,
                                                 ignore_pattern=[
                                                     "*.pt", "*.safetensors",
-                                                    "*.bin", "*.tensors"
+                                                    "*.bin", "*.tensors",
+                                                    "*.pth"
                                                 ])
                 self.tokenizer = object_storage_model.dir
                 return
@@ -852,9 +853,12 @@ class ModelConfig:
         # Only download tokenizer if needed and not already handled
         if is_runai_obj_uri(tokenizer):
             object_storage_tokenizer = ObjectStorageModel()
-            object_storage_tokenizer.pull_files(
-                model,
-                ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors"])
+            object_storage_tokenizer.pull_files(model,
+                                                ignore_pattern=[
+                                                    "*.pt", "*.safetensors",
+                                                    "*.bin", "*.tensors",
+                                                    "*.pth"
+                                                ])
             self.tokenizer = object_storage_tokenizer.dir
 
     def _get_encoder_config(self):


### PR DESCRIPTION
## Purpose
When pulling files for model and tokenizer in `maybe_pull_model_tokenizer_for_runai`, *.pth files are not excluded from being pulled. Some huggingface repos like https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct/tree/main/original contain .pth files, which adds a significant amount of unnecessary latency to startup times. 
## Test Plan
I timed the ModelConfig creation time and ensured that the startup latency went down. 
## Test Result
N/A

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

