### PR TITLE
[Bug] Fix AttributeError: 'FusedMoE' object has no attribute 'w13_weight_scale'. Did you mean: 'w13_weight_scale_inv'

### DIFF
--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -53,9 +53,13 @@ def _extract_data_from_fused_moe_module(
     """
     assert isinstance(m, FusedMoE)
     w13 = m.w13_weight
-    w13_s = getattr(m, "w13_weight_scale_inv", m.w13_weight_scale)
+    w13_s = getattr(m, "w13_weight_scale_inv", None)
+    if w13_s is None:
+        w13_s = m.w13_weight_scale
     w2 = m.w2_weight
-    w2_s = getattr(m, "w2_weight_scale_inv", m.w2_weight_scale)
+    w2_s = getattr(m, "w2_weight_scale_inv", None)
+    if w2_s is None:
+        w2_s = m.w2_weight_scale
     num_topk = m.top_k
 
     assert isinstance(w13, torch.Tensor)

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -57,9 +57,7 @@ def _extract_data_from_fused_moe_module(
     if w13_s is None:
         w13_s = m.w13_weight_scale
     w2 = m.w2_weight
-    w2_s = getattr(m, "w2_weight_scale_inv", None)
-    if w2_s is None:
-        w2_s = m.w2_weight_scale
+    w2_s = m.w2_weight_scale_inv if hasattr(m, "w2_weight_scale_inv") else m.w2_weight_scale
     num_topk = m.top_k
 
     assert isinstance(w13, torch.Tensor)

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -53,9 +53,11 @@ def _extract_data_from_fused_moe_module(
     """
     assert isinstance(m, FusedMoE)
     w13 = m.w13_weight
-    w13_s = m.w13_weight_scale_inv if hasattr(m, "w13_weight_scale_inv") else m.w13_weight_scale
+    w13_s = m.w13_weight_scale_inv if hasattr(
+        m, "w13_weight_scale_inv") else m.w13_weight_scale
     w2 = m.w2_weight
-    w2_s = m.w2_weight_scale_inv if hasattr(m, "w2_weight_scale_inv") else m.w2_weight_scale
+    w2_s = m.w2_weight_scale_inv if hasattr(
+        m, "w2_weight_scale_inv") else m.w2_weight_scale
     num_topk = m.top_k
 
     assert isinstance(w13, torch.Tensor)

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -53,9 +53,7 @@ def _extract_data_from_fused_moe_module(
     """
     assert isinstance(m, FusedMoE)
     w13 = m.w13_weight
-    w13_s = getattr(m, "w13_weight_scale_inv", None)
-    if w13_s is None:
-        w13_s = m.w13_weight_scale
+    w13_s = m.w13_weight_scale_inv if hasattr(m, "w13_weight_scale_inv") else m.w13_weight_scale
     w2 = m.w2_weight
     w2_s = m.w2_weight_scale_inv if hasattr(m, "w2_weight_scale_inv") else m.w2_weight_scale
     num_topk = m.top_k


### PR DESCRIPTION
## Purpose

`vllm bench throughput --model Qwen/Qwen3-30B-A3B-FP8 --load-format dummy --input-len 1000 --output-len 100 --trust_remote_code --enable-expert-parallel`

will raise error

```bash
(EngineCore_DP0 pid=265229)     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/v1/executor/abstract.py", line 75, in initialize_from_config
(EngineCore_DP0 pid=265229)     self.collective_rpc("compile_or_warm_up_model")
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/executor/uniproc_executor.py", line 83, in collective_rpc
(EngineCore_DP0 pid=265229)     return [run_method(self.driver_worker, method, args, kwargs)]
(EngineCore_DP0 pid=265229)             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/utils/__init__.py", line 3010, in run_method
(EngineCore_DP0 pid=265229)     return func(*args, **kwargs)
(EngineCore_DP0 pid=265229)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_worker.py", line 341, in compile_or_warm_up_model
(EngineCore_DP0 pid=265229)     kernel_warmup(self)
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/model_executor/warmup/kernel_warmup.py", line 34, in kernel_warmup
(EngineCore_DP0 pid=265229)     deep_gemm_warmup(model, max_tokens)
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/model_executor/warmup/deep_gemm_warmup.py", line 228, in deep_gemm_warmup
(EngineCore_DP0 pid=265229)     deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(model, max_tokens)
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/model_executor/warmup/deep_gemm_warmup.py", line 221, in deepgemm_grouped_fp8_gemm_nt_contiguous_warmup
(EngineCore_DP0 pid=265229)     _extract_data_from_fused_moe_module(dgm))
(EngineCore_DP0 pid=265229)     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=265229)   File "/home/wentao/vllm-source/vllm/model_executor/warmup/deep_gemm_warmup.py", line 56, in _extract_data_from_fused_moe_module
(EngineCore_DP0 pid=265229)     w13_s = getattr(m, "w13_weight_scale_inv", m.w13_weight_scale)
(EngineCore_DP0 pid=265229)                                                ^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=265229)   File "/home/wentao/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1940, in __getattr__
(EngineCore_DP0 pid=265229)     raise AttributeError(
(EngineCore_DP0 pid=265229) AttributeError: 'FusedMoE' object has no attribute 'w13_weight_scale'. Did you mean: 'w13_weight_scale_inv'?
```

This PR fixes that

## Test 

```bash
Throughput: 43.80 requests/s, 48056.39 total tokens/s, 4379.63 output tokens/s
Total num prompt tokens:  997271
Total num output tokens:  100000
```