### PR TITLE
[BugFix] Fix MLA assert with CUTLASS MLA

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -436,7 +436,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
     """
     reorder_batch_threshold: ClassVar[int] = 1
 
-    _CHUNKED_PREFILL_WORKSPACE_SIZE: ClassVar[int] = -1
+    CHUNKED_PREFILL_WORKSPACE_SIZE: ClassVar[int] = -1
 
     def __init__(self,
                  kv_cache_spec: AttentionSpec,

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -486,6 +486,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         self.chunked_prefill_workspace_size = max(
             self.chunked_prefill_workspace_size,
             scheduler_config.max_num_seqs * cache_config.block_size)
+
         if self.dcp_world_size > 1:
             # Note(hc): The local kvcache is incomplete when DCP is triggered,
             # an additional kvcache allgather across the DCP group is therefore

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -469,7 +469,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             self.page_size = self.kv_cache_spec.block_size
 
         self.chunked_prefill_workspace_size = min(
-            # Try for full length request or at least 4 pages per-request
+            # Try for 8 full length request or at least 4 pages per-request
             max(8 * self.model_config.max_model_len,
                 4 * scheduler_config.max_num_seqs * cache_config.block_size),
             # For long-context models try not to over-allocate limiting


### PR DESCRIPTION
Cutlass MLA has a block_size of 128 so following https://github.com/vllm-project/vllm/pull/25290 this would assert since default `max_num_seqs` is 1024

also make sure we capture the size of the up-projection in the profile run (this was in v0 backend but failed to make it to v0)