### PR TITLE
[WIP][ROCm][FP8] determine the kv cache dtype according to the platform in aiter attention backend

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -479,8 +479,13 @@ class AiterFlashAttentionImpl(AttentionImpl):
             )
 
         if self.kv_cache_dtype.startswith("fp8"):
-            key_cache = key_cache.view(current_platform.fp8_dtype())
-            value_cache = value_cache.view(current_platform.fp8_dtype())
+            if current_platform.is_fp8_fnuz():
+                # MI300/308 only support fp8_e4m3fnuz
+                key_cache = key_cache.view(torch.float8_e4m3fnuz)
+                value_cache = value_cache.view(torch.float8_e4m3fnuz)
+            else:
+                key_cache = key_cache.view(torch.float8_e4m3fn)
+                value_cache = value_cache.view(torch.float8_e4m3fn)
 
         if not attn_metadata.use_cascade:
             cu_seqlens_q = attn_metadata.query_start_loc


### PR DESCRIPTION
For the platform only supports the fp8_fnuz, the kv cache should be viewed as the associated fp8 datatype. Here we have a PR for MI300/MI308 to view the kv cache to the supported fp8 datatype before attention.