### PR TITLE
[IGNORE][CI] Docker caching test: vLLM source modification should only trigger last-layer cache miss in typical case

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -256,7 +256,7 @@ class RemoteOpenAIServerCustom(RemoteOpenAIServer):
                          env_dict=env_dict,
                          seed=seed,
                          auto_port=auto_port,
-                         max_wait_seconds=max_wait_seconds)
+                         max_wait_seconds=max_wait_seconds + 1)
 
     def _poll(self) -> Optional[int]:
         return self.proc.exitcode


### PR DESCRIPTION
PLEASE DO NOT REVIEW OR OTHERWISE INTERACT WITH THE PR.

## Purpose

The purpose of this PR is to test caching optimization for `docker pull` operations in the vLLM CI system.

The vLLM `test` docker image separates vLLM dependency installation and vLLM source installation into separate layers, deferring the vLLM source installation into [nearly the final layer](https://github.com/vllm-project/vllm/blob/838d7116ba59db528647b29f0d000742f4af9d4b/docker/Dockerfile#L502). In theory this should maximize the number of layer cache hits during docker pull operations in the typical regression-test scenario where a PR only modifies the vLLM source.

## Test Plan

The purpose of this PR is to make a trivial modification to the vLLM source - and nothing else i.e. no dependency modifications - as a test; ideally we would see that most regression tests only have cache misses for the layer which installs vLLM. Any other result may suggest that cache is not being used effectively

## Test Result

TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

