### PR TITLE
[Misc] Add is_singleton_prompt type guard function 

### DIFF
--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -4,6 +4,7 @@
 import pytest
 
 from vllm.inputs import zip_enc_dec_prompts
+from vllm.inputs.data import is_singleton_prompt
 from vllm.inputs.parse import parse_and_batch_prompt
 
 STRING_INPUTS = [
@@ -78,3 +79,38 @@ def test_zip_enc_dec_prompts(mm_processor_kwargs, expected_mm_kwargs):
         assert zipped['encoder_prompt'] == enc
         assert zipped['decoder_prompt'] == dec
         assert zipped['mm_processor_kwargs'] == exp_kwargs
+
+
+@pytest.mark.parametrize(
+    'prompt,expected',
+    [
+        # SingletonPrompt cases (should return True)
+        ({
+            "prompt_token_ids": [1, 2, 3]
+        }, True),
+        ({
+            "prompt_token_ids": [1]
+        }, True),
+        ({
+            "prompt_token_ids": []
+        }, True),
+        ({
+            "prompt_token_ids": [1, 2, 3],
+            "prompt": "Hello world"
+        }, True),
+        # ExplicitEncoderDecoderPrompt cases (should return False)
+        ({
+            "encoder_prompt": "Encoder text",
+            "decoder_prompt": "Decoder text"
+        }, False),
+        ({
+            "encoder_prompt": "Encoder text",
+            "decoder_prompt": None
+        }, False),
+        ({
+            "decoder_prompt": "Decoder text"
+        }, False),
+    ])
+def test_is_singleton_prompt(prompt, expected):
+    """Test is_singleton_prompt function."""
+    assert is_singleton_prompt(prompt) is expected

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -120,15 +120,15 @@ Note that "singleton" is as opposed to a data structure
 which encapsulates multiple prompts, i.e. of the sort
 which may be utilized for encoder/decoder models when
 the user desires to express both the encoder & decoder
-prompts explicitly, i.e. 
+prompts explicitly, i.e.
 [`ExplicitEncoderDecoderPrompt`][vllm.inputs.data.ExplicitEncoderDecoderPrompt]
 
-A prompt of type [`SingletonPrompt`][vllm.inputs.data.SingletonPrompt] may be 
+A prompt of type [`SingletonPrompt`][vllm.inputs.data.SingletonPrompt] may be
 employed as (1) input to a decoder-only model, (2) input to
 the encoder of an encoder/decoder model, in the scenario
 where the decoder-prompt is not specified explicitly, or
 (3) as a member of a larger data structure encapsulating
-more than one prompt, i.e. 
+more than one prompt, i.e.
 [`ExplicitEncoderDecoderPrompt`][vllm.inputs.data.ExplicitEncoderDecoderPrompt]
 """
 
@@ -194,6 +194,17 @@ both decoder-only and encoder/decoder input types:
 - A single data structure containing both an encoder and a decoder prompt
   ([`ExplicitEncoderDecoderPrompt`][vllm.inputs.data.ExplicitEncoderDecoderPrompt])
 """
+
+
+def is_singleton_prompt(prompt: PromptType) -> TypeIs[SingletonPrompt]:
+    """Return True if the given prompt is SingletonPrompt."""
+    if isinstance(prompt, dict):
+        # Explicit encoder/decoder prompt → not a singleton
+        if "encoder_prompt" in prompt or "decoder_prompt" in prompt:
+            return False
+        # TokensPrompt: must contain "prompt_token_ids"
+        return "prompt_token_ids" in prompt
+    return False
 
 
 class TokenInputs(TypedDict):
@@ -287,7 +298,7 @@ class EncoderDecoderInputs(TypedDict):
 
 SingletonInputs = Union[TokenInputs, EmbedsInputs, "MultiModalInputs"]
 """
-A processed [`SingletonPrompt`][vllm.inputs.data.SingletonPrompt] which can be 
+A processed [`SingletonPrompt`][vllm.inputs.data.SingletonPrompt] which can be
 passed to [`vllm.sequence.Sequence`][].
 """
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Given a prompt with type `PromptType`, `is_singleton_prompt` function is a type guard that determines whether a given `PromptType` is a `SingletonPrompt` or not. The usage of this function could be used before using `is_tokens_prompt`, which requires the prompt type to be `SingletonPrompt`. For example, 

```
if is_singleton_prompt(prompt) and is_tokens_prompt(prompt)
```

## Test Plan

```
pytest tests/test_inputs.py 
```

## Test Result

```
======================================================================== test session starts ========================================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/huaminli/vllm
configfile: pyproject.toml
plugins: anyio-4.10.0
collected 25 items                                                                                                                                                  

tests/test_inputs.py .........................                                                                                                                [100%]

======================================================================== 25 passed in 4.98s =========================================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

