### PR TITLE
[Bug] Fix Negative Cuda Memory Usage

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3322,7 +3322,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         compilation_counter.num_gpu_runner_capture_triggers += 1
 
         start_time = time.perf_counter()
-        start_free_gpu_memory = torch.cuda.mem_get_info()[0]
 
         @contextmanager
         def freeze_gc():
@@ -3345,6 +3344,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # can reuse the memory pool allocated for the large shapes.
         set_cudagraph_capturing_enabled(True)
         with freeze_gc(), graph_capture(device=self.device):
+            start_free_gpu_memory = torch.cuda.mem_get_info()[0]
             cudagraph_mode = self.compilation_config.cudagraph_mode
             assert cudagraph_mode is not None
             if cudagraph_mode.mixed_mode() != CUDAGraphMode.NONE:
@@ -3373,6 +3373,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     cudagraph_runtime_mode=CUDAGraphMode.FULL,
                     uniform_decode=True)
 
+            torch.cuda.synchronize()
+            end_free_gpu_memory = torch.cuda.mem_get_info()[0]
+
         # Disable cudagraph capturing globally, so any unexpected cudagraph
         # capturing will be detected and raise an error after here.
         # Note: We don't put it into graph_capture context manager because
@@ -3381,7 +3384,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         set_cudagraph_capturing_enabled(False)
 
         end_time = time.perf_counter()
-        end_free_gpu_memory = torch.cuda.mem_get_info()[0]
         elapsed_time = end_time - start_time
         cuda_graph_size = start_free_gpu_memory - end_free_gpu_memory
         # This usually takes 5~20 seconds.


### PR DESCRIPTION
## Purpose

```bash
2025-09-24T04:15:29.297966219Z (EngineCore_DP4 pid=1673) INFO 09-24 00:15:29 [v1/worker/gpu_model_runner.py:3380] Graph capturing finished in 79 secs, took -9.96 GiB
2025-09-24T04:15:29.298151199Z (EngineCore_DP4 pid=1673) DEBUG 09-24 00:15:29 [v1/worker/gpu_worker.py:401] Free memory on device (176.17/178.35 GiB) on startup. Desired GPU memory utilization is (0.9, 160.52 GiB). Actual usage is 60.79 GiB for weight, 13.33 GiB for peak activation, 10.96 GiB for non-torch memory, and -9.96 GiB for CUDAGraph memory. Replace gpu_memory_utilization config with `--kv-cache-memory=91539781222` (85.25 GiB) to fit into requested memory, or `--kv-cache-memory=108345741312` (100.9 GiB) to fully utilize gpu memory. Current kv cache memory in use is 75.44 GiB.
```

This PR updates the logic for memory usage capture, hopefully fix the issue.

## Test

@smarterclayton Could you try again using this branch?
