### PR TITLE
Add `VLLM_NVTX_SCOPES_FOR_PROFILING=1` to enable `nvtx.annotate` scopes

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -187,6 +187,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_PAD_FOR_CUDAGRAPH: bool = False
     VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
+    VLLM_NVTX_SCOPES_FOR_PROFILING: bool = False
     VLLM_KV_EVENTS_USE_INT_BLOCK_HASHES: bool = True
     VLLM_OBJECT_STORAGE_SHM_BUFFER_NAME: str = "VLLM_OBJECT_STORAGE_SHM_BUFFER"
     VLLM_DEEPEP_BUFFER_SIZE_MB: int = 1024
@@ -1382,6 +1383,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Add optional custom scopes for profiling, disable to avoid overheads
     "VLLM_CUSTOM_SCOPES_FOR_PROFILING":
     lambda: bool(int(os.getenv("VLLM_CUSTOM_SCOPES_FOR_PROFILING", "0"))),
+
+    # Add optional nvtx scopes for profiling, disable to avoid overheads
+    "VLLM_NVTX_SCOPES_FOR_PROFILING":
+    lambda: bool(int(os.getenv("VLLM_NVTX_SCOPES_FOR_PROFILING", "0"))),
 
     # Represent block hashes in KV cache events as 64-bit integers instead of
     # raw bytes. Defaults to True for backward compatibility.

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -378,5 +378,8 @@ def report_usage_stats(
 def record_function_or_nullcontext(name: str) -> AbstractContextManager:
     if envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING:
         return record_function(name)
+    elif envs.VLLM_NVTX_SCOPES_FOR_PROFILING:
+        import nvtx
+        return nvtx.annotate(name)
     else:
         return contextlib.nullcontext()

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -375,11 +375,22 @@ def report_usage_stats(
         })
 
 
+_PROFILER_FUNC = None
+
+
 def record_function_or_nullcontext(name: str) -> AbstractContextManager:
+    global _PROFILER_FUNC
+
+    # fast path assume it is set
+    if _PROFILER_FUNC is not None:
+        return _PROFILER_FUNC(name)
+
+    func = contextlib.nullcontext
     if envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING:
-        return record_function(name)
+        func = record_function
     elif envs.VLLM_NVTX_SCOPES_FOR_PROFILING:
         import nvtx
-        return nvtx.annotate(name)
-    else:
-        return contextlib.nullcontext()
+        func = nvtx.annotate
+
+    _PROFILER_FUNC = func
+    return func(name)


### PR DESCRIPTION
## Purpose

This PR adds `nvtx.annotate` calls in `record_function_or_nullcontext`, which is called in [GPUModelRunner::execute_model](https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/gpu_model_runner.py#L2150).

This helps debug how long each section is taking with nvidia tools.

It shows up like this in nsight systems:

<img width="1113" height="321" alt="image" src="https://github.com/user-attachments/assets/7943a6ff-8a2b-4f68-b2e9-8da9547c4d56" />

