### PR TITLE
[Doc] Fixed shape description for fused_batched_moe.py

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -355,7 +355,7 @@ def batched_triton_kernel(
 
 def invoke_moe_batched_triton_kernel(
         A: torch.Tensor,  # [E, max_tokens, K]
-        B: torch.Tensor,  # [E, K, N]
+        B: torch.Tensor,  # [E, N, K]
         C: torch.Tensor,  # [E, max_tokens, N]
         expert_num_tokens: torch.Tensor,  # [E]
         compute_type: tl.dtype,


### PR DESCRIPTION
Existing comment is wrong and misleading.

Based on 
```
 grid = (expert_num_tokens.size(0), triton.cdiv(max_num_tokens, BLOCK_M) *
            triton.cdiv(B.size(1), BLOCK_N))
```
and further position of `B.stride(1)` in `stride_bn` the N should be on the 1st position.
