### PR TITLE
[Perf] Further optimization for Qwen3-VL `fast_pos_embed_interpolate`

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -406,25 +406,39 @@ class Qwen3_VisionTransformer(nn.Module):
             dh = h_idxs - h_floor
             dw = w_idxs - w_floor
 
-            w00 = ((1 - dh)[:, None] * (1 - dw)[None, :]).reshape(-1)
-            w01 = ((1 - dh)[:, None] * dw[None, :]).reshape(-1)
-            w10 = (dh[:, None] * (1 - dw)[None, :]).reshape(-1)
-            w11 = (dh[:, None] * dw[None, :]).reshape(-1)
+            # Create meshgrid view for all h, w vars
+            dh_grid, dw_grid = torch.meshgrid(dh, dw, indexing='ij')
+            h_floor_grid, w_floor_grid = torch.meshgrid(h_floor,
+                                                        w_floor,
+                                                        indexing='ij')
+            h_ceil_grid, w_ceil_grid = torch.meshgrid(h_ceil,
+                                                      w_ceil,
+                                                      indexing='ij')
+            h_floor_grid_idx = h_floor_grid * num_grid_per_side
+            h_ceil_grid_idx = h_ceil_grid * num_grid_per_side
 
-            idx00 = (h_floor[:, None] * num_grid_per_side +
-                     w_floor[None, :]).reshape(-1)
-            idx01 = (h_floor[:, None] * num_grid_per_side +
-                     w_ceil[None, :]).reshape(-1)
-            idx10 = (h_ceil[:, None] * num_grid_per_side +
-                     w_floor[None, :]).reshape(-1)
-            idx11 = (h_ceil[:, None] * num_grid_per_side +
-                     w_ceil[None, :]).reshape(-1)
+            # original computation of weights
+            # w00 = (1 - dh_grid) * (1 - dw_grid)
+            # w01 = (1 - dh_grid) * dw_grid
+            # w10 = dh_grid * (1 - dw_grid)
+            # w11 = dh_grid * dw_grid
+            # we reuse w11 here to avoid duplicate
+            # dh_grid * dw_grid computation
+            w11 = dh_grid * dw_grid
+            w10 = dh_grid - w11
+            w01 = dw_grid - w11
+            w00 = 1 - dh_grid - dw_grid + w11
 
-            indices = torch.stack([idx00, idx01, idx10, idx11], dim=0)
+            idx00 = h_floor_grid_idx + w_floor_grid
+            idx01 = h_floor_grid_idx + w_ceil_grid
+            idx10 = h_ceil_grid_idx + w_floor_grid
+            idx11 = h_ceil_grid_idx + w_ceil_grid
+
+            indices = torch.stack([idx00, idx01, idx10, idx11],
+                                  dim=0).reshape(4, -1)
             weights = torch.stack([w00, w01, w10, w11],
-                                  dim=0).to(dtype=self.dtype,
-                                            device=self.device)
-            weights = weights.unsqueeze(-1)
+                                  dim=0).reshape(4, -1, 1)
+            weights = weights.to(dtype=self.dtype, device=self.device)
 
             embeds = self.pos_embed(indices)
             weighted_embeds = embeds * weights


### PR DESCRIPTION
## Purpose
- Following PR for #25337
- Just found that we can further optimize weights computation for `fast_pos_embed_interpolate` by reducing duplicated multiply.
- Also improve the readability for `weights` and `indices` computation with `torch.meshgrid` vectorization

## Test Plan
```
vllm bench serve  --backend openai-chat   --endpoint-type openai-chat --model /home/mozf/LLM/Qwen3-VL-4B-Instruct/   --endpoint /v1/chat/completions   --dataset-name hf   --data
set-path "lmarena-ai/VisionArena-Chat"   --hf-split train   --num-prompts 500 --max-concurrency 64
```

## Test Result
**Main branch**
```
============ Serving Benchmark Result ============
Successful requests:                     500       
Maximum request concurrency:             64        
Benchmark duration (s):                  85.76     
Total input tokens:                      34073     
Total generated tokens:                  61091     
Request throughput (req/s):              5.83      
Output token throughput (tok/s):         712.33    
Peak output token throughput (tok/s):    2431.00   
Peak concurrent requests:                82.00     
Total Token throughput (tok/s):          1109.62   
---------------Time to First Token----------------
Mean TTFT (ms):                          1301.41   
Median TTFT (ms):                        1037.53   
P99 TTFT (ms):                           6141.91   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          83.71     
Median TPOT (ms):                        81.09     
P99 TPOT (ms):                           375.42    
---------------Inter-token Latency----------------
Mean ITL (ms):                           77.71     
Median ITL (ms):                         28.33     
P99 ITL (ms):                            444.94    
==================================================
```

**PR**
```
============ Serving Benchmark Result ============
Successful requests:                     500       
Maximum request concurrency:             64        
Benchmark duration (s):                  84.81     
Total input tokens:                      34073     
Total generated tokens:                  61174     
Request throughput (req/s):              5.90      
Output token throughput (tok/s):         721.35    
Peak output token throughput (tok/s):    2367.00   
Peak concurrent requests:                81.00     
Total Token throughput (tok/s):          1123.13   
---------------Time to First Token----------------
Mean TTFT (ms):                          1212.60   
Median TTFT (ms):                        952.82    
P99 TTFT (ms):                           5926.17   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          82.54     
Median TPOT (ms):                        80.58     
P99 TPOT (ms):                           370.48    
---------------Inter-token Latency----------------
Mean ITL (ms):                           77.33     
Median ITL (ms):                         28.42     
P99 ITL (ms):                            437.87    
==================================================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

