### PR TITLE
[Bugfix] Add Flash Attention guards in MLACommonImpl constructor

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -971,7 +971,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 self._run_prefill_context_chunk_cudnn
             self._run_prefill_new_tokens = self._run_prefill_new_tokens_cudnn
             self._pad_v = False
-        elif is_vllm_fa:  # Use FlashAttention
+        elif "flash_attn_varlen_func" in globals():  # Use FlashAttention
             logger.debug_once("Using FlashAttention prefill for MLA")
             self._run_prefill_context_chunk = self._run_prefill_context_chunk_fa
             self._run_prefill_new_tokens = self._run_prefill_new_tokens_fa

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -971,7 +971,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 self._run_prefill_context_chunk_cudnn
             self._run_prefill_new_tokens = self._run_prefill_new_tokens_cudnn
             self._pad_v = False
-        else:  # Use FlashAttention
+        elif is_vllm_fa:  # Use FlashAttention
             logger.debug_once("Using FlashAttention prefill for MLA")
             self._run_prefill_context_chunk = self._run_prefill_context_chunk_fa
             self._run_prefill_new_tokens = self._run_prefill_new_tokens_fa


### PR DESCRIPTION
This PR adds a guard preventing non-FlashAttention backends from crashing when inheriting from `MLACommonImpl` - in such scenarios, `flash_attn_varlen_func` is undefined and construction will fail on `NameError: name 'flash_attn_varlen_func' is not defined`, which wasn't the case in V0 `MLACommonImpl`.