### PR TITLE
[Bugfix] fixing streaming issues and tool call output for gpt-oss (#22704, #23335)

### DIFF
--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -22,10 +22,10 @@ from openai.types.responses import (
     ResponseCodeInterpreterCallCompletedEvent,
     ResponseCodeInterpreterCallInProgressEvent,
     ResponseCodeInterpreterCallInterpretingEvent,
-    ResponseFunctionCallArgumentsDeltaEvent,
     ResponseCodeInterpreterToolCallParam, ResponseCompletedEvent,
     ResponseContentPartAddedEvent, ResponseContentPartDoneEvent,
-    ResponseCreatedEvent, ResponseFunctionToolCall, ResponseFunctionWebSearch,
+    ResponseCreatedEvent, ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionToolCall, ResponseFunctionWebSearch,
     ResponseInProgressEvent, ResponseOutputItem, ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent, ResponseOutputMessage, ResponseOutputText,
     ResponseReasoningItem, ResponseReasoningTextDeltaEvent,
@@ -1414,13 +1414,14 @@ class OpenAIServingResponses(OpenAIServing):
                             logprobs=[],
                         ))
                 elif (ctx.parser.current_channel == "commentary"
-                      and ctx.parser.current_recipient is not None
-                      and ctx.parser.current_recipient.startswith("functions.")):
+                      and ctx.parser.current_recipient is not None and
+                      ctx.parser.current_recipient.startswith("functions.")):
                     # Start or continue streaming function-call arguments
                     if not sent_output_item_added:
                         sent_output_item_added = True
                         current_item_id = f"fc_{random_uuid()}"
-                        _func_name = ctx.parser.current_recipient.split(".", 1)[1]
+                        _func_name = ctx.parser.current_recipient.split(
+                            ".", 1)[1]
                         yield _increment_sequence_number_and_return(
                             ResponseOutputItemAddedEvent(
                                 type="response.output_item.added",
@@ -1538,7 +1539,8 @@ class OpenAIServingResponses(OpenAIServing):
                                 type="function_call",
                                 id=current_item_id or f"fc_{random_uuid()}",
                                 name=previous_item.recipient.split(".", 1)[1],
-                                call_id=f"call_{current_item_id}" if current_item_id else f"call_{random_uuid()}",
+                                call_id=f"call_{current_item_id}" if
+                                current_item_id else f"call_{random_uuid()}",
                                 arguments=previous_item.content[0].text,
                             ),
                         ))


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Closely related to two bugs associated with streaming for gpt-oss (#22704, #23335):

In `vllm/entrypoints/openai/serving_responses.py`, the stream loop was advancing the “current content index” while still producing a single output. For gpt-oss, which emits one content item, this advanced past the only item mid-stream, so the flow never completed and response.completed was not observed. I adjusted the logic so the index remains steady during a single output and only advances when a new output item begins. With this change, the stream now closes cleanly and response.completed is emitted reliably.

Separately, Harmony’s streaming didn’t support `functions.*` tool calls at all. We handled reasoning on `analysis`, final text on `final`, and built-ins like code/web—but `"commentary"` messages with a `recipient="functions.NAME"` had a no-op branch.

## Test Plan

First, tested GPT-OSS with a basic set of instructions, few-shot examples, a function definition, and a prompt to find the weather in San Francisco, using the get_weather function call as input.

Next, tested with the following relevant tests:
```
- pytest -s -v /home/ubuntu/vllm/tests/v1/entrypoints/openai/responses/test_basic.py::test_simple_input
- pytest -s -v /home/ubuntu/vllm/tests/v1/entrypoints/openai/responses/test_basic.py::test_streaming

```

## Test Result

First set of tests:
### Before
```
event: response.created
event: response.in_progress
event: response.output_item.added
event: response.content_part.added
event: response.reasoning_text.delta
...
event: response.reasoning_text.delta
event: response.reasoning_text.done
event: response.content_part.done
event: response.output_item.done
event: response.output_item.added
event: response.content_part.added
event: response.output_text.delta
event: response.output_text.delta
stream error: list index out of range
finalization error: Didn't receive a `response.completed` event.
```

### After:
```
event: response.created
event: response.in_progress
event: response.output_item.added
event: response.reasoning_part.added
event: response.reasoning_text.delta
...
event: response.reasoning_text.delta
event: response.reasoning_text.delta
event: response.reasoning_text.done
event: response.reasoning_part.done
event: response.output_item.done
event: response.output_item.added
event: response.function_call_arguments.delta
event: response.function_call_arguments.delta
...
event: response.function_call_arguments.delta
event: response.output_item.done
event: response.completed
```

Second set of tests:
```
vllm/tests/v1/entrypoints/openai/responses/test_basic.py::test_simple_input
==================================== test session starts========================
(APIServer pid=1731543) INFO:     127.0.0.1:34584 - "POST /v1/responses HTTP/1.1" 200 OK
Response(id='resp_e07cead1562649adb4fe82059b5e7762', created_at=1758838166.0, error=None, incomplete_details=None, instructions=None, metadata=None, model='Qwen/Qwen3-0.6B', object='response', output=[ResponseReasoningItem(id='rs_5d2b6495e9ce4dc58c85f62fd01355a2', summary=[], type='reasoning', content=[Content(text="\nOkay, so I need to figure out what 13 multiplied by 24 is. Let me start by recalling how multiplication works. When you multiply two numbers, you can think of it as adding the second number to itself multiple times. So, 13 times 24... Hmm, maybe breaking it down would help. \n\nFirst, I know that 13 times 20 is 260, right? Because 13 times 20 is straightforward. Then, 13 times 4 is 52. Adding those together: 260 plus 52. Let me do that addition. 260 plus 50 is 310, and then plus 2 more makes 312. So, 13 times 24 should be 312. \n\nWait, but maybe there's another way to check. Sometimes, breaking down the multiplication into smaller parts is easier. For example, 24 can be broken into 20 + 4, which I did earlier. Alternatively, 24 is 10 + 14, but that might complicate things. Let me try that. 13 times 10 is 130, and 13 times 14... Hmm, 13 times 10 is 130, and 13 times 4 is 52. Adding those gives me 130 + 52 again, which is 182. Wait, that's conflicting with the previous result. Wait, no, hold on. Wait, 24 is 10 + 14, so 13*(10 + 14) = 13*10 + 13*14. Which is 130 + 182. Wait, 130 + 182 is 312. Oh, okay, so that's consistent. So both methods give me 312. \n\nBut let me verify with another method. Maybe using the standard algorithm for multiplication. Let's write 13 multiplied by 24. \n\nMultiplying 13 by 24:\n\nFirst, multiply 13 by 4: 13*4=52. Then, multiply 13 by 20: 13*20=260. Then add 52 and 260: 260 + 52 = 312. Yep, same answer. \n\nAlternatively, maybe using a calculator would confirm. But since I don't have a calculator here, I need to rely on manual calculation. \n\nWait, but let me check if I made any mistakes in the steps. For example, when I broke down 24 into 20 + 4, I added 260 and 52. 260 + 52. Let me add them again. 260 + 50 is 310, plus 2 is 312. Correct. \n\nAlternatively, if I thought of 24 as 2*12, then 13*2*12. Which is 2*13*12. Which is 2*13*12. 2*13 is 26, 26*12. 26*10 is 260, 26*2 is 52, so 260 + 52 = 312. Same result. \n\nSo all methods point to 312. Therefore, I think that's the correct answer. \n\n**Final Answer**\nThe product of 13 and 24 is \\boxed{312}.\n", type='reasoning_text')], encrypted_content=None, status=None), ResponseOutputMessage(id='msg_c000502654f740cabeb19ba506da02f1', content=[ResponseOutputText(annotations=[], text='\n\nTo find the product of 13 and 24, we can approach it using different methods to ensure accuracy:\n\n---\n\n### **Method 1: Breaking Down Multiplication**\n\nWe can break 24 into smaller parts:\n\n- $13 \\times 20 = 260$\n- $13 \\times 4 = 52$\n\nNow add these results together:\n\n$$\n260 + 52 = 312\n$$\n\n---\n\n### **Method 2: Using Standard Multiplication**\n\nWe can multiply 13 by 24 directly:\n\n$$\n13 \\times 24 = 13 \\times (20 + 4) = 13 \\times 20 + 13 \\times 4 = 260 + 52 = 312\n$$\n\n---\n\n### **Method 3: Factoring and Simplifying**\n\nAlternatively, we can write:\n\n$$\n13 \\times 24 = (2 \\times 10 + 14) \\times 13 = 2 \\times 13 \\times 10 + 13 \\times 14 = 260 + 182 = 312\n$$\n\n---\n\n### **Conclusion**\n\nAll methods consistently lead to the same result:\n\n$$\n13 \\times 24 = \\boxed{312}\n$$', type='output_text', logprobs=None)], role='assistant', status='completed', type='message')], parallel_tool_calls=True, temperature=0.6, tool_choice='auto', tools=[], top_p=0.95, background=False, conversation=None, max_output_tokens=8174, max_tool_calls=None, previous_response_id=None, prompt=None, prompt_cache_key=None, reasoning=None, safety_identifier=None, service_tier='auto', status='completed', text=None, top_logprobs=None, truncation='disabled', usage=ResponseUsage(input_tokens=18, input_tokens_details=InputTokensDetails(cached_tokens=0), output_tokens=1096, output_tokens_details=OutputTokensDetails(reasoning_tokens=0, tool_output_tokens=0), total_tokens=1114), user=None)
PASSEDWARNING 09-25 22:09:41 [interface.py:509] Current platform cpu does not have 'empty_cache' attribute.
(APIServer pid=1731543) WARNING 09-25 22:09:41 [launcher.py:98] port 54307 is used by process psutil.Process(pid=1731543, name='vllm', status='running', started='22:08:57') launched with command:
(APIServer pid=1731543) WARNING 09-25 22:09:41 [launcher.py:98] /home/ubuntu/playground/.venv/bin/python /home/ubuntu/playground/.venv/bin/vllm serve Qwen/Qwen3-0.6B --max-model-len 8192 --enforce-eager --reasoning-parser deepseek_r1 --port 54307 --seed 0
(APIServer pid=1731543) INFO 09-25 22:09:41 [launcher.py:101] Shutting down FastAPI HTTP server.
[rank0]:[W925 22:09:41.139633078 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
(APIServer pid=1731543) INFO:     Shutting down
(APIServer pid=1731543) INFO:     Waiting for application shutdown.
(APIServer pid=1731543) INFO:     Application shutdown complete.
=================== 1 passed, 2 warnings in 45.32s=================================
                                                                                              
Running 1 items in this shard: tests/v1/entrypoints/openai/responses/test_basic.py::test_streaming
(APIServer pid=1732776) INFO 09-25 22:11:02 [chat_utils.py:538] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=1732776) INFO:     127.0.0.1:35668 - "POST /v1/responses HTTP/1.1" 200 OK
(EngineCore_DP0 pid=1732966) WARNING 09-25 22:11:02 [cudagraph_dispatcher.py:102] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(APIServer pid=1732776) INFO 09-25 22:11:10 [loggers.py:123] Engine 000: Avg prompt throughput: 1.7 tokens/s, Avg generation throughput: 58.2 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.2%, Prefix cache hit rate: 0.0%
PASSEDWARNING 09-25 22:11:17 [interface.py:509] Current platform cpu does not have 'empty_cache' attribute.
(APIServer pid=1732776) WARNING 09-25 22:11:17 [launcher.py:98] port 57899 is used by process psutil.Process(pid=1732776, name='vllm', status='running', started='22:10:33') launched with command:
(APIServer pid=1732776) WARNING 09-25 22:11:17 [launcher.py:98] /home/ubuntu/playground/.venv/bin/python /home/ubuntu/playground/.venv/bin/vllm serve Qwen/Qwen3-0.6B --max-model-len 8192 --enforce-eager --reasoning-parser deepseek_r1 --port 57899 --seed 0
(APIServer pid=1732776) INFO 09-25 22:11:17 [launcher.py:101] Shutting down FastAPI HTTP server.
[rank0]:[W925 22:11:17.416301742 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
(APIServer pid=1732776) INFO:     Shutting down
(APIServer pid=1732776) INFO:     Waiting for application shutdown.
(APIServer pid=1732776) INFO:     Application shutdown complete.
================= 1 passed, 2 warnings in 45.79s================================================
```