### PR TITLE
Fix `validate-config` pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,9 +164,7 @@ repos:
     name: Validate configuration has default values and that each field has a docstring
     entry: python tools/validate_config.py
     language: python
-    types: [python]
-    pass_filenames: true
-    files: vllm/config.py|tests/test_config.py|vllm/entrypoints/openai/cli_args.py
+    additional_dependencies: [regex]
   # Keep `suggestion` last
   - id: suggestion
     name: Suggestion

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -449,6 +449,8 @@ class ModelConfig:
 
     # Multimodal config and init vars
     multimodal_config: Optional[MultiModalConfig] = None
+    """Configuration for multimodal model. If `None`, this will be inferred
+    from the architecture of `self.model`."""
     limit_mm_per_prompt: InitVar[Optional[dict[str, int]]] = None
     media_io_kwargs: InitVar[Optional[dict[str, dict[str, Any]]]] = None
     mm_processor_kwargs: InitVar[Optional[dict[str, Any]]] = None


### PR DESCRIPTION
The check that decided whether or not to run the check was brittle.

This PR:

- Simplifies the config in `.pre-commit-config.yaml` so that we don't need to manually specify which files it runs on
- Fixes the script so that:
  - `InitVar`s are also skipped
  - When it fails an error is actually raised and the hook fails
  - It checks which files it should validate using a robust check for the presence of `@config`
- Fixes the issue that went unnoticed because this hook wasn't running properly