### PR TITLE
[Docs] Fix griffe warnings in vllm/multimodal

### DIFF
--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -569,8 +569,8 @@ class MultiModalFieldConfig:
         Args:
             modality: The modality of the multi-modal item that uses this
                 keyword argument.
-            slices: For each multi-modal item, the size of the slice that
-                is used to extract the data corresponding to it.
+            size_per_item: For each multi-modal item, the size of the slice
+                that is used to extract the data corresponding to it.
             dim: The dimension to slice, default to 0.
 
         Example:
@@ -590,7 +590,7 @@ class MultiModalFieldConfig:
 
         ```
         Given:
-            slices: [3, 4, 2]
+            size_per_item: [3, 4, 2]
             dim: 1
 
         Input:

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -395,7 +395,9 @@ def group_mm_kwargs_by_modality(
     modality together into the same `MultiModalKwargs` instance.
 
     Args:
-        mm_inputs: List of `MultiModalKwargsItem`.
+        mm_kwargs: List of `MultiModalKwargsItem`.
+        device: The device to place the grouped tensors on.
+        pin_memory: Whether to pin memory for faster host-to-device transfer.
 
     Yields:
         A tuple `(modality, num_items, grouped_kwargs)`.


### PR DESCRIPTION
Fix these warnings:

```
WARNING - griffe: vllm/multimodal/inputs.py:571: No type or annotation for parameter 'slices'
WARNING - griffe: vllm/multimodal/inputs.py:571: Parameter 'slices' does not appear in the function signature
WARNING - griffe: vllm/multimodal/utils.py:398: No type or annotation for parameter 'mm_inputs'
WARNING - griffe: vllm/multimodal/utils.py:398: Parameter 'mm_inputs' does not appear in the function signature
```
Related to issue #25020 