### PR TITLE
[Core] Make Whisper work with b200 + flashinfer

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -162,8 +162,8 @@ Priority is **1 = highest** (tried first).
 | Backend | Version | Dtypes | KV Dtypes | Block Sizes | Head Sizes | Sink | MM Prefix | Attention Types | Compute Cap. |
 |---------|---------|--------|-----------|-------------|------------|------|-----------|-----------------|--------------|
 | `CPU_ATTN` |  | fp16, bf16, fp32 | `auto` | Any | 32, 64, 80, 96, 112, 128, 160, 192, 224, 256 | ❌ | ❌ | All | N/A |
-| `FLASHINFER` | Native† | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32, 64 | 64, 128, 256 | ❌ | ❌ | Decoder | 7.x-9.x |
-| `FLASHINFER` | TRTLLM† | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32, 64 | 64, 128, 256 | ✅ | ❌ | Decoder | 10.x |
+| `FLASHINFER` | Native† | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32, 64 | 64, 128, 256 | ❌ | ❌ | Decoder, Enc-Dec | 7.x-9.x |
+| `FLASHINFER` | TRTLLM† | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32, 64 | 64, 128, 256 | ✅ | ❌ | Decoder, Enc-Dec | 10.x |
 | `FLASH_ATTN` | FA2* | fp16, bf16 | `auto`, `bfloat16` | %16 | Any | ❌ | ❌ | All | ≥8.0 |
 | `FLASH_ATTN` | FA3* | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | Any | ✅ | ❌ | All | 9.x |
 | `FLASH_ATTN_DIFFKV` |  | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | Decoder | Any |


### PR DESCRIPTION
These changes were necessary to get Whisper working on a B200 machine
with the flashinfer attention backend. There are three changes:

1. Make flashinfer not reject `ENCODER_DECODER`` attention.

2. Make flashinfer handle the case where `key` and `value` are None.
   With cross attention (`ENCODER_DECODER`), `key` and `value` are only
   set the first pass through the decoder for a given request. It is
   then cached in the kv cache for subsequent passes.

3. In the GPU model runner, this configuration enabled a code path
   where `force_attention` was set to `True` in `_dummy_run()`.
   We need to pass a non-None `encoder_seq_lens` to the cross attention
   metadata builder.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
