### PR TITLE
[Bugfix] Fix for the import error from #24588

### DIFF
--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -23,7 +23,7 @@ if has_triton_kernels():
         from triton_kernels.routing import (RoutingData, routing,
                                             routing_from_bitmatrix)
         from triton_kernels.tensor import Bitmatrix
-    except (ModuleNotFoundError, AttributeError) as e:
+    except (ModuleNotFoundError, AttributeError, ImportError) as e:
         logger.error(
             "Failed to import Triton kernels. Please make sure your triton "
             "version is compatible. Error: %s", e)

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -23,7 +23,7 @@ if has_triton_kernels():
         from triton_kernels.routing import (RoutingData, routing,
                                             routing_from_bitmatrix)
         from triton_kernels.tensor import Bitmatrix
-    except (ModuleNotFoundError, AttributeError, ImportError) as e:
+    except (AttributeError, ImportError) as e:
         logger.error(
             "Failed to import Triton kernels. Please make sure your triton "
             "version is compatible. Error: %s", e)


### PR DESCRIPTION
Fix for getting
```
(APIServer pid=408377) ImportError: cannot import name 'routing_from_bitmatrix' from 'triton_kernels.routing' (/usr/local/lib/python3.12/dist-packages/triton_kernels/routing.py). Did you mean: '_routing_clear_bitmatrix'?
```
when running any quantized model after #24588 when using an incompatible version of triton_kernels