### PR TITLE
[Docs] Fix API Reference

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -79,7 +79,7 @@ plugins:
         - "re:vllm\\._.*"  # Internal modules
         - "vllm.third_party"
         - "vllm.vllm_flash_attn"
-        - !ENV [API_AUTONAV_EXCLUDE, ""]
+        - !ENV [API_AUTONAV_EXCLUDE, "re:^$"]  # Match nothing by default
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
Fixes new build features added in https://github.com/vllm-project/vllm/pull/25099

The default, `""`, was matching everything, so I changed it to `"re:^$"` which matches nothing