### PR TITLE
Ignore invalid READY EngineCoreRequestType

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -876,10 +876,13 @@ class EngineCoreProc(EngineCore):
                     if raw_type not in EngineCoreRequestType._value2member_map_:
                         # If type is a stray coordinator control token, ignore
                         if raw_type == b"READY":
-                            logger.debug("Ignoring stray READY on input socket.")
+                            logger.debug(
+                                "Ignoring stray READY on input socket.")
                             continue
                         # Surface unexpected types
-                        raise ValueError(f"Unexpected request type on input socket: {raw_type!r}")
+                        raise ValueError(
+                            f"Unexpected request type on input socket: "
+                            f"{raw_type!r}")
 
                     request_type = EngineCoreRequestType(raw_type)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When utilizing `data_parallel_size=2` in an `AsyncLLMEngine` vllm has failed to start with the following error:
```
(EngineCore_1 pid=309) Exception in thread Thread-3 (process_input_sockets):
(EngineCore_1 pid=309) Traceback (most recent call last):
(EngineCore_1 pid=309)   File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
(EngineCore_1 pid=309)     self.run()
(EngineCore_1 pid=309)   File "/usr/lib/python3.10/threading.py", line 953, in run
(EngineCore_1 pid=309)     self._target(*self._args, **self._kwargs)
(EngineCore_1 pid=309)   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 858, in process_input_sockets
(EngineCore_1 pid=309)     request_type = EngineCoreRequestType(
(EngineCore_1 pid=309)   File "/usr/lib/python3.10/enum.py", line 385, in __call__
(EngineCore_1 pid=309)     return cls.__new__(cls, value)
(EngineCore_1 pid=309)   File "/usr/lib/python3.10/enum.py", line 710, in __new__
(EngineCore_1 pid=309)     raise ve_exc
(EngineCore_1 pid=309) ValueError: b'READY' is not a valid EngineCoreRequestType
(EngineCore_0 pid=306) Exception in thread Thread-3 (process_input_sockets):
(EngineCore_0 pid=306) Traceback (most recent call last):
(EngineCore_0 pid=306)   File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
(EngineCore_0 pid=306)     self.run()
(EngineCore_0 pid=306)   File "/usr/lib/python3.10/threading.py", line 953, in run
(EngineCore_0 pid=306)     self._target(*self._args, **self._kwargs)
(EngineCore_0 pid=306)   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 858, in process_input_sockets
(EngineCore_0 pid=306)     request_type = EngineCoreRequestType(
(EngineCore_0 pid=306)   File "/usr/lib/python3.10/enum.py", line 385, in __call__
(EngineCore_0 pid=306)     return cls.__new__(cls, value)
(EngineCore_0 pid=306)   File "/usr/lib/python3.10/enum.py", line 710, in __new__
(EngineCore_0 pid=306)     raise ve_exc
(EngineCore_0 pid=306) ValueError: b'READY' is not a valid EngineCoreRequestType
```
This has consistently happened when tested with `0.10.1` and `0.10.2`.
The setup for this failure has been the following:

- 2xNVIDIA® L40S PCIe
- CUDA Version: 12.8
- GPTQ-quantized Mistral model (see config.json below)
- `tensor_parallel_size`: 0
- `pipeline_parallel_size`: 0
- `data_parallel_size`: 2
- `enforce_eager`: True

<details>
<summary>Model config.json</summary>

``` json
{
--
"architectures": [
"MistralForCausalLM"
],
"attention_dropout": 0.0,
"bos_token_id": 1,
"eos_token_id": 2,
"head_dim": 128,
"hidden_act": "silu",
"hidden_size": 5120,
"initializer_range": 0.02,
"intermediate_size": 32768,
"max_position_embeddings": 32768,
"model_type": "mistral",
"num_attention_heads": 32,
"num_hidden_layers": 40,
"num_key_value_heads": 8,
"quantization_config": {
"bits": 4,
"checkpoint_format": "gptq",
"desc_act": true,
"group_size": 128,
"lm_head": false,
"meta": {
"damp_auto_increment": 0.0025,
"damp_percent": 0.01,
"mse": 0.0,
"quantizer": [
"gptqmodel:2.2.0"
],
"static_groups": false,
"true_sequential": true,
"uri": "https://github.com/modelcloud/gptqmodel"
},
"pack_dtype": "int32",
"quant_method": "gptq",
"sym": true
},
"rms_norm_eps": 1e-05,
"rope_theta": 100000000.0,
"sliding_window": null,
"tie_word_embeddings": false,
"torch_dtype": "bfloat16",
"transformers_version": "4.51.3",
"use_cache": true,
"vocab_size": 131072
}
```

</details>

It looks like the source of the issue is the `DPCoordinator` dispatching a `b'READY'` message here:
https://github.com/vllm-project/vllm/blob/064cac7bb7251862a841d8057d83581350edf837/vllm/v1/engine/coordinator.py#L185

which then throws an error as an invalid enum value within the engine core here:
https://github.com/vllm-project/vllm/blob/064cac7bb7251862a841d8057d83581350edf837/vllm/v1/engine/core.py#L873

resulting in the crash.

## Test Results
I have confirmed that the issue is resolved by this PR and models are loaded and can be inferenced as expected.
Scope of this test has been the same environment as described above. 2xL40S, quantized mistral model, data parallelism of 2.

If this is fixing the issue in the wrong place (at reception of the invalid type instead of dispatchment) please advise on how it should be addressed instead. Thank you!

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x ] The test plan, such as providing test command.
- [ x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

