### PR TITLE
[UX] Integrate DeepGEMM into vLLM wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -963,6 +963,7 @@ endif()
 # For CUDA we also build and ship some external projects.
 if (VLLM_GPU_LANG STREQUAL "CUDA")
     include(cmake/external_projects/flashmla.cmake)
+    include(cmake/external_projects/deepgemm.cmake)
 
     # vllm-flash-attn should be last as it overwrites some CMake functions
     include(cmake/external_projects/vllm_flash_attn.cmake)

--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -37,7 +37,7 @@ message(STATUS "DeepGEMM git reference: ${DEEPGEMM_GIT_REF}")
 # Create the _deepgemm_C target that runs the install script with custom git ref
 add_custom_target(_deepgemm_C
     COMMAND ${CMAKE_COMMAND} -E echo "Installing DeepGEMM using tools/install_deepgemm.sh..."
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_deepgemm.sh --ref ${DEEPGEMM_GIT_REF}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_deepgemm.sh --ref ${DEEPGEMM_GIT_REF} --cuda-version ${CMAKE_CUDA_COMPILER_VERSION}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Installing DeepGEMM Python package"
     VERBATIM

--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -1,0 +1,42 @@
+# DeepGEMM requires CUDA 12.8+ and only works on sm90 and sm100 architectures
+# Check CUDA version requirement
+if(NOT ${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
+    message(STATUS "Not installing DeepGEMM as CUDA Compiler version is "
+                   "not >= 12.8 (current: ${CMAKE_CUDA_COMPILER_VERSION}). "
+                   "DeepGEMM requires CUDA 12.8 or later.")
+    # Create an empty target for setup.py when CUDA version is insufficient
+    add_custom_target(_deepgemm_C)
+    return()
+endif()
+
+# Only install DeepGEMM if we are building for compatible architectures (sm90, sm100)
+cuda_archs_loose_intersection(DEEPGEMM_ARCHS "9.0;9.0a;10.0;10.0a;10.1;10.1a" "${CUDA_ARCHS}")
+if(NOT DEEPGEMM_ARCHS)
+    message(STATUS "Not installing DeepGEMM as no compatible archs found "
+                   "in CUDA target architectures. DeepGEMM requires sm90 or sm100.")
+    # Create an empty target for setup.py when not targeting compatible systems
+    add_custom_target(_deepgemm_C)
+    return()
+endif()
+
+message(STATUS "Installing DeepGEMM using tools/install_deepgemm.sh for archs: ${DEEPGEMM_ARCHS}")
+
+# Create a timestamp file to track when DeepGEMM was last installed
+set(DEEPGEMM_INSTALL_STAMP "${CMAKE_BINARY_DIR}/deepgemm_install.stamp")
+
+# Create a custom target that runs the install script
+add_custom_command(
+    OUTPUT ${DEEPGEMM_INSTALL_STAMP}
+    COMMAND ${CMAKE_COMMAND} -E echo "Installing DeepGEMM using tools/install_deepgemm.sh..."
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_deepgemm.sh
+    COMMAND ${CMAKE_COMMAND} -E touch ${DEEPGEMM_INSTALL_STAMP}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Installing DeepGEMM Python package"
+    VERBATIM
+)
+
+# Create the _deepgemm_C target that depends on the install step
+add_custom_target(_deepgemm_C
+    DEPENDS ${DEEPGEMM_INSTALL_STAMP}
+    COMMENT "DeepGEMM installation target"
+)

--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -19,24 +19,26 @@ if(NOT DEEPGEMM_ARCHS)
     return()
 endif()
 
+# Support customizing DeepGEMM git reference
+# Can be set as environment variable or cmake argument
+# Environment variable takes precedence
+if (DEFINED ENV{DEEPGEMM_GIT_REF})
+  set(DEEPGEMM_GIT_REF $ENV{DEEPGEMM_GIT_REF})
+endif()
+
+# Use default from tools/install_deepgemm.sh if not specified
+if(NOT DEFINED DEEPGEMM_GIT_REF)
+    set(DEEPGEMM_GIT_REF "ea9c5d9270226c5dd7a577c212e9ea385f6ef048")
+endif()
+
 message(STATUS "Installing DeepGEMM using tools/install_deepgemm.sh for archs: ${DEEPGEMM_ARCHS}")
+message(STATUS "DeepGEMM git reference: ${DEEPGEMM_GIT_REF}")
 
-# Create a timestamp file to track when DeepGEMM was last installed
-set(DEEPGEMM_INSTALL_STAMP "${CMAKE_BINARY_DIR}/deepgemm_install.stamp")
-
-# Create a custom target that runs the install script
-add_custom_command(
-    OUTPUT ${DEEPGEMM_INSTALL_STAMP}
+# Create the _deepgemm_C target that runs the install script with custom git ref
+add_custom_target(_deepgemm_C
     COMMAND ${CMAKE_COMMAND} -E echo "Installing DeepGEMM using tools/install_deepgemm.sh..."
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_deepgemm.sh
-    COMMAND ${CMAKE_COMMAND} -E touch ${DEEPGEMM_INSTALL_STAMP}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_deepgemm.sh --ref ${DEEPGEMM_GIT_REF}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Installing DeepGEMM Python package"
     VERBATIM
-)
-
-# Create the _deepgemm_C target that depends on the install step
-add_custom_target(_deepgemm_C
-    DEPENDS ${DEEPGEMM_INSTALL_STAMP}
-    COMMENT "DeepGEMM installation target"
 )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -439,12 +439,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -r requirements/build.txt \
         --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
 
-# Install DeepGEMM from source
-ARG DEEPGEMM_GIT_REF
-COPY tools/install_deepgemm.sh /tmp/install_deepgemm.sh
-RUN --mount=type=cache,target=/root/.cache/uv \
-    VLLM_DOCKER_BUILD_CONTEXT=1 /tmp/install_deepgemm.sh --cuda-version "${CUDA_VERSION}" ${DEEPGEMM_GIT_REF:+--ref "$DEEPGEMM_GIT_REF"} 
-
 COPY tools/install_gdrcopy.sh install_gdrcopy.sh
 RUN set -eux; \
     case "${TARGETPLATFORM}" in \


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Integrate DeepGEMM installation into vLLM's cmake build system to eliminate the need for manual installation via `tools/install_deepgemm.sh`, like we currently had to do in the Dockerfile.
This PR adds DeepGEMM as an external project (`cmake/external_projects/deepgemm.cmake`) that automatically installs the Python wheel during cmake builds when targeting compatible hardware (sm90/sm100 with CUDA 12.8+).

Now that we have `VLLM_USE_DEEP_GEMM` set to True by default, we should improve the ease of use for wheel users.

NOTE: This doesn't actually work :(

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

