### PR TITLE
[gpt-oss][bugfix] remove logic to require resp_ in ResponseAPI

### DIFF
--- a/tests/entrypoints/openai/test_response_api_with_harmony.py
+++ b/tests/entrypoints/openai/test_response_api_with_harmony.py
@@ -512,11 +512,11 @@ async def test_function_calling(client: OpenAI, model_name: str):
     }]
 
     response = await client.responses.create(
-        # id="test_function_calling_non_resp", # TODO
         model=model_name,
         input="What's the weather like in Paris today?",
         tools=tools,
         temperature=0.0,
+        extra_body={"request_id": "test_function_calling_non_resp"},
     )
     assert response is not None
     assert response.status == "completed"

--- a/tests/entrypoints/openai/test_response_api_with_harmony.py
+++ b/tests/entrypoints/openai/test_response_api_with_harmony.py
@@ -512,6 +512,7 @@ async def test_function_calling(client: OpenAI, model_name: str):
     }]
 
     response = await client.responses.create(
+        # id="test_function_calling_non_resp", # TODO
         model=model_name,
         input="What's the weather like in Paris today?",
         tools=tools,

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -233,7 +233,6 @@ class OpenAIServingResponses(OpenAIServing):
             )
 
         # Handle the previous response ID.
-        # fbvscode.set_trace()
         prev_response_id = request.previous_response_id
         if prev_response_id is not None:
             async with self.response_store_lock:

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -233,10 +233,9 @@ class OpenAIServingResponses(OpenAIServing):
             )
 
         # Handle the previous response ID.
+        # fbvscode.set_trace()
         prev_response_id = request.previous_response_id
         if prev_response_id is not None:
-            if not prev_response_id.startswith("resp_"):
-                return self._make_invalid_id_error(prev_response_id)
             async with self.response_store_lock:
                 prev_response = self.response_store.get(prev_response_id)
             if prev_response is None:
@@ -915,9 +914,6 @@ class OpenAIServingResponses(OpenAIServing):
         stream: Optional[bool],
     ) -> Union[ErrorResponse, ResponsesResponse, AsyncGenerator[
             StreamingResponsesResponse, None]]:
-        if not response_id.startswith("resp_"):
-            return self._make_invalid_id_error(response_id)
-
         async with self.response_store_lock:
             response = self.response_store.get(response_id)
 
@@ -935,9 +931,6 @@ class OpenAIServingResponses(OpenAIServing):
         self,
         response_id: str,
     ) -> Union[ErrorResponse, ResponsesResponse]:
-        if not response_id.startswith("resp_"):
-            return self._make_invalid_id_error(response_id)
-
         async with self.response_store_lock:
             response = self.response_store.get(response_id)
             if response is None:
@@ -962,13 +955,6 @@ class OpenAIServingResponses(OpenAIServing):
                 logger.exception("Background task for %s was cancelled",
                                  response_id)
         return response
-
-    def _make_invalid_id_error(self, response_id: str) -> ErrorResponse:
-        return self.create_error_response(
-            err_type="invalid_request_error",
-            message=(f"Invalid 'response_id': '{response_id}'. "
-                     "Expected an ID that begins with 'resp'."),
-        )
 
     def _make_not_found_error(self, response_id: str) -> ErrorResponse:
         return self.create_error_response(


### PR DESCRIPTION
## Purpose

currently the logic is:
- if responses.request_id is None, we generate one with resp_ prefix (https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/protocol.py#L304)
- if responses.request_id is provided, we use it
- HOWEVER, the logic for cancelling / retrieving responses expects the resp_prefix. Thus, if a user of vLLM passes in a response id with an arbitrary prefix, and then tries to retrieve it later, you'll get a runtime error.

I think the best fix is to remove the resp_ prefix. This has no backwards compatibility issues, and provides more flexibility for users of vllm.

## Test Plan

server
```
 VLLM_ENABLE_RESPONSES_API_STORE=1 CUDA_VISIBLE_DEVICES=2,3 with-proxy vllm serve "/data/users/axia/checkpoints/gpt-oss-120b" -tp 2 --port 20001
```

client request 1
```
(gpt_oss_edit) [axia@devvm30969.cln0 /data/users/axia/gitrepos/vllm (main)]$ curl http://localhost:20001/v1/responses   -H "Content-Type: application/json"   -N   -d '{
    "model": "/data/users/axia/checkpoints/gpt-oss-120b",
    "input": [
        {
            "role": "user",
            "content": "Hello."
        }
    ],
    "temperature": 0.7,
    "max_output_tokens": 256,
    "stream": true, "enable_response_messages": true, "request_id": "hello", "store": true, "background": true
}' 
```

client request 2
```
(gpt_oss_edit) [axia@devvm30969.cln0 /data/users/axia/gitrepos/vllm (main)]$ curl http://localhost:20001/v1/responses   -H "Content-Type: application/json"   -N   -d '{
    "model": "/data/users/axia/checkpoints/gpt-oss-120b",
    "input": [
        {
            "role": "user",
            "content": "Hello."
        }
    ],
    "temperature": 0.7, "previous_response_id": "hello",
    "max_output_tokens": 256,
    "stream": true, "enable_response_messages": true, "request_id": "he2llo"
}' 
```

## Test Result

the second client request is able to retrieve the first client request.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

