### PR TITLE
[Rocm] [quickreduce] optimize quickduce for mi 350_355

### DIFF
--- a/csrc/quickreduce/base.h
+++ b/csrc/quickreduce/base.h
@@ -19,7 +19,7 @@ using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
 
 // Setup acquire-release semantics for vector memory reads (mubuf instruction)
 // as per architecture.
-#if defined(__gfx942__)
+#if defined(__gfx942__) || defined(__gfx950__)
 // CDNA3: Scope bits sc0, sc1
   #define MUBUF_ACQUIRE 16
   #define MUBUF_RELEASE 16
@@ -88,7 +88,7 @@ __quickreduce_device_inline__ static void buffer_store_dwordx4(
     int32_t aux) __asm("llvm.amdgcn.raw.buffer.store.v4i32");
 
 __quickreduce_device_inline__ static void set_fp16_ovfl(bool const value) {
-#if defined(__gfx942__)
+#if defined(__gfx942__) || defined(__gfx950__)
   if (value) {
     asm volatile("s_setreg_imm32_b32 0xdc1, 1;" ::);
   } else {


### PR DESCRIPTION

TODO:
1.Make modifications to the macro definitions in the CU code based on the architecture.
2.Support asymmetric quantization to enhance precision
3.Optimized pattern for Mi 350.
4.Improve the inference speed of BF16

(Please do not refer to the modifications here.)