### PR TITLE
[Bugfix] GPT OSS Attritbute error on H100

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
 
 import torch
 
@@ -14,7 +14,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.utils import cdiv, has_triton_kernels
 from vllm.utils.flashinfer import has_flashinfer_cutlass_fused_moe
 
-if TYPE_CHECKING and has_triton_kernels:
+if has_triton_kernels():
     from triton_kernels.matmul_ogs import PrecisionConfig
 
 logger = init_logger(__name__)

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -638,8 +638,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             return None
 
         if self.mxfp4_backend == Mxfp4Backend.TRITON:
-            w1_scale = layer.w13_precision_config
-            w2_scale = layer.w2_precision_config
+            w1_scale = self.w13_precision_config
+            w2_scale = self.w2_precision_config
         else:
             w1_scale = layer.w13_weight_scale
             w2_scale = layer.w2_weight_scale


### PR DESCRIPTION
## Purpose
Executing GPTOSS on H100 triggers an attribute error.
Command `vllm serve openai/gpt-oss-20b` on `main` on H100 triggers,
```
...
(EngineCore_DP0 pid=1838968)     self.ensure_moe_quant_config()
(EngineCore_DP0 pid=1838968)   File "/home/varun/code/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 1535, in ensure_moe_quant_config
(EngineCore_DP0 pid=1838968)     self.quant_method.get_fused_moe_quant_config(self))
(EngineCore_DP0 pid=1838968)   File "/home/varun/code/vllm/vllm/model_executor/layers/quantization/mxfp4.py", line 641, in get_fused_moe_quant_config
(EngineCore_DP0 pid=1838968)     w1_scale = layer.w13_precision_config
(EngineCore_DP0 pid=1838968)   File "/home/varun/code/vllm/vllm-test/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1964, in __getattr__
(EngineCore_DP0 pid=1838968)     raise AttributeError(
(EngineCore_DP0 pid=1838968) AttributeError: 'FusedMoE' object has no attribute 'w13_precision_config'
[rank0]:[W919 05:11:47.324967971 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
...
```

## Test Plan
Command : `vllm serve openai/gpt-oss-20b `

## Test Result
Runs successfully with this PR 
