### PR TITLE
[BugFix] Exclude self when checking for port collision

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -987,8 +987,9 @@ def find_process_using_port(port: int) -> Optional[psutil.Process]:
     if sys.platform.startswith("darwin"):
         return None
 
+    our_pid = os.getpid()
     for conn in psutil.net_connections():
-        if conn.laddr.port == port:
+        if conn.laddr.port == port and conn.pid != our_pid:
             try:
                 return psutil.Process(conn.pid)
             except psutil.NoSuchProcess:

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -989,7 +989,8 @@ def find_process_using_port(port: int) -> Optional[psutil.Process]:
 
     our_pid = os.getpid()
     for conn in psutil.net_connections():
-        if conn.laddr.port == port and conn.pid != our_pid:
+        if conn.laddr.port == port and (conn.pid is not None
+                                        and conn.pid != our_pid):
             try:
                 return psutil.Process(conn.pid)
             except psutil.NoSuchProcess:


### PR DESCRIPTION
This log was recently changed to warning level. It's intended to find other procs that were using the same port, but currently doesn't exclude the vllm process itself. So the warning is now unintentionally logged during normal shutdown.

```
(APIServer pid=2469774) WARNING 09-19 19:48:19 [launcher.py:96] port 8001 is used by process psutil.Process(pid=2469774, name='vllm', status='running', started='19:27:09') launched with command:
(APIServer pid=2469774) WARNING 09-19 19:48:19 [launcher.py:96] /home/nickhill/workspace/vllm/vllm/.venv/bin/python3 /home/nickhill/workspace/vllm/vllm/.venv/bin/vllm serve meta-llama/Llama-3.2-1B-Instruct --disable-log-requests --uvicorn-log-level=error --port 8001 --async-scheduling
(APIServer pid=2469774) INFO 09-19 19:48:19 [launcher.py:99] Shutting down FastAPI HTTP server.
(Worker pid=2470344) INFO 09-19 19:48:19 [multiproc_executor.py:558] Parent process exited, terminating worker
```