### PR TITLE
[BugFix] Fix using `dbo_decode_token_threshold` always (and ignoring `dbo_prefill_token_threshold`)

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1034,7 +1034,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_tokens_unpadded)
         uniform_decode = \
             (max_num_scheduled_tokens == self.uniform_decode_query_len) and \
-            (num_scheduled_tokens == num_reqs * max_num_scheduled_tokens)
+            (total_num_scheduled_tokens == num_reqs * max_num_scheduled_tokens)
         ubatch_slices, num_tokens_after_padding = \
             ubatch_split(num_scheduled_tokens,
                          num_tokens_unpadded,

--- a/vllm/v1/worker/ubatch_splitting.py
+++ b/vllm/v1/worker/ubatch_splitting.py
@@ -139,6 +139,7 @@ def ubatch_split(
     num_scheduled_tokens_per_request: np.ndarray,
     num_tokens_unpadded: int,
     num_tokens_padded: int,
+    uniform_decode: bool,
     vllm_config: VllmConfig,
 ) -> tuple[Optional[UBatchSlices], Optional[torch.Tensor]]:
     """
@@ -164,7 +165,7 @@ def ubatch_split(
     should_attempt_ubatching = check_ubatch_thresholds(
         parallel_config,
         num_tokens_unpadded,
-        vllm_config,
+        uniform_decode=uniform_decode,
     )
 
     # Don't microbatch unless every other DP worker is also microbatching


### PR DESCRIPTION
This fixes a bug where we use `dbo_decode_token_threshold` for checking non-decode batches instead of `dbo_prefill_token_threshold`
