### PR TITLE
[wip|not for land] map torchao quant checkpoints to vLLM MoE kernels

### DIFF
--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Any, Optional
+from typing import Any, Callable, Optional, Union
 
 import torch
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.layer import (FusedMoE,
+                                                        FusedMoEConfig,
+                                                        FusedMoEMethodBase)
 from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
                                                UnquantizedLinearMethod)
 from vllm.model_executor.layers.quantization import QuantizationMethods
@@ -114,10 +117,65 @@ class TorchAOConfig(QuantizationConfig):
 
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> Optional["QuantizeMethodBase"]:
+        from torchao.quantization import ModuleFqnToConfig
+
+        if isinstance(layer, FusedMoE):
+            module_fqn = prefix
+
+            # TODO(future, low pri): also support TorchAOConfig, but low-pri
+            # because we need to keep gates in high precision to maximize
+            # acccuracy, and any setup which does that will use
+            # `ModuleFqnToConfig` (per-layer) and not `TorchAOConfig` (global
+            # per-model config).
+            assert isinstance(
+                self.torchao_config, ModuleFqnToConfig
+            ), f'unsupported type {type(self.torchao_config)}'
+
+            # module_fqn is FQN of the MoE layer, for example
+            #
+            #   model.layers.0.mlp.experts
+            #
+            # module_fqn_to_config has configs for individual linears, for
+            # example
+            #
+            #   {
+            #     'model.layers.9.mlp.experts.9.up_proj':
+            #       Float8DynamicActivationFloat8WeightConfig(...),
+            #     ...,
+            #   }
+            #
+            # (i) to properly stitch E 2d experts into one 3d expert we need
+            #     all E 2d experts to be quantized the same way
+            # (ii) to call existing fused MoE kernels, we need w13 and w2 to
+            #     be quantized the same way. Note that this technically doesn't
+            #     apply to weight-only quant, but for now let's keep things
+            #     simple and enforce it.
+            #
+            # (i) && (ii) means that we can only have one unique quant config
+            # on all of the expert weights.  The code below enforces this.
+            #
+            # Note: torchao configs are not hashable
+            # (see https://github.com/pytorch/ao/issues/3062),
+            # so for now we do this check with a for loop.
+            first_config = None
+            for k, cur_config in self.torchao_config.module_fqn_to_config.items(
+            ):
+                if k.startswith(module_fqn):
+                    if first_config is None:
+                        first_config = cur_config
+                    elif cur_config == first_config:
+                        pass
+                    else:
+                        raise AssertionError(
+                            f'inconsistent configs {first_config} and '
+                            f'{cur_config} in a single MoE module, this is '
+                            'not supported')
+            return TorchAOMoEMethod(
+                TorchAOConfig(first_config, self.skip_modules),
+                layer.moe_config)
+
         if not isinstance(layer, LinearBase):
             return None
-
-        from torchao.quantization import ModuleFqnToConfig
 
         if should_skip(prefix, self.skip_modules):
             return UnquantizedLinearMethod()
@@ -212,3 +270,115 @@ class TorchAOLinearMethod(LinearMethodBase):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return F.linear(x, layer.weight, bias)
+
+
+class TorchAOMoEMethod(FusedMoEMethodBase):
+    """
+    TODO(before land): write me
+    """
+
+    def __init__(
+        self,
+        quant_config: TorchAOConfig,
+        moe_config: FusedMoEConfig,
+    ):
+        super().__init__(moe_config)
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        layer.intermediate_size_per_partition = intermediate_size_per_partition
+        layer.hidden_size = hidden_size
+        layer.num_experts = num_experts
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+
+        w13_weight = torch.nn.Parameter(torch.empty(
+            num_experts,
+            2 * intermediate_size_per_partition,
+            hidden_size,
+            dtype=params_dtype),
+                                        requires_grad=False)
+        w13_weight = torchao_quantize_param_data(
+            w13_weight, self.quant_config.torchao_config)
+        layer.register_parameter("w13_weight", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+
+        w2_weight = torch.nn.Parameter(torch.empty(
+            num_experts,
+            hidden_size,
+            intermediate_size_per_partition,
+            dtype=params_dtype),
+                                       requires_grad=False)
+        w2_weight = torchao_quantize_param_data(
+            w2_weight, self.quant_config.torchao_config)
+        layer.register_parameter("w2_weight", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        renormalize: bool,
+        use_grouped_topk: bool = False,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        global_num_experts: int = -1,
+        expert_map: Optional[torch.Tensor] = None,
+        custom_routing_function: Optional[Callable] = None,
+        scoring_func: str = "softmax",
+        routed_scaling_factor: float = 1.0,
+        e_score_correction_bias: Optional[torch.Tensor] = None,
+        apply_router_weight_on_input: bool = False,
+        activation: str = "silu",
+        enable_eplb: bool = False,
+        expert_load_view: Optional[torch.Tensor] = None,
+        logical_to_physical_map: Optional[torch.Tensor] = None,
+        logical_replica_count: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        from vllm.model_executor.layers.fused_moe import fused_experts
+        assert self.fused_experts is None
+
+        if enable_eplb:
+            raise NotImplementedError(
+                "EPLB not supported for `TorchAOMoEMethod` yet.")
+
+        topk_weights, topk_ids = FusedMoE.select_experts(
+            hidden_states=x,
+            router_logits=router_logits,
+            use_grouped_topk=use_grouped_topk,
+            top_k=top_k,
+            renormalize=renormalize,
+            topk_group=topk_group,
+            num_expert_group=num_expert_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
+            e_score_correction_bias=e_score_correction_bias,
+            indices_type=self.topk_indices_dtype)
+
+        # for now, just dequantize the weights and run MoE in bf16
+        # TODO(future): logic to select best MoE kernel to run should go here
+        w13 = layer.w13_weight.dequantize()
+        w2 = layer.w2_weight.dequantize()
+        return fused_experts(
+            hidden_states=x,
+            w1=w13,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            inplace=True,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+        )


### PR DESCRIPTION
Summary:

This is not ready for review yet, for now just hacking to understand quantization and MoEs in vLLM.

High level, I want to map torchao generated MoE checkpoints to vLLM optimized fused kernels. Note that I **do not** want torchao to take over the kernels here, instead torchao just provides the checkpoint and there is glue code to let vLLM select the kernels.

TODO iterate some more and write down the design in more detail

Needs https://github.com/pytorch/ao/pull/3053

Test Plan:

Tested locally with Qwen1.5-MoE-A2.7B with experts quantized to float8 with rowwise scaling.

Reviewers:

Subscribers:

Tasks:

Tags:


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

