### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,10 +67,14 @@ CMakeLists.txt @tlrmchlsmth @LucasWilkinson
 
 # Docs
 /docs/mkdocs @hmellor
-/docs/**.yaml @hmellor
-/docs/**.yml @hmellor
+/docs/**/*.yml @hmellor
 /requirements/docs.txt @hmellor
+.readthedocs.yaml @hmellor
 mkdocs.yaml @hmellor
+
+# Linting
+.markdownlint.yaml @hmellor
+.pre-commit-config.yaml @hmellor
 
 # CPU
 /vllm/v1/worker/cpu* @bigPYJ1151

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,18 +66,21 @@ CMakeLists.txt @tlrmchlsmth @LucasWilkinson
 /tests/models/test_transformers.py @hmellor
 
 # Docs
-/docs @hmellor
+/docs/mkdocs @hmellor
+/docs/**.yaml @hmellor
+/docs/**.yml @hmellor
+/requirements/docs.txt @hmellor
 mkdocs.yaml @hmellor
 
 # CPU
-/vllm/v1/worker/^cpu @bigPYJ1151
+/vllm/v1/worker/cpu* @bigPYJ1151
 /csrc/cpu @bigPYJ1151
 /vllm/platforms/cpu.py @bigPYJ1151
 /cmake/cpu_extension.cmake @bigPYJ1151
 /docker/Dockerfile.cpu @bigPYJ1151
 
 # Intel GPU
-/vllm/v1/worker/^xpu @jikunshang
+/vllm/v1/worker/xpu* @jikunshang
 /vllm/platforms/xpu.py @jikunshang
 /docker/Dockerfile.xpu @jikunshang
 


### PR DESCRIPTION
- Changed my docs codeownership to be restricted to the docs build machinery/config. I don't need to get a ping every time a `.md` file is updated
- Own the linter configs
- Fix pattern for CPU/XPU ownership