### PR TITLE
[Perf] Change default CUDAGraphMode from PIECEWISE to FULL_AND_PIECEWISE

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -509,8 +509,15 @@ class VllmConfig:
             if self.compilation_config.cudagraph_mode is None:
                 if envs.VLLM_USE_V1 and self.compilation_config.level \
                     == CompilationLevel.PIECEWISE:
+                    # default to full and piecewise for most models
                     self.compilation_config.cudagraph_mode = \
                         CUDAGraphMode.FULL_AND_PIECEWISE
+
+                    # pooling model does not support full cudagraphs
+                    if self.model_config is not None and \
+                        self.model_config.pooler_config is not None:
+                        self.compilation_config.cudagraph_mode = \
+                            CUDAGraphMode.PIECEWISE
                 else:
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -510,7 +510,7 @@ class VllmConfig:
                 if envs.VLLM_USE_V1 and self.compilation_config.level \
                     == CompilationLevel.PIECEWISE:
                     self.compilation_config.cudagraph_mode = \
-                        CUDAGraphMode.PIECEWISE
+                        CUDAGraphMode.FULL_AND_PIECEWISE
                 else:
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -228,15 +228,14 @@ class CompilationConfig:
     The mode of the cudagraph:
 
     - NONE, no cudagraph capture.
-    - PIECEWISE. (v1 default)
+    - PIECEWISE.
     - FULL.
     - FULL_DECODE_ONLY.
-    - FULL_AND_PIECEWISE.
+    - FULL_AND_PIECEWISE. (v1 default)
 
     PIECEWISE mode build piecewise cudagraph only, keeping the cudagraph
     incompatible ops (i.e. some attention ops) outside the cudagraph
     for general flexibility.
-    This is the default mode.
 
     FULL mode: Capture full cudagraph for all batches. Can be good for small
     models or workloads with small prompts; not supported by many backends.
@@ -249,7 +248,7 @@ class CompilationConfig:
     
     FULL_AND_PIECEWISE mode: Capture full cudagraph for decode batches and
     piecewise cudagraph for prefill and mixed prefill-decode batches.
-    This is like the most performant mode for most models.
+    This is the most performant mode for most models and is the default.
 
     Currently, the cudagraph mode is only used for the v1 engine.
     Note that the cudagraph logic is generally orthogonal to the 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3581,14 +3581,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     CUDAGraphMode.NONE
             logger.warning(msg)
 
-        # pooling model does not support full cudagraphs
-        if cudagraph_mode.has_full_cudagraphs() and self.is_pooling_model:
-            msg = (f"CUDAGraphMode.{cudagraph_mode.name} is not supported "
-                   "with pooling model; setting cudagraph_mode=PIECEWISE")
-            cudagraph_mode = self.compilation_config.cudagraph_mode = \
-                CUDAGraphMode.PIECEWISE
-            logger.warning(msg)
-
         # check that if we are doing spec-decode + decode full-cudagraphs it is
         # supported
         if (cudagraph_mode.decode_mode() == CUDAGraphMode.FULL

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2960,8 +2960,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # TODO(luka) better system for describing dummy batches
                 seq_lens = [1] * num_decode_tokens + [num_prefill_tokens + 1]
             else:
-                # Make sure max_model_len is used at the graph capture time.
-                seq_lens = self.max_model_len
+                seq_lens = max_query_len
             self.seq_lens.np[:num_reqs] = seq_lens
             self.seq_lens.np[num_reqs:] = 0
             self.seq_lens.copy_to_gpu()
@@ -3560,6 +3559,34 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 msg += "; setting cudagraph_mode=FULL_DECODE_ONLY"
                 cudagraph_mode = self.compilation_config.cudagraph_mode = \
                     CUDAGraphMode.FULL_DECODE_ONLY
+            logger.warning(msg)
+
+        # check that if we are doing decode full-cudagraphs it is supported
+        if (cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+                and min_cg_support == AttentionCGSupport.NEVER):
+            msg = (f"CUDAGraphMode.{cudagraph_mode.name} is not supported "
+                   f"with {min_cg_builder_name} backend (support: "
+                   f"{min_cg_support})")
+            if (self.compilation_config.level == CompilationLevel.PIECEWISE and
+                (self.compilation_config.splitting_ops_contain_attention()
+                 or self.compilation_config.use_inductor_graph_partition)):
+                msg += "; setting cudagraph_mode=PIECEWISE because "\
+                    "attention is compiled piecewise"
+                cudagraph_mode = self.compilation_config.cudagraph_mode = \
+                    CUDAGraphMode.PIECEWISE
+            else:
+                msg += "; setting cudagraph_mode=NONE because "\
+                    "attention is not compiled piecewise"
+                cudagraph_mode = self.compilation_config.cudagraph_mode = \
+                    CUDAGraphMode.NONE
+            logger.warning(msg)
+
+        # pooling model does not support full cudagraphs
+        if cudagraph_mode.has_full_cudagraphs() and self.is_pooling_model:
+            msg = (f"CUDAGraphMode.{cudagraph_mode.name} is not supported "
+                   "with pooling model; setting cudagraph_mode=PIECEWISE")
+            cudagraph_mode = self.compilation_config.cudagraph_mode = \
+                CUDAGraphMode.PIECEWISE
             logger.warning(msg)
 
         # check that if we are doing spec-decode + decode full-cudagraphs it is


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR proposes to enable using full cudagraphs by default in vLLM V1. Support for cudagraphs beyond piecewise only was added over the past months (notably https://github.com/vllm-project/vllm/pull/20059) and while the startup time increase is measurable, we believe the performance gain for full cudagraphs is worth it, especially for low latency with small models or MoEs.

For instance, running Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 on 1xH100 with vLLM for 10 requests of 1024 in and 128 out results in the following throughputs:
* `vllm serve` (default): 4.07 req/s
* `vllm serve --async-scheduling`: 4.29 req/s
* `vllm serve -O.cudagraph_mode=FULL`: 5.83 req/s
* `vllm serve --async-scheduling -O.cudagraph_mode=FULL`: 6.03 req/s
* `vllm serve -O.cudagraph_mode=FULL_AND_PIECEWISE`: 5.98 req/s
* `vllm serve --async-scheduling -O.cudagraph_mode=FULL_AND_PIECEWISE`: 6.20 req/s

Benchmark command: `vllm bench serve --model Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 --port 8000 --num-prompts 10`

====

Startup time impact:

```
main: python -c "from vllm import LLM;LLM('Qwen/Qwen3-0.6B')"  34.05s user 7.32s system 190% cpu 21.684 total
pr:   python -c "from vllm import LLM;LLM('Qwen/Qwen3-0.6B')"  34.99s user 9.01s system 175% cpu 25.005 total
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

