### PR TITLE
[Benchmark] Fix regression in structured output benchmark

### DIFF
--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -449,7 +449,8 @@ async def benchmark(
     def prepare_extra_body(request) -> dict:
         extra_body = {}
         # Add the schema to the extra_body
-        extra_body[request.structure_type] = request.schema
+        extra_body["structured_outputs"] = {}
+        extra_body["structured_outputs"][request.structure_type] = request.schema
         return extra_body
 
     print("Starting initial single prompt test run...")


### PR DESCRIPTION
This was a mistake introduced by #22772. Structured output requests
were not actually working because the format spec was not placed in
the proper new location in the request body.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
