### PR TITLE
[GDN] cherry-pick bugfix for scaled_dot_kkt from upstream FLA.

### DIFF
--- a/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
@@ -69,8 +69,7 @@ def chunk_scaled_dot_kkt_fwd_kernel(
                                 (Hg * K, 1), (i_t * BT, i_k * BK), (BT, BK),
                                 (1, 0))
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_kb = b_k * b_beta[:, None]
-        b_A += tl.dot(b_kb.to(b_k.dtype), tl.trans(b_k))
+        b_A += tl.dot(b_k, tl.trans(b_k))
 
     if USE_G:
         p_g = tl.make_block_ptr(g_cumsum + bos * H + i_h, (T, ), (H, ),
@@ -78,6 +77,7 @@ def chunk_scaled_dot_kkt_fwd_kernel(
         b_g = tl.load(p_g, boundary_check=(0, ))
         b_g_diff = b_g[:, None] - b_g[None, :]
         b_A = b_A * exp(b_g_diff)
+    b_A = b_A * b_beta[:, None]
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)


### PR DESCRIPTION
See also: https://github.com/fla-org/flash-linear-attention/commit/d57a3b072820ac23ea1df890d25ab416386f9472