### PR TITLE
Suppress FA3 "wgmma.mma_async instructions are serialized" warning

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -62,6 +62,12 @@ install(CODE "set(CMAKE_INSTALL_PREFIX \"\${CMAKE_INSTALL_PREFIX}/vllm/\")" ALL_
 FetchContent_MakeAvailable(vllm-flash-attn)
 message(STATUS "vllm-flash-attn is available at ${vllm-flash-attn_SOURCE_DIR}")
 
+# Suppress ptxas warnings for flash attention compilation
+if(VLLM_GPU_LANG STREQUAL "CUDA")
+  # Add ptxas flags to suppress C7520 warnings about wgmma.mma_async serialization
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xptxas --diag_suppress=7520")
+endif()
+
 # Restore the install prefix
 install(CODE "set(CMAKE_INSTALL_PREFIX \"\${OLD_CMAKE_INSTALL_PREFIX}\")" ALL_COMPONENTS)
 install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

When compiling FA3 during vLLM's build, we see many warnings that we intentionally ignore. We should ignore these explicitly to avoid cluttering our logs. cc @LucasWilkinson 

Example:
```
[279/502] Building CUDA object vllm-flash-attn/CMakeFiles/_vllm_fa3_C.dir/hopper/instantiations/flash_fwd_hdim64_256_bf16_split_sm90.cu.o
ptxas info    : (C7520) Potential Performance Loss: wgmma.mma_async instructions are serialized due to program dependence on compiler-inserted WG.AR in divergent path in the function '_ZZN5flash25CollectiveMainloopFwdSm90ILi2EN4cute5tupleIJNS1_1CILi1EEES4_S4_EEENS2_IJNS3_ILi128EEENS3_ILi112EEENS3_ILi64EEEEEELi256EN7cutlass10bfloat16_tEfNSA_4arch4Sm90ELb0ELb1ELb0ELb1ELb0ELb0ELb0ELb1ELb0ELb1ELb1ELb0ESB_Li1EE3mmaINS_16FlashAttnFwdSm90ISE_NS_21CollectiveEpilogueFwdINS2_IJS6_NS3_ILi256EEES7_EEES5_SB_SD_Li256ELb1ELb1ELb1ELb0ELi1EEENS_36VarlenDynamicPersistentTileSchedulerILi128ELi256ELi128ELb1ELb1ELb1EEEE13SharedStorageENS1_6TensorINS1_11ArrayEngineIfLm128EEENS1_6LayoutINS2_IJNS2_IJNS3_ILi2EEEST_NS3_ILi32EEEEEES4_S4_EEENS2_IJNS2_IJS4_ST_NS3_ILi4EEEEEENS3_ILi0EEESZ_EEEEEEENS_7SoftmaxILi2ELi0EEEEEbRKNSE_6ParamsENSA_25PipelineTmaAsyncNoClusterILi2ENSA_16PipelineTmaAsyncILi2EEEEES1B_RNSA_13PipelineStateILj2EEERT0_RT1_iRiRKNS_16SeqlenInfoQKNewKILb1ELb0EEENS2_IJiiiiEEERT_ENKUliT_T0_T1_E_clIZSF_ISO_S12_S14_EbS17_S1B_S1B_S1E_S1G_S1I_iS1J_S1N_S1O_S1Q_EUlRS1R_iE1_NS3_ILb0EEENS3_ILb1EEEEEDaiS1R_S1S_S1T_'
ptxas info    : (C7520) Potential Performance Loss: wgmma.mma_async instructions are serialized due to program dependence on compiler-inserted WG.AR in divergent path in the function '_ZZN5flash25CollectiveMainloopFwdSm90ILi2EN4cute5tupleIJNS1_1CILi1EEES4_S4_EEENS2_IJNS3_ILi128EEENS3_ILi112EEENS3_ILi64EEEEEELi256EN7cutlass10bfloat16_tEfNSA_4arch4Sm90ELb0ELb1ELb0ELb1ELb0ELb1ELb0ELb1ELb0ELb1ELb1ELb0ESB_Li1EE3mmaINS_16FlashAttnFwdSm90ISE_NS_21CollectiveEpilogueFwdINS2_IJS6_NS3_ILi256EEES7_EEES5_SB_SD_Li256ELb1ELb1ELb1ELb0ELi1EEENS_36VarlenDynamicPersistentTileSchedulerILi128ELi256ELi128ELb1ELb1ELb1EEEE13SharedStorageENS1_6TensorINS1_11ArrayEngineIfLm128EEENS1_6LayoutINS2_IJNS2_IJNS3_ILi2EEEST_NS3_ILi32EEEEEES4_S4_EEENS2_IJNS2_IJS4_ST_NS3_ILi4EEEEEENS3_ILi0EEESZ_EEEEEEENS_7SoftmaxILi2ELi0EEEEEbRKNSE_6ParamsENSA_25PipelineTmaAsyncNoClusterILi2ENSA_16PipelineTmaAsyncILi2EEEEES1B_RNSA_13PipelineStateILj2EEERT0_RT1_iRiRKNS_16SeqlenInfoQKNewKILb1ELb1EEENS2_IJiiiiEEERT_ENKUliT_T0_T1_E_clIZSF_ISO_S12_S14_EbS17_S1B_S1B_S1E_S1G_S1I_iS1J_S1N_S1O_S1Q_EUlRS1R_iE0_NS3_ILb1EEES1Y_EEDaiS1R_S1S_S1T_'
ptxas info    : (C7520) Potential Performance Loss: wgmma.mma_async instructions are serialized due to program dependence on compiler-inserted WG.AR in divergent path in the function '_ZZN5flash25CollectiveMainloopFwdSm90ILi2EN4cute5tupleIJNS1_1CILi1EEES4_S4_EEENS2_IJNS3_ILi128EEENS3_ILi112EEENS3_ILi64EEEEEELi256EN7cutlass10bfloat16_tEfNSA_4arch4Sm90ELb0ELb1ELb0ELb1ELb0ELb0ELb1ELb1ELb0ELb1ELb1ELb0ESB_Li1EE3mmaINS_16FlashAttnFwdSm90ISE_NS_21CollectiveEpilogueFwdINS2_IJS6_NS3_ILi256EEES7_EEES5_SB_SD_Li256ELb1ELb1ELb1ELb0ELi1EEENS_36VarlenDynamicPersistentTileSchedulerILi128ELi256ELi128ELb1ELb1ELb1EEEE13SharedStorageENS1_6TensorINS1_11ArrayEngineIfLm128EEENS1_6LayoutINS2_IJNS2_IJNS3_ILi2EEEST_NS3_ILi32EEEEEES4_S4_EEENS2_IJNS2_IJS4_ST_NS3_ILi4EEEEEENS3_ILi0EEESZ_EEEEEEENS_7SoftmaxILi2ELi0EEEEEbRKNSE_6ParamsENSA_25PipelineTmaAsyncNoClusterILi2ENSA_16PipelineTmaAsyncILi2EEEEES1B_RNSA_13PipelineStateILj2EEERT0_RT1_iRiRKNS_16SeqlenInfoQKNewKILb1ELb0EEENS2_IJiiiiEEERT_ENKUliT_T0_T1_E_clIZSF_ISO_S12_S14_EbS17_S1B_S1B_S1E_S1G_S1I_iS1J_S1N_S1O_S1Q_EUlRS1R_iE1_NS3_ILb0EEENS3_ILb1EEEEEDaiS1R_S1S_S1T_'
ptxas info    : (C7520) Potential Performance Loss: wgmma.mma_async instructions are serialized due to program dependence on compiler-inserted WG.AR in divergent path in the function '_ZZN5flash25CollectiveMainloopFwdSm90ILi2EN4cute5tupleIJNS1_1CILi1EEES4_S4_EEENS2_IJNS3_ILi128EEENS3_ILi112EEENS3_ILi64EEEEEELi256EN7cutlass10bfloat16_tEfNSA_4arch4Sm90ELb0ELb1ELb0ELb1ELb0ELb1ELb1ELb1ELb0ELb1ELb1ELb0ESB_Li1EE3mmaINS_16FlashAttnFwdSm90ISE_NS_21CollectiveEpilogueFwdINS2_IJS6_NS3_ILi256EEES7_EEES5_SB_SD_Li256ELb1ELb1ELb1ELb0ELi1EEENS_36VarlenDynamicPersistentTileSchedulerILi128ELi256ELi128ELb1ELb1ELb1EEEE13SharedStorageENS1_6TensorINS1_11ArrayEngineIfLm128EEENS1_6LayoutINS2_IJNS2_IJNS3_ILi2EEEST_NS3_ILi32EEEEEES4_S4_EEENS2_IJNS2_IJS4_ST_NS3_ILi4EEEEEENS3_ILi0EEESZ_EEEEEEENS_7SoftmaxILi2ELi0EEEEEbRKNSE_6ParamsENSA_25PipelineTmaAsyncNoClusterILi2ENSA_16PipelineTmaAsyncILi2EEEEES1B_RNSA_13PipelineStateILj2EEERT0_RT1_iRiRKNS_16SeqlenInfoQKNewKILb1ELb1EEENS2_IJiiiiEEERT_ENKUliT_T0_T1_E_clIZSF_ISO_S12_S14_EbS17_S1B_S1B_S1E_S1G_S1I_iS1J_S1N_S1O_S1Q_EUlRS1R_iE0_NS3_ILb1EEES1Y_EEDaiS1R_S1S_S1T_'
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

