### PR TITLE
[BUG FIX][NON-CUDA]quick fix to avoid call cudagraph_unsafe in attention

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -29,6 +29,8 @@ from vllm.utils import GiB_bytes, direct_register_custom_op
 
 logger = init_logger(__name__)
 USE_XFORMERS_OPS = None
+tag_cudagraph_unsafe = (torch._C.Tag.cudagraph_unsafe,
+                        ) if current_platform.is_cuda_alike() else ()
 
 
 def check_xformers_availability():
@@ -577,7 +579,7 @@ direct_register_custom_op(
     mutates_args=[],
     fake_impl=unified_attention_fake,
     dispatch_key=current_platform.dispatch_key,
-    tags=(torch._C.Tag.cudagraph_unsafe, ),
+    tags=tag_cudagraph_unsafe,
 )
 
 
@@ -628,5 +630,5 @@ direct_register_custom_op(
     mutates_args=["output", "output_block_scale"],
     fake_impl=unified_attention_with_output_fake,
     dispatch_key=current_platform.dispatch_key,
-    tags=(torch._C.Tag.cudagraph_unsafe, ),
+    tags=tag_cudagraph_unsafe,
 )

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -32,7 +32,7 @@ USE_XFORMERS_OPS = None
 try:
     tag_cudagraph_unsafe = (torch._C.Tag.cudagraph_unsafe, )
 except AttributeError:
-    tag_cudagraph_unsafe = ()
+    tag_cudagraph_unsafe = ()  # type: ignore[assignment]
 
 
 def check_xformers_availability():

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -29,8 +29,10 @@ from vllm.utils import GiB_bytes, direct_register_custom_op
 
 logger = init_logger(__name__)
 USE_XFORMERS_OPS = None
-tag_cudagraph_unsafe = (torch._C.Tag.cudagraph_unsafe,
-                        ) if current_platform.is_cuda_alike() else ()
+try:
+    tag_cudagraph_unsafe = (torch._C.Tag.cudagraph_unsafe, )
+except AttributeError:
+    tag_cudagraph_unsafe = ()
 
 
 def check_xformers_availability():


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix failing for non cuda device when calling torch._C.Tag.cudagraph_unsafe
from https://github.com/vllm-project/vllm/pull/24281

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

