### PR TITLE
[CI/Build] Use CPU in test_collective_rpc CI

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -128,7 +128,7 @@ steps:
   - tests/entrypoints/test_chat_utils
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/openai/test_collective_rpc.py # PYTHONPATH is needed to import custom Worker extension
+  - VLLM_CPU_ONLY=1 CUDA_VISIBLE_DEVICES="" PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/openai/test_collective_rpc.py # PYTHONPATH is needed to import custom Worker extension
   - pytest -v -s entrypoints/openai --ignore=entrypoints/openai/test_chat_with_tool_reasoning.py --ignore=entrypoints/openai/test_oot_registration.py --ignore=entrypoints/openai/test_tensorizer_entrypoint.py --ignore=entrypoints/openai/correctness/ --ignore=entrypoints/openai/test_collective_rpc.py --ignore=entrypoints/openai/tool_parsers/
   - pytest -v -s entrypoints/test_chat_utils.py
 

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -128,7 +128,7 @@ steps:
   - tests/entrypoints/test_chat_utils
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - VLLM_CPU_ONLY=1 CUDA_VISIBLE_DEVICES="" PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/openai/test_collective_rpc.py # PYTHONPATH is needed to import custom Worker extension
+  - VLLM_CPU_ONLY=1 PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/openai/test_collective_rpc.py # PYTHONPATH is needed to import custom Worker extension
   - pytest -v -s entrypoints/openai --ignore=entrypoints/openai/test_chat_with_tool_reasoning.py --ignore=entrypoints/openai/test_oot_registration.py --ignore=entrypoints/openai/test_tensorizer_entrypoint.py --ignore=entrypoints/openai/correctness/ --ignore=entrypoints/openai/test_collective_rpc.py --ignore=entrypoints/openai/tool_parsers/
   - pytest -v -s entrypoints/test_chat_utils.py
 


### PR DESCRIPTION
## Purpose
`test_collective_rpc ` is added to CI in #23075, however it doesn't work with [AMD](https://github.com/22quinn/vllm/blob/316efabb6acd3d7561601d4308c750ec81e148fa/.buildkite/test-pipeline.yaml#L119) with default settings, so we will see the [errors](https://buildkite.com/vllm/ci/builds/32379#_) like this:
```

[2025-09-25T02:35:55Z]             if not self.device_type:
--
  | [2025-09-25T02:35:55Z] >               raise RuntimeError(
  | [2025-09-25T02:35:55Z]                     "Failed to infer device type, please set "
  | [2025-09-25T02:35:55Z]                     "the environment variable `VLLM_LOGGING_LEVEL=DEBUG` "
  | [2025-09-25T02:35:55Z]                     "to turn on verbose logging to help debug the issue.")
  | [2025-09-25T02:35:55Z] E               RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
  | [2025-09-25T02:35:55Z]
  | [2025-09-25T02:35:55Z] /usr/local/lib/python3.12/dist-packages/vllm/config/device.py:58: RuntimeError
  | [2025-09-25T02:35:55Z] =============================== warnings summary ===============================
  | [2025-09-25T02:35:55Z] ../../usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63
  | [2025-09-25T02:35:55Z]   /usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  | [2025-09-25T02:35:55Z]     import pynvml  # type: ignore[import]
  | [2025-09-25T02:35:55Z]
  | [2025-09-25T02:35:55Z] ../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
  | [2025-09-25T02:35:55Z]   /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
  | [2025-09-25T02:35:55Z]     ref_error: type[Exception] = jsonschema.RefResolutionError,
  | [2025-09-25T02:35:55Z]
  | [2025-09-25T02:35:55Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
  | [2025-09-25T02:35:55Z] =========================== short test summary info ============================
  | [2025-09-25T02:35:55Z] ERROR entrypoints/openai/test_collective_rpc.py::test_get_model_name - RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
  | [2025-09-25T02:35:55Z] ERROR entrypoints/openai/test_collective_rpc.py::test_return_none - RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
  | [2025-09-25T02:35:55Z] ERROR entrypoints/openai/test_collective_rpc.py::test_echo_args_kwargs - RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
  | [2025-09-25T02:35:55Z] ======================== 2 warnings, 3 errors in 3.83s =========================
  | [2025-09-25T02:35:57Z] 🚨 Error: The command exited with status 1
```

This PR forces vLLM to run in CPU mode so that it can be HW agnostic.
## Test Plan
```
VLLM_CPU_ONLY=1 \
PYTHONPATH=/data/users/zhewenli/gitrepos/vllm \
pytest -q tests/entrypoints/openai/test_collective_rpc.py::test_get_model_name -s
```
## Test Result
```
=================================================================== warnings summary ====================================================================
../../../../../home/zhewenli/uv_env/vllm/lib64/python3.12/site-packages/torch/cuda/__init__.py:63
  /home/zhewenli/uv_env/vllm/lib64/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
    import pynvml  # type: ignore[import]

../../../../../home/zhewenli/uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305
  /home/zhewenli/uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
3 passed, 2 warnings in 36.55s
```

