### PR TITLE
[Bugfix] Typos in error message for missing model config file

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -525,9 +525,9 @@ def get_config(
                 raise ValueError(
                     "Could not detect config format for no config file found. "
                     "With config_format 'auto', ensure your model has either "
-                    "config.json (HF format) or params.json (Mistral format)."
-                    "Otherwise please specify your_custom_config_format"
-                    "in engine args for customized config parser")
+                    "config.json (HF format) or params.json (Mistral format). "
+                    "Otherwise please specify your_custom_config_format "
+                    "in engine args for customized config parser.")
 
         except Exception as e:
             error_message = (

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -524,7 +524,7 @@ def get_config(
             else:
                 raise ValueError(
                     "Could not detect config format for no config file found. "
-                    "With config_format 'auto', ensure your model has either"
+                    "With config_format 'auto', ensure your model has either "
                     "config.json (HF format) or params.json (Mistral format)."
                     "Otherwise please specify your_custom_config_format"
                     "in engine args for customized config parser")


### PR DESCRIPTION
## Purpose

Fixes #25338.

## Test Plan

Check that error message from running `vllm serve unsloth/Qwen3-4B-Instruct-2507-GGUF` has no typos.

## Test Result

No typos.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

