### PR TITLE
[BugFix] Ensure appropriate guards in destructors

### DIFF
--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -1183,7 +1183,7 @@ class AllReduceFusionPass(VllmInductorPass):
         self.end_and_log()
 
     def __del__(self):
-        if self.disabled:
+        if getattr(self, "disabled", True):
             return
         if flashinfer_comm is not None:
             flashinfer_comm.trtllm_destroy_ipc_workspace_for_all_reduce(

--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -268,7 +268,7 @@ class QuickAllReduce:
         return out
 
     def close(self):
-        if not self.disabled and hasattr(self, "_ptr"):
+        if not self.disabled and getattr(self, "_ptr", None):
             if ops is not None:
                 ops.qr_destroy(self._ptr)
             self._ptr = 0

--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -268,7 +268,7 @@ class QuickAllReduce:
         return out
 
     def close(self):
-        if not self.disabled and getattr(self, "_ptr", None):
+        if not self.disabled and hasattr(self, "_ptr"):
             if ops is not None:
                 ops.qr_destroy(self._ptr)
             self._ptr = 0

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -569,9 +569,10 @@ class NixlConnectorWorker:
 
     def __del__(self):
         """Cleanup background threads on destruction."""
-        self._handshake_initiation_executor.shutdown(wait=False)
-        if self._nixl_handshake_listener_t:
-            self._nixl_handshake_listener_t.join(timeout=0)
+        if executor := getattr(self, "_handshake_initiation_executor", None):
+            executor.shutdown(wait=False)
+        if listener_t := getattr(self, "_nixl_handshake_listener_t", None):
+            listener_t.join(timeout=0)
 
     @staticmethod
     def _nixl_handshake_listener(metadata: NixlAgentMetadata,

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -235,9 +235,6 @@ class ExecutorBase(ABC):
         """Shutdown the executor."""
         self.collective_rpc("shutdown")
 
-    def __del__(self):
-        self.shutdown()
-
     async def execute_model_async(
             self,
             execute_model_req: ExecuteModelRequest) -> List[SamplerOutput]:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -683,7 +683,8 @@ class Worker(WorkerBase):
             tensorizer_config=tensorizer_config, )
 
     def shutdown(self) -> None:
-        self.model_runner.ensure_kv_transfer_shutdown()
+        if runner := getattr(self, "model_runner", None):
+            runner.ensure_kv_transfer_shutdown()
 
 
 def init_worker_distributed_environment(


### PR DESCRIPTION
Care must be taken in destructors to check for attributes that might not exist if the constructor failed.

Some secondary startup error logs have been seen recently due to this.