### PR TITLE
add logs for avg prefill bs and avg decode bs

### DIFF
--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -395,12 +395,18 @@ class LoggingStatLogger(StatLoggerBase):
                 # Avoid log noise on an idle production system
                 log_fn = logger.debug
 
+            # Get enhanced batch statistics if available
+            avg_prefill_bs = getattr(stats, 'avg_prefill_batch_size', 0.0)
+            avg_decode_bs = getattr(stats, 'avg_decode_batch_size', 0.0)
+
+            # Always log with batch size information
             log_fn(
                 "Avg prompt throughput: %.1f tokens/s, "
                 "Avg generation throughput: %.1f tokens/s, "
                 "Running: %d reqs, Swapped: %d reqs, "
                 "Pending: %d reqs, GPU KV cache usage: %.1f%%, "
-                "CPU KV cache usage: %.1f%%.",
+                "CPU KV cache usage: %.1f%%, "
+                "Avg prefill BS: %.1f, Avg decode BS: %.1f.",
                 prompt_throughput,
                 generation_throughput,
                 stats.num_running_sys,
@@ -408,6 +414,8 @@ class LoggingStatLogger(StatLoggerBase):
                 stats.num_waiting_sys,
                 stats.gpu_cache_usage_sys * 100,
                 stats.cpu_cache_usage_sys * 100,
+                avg_prefill_bs,
+                avg_decode_bs,
             )
             if (stats.cpu_prefix_cache_hit_rate >= 0
                     or stats.gpu_prefix_cache_hit_rate >= 0):

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -124,14 +124,19 @@ class LoggingStatLogger(StatLoggerBase):
         self.last_generation_throughput = generation_throughput
         self.last_prompt_throughput = prompt_throughput
 
-        # Format and print output.
+        # Get batch statistics directly from scheduler_stats
+        avg_prefill_bs = scheduler_stats.get_avg_prefill_batch_size()
+        avg_decode_bs = scheduler_stats.get_avg_decode_batch_size()
+
+        # Log with batch size information
         log_fn(
             "Engine %03d: "
             "Avg prompt throughput: %.1f tokens/s, "
             "Avg generation throughput: %.1f tokens/s, "
             "Running: %d reqs, Waiting: %d reqs, "
             "GPU KV cache usage: %.1f%%, "
-            "Prefix cache hit rate: %.1f%%",
+            "Prefix cache hit rate: %.1f%%, "
+            "Avg prefill BS: %.1f, Avg decode BS: %.1f.",
             self.engine_index,
             prompt_throughput,
             generation_throughput,
@@ -139,6 +144,8 @@ class LoggingStatLogger(StatLoggerBase):
             scheduler_stats.num_waiting_reqs,
             scheduler_stats.kv_cache_usage * 100,
             self.prefix_caching_metrics.hit_rate * 100,
+            avg_prefill_bs,
+            avg_decode_bs,
         )
         self.spec_decoding_logging.log(log_fn=log_fn)
         self.kv_transfer_logging.log(log_fn=log_fn)

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -3,7 +3,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 import torch
 
@@ -122,6 +122,9 @@ class ModelRunnerOutput:
 
     # req_id -> num_nans_in_logits
     num_nans_in_logits: Optional[dict[str, int]] = None
+
+    # Batch statistics for scheduler integration
+    batch_stats: Optional[dict[str, Any]] = None
 
 
 # ModelRunnerOutput wrapper for async scheduling.


### PR DESCRIPTION
Summary:
Having prefill bs and decode bs in logs can help understanding whether the computation is prefill-boudned or decode-bounded. Previously, vllm does not log these two metrics.

This diff calcuates the bs by comparing the num_computed_tokens and num_prompt_tokens. num_computed_tokens < num_prompt_tokens means there are remaining tokens to be processed from the prompt, that is, the req is still in the prefill stage. Otherwise, it is in the decode stage.

Test Plan:
Run vllm.

In server logs, before:

`INFO 08-26 14:12:49 [loggers.py:182] Engine 000: Avg prompt throughput: 14861.5 tokens/s, Avg generation throughput: 78.2 tokens/s, Running: 35 reqs, Waiting: 16 reqs, GPU KV cache usage: 38.4%, Prefix cache hit rate: 0.0%`

after:
`
INFO 08-26 18:27:07 [loggers.py:186] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 1621.1 tokens/s, Running: 74 reqs, Waiting: 54 reqs, GPU KV cache usage: 98.9%, Prefix cache hit rate: 1.2%, Avg prefill BS: 2.0, Avg decode BS: 78.3.`

Differential Revision: D81097003


