### PR TITLE
Don't skip special tokens with hermes-style tool calling

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
@@ -98,6 +98,15 @@ class Hermes2ProToolParser(ToolParser):
             else:
                 return delta_text
 
+    def adjust_request(
+            self, request: ChatCompletionRequest) -> ChatCompletionRequest:
+        if request.tools and request.tool_choice != 'none':
+            # do not skip special tokens because the tool_call tokens are
+            # marked "special" in some models. Since they are skipped
+            # prior to the call to the tool parser, it breaks tool calling.
+            request.skip_special_tokens = False
+        return request
+
     def extract_tool_calls(
         self,
         model_output: str,


### PR DESCRIPTION
This PR is to prevent skipping special tokens with the Hermes tool parser because the tool_call tokens are marked "special" in some models. Since they are skipped prior to the call to the tool parser, it breaks tool calling. The same is already done in 4 other tool parsers: `step3_tool_parser.py, jamba_tool_parser.py, internlm2_tool_parser.py, mistral_tool_parser.py`

cc: @DarkLight1337 