### PR TITLE
[CI/build] Abort CI if pre-commit fails

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -31,14 +31,6 @@
 steps:
 ##### fast check tests  #####
 
-- label: Pre-commit Checks # 5min
-  timeout_in_minutes: 15
-  fast_check: true
-  commands:
-  - pip install pre-commit
-  - pre-commit install
-  - pre-commit run --all-files --hook-stage manual
-
 - label: Pytorch Nightly Dependency Override Check # 2min
   # if this test fails, it means the nightly torch version is not compatible with some
   # of the dependencies. Please check the error message and add the package to whitelist

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -31,6 +31,14 @@
 steps:
 ##### fast check tests  #####
 
+- label: Pre-commit Checks # 5min
+  timeout_in_minutes: 15
+  fast_check: true
+  commands:
+  - pip install pre-commit
+  - pre-commit install
+  - pre-commit run --all-files --hook-stage manual
+
 - label: Pytorch Nightly Dependency Override Check # 2min
   # if this test fails, it means the nightly torch version is not compatible with some
   # of the dependencies. Please check the error message and add the package to whitelist

--- a/test_precommit_issues.md
+++ b/test_precommit_issues.md
@@ -1,0 +1,41 @@
+# Test Pre-commit Issues
+
+This is a test markdown file with intentional issues to trigger pre-commit checks.
+
+## Bad formatting
+
+This paragraph has no blank line after the heading.
+
+This paragraph has multiple spaces    and bad formatting.
+
+- Bad list item
+-Another bad list item
+-   Bad indentation
+
+## More Issues
+
+This line is way too long and should trigger the line length rule because it exceeds the maximum allowed characters per line and continues on and on and on.
+
+### Bad heading with trailing spaces    
+
+This heading has trailing spaces.
+
+## Code block without language
+
+```
+def bad_code():
+    return "no language specified"
+```
+
+## Bad link formatting
+
+[Bad link](https://example.com "title with spaces")
+
+## Bad emphasis
+
+This text has **bad** *emphasis* formatting.
+
+## Missing blank lines
+
+This paragraph is missing a blank line.
+This is another paragraph without proper spacing.

--- a/test_precommit_issues.py
+++ b/test_precommit_issues.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# This file is intentionally created to test pre-commit checks
+# It contains various issues that should trigger pre-commit hooks
+
+import os,sys
+import json
+from typing import *
+
+def bad_function(  x,y  ):
+    """This function has bad formatting and typos"""
+    # Bad spacing and formatting
+    result=  x+y
+    if result>10:
+        print("The resutl is greater than ten")
+    return result
+
+def another_bad_function():
+    # Missing type hints
+    data = {"key": "value", "number": 42}
+    for key, value in data.items():
+        print(f"{key}: {value}")
+    
+    # Bad import style
+    import re
+    pattern = re.compile(r'\d+')
+    return pattern
+
+class BadClass:
+    def __init__(self):
+        self.value = None
+    
+    def method_with_issues(self):
+        # More formatting issues
+        x=1
+        y=2
+        z=x+y
+        return z
+
+# Bad spacing and formatting at module level
+x=1
+y=2
+z=x+y
+
+# This will cause issues with various linters
+def unused_function():
+    pass
+
+# Bad string formatting
+message = "Hello" + " " + "World"
+
+# This will trigger the regex import check
+import re
+def regex_function():
+    pattern = re.compile(r'\d+')
+    return pattern
+
+# This will trigger the triton import check
+import triton
+
+# This will trigger the pickle import check
+import pickle
+import cloudpickle


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Related Issue: https://github.com/vllm-project/vllm/issues/23452

Tests will need to be re-run regardless in this case so it's better to fail and have the PR author fix linting issues than proceed to run the whole job.

It would be good to still run pre-commit in parallel so the total running time isn't impacted, just abort other tests (if possible).


## Test Plan
Run pre-commit checks on bad code and see if it aborts the pipeline.


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

