### PR TITLE
Fix triton_reshape_and_cache_flash.py triton import

### DIFF
--- a/vllm/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/attention/ops/triton_reshape_and_cache_flash.py
@@ -2,10 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-import triton
-import triton.language as tl
 
 from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
 
 
 @triton.jit


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Currently failing pre-commit

```
Forbid direct 'import triton'.......................................................................Failed
- hook id: forbid-direct-triton-import
- exit code: 1

❌ Forbidden direct `import triton` detected. ➤ Use `from vllm.triton_utils import triton` instead.

❌ vllm/attention/ops/triton_reshape_and_cache_flash.py:5: import triton
❌ vllm/attention/ops/triton_reshape_and_cache_flash.py:6: import triton.language as tl

```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

