### PR TITLE
[Perf] These changes enhance the NUMA functionality of vllm for systems with more than one NUMA nodes per socket

### DIFF
--- a/csrc/cpu/utils.cpp
+++ b/csrc/cpu/utils.cpp
@@ -44,18 +44,23 @@ std::string init_cpu_threads_env(const std::string& cpu_ids) {
 
   // Memory node binding
   if (numa_available() != -1) {
-    int mem_node_id = numa_node_of_cpu(omp_cpu_ids.front());
-    // Verify all CPUs are on the same NUMA node
-    for (size_t i = 1; i < omp_cpu_ids.size(); ++i) {
-      int node_id = numa_node_of_cpu(omp_cpu_ids[i]);
-      TORCH_CHECK(node_id == mem_node_id, "CPU ", omp_cpu_ids[i],
-                  " is on NUMA node ", node_id, ", but CPU ",
-                  omp_cpu_ids.front(), " is on NUMA node ", mem_node_id,
-                  ". All CPUs should be on the same NUMA node for optimal "
-                  "performance. Memory will be bound to NUMA node ",
-                  mem_node_id, ".");
+    std::set<int> node_ids;
+    for (const auto& cpu_id : omp_cpu_ids) {
+      int node_id = numa_node_of_cpu(cpu_id);
+      if (node_id != -1) {
+        node_ids.insert(node_id);
+      }
     }
-    bitmask* mask = numa_parse_nodestring(std::to_string(mem_node_id).c_str());
+    // Concatenate all node_ids into a single comma-separated string
+    std::string node_ids_str;
+    for (const int node_id : node_ids) {
+      if (!node_ids_str.empty()) {
+        node_ids_str += ",";
+      }
+      node_ids_str += std::to_string(node_id);
+    }
+
+    bitmask* mask = numa_parse_nodestring(node_ids_str.c_str());
     bitmask* src_mask = numa_get_membind();
 
     int pid = getpid();


### PR DESCRIPTION
This PR enhances NUMA memory placement for CPU executions. Previously, all memory allocations were pinned to NUMA node 0 regardless of how many NUMA nodes are getting used in the workload, leading to excessive remote memory accesses and degraded performance. With this change, allocations follow the active NUMA topology and are placed on the appropriate node(s), reducing cross-node traffic and improving locality. The update has been validated on CPU-only workloads.

## Purpose
To resolve the membind issue in NUMA settings. And this is the fix for the below issue
https://github.com/vllm-project/vllm/issues/21436

## Test Plan
Tested it with below parameters
python benchmark_throughput.py --input-len 128 --output-len 128 --model meta-llama/Meta-Llama-3-8B-Instruct --num-prompts 160 --dtype bfloat16 --max-num-seqs 32

No behavioral change for single-node systems
## Test Result
On systems with more than one NUMA node per socket, aligning memory allocation with the active NUMA topology (placing pages on the node where the threads are executing the workload) improved locality and yielded a significant throughput increase compared to the baseline that allocated memory on node 0. Following performance numbers are captured on AMD EPYC 9654 96-Core Processor.

<img width="536" height="153" alt="image" src="https://github.com/user-attachments/assets/499e6ef2-bcc0-4c86-8f64-9e340e9b278c" />


<img width="538" height="153" alt="image" src="https://github.com/user-attachments/assets/e8327132-4c57-488f-826f-c135a468c8eb" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

