### PR TITLE
TokenizerBase#convert_ids_to_tokens adds support for single id conversion

### DIFF
--- a/tests/tokenization/test_mistral_tokenizer.py
+++ b/tests/tokenization/test_mistral_tokenizer.py
@@ -10,6 +10,8 @@ from mistral_common.protocol.instruct.tool_calls import (Function,
                                                          FunctionCall, Tool,
                                                          ToolCall)
 
+from vllm.transformers_utils.tokenizer import get_tokenizer
+from vllm.transformers_utils.tokenizer_base import TokenizerBase
 from vllm.transformers_utils.tokenizers.mistral import (
     make_mistral_chat_completion_request)
 
@@ -186,3 +188,20 @@ def test_make_mistral_chat_completion_request_list_content(
     actual_request = make_mistral_chat_completion_request(
         openai_request["messages"], openai_request["tools"])
     assert actual_request == expected_mistral_request
+
+
+def test_convert_ids_to_tokens():
+    tokenizer = get_tokenizer("mistralai/Mistral-7B-Instruct-v0.1",
+                              revision="main",
+                              tokenizer_mode="mistral")
+    assert isinstance(tokenizer, TokenizerBase)
+
+    ids: list[int] = tokenizer.encode("Hello World")
+
+    # Test single id
+    contents = tokenizer.convert_ids_to_tokens(ids[1])
+    assert contents == '▁Hello'
+
+    # Test list of integers
+    contents = tokenizer.convert_ids_to_tokens(ids)
+    assert contents == ['<s>', '▁Hello', '▁World']

--- a/tests/tokenization/test_tokenizer_registry.py
+++ b/tests/tokenization/test_tokenizer_registry.py
@@ -106,9 +106,9 @@ class TestTokenizer(TokenizerBase):
 
     def convert_ids_to_tokens(
         self,
-        ids: list[int],
+        ids: Union[int, list[int]],
         skip_special_tokens: bool = True,
-    ) -> list[str]:
+    ) -> Union[str, list[str]]:
         raise NotImplementedError()
 
 

--- a/vllm/transformers_utils/detokenizer_utils.py
+++ b/vllm/transformers_utils/detokenizer_utils.py
@@ -72,6 +72,8 @@ def convert_prompt_ids_to_tokens(
     new_tokens = tokenizer.convert_ids_to_tokens(
         prompt_ids[-INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET - 2:],
         skip_special_tokens=skip_special_tokens)
+    # Since we're passing a list of IDs, we know we'll get back a list of tokens
+    assert isinstance(new_tokens, list)
     read_offset = len(new_tokens)
     prefix_offset = max(
         read_offset - INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET, 0)
@@ -155,7 +157,7 @@ def detokenize_incrementally(
     if 0 <= new_token_id < len(tokenizer):
         # Put new_token_id in a list so skip_special_tokens is respected
         new_tokens = tokenizer.convert_ids_to_tokens(
-            [new_token_id], skip_special_tokens=skip_special_tokens)
+            new_token_id, skip_special_tokens=skip_special_tokens)
         if isinstance(new_tokens, str):
             new_tokens = [new_tokens]
     else:

--- a/vllm/transformers_utils/tokenizer_base.py
+++ b/vllm/transformers_utils/tokenizer_base.py
@@ -125,9 +125,9 @@ class TokenizerBase(ABC):
     @abstractmethod
     def convert_ids_to_tokens(
         self,
-        ids: list[int],
+        ids: Union[int, list[int]],
         skip_special_tokens: bool = True,
-    ) -> list[str]:
+    ) -> Union[str, list[str]]:
         raise NotImplementedError()
 
 


### PR DESCRIPTION
## Purpose
`TokenizerBase`#`convert_ids_to_tokens` add supports single ID conversion, ensuring consistency with `PreTrainedTokenizer` and `PreTrainedTokenizerFast`. This has the following advantages:

1）Maintain interface consistency: 
A single id can be safely converted to a token. For example, the `detokenize_incrementally` function no longer needs to convert `new_token_id` into a list:
```
new_tokens = tokenizer.convert_ids_to_tokens(new_token_id, skip_special_tokens=skip_special_tokens)
```

2）Avoid repeatedly converting between a single id and a list:
For example, `PreTrainedTokenizer` and `PreTrainedTokenizerFast` directly return the converted token for the single id, eliminating the need to create a list.

## Test Plan
Only MistralTokenizer inherits from TokenizerBase, so we only need to add:  `test_mistral_tokenizer#test_convert_ids_to_tokens`

## Test Result
Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

