### PR TITLE
[Bug] fix import and unit test

### DIFF
--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -11,7 +11,7 @@ from vllm.v1.attention.backends.utils import (UBatchSlice,
                                               slice_query_start_locs,
                                               split_attn_metadata,
                                               split_decodes_and_prefills)
-from vllm.v1.worker.ubatch_utils import create_ubatch_slices
+from vllm.v1.worker.ubatch_splitting import create_ubatch_slices
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
https://github.com/vllm-project/vllm/pull/24845 introduced a wrong import which results in errors of `pytest tests/v1/attention/test_attention_splitting.py`.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

