### PR TITLE
[Feature] Improve GGUF loading from HuggingFace user experience

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -97,6 +97,9 @@ class ModelConfig:
     """Name or path of the Hugging Face model to use. It is also used as the
     content for `model_name` tag in metrics output when `served_model_name` is
     not specified."""
+    gguf_file: Optional[str] = None
+    """Name or relative path of the GGUF file to load when using GGUF 
+    weights."""
     runner: RunnerOption = "auto"
     """The type of model runner to use. Each vLLM instance only supports one
     model runner, even if the same model can be used for multiple types."""
@@ -309,6 +312,7 @@ class ModelConfig:
         """
         factors: list[Any] = []
         factors.append(self.model)
+        factors.append(self.gguf_file)
         factors.append(self.dtype)
         factors.append(self.quantization)
         factors.append(self.revision)
@@ -378,6 +382,13 @@ class ModelConfig:
                     "affect the random state of the Python process that "
                     "launched vLLM.", self.seed)
 
+        if self.gguf_file:
+            if self.quantization is not None and self.quantization != "gguf":
+                raise ValueError(
+                    "GGUF quantization was requested via the model spec, but "
+                    f"quantization is set to {self.quantization!r}.")
+            self.quantization = "gguf"
+
         # Keep set served_model_name before maybe_model_redirect(self.model)
         self.served_model_name = get_served_model_name(self.model,
                                                        self.served_model_name)
@@ -425,7 +436,8 @@ class ModelConfig:
                 model=self.model,
                 tokenizer=self.tokenizer,
                 revision=self.revision,
-                trust_remote_code=self.trust_remote_code)
+                trust_remote_code=self.trust_remote_code,
+                gguf_file=self.gguf_file)
 
         if (backend := envs.VLLM_ATTENTION_BACKEND
             ) and backend == "FLASHINFER" and find_spec("flashinfer") is None:
@@ -454,7 +466,8 @@ class ModelConfig:
                                self.code_revision,
                                self.config_format,
                                hf_overrides_kw=hf_overrides_kw,
-                               hf_overrides_fn=hf_overrides_fn)
+                               hf_overrides_fn=hf_overrides_fn,
+                               gguf_file=self.gguf_file)
 
         self.hf_config = hf_config
         self.hf_text_config = get_hf_text_config(self.hf_config)
@@ -1446,6 +1459,10 @@ class ModelConfig:
                 self.hf_config_path or self.model,
                 trust_remote_code=self.trust_remote_code,
                 revision=self.revision,
+                # Don't use the GGUF file to fetch the config when
+                # an explicit HF config path is passed
+                gguf_file=self.gguf_file
+                if self.hf_config_path is None else None,
             )
         else:
             config = try_get_generation_config(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -27,7 +27,7 @@ from transformers.utils import CONFIG_NAME as HF_CONFIG_NAME
 from vllm import envs
 from vllm.logger import init_logger
 from vllm.transformers_utils.config_parser_base import ConfigParserBase
-from vllm.transformers_utils.utils import check_gguf_file
+from vllm.transformers_utils.utils import is_model_local_gguf_file
 
 if envs.VLLM_USE_MODELSCOPE:
     from modelscope import AutoConfig
@@ -319,6 +319,124 @@ def list_repo_files(
     return with_retry(lookup_files, "Error retrieving file list")
 
 
+def _normalize_repo_file_path(path: str) -> str:
+    """Return a normalized representation of a repo-relative path.
+
+    Args:
+        path: Path to normalize.
+
+    Returns:
+        Normalized path.
+    """
+    return path.replace("\\", "/")
+
+
+def resolve_gguf_filename(
+    repo_id: str,
+    quantization: str,
+    *,
+    revision: Optional[str] = None,
+    token: Union[str, bool, None] = None,
+) -> str:
+    """Resolve a GGUF quantization specifier to a concrete file name.
+
+    Args:
+        repo_id: Hugging Face repo ID or local directory containing GGUF files.
+        quantization: Quantization specifier, e.g. ``"Q4_K_M"`` or a file name.
+        revision: Optional revision to query from the hub.
+        token: Optional Hugging Face token (string or ``True`` to use cached).
+
+    Returns:
+        The repo-relative path to the resolved GGUF file.
+    """
+    quant_spec = quantization.strip()
+    if not quant_spec:
+        raise ValueError("GGUF quantization specifier cannot be empty.")
+
+    files = list_repo_files(
+        repo_id,
+        revision=revision,
+        token=token if token is not None else _get_hf_token())
+    gguf_files = [
+        file for file in files
+        if _normalize_repo_file_path(file).lower().endswith(".gguf")
+    ]
+
+    if not gguf_files:
+        raise ValueError(
+            "No GGUF files were found in the repository or directory "
+            f"'{repo_id}'.")
+
+    original_and_normalized_files = [
+        (file, _normalize_repo_file_path(file).lower()) for file in gguf_files
+    ]
+
+    quant_norm = _normalize_repo_file_path(quant_spec).lower()
+    quant_with_ext = (quant_norm if quant_norm.endswith(".gguf") else
+                      f"{quant_norm}.gguf")
+    quant_basename = quant_norm.split("/")[-1]
+    quant_basename_with_ext = (quant_basename
+                               if quant_basename.endswith(".gguf") else
+                               f"{quant_basename}.gguf")
+    quant_base = (quant_basename_with_ext[:len(".gguf")]
+                  if quant_basename_with_ext.endswith(".gguf") else
+                  quant_basename_with_ext)
+
+    def _pick_single(candidates: list[str]) -> Optional[str]:
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+        raise ValueError(
+            "Multiple GGUF files match the requested quantization "
+            f"'{quantization}': {', '.join(sorted(candidates))}. "
+            "Please provide a more specific identifier.")
+
+    # Highest priority: full path match (with or without explicit extension).
+    full_path_matches = [
+        original for original, normalized in original_and_normalized_files
+        if normalized in (quant_norm, quant_with_ext)
+    ]
+    match = _pick_single(full_path_matches)
+    if match:
+        return match
+
+    # Next priority: match by final path component (file name).
+    name_matches = [
+        original for original, normalized in original_and_normalized_files
+        if normalized.split("/")[-1] in (quant_basename,
+                                         quant_basename_with_ext)
+    ]
+    match = _pick_single(name_matches)
+    if match:
+        return match
+
+    # Lowest priority: suffix match on the file stem (e.g. "*-Q4_K_M.gguf").
+    suffix_matches: list[str] = []
+    for original, normalized in original_and_normalized_files:
+        name = normalized.split("/")[-1]
+        if not name.endswith(".gguf"):
+            continue
+        stem = name[:len(".gguf")]
+        if stem == quant_base:
+            suffix_matches.append(original)
+            continue
+        if quant_base and stem.endswith(quant_base):
+            prefix_index = len(stem) - len(quant_base) - 1
+            if prefix_index < 0 or not stem[prefix_index].isalnum():
+                suffix_matches.append(original)
+
+    match = _pick_single(suffix_matches)
+    if match:
+        return match
+
+    formatted = sorted({Path(f).name for f in gguf_files})
+    available = ", ".join(formatted) if formatted else "<none>"
+    raise ValueError(
+        "Unable to find a GGUF file matching quantization "
+        f"'{quantization}' in '{repo_id}'. Available GGUF files: {available}.")
+
+
 def file_exists(
     repo_id: str,
     file_name: str,
@@ -468,15 +586,19 @@ def maybe_override_with_speculators_target_model(
     tokenizer: str,
     trust_remote_code: bool,
     revision: Optional[str] = None,
+    gguf_file: Optional[str] = None,
     **kwargs,
 ) -> tuple[str, str]:
     """
     If running a speculators config, override running model with target model
     """
-    is_gguf = check_gguf_file(model)
-    if is_gguf:
+    is_local_gguf = is_model_local_gguf_file(model)
+    if is_local_gguf:
         kwargs["gguf_file"] = Path(model).name
         gguf_model_repo = Path(model).parent
+    elif gguf_file is not None:
+        kwargs["gguf_file"] = gguf_file
+        gguf_model_repo = model
     else:
         gguf_model_repo = None
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
@@ -506,11 +628,16 @@ def get_config(
     **kwargs,
 ) -> PretrainedConfig:
     # Separate model folder from file path for GGUF models
+    gguf_file_arg = kwargs.pop("gguf_file", None)
 
-    is_gguf = check_gguf_file(model)
-    if is_gguf:
+    is_local_gguf = is_model_local_gguf_file(model)
+    if is_local_gguf:
         kwargs["gguf_file"] = Path(model).name
         model = Path(model).parent
+    elif gguf_file_arg is not None:
+        kwargs["gguf_file"] = gguf_file_arg
+
+    is_gguf = is_local_gguf or gguf_file_arg is not None
 
     if config_format == "auto":
         try:
@@ -890,7 +1017,7 @@ def get_hf_image_processor_config(
     if envs.VLLM_USE_MODELSCOPE:
         return dict()
     # Separate model folder from file path for GGUF models
-    if check_gguf_file(model):
+    if is_model_local_gguf_file(model):
         model = Path(model).parent
     return get_image_processor_config(model,
                                       token=hf_token,
@@ -917,6 +1044,7 @@ def try_get_generation_config(
     model: str,
     trust_remote_code: bool,
     revision: Optional[str] = None,
+    gguf_file: Optional[str] = None,
 ) -> Optional[GenerationConfig]:
     try:
         return GenerationConfig.from_pretrained(
@@ -925,11 +1053,10 @@ def try_get_generation_config(
         )
     except OSError:  # Not found
         try:
-            config = get_config(
-                model,
-                trust_remote_code=trust_remote_code,
-                revision=revision,
-            )
+            config = get_config(model,
+                                trust_remote_code=trust_remote_code,
+                                revision=revision,
+                                gguf_file=gguf_file)
             return GenerationConfig.from_model_config(config)
         except OSError:  # Not found
             return None

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -378,7 +378,7 @@ def resolve_gguf_filename(
     quant_basename_with_ext = (quant_basename
                                if quant_basename.endswith(".gguf") else
                                f"{quant_basename}.gguf")
-    quant_base = (quant_basename_with_ext[:len(".gguf")]
+    quant_base = (quant_basename_with_ext[:-len(".gguf")]
                   if quant_basename_with_ext.endswith(".gguf") else
                   quant_basename_with_ext)
 
@@ -417,7 +417,7 @@ def resolve_gguf_filename(
         name = normalized.split("/")[-1]
         if not name.endswith(".gguf"):
             continue
-        stem = name[:len(".gguf")]
+        stem = Path(name).stem
         if stem == quant_base:
             suffix_matches.append(original)
             continue

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -598,7 +598,7 @@ def maybe_override_with_speculators_target_model(
         gguf_model_repo = Path(model).parent
     elif gguf_file is not None:
         kwargs["gguf_file"] = gguf_file
-        gguf_model_repo = model
+        gguf_model_repo = Path(model)
     else:
         gguf_model_repo = None
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE

--- a/vllm/transformers_utils/utils.py
+++ b/vllm/transformers_utils/utils.py
@@ -17,8 +17,8 @@ def is_s3(model_or_path: str) -> bool:
     return model_or_path.lower().startswith('s3://')
 
 
-def check_gguf_file(model: Union[str, PathLike]) -> bool:
-    """Check if the file is a GGUF model."""
+def is_model_local_gguf_file(model: Union[str, PathLike]) -> bool:
+    """Check if the model is a local GGUF file."""
     model = Path(model)
     if not model.is_file():
         return False


### PR DESCRIPTION
## Purpose

Fixes #25182.

TODO:
- [ ] Add tests
- [ ] Update documentation

## Test Plan

Try it out locally:

```bash
vllm serve unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_S
```

works on single L4 machine.

Should check:
- [ ] Something like `vllm serve unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_XL` works
- [ ] Model caching works

## Test Result

```bash
vllm serve unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_S --max_model_len 4128
```
<details>
<summary> Full logs </summary>
```bash
$ vllm serve unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_S --max_model_len 4128
/home/danielssonsimon/code/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
INFO 09-21 12:26:17 [__init__.py:216] Automatically detected platform cuda.
(APIServer pid=66501) INFO 09-21 12:26:20 [api_server.py:1822] vLLM API server version 0.10.2rc3.dev169+ge3db5ebb6.d20250917
(APIServer pid=66501) INFO 09-21 12:26:20 [utils.py:328] non-default args: {'model_tag': 'unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_S', 'model': 'unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_S', 'max_model_len': 4128}
(APIServer pid=66501) INFO 09-21 12:26:21 [arg_utils.py:1001] Using GGUF file Qwen3-4B-Instruct-2507-Q4_K_S.gguf from unsloth/Qwen3-4B-Instruct-2507-GGUF
Qwen3-4B-Instruct-2507-Q4_K_S.gguf: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.38G/2.38G [00:15<00:00, 154MB/s]
(APIServer pid=66501) INFO 09-21 12:27:21 [model.py:576] Resolved architecture: Qwen3ForCausalLM
(APIServer pid=66501) `torch_dtype` is deprecated! Use `dtype` instead!
(APIServer pid=66501) ERROR 09-21 12:27:21 [config.py:274] Error retrieving safetensors: 'unsloth/Qwen3-4B-Instruct-2507-GGUF' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files., retrying 1 of 2
(APIServer pid=66501) ERROR 09-21 12:27:23 [config.py:272] Error retrieving safetensors: 'unsloth/Qwen3-4B-Instruct-2507-GGUF' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files.
(APIServer pid=66501) INFO 09-21 12:27:23 [model.py:1864] Downcasting torch.float32 to torch.bfloat16.
(APIServer pid=66501) INFO 09-21 12:27:23 [model.py:1644] Using max model len 4128
(APIServer pid=66501) INFO 09-21 12:27:48 [scheduler.py:218] Chunked prefill is enabled with max_num_batched_tokens=2048.
/home/danielssonsimon/code/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
INFO 09-21 12:29:13 [__init__.py:216] Automatically detected platform cuda.
(EngineCore_DP0 pid=66914) INFO 09-21 12:29:19 [core.py:644] Waiting for init message from front-end.
(EngineCore_DP0 pid=66914) INFO 09-21 12:29:20 [core.py:77] Initializing a V1 LLM engine (v0.10.2rc3.dev169+ge3db5ebb6.d20250917) with config: model='unsloth/Qwen3-4B-Instruct-2507-GGUF', speculative_config=None, tokenizer='unsloth/Qwen3-4B-Instruct-2507-GGUF', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=4128, download_dir=None, load_format=gguf, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=gguf, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_S, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":3,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output","vllm.mamba_mixer2","vllm.mamba_mixer","vllm.short_conv","vllm.linear_attention","vllm.plamo2_mamba_mixer","vllm.gdn_attention"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"cudagraph_mode":1,"use_cudagraph":true,"cudagraph_num_of_warmups":1,"cudagraph_capture_sizes":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"use_inductor_graph_partition":false,"pass_config":{},"max_capture_size":512,"local_cache_dir":null}
(EngineCore_DP0 pid=66914) W0921 12:29:20.475000 66914 torch/utils/cpp_extension.py:2425] TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation.
(EngineCore_DP0 pid=66914) W0921 12:29:20.475000 66914 torch/utils/cpp_extension.py:2425] If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'] to specific architectures.
[W921 12:29:22.571690356 ProcessGroupNCCL.cpp:981] Warning: TORCH_NCCL_AVOID_RECORD_STREAMS is the default now, this environment variable is thus deprecated. (function operator())
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=66914) INFO 09-21 12:29:22 [parallel_state.py:1206] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=66914) INFO 09-21 12:29:22 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
(EngineCore_DP0 pid=66914) INFO 09-21 12:29:22 [gpu_model_runner.py:2530] Starting to load model unsloth/Qwen3-4B-Instruct-2507-GGUF...
(EngineCore_DP0 pid=66914) INFO 09-21 12:29:22 [gpu_model_runner.py:2562] Loading model from scratch...
(EngineCore_DP0 pid=66914) INFO 09-21 12:30:10 [cuda.py:371] Using Flash Attention backend on V1 engine.
(EngineCore_DP0 pid=66914) INFO 09-21 12:30:37 [gpu_model_runner.py:2581] Model loading took 2.2845 GiB and 74.270197 seconds
(EngineCore_DP0 pid=66914) INFO 09-21 12:30:59 [backends.py:548] Using cache directory: /home/danielssonsimon/.cache/vllm/torch_compile_cache/d975dcaa4f/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_DP0 pid=66914) INFO 09-21 12:30:59 [backends.py:559] Dynamo bytecode transform time: 20.88 s
(EngineCore_DP0 pid=66914) INFO 09-21 12:31:06 [backends.py:197] Cache the graph for dynamic shape for later use
(EngineCore_DP0 pid=66914) INFO 09-21 12:31:40 [backends.py:218] Compiling a graph for dynamic shape takes 39.75 s
(EngineCore_DP0 pid=66914) INFO 09-21 12:31:42 [monitor.py:34] torch.compile takes 60.62 s in total
(EngineCore_DP0 pid=66914) INFO 09-21 12:31:46 [gpu_worker.py:299] Available KV cache memory: 16.93 GiB
(EngineCore_DP0 pid=66914) INFO 09-21 12:31:47 [kv_cache_utils.py:1087] GPU KV cache size: 123,280 tokens
(EngineCore_DP0 pid=66914) INFO 09-21 12:31:47 [kv_cache_utils.py:1091] Maximum concurrency for 4,128 tokens per request: 29.86x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:32<00:00,  2.08it/s]
(EngineCore_DP0 pid=66914) INFO 09-21 12:32:21 [gpu_model_runner.py:3379] Graph capturing finished in 34 secs, took 0.79 GiB
(EngineCore_DP0 pid=66914) INFO 09-21 12:32:21 [gpu_worker.py:392] Free memory on device (21.73/21.95 GiB) on startup. Desired GPU memory utilization is (0.9, 19.76 GiB). Actual usage is 2.28 GiB for weight, 0.52 GiB for peak activation, 0.02 GiB for non-torch memory, and 0.79 GiB for CUDAGraph memory. Replace gpu_memory_utilization config with `--kv-cache-memory=17174945587` to fit into requested memory, or `--kv-cache-memory=19298987008` to fully utilize gpu memory. Current kv cache memory in use is 18179481395 bytes.
(EngineCore_DP0 pid=66914) INFO 09-21 12:32:22 [core.py:210] init engine (profile, create kv cache, warmup model) took 104.23 seconds
(APIServer pid=66501) INFO 09-21 12:32:50 [loggers.py:148] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 7705
(APIServer pid=66501) INFO 09-21 12:32:51 [api_server.py:1618] Supported_tasks: ['generate']
(APIServer pid=66501) INFO 09-21 12:34:05 [api_server.py:1895] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:34] Available routes are:
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /docs, Methods: GET, HEAD
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /redoc, Methods: GET, HEAD
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /health, Methods: GET
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /load, Methods: GET
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /ping, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /ping, Methods: GET
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /tokenize, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /detokenize, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/models, Methods: GET
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /version, Methods: GET
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/responses, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/chat/completions, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/completions, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/embeddings, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /pooling, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /classify, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /score, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/score, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/audio/translations, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /rerank, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v1/rerank, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /v2/rerank, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /invocations, Methods: POST
(APIServer pid=66501) INFO 09-21 12:34:05 [launcher.py:42] Route: /metrics, Methods: GET
(APIServer pid=66501) INFO:     Started server process [66501]
(APIServer pid=66501) INFO:     Waiting for application startup.
(APIServer pid=66501) INFO:     Application startup complete.
```
</details>

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

