### PR TITLE
[CI Failure] Fix fp8 kv cache on <SM90

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -286,6 +286,8 @@ class CudaPlatformBase(Platform):
             TREE_ATTN_V1 = "vllm.v1.attention.backends.tree_attn.TreeAttentionBackend"  # noqa: E501
             XFORMERS_V1 = "vllm.v1.attention.backends.xformers.XFormersAttentionBackend"  # noqa: E501
 
+            use_fp8_kv_cache = (kv_cache_dtype is not None and kv_cache_dtype.startswith("fp8"))
+
             if selected_backend == _Backend.FLASHINFER:
                 logger.info_once("Using FlashInfer backend on V1 engine.")
                 if cls.has_device_capability(100):
@@ -334,10 +336,10 @@ class CudaPlatformBase(Platform):
 
             # FlashAttention is the default for SM 8.0+ GPUs
             if cls.has_device_capability(80):
-                if has_sink and not cls.is_device_capability(90):
+                if (has_sink or use_fp8_kv_cache) and not cls.is_device_capability(90):
                     logger.info_once("Using Triton backend on V1 engine.")
                     return TRITON_ATTN_VLLM_V1
-                if is_default_backend_supported := is_attn_backend_supported(
+                elif is_default_backend_supported := is_attn_backend_supported(
                         FLASH_ATTN_V1, head_size, dtype,
                         allow_import_error=False):
                     logger.info_once("Using Flash Attention backend on "

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -286,7 +286,8 @@ class CudaPlatformBase(Platform):
             TREE_ATTN_V1 = "vllm.v1.attention.backends.tree_attn.TreeAttentionBackend"  # noqa: E501
             XFORMERS_V1 = "vllm.v1.attention.backends.xformers.XFormersAttentionBackend"  # noqa: E501
 
-            use_fp8_kv_cache = (kv_cache_dtype is not None and kv_cache_dtype.startswith("fp8"))
+            use_fp8_kv_cache = (kv_cache_dtype is not None
+                                and kv_cache_dtype.startswith("fp8"))
 
             if selected_backend == _Backend.FLASHINFER:
                 logger.info_once("Using FlashInfer backend on V1 engine.")
@@ -336,7 +337,8 @@ class CudaPlatformBase(Platform):
 
             # FlashAttention is the default for SM 8.0+ GPUs
             if cls.has_device_capability(80):
-                if (has_sink or use_fp8_kv_cache) and not cls.is_device_capability(90):
+                if (has_sink or
+                        use_fp8_kv_cache) and not cls.is_device_capability(90):
                     logger.info_once("Using Triton backend on V1 engine.")
                     return TRITON_ATTN_VLLM_V1
                 elif is_default_backend_supported := is_attn_backend_supported(


### PR DESCRIPTION
## Purpose

The "Quantization Test" has been broken for a few days due to FA2 being chosen for fp8 kv cache on SM80 and SM89 after this PR removed V0 fallback https://github.com/vllm-project/vllm/pull/25033

<img width="1081" height="466" alt="Screenshot 2025-09-22 at 1 23 20 PM" src="https://github.com/user-attachments/assets/ad99bcc2-380a-4235-af1e-af4d698c5b94" />

https://buildkite.com/vllm/ci/builds/31806/steps/canvas?jid=0199716c-38f4-4409-affd-a1c35d55bc0e
```
[2025-09-22T14:14:38Z] (EngineCore_DP0 pid=12418) NotImplementedError: FlashAttention does not support fp8 kv-cache on this device.
```

<img width="1084" height="965" alt="Screenshot 2025-09-22 at 11 25 06 AM" src="https://github.com/user-attachments/assets/aadc74a2-d6f5-4e57-9c66-c562f140d18e" />

## Test Plan

## Test Result

`pytest -s -v "tests/quantization/test_fp8.py::test_kv_cache_model_load_and_run[False-neuralmagic/Meta-Llama-3-8B-Instruct-FP8-KV]"` works on L40s

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

