### PR TITLE
[Bug] Fix torch Compilation Cache Hit Error

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -563,18 +563,6 @@ class CompilationConfig:
                 self.cudagraph_mode = CUDAGraphMode.FULL
             self.splitting_ops = []
 
-        if envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput":
-            # exclude MoE dispatch/combine from capture by ensuring
-            # piecewise splitting includes them, so communication remains
-            # outside CUDA graphs while compute can still be graphed.
-            moe_ops = [
-                "vllm.moe_forward",
-                "vllm.moe_forward_shared",
-            ]
-            for op in moe_ops:
-                if op not in self.splitting_ops:
-                    self.splitting_ops.append(op)
-
     def splitting_ops_contain_attention(self) -> bool:
         return self.splitting_ops is not None and all(
             op in self.splitting_ops for op in self._attention_ops)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -192,6 +192,9 @@ class CudaPlatformBase(Platform):
         if (envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
                 and parallel_config.data_parallel_size > 1
                 and compilation_config.cudagraph_mode != CUDAGraphMode.NONE):
+            # TODO: Piecewise Cuda graph might be enabled
+            # if torch compile cache key issue fixed
+            # See https://github.com/vllm-project/vllm/pull/25093
             logger.info(
                 "Data Parallel: disabling cudagraphs since DP "
                 "with DeepEP high-throughput kernels are not CUDA Graph "

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -199,8 +199,6 @@ class CudaPlatformBase(Platform):
                 "compatible. Set the all_to_all backend to deepep_low_latency "
                 "to use those kernels instead.")
             compilation_config.cudagraph_mode = CUDAGraphMode.NONE
-            if model_config is not None:
-                model_config.enforce_eager = True
 
     @classmethod
     def get_current_memory_usage(cls,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -191,14 +191,16 @@ class CudaPlatformBase(Platform):
         compilation_config = vllm_config.compilation_config
         if (envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
                 and parallel_config.data_parallel_size > 1
-                and compilation_config.cudagraph_mode
-                not in [CUDAGraphMode.NONE, CUDAGraphMode.PIECEWISE]):
+                and compilation_config.cudagraph_mode != CUDAGraphMode.NONE):
             logger.info(
-                "Data Parallel with DeepEP high-throughput: using PIECEWISE "
-                "CUDA graphs and excluding MoE ops from capture. Set "
-                "VLLM_ALL2ALL_BACKEND=deepep_low_latency if you need MoE "
-                "graphs captured as well.")
-            compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                "Data Parallel: disabling cudagraphs since DP "
+                "with DeepEP high-throughput kernels are not CUDA Graph "
+                "compatible. The DeepEP low-latency kernels are CUDA Graph "
+                "compatible. Set the all_to_all backend to deepep_low_latency "
+                "to use those kernels instead.")
+            compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            if model_config is not None:
+                model_config.enforce_eager = True
 
     @classmethod
     def get_current_memory_usage(cls,


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/24915

The root cause of this issue is from `(runtime_shape, graph_index, backend_name)` is not a strong enough cache key for compiled cuda graph. And in complicated situation like DeepEP HT, we split the piecewise graph `moe_forward` and `moe_forward_shared` and make the wrong cache hit.

I am not sure if it is a good idea to refactor the cache key system throughly just for the support of piecewise graph for HT (Perhaps not worth enough), so simply cancel the support for HT graph now. If we encounter other scenarios where the cache key proves insufficient, we should revisit and redesign the cache system.

Note: The rough idea to refactor the cache system: Adding a fourth key introducing the signature of sub_graph like. Works good locally

```bash
def compute_subgraph_signature(graph: fx.GraphModule) -> str:
    parts: list[str] = []
    for node in graph.graph.nodes:
        parts.append(f"{node.op}:{str(node.target)}")
    sig = "|".join(parts)
    return hashlib.md5(sig.encode(), usedforsecurity=False).hexdigest()[:16]
```

## Test

Originally: Wrong graph cache hit in the second run

```bash
(EngineCore_DP6 pid=2464687)     hidden_states = self.model(input_ids, positions, intermediate_tensors,
(EngineCore_DP6 pid=2464687)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/compilation/decorators.py", line 305, in __call__
(EngineCore_DP6 pid=2464687)     output = self.compiled_callable(*args, **kwargs)
(EngineCore_DP6 pid=2464687)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 655, in _fn
(EngineCore_DP6 pid=2464687)     return fn(*args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/model_executor/models/deepseek_v2.py", line 767, in forward
(EngineCore_DP6 pid=2464687)     def forward(
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(EngineCore_DP6 pid=2464687)     return self._call_impl(*args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(EngineCore_DP6 pid=2464687)     return forward_call(*args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 838, in _fn
(EngineCore_DP6 pid=2464687)     return fn(*args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 830, in call_wrapped
(EngineCore_DP6 pid=2464687)     return self._wrapped_call(self, *args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 406, in __call__
(EngineCore_DP6 pid=2464687)     raise e
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 393, in __call__
(EngineCore_DP6 pid=2464687)     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(EngineCore_DP6 pid=2464687)     return self._call_impl(*args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(EngineCore_DP6 pid=2464687)     return forward_call(*args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "<eval_with_key>.240", line 723, in forward
(EngineCore_DP6 pid=2464687)     submod_10 = self.submod_10(submod_9, s0, getitem_22, l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_fused_qkv_a_proj_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_fused_qkv_a_proj_parameters_weight_scale_inv_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_a_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_b_proj_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_b_proj_parameters_weight_scale_inv_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_rotary_emb_buffers_cos_sin_cache_, l_positions_);  submod_9 = getitem_22 = l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_fused_qkv_a_proj_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_fused_qkv_a_proj_parameters_weight_scale_inv_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_b_proj_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_b_proj_parameters_weight_scale_inv_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = None
(EngineCore_DP6 pid=2464687)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/compilation/cuda_graph.py", line 119, in __call__
(EngineCore_DP6 pid=2464687)     return self.runnable(*args, **kwargs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/compilation/cuda_piecewise_backend.py", line 90, in __call__
(EngineCore_DP6 pid=2464687)     return self.compiled_graph_for_general_shape(*args)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/compilation/compiler_interface.py", line 518, in compiled_graph
(EngineCore_DP6 pid=2464687)     graph_output = inductor_compiled_graph(list_args)
(EngineCore_DP6 pid=2464687)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 460, in __call__
(EngineCore_DP6 pid=2464687)     return self.current_callable(inputs)
(EngineCore_DP6 pid=2464687)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=2464687)   File "/data/vllm-community-homes/vllm-user-6/.cache/vllm/torch_compile_cache/827a4e48c2/rank_0_6/inductor_cache/u3/cu35tgdepztiquv25xuh6ksxtdembn2u7jrhps4jbvwlcnvv4bzl.py", line 441, in call
(EngineCore_DP6 pid=2464687)     arg0_1, arg1_1, arg2_1, arg3_1, arg4_1, arg5_1, arg6_1, arg7_1, arg8_1, arg9_1, arg10_1, arg11_1, arg12_1 = args
(EngineCore_DP6 pid=2464687)     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=2464682)     return self.compiled_graph_for_general_shape(*args)
(EngineCore_DP6 pid=2464687) ValueError: not enough values to unpack (expected 13, got 12)
(EngineCore_DP1 pid=2464682)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=2464682)   File "/data/vllm-community-homes/vllm-user-6/vllm/vllm/compilation/compiler_interface.py", line 518, in compiled_graph
(EngineCore_DP1 pid=2464682)     graph_output = inductor_compiled_graph(list_args)
(EngineCore_DP1 pid=2464682)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=2464682)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 460, in __call__
(EngineCore_DP1 pid=2464682)     return self.current_callable(inputs)
(EngineCore_DP1 pid=2464682)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=2464682)   File "/data/vllm-community-homes/vllm-user-6/.cache/vllm/torch_compile_cache/827a4e48c2/rank_0_1/inductor_cache/5x/c5xlzojszbnaoiyl4la7syjq6lh2rfdc3q3emyo3ase2b6w6hizw.py", line 441, in call
(EngineCore_DP1 pid=2464682)     arg0_1, arg1_1, arg2_1, arg3_1, arg4_1, arg5_1, arg6_1, arg7_1, arg8_1, arg9_1, arg10_1, arg11_1, arg12_1 = args
(EngineCore_DP1 pid=2464682)     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=2464682) ValueError: not enough values to unpack (expected 13, got 12)
```

Now:

```bash
(APIServer pid=1527118) INFO:     Started server process [1527118]
(APIServer pid=1527118) INFO:     Waiting for application startup.
(APIServer pid=1527118) INFO:     Application startup complete.
```
