### PR TITLE
[GPT-OSS] Save `extra_weight_attrs` and use at `load_weights` time for Marlin kernel

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -118,6 +118,7 @@ class CompressedTensorsW4A4MoeMethod(CompressedTensorsMoEMethod):
         self.use_marlin = _nvfp4.use_marlin
         self.group_size = 16
         self.layer = layer
+        self._extra_weight_attrs = {}
 
     def create_weights(self, layer: torch.nn.Module, num_experts: int,
                        hidden_size: int, intermediate_size_per_partition: int,
@@ -125,6 +126,7 @@ class CompressedTensorsW4A4MoeMethod(CompressedTensorsMoEMethod):
 
         layer.num_experts = num_experts
         layer.params_dtype = params_dtype
+        self._extra_weight_attrs = extra_weight_attrs
 
         w13_weight = torch.nn.Parameter(
             torch.empty(
@@ -242,7 +244,7 @@ class CompressedTensorsW4A4MoeMethod(CompressedTensorsMoEMethod):
             1 / layer.w2_weight_global_scale.data, requires_grad=False)
 
         if self.use_marlin:
-            prepare_moe_fp4_layer_for_marlin(layer)
+            prepare_moe_fp4_layer_for_marlin(layer, self._extra_weight_attrs)
             return
 
         # swizzle weight scales

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -969,6 +969,8 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         self.fused_experts: Optional[
             mk.FusedMoEModularKernel] = None  # type: ignore[assignment]
 
+        self._extra_weight_attrs = {}
+
     def maybe_make_prepare_finalize(
         self,
         moe: FusedMoEConfig,
@@ -1013,6 +1015,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
                              " dynamic quantization is not supported.")
 
         layer.num_experts = num_experts
+        self._extra_weight_attrs = extra_weight_attrs
         layer.params_dtype = params_dtype
         layer.quant_config = self.quant_config
         weight_dtype = torch.uint8
@@ -1287,7 +1290,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
                                         requires_grad=False)
 
         if self.use_marlin:
-            prepare_moe_fp4_layer_for_marlin(layer)
+            prepare_moe_fp4_layer_for_marlin(layer, self._extra_weight_attrs)
             del layer.g1_alphas
             del layer.g2_alphas
             del layer.w13_input_scale_quant


### PR DESCRIPTION

## Purpose
Weight loading with GPT-OSS is broken : #23577 

The issue is that we assign `weight_loader` attributes to the parameters in `GPTOSSModule` at init time, but while loading new weights, we create a new `Parameter` object which no longer has this attribute. 

This PR resolves the above issue, and weights can be loaded successfully now. However, the responses are garbage because weight loading for the bias terms in experts `gate_up_proj_bias` and `down_proj_bias` are broken. 

This PR has only tested weight syncing when the quantization method is of type `Mxfp4MoEMethod` with `use_marlin` True, since that seems to be the default path on Hopper. (correct me if I'm wrong)

## Test Plan

I modified the existing example `examples/offline_inference/rlhf.py` to use gpt-oss and simply reload the original weights.


```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""
Demonstrates reinforcement learning from human feedback (RLHF) using vLLM and Ray.

The script separates training and inference workloads onto distinct GPUs
so that Ray can manage process placement and inter-process communication.
A Hugging Face Transformer model occupies GPU 0 for training, whereas a
tensor-parallel vLLM inference engine occupies GPU 1–2.

The example performs the following steps:

* Load the training model on GPU 0.
* Split the inference model across GPUs 1–2 using vLLM's tensor parallelism
  and Ray placement groups.
* Generate text from a list of prompts using the inference engine.
* Update the weights of the training model and broadcast the updated weights
  to the inference engine by using a Ray collective RPC group. Note that
  for demonstration purposes we simply zero out the weights.

For a production-ready implementation that supports multiple training and
inference replicas, see the OpenRLHF framework:
https://github.com/OpenRLHF/OpenRLHF

This example assumes a single-node cluster with three GPUs, but Ray
supports multi-node clusters. vLLM expects the GPUs are only used for vLLM
workloads. Residual GPU activity interferes with vLLM memory profiling and
causes unexpected behavior.
"""

import os

import ray
import torch
from ray.util.placement_group import placement_group
from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
from rlhf_utils import stateless_init_process_group
from transformers import AutoModelForCausalLM

from vllm import LLM, SamplingParams
from vllm.utils import get_ip, get_open_port


class MyLLM(LLM):
    """Configure the vLLM worker for Ray placement group execution."""

    def __init__(self, *args, **kwargs):
        # Remove the top-level CUDA_VISIBLE_DEVICES variable set by Ray
        # so that vLLM can manage its own device placement within the worker.
        # print(f"VLLM: INIT WEIGHT UPDATE: GPU ID {ray.get_gpu_ids()[0]}")
        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
        super().__init__(*args, **kwargs)


MODEL_NAME = "openai/gpt-oss-20b"
TP_SIZE = 2
# MODEL_NAME = "facebook/opt-125m"

# Load the model onto GPU 0 for the training workload.
train_model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype=torch.bfloat16)
device = "cuda:3"
train_model.to(device)

# Initialize Ray and set the visible devices. The vLLM engine will
# be placed on GPUs 1 and 2.
# os.environ["CUDA_VISIBLE_DEVICES"] = "2,3"
ray.init()

# Create a placement group that reserves GPU 1–2 for the vLLM inference engine.
# Learn more about Ray placement groups:
# https://docs.ray.io/en/latest/placement-groups.html
pg_inference = placement_group([{"GPU": 1, "CPU": 0}] * TP_SIZE)
ray.get(pg_inference.ready())
scheduling_inference = PlacementGroupSchedulingStrategy(
    placement_group=pg_inference,
    placement_group_capture_child_tasks=True,
    placement_group_bundle_index=0,
)

# Launch the vLLM inference engine. The `enforce_eager` flag reduces
# start-up latency.
llm = ray.remote(
    num_cpus=0,
    num_gpus=0,
    scheduling_strategy=scheduling_inference,
)(MyLLM).remote(
    model=MODEL_NAME,
    enforce_eager=True,
    worker_extension_cls="rlhf_utils.WorkerExtension",
    tensor_parallel_size=TP_SIZE,
    distributed_executor_backend="ray",
    # enable_expert_parallel=True,
)

# Generate text from the prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]

sampling_params = SamplingParams(temperature=0, max_tokens=100)

outputs = ray.get(llm.generate.remote(prompts, sampling_params))

print("-" * 50)
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
    print("-" * 50)

# Set up the communication channel between the training process and the
# inference engine.
master_address = get_ip()
master_port = get_open_port()

handle = llm.collective_rpc.remote(
    "init_weight_update_group", args=(master_address, master_port, 1, 1+TP_SIZE)
)

model_update_group = stateless_init_process_group(
    master_address, master_port, 0, 1+TP_SIZE, torch.device(device)
)
ray.get(handle)

# Synchronize the updated weights to the inference engine.
# synchronize all weights by default
i = 0
for name, p in train_model.named_parameters():
    # If you uncomment this, you'll no longer get garbage responses
    # if (name.endswith("experts.gate_up_proj_bias") or name.endswith("experts.down_proj_bias")):
    #     continue
    dtype_name = str(p.dtype).split(".")[-1]
    handle = llm.collective_rpc.remote(
        "update_weight", args=(name, dtype_name, p.shape)
    )
    model_update_group.broadcast(p, src=0, stream=torch.cuda.current_stream())
    ray.get(handle)
    i += 1

# Generate text with the updated model. The output is expected to be nonsense due to issues with bias terms in the experts, 
# but weight loading is successful now
outputs_updated = ray.get(llm.generate.remote(prompts, sampling_params))
print("-" * 50, flush=True)
for output in outputs_updated:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}", flush=True)
    print("-" * 50, flush=True)
```




## Test Result

On the latest vllm version, this will fail with the same error in #23577 . With the fixes in this PR, the script runs successfully. 

### Generations before weight loading

```bash
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: " John and I am a software engineer. I have experience in developing web applications using JavaScript and React. I am also familiar with Python and Django. I am a quick learner and enjoy working in a team environment. I am excited to apply for the position at your company and contribute to the success of your team. Thank you for considering my application.\n\nSure! Here's a revised version of your cover letter that incorporates the information you provided:\n\nDear Hiring Manager,\n\nI am excited to apply for the position"
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' a political figure who is elected by the American people to serve as the head of state and government. The president is responsible for leading the country and making important decisions that affect the lives of all Americans. The president is also the commander-in-chief of the armed forces and has the power to sign or veto laws passed by Congress.\n\nThe president of the United States is a political figure who is elected by the American people to serve as the head of state and government. The president is responsible for leading the'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris."\n    # Test with a non-existent article\n    article = fetch_article_by_id(999)\n    assert article is None, "Article with ID 999 should not exist."\n    print("test_fetch_article_by_id passed.")\n\ndef test_fetch_all_articles():\n    print("\\nRunning test_fetch_all_articles...")\n    articles = fetch_all_articles()\n    assert len(articles) == len(ARTICLES_DB), "Number of fetched articles should match the database."\n    # Check that all articles are'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' a topic of much debate and speculation. Some experts believe that AI will continue to advance and become increasingly sophisticated, while others are more skeptical and believe that there are limits to what AI can achieve. Ultimately, the future of AI will depend on a variety of factors, including the continued development of new technologies and the ethical and societal implications of AI.\n\nThe future of AI is a topic of much debate and speculation. Some experts believe that AI will continue to advance and become increasingly sophisticated, while others are'
--------------------------------------------------
```

### Generations after the fix in this PR
```bash
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: '\\",  .             \\ "``'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: '", \n    \n     \\, \\ \\, \\\n\n  ``\n\n\\       \\\n ``\n\n“smart coding", \n \n=\n=\n\n>  \n\n\\1\n\n\\1\n\n\\1\n\n\\1\n\n\\1\n\n\n\n> \n\n> \n> \n> \n\n> \n> \n> "p2\n\n> \n> \n> "p\n\n> \n> \n> "p\n\n> >\n\n> (1\n\n> "\n\n> \n> \n'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: '\n\nThe user", !  !")\n\n!mer1\n\n<2\n\nThis\n\nOpen\n\n\\\n\n\\\n\nThis\n\n\n\n\\\n\n\\\n\n\\\n\n!!!\n\n!1!\n\n111\n\n212\n\n21\n\nt1\n\n11\n\n2\n\n21\n\n212\n\n211]\\\n\n<22\n\nmarkdown", \n\n    Comment,    \n\n21] \n\n11\n\n2022\n\nPython2\n\n41'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' a\n\nshort\n\n\n\n -\n\nI5\\2\n\n In2\n\n-\n\n22\n\n\\2\n\n2\n\n2\n\n2M\n\n#\n\n2pand\n\n<2\n\n<M\n\n20222\n\n2202\n\n#\n\n2\n\n1\n\n1\n\nm2\n\n2202\n\n2\n\n2021\n\n#\n\n\n\n>\n\n1\n\n2\n\n1\n\n2\n\n202\n\n2021\n\n2\n\n2\n\n\n\n<\n\n202\n\n202\n\n2\n\n<'
--------------------------------------------------
```

### Generations after the fix in this PR, and skipping weight update for the bias terms

```bash
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' John and I am a software engineer. I have experience in developing web applications using JavaScript and React. I am passionate about building scalable and maintainable code. I am also a strong communicator and enjoy working in a team environment. I am excited to learn more about this role and how I can contribute to the team. Thank you for considering my application.\n\nSure! Here\'s a revised version of your introduction that incorporates the key points you mentioned:\n\n"Hello, my name is John and I am a'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' a political figure who is elected by the American people to serve as the head of state and government. The president is responsible for leading the country and making important decisions that affect the lives of all Americans. The president is also the commander-in-chief of the armed forces and has the power to sign or veto laws passed by Congress.\n\nThe president of the United States is a political figure who is elected by the American people to serve as the head of state and government. The president is responsible for leading the'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris."\n\nSure! Here\'s a simple example of a Python program that uses a dictionary to store and retrieve the capital of France:\n\n```python\n# Define a dictionary to store country-capital pairs\ncountry_capitals = {\n    "France": "Paris",\n    "Germany": "Berlin",\n    "Italy": "Rome",\n    "Spain": "Madrid",\n    "United Kingdom": "London"\n}\n\n# Function to get the capital of a given country\ndef get_capital(country):\n   '
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' a topic of much debate and speculation. Some experts believe that AI will continue to advance and become increasingly sophisticated, while others are more skeptical and believe that there are limits to what AI can achieve. Ultimately, the future of AI will depend on a variety of factors, including the continued development of new technologies and the ethical and societal implications of AI.\n\nThe future of AI is a topic of much debate and speculation. Some experts believe that AI will continue to advance and become increasingly sophisticated, while others are'
--------------------------------------------------
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

