### PR TITLE
[chore] suppress annoying pre-commit error on MacOS

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -3,8 +3,8 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
-from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
 
+from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)


### PR DESCRIPTION

## Purpose

Fix https://github.com/vllm-project/vllm/issues/25529

just a newline after `import`

[repeat the major issue content here]
> This issue may not be encountered on Linux, But every time on my MacOS.
> Whenever I `git commit` my change, the `isort` hook in `pre-commit` will modify this file (which I didn't touch), and complain with error.
> It's time to suppress and get rid of it .
> 
> I know, it seems a trivial  and not even worthy  an issue or PR, but it will save times for many MacOS contributors at least for me.
> 




## Test Result

BEFORE

```
pre-commit run isort -a

isort...............................................................................................Failed
- hook id: isort
- files were modified by this hook

Fixing /Users/peterpan/go/src/vllm/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
Skipped 171 files

```


AFTER

```
pre-commit run isort -a
isort....................................................................Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

