### PR TITLE
[Kernel] [Mamba] Remove BLOCK_H=1 from list of tuneable configurations for `_chunk_cumsum_fwd_kernel`

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/ssd_chunk_state.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_chunk_state.py
@@ -17,7 +17,6 @@ from .mamba_ssm import softplus
 
 @triton.autotune(
     configs=[
-        triton.Config({'BLOCK_SIZE_H': 1}),
         triton.Config({'BLOCK_SIZE_H': 2}),
         triton.Config({'BLOCK_SIZE_H': 4}),
         triton.Config({'BLOCK_SIZE_H': 8}),


### PR DESCRIPTION

## Purpose

Resolves #25194

The call to `tl.cumsum` in `_chunk_cumsum_fwd_kernel` produces numerically different output depending on whether `BLOCK_H=1` vs. `BLOCK_H>1`. We suspect it is using a different implementation in the former case (e.g., parallel reduction in sequence dimension) whereas in the latter case it may instead rely on parallelism in the head dimension. 

The auto-tuner can naturally pick different configuration each time due to fluctuations in runtime, but if it happens to choose `BLOCK_H=1` the user will see numerically different output. 

We propose removing this configuration from the list to remove this source of non-determinism for mamba-based models. 

## Test Plan

Script from  #25194

## Test Result

Now always produces the same output.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

