### PR TITLE
[BugFix][ModelRunner] properly handle unused buffer

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1084,6 +1084,8 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             logits_indices = query_start_loc[1:] - 1
             num_draft_tokens = None
             spec_decode_metadata = None
+            self.num_draft_tokens.gpu = None
+            self.num_accepted_tokens.gpu = None
         else:
             # Get the number of draft tokens for each request.
             # Iterate over the dictionary rather than all requests since not all


### PR DESCRIPTION
## Purpose
#24526 introduced 2 more CpuGpuBuffer `self.num_draft_tokens` and `self.num_accepted_tokens` for Qwen3-next support. But in un-spec-decode case, they are actually not used. We found it trigger memory error(OOM) on XPU platform. This PR is trying to fix it and verified.

## Test Plan

## Test Result
