### PR TITLE
fix(tracing): Prevent AssertionError in do_tracing when stats are not…

### DIFF
--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -475,9 +475,9 @@ class OutputProcessor:
     def do_tracing(self, engine_core_output: EngineCoreOutput,
                    req_state: RequestState,
                    iteration_stats: Optional[IterationStats]) -> None:
-        assert req_state.stats is not None
-        assert iteration_stats is not None
-        assert self.tracer is not None
+        if (req_state.stats is None or self.tracer is None
+                or iteration_stats is None):
+            return
 
         arrival_time_nano_seconds = int(req_state.stats.arrival_time * 1e9)
         trace_context = extract_trace_context(engine_core_output.trace_headers)


### PR DESCRIPTION
## Purpose

Fixes #25352. `do_tracing` previously asserted that request stats, iteration stats, and a tracer were all present. With tracing configured but stat logging disabled, request stats can be absent and the assertion terminates processing.

Return early when **any** of `req_state.stats`, `iteration_stats`, or `self.tracer` is `None`.

## Test Plan

In a compatible vLLM environment, use a local model and an OTLP endpoint. The example now explicitly disables stat logging to match the reported condition:

```python
from vllm import LLM, SamplingParams

if __name__ == "__main__":
    llm = LLM(
        model="/path/to/Qwen3-0.6B",
        otlp_traces_endpoint="http://127.0.0.1:4317",
        disable_log_stats=True,
        max_num_batched_tokens=40960,
        max_model_len=256,
    )
    outputs = llm.generate(["你是谁"], SamplingParams(temperature=0.8, top_p=0.95))
    for output in outputs:
        print(output.outputs[0].text)
```

## Historical Test Result

The original PR reports an `AssertionError` at `assert req_state.stats is not None` before the fix and completion afterward. Its original script did not explicitly set `disable_log_stats=True`; the corrected example above and the historical environment were not rerun for this description update.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
