### PR TITLE
[Model] A fast tool-only tool parser and Jinja template for GLM-4.5 model

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -43,6 +43,10 @@ argcomplete==3.5.1
     # via datamodel-code-generator
 arrow==1.3.0
     # via isoduration
+async-timeout==5.0.1
+    # via
+    #   aiohttp
+    #   redis
 attrs==24.2.0
     # via
     #   aiohttp
@@ -196,6 +200,11 @@ eval-type-backport==0.2.2
     # via mteb
 evaluate==0.4.3
     # via lm-eval
+exceptiongroup==1.3.0
+    # via
+    #   anyio
+    #   hypothesis
+    #   pytest
 fastapi==0.116.1
     # via mlflow-skinny
 fastparquet==2024.11.0
@@ -978,7 +987,6 @@ setuptools==77.0.3
     # via
     #   lightning-utilities
     #   pytablewriter
-    #   torch
     #   triton
 shapely==2.1.1
     # via
@@ -1074,8 +1082,15 @@ tokenizers==0.21.1
     # via
     #   -r requirements/test.in
     #   transformers
+toml==0.10.2
+    # via datamodel-code-generator
 tomli==2.2.1
-    # via schemathesis
+    # via
+    #   alembic
+    #   black
+    #   coverage
+    #   pytest
+    #   schemathesis
 tomli-w==1.2.0
     # via schemathesis
 torch==2.8.0+cu128
@@ -1112,7 +1127,7 @@ torchaudio==2.8.0+cu128
     #   -r requirements/test.in
     #   encodec
     #   vocos
-torchgeo==0.7.0
+torchgeo==0.6.2
     # via terratorch
 torchmetrics==1.7.4
     # via
@@ -1182,6 +1197,9 @@ typing-extensions==4.12.2
     # via
     #   albumentations
     #   alembic
+    #   anyio
+    #   black
+    #   exceptiongroup
     #   fastapi
     #   graphene
     #   huggingface-hub
@@ -1191,6 +1209,7 @@ typing-extensions==4.12.2
     #   mistral-common
     #   mlflow-skinny
     #   mteb
+    #   multidict
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -1199,12 +1218,13 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pydantic-extra-types
     #   pytorch-lightning
+    #   rich
     #   sqlalchemy
     #   torch
-    #   torchgeo
     #   typer
     #   typeshed-client
     #   typing-inspection
+    #   uvicorn
 typing-inspection==0.4.1
     # via pydantic
 tzdata==2024.2
@@ -1240,7 +1260,7 @@ word2number==1.1
     # via lm-eval
 wrapt==1.17.2
     # via smart-open
-xarray==2025.7.1
+xarray==2025.6.1
     # via rioxarray
 xxhash==3.5.0
     # via

--- a/tests/tool_use/test_glm4_tool_only_parser.py
+++ b/tests/tool_use/test_glm4_tool_only_parser.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the GLM4 tool-only parser."""
+
+import unittest
+from unittest.mock import Mock
+
+from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.tool_parsers.glm4_tool_only_parser import (
+    Glm4ToolOnlyParser)
+
+
+class TestGlm4ToolOnlyParser(unittest.TestCase):
+
+    def setUp(self):
+        # Mock tokenizer
+        mock_tokenizer = Mock()
+        mock_tokenizer.vocab = {}
+
+        self.parser = Glm4ToolOnlyParser(mock_tokenizer)
+        self.request = ChatCompletionRequest(
+            model="glm-4",
+            messages=[],
+            tools=[],
+        )
+
+    def test_multiple_tool_calls_streaming(self):
+        """Test streaming multiple tool calls chunk by chunk."""
+        # Simulate the streaming chunks from the example
+        chunks = [
+            "search",
+            "_web",
+            "\n",
+            "<arg_key>",
+            "query",
+            "</arg_key>",
+            "\n",
+            "<arg_value>",
+            "hot",
+            "els",
+            " near",
+            " Union",
+            " Square",
+            " New",
+            " York",
+            " recommendations",
+            " ",
+            "202",
+            "4",
+            "</arg_value>",
+            "\n",
+            "</tool_call>",
+            # Second tool call
+            "<tool_call>",
+            "get",
+            "_weather",
+            "\n",
+            "<arg_key>",
+            "location",
+            "</arg_key>",
+            "\n",
+            "<arg_value>",
+            "San Francisco",
+            "</arg_value>",
+            "\n",
+            "</tool_call>",
+        ]
+
+        results = []
+        previous_text = ""
+        current_text = ""
+
+        for chunk in chunks:
+            previous_text = current_text
+            current_text += chunk
+
+            result = self.parser.extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=chunk,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=self.request,
+            )
+
+            if result and result.tool_calls:
+                for tool_call in result.tool_calls:
+                    results.append(tool_call.model_dump())
+
+        # Assert exact structure for all streaming results
+        self.assertEqual(len(results), 7,
+                         "Unexpected number of streaming results")
+
+        # First tool call results
+        self.assertDictEqual(
+            results[0], {
+                "id": "0",
+                "type": "function",
+                "index": 0,
+                "function": {
+                    "name": "search",
+                    "arguments": None
+                }
+            })
+        self.assertDictEqual(
+            results[1], {
+                "id": "0",
+                "type": "function",
+                "index": 0,
+                "function": {
+                    "name": "_web",
+                    "arguments": None
+                }
+            })
+        self.assertDictEqual(
+            results[2],
+            {
+                "id": "0",
+                "type": "function",
+                "index": 0,
+                "function": {
+                    "name":
+                    None,
+                    "arguments":
+                    ('{"query": "hotels near Union Square New York '
+                     'recommendations 2024"}'),
+                },
+            },
+        )
+
+        # Empty chunk at beginning for second tool call
+        self.assertDictEqual(
+            results[3], {
+                "id": "1",
+                "type": "function",
+                "index": 1,
+                "function": {
+                    "name": None,
+                    "arguments": None
+                }
+            })
+        # Second tool call results
+        self.assertDictEqual(
+            results[4], {
+                "id": "1",
+                "type": "function",
+                "index": 1,
+                "function": {
+                    "name": "get",
+                    "arguments": None
+                }
+            })
+        self.assertDictEqual(
+            results[5], {
+                "id": "1",
+                "type": "function",
+                "index": 1,
+                "function": {
+                    "name": "_weather",
+                    "arguments": None
+                }
+            })
+        self.assertDictEqual(
+            results[6],
+            {
+                "id": "1",
+                "type": "function",
+                "index": 1,
+                "function": {
+                    "name": None,
+                    "arguments": '{"location": "San Francisco"}',
+                },
+            },
+        )
+
+    def test_single_tool_call_non_streaming(self):
+        """Test non-streaming extraction of a single tool call."""
+        # Model output without <tool_call> wrapper (template adds it)
+        model_output = """search_web
+<arg_key>query</arg_key>
+<arg_value>hotels near Union Square New York recommendations 2024</arg_value>
+</tool_call>"""
+
+        result = self.parser.extract_tool_calls(model_output, self.request)
+
+        self.assertTrue(result.tools_called)
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.content,
+                         "")  # Tool-only mode never returns content
+
+        tool_call = result.tool_calls[0]
+        self.assertEqual(tool_call.function.name, "search_web")
+
+        import json
+        args = json.loads(tool_call.function.arguments)
+        self.assertEqual(
+            args["query"],
+            "hotels near Union Square New York recommendations 2024")
+
+    def test_multiple_tool_calls_non_streaming(self):
+        """Test non-streaming extraction of multiple tool calls."""
+        model_output = """search_web
+<arg_key>query</arg_key>
+<arg_value>restaurants NYC</arg_value>
+</tool_call>
+<tool_call>get_weather
+<arg_key>location</arg_key>
+<arg_value>San Francisco</arg_value>
+</tool_call>"""
+
+        result = self.parser.extract_tool_calls(model_output, self.request)
+
+        self.assertTrue(result.tools_called)
+        self.assertEqual(len(result.tool_calls), 2)
+        self.assertEqual(result.content, "")
+
+        import json
+
+        # Check first tool call
+        self.assertEqual(result.tool_calls[0].function.name, "search_web")
+        args1 = json.loads(result.tool_calls[0].function.arguments)
+        self.assertEqual(args1["query"], "restaurants NYC")
+
+        # Check second tool call
+        self.assertEqual(result.tool_calls[1].function.name, "get_weather")
+        args2 = json.loads(result.tool_calls[1].function.arguments)
+        self.assertEqual(args2["location"], "San Francisco")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm/entrypoints/openai/tool_parsers/glm4_tool_only_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/glm4_tool_only_parser.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+GLM4 Tool-Only Parser - Optimized for ultra-low latency tool calling.
+
+This parser works exclusively with glm4_tool_only_chat_template.jinja to force
+GLM4 models to emit ONLY tool calls (no text/reasoning), significantly reducing
+tool calling latency by eliminating all non-essential tokens.
+
+The template ends with "<tool_call>" so the model's first token is the function
+name, followed only by XML argument tags. Cannot be used for general-purpose
+tool calling - use Glm4MoeModelToolParser for mixed content instead.
+
+Usage: tool_parser="glm4_tool_only"
+"""
+
+import json
+from collections.abc import Sequence
+from typing import Any, Optional
+
+from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                              DeltaFunctionCall, DeltaMessage,
+                                              DeltaToolCall,
+                                              ExtractedToolCallInformation)
+from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
+    ToolParserManager)
+from vllm.entrypoints.openai.tool_parsers.glm4_moe_tool_parser import (
+    Glm4MoeModelToolParser, glm4_deserialize, glm4_is_string_type)
+from vllm.logger import init_logger
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+
+logger = init_logger(__name__)
+
+
+@ToolParserManager.register_module("glm4_tool_only")
+class Glm4ToolOnlyParser(Glm4MoeModelToolParser):
+    """
+    Parser for tool-only GLM4 output where the template pre-fills <tool_call>.
+    The model's first token is the function name, followed only by argument XML.
+    """
+
+    def __init__(self, tokenizer: AnyTokenizer):
+        super().__init__(tokenizer)
+
+        # We start assuming we're already inside <tool_call> since the
+        # template adds it
+        self._current_tool_id: int = 0
+        self._current_tool_name: Optional[str] = ""  # Ready for name
+        self._current_arg_name: Optional[str] = None
+        self._current_arg_value: Optional[str] = None
+        self._args_dict: dict[str, Any] = {}
+        self._tool_id_counter = 0
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """
+        Non-streaming extraction. Since template adds <tool_call>, we prepend it
+        to the model output and use the parent parser.
+        """
+        # The template ends with <tool_call>, so model output starts with
+        # function name
+        wrapped_output = f"<tool_call>{model_output}"
+
+        # Use parent's extraction logic
+        result = super().extract_tool_calls(wrapped_output, request)
+
+        # In tool-only mode, we never return content
+        result.content = ""
+        return result
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        """
+        Streaming extraction for tool-only mode.
+        Since the template ends with <tool_call>, we start inside a tool call.
+        """
+
+        if delta_text == "<tool_call>":
+            if self._current_tool_name is not None:
+                logger.error("Misplaced <tool_call> for tool call: %s",
+                             current_text)
+            self._tool_id_counter += 1
+            self._current_tool_id = self._tool_id_counter
+            self._current_tool_name = ""
+            self._current_arg_name = None
+            self._current_arg_value = None
+            self._args_dict = {}
+            return self._create_result()
+
+        if delta_text == "</tool_call>":
+            if self._current_tool_name:
+                self._current_tool_name = None
+                return self._create_result(
+                    delta_args=json.dumps(self._args_dict))
+            else:
+                logger.error("Misplaced </tool_call> for tool call: %s",
+                             current_text)
+                return None
+
+        if delta_text == "<arg_key>":
+            if self._current_arg_name is not None:
+                logger.error("Misplaced <arg_key> for tool call: %s",
+                             current_text)
+            self._current_arg_name = ""
+            return None
+
+        if delta_text == "</arg_key>":
+            if not self._current_tool_name:
+                logger.error("Misplaced </arg_key> for tool call: %s",
+                             current_text)
+                return None
+            return None
+
+        if delta_text == "<arg_value>":
+            if self._current_arg_value is not None:
+                logger.error("Misplaced <arg_value> for tool call: %s",
+                             current_text)
+            self._current_arg_value = ""
+            return None
+
+        if delta_text == "</arg_value>":
+            if (self._current_tool_name and self._current_arg_value
+                    and self._current_arg_name):
+                if glm4_is_string_type(self._current_tool_name,
+                                       self._current_arg_name, request.tools):
+                    arg_val = self._current_arg_value
+                else:
+                    arg_val = glm4_deserialize(self._current_arg_value)
+                self._args_dict[self._current_arg_name] = arg_val
+                self._current_arg_name = None
+                self._current_arg_value = None
+            else:
+                logger.error("Misplaced </arg_value> for tool call: %s",
+                             current_text)
+            return None
+
+        if delta_text == "\n":
+            return None
+
+        # Handle content tokens depending on where we are at
+        if self._current_arg_value is not None:
+            self._current_arg_value += delta_text
+            return None
+        if self._current_arg_name is not None:
+            self._current_arg_name += delta_text
+            return None
+        if self._current_tool_name is not None:
+            self._current_tool_name += delta_text
+            return self._create_result(delta_name=delta_text)
+
+        # If we got here, we're likely not in a tool call at all
+        return None
+
+    def _create_result(self,
+                       delta_name: Optional[str] = None,
+                       delta_args: Optional[str] = None) -> DeltaMessage:
+        return DeltaMessage(tool_calls=[
+            DeltaToolCall(
+                id=str(self._current_tool_id),
+                index=self._current_tool_id,
+                type="function",
+                function=DeltaFunctionCall(name=delta_name,
+                                           arguments=delta_args),
+            )
+        ])

--- a/vllm/transformers_utils/chat_templates/glm4_tool_only_chat_template.jinja
+++ b/vllm/transformers_utils/chat_templates/glm4_tool_only_chat_template.jinja
@@ -1,0 +1,88 @@
+[gMASK]<sop>
+{%- if tools -%}
+<|system|>
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{% for tool in tools %}
+{{ tool | tojson(ensure_ascii=False) }}
+{% endfor %}
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+<tool_call>{function-name}
+<arg_key>{arg-key-1}</arg_key>
+<arg_value>{arg-value-1}</arg_value>
+<arg_key>{arg-key-2}</arg_key>
+<arg_value>{arg-value-2}</arg_value>
+...
+</tool_call>{%- endif -%}
+{%- macro visible_text(content) -%}
+    {%- if content is string -%}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item.type == 'text' -%}
+                {{- item.text }}
+            {%- elif item is string -%}
+                {{- item }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{- content }}
+    {%- endif -%}
+{%- endmacro -%}
+{% for m in messages %}
+{%- if m.role == 'user' -%}<|user|>
+{{ visible_text(m.content) }}/nothing
+{%- elif m.role == 'assistant' -%}
+<|assistant|>
+<think></think>
+{%- set content = visible_text(m.content) %}
+{%- if '</think>' in content %}
+    {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+{%- endif %}
+{% if m.tool_calls %}
+{% for tc in m.tool_calls %}
+{%- if tc.function %}
+    {%- set tc = tc.function %}
+{%- endif %}
+{{ '\n<tool_call>' + tc.name }}
+{% set _args = tc.arguments %}
+{% for k, v in _args.items() %}
+<arg_key>{{ k }}</arg_key>
+<arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>
+{% endfor %}
+</tool_call>{% endfor %}
+{% endif %}
+{%- if content.strip() -%}
+{{ '\n' + content.strip() }}
+{%- endif %}
+{%- elif m.role == 'tool' -%}
+{%- if m.content is string -%}
+{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+    {{- '<|observation|>' }}
+{%- endif %}
+{{- '\n<tool_response>\n' }}
+{{- m.content }}
+{{- '\n</tool_response>' }}
+{%- else -%}
+<|observation|>{% for tr in m.content %}
+
+<tool_response>
+{{ tr.output if tr.output is defined else tr }}
+</tool_response>{% endfor -%}
+{% endif -%}
+{%- elif m.role == 'system' -%}
+<|system|>
+{{ visible_text(m.content) }}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+<|assistant|>
+<think></think>
+<tool_call>
+{%- endif -%}


### PR DESCRIPTION
## Purpose
Adds a new Jinja template and a streaming tool calling parser for GLM-4.5 models that optimize for the scenario when the model is forced to make a tool call ASAP and output nothing else.


## Test Plan
- unittests `pytest tests/tool_use/test_glm4_*`
- tested locally that GLM emits a tool call and the tool parser works
```
vllm serve zai-org/GLM-4.5-Air-FP8 \
	--tensor-parallel-size 2 \
	--gpu-memory-utilization 0.9 \
	--dtype auto \
	--kv-cache-dtype auto \
	--enable-auto-tool-choice \
	--port 30000 \
	--chat_template glm4_tool_only_chat_template.jinja \
      	--tool-parser-plugin glm4_tool_only_parser.py \
        --tool-call-parser glm45_tool_only
```
- tested with `GLM-4.5-Air` and `GLM-4.5-Air-FP8` models, but expected to work with all GLM-4.5 models that use the same tool calling syntax.

## Test Result
- unit tests pass
- in our setup, tool calling latency goes down from 500ms+ to 60ms
