### PR TITLE
[Misc] Fix internal invocation of _register_fake

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -2667,7 +2667,9 @@ def direct_register_custom_op(
     my_lib.define(op_name + schema_str, tags=tags)
     my_lib.impl(op_name, op_func, dispatch_key=dispatch_key)
     if fake_impl is not None:
-        my_lib._register_fake(op_name, fake_impl)
+        torch.library.register_fake(f"{my_lib.ns}::{op_name}",
+                                    fake_impl,
+                                    lib=my_lib)
 
 
 def resolve_obj_by_qualname(qualname: str) -> Any:


### PR DESCRIPTION
<!-- markdownlint-disable -->

run ci temporarily.

## Purpose

Fix internal invocation of `_register_fake` by replacing it with the public `torch.library.register_fake`.  
Keep `direct_register_custom_op` unchanged, in order to avoid overhead brought by customop

Resolves: #25372

## Test Plan

## Test Result


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

