### PR TITLE
[bugfix] fix structured outputs key missing issue from #24929

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -576,8 +576,10 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_decode_tokens,
             req_to_new_blocks,
         )
+        scheduled_requests = (scheduled_new_reqs + scheduled_running_reqs +
+                              scheduled_resumed_reqs)
         structured_output_request_ids, grammar_bitmask = (
-            self.get_grammar_bitmask(self.running,
+            self.get_grammar_bitmask(scheduled_requests,
                                      scheduled_spec_decode_tokens))
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -90,13 +90,14 @@ def apply_grammar_bitmask(
     seq = sorted(scheduler_output.structured_output_request_ids.items(),
                  key=lambda x: x[1])
     for req_id, _ in seq:
-        logit_index = struct_out_req_batch_indices[req_id]
         num_spec_tokens = len(
             scheduler_output.scheduled_spec_decode_tokens.get(req_id, []))
-        for i in range(1 + num_spec_tokens):
-            sorted_bitmask[logit_index + i] = \
-                grammar_bitmask[cumulative_index + i]
-            out_indices.append(logit_index + i)
+        if req_id in struct_out_req_batch_indices:
+            logit_index = struct_out_req_batch_indices[req_id]
+            for i in range(1 + num_spec_tokens):
+                sorted_bitmask[logit_index + i] = \
+                    grammar_bitmask[cumulative_index + i]
+                out_indices.append(logit_index + i)
         cumulative_index += 1 + num_spec_tokens
     grammar_bitmask = sorted_bitmask
 

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -90,6 +90,9 @@ def apply_grammar_bitmask(
     seq = sorted(scheduler_output.structured_output_request_ids.items(),
                  key=lambda x: x[1])
     for req_id, _ in seq:
+        if req_id not in struct_out_req_batch_indices:
+            # preempted req ids are not in input_batch, we skip in this case
+            continue
         logit_index = struct_out_req_batch_indices[req_id]
         num_spec_tokens = len(
             scheduler_output.scheduled_spec_decode_tokens.get(req_id, []))

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -90,9 +90,6 @@ def apply_grammar_bitmask(
     seq = sorted(scheduler_output.structured_output_request_ids.items(),
                  key=lambda x: x[1])
     for req_id, _ in seq:
-        if req_id not in struct_out_req_batch_indices:
-            # preempted req ids are not in input_batch, we skip in this case
-            continue
         logit_index = struct_out_req_batch_indices[req_id]
         num_spec_tokens = len(
             scheduler_output.scheduled_spec_decode_tokens.get(req_id, []))


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix issue https://github.com/vllm-project/vllm/issues/24929

Based on original logic from https://github.com/vllm-project/vllm/pull/23361 refactoring

we should get_grammar_bitmask from scheduled requests instead of self.running,
also fix apply_grammar_bitmask to be safe to avoid crashing.

## Test Plan

```
python3 examples/offline_inference/structured_outputs.py
```

## Test Result

```
--------------------------------------------------
Structured outputs by Choice: Positive
--------------------------------------------------
Structured outputs by Regex: AlanTuring@enigma.com
--------------------------------------------------
Structured outputs by JSON: { "brand": "Lamborghini", "model": "Countach", "car_type": "Coupe" }
--------------------------------------------------
Structured outputs by Grammar: SELECT col_1  from table_1  where col_2 = 1 
--------------------------------------------------
```
