### PR TITLE
[Bugfix] Correct import error on TPU accelerator

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -93,3 +93,4 @@ class TritonLanguagePlaceholder(types.ModuleType):
         self.dtype = None
         self.int64 = None
         self.int32 = None
+        self.tensor = None


### PR DESCRIPTION
PR #23991 use another attribute from triton.language, which cause import error in TPU setup.

Enhance the placeholder for TPU environment.

## Purpose

Make TPU accelerator setup working again.

## Test Plan

Test locally.

## Test Result

Pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
