### PR TITLE
Suppress benign cuBLAS warning when capturing cudagraphs with DBO

### DIFF
--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -104,6 +104,7 @@ class UBatchWrapper:
             self.graph_pool = current_platform.get_global_graph_pool()
 
         self.sm_control = self._create_sm_control_context(vllm_config)
+        self.device = device
 
     @staticmethod
     def _create_sm_control_context(vllm_config: VllmConfig):
@@ -168,6 +169,7 @@ class UBatchWrapper:
 
         @torch.inference_mode()
         def _capture_ubatch_thread(results, ubatch_metadata):
+            torch.cuda.set_device(self.device)
             ubatch_context = ubatch_metadata.context
             with torch.cuda.stream(ubatch_context.compute_stream):
                 _ = torch.cuda.current_blas_handle()


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Currently on vllm will output the following warning when capturing DBO cudagraphs.

```
/home/sage/git/nm-vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:1166: UserWarning: Attempting to run cuBLAS, but there was no current CUDA context! Attempting to set the primary context... (Triggered internally at /pytorch/aten/src/ATen/cuda/CublasHandlePool.cpp:179.)
(EngineCore_DP0 pid=3571065)   return torch._C._cuda_getCurrentBlasHandle()
(EngineCore_DP1 pid=3571066) /home/sage/git/nm-vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:1166: UserWarning: Attempting to run cuBLAS, but there was no current CUDA context! Attempting to set the primary context... (Triggered internally at /pytorch/aten/src/ATen/cuda/CublasHandlePool.cpp:179.)
(EngineCore_DP1 pid=3571066)   return torch._C._cuda_getCurrentBlasHandle()
```

This warning is completely benign so we should suppress it.

## Test Plan
Spun up a vllm server with DBO enabled and confirmed that the message no longer appears

## Test Result
` VLLM_ALL2ALL_BACKEND=deepep_low_latency vllm serve --model="deepseek-ai/DeepSeek-V2-Lite" --data-parallel-size 2 --enable-expert-parallel --gpu-memory-utilization 0.75  --enable-dbo`

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3567|±  |0.0277|
|     |       |strict-match    |     5|exact_match|↑  |0.3533|±  |0.0276|
```
