### PR TITLE
[Compile] Fix Compile Warning for Ignoring `MIN_BLOCK_PER_SM`

### DIFF
--- a/csrc/launch_bounds_utils.h
+++ b/csrc/launch_bounds_utils.h
@@ -4,8 +4,8 @@
 #include <algorithm>
 
 // maximum blocks per SM cap
-#ifndef VLLM_LAUNCH_MAX_BLOCKS
-  #define VLLM_LAUNCH_MAX_BLOCKS 8
+#ifndef VLLM_LAUNCH_BLOCKS_CAP
+  #define VLLM_LAUNCH_BLOCKS_CAP 4
 #endif
 
 // compile-time estimate of max threads per SM for launch bounds.
@@ -17,11 +17,11 @@
   #endif
 #endif
 
-// compute the maximum number of blocks per SM to request in __launch_bounds__
+// compute the number of blocks per SM to request in __launch_bounds__
 #define VLLM_BLOCKS_DIV(VAL) (VLLM_MAX_THREADS_PER_SM / (VAL))
 #define VLLM_CLAMP_BLOCKS_PER_SM(VAL) \
   (((VAL) <= 0)                       \
        ? 1                            \
-       : (((VAL) < VLLM_LAUNCH_MAX_BLOCKS) ? (VAL) : VLLM_LAUNCH_MAX_BLOCKS))
+       : (((VAL) < VLLM_LAUNCH_BLOCKS_CAP) ? (VAL) : VLLM_LAUNCH_BLOCKS_CAP))
 #define VLLM_BLOCKS_PER_SM(BLOCK_THREADS) \
   VLLM_CLAMP_BLOCKS_PER_SM(VLLM_BLOCKS_DIV(BLOCK_THREADS))

--- a/csrc/launch_bounds_utils.h
+++ b/csrc/launch_bounds_utils.h
@@ -25,3 +25,14 @@
        : (((VAL) < VLLM_LAUNCH_BLOCKS_CAP) ? (VAL) : VLLM_LAUNCH_BLOCKS_CAP))
 #define VLLM_BLOCKS_PER_SM(BLOCK_THREADS) \
   VLLM_CLAMP_BLOCKS_PER_SM(VLLM_BLOCKS_DIV(BLOCK_THREADS))
+
+// runtime-time helper to compute blocks/SM
+static inline int vllm_runtime_blocks_per_sm(int block_threads) {
+  int device = -1;
+  cudaGetDevice(&device);
+  int max_threads_per_sm = VLLM_MAX_THREADS_PER_SM;
+  cudaDeviceGetAttribute(&max_threads_per_sm,
+                         cudaDevAttrMaxThreadsPerMultiProcessor, device);
+  int blocks = (block_threads > 0) ? (max_threads_per_sm / block_threads) : 1;
+  return VLLM_CLAMP_BLOCKS_PER_SM(blocks);
+}

--- a/csrc/launch_bounds_utils.h
+++ b/csrc/launch_bounds_utils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cuda_runtime_api.h>
+#include <algorithm>
+
+// maximum blocks per SM cap
+#ifndef VLLM_LAUNCH_MAX_BLOCKS
+  #define VLLM_LAUNCH_MAX_BLOCKS 8
+#endif
+
+// compile-time estimate of max threads per SM for launch bounds.
+#ifndef VLLM_MAX_THREADS_PER_SM
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 300
+    #define VLLM_MAX_THREADS_PER_SM 1536
+  #else
+    #define VLLM_MAX_THREADS_PER_SM 2048
+  #endif
+#endif
+
+// compute the maximum number of blocks per SM to request in __launch_bounds__
+#define VLLM_BLOCKS_DIV(VAL) (VLLM_MAX_THREADS_PER_SM / (VAL))
+#define VLLM_CLAMP_BLOCKS_PER_SM(VAL) \
+  (((VAL) <= 0)                       \
+       ? 1                            \
+       : (((VAL) < VLLM_LAUNCH_MAX_BLOCKS) ? (VAL) : VLLM_LAUNCH_MAX_BLOCKS))
+#define VLLM_BLOCKS_PER_SM(BLOCK_THREADS) \
+  VLLM_CLAMP_BLOCKS_PER_SM(VLLM_BLOCKS_DIV(BLOCK_THREADS))

--- a/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
+++ b/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
@@ -132,7 +132,8 @@ void silu_and_mul_nvfp4_quant_sm1xxa(torch::Tensor& output,  // [..., d]
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
   auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
   dim3 block(std::min(int(n / ELTS_PER_THREAD), 1024));
-  int const numBlocksPerSM = VLLM_BLOCKS_PER_SM(block.x);
+  int const numBlocksPerSM =
+      vllm_runtime_blocks_per_sm(static_cast<int>(block.x));
   dim3 grid(std::min(int(m), multiProcessorCount * numBlocksPerSM));
 
   VLLM_DISPATCH_HALF_TYPES(

--- a/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
+++ b/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
@@ -26,6 +26,7 @@
 #include "dispatch_utils.h"
 
 #include "cuda_utils.h"
+#include "launch_bounds_utils.h"
 #include "nvfp4_utils.cuh"
 
 namespace vllm {
@@ -63,7 +64,7 @@ __inline__ __device__ PackedVec<Type> compute_silu_mul(PackedVec<Type>& vec,
 
 // Use UE4M3 by default.
 template <class Type, bool UE8M0_SF = false>
-__global__ void __launch_bounds__(1024, 4)
+__global__ void __launch_bounds__(1024, VLLM_BLOCKS_PER_SM(1024))
     silu_mul_cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
                              float const* SFScale, uint32_t* out,
                              uint32_t* SFout) {
@@ -131,7 +132,7 @@ void silu_and_mul_nvfp4_quant_sm1xxa(torch::Tensor& output,  // [..., d]
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
   auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
   dim3 block(std::min(int(n / ELTS_PER_THREAD), 1024));
-  int const numBlocksPerSM = 2048 / block.x;
+  int const numBlocksPerSM = VLLM_BLOCKS_PER_SM(block.x);
   dim3 grid(std::min(int(m), multiProcessorCount * numBlocksPerSM));
 
   VLLM_DISPATCH_HALF_TYPES(

--- a/csrc/quantization/fp4/nvfp4_experts_quant.cu
+++ b/csrc/quantization/fp4/nvfp4_experts_quant.cu
@@ -234,8 +234,9 @@ void quant_impl(void* output, void* output_scale, void* input,
   int const workSizePerRow = k / ELTS_PER_THREAD;
   int const totalWorkSize = m_topk * workSizePerRow;
   dim3 block(std::min(workSizePerRow, 512));
-  // Get number of blocks per SM (assume we can fully utilize the SM).
-  int const numBlocksPerSM = VLLM_BLOCKS_PER_SM(static_cast<int>(block.x));
+  // Get number of blocks per SM
+  int const numBlocksPerSM =
+      vllm_runtime_blocks_per_sm(static_cast<int>(block.x));
   dim3 grid(std::min(static_cast<int>((totalWorkSize + block.x - 1) / block.x),
                      multiProcessorCount * numBlocksPerSM));
   while (grid.x <= multiProcessorCount && block.x > 64) {

--- a/csrc/quantization/fp4/nvfp4_experts_quant.cu
+++ b/csrc/quantization/fp4/nvfp4_experts_quant.cu
@@ -26,12 +26,13 @@
 #include "dispatch_utils.h"
 
 #include "nvfp4_utils.cuh"
+#include "launch_bounds_utils.h"
 
 namespace vllm {
 
 // Use UE4M3 by default.
 template <class Type, bool UE8M0_SF = false, bool SMALL_NUM_EXPERTS = false>
-__global__ void __launch_bounds__(512, 4)
+__global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
     cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
                     float const* SFScale, uint32_t* out, uint32_t* SFout,
                     uint32_t* input_offset_by_experts,
@@ -129,7 +130,7 @@ __global__ void __launch_bounds__(512, 4)
 
 // Kernel for LARGE_M_TOPK = true (large m_topk optimized version)
 template <class Type, bool UE8M0_SF = false, bool SMALL_NUM_EXPERTS = false>
-__global__ void __launch_bounds__(1024, 4)
+__global__ void __launch_bounds__(1024, VLLM_BLOCKS_PER_SM(1024))
     cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
                     float const* SFScale, uint32_t* out, uint32_t* SFout,
                     uint32_t* input_offset_by_experts,
@@ -234,7 +235,7 @@ void quant_impl(void* output, void* output_scale, void* input,
   int const totalWorkSize = m_topk * workSizePerRow;
   dim3 block(std::min(workSizePerRow, 512));
   // Get number of blocks per SM (assume we can fully utilize the SM).
-  int const numBlocksPerSM = 2048 / block.x;
+  int const numBlocksPerSM = VLLM_BLOCKS_PER_SM(static_cast<int>(block.x));
   dim3 grid(std::min(static_cast<int>((totalWorkSize + block.x - 1) / block.x),
                      multiProcessorCount * numBlocksPerSM));
   while (grid.x <= multiProcessorCount && block.x > 64) {

--- a/csrc/quantization/fp4/nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_kernels.cu
@@ -26,13 +26,14 @@
 #include "dispatch_utils.h"
 
 #include "cuda_utils.h"
+#include "launch_bounds_utils.h"
 #include "nvfp4_utils.cuh"
 
 namespace vllm {
 
 // Use UE4M3 by default.
 template <class Type, bool UE8M0_SF = false>
-__global__ void __launch_bounds__(512, 4)
+__global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
     cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
                     float const* SFScale, uint32_t* out, uint32_t* SFout) {
   using PackedVec = PackedVec<Type>;
@@ -76,7 +77,7 @@ void invokeFP4Quantization(int m, int n, T const* input, float const* SFScale,
   // Each thread converts 8 values.
   dim3 block(std::min(int(n / ELTS_PER_THREAD), 512));
   // Get number of blocks per SM (assume we can fully utilize the SM).
-  int const numBlocksPerSM = 2048 / block.x;
+  int const numBlocksPerSM = VLLM_BLOCKS_PER_SM(block.x);
   dim3 grid(std::min(int(m), multiProcessorCount * numBlocksPerSM));
 
   // Launch the cvt kernel.

--- a/csrc/quantization/fp4/nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_kernels.cu
@@ -76,8 +76,9 @@ void invokeFP4Quantization(int m, int n, T const* input, float const* SFScale,
   // Grid, Block size.
   // Each thread converts 8 values.
   dim3 block(std::min(int(n / ELTS_PER_THREAD), 512));
-  // Get number of blocks per SM (assume we can fully utilize the SM).
-  int const numBlocksPerSM = VLLM_BLOCKS_PER_SM(block.x);
+  // Get number of blocks per SM
+  int const numBlocksPerSM =
+      vllm_runtime_blocks_per_sm(static_cast<int>(block.x));
   dim3 grid(std::min(int(m), multiProcessorCount * numBlocksPerSM));
 
   // Launch the cvt kernel.


### PR DESCRIPTION
## Purpose

Originally:

```bash
[2/5] Building CUDA object CMakeFiles/_C.dir/csrc/qu...ation/fp4/activation_nvfp4_quant_fusion_kernels.cu.o
ptxas warning : Value of threads per SM for entry _ZN4vllm24silu_mul_cvt_fp16_to_fp4I13__nv_bfloat16Lb0EEEviiPKT_PKfPjS7_ is out of range. .minnctapersm will be ignored
ptxas warning : Value of threads per SM for entry _ZN4vllm24silu_mul_cvt_fp16_to_fp4I6__halfLb0EEEviiPKT_PKfPjS7_ is out of range. .minnctapersm will be ignored
[3/5] Building CUDA object CMakeFiles/_C.dir/csrc/quantization/fp4/nvfp4_experts_quant.cu.o
ptxas warning : Value of threads per SM for entry _ZN4vllm15cvt_fp16_to_fp4I13__nv_bfloat16Lb0ELb1EEEviiPKT_PKfPjS7_S7_S7_i is out of range. .minnctapersm will be ignored
ptxas warning : Value of threads per SM for entry _ZN4vllm15cvt_fp16_to_fp4I13__nv_bfloat16Lb0ELb0EEEviiPKT_PKfPjS7_S7_S7_i is out of range. .minnctapersm will be ignored
ptxas warning : Value of threads per SM for entry _ZN4vllm15cvt_fp16_to_fp4I6__halfLb0ELb1EEEviiPKT_PKfPjS7_S7_S7_i is out of range. .minnctapersm will be ignored
ptxas warning : Value of threads per SM for entry _ZN4vllm15cvt_fp16_to_fp4I6__halfLb0ELb0EEEviiPKT_PKfPjS7_S7_S7_i is out of range. .minnctapersm will be ignored
```

Now:

```bash
4/5] Install the project...
-- Install configuration: "Release"
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/cumem_allocator.abi3.so
-- Installing: /data/vllm-community-homes/vllm-user-6/vllm/vllm/_C.abi3.so
-- Set non-toolchain portion of runtime path of "/data/vllm-community-homes/vllm-user-6/vllm/vllm/_C.abi3.so" to ""
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/_moe_C.abi3.so
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/_vllm_fa2_C.abi3.so
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/_vllm_fa3_C.abi3.so
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops/triton
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops/triton/rotary.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops/triton/__init__.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/layers
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/layers/rotary.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/layers/__init__.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/__init__.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops/triton
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops/triton/rotary.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/ops/triton/__init__.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/layers
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/layers/rotary.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/layers/__init__.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/__init__.py
-- Up-to-date: /data/vllm-community-homes/vllm-user-6/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
```