### PR TITLE
[Docs] Fix griffe warnings in vllm/lora/ops

### DIFF
--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -83,8 +83,8 @@ class LoRAKernelMeta:
         Prepare kernel metadata tensors for the current forward pass.
 
         Args:
-            token_lora_tensor (torch.Tensor): Tensor containing lora indices
-            for each input token.
+            token_lora_mapping (torch.Tensor): Tensor containing lora indices
+                for each input token.
         """
 
         self._reset()
@@ -136,7 +136,7 @@ class LoRAKernelMeta:
 
         Args:
             token_nums (int): Number of input tokens in the current forward
-            pass. 
+                pass of the kernel.
         """
         return (
             self.token_lora_mapping[:token_nums],

--- a/vllm/lora/ops/xla_ops/lora_ops.py
+++ b/vllm/lora/ops/xla_ops/lora_ops.py
@@ -93,7 +93,6 @@ def bgmv_shrink(
         inputs (torch.Tensor): Input tensor of shape [num_tokens, hidden_size].
         lora_b_weights (torch.Tensor): LoRA weights of shape
             [num_loras, lora_rank, hidden_size].
-        output_tensor (torch.Tensor): (Unused) output tensor (placeholder).
         lora_indices_tensor (torch.Tensor): Tensor of shape [num_tokens]
             indicating which LoRA matrix to use for each token.
         scaling (float, optional): Scalar multiplier applied to the output.


### PR DESCRIPTION
Fix these warnings:

```
WARNING - griffe: vllm/lora/ops/triton_ops/lora_kernel_metadata.py:138:
Failed to get 'name: description' pair from 'pass.'

WARNING - griffe: vllm/lora/ops/triton_ops/lora_kernel_metadata.py:86:
Failed to get 'name: description' pair from 'for each input token.'

WARNING - griffe: vllm/lora/ops/triton_ops/lora_kernel_metadata.py:85:
Parameter 'token_lora_tensor' does not appear in the function signature

WARNING - griffe: vllm/lora/ops/xla_ops/lora_ops.py:95:
Parameter 'output_tensor' does not appear in the function signature
```
Related to issue https://github.com/vllm-project/vllm/issues/25020