### PR TITLE
[Bugfix] Add triton.language.tensor placeholder

### DIFF
--- a/tests/test_triton_utils.py
+++ b/tests/test_triton_utils.py
@@ -69,6 +69,8 @@ def test_triton_placeholder_language():
     assert lang.constexpr is None
     assert lang.dtype is None
     assert lang.int64 is None
+    assert lang.int32 is None
+    assert lang.tensor is None
 
 
 def test_triton_placeholder_language_from_parent():

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -93,3 +93,4 @@ class TritonLanguagePlaceholder(types.ModuleType):
         self.dtype = None
         self.int64 = None
         self.int32 = None
+        self.tensor = None


### PR DESCRIPTION
Fix issue:
`AttributeError: module 'triton.language' has no attribute 'tensor'`

As LanguagePlaceholder doesn't have this field that is being used in compute_identity_kernel in vllm/model_executor/layers/fused_moe/fused_moe.py:670

Regression after: https://github.com/vllm-project/vllm/pull/23991 