### PR TITLE
[Core] Force PIECEWISE CUDAGraph mode for encoder-decoder

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -364,9 +364,11 @@ class VllmConfig:
                     self.compilation_config.cudagraph_mode = \
                         CUDAGraphMode.FULL_AND_PIECEWISE
 
-                    # pooling model does not support full cudagraphs
+                    # pooling models and encoder-decoder models
+                    # do not support full cudagraphs
                     if self.model_config is not None and \
-                        self.model_config.pooler_config is not None:
+                        (self.model_config.pooler_config is not None
+                         or self.model_config.is_encoder_decoder):
                         self.compilation_config.cudagraph_mode = \
                             CUDAGraphMode.PIECEWISE
                 else:


### PR DESCRIPTION
Whisper does not work with full cudagraphs. That is being worked on in
PR #25208.

The failure can be reproduced reliably via
`tests/models/multimodal/generation/test_whisper.py`, at least in my
H100 development environment. The tests passed on the PR and I'm not
sure why.

Regardless, this seems like the right change to make until #25208
sorts out exactly what changes are needed.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
