### PR TITLE
[XPU] Fix `compile_size` is `None` case.

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -113,6 +113,8 @@ class XPUPlatform(Platform):
         # lazy import to avoid circular import
         from vllm.config import CompilationLevel, CUDAGraphMode
         compilation_config = vllm_config.compilation_config
+        if compilation_config.compile_sizes is None:
+            compilation_config.compile_sizes = []
 
         assert compilation_config.cudagraph_mode == CUDAGraphMode.NONE, \
             "CUDA graph mode should be NONE on XPU"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

previously, we will set `compile_size`in `init_with_cudagraph_size`. 
in #25161, xpu platform make `support_static_graph_mode` is False, which will not fall into previous path and leave compile size be None instead of a empty list even we don't set this. 
this PR will set this in xpu.py to avoid runtime error.

## Test Plan
CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

