### PR TITLE
[Bug] Fix AssertionError: Do not capture `num_reqs > max_num_reqs` for uniform batch

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -489,7 +489,7 @@ class Worker(WorkerBase):
                     sort_by="self_cuda_time_total"))
 
     def execute_dummy_batch(self) -> None:
-        self.model_runner._dummy_run(1, uniform_decode=True)
+        self.model_runner._dummy_run(1)
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_runner.add_lora(lora_request)


### PR DESCRIPTION
## Purpose

FIxes https://github.com/vllm-project/vllm/issues/25494

## Test Plan

```bash
============ Serving Benchmark Result ============
Successful requests:                     1         
Benchmark duration (s):                  0.90      
Total input tokens:                      129999    
Total generated tokens:                  1         
Request throughput (req/s):              1.11      
Output token throughput (tok/s):         1.11      
Peak output token throughput (tok/s):    1.00      
Peak concurrent requests:                1.00      
Total Token throughput (tok/s):          144353.62 
---------------Time to First Token----------------
Mean TTFT (ms):                          899.48    
Median TTFT (ms):                        899.48    
P99 TTFT (ms):                           899.48    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================
```