### PR TITLE
[Core] Drop overly aggressive whisper assertion

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -463,10 +463,6 @@ class Scheduler(SchedulerInterface):
                     # always padded to the maximum length. If we support other
                     # encoder-decoder models, this will need to be updated if we
                     # want to only allocate what is needed.
-                    assert ("whisper"
-                            in self.vllm_config.model_config.model.lower()), (
-                                "Whisper is the only supported "
-                                "encoder-decoder model.")
                     num_encoder_tokens =\
                         self.scheduler_config.max_num_encoder_input_tokens
                 else:


### PR DESCRIPTION
This assertion is causing a failure in a legitimate configuration. The
assertion isn't as valuable anymore since whisper is the only
encoder-decoder model left in vLLM. It made more sense we had all of
the other models that were still supoprted in V0.

Closes #25318

Signed-off-by: Russell Bryant <rbryant@redhat.com>
