### PR TITLE
Fix LogprobsLists dimension comments to clarify context-dependent usage

### DIFF
--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -14,11 +14,11 @@ if TYPE_CHECKING:
 
 class LogprobsLists(NamedTuple):
 
-    # [num_reqs, max_num_logprobs + 1]
+    # [num_reqs or num_tokens, max_num_logprobs + 1]
     logprob_token_ids: list[list[int]]
-    # [num_reqs, max_num_logprobs + 1]
+    # [num_reqs or num_tokens, max_num_logprobs + 1]
     logprobs: list[list[float]]
-    # [num_reqs]
+    # [num_reqs or num_tokens]
     sampled_token_ranks: list[int]
 
     def slice(self, start: int, end: int):
@@ -31,11 +31,11 @@ class LogprobsLists(NamedTuple):
 
 class LogprobsTensors(NamedTuple):
 
-    # [num_reqs, max_num_logprobs + 1]
+    # [num_reqs or num_tokens, max_num_logprobs + 1]
     logprob_token_ids: torch.Tensor
-    # [num_reqs, max_num_logprobs + 1]
+    # [num_reqs or num_tokens, max_num_logprobs + 1]
     logprobs: torch.Tensor
-    # [num_reqs]
+    # [num_reqs or num_tokens]
     selected_token_ranks: torch.Tensor
 
     def tolists(self):


### PR DESCRIPTION
## Purpose
Fix dimension comments in `LogprobsLists` and `LogprobsTensors` classes to clarify that the first dimension has different meanings depending on the usage context.

The original comments used `[num_reqs, ...]` for all cases, which was misleading because:

1. In `ModelRunnerOutput` context: first dimension represents number of requests (`num_reqs`)
2. In `EngineCoreOutput` context: first dimension represents number of output tokens (`num_tokens`, usually 1, can be >1 in speculative decoding)

This inconsistency caused confusion when reading the code, especially when understanding how `LogprobsLists.slice()` works in the scheduler.

## Test Plan
Not needed.

## Test Result
Not needed.
---
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
