### PR TITLE
[Log] Optimize kv cache memory log from Bytes to GiB

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -391,7 +391,7 @@ class Worker(WorkerBase):
                 f"utilize gpu memory. Current kv cache memory in use is "
                 f"{GiB(self.available_kv_cache_memory_bytes)} GiB.")
 
-            logger.info(msg)
+            logger.debug(msg)
 
         # Warm up sampler and preallocate memory buffer for logits and other
         # sampling related tensors of max possible shape to avoid memory

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -383,9 +383,11 @@ class Worker(WorkerBase):
                 f"for non-torch memory, and {GiB(cuda_graph_memory_bytes)} "
                 f"GiB for CUDAGraph memory. Replace gpu_memory_utilization "
                 f"config with `--kv-cache-memory="
-                f"{GiB(kv_cache_memory_bytes_to_requested_limit)} GiB to fit "
+                f"{kv_cache_memory_bytes_to_requested_limit}` "
+                f"({GiB(kv_cache_memory_bytes_to_requested_limit)} GiB) to fit "
                 f"into requested memory, or `--kv-cache-memory="
-                f"{GiB(kv_cache_memory_bytes_to_gpu_limit)} GiB` to fully "
+                f"{kv_cache_memory_bytes_to_gpu_limit}` "
+                f"({GiB(kv_cache_memory_bytes_to_gpu_limit)} GiB) to fully "
                 f"utilize gpu memory. Current kv cache memory in use is "
                 f"{GiB(self.available_kv_cache_memory_bytes)} GiB.")
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -383,11 +383,11 @@ class Worker(WorkerBase):
                 f"for non-torch memory, and {GiB(cuda_graph_memory_bytes)} "
                 f"GiB for CUDAGraph memory. Replace gpu_memory_utilization "
                 f"config with `--kv-cache-memory="
-                f"{kv_cache_memory_bytes_to_requested_limit}` to fit into "
-                f"requested memory, or `--kv-cache-memory="
-                f"{kv_cache_memory_bytes_to_gpu_limit}` to fully "
+                f"{GiB(kv_cache_memory_bytes_to_requested_limit)} GiB to fit "
+                f"into requested memory, or `--kv-cache-memory="
+                f"{GiB(kv_cache_memory_bytes_to_gpu_limit)} GiB` to fully "
                 f"utilize gpu memory. Current kv cache memory in use is "
-                f"{int(self.available_kv_cache_memory_bytes)} bytes.")
+                f"{GiB(self.available_kv_cache_memory_bytes)} GiB.")
 
             logger.info(msg)
 


### PR DESCRIPTION
## Purpose

`Actual usage is 95.97 GiB for weight, 5.42 GiB for peak activation, 2.75 GiB for non-torch memory, and 1.31 GiB for CUDAGraph memory. Replace gpu_memory_utilization config with `--kv-cache-memory=58969782886` to fit into requested memory, or `--kv-cache-memory=77365384192` to fully utilize gpu memory. Current kv cache memory in use is 60536355430 bytes.`

Changing to:

`Actual usage is 95.97 GiB for weight, 5.68 GiB for peak activation, 2.75 GiB for non-torch memory, and 0.0 GiB for CUDAGraph memory. Replace gpu_memory_utilization config with `--kv-cache-memory=58969782886` (54.9 GiB) to fit into requested memory, or `--kv-cache-memory=77365384192` (73.1 GiB) to fully utilize gpu memory. Current kv cache memory in use is 38.28 GiB.`
