### PR TITLE
[Docs] Fix warnings in mkdocs build (continued)

### DIFF
--- a/vllm/distributed/device_communicators/shm_object_storage.py
+++ b/vllm/distributed/device_communicators/shm_object_storage.py
@@ -253,7 +253,7 @@ class SingleWriterShmRingBuffer:
 
         Args:
             nbytes (int, optional): The size of the buffer to free. If None,
-            frees the maximum size of the ring buffer.
+                frees the maximum size of the ring buffer.
         '''
 
         assert self.is_writer, "Only the writer can free buffers."

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -697,9 +697,7 @@ class OpenAIServing:
         add_special_tokens: bool = True,
     ) -> TextTokensPrompt:
         """
-        A simpler implementation of
-        [`_tokenize_prompt_input_or_inputs`][vllm.entrypoints.openai.serving_engine.OpenAIServing._tokenize_prompt_input_or_inputs]
-        that assumes single input.
+        A simpler implementation that tokenizes a single prompt input.
         """
         async for result in self._tokenize_prompt_inputs_async(
                 request,
@@ -718,9 +716,7 @@ class OpenAIServing:
         add_special_tokens: bool = True,
     ) -> AsyncGenerator[TextTokensPrompt, None]:
         """
-        A simpler implementation of
-        [`_tokenize_prompt_input_or_inputs`][vllm.entrypoints.openai.serving_engine.OpenAIServing._tokenize_prompt_input_or_inputs]
-        that assumes multiple inputs.
+        A simpler implementation that tokenizes multiple prompt inputs.
         """
         for prompt in prompt_inputs:
             if isinstance(prompt, str):


### PR DESCRIPTION
Continued #23649, #23743, #24092, #24740, #24791

Related: #25020

---

> [!NOTE]
> Warnings fixed:

```bash
WARNING -  mkdocs_autorefs: api/vllm/entrypoints/openai/serving_engine.md: from /Users/zerohertz/Downloads/opensources/vllm/vllm/entrypoints/openai/serving_engine.py:699: (vllm.entrypoints.openai.serving_engine.OpenAIServing._tokenize_prompt_input_async) Could not find cross-reference target 'vllm.entrypoints.openai.serving_engine.OpenAIServing._tokenize_prompt_input_or_inputs'
WARNING -  mkdocs_autorefs: api/vllm/entrypoints/openai/serving_engine.md: from /Users/zerohertz/Downloads/opensources/vllm/vllm/entrypoints/openai/serving_engine.py:720: (vllm.entrypoints.openai.serving_engine.OpenAIServing._tokenize_prompt_inputs_async) Could not find cross-reference target 'vllm.entrypoints.openai.serving_engine.OpenAIServing._tokenize_prompt_input_or_inputs'

WARNING -  griffe: vllm/distributed/device_communicators/shm_object_storage.py:255: Failed to get 'name: description' pair from 'frees the maximum size of the ring buffer.'
```