### PR TITLE
Remove RFC review hours reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/750-RFC.yml
+++ b/.github/ISSUE_TEMPLATE/750-RFC.yml
@@ -43,10 +43,6 @@ body:
       Any other things you would like to mention.
   validations:
     required: false
-- type: markdown
-  attributes:
-    value: >
-      Thanks for contributing 🎉! The vLLM core team hosts a biweekly RFC review session at 9:30AM Pacific Time, while most RFCs can be discussed online, you can optionally sign up for a slot to discuss your RFC online [here](https://docs.google.com/document/d/1CiLVBZeIVfR7_PNAKVSusxpceywkoOOB78qoWqHvSZc/edit).
 - type: checkboxes
   id: askllm
   attributes:


### PR DESCRIPTION
## Summary
- remove the RFC review session sign-up note from the RFC issue form to stop referencing review hours

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d18e9b71c08329ae32ef3bc3871c3d