### PR TITLE
[benchmarks]allow skip ready check for bench serve

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -545,6 +545,8 @@ async def benchmark(
                 f"are correctly specified. Error: {test_output.error}")
         else:
             print("Initial test run completed. Starting main benchmark run...")
+    else:
+        print("Skipping ready check as requested.")
 
     if lora_modules:
         # For each input request, choose a LoRA module at random.


### PR DESCRIPTION
Summary: Allow skip ready check for bench serve through `--ready-check-timeout-sec 0`

Test Plan: `vllm bench serve  --ready-check-timeout-sec 0`

Differential Revision: D82995002


