### PR TITLE
[Triton] Fix TritonLanguagePlaceholder missing tensor attribute

### DIFF
--- a/tests/test_triton_utils.py
+++ b/tests/test_triton_utils.py
@@ -69,6 +69,7 @@ def test_triton_placeholder_language():
     assert lang.constexpr is None
     assert lang.dtype is None
     assert lang.int64 is None
+    assert lang.tensor is None
 
 
 def test_triton_placeholder_language_from_parent():

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -93,3 +93,4 @@ class TritonLanguagePlaceholder(types.ModuleType):
         self.dtype = None
         self.int64 = None
         self.int32 = None
+        self.tensor = None


### PR DESCRIPTION
## Purpose
Fix TritonLanguagePlaceholder missing tensor attribute, this is because TritonLanguagePlaceholder does not have a tensor attribute, but compute_identity_kernel in fused_moe.py uses tl.tensor

## Test Plan
existed CI passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
