### PR TITLE
[Bugfix] Lower gpt-oss max cudagraph size to 992 to be compatible with FA3

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -266,24 +266,24 @@ class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
         if structured_outputs_config.reasoning_parser == "":
             structured_outputs_config.reasoning_parser = "openai_gptoss"
 
-        # Increase the max capture size from 512 to 1024 for performance.
+        # Increase the max capture size from 512 to 992 for performance.
         # NOTE(woosuk): This will increase the number of CUDA graphs
-        # from 67 to 83.
+        # from 67 to 81.
         scheduler_config = vllm_config.scheduler_config
         if len(scheduler_config.cuda_graph_sizes) == 1:
             max_capture_size = scheduler_config.cuda_graph_sizes[0]
             # FIXME(woosuk): When using full cuda graph with FA3, the max
             # supported size is 992.
-            if max_capture_size < 1024:
+            if max_capture_size < 992:
                 cuda_graph_sizes = [1, 2, 4]
                 # Step size 8 for small batch sizes
                 cuda_graph_sizes += [i for i in range(8, 256, 8)]
                 # Step size 16 for larger batch sizes
-                cuda_graph_sizes += [i for i in range(256, 1025, 16)]
+                cuda_graph_sizes += [i for i in range(256, 993, 16)]
                 scheduler_config.cuda_graph_sizes = cuda_graph_sizes
                 logger.info(
                     "Overriding max cuda graph capture size to "
-                    "%d for performance.", 1024)
+                    "%d for performance.", 992)
 
 
 class MambaModelConfig(VerifyAndUpdateConfig):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Due to compiling full cudagraphs by default now in https://github.com/vllm-project/vllm/pull/25444, gpt-oss crashes on Hopper.

```
vllm serve openai/gpt-oss-20b
...
(EngineCore_DP0 pid=2061997)   File "/home/mgoin/code/vllm/vllm/v1/worker/gpu_model_runner.py", line 3503, in create_attn_groups
(EngineCore_DP0 pid=2061997)     attn_metadata_builders.append(attn_backend.get_builder_cls()(
(EngineCore_DP0 pid=2061997)                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2061997)   File "/home/mgoin/code/vllm/vllm/v1/attention/backends/flash_attn.py", line 204, in __init__
(EngineCore_DP0 pid=2061997)     raise ValueError(
(EngineCore_DP0 pid=2061997) ValueError: Capture size larger than 992 is not supported for full cuda graph.
```

## Test Plan

## Test Result

`vllm serve openai/gpt-oss-20b` crashes on main but succeeds with this PR

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

