### PR TITLE
[TPU][Bugfix][CI] Fix broken tests/build dependency

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-tpu-v1-test-part2.sh
+++ b/.buildkite/scripts/hardware_ci/run-tpu-v1-test-part2.sh
@@ -62,7 +62,7 @@ echo "--- Installing Python dependencies ---"
 python3 -m pip install --progress-bar off git+https://github.com/thuml/depyf.git \
     && python3 -m pip install --progress-bar off pytest pytest-asyncio tpu-info \
     && python3 -m pip install --progress-bar off "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d" \
-    && python3 -m pip install --progress-bar off hf-transfer
+    && python3 -m pip install --progress-bar off hf-transfer tblib==3.1.0
 echo "--- Python dependencies installed ---"
 export VLLM_USE_V1=1
 export VLLM_XLA_CHECK_RECOMPILATION=1

--- a/.buildkite/scripts/hardware_ci/run-tpu-v1-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-tpu-v1-test.sh
@@ -62,7 +62,7 @@ echo "--- Installing Python dependencies ---"
 python3 -m pip install --progress-bar off git+https://github.com/thuml/depyf.git \
     && python3 -m pip install --progress-bar off pytest pytest-asyncio tpu-info \
     && python3 -m pip install --progress-bar off "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d" \
-    && python3 -m pip install --progress-bar off hf-transfer
+    && python3 -m pip install --progress-bar off hf-transfer tblib==3.1.0
 echo "--- Python dependencies installed ---"
 export VLLM_USE_V1=1
 export VLLM_XLA_CHECK_RECOMPILATION=1

--- a/tests/vllm_test_utils/setup.py
+++ b/tests/vllm_test_utils/setup.py
@@ -7,5 +7,4 @@ setup(
     name='vllm_test_utils',
     version='0.1',
     packages=['vllm_test_utils'],
-    install_requires=['tblib'],
 )

--- a/tests/vllm_test_utils/setup.py
+++ b/tests/vllm_test_utils/setup.py
@@ -7,4 +7,5 @@ setup(
     name='vllm_test_utils',
     version='0.1',
     packages=['vllm_test_utils'],
+    install_requires=['tblib'],
 )


### PR DESCRIPTION
Current TPU tests are broken (most recent run I could find https://buildkite.com/vllm/fastcheck/builds/43254#01996191-3363-4e91-aa8d-b515f77f9953) .

```
ImportError while loading conftest '/workspace/vllm/tests/conftest.py'.
2025-09-19 12:51:03 UTC
tests/conftest.py:6: in <module>
2025-09-19 12:51:03 UTC
    from tblib import pickling_support
2025-09-19 12:51:03 UTC
E   ModuleNotFoundError: No module named 'tblib'
```

This patch adds `tblib` to be installed with vllm_test_utils package which is then in turn installed on TPU. 

I am not quite familiar with this  `vllm_test_utils` package, so hoping to get some better feedback here.

Maybe @DarkLight1337 @hmellor ? Sorry about the wide ping.