### PR TITLE
[Build] Update Xgrammar to 0.1.24 to get a CVE fix

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,7 +24,7 @@ outlines_core == 0.2.11
 # required for outlines backend disk cache
 diskcache == 5.6.3
 lark == 1.2.2
-xgrammar == 0.1.23; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64"
+xgrammar == 0.1.24; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-9q5r-wfvf-rr7f

Signed-off-by: Russell Bryant <rbryant@redhat.com>
