### PR TITLE
[ROCm][Bugfix] Only enable +rms_norm based on aiter if not explicitly disabled

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -349,7 +349,8 @@ class RocmPlatform(Platform):
                 else:
                     parallel_config.worker_cls = "vllm.worker.worker.Worker"
         #  Aiter rms norm perform best when CUDA Graph capture is enabled.
-        if use_v1 and use_aiter_rms_norm and not is_eager_execution:
+        if (use_v1 and use_aiter_rms_norm and not is_eager_execution
+                and "-rms_norm" not in compilation_config.custom_ops):
             compilation_config.custom_ops.append("+rms_norm")
 
     @classmethod


### PR DESCRIPTION
Follow up on #23412
If VLLM_ROCM_USE_AITER is enabled, and "-rms_norm" is explicitly set in the compilation config, an assertion is going to be thrown that an operation can't be both enabled and disabled.
Changing the enablement logic from the PR to respect explicit disablement.