### PR TITLE
[Core] Enable sharded state loader for V1 engine and enhance test coverage

### DIFF
--- a/tests/test_sharded_state_loader.py
+++ b/tests/test_sharded_state_loader.py
@@ -57,10 +57,19 @@ def llama_3p2_1b_files():
 
 def _run_writer(input_dir, output_dir, weights_patterns, **kwargs):
     llm_sharded_writer = LLM(model=input_dir, **kwargs)
-
+    # Check which engine version is being used
+    is_v1_engine = hasattr(llm_sharded_writer.llm_engine, "engine_core")
     # Dump worker states to output directory
-    llm_sharded_writer.llm_engine.model_executor.save_sharded_state(
-        path=output_dir)
+    if is_v1_engine:
+        # For V1 engine, we need to use engine_core.save_sharded_state
+        print("Using V1 engine save path")
+        llm_sharded_writer.llm_engine.engine_core.save_sharded_state(
+            path=output_dir)
+    else:
+        # For V0 engine
+        print("Using V0 engine save path")
+        model_executor = llm_sharded_writer.llm_engine.model_executor
+        model_executor.save_sharded_state(path=output_dir)
 
     # Copy metadata files to output directory
     for file in os.listdir(input_dir):
@@ -91,8 +100,6 @@ def test_sharded_state_loader(enable_lora, tp_size, num_gpus_available,
     gpu_memory_utilization = 0.8
     input_dir = llama_3p2_1b_files
     ctx = mp.get_context("spawn")
-    # The interface in v1 engine has changed, run in v1 engine will hang.
-    monkeypatch.setenv("VLLM_USE_V1", "0")
 
     # Run in separate processes for memory & CUDA isolation
     with TemporaryDirectory() as output_dir:
@@ -100,7 +107,6 @@ def test_sharded_state_loader(enable_lora, tp_size, num_gpus_available,
                         args=(input_dir, output_dir, weights_patterns),
                         kwargs=dict(
                             tensor_parallel_size=tp_size,
-                            distributed_executor_backend="mp",
                             gpu_memory_utilization=gpu_memory_utilization,
                             enforce_eager=True,
                         ))
@@ -112,7 +118,6 @@ def test_sharded_state_loader(enable_lora, tp_size, num_gpus_available,
         p = ctx.Process(target=_run_generate,
                         args=(input_dir, queue),
                         kwargs=dict(
-                            distributed_executor_backend="mp",
                             enable_lora=enable_lora,
                             gpu_memory_utilization=gpu_memory_utilization,
                             tensor_parallel_size=tp_size,
@@ -133,7 +138,6 @@ def test_sharded_state_loader(enable_lora, tp_size, num_gpus_available,
         p = ctx.Process(target=_run_generate,
                         args=(output_dir, queue),
                         kwargs=dict(
-                            distributed_executor_backend="mp",
                             enable_lora=enable_lora,
                             gpu_memory_utilization=gpu_memory_utilization,
                             tensor_parallel_size=tp_size,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1482,12 +1482,6 @@ class EngineArgs:
         #############################################################
         # Unsupported Feature Flags on V1.
 
-        if self.load_format == "sharded_state":
-            _raise_or_fallback(
-                feature_name=f"--load_format {self.load_format}",
-                recommend_to_remove=False)
-            return False
-
         if (self.logits_processor_pattern
                 != EngineArgs.logits_processor_pattern):
             _raise_or_fallback(feature_name="--logits-processor-pattern",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR remove V1 engine restriction for sharded state loader,  improving compatibility and enabling users to use sharded state loading with both V0 and V1 engines. 

In addition, this PR improves the unit tests for the sharded state loader, adding coverage for the V1 engine.

Previously, the sharded state loader was artificially restricted to only work with the V0 engine, even though the underlying functionality was already supported in the V1 engine. This limitation prevented users from taking advantage of V1 engine optimizations when using sharded model checkpoints.

Specifically, this PR:
- Updates the `test_sharded_state_loader.py` test to detect which engine version is being used (V0 or V1) and use the appropriate API for saving sharded state based on the engine version
- Removes the restriction that forced V0 engine usage in the sharded state loader tests
- Removes unnecessary `distributed_executor_backend="mp"` parameters from the test configuration
- Updates `engine/arg_utils.py` to remove the restriction that prevented using `load_format="sharded_state"` with V1 engine
- Allows sharded state loading functionality in V1 engine

This change is important for users who want to leverage the performance benefits of the V1 engine while still using sharded state loading capabilities.

## Test Plan
To test these changes, run the sharded state loader tests:

```bash
pytest tests/test_sharded_state_loader.py -v
```

The tests have been updated to work with both V0 and V1 engines, automatically detecting which engine is being used and adapting the API calls accordingly.

## Test Result
Tests pass successfully with both V0 and V1 engines, demonstrating that the sharded state loader functionality works correctly in both engine versions.

The updated tests verify that:

1. Sharded state can be saved correctly using the appropriate API for each engine version
2. Sharded state can be loaded correctly in both V0 and V1 engines
3. The functionality works with different tensor parallel sizes
4. The functionality works with LoRA adapters enabled

The test log: 
[shareds-pr-log.txt](https://github.com/user-attachments/files/22439251/shareds-pr-log.txt)


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

