### PR TITLE
[ROCm][AITER][Bugfix] Switch AITER to use PIECEWISE_AND_FULL compilation

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -232,7 +232,7 @@ class AiterFlashAttentionMetadata:
 
 class AiterFlashAttentionMetadataBuilder(
         AttentionMetadataBuilder[AiterFlashAttentionMetadata]):
-    cudagraph_support = AttentionCGSupport.ALWAYS
+    cudagraph_support = AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
     def __init__(self, kv_cache_spec: AttentionSpec, layer_names: list[str],
                  vllm_config: VllmConfig, device: torch.device):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
AiterFlashAttentionBackend (enabled through VLLM_ROCM_USE_AITER_MHA=1) does not work correctly with cudagraph_mode = FULL, since it calls two AITER kernels for prefill (aiter.flash_attn_varlen_func) and decode (aiter.paged_attention_v1). The correct AttentionCGSupport and cudagraph_mode to use here are `AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE` and `FULL_AND_PIECEWISE` respectively.

## Test Plan
For e.g. Llama 3.3 70B FP8 TP1 max_conc=256 on MI355, this fixes both OOMs as well as some accuracy issues we've been seeing.

## Test Result

Serving command:
```
vllm serve amd/Llama-3.1-70B-Instruct-FP8-KV -tp 1 --max-num-batched-tokens 131072 --max-num-seqs 1024 --max-seq-len-to-capture 16384 --max-model-len 10240 --swap-space 64 --no-enable-prefix-caching --disable-log-requests --disable-uvicorn-access-log --trust-remote-code --gpu-memory-utilization 0.90 -O '{"compilation_config":"FULL"}'
```

CG capture:
<img width="1342" height="720" alt="image" src="https://github.com/user-attachments/assets/96523a59-a889-4007-bc79-bd883fc32044" />

LM-Eval:

```
lm_eval --model local-completions --model_args model=$MODEL,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=256,max_retries=10,max_gen_toks=2048 --batch_size auto --tasks gsm8k --num_fewshot 5 --limit 250  --output_path . --apply_chat_template 2>&1 | tee -a eval.log
INFO 09-17 22:05:58 [__init__.py:241] Automatically detected platform rocm.
2025-09-17:22:06:00 WARNING  [__main__:369]  --limit SHOULD ONLY BE USED FOR TESTING.REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT.
2025-09-17:22:06:00 INFO     [__main__:446] Selected Tasks: ['gsm8k']
2025-09-17:22:06:00 INFO     [evaluator:202] Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234 | Setting fewshot manual seed to 1234
2025-09-17:22:06:00 INFO     [evaluator:240] Initializing local-completions model, with arguments: {'model': 'amd/Llama-3.1-70B-Instruct-FP8-KV', 'base_url':
        'http://0.0.0.0:8000/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048}
2025-09-17:22:06:00 WARNING  [models.api_models:158] Automatic batch size is not supported for API models. Defaulting to batch size 1.
2025-09-17:22:06:00 INFO     [models.api_models:170] Using max length 2048 - 1
2025-09-17:22:06:00 INFO     [models.api_models:189] Using tokenizer huggingface
2025-09-17:22:06:04 INFO     [evaluator:305] gsm8k: Using gen_kwargs: {'until': ['Question:', '</s>', '<|im_end|>'], 'do_sample': False, 'temperature': 0.0}
2025-09-17:22:06:04 WARNING  [evaluator:324] Overwriting default num_fewshot of gsm8k from 5 to 5
2025-09-17:22:06:04 WARNING  [evaluator:480] Chat template formatting change affects loglikelihood and multiple-choice tasks. See docs/chat-template-readme.md for details.
2025-09-17:22:06:04 INFO     [api.task:434] Building contexts for gsm8k on rank 0...
100%|██████████| 250/250 [00:00<00:00, 754.99it/s]
2025-09-17:22:06:04 INFO     [evaluator:574] Running generate_until requests
2025-09-17:22:06:05 WARNING  [models.api_models:756] Some contexts exceeded (max length: (2047) - max_gen_toks (2048). They were left truncated.
Requesting API: 100%|██████████| 250/250 [01:02<00:00,  4.03it/s]
fatal: detected dubious ownership in repository at '/home/ropotdar/Desktop/MAD-private'
To add an exception for this directory, call:

        git config --global --add safe.directory /home/ropotdar/Desktop/MAD-private
2025-09-17:22:07:07 INFO     [loggers.evaluation_tracker:209] Saving results aggregated
local-completions (model=amd/Llama-3.1-70B-Instruct-FP8-KV,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=256,max_retries=10,max_gen_toks=2048), gen_kwargs: (None), limit: 250.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.854|±  |0.0252|
|     |       |strict-match    |     5|exact_match|↑  |0.208|±  |0.0257|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

