### PR TITLE
[OOT] Support sync_model_loading for OOT

### DIFF
--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -52,8 +52,7 @@ class BasevLLMParameter(Parameter):
         # This sometimes causes OOM errors during model loading. To avoid this,
         # we sync the param tensor after its weight loader is called.
         from vllm.platforms import current_platform
-        if current_platform.is_tpu(
-        ) or current_platform.use_sync_weight_loader():
+        if current_platform.use_sync_weight_loader():
             weight_loader = current_platform.make_synced_weight_loader(
                 weight_loader)
 

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -12,7 +12,6 @@ from torch.nn import Parameter
 from vllm.distributed import (get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size)
 from vllm.logger import init_logger
-from vllm.model_executor.utils import _make_synced_weight_loader
 
 __all__ = [
     "BasevLLMParameter", "PackedvLLMParameter", "PerTensorScaleParameter",
@@ -53,8 +52,10 @@ class BasevLLMParameter(Parameter):
         # This sometimes causes OOM errors during model loading. To avoid this,
         # we sync the param tensor after its weight loader is called.
         from vllm.platforms import current_platform
-        if current_platform.is_tpu():
-            weight_loader = _make_synced_weight_loader(weight_loader)
+        if current_platform.is_tpu(
+        ) or current_platform.use_sync_weight_loader():
+            weight_loader = current_platform.make_synced_weight_loader(
+                weight_loader)
 
         self._weight_loader = weight_loader
         self.tp_rank = get_tensor_model_parallel_rank()

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -44,21 +44,11 @@ def set_weight_attrs(
         # TODO(woosuk): Remove this hack once we have a better solution.
         from vllm.platforms import current_platform
 
-        if current_platform.is_tpu() and key == "weight_loader":
-            value = _make_synced_weight_loader(value)
+        if (current_platform.is_tpu()
+                or current_platform.use_sync_weight_loader()
+            ) and key == "weight_loader":
+            value = current_platform.make_synced_weight_loader(value)
         setattr(weight, key, value)
-
-
-def _make_synced_weight_loader(original_weight_loader):
-
-    def _synced_weight_loader(param, *args, **kwargs):
-        out = original_weight_loader(param, *args, **kwargs)
-        # torch._sync doesn't support, is not needed for CPU tensors.
-        if param.device != torch.device("cpu"):
-            torch._sync(param)
-        return out
-
-    return _synced_weight_loader
 
 
 def get_packed_modules_mapping(model: torch.nn.Module) -> dict[str, list[str]]:

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -44,9 +44,8 @@ def set_weight_attrs(
         # TODO(woosuk): Remove this hack once we have a better solution.
         from vllm.platforms import current_platform
 
-        if (current_platform.is_tpu()
-                or current_platform.use_sync_weight_loader()
-            ) and key == "weight_loader":
+        if current_platform.use_sync_weight_loader(
+        ) and key == "weight_loader":
             value = current_platform.make_synced_weight_loader(value)
         setattr(weight, key, value)
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -594,6 +594,29 @@ class Platform:
         """
         return False
 
+    @classmethod
+    def use_sync_weight_loader(cls) -> bool:
+        """
+        Returns if the current platform needs to sync weight loader.
+        """
+        return False
+
+    @classmethod
+    def make_synced_weight_loader(cls, original_weight_loader):
+        """
+        Wrap the original weight loader to make it synced.
+        """
+        if not cls.use_sync_weight_loader():
+            return original_weight_loader
+
+        def _synced_weight_loader(param, *args, **kwargs):
+            out = original_weight_loader(param, *args, **kwargs)
+            if param.device != torch.device("cpu"):
+                torch._sync(param)
+            return out
+
+        return _synced_weight_loader
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -226,6 +226,10 @@ class TpuPlatform(Platform):
         torch.ops.xla.dynamo_set_buffer_donor_(src_cache, True)
         dst_cache[dst_block_indices] = src_cache[src_block_indices].cpu()
 
+    @classmethod
+    def use_sync_weight_loader(cls) -> bool:
+        return True
+
 
 try:
     from tpu_commons.platforms import TpuPlatform as TpuCommonsPlatform


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add use_sync_weight_loader and make_synced_weight_loader in current_platform so OOT plugin can also apply do synced_model_loading if needed.

This is specifically needed by Intel Gaudi device, Previously, we were doing monkey patch in plugin to update model_loader as synced_model_loader, but recently, the monkey_patch raises a circular import error. So we would like to enable oot synced_model_load support

## Test Plan

using existing test

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

