### PR TITLE
add str format for proxy port

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -101,7 +101,7 @@ class P2pNcclEngine:
         if proxy_ip == "" or proxy_port == "":
             self.proxy_address = ""
         else:
-            self.proxy_address = proxy_ip + ":" + proxy_port
+            self.proxy_address = proxy_ip + ":" + str(proxy_port)
 
         self.context = zmq.Context()
         self.router_socket = self.context.socket(zmq.ROUTER)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When the `proxy_port` in the `kv_connector_extra_config` parameter of `vllm serve` is an integer, it will trigger a `TypeError: can only concatenate str (not "int") to str`. This is because no type check is performed before initializing `P2pNcclEngine`. It is therefore recommended that `proxy_port` be formatted as a string.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

