### PR TITLE
[Misc] Retry HF processing if "Already borrowed" error occurs

### DIFF
--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Union
@@ -139,6 +140,9 @@ class InputProcessingContext(InputContext):
         hf_processor: ProcessorMixin,
         data: Mapping[str, object],
         kwargs: Mapping[str, object] = {},
+        *,
+        num_tries: int = 1,
+        max_tries: int = 5,
     ) -> Union[BatchFeature, JSONTree]:
         """
         Call `hf_processor` on the prompt `data`
@@ -180,6 +184,19 @@ class InputProcessingContext(InputContext):
             return cast_output
 
         except Exception as exc:
+            if exc.args[0] == "Already borrowed" and num_tries < max_tries:
+                logger.exception(
+                    "Failed to acquire tokenizer in current thread. "
+                    "Retrying (%d/%d)...", num_tries, max_tries)
+                time.sleep(0.5)
+                return self.call_hf_processor(
+                    hf_processor,
+                    data,
+                    kwargs,
+                    num_tries=num_tries + 1,
+                    max_tries=max_tries,
+                )
+
             msg = (f"Failed to apply {type(hf_processor).__name__} "
                    f"on data={data} with kwargs={allowed_kwargs}")
 

--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -184,8 +184,11 @@ class InputProcessingContext(InputContext):
             return cast_output
 
         except Exception as exc:
-            if exc.args[0] == "Already borrowed" and num_tries < max_tries:
-                logger.exception(
+            # See https://github.com/huggingface/tokenizers/issues/537
+            if (isinstance(exc, RuntimeError) and exc
+                    and exc.args[0] == "Already borrowed"
+                    and num_tries < max_tries):
+                logger.warning(
                     "Failed to acquire tokenizer in current thread. "
                     "Retrying (%d/%d)...", num_tries, max_tries)
                 time.sleep(0.5)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

I've noticed that when using fast tokenizer inside HF processor, there is a chance that "Already borrowed" error (https://github.com/huggingface/tokenizers/issues/537) can occur under high concurrency. Instead of failing the request immediately, it makes more sense to retry the HF processor after a short delay.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

