### PR TITLE
[Bug] Dynamo Unsupported due to `BasevLLMParameter.torch_function` calling disabled super()

### DIFF
--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -116,7 +116,7 @@ class BasevLLMParameter(Parameter):
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
         if not is_torch_equal_or_newer("2.8.0"):
-            logger.warning(
+            logger.warning_once(
                 "Torch %s detected (<2.8.0): returning NotImplemented in "
                 "BasevLLMParameter.__torch_function__ to avoid potential "
                 "TorchDynamo issues.",

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -12,6 +12,7 @@ from torch.nn import Parameter
 from vllm.distributed import (get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size)
 from vllm.logger import init_logger
+from vllm.utils import is_torch_equal_or_newer
 
 __all__ = [
     "BasevLLMParameter", "PackedvLLMParameter", "PerTensorScaleParameter",
@@ -114,6 +115,15 @@ class BasevLLMParameter(Parameter):
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if not is_torch_equal_or_newer("2.8.0"):
+            logger.warning(
+                "Torch %s detected (<2.8.0): returning NotImplemented in "
+                "BasevLLMParameter.__torch_function__ to avoid potential "
+                "TorchDynamo issues.",
+                torch.__version__,
+            )
+            return NotImplemented
+
         if kwargs is None:
             kwargs = {}
         return super().__torch_function__(func, types, args, kwargs)


### PR DESCRIPTION
## Purpose

Added clear instructions for https://github.com/vllm-project/vllm/issues/25604#issuecomment-3330707969

## Test

After upgrading to torch 2.8.0, the issue disappear

`vllm bench throughput --model Qwen/Qwen3-30B-A3B-FP8 --load-format dummy --input-len 1000 --output-len 100 --trust_remote_code --enable-expert-parallel`

```bash
Throughput: 20.97 requests/s, 23004.43 total tokens/s, 2096.51 output tokens/s
Total num prompt tokens:  997271
Total num output tokens:  100000
```