### PR TITLE
[BUGFIX] GPTQ quantization compatibility for Qwen3 Next MOE models (AutoGPTQ and AutoRound-GPTQ)

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -148,9 +148,11 @@ class Qwen3NextSparseMoeBlock(nn.Module):
 
     def _maybe_ignore_quant_config(self, quant_config: QuantizationConfig):
         # GPTQ configs do not have a list of ignored modules, however AutoGPTQ
-        # seems to avoid gate quantization.
-        # See: https://huggingface.co/Qwen/Qwen3-30B-A3B-GPTQ-Int4
-        if isinstance(quant_config, (GPTQConfig, GPTQMarlinConfig)):
+        # seems to avoid gate quantization while AutoRound does.
+        if isinstance(
+                quant_config,
+            (GPTQConfig,
+             GPTQMarlinConfig)) and not quant_config.autoround_version:
             return None
         return quant_config
 


### PR DESCRIPTION
Hi everyone! This PR fixes the same issue as the following PR: https://github.com/vllm-project/vllm/pull/23994
Only for qwen3 next, you need to check if it has been quantized with auto_gptq using https://github.com/intel/auto-round

Command:

auto_round --model Qwen/Qwen3-Next-80B-A3B-Instruct --bits 8 --format "auto_gptq" --output_dir /workspace/outputs

@Isotr0py, it simply rechecks the key extracted from the quant_config. I've verified that it works. Could you try the following model? https://huggingface.co/Intel/Qwen3-Next-80B-A3B-Instruct-int4-AutoRound

IMPORTANT NOTE:
Platform: ROCM
In order to run Qwen3-Next-80B-A3B-Instruct-w4g128 AutoRound-GPTQ, I had to merge the following PR because the block size of attention is 272.
https://github.com/vllm-project/vllm/pull/24486
EDIT:  PR #25105 Solved