### PR TITLE
Make pickle import check fast

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,11 +155,10 @@ repos:
     additional_dependencies: [regex]
   - id: check-pickle-imports
     name: Prevent new pickle/cloudpickle imports
-    entry: python tools/check_pickle_imports.py
+    entry: python tools/pre_commit/check_pickle_imports.py
     language: python
     types: [python]
-    pass_filenames: false
-    additional_dependencies: [pathspec, regex]
+    additional_dependencies: [regex]
   - id: validate-config
     name: Validate configuration has default values and that each field has a docstring
     entry: python tools/validate_config.py


### PR DESCRIPTION
Before:

```bash
$ pre-commit run check-pickle-imports -va
Prevent new pickle/cloudpickle imports...................................Passed
- hook id: check-pickle-imports
- duration: 2.29s
```

After

```bash
$ pre-commit run check-pickle-imports -va
Prevent new pickle/cloudpickle imports...................................Passed
- hook id: check-pickle-imports
- duration: 0.16s
```