### PR TITLE
fix(attn): Correct inconsistent TorchSDPAMetadata definition in cpu_a…

### DIFF
--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -86,6 +86,9 @@ class TorchSDPABackend(AttentionBackend):
 @dataclass
 class TorchSDPAMetadata(AttentionMetadata):
     """Metadata for PagedAttention."""
+    num_prefill_tokens: int
+    num_decode_tokens: int
+    slot_mapping: torch.Tensor
     # (batch_size,). The length of sequences (entire tokens seen so far) per
     # sequence.
     seq_lens_tensor: Optional[torch.Tensor]
@@ -400,7 +403,6 @@ class TorchSDPAMetadataBuilderV1(AttentionMetadataBuilder[TorchSDPAMetadata]):
         block_table_tensor = common_attn_metadata.block_table_tensor
 
         attn_metadata = TorchSDPAMetadata(
-            num_prefills=num_prompt_req,
             num_prefill_tokens=num_prefill_tokens,
             num_decode_tokens=num_decode_tokens,
             slot_mapping=slot_mapping,
@@ -420,7 +422,6 @@ class TorchSDPAMetadataBuilderV1(AttentionMetadataBuilder[TorchSDPAMetadata]):
                                                     num_prompt_req],  # prefill
             query_start_loc=query_start_loc_cpu[:num_reqs +
                                                 1],  # for logits index
-            enable_kv_scales_calculation=False,
         )
 
         return attn_metadata


### PR DESCRIPTION
## Purpose

Fixes #25630. Align `TorchSDPAMetadata` with its builder and CPU attention consumer:

- Add `num_prefill_tokens`, `num_decode_tokens`, and `slot_mapping` to the dataclass.
- Remove the unsupported constructor arguments `num_prefills` and `enable_kv_scales_calculation`.

The mismatched fields and arguments caused `TypeError` or `AttributeError` during CPU attention setup and execution.

## Test Plan

Use a compatible CPU vLLM environment and a local model:

```python
from vllm import LLM, SamplingParams

if __name__ == "__main__":
    llm = LLM(
        model="/path/to/Qwen3-0.6B",
        max_num_batched_tokens=40960,
        max_model_len=256,
    )
    outputs = llm.generate(["你是谁?"], SamplingParams(temperature=0.8, top_p=0.95))
    for output in outputs:
        print(output.outputs[0].text)
```

Run with `python test.py`.

## Historical Test Result

The original PR reports an unexpected `num_prefill_tokens` constructor argument before the fix, or a missing `slot_mapping` attribute when only the constructor is patched. It reports that the completed change lets the engine proceed past these errors. That historical CPU test was not rerun for this description update.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
