### PR TITLE
[IGNORE][CI] Docker caching test: vLLM dependency modification should only trigger cache misses starting with dependency install layer

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -9,3 +9,4 @@ wheel
 jinja2>=3.1.6
 regex
 build
+banana


### PR DESCRIPTION
PLEASE DO NOT REVIEW OR OTHERWISE INTERACT WITH THE PR.

## Purpose

The purpose of this PR is to test caching optimization for `docker pull` operations in the vLLM CI system.

The vLLM `test` docker image separates vLLM dependency installation and vLLM source installation into separate layers; the `cuda` and `build` dependencies are installed in the `vllm-base` stage, while the `dev` dependencies are installed in the `test` stage (in the case where your build is targeting the test stage). In theory this should maximize the number of layer cache hits for layers associated with installation of dependencies.

## Test Plan

The purpose of this PR is to make a trivial modification to the `build` dependencies - and nothing else i.e. no modifications to other dependencies or to vLLM source - as a test; ideally we would see that most regression tests only have cache misses for the layer which installs the `build` dependencies and all subsequent layers. Any other result may suggest that cache is not being used effectively

## Test Result

TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

