### PR TITLE
skip InternS1ForConditionalGeneration for test_can_initialize_large_s…

### DIFF
--- a/tests/models/test_initialization.py
+++ b/tests/models/test_initialization.py
@@ -123,12 +123,15 @@ def test_can_initialize_small_subset(model_arch: str,
 def test_can_initialize_large_subset(model_arch: str,
                                      monkeypatch: pytest.MonkeyPatch):
     """Test initializing large subset of supported models
-    
+
     This test covers the complement of the tests covered in the "small subset"
     test.
     """
     if model_arch == "Lfm2ForCausalLM":
         pytest.skip("Skipping until test supports V1-only models")
+    if model_arch == "InternS1ForConditionalGeneration":
+        pytest.skip(
+            "Skipping as the model is failing on the Transformers Nightly")
     can_initialize(model_arch, monkeypatch, HF_EXAMPLE_MODELS)
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Looking the nightly build CI in the past few days https://app.hex.tech/533fe68e-dcd8-4a52-a101-aefba762f581/app/vLLM-CI-030kdEgDv6lSlh1UPYOkWP/latest , i found that `tests/models/test_initialization.py::test_can_initialize_large_subset[InternS1ForConditionalGeneration]` kept failing with the error like
```

[2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708] EngineCore failed to start.
--
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708] Traceback (most recent call last):
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/inputs/registry.py", line 166, in call_hf_processor
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]     output = hf_processor(**data,
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]              ^^^^^^^^^^^^^^^^^^^^
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/transformers/models/internvl/processing_internvl.py", line 224, in __call__
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]     video_inputs = self.video_processor(videos=videos, **output_kwargs["videos_kwargs"])
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/transformers/video_processing_utils.py", line 209, in __call__
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]     return self.preprocess(videos, **kwargs)
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/transformers/video_processing_utils.py", line 390, in preprocess
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]     preprocessed_videos = self._preprocess(videos=videos, **kwargs)
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | [2025-09-24T04:18:47Z] (EngineCore_DP0 pid=3162) ERROR 09-23 21:18:47 [core.py:708] TypeError: InternS1VideoProcessor._preprocess() got an unexpected keyword argument 'pad_size'
```
sample job link https://buildkite.com/vllm/ci/builds/32227/steps/canvas?sid=019979e1-da27-4a3e-b27f-f9618b32c93b

we might want to skip this particular test to make all the test good for all the other models otherwise it is flaky and lose the point of testing

i found one similar issue reported on hf transformer side https://github.com/huggingface/transformers/issues/41079 and i will create a new issue

## Test Plan

CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

