### PR TITLE
Fix .coveragerc to use absolute source path

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = vllm
+source = /vllm-workspace/vllm
 omit =
     */tests/*
     */test_*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = /vllm-workspace/vllm
+source = vllm
 omit =
     */tests/*
     */test_*
@@ -30,3 +30,4 @@ directory = htmlcov
 
 [xml]
 output = coverage.xml
+


### PR DESCRIPTION
Change 'source = vllm' to 'source = /vllm-workspace/vllm' to ensure consistent coverage path reporting regardless of test working directory.

This prevents codecov from seeing duplicated paths when tests run from different directories (/vllm-workspace/tests vs /vllm-workspace/examples vs /vllm-workspace/).

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

