### PR TITLE
[Compile] Fix AMD Compile Error

### DIFF
--- a/csrc/quantization/activation_kernels.cu
+++ b/csrc/quantization/activation_kernels.cu
@@ -23,9 +23,14 @@
 typedef __hip_bfloat162 __nv_bfloat162;
 typedef __hip_bfloat16 __nv_bfloat16;
 typedef __hip_bfloat16_raw __nv_bfloat16_raw;
-
+#if defined(HIP_FP8_TYPE_OCP)
 typedef __hip_fp8_e4m3 __nv_fp8_e4m3;
 typedef __hip_fp8x4_e4m3 __nv_fp8x4_e4m3;
+#else
+// ROCm 6.2 fallback: only *_fnuz types exist
+typedef __hip_fp8_e4m3_fnuz __nv_fp8_e4m3;
+typedef __hip_fp8x4_e4m3_fnuz __nv_fp8x4_e4m3;
+#endif
 #endif
 
 #include "core/registration.h"

--- a/csrc/quantization/activation_kernels.cu
+++ b/csrc/quantization/activation_kernels.cu
@@ -23,14 +23,14 @@
 typedef __hip_bfloat162 __nv_bfloat162;
 typedef __hip_bfloat16 __nv_bfloat16;
 typedef __hip_bfloat16_raw __nv_bfloat16_raw;
-#if defined(HIP_FP8_TYPE_OCP)
+  #if defined(HIP_FP8_TYPE_OCP)
 typedef __hip_fp8_e4m3 __nv_fp8_e4m3;
 typedef __hip_fp8x4_e4m3 __nv_fp8x4_e4m3;
-#else
+  #else
 // ROCm 6.2 fallback: only *_fnuz types exist
 typedef __hip_fp8_e4m3_fnuz __nv_fp8_e4m3;
 typedef __hip_fp8x4_e4m3_fnuz __nv_fp8x4_e4m3;
-#endif
+  #endif
 #endif
 
 #include "core/registration.h"

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -25,6 +25,12 @@
 #include "../attention/dtype_fp8.cuh"
 #include "../quantization/fp8/amd/quant_utils.cuh"
 
+// ROCm 6.2 compatibility: map OCP fp8 types to FNUZ variants if OCP is absent
+#if !defined(HIP_FP8_TYPE_OCP)
+using __hip_fp8_e4m3 = __hip_fp8_e4m3_fnuz;
+using __hip_fp8_e5m2 = __hip_fp8_e5m2_fnuz;
+#endif
+
 #if defined(__HIPCC__) && \
     (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__))
   #define __HIP__GFX9__


### PR DESCRIPTION
## Purpose

Fix AMD Compile Error in MI300

Originally

```bash
/mnt/nvme5n1p1/wentao/vllm/cmake-build-release/csrc/rocm/attention.hip:131:33: error: use of undeclared identifier '__hip_fp8_e4m3'
  131 |   if constexpr (std::is_same<T, __hip_fp8_e4m3>::value) {
      |                                 ^
/mnt/nvme5n1p1/wentao/vllm/cmake-build-release/csrc/rocm/attention.hip:134:40: error: use of undeclared identifier '__hip_fp8_e5m2'
  134 |   } else if constexpr (std::is_same<T, __hip_fp8_e5m2>::value) {
      |                                        ^
/mnt/nvme5n1p1/wentao/vllm/cmake-build-release/csrc/rocm/attention.hip:647:40: error: use of undeclared identifier '__hip_fp8_e4m3'
  647 |                 gcn_mfma16x16x32_instr<__hip_fp8_e4m3, 0, 0, 0>(
      |                                        ^
/mnt/nvme5n1p1/wentao/vllm/cmake-build-release/csrc/rocm/attention.hip:848:50: error: use of undeclared identifier '__hip_fp8_e4m3'
  848 |                 tmp_out = gcn_mfma16x16x32_instr<__hip_fp8_e4m3, 0, 0, 0>(
      |                                                  ^
4 errors generated when compiling for gfx942
```

Now

```bash
[7/8] Install the project...
-- Install configuration: "Release"
-- Installing: /mnt/nvme5n1p1/wentao/vllm/vllm/_C.abi3.so
-- Set non-toolchain portion of runtime path of "/mnt/nvme5n1p1/wentao/vllm/vllm/_C.abi3.so" to ""
-- Installing: /mnt/nvme5n1p1/wentao/vllm/vllm/_moe_C.abi3.so
-- Set non-toolchain portion of runtime path of "/mnt/nvme5n1p1/wentao/vllm/vllm/_moe_C.abi3.so" to ""
-- Installing: /mnt/nvme5n1p1/wentao/vllm/vllm/_rocm_C.abi3.so
-- Set non-toolchain portion of runtime path of "/mnt/nvme5n1p1/wentao/vllm/vllm/_rocm_C.abi3.so" to ""
```