### PR TITLE
Remove Redundant Assignment in Qwen3_VisionPatchMerger

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -223,9 +223,7 @@ class Qwen3_VisionPatchMerger(nn.Module):
 
         if norm_layer is None:
             norm_layer = partial(nn.LayerNorm, eps=1e-6)
-        self.use_postshuffle_norm = use_postshuffle_norm
-        self.norm = norm_layer(
-            self.hidden_size if use_postshuffle_norm else context_dim)
+        self.norm = norm_layer(context_dim)
         self.linear_fc1 = ColumnParallelLinear(self.hidden_size,
                                                self.hidden_size,
                                                bias=True,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR refactors the Qwen3_VisionPatchMerger class to remove redundant assignments related to use_postshuffle_norm and the initialization of the normalization layer. 
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

