### PR TITLE
Fix AMD build issues

### DIFF
--- a/csrc/quantization/activation_kernels.cu
+++ b/csrc/quantization/activation_kernels.cu
@@ -24,8 +24,16 @@ typedef __hip_bfloat162 __nv_bfloat162;
 typedef __hip_bfloat16 __nv_bfloat16;
 typedef __hip_bfloat16_raw __nv_bfloat16_raw;
 
+  #if HIP_FP8_TYPE_OCP
 typedef __hip_fp8_e4m3 __nv_fp8_e4m3;
 typedef __hip_fp8x4_e4m3 __nv_fp8x4_e4m3;
+typedef __hip_fp8_e5m2 __nv_fp8_e5m2;
+  #else
+typedef __hip_fp8_e4m3_fnuz __nv_fp8_e4m3;
+typedef __hip_fp8x4_e4m3_fnuz __nv_fp8x4_e4m3;
+typedef __hip_fp8_e5m2_fnuz __nv_fp8_e5m2;
+  #endif
+
 #endif
 
 #include "core/registration.h"

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -21,6 +21,14 @@
 #include <hip/hip_bf16.h>
 #include "../cuda_compat.h"
 
+#if HIP_FP8_TYPE_OCP
+typedef __hip_fp8_e4m3 __hip_fp8_e4m3;
+typedef __hip_fp8_e5m2 __hip_fp8_e5m2;
+#else
+typedef __hip_fp8_e4m3_fnuz __hip_fp8_e4m3;
+typedef __hip_fp8_e5m2_fnuz __hip_fp8_e5m2;
+#endif
+
 #include <algorithm>
 #include "../attention/dtype_fp8.cuh"
 #include "../quantization/fp8/amd/quant_utils.cuh"
@@ -324,8 +332,8 @@ __launch_bounds__(NUM_THREADS, 5) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const scalar_t* __restrict__ q,         // [num_seqs, num_heads, head_size]
     const cache_t* __restrict__ k_cache,    // [num_blocks, num_kv_heads, head_size/x, block_size, x]
     const cache_t* __restrict__ v_cache,    // [num_blocks, num_kv_heads, head_size, block_size]
-    const int num_kv_heads,   
-    const float scale,    
+    const int num_kv_heads,
+    const float scale,
     const int* __restrict__ block_tables,   // [num_seqs, max_num_blocks_per_seq]
     const int* __restrict__ seq_lens,   // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,   // [num_seqs]
@@ -3648,7 +3656,7 @@ void paged_attention(
     torch::Tensor& query,       // [num_seqs, num_heads, head_size]
     torch::Tensor& key_cache,   // [num_blocks, num_heads, head_size/x, block_size, x]
     torch::Tensor& value_cache, // [num_blocks, num_heads, head_size, block_size]
-    int64_t num_kv_heads, 
+    int64_t num_kv_heads,
     double scale,
     torch::Tensor& block_tables, // [num_seqs, max_num_blocks_per_seq]
     torch::Tensor& seq_lens, // [num_seqs]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

With the recent change from https://github.com/vllm-project/vllm/pull/24054 , on `ROCM_VERSION >= 60200`, we found the AMD build fails with the error msg like
```
unknown type name '__hip_fp8_e4m3'
   29 | typedef __hip_fp8_e4m3 __nv_fp8_e4m3;
      |         ^
```

This PR uses the approach from https://github.com/vllm-project/vllm/pull/14245 to utilize the marco `HIP_FP8_TYPE_OCP` to handle the issue.

## Test Plan

CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

