### PR TITLE
test: Remove vestigial skip for prompt embeds tests after landing v1 Prompt Embeds support

### DIFF
--- a/tests/entrypoints/openai/test_completion_with_prompt_embeds.py
+++ b/tests/entrypoints/openai/test_completion_with_prompt_embeds.py
@@ -14,9 +14,6 @@ from transformers import AutoConfig
 
 from ...utils import RemoteOpenAIServer
 
-pytest.skip("Skipping prompt_embeds test until V1 supports it.",
-            allow_module_level=True)
-
 # any model with a chat template should work here
 MODEL_NAME = "HuggingFaceH4/zephyr-7b-beta"
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#24278 landed support for v1 Prompt Embeds. #25025 introduced a temporary test skip for prompt embeds support in the API that I had missed when merging in main. This removes that now-unnecessary test skip.

## Test Plan

No new tests were needed; just enabling tests that were working two days ago.

## Test Result

Tests pass locally. Pending CI.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

