### PR TITLE
[Misc] Don't log shm dequeue delay warning on worker side

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -432,7 +432,8 @@ class MessageQueue:
     @contextmanager
     def acquire_read(self,
                      timeout: Optional[float] = None,
-                     cancel: Optional[Event] = None):
+                     cancel: Optional[Event] = None,
+                     indefinite: bool = False):
         assert self._is_local_reader, "Only readers can acquire read"
         start_time = time.monotonic()
         n_warning = 1
@@ -453,23 +454,23 @@ class MessageQueue:
                     self._read_spin_timer.spin()
 
                     # if we wait for a long time, log a message
-                    if (time.monotonic() - start_time
-                            > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning):
+                    elapsed = time.monotonic() - start_time
+                    if not indefinite and (elapsed
+                                           > VLLM_RINGBUFFER_WARNING_INTERVAL *
+                                           n_warning):
                         logger.info(
-                            ("No available shared memory broadcast block found"
-                             " in %s seconds. This typically happens when some"
-                             " processes are hanging, doing some time-consuming"
-                             " work (e.g. compilation), or sitting idle."),
-                            VLLM_RINGBUFFER_WARNING_INTERVAL,
-                        )
+                            "No available shared memory broadcast block found"
+                            " in %s seconds. This typically happens when some"
+                            " processes are hanging, doing some time-consuming"
+                            " work (e.g. compilation), or sitting idle.",
+                            VLLM_RINGBUFFER_WARNING_INTERVAL)
                         n_warning += 1
 
                     if cancel is not None and cancel.is_set():
                         raise RuntimeError("cancelled")
 
                     # if we time out, raise an exception
-                    if (timeout is not None
-                            and time.monotonic() - start_time > timeout):
+                    if timeout is not None and elapsed > timeout:
                         raise TimeoutError
 
                     continue
@@ -505,10 +506,11 @@ class MessageQueue:
 
     def dequeue(self,
                 timeout: Optional[float] = None,
-                cancel: Optional[Event] = None):
+                cancel: Optional[Event] = None,
+                indefinite: bool = False):
         """ Read from message queue with optional timeout (in seconds) """
         if self._is_local_reader:
-            with self.acquire_read(timeout, cancel) as buf:
+            with self.acquire_read(timeout, cancel, indefinite) as buf:
                 overflow = buf[0] == 1
                 if not overflow:
                     # no need to know the size of serialized object

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -653,7 +653,7 @@ class WorkerProc:
         """Main busy loop for Multiprocessing Workers"""
         while True:
             method, args, kwargs, output_rank = self.rpc_broadcast_mq.dequeue(
-                cancel=cancel)
+                cancel=cancel, indefinite=True)
             try:
                 if isinstance(method, str):
                     func = getattr(self.worker, method)


### PR DESCRIPTION
It doesn't make sense to periodically log the "taking a long time" warning on the worker side which is waiting indefinitely when in an idle state.

```
(Worker_DP0_TP1_EP1 pid=1682938) INFO 09-25 19:55:44 [distributed/device_communicators/shm_broadcast.py:458] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging, doing some time-consuming work (e.g. compilation), or sitting idle.
```

We'll still log it on the sender side when waiting for the response to a broadcast.

As part of this PR I also reordered the checks into what I think is a more logical order.

cc @youkaichao 