### PR TITLE
[Docs] Fix warnings in vllm/profiler and vllm/transformers_utils

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -102,6 +102,7 @@ plugins:
           - https://numpy.org/doc/stable/objects.inv
           - https://pytorch.org/docs/stable/objects.inv
           - https://psutil.readthedocs.io/en/stable/objects.inv
+          - https://huggingface.co/docs/transformers/main/en/objects.inv
 
 markdown_extensions:
   - attr_list

--- a/vllm/profiler/layerwise_profile.py
+++ b/vllm/profiler/layerwise_profile.py
@@ -353,8 +353,8 @@ class layerwise_profile(profile):
 
         Args:
             num_running_seqs (Optional[int], optional): When given,
-            num_running_seqs will be passed to LayerProfileResults for metadata
-            update. Defaults to None.
+                num_running_seqs will be passed to LayerProfileResults
+                for metadata update. Defaults to None.
         """
         super().__init__(
             activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],

--- a/vllm/transformers_utils/configs/jais.py
+++ b/vllm/transformers_utils/configs/jais.py
@@ -74,8 +74,7 @@ class JAISConfig(PretrainedConfig):
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should return the last key/values
             attentions (not used by all models).
-        scale_attn_by_inverse_layer_idx
-            (`bool`, *optional*, defaults to `False`): 
+        scale_attn_by_inverse_layer_idx (`bool`, *optional*, default `True`):
             Whether to additionally scale attention weights 
             by `1 / layer_idx + 1`.
         reorder_and_upcast_attn (`bool`, *optional*, defaults to `False`):


### PR DESCRIPTION
Fix these warnings:

```
WARNING - griffe: vllm/profiler/layerwise_profile.py:355: Failed to get 'name: description' pair
from 'num_running_seqs will be passed to LayerProfileResults for metadata'

WARNING - griffe: vllm/profiler/layerwise_profile.py:356: Failed to get 'name: description' pair
from 'update. Defaults to None.'

WARNING - griffe: vllm/transformers_utils/configs/jais.py:76: Failed to get 'name: description' pair
from 'scale_attn_by_inverse_layer_idx'

WARNING - mkdocs_autorefs: api/vllm/transformers_utils/dynamic_module.md: from
/home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/24820/vllm/transformers_utils/dynamic_module.py:29: (vllm.transformers_utils.dynamic_module.try_get_class_from_dynamic_module)
Could not find cross-reference target 'transformers.dynamic_module_utils.get_class_from_dynamic_module'
```
Related to https://github.com/vllm-project/vllm/issues/25020