### PR TITLE
[Ray][CPU] Ray executor and Ray DP support for CPU backend

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-cpu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test.sh
@@ -87,7 +87,6 @@ function cpu_tests() {
     set -e
     pytest -x -s -v \
     tests/lora/test_qwen2vl.py"
-
   # online serving: tp+pp
   docker exec cpu-test-"$NUMA_NODE" bash -c '
     set -e
@@ -114,6 +113,42 @@ function cpu_tests() {
       --model meta-llama/Llama-3.2-3B-Instruct \
       --num-prompts 20 \
       --endpoint /v1/completions
+    kill -s SIGTERM $server_pid &'
+}
+  # online serving: Ray dp+tp
+  docker exec cpu-test-"$NUMA_NODE" bash -c '
+    set -e
+    VLLM_CPU_KVCACHE_SPACE=1 VLLM_RAY_PER_WORKER_CPUS=1 VLLM_CPU_SGL_KERNEL=1 vllm serve Qwen/Qwen3-0.6B -tp=2 -dp=2 --data-parallel-backend=ray --max-model-len=20 &
+    server_pid=$!
+    timeout 600 bash -c "until curl localhost:8000/v1/models; do sleep 1; done" || exit 1
+    vllm bench serve \
+        --backend vllm \
+        --dataset-name random \
+        --model Qwen/Qwen3-0.6B \
+        --num-prompts 10 \
+        --random-output-len 10 \
+        --random-input-len 10 \
+        --endpoint /v1/completions
+    output=$(ray list actors --detail --filter "State=ALIVE")
+    echo "$output" && [ $(echo "$output" | grep -c "RayWorkerWrapper") -eq 4 ] && echo "Ray: OK" || echo "unexpected number of workers"
+    kill -s SIGTERM $server_pid &'
+}
+  # online serving: Ray pp+tp
+  docker exec cpu-test-"$NUMA_NODE" bash -c '
+    set -e
+    VLLM_CPU_KVCACHE_SPACE=1 VLLM_RAY_PER_WORKER_CPUS=1 VLLM_CPU_SGL_KERNEL=1 vllm serve Qwen/Qwen3-0.6B -tp=2 -pp=2 --distributed-executor-backend=ray --max-model-len=20 &
+    server_pid=$!
+    timeout 600 bash -c "until curl localhost:8000/v1/models; do sleep 1; done" || exit 1
+    vllm bench serve \
+        --backend vllm \
+        --dataset-name random \
+        --model Qwen/Qwen3-0.6B \
+        --num-prompts 10 \
+        --random-output-len 10 \
+        --random-input-len 10 \
+        --endpoint /v1/completions
+    output=$(ray list actors --detail --filter "State=ALIVE")
+    echo "$output" && [ $(echo "$output" | grep -c "RayWorkerWrapper") -eq 4 ] && echo "Ray: OK" || echo "unexepected number of workers"
     kill -s SIGTERM $server_pid &'
 }
 

--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -99,12 +99,13 @@ Currently, there are no pre-built CPU wheels.
 - `CPU_VISIBLE_MEMORY_NODES`: specify visible NUMA memory nodes for vLLM CPU workers, similar to ```CUDA_VISIBLE_DEVICES```. The variable only takes effect when VLLM_CPU_OMP_THREADS_BIND is set to `auto`. The variable provides more control for the auto thread-binding feature, such as masking nodes and changing nodes binding sequence.
 - `VLLM_CPU_MOE_PREPACK` (x86 only): whether to use prepack for MoE layer. This will be passed to `ipex.llm.modules.GatedMLPMOE`. Default is `1` (True). On unsupported CPUs, you might need to set this to `0` (False).
 - `VLLM_CPU_SGL_KERNEL` (x86 only, Experimental): whether to use small-batch optimized kernels for linear layer and MoE layer, especially for low-latency requirements like online serving. The kernels require AMX instruction set, BFloat16 weight type and weight shapes divisible by 32. Default is `0` (False).
+- `VLLM_RAY_PER_WORKER_CPUS`: (For Ray executor): this will set the number of logical CPUs requested by each ray worker.  Default is `1`.
 
 ## FAQ
 
 ### Which `dtype` should be used?
 
-- Currently vLLM CPU uses model default settings as `dtype`. However, due to unstable float16 support in torch CPU, it is recommended to explicitly set `dtype=bfloat16` if there are any performance or accuracy problem.  
+- Currently vLLM CPU uses model default settings as `dtype`. However, due to unstable float16 support in torch CPU, it is recommended to explicitly set `dtype=bfloat16` if there are any performance or accuracy problem.
 
 ### How to launch a vLLM service on CPU?
 

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -11,6 +11,7 @@ setuptools>=77.0.3,<80.0.0
 torch==2.6.0+cpu; platform_machine == "x86_64" # torch>2.6.0+cpu has performance regression on x86 platform, see https://github.com/pytorch/pytorch/pull/151218
 torch==2.8.0; platform_system == "Darwin"
 torch==2.8.0; platform_machine == "ppc64le" or platform_machine == "aarch64"
+ray[cgraph]>=2.48.0
 
 # required for the image processor of minicpm-o-2_6, this must be updated alongside torch
 torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -120,6 +120,7 @@ if TYPE_CHECKING:
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
+    VLLM_RAY_PER_WORKER_CPUS: int = 1
     VLLM_RAY_BUNDLE_INDICES: str = ""
     VLLM_CUDART_SO_PATH: Optional[str] = None
     VLLM_DP_RANK: int = 0
@@ -223,13 +224,13 @@ def env_with_choices(
         case_sensitive: bool = True) -> Callable[[], Optional[str]]:
     """
     Create a lambda that validates environment variable against allowed choices
-    
+
     Args:
         env_name: Name of the environment variable
         default: Default value if not set (can be None)
         choices: List of valid string options or callable that returns list
         case_sensitive: Whether validation should be case sensitive
-        
+
     Returns:
         Lambda function for environment_variables dict
     """
@@ -951,6 +952,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # so that users can colocate other actors on the same GPUs as vLLM.
     "VLLM_RAY_PER_WORKER_GPUS":
     lambda: float(os.getenv("VLLM_RAY_PER_WORKER_GPUS", "1.0")),
+
+
+     # (CPU platform) Number of CPU cores per worker in Ray, must be >=1,
+     # will influence how ray schedules actors across nodes
+    "VLLM_RAY_PER_WORKER_CPUS":
+    lambda: int(os.getenv("VLLM_RAY_PER_WORKER_CPUS", "1")),
 
     # Bundle indices for Ray, if it is set, it can control precisely
     # which indices are used for the Ray bundle, for every worker.

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import msgspec
 
+import vllm.envs as envs
 import vllm.platforms
 from vllm.config import ParallelConfig
 from vllm.distributed import get_pp_group
@@ -61,8 +62,11 @@ try:
             if not device_key:
                 raise RuntimeError("current platform %s does not support ray.",
                                    vllm.platforms.current_platform.device_name)
-            gpu_ids = ray.get_runtime_context().get_accelerator_ids(
-            )[device_key]
+            if device_key == "CPU":
+                gpu_ids = []
+            else:
+                gpu_ids = ray.get_runtime_context().get_accelerator_ids(
+                )[device_key]
             return node_id, gpu_ids
 
         def execute_model_spmd(
@@ -325,11 +329,12 @@ def initialize_ray_cluster(
 
         # We are in a placement group
         bundles = current_placement_group.bundle_specs
+
         # Verify that we can use the placement group.
         device_bundles = 0
         for bundle in bundles:
             bundle_devices = bundle.get(device_str, 0)
-            if bundle_devices > 1:
+            if bundle_devices > 1 and not current_platform.is_cpu():
                 raise ValueError(
                     "Placement group bundle cannot have more than 1 "
                     f"{device_str}.")
@@ -353,15 +358,20 @@ def initialize_ray_cluster(
                 "The number of required %ss exceeds the total "
                 "number of available %ss in the placement group.", device_str,
                 device_str)
+
+        num_devices = 1.0
+        if device_str == "CPU":
+            num_devices = envs.VLLM_RAY_PER_WORKER_CPUS
         # Create a new placement group
         placement_group_specs: List[Dict[str, float]] = ([{
-            device_str: 1.0
+            device_str:
+            num_devices
         } for _ in range(parallel_config.world_size)])
 
         # vLLM engine is also a worker to execute model with an accelerator,
         # so it requires to have the device in a current node. Check if
         # the current node has at least one device.
-        current_ip = get_ip()
+        current_ip = ray.util.get_node_ip_address()
         current_node_id = ray.get_runtime_context().get_node_id()
         current_node_resource = available_resources_per_node()[current_node_id]
         if current_node_resource.get(device_str, 0) < 1:
@@ -408,3 +418,16 @@ def get_num_nodes_in_placement_group() -> int:
         num_nodes = len(nodes_in_pg)
 
     return num_nodes
+
+
+def get_local_world_size() -> int:
+    pg_table = ray.util.placement_group_table()
+    current_pg = ray.util.get_current_placement_group()
+    current_node_id = ray.get_runtime_context().get_node_id()
+    num_local_workers = 0
+    if current_pg:
+        for pg_key, pg in pg_table.items():
+            if pg_key == current_pg.id.hex():
+                num_local_workers = list(
+                    pg["bundles_to_node_id"].values()).count(current_node_id)
+    return num_local_workers

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -69,6 +69,10 @@ class CpuPlatform(Platform):
     device_type: str = "cpu"
     dispatch_key: str = "CPU"
     dist_backend: str = "gloo"
+    ray_device_key: str = "CPU"
+    additional_env_vars: list[str] = [
+        "GLOO_SOCKET_IFNAME",
+    ]
     device_control_env_var = "CPU_VISIBLE_MEMORY_NODES"
 
     @property
@@ -132,6 +136,7 @@ class CpuPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        import vllm.envs as envs
         model_config = vllm_config.model_config
 
         if model_config is not None:
@@ -174,13 +179,20 @@ class CpuPlatform(Platform):
         parallel_config = vllm_config.parallel_config
         if (parallel_config.world_size > 1
                 and parallel_config.distributed_executor_backend is not None
-                and parallel_config.distributed_executor_backend != "mp"):
+                and parallel_config.distributed_executor_backend
+                not in ["mp", "ray"]):
             logger.warning(("%s is not supported on CPU, fallback to mp "
                             "distributed executor backend."),
                            parallel_config.distributed_executor_backend)
             parallel_config.distributed_executor_backend = "mp"
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.cpu_worker.CPUWorker"
+        if (parallel_config.distributed_executor_backend == "ray"
+                and envs.VLLM_CPU_OMP_THREADS_BIND != "auto"):
+            logger.warning(
+                "VLLM_CPU_OMP_THREADS_BIND is set but Ray distributed"
+                "executor on CPU will fallback"
+                "to VLLM_CPU_OMP_THREADS_BIND=auto")
         # Disable DBO
         if parallel_config.enable_dbo:
             logger.warning(

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -757,6 +757,10 @@ async def collect_from_async_generator(
 
 def get_ip() -> str:
     host_ip = envs.VLLM_HOST_IP
+    if is_in_ray_actor():
+        import ray
+        host_ip = ray.util.get_node_ip_address()
+
     if "HOST_IP" in os.environ and "VLLM_HOST_IP" not in os.environ:
         logger.warning(
             "The environment variable HOST_IP is deprecated and ignored, as"

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -205,9 +205,8 @@ class CPUWorker(Worker):
             max_cpus = int(envs.VLLM_RAY_PER_WORKER_CPUS)
             if max_cpus is not None:
                 if max_cpus <= 0:
-                    raise ValueError(
-                        "VLLM_RAY_PER_WORKER_CPUS must be positive,"
-                        "got %s", max_cpus)
+                    raise ValueError(f"VLLM_RAY_PER_WORKER_CPUS"
+                                     f"must be positive, got {max_cpus}")
                 if max_cpus < len(logical_cpu_list):
                     logical_cpu_list = logical_cpu_list[:max_cpus]
                     logger.info(

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -39,10 +39,15 @@ class CPUWorker(Worker):
                          is_driver_worker=is_driver_worker)
 
         self.parallel_config.disable_custom_all_reduce = True
+        self.use_ray = (
+            self.parallel_config.distributed_executor_backend == "ray")
 
     def init_device(self):
         # Setup OpenMP threads affinity.
         omp_cpuids = envs.VLLM_CPU_OMP_THREADS_BIND
+        if self.use_ray:
+            # Ray sets OMP_NUM_THREADS=<num_cpus> by default
+            self.omp_cpuids = "auto"
         if omp_cpuids == "auto" and platform.system() == "Linux":
             cpu_arch = current_platform.get_cpu_architecture()
             if cpu_arch in (CpuArchEnum.POWERPC, CpuArchEnum.S390X):
@@ -141,21 +146,26 @@ class CPUWorker(Worker):
                                      list[LogicalCPUInfo]]
     ) -> str:
         """
-        Return CPU ids to bind based on NUMA nodes. 
-        Currently for rank N, only CPU ids on the N-th node in available NUMA 
+        Return CPU ids to bind based on NUMA nodes.
+        Currently for rank N, only CPU ids on the N-th node in available NUMA
         node list will be selected.
         Args:
-            cpu_selector: a callable object to select CPUs from a CPU list 
+            cpu_selector: a callable object to select CPUs from a CPU list
             of a physical core. The input is a LogicalCPUInfo list, sorted by
-            the LogicalCPUInfo.id. A selected LogicalCPUInfo list should be 
+            the LogicalCPUInfo.id. A selected LogicalCPUInfo list should be
             returned.
         """
+        local_world_size = self.parallel_config.world_size
+
+        if self.use_ray:
+            from vllm.executor.ray_utils import get_local_world_size
+            local_world_size = get_local_world_size()
 
         allowed_numa_nodes, logical_cpu_list = \
             CpuPlatform.get_allowed_cpu_core_node_list()
-        assert len(allowed_numa_nodes) >= self.parallel_config.world_size, (
+        assert len(allowed_numa_nodes) >= local_world_size, (
             f"No enough allowed NUMA nodes to bind threads of "
-            f"{self.parallel_config.world_size} CPUWorkers. "
+            f"{local_world_size} CPUWorkers. "
             f"Allowed NUMA nodes are {allowed_numa_nodes}. "
             "Please try to bind threads manually.")
 
@@ -189,6 +199,20 @@ class CPUWorker(Worker):
             f"should less than {len(logical_cpu_list)}.")
         if reserve_cpu_num != 0:
             logical_cpu_list = logical_cpu_list[:-reserve_cpu_num]
+
+        # Ray: Limit CPUs list to respect VLLM_RAY_PER_WORKER_CPUS
+        if self.use_ray:
+            max_cpus = int(envs.VLLM_RAY_PER_WORKER_CPUS)
+            if max_cpus is not None:
+                if max_cpus <= 0:
+                    raise ValueError(
+                        "VLLM_RAY_PER_WORKER_CPUS must be positive,"
+                        "got %s", max_cpus)
+                if max_cpus < len(logical_cpu_list):
+                    logical_cpu_list = logical_cpu_list[:max_cpus]
+                    logger.info(
+                        "Limited CPU list to %s CPUs due to"
+                        "VLLM_RAY_PER_WORKER_CPUS constraint", max_cpus)
 
         logger.info("auto thread-binding list (id, physical core): %s",
                     [(x.id, x.physical_core) for x in logical_cpu_list])


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Add Ray support for CPU platform in order to support multi-node, this includes both:
- ray executor support for CPU
- ray data-parallel-backend support for CPU

The env variable VLLM_RAY_PER_WORKER_CPUS (default 1) let the user select how many cpu cores each worker should have. This will be used by ray to create bundles and schedule workers.

Details:

- VLLM_CPU_OMP_THREADS_BIND: fallback to "auto" mode.
- VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: also enforce "auto" mode
- For architectures using `_get_autobind_cpu_ids` , make sure that the existing rules are applied with the local world size and, if necessary, the number of core is adjusted to VLLM_RAY_PER_WORKER_CPUS.
- Get the node ip from ray to ensure compatibility when Ray node is setup with non-default IP.

Testing: I'm happy to add some multi-node test for cpu, but not sure of the best way to add them in the CI , I'll take any advice 🙂  


## Test Plan

I have ran simple e2e tests to validate from a 2 physical nodes setup, 

- 2 Ray nodes test setup:
node 0:
`ray start --head --num-cpus=8`
node 1:
` ray start --address='<node_0_ip>:6379' --num-cpus=8`

- PP + TP 

`VLLM_CPU_KVCACHE_SPACE=1  VLLM_RAY_PER_WORKER_CPUS=4  vllm serve --distributed-executor-backend=ray --pipeline-parallel-size=2 --tensor-parallel-size=2 --max-model-len=20`

-> verifies that 4 RayWorkerWrapper actors exists, 2 per node.
`ray list actors --detail --filter "State=ALIVE"`

- DP + TP

`VLLM_CPU_KVCACHE_SPACE=1 VLLM_RAY_PER_WORKER_CPUS=4 vllm serve --data-parallel-backend=ray    --data-parallel-size=2 --data-parallel-size-local 1 --tensor-parallel-size=2 --max-model-len=20`

-> verifies that 4 RayWorkerWrapper actors exists (2 per node) and 2 DPEngineCoreActor exist (1 per node)
`ray list actors --detail --filter "State=ALIVE"`

- DP+TP+PP

`VLLM_CPU_KVCACHE_SPACE=1 VLLM_RAY_PER_WORKER_CPUS=1 vllm serve --data-parallel-backend=ray  --max-model-len=20  --data-parallel-size=2 --data-parallel-size-local 1 -tp=2 -pp=2`

-> verifies that 8 RayWorkerWrapper actors exists (4 per node) and 2 DPEngineCoreActor exist (1 per node).
`ray list actors --detail --filter "State=ALIVE"`


- For each config also tested sending some inputs:
`vllm bench serve --backend vllm  --model Qwen/Qwen3-0.6B --dataset-name random --num-prompts 4 --random-output-len 10  --random-input-len 10 `

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

