### PR TITLE
[Bug] Fix Long Context OOM Issue

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -480,7 +480,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             # which would result in up-projected context being
             #   2*(192*128)*(64*1024) = 3gb
             # (assuming 192 QK head dim, 128 heads, and fp16)
-            128 * 1024)
+            64 * 1024)
         assert self.chunked_prefill_workspace_size >= \
             scheduler_config.max_num_seqs * cache_config.block_size
         if self.dcp_world_size > 1:


### PR DESCRIPTION
## Purpose

Context from @smarterclayton 

>Trying to test a very long context response - 128k input, 1 output token.  I used DeepSeek-V3.1 and changed --max-model-len (although deepseek v3.1 is 128k automatically).
>When I try to run a single request I'm getting an OOM:

```bash
(EngineCore_DP0 pid=948) ERROR 09-16 14:10:49 [v1/engine/core.py:720] torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 4.12 GiB. GPU 0 has a total capacity of 178.35 GiB of which 3.91 GiB is free. Including non-PyTorch memory, this process has 174.41 GiB memory in use. Of the allocated memory 154.86 GiB is allocated by PyTorch, with 3.79 GiB allocated in private pools (e.g., CUDA Graphs), and 1.95 GiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
```
>I had 53GB for KVcache per GPU on this DP=16 2 node B200 config.

The main reason is we allocated too much mem for MLA chunk padding, this PR fixes the issue.

Note: As the comments said, 

```bash
# For long-context models try not to over-allocate limiting
            # kv-cache space, limiting it to 64k tokens,
            # which would result in the workspace being:
            #   2*(576)*(64*1024) = 144mb
            # (assuming 576 MLA head dim, and fp16)
            # which would result in up-projected context being
            #   2*(192*128)*(64*1024) = 3gb
            # (assuming 192 QK head dim, 128 heads, and fp16)
```

We should assign `64 * 1024` instead of `128 * 1024` here as well, so this PR also fixes the consistency between comments and code.

**The OOM issue is reasonable if we have even more context length using limited GPU memory, considering add `tp` or reduce --gpu-memory-utilization 0.9 to a smaller number when OOM. **

## Test

Now it is fixed.

```bash
============ Serving Benchmark Result ============
Successful requests:                     1         
Benchmark duration (s):                  186.05    
Total input tokens:                      129999    
Total generated tokens:                  1         
Request throughput (req/s):              0.01      
Output token throughput (tok/s):         0.01      
Peak output token throughput (tok/s):    1.00      
Peak concurrent requests:                1.00      
Total Token throughput (tok/s):          698.74    
---------------Time to First Token----------------
Mean TTFT (ms):                          167585.20 
Median TTFT (ms):                        167585.20 
P99 TTFT (ms):                           167585.20 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================
```