### PR TITLE
[Profiling] Enable Ray worker process profiling using unitrace on Intel(R) GPUs

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -160,7 +160,7 @@ GUI example:
 
 <img width="1799" alt="Screenshot 2025-03-05 at 11 48 42 AM" src="https://github.com/user-attachments/assets/c7cff1ae-6d6f-477d-a342-bd13c4fc424c" />
 
-## Profile with Unitrace
+## Profile with Unitrace on Intel(R) GPU
 
 If you run your workload on Intel(R) GPUs, you need the unitrace tool for GPU profiling. The tool is open sourced. Please follow the [instructions](https://github.com/intel/pti-gpu/blob/master/tools/unitrace/README.md) to build and install the tool.
 

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -201,6 +201,7 @@ Right before the client is started, you can run
 ```bash
 unitrace --resume <session>
 ```
+
 to start profiling.
 
 ```bash

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -164,6 +164,8 @@ GUI example:
 
 If you run your workload on Intel(R) GPUs, you need the unitrace tool for GPU profiling. The tool is open sourced. Please follow the [instructions](https://github.com/intel/pti-gpu/blob/master/tools/unitrace/README.md) to build and install the tool.
 
+### Example Commands and Usage
+
 #### Offline Inference
 
 For basic usage, you can just append `unitrace <options>`, for example, `unitrace --chrome-kernel-logging`, before any existing script you would run for offline inference.

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -150,6 +150,7 @@ class ParallelConfig:
 
     # Whether to profile Ray workers with unitrace
     ray_workers_use_unitrace: bool = False
+    """Whether to profile Ray workers with unitrace, see https://docs.ray.io/en/latest/ray-observability/user-guides/profiling.html#profiling-unitrace-profiler."""
 
     ray_runtime_env: Optional[RuntimeEnv] = None
     """Ray runtime environment to pass to distributed workers."""

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -148,6 +148,9 @@ class ParallelConfig:
     ray_workers_use_nsight: bool = False
     """Whether to profile Ray workers with nsight, see https://docs.ray.io/en/latest/ray-observability/user-guides/profiling.html#profiling-nsight-profiler."""
 
+    # Whether to profile Ray workers with unitrace
+    ray_workers_use_unitrace: bool = False
+
     ray_runtime_env: Optional[RuntimeEnv] = None
     """Ray runtime environment to pass to distributed workers."""
 
@@ -484,6 +487,10 @@ class ParallelConfig:
                 "supported on current platform.")
         if self.ray_workers_use_nsight and not self.use_ray:
             raise ValueError("Unable to use nsight profiling unless workers "
+                             "run with Ray.")
+
+        if self.ray_workers_use_unitrace and not self.use_ray:
+            raise ValueError("Unable to use unitrace profiling unless workers "
                              "run with Ray.")
 
         return self

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -500,6 +500,8 @@ class SpeculativeConfig:
             disable_custom_all_reduce,
             ray_workers_use_nsight=target_parallel_config.
             ray_workers_use_nsight,
+            ray_workers_use_unitrace=target_parallel_config.
+            ray_workers_use_unitrace,
             placement_group=target_parallel_config.placement_group,
         )
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -402,6 +402,7 @@ class EngineArgs:
     lora_extra_vocab_size: int = LoRAConfig.lora_extra_vocab_size
 
     ray_workers_use_nsight: bool = ParallelConfig.ray_workers_use_nsight
+    ray_workers_use_unitrace: bool = ParallelConfig.ray_workers_use_unitrace
     num_gpu_blocks_override: Optional[
         int] = CacheConfig.num_gpu_blocks_override
     num_lookahead_slots: int = SchedulerConfig.num_lookahead_slots
@@ -745,6 +746,9 @@ class EngineArgs:
         parallel_group.add_argument(
             "--ray-workers-use-nsight",
             **parallel_kwargs["ray_workers_use_nsight"])
+        parallel_group.add_argument(
+            "--ray-workers-use-unitrace",
+            **parallel_kwargs["ray_workers_use_unitrace"])
         parallel_group.add_argument(
             "--disable-custom-all-reduce",
             **parallel_kwargs["disable_custom_all_reduce"])
@@ -1365,6 +1369,7 @@ class EngineArgs:
             max_parallel_loading_workers=self.max_parallel_loading_workers,
             disable_custom_all_reduce=self.disable_custom_all_reduce,
             ray_workers_use_nsight=self.ray_workers_use_nsight,
+            ray_workers_use_unitrace=self.ray_workers_use_unitrace,
             ray_runtime_env=ray_runtime_env,
             placement_group=placement_group,
             distributed_executor_backend=self.distributed_executor_backend,

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -145,13 +145,13 @@ class RayDistributedExecutor(DistributedExecutorBase):
 
         return ray_remote_kwargs
 
-    def _configure_ray_workers_use_unitrace(self,
-            ray_remote_kwargs) -> Dict[str, Any]:
+    def _configure_ray_workers_use_unitrace(
+            self, ray_remote_kwargs) -> Dict[str, Any]:
         # If unitrace profiling is enabled, we need to set the profiling
         # configuration for the ray workers as runtime env.
         runtime_env = ray_remote_kwargs.setdefault("runtime_env", {})
         runtime_env.update({"unitrace": {
-                "chrome-kernel-logging": "",
+            "chrome-kernel-logging": "",
         }})
 
         return ray_remote_kwargs

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -146,15 +146,13 @@ class RayDistributedExecutor(DistributedExecutorBase):
         return ray_remote_kwargs
 
     def _configure_ray_workers_use_unitrace(self,
-                                          ray_remote_kwargs) -> Dict[str, Any]:
+            ray_remote_kwargs) -> Dict[str, Any]:
         # If unitrace profiling is enabled, we need to set the profiling
         # configuration for the ray workers as runtime env.
         runtime_env = ray_remote_kwargs.setdefault("runtime_env", {})
-        runtime_env.update({
-            "unitrace": {
+        runtime_env.update({"unitrace": {
                 "chrome-kernel-logging": "",
-            }
-        })
+        }})
 
         return ray_remote_kwargs
 

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -145,6 +145,19 @@ class RayDistributedExecutor(DistributedExecutorBase):
 
         return ray_remote_kwargs
 
+    def _configure_ray_workers_use_unitrace(self,
+                                          ray_remote_kwargs) -> Dict[str, Any]:
+        # If unitrace profiling is enabled, we need to set the profiling
+        # configuration for the ray workers as runtime env.
+        runtime_env = ray_remote_kwargs.setdefault("runtime_env", {})
+        runtime_env.update({
+            "unitrace": {
+                "chrome-kernel-logging": "",
+            }
+        })
+
+        return ray_remote_kwargs
+
     # child class could overwrite this to return actual env vars.
     def _get_env_vars_to_be_updated(self):
         return self._env_vars_for_all_workers
@@ -166,6 +179,10 @@ class RayDistributedExecutor(DistributedExecutorBase):
 
         if self.parallel_config.ray_workers_use_nsight:
             ray_remote_kwargs = self._configure_ray_workers_use_nsight(
+                ray_remote_kwargs)
+
+        if self.parallel_config.ray_workers_use_unitrace:
+            ray_remote_kwargs = self._configure_ray_workers_use_unitrace(
                 ray_remote_kwargs)
 
         logger.info("use_ray_spmd_worker: %s", self.use_ray_spmd_worker)


### PR DESCRIPTION
## Purpose

This PR enables Ray worker process profiling using unitrace tool on Intel(R) GPUs. 

Similar to nsight profiling support, this PR introduces an option "ray_workers_use_unitrace". This option enables Ray worker process profiling using unitrace on Intel(R) GPUs.

## Test Plan

This PR depends on https://github.com/ray-project/ray/pull/56843. Once https://github.com/ray-project/ray/pull/56724 is merged. We can run vLLM with "ray_workers_use_unitrace" on Intel(R) GPU. After the run completes, there will be .json files created by unitrace. The .json files can be viewed by following instructions at https://github.com/intel/pti-gpu/tree/master/tools/unitrace#view

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

