### PR TITLE
[Bugfix] [Frontend] Cleanup gpt-oss non-streaming chat tool calls

### DIFF
--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -194,6 +194,7 @@ async def test_gpt_oss_multi_turn_chat(gptoss_client: OpenAI,
     assert tc.function is not None and tc.function.name == "get_current_weather"
     args1 = tc.function.arguments
     assert args1 is not None and len(args1) > 0
+    assert not first_msg.content
 
     messages.append({"role": "assistant", "content": args1})
     messages.append({

--- a/tests/tool_use/test_openai_tool_parser.py
+++ b/tests/tool_use/test_openai_tool_parser.py
@@ -70,7 +70,12 @@ def test_extract_tool_calls_no_tools(openai_tool_parser, harmony_encoding):
     assert extracted_info.content == "This is a test"
 
 
-def test_extract_tool_calls_single_tool(openai_tool_parser, harmony_encoding):
+@pytest.mark.parametrize("tool_args", [
+    '{"location": "Tokyo"}',
+    '{\n"location": "Tokyo"\n}',
+])
+def test_extract_tool_calls_single_tool(openai_tool_parser, harmony_encoding,
+                                        tool_args):
     convo = Conversation.from_messages([
         Message.from_role_and_content(Role.USER,
                                       "What is the weather in Tokyo?"),
@@ -80,7 +85,7 @@ def test_extract_tool_calls_single_tool(openai_tool_parser, harmony_encoding):
         ).with_channel("analysis"),
         Message.from_role_and_content(
             Role.ASSISTANT,
-            '{"location": "Tokyo"}').with_channel("commentary").with_recipient(
+            tool_args).with_channel("commentary").with_recipient(
                 "functions.get_current_weather").with_content_type("json"),
     ])
     token_ids = harmony_encoding.render_conversation_for_completion(

--- a/tests/tool_use/test_openai_tool_parser.py
+++ b/tests/tool_use/test_openai_tool_parser.py
@@ -126,6 +126,17 @@ def test_extract_tool_calls_multiple_tools(
             Role.ASSISTANT,
             '{"location": "Tokyo"}').with_channel("commentary").with_recipient(
                 "functions.get_user_location").with_content_type("json"),
+        Message.from_role_and_content(
+            Role.ASSISTANT, '{"location": "Tokyo"}').with_channel(
+                "commentary").with_recipient("functions.no_content_type"),
+        Message.from_role_and_content(Role.ASSISTANT, "foo").with_channel(
+            "commentary").with_recipient("functions.not_json_no_content_type"),
+        Message.from_role_and_content(
+            Role.ASSISTANT, '{}').with_channel("commentary").with_recipient(
+                "functions.empty_args").with_content_type("json"),
+        Message.from_role_and_content(
+            Role.ASSISTANT, '').with_channel("commentary").with_recipient(
+                "functions.no_args").with_content_type("json"),
     ])
     token_ids = harmony_encoding.render_conversation_for_completion(
         convo,
@@ -146,7 +157,63 @@ def test_extract_tool_calls_multiple_tools(
         ToolCall(function=FunctionCall(
             name="get_user_location",
             arguments=json.dumps({"location": "Tokyo"}),
+        )),
+        ToolCall(function=FunctionCall(
+            name="no_content_type",
+            arguments=json.dumps({"location": "Tokyo"}),
+        )),
+        ToolCall(function=FunctionCall(
+            name="not_json_no_content_type",
+            arguments="foo",
+        )),
+        ToolCall(function=FunctionCall(
+            name="empty_args",
+            arguments=json.dumps({}),
+        )),
+        ToolCall(function=FunctionCall(
+            name="no_args",
+            arguments="",
         ))
     ]
     assert_tool_calls(extracted_info.tool_calls, expected_tool_calls)
     assert extracted_info.content is None
+
+
+def test_extract_tool_calls_with_content(
+    openai_tool_parser,
+    harmony_encoding,
+):
+    final_content = "This tool call will get the weather."
+    convo = Conversation.from_messages([
+        Message.from_role_and_content(
+            Role.USER, "What is the weather in Tokyo based on where I'm at?"),
+        Message.from_role_and_content(
+            Role.ASSISTANT,
+            'User asks: "What is the weather in Tokyo?" based on their location. We need to use get_current_weather tool and get_user_location tool.',  #  noqa: E501
+        ).with_channel("analysis"),
+        Message.from_role_and_content(
+            Role.ASSISTANT,
+            '{"location": "Tokyo"}').with_channel("commentary").with_recipient(
+                "functions.get_current_weather").with_content_type("json"),
+        Message.from_role_and_content(Role.ASSISTANT,
+                                      final_content).with_channel("final"),
+    ])
+    token_ids = harmony_encoding.render_conversation_for_completion(
+        convo,
+        Role.ASSISTANT,
+    )
+
+    extracted_info = openai_tool_parser.extract_tool_calls(
+        "",
+        request=None,
+        token_ids=token_ids,
+    )
+    assert extracted_info.tools_called
+    expected_tool_calls = [
+        ToolCall(function=FunctionCall(
+            name="get_current_weather",
+            arguments=json.dumps({"location": "Tokyo"}),
+        )),
+    ]
+    assert_tool_calls(extracted_info.tool_calls, expected_tool_calls)
+    assert extracted_info.content == final_content

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1186,6 +1186,10 @@ class OpenAIServingChat(OpenAIServing):
                 logprobs = None
 
             if self.use_harmony:
+                reasoning_content, content, _ = parse_chat_output(token_ids)
+                if not request.include_reasoning:
+                    reasoning_content = None
+
                 if self.tool_parser is not None:
                     tool_parser = self.tool_parser(tokenizer)
                     # NOTE: We use token_ids for openai tool parser
@@ -1194,10 +1198,7 @@ class OpenAIServingChat(OpenAIServing):
                         request=request,
                         token_ids=token_ids,  # type: ignore
                     )
-                    reasoning_content, content = None, tool_call_info.content
-                    if request.include_reasoning:
-                        reasoning_content, content, _ = parse_chat_output(
-                            token_ids)
+                    content = tool_call_info.content
                     message = ChatMessage(
                         role=role,
                         reasoning_content=reasoning_content,
@@ -1205,10 +1206,6 @@ class OpenAIServingChat(OpenAIServing):
                         tool_calls=tool_call_info.tool_calls,
                     )
                 else:
-                    reasoning_content, content, _ = parse_chat_output(
-                        token_ids)
-                    if not request.include_reasoning:
-                        reasoning_content = None
                     message = ChatMessage(
                         role=role,
                         reasoning_content=reasoning_content,


### PR DESCRIPTION
## Purpose

This fixes an issue identified in #22337 that was not entirely fixed by #22386 around tool call parsing in gpt-oss models in the non-streaming case and the model output returned to the user.

The main change here is to remove the parsed tool call out of the ChatCompletion message `content`, so that the generated tool call only shows up in its parsed form as an entry in `tool_calls` instead of in both `tool_calls` and `content`.

A small related change is to ensure we're not sending newline characters in the JSON arguments string of the parsed tool call, since we don't do this for other tool calls.

Together these should get non-streaming tool calls via the Chat Completions API working for gpt-oss models for typical use-cases. There may still be some edge cases the openai_tool_parser.py and/or serving_chat.py code need to handle, but this at least closes some known gaps.

## Test Plan

A couple of tests were tweaked here to test for both of these fixes. I ensured the tests failed before my fixes, and that they now pass with the fixes.

Here's how I ran the changed tests:

```
pytest -sv tests/tool_use/test_openai_tool_parser.py
pytest -sv tests/entrypoints/openai/test_serving_chat.py
```

I also manually ran the example shown in #22337, copied here for completeness sake:

```python
from openai import OpenAI

client = OpenAI(
    base_url="http://localhost:8000/v1",
    api_key="fake"
)
tools = [
    {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get current weather in a given city",
            "parameters": {
                "type": "object",
                "properties": {"city": {"type": "string"}},
                "required": ["city"]
            },
        },
    }
]
response = client.chat.completions.create(
    model="openai/gpt-oss-120b",
    messages=[{"role": "user", "content": "What's the weather in Berlin right now?"}],
    tools=tools,
    tool_choice="required"
)

print(response.choices[0].message)
```

This example was run from a recent main of vLLM with my changes from this PR, as below:

```
vllm serve openai/gpt-oss-120b \
  --async-scheduling \
  --tensor-parallel-size 4 \
  --enable-auto-tool-choice \
  --tool-call-parser openai
```

## Test Result

All tests in the test commands described above passed.


In addition, I ran this manual test taken from #22337 and it now turns the expected content:

`ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=[ChatCompletionMessageFunctionToolCall(id='chatcmpl-tool-7567964c8f8447e89e64b23eecbc7931', function=Function(arguments='{"city": "Berlin"}', name='get_weather'), type='function')], reasoning_content='User asks for current weather in Berlin. We have a function get_weather. Use it.')`

For reference, here is the old (ie wrong) results from before my change:

`ChatCompletionMessage(content='{\n  "city": "Berlin"\n}', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=[ChatCompletionMessageFunctionToolCall(id='chatcmpl-tool-f229827765c04578ad151be5fb69c79c', function=Function(arguments='{\n  "city": "Berlin"\n}', name='get_weather'), type='function')], reasoning_content='User asks for current weather in Berlin. We have a function get_weather. We need to call it with city "Berlin".')`

Note that the wrong content includes the function call within the `content` parameter, which it should not. And see it also includes newline characters within the JSON `arguments` string, which may be ok but is not consistent with the JSON strings we return from other tool call parsers that don't include any newlines.

