### PR TITLE
[RFC][Core] propagate the error message up to the frontend process

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -654,9 +654,10 @@ class EngineCoreProc(EngineCore):
         else:
             assert local_client
             local_handshake = self._perform_handshake(
-                input_ctx, client_handshake_address, identity, True, False, vllm_config
-            )
-            with handshake as (addresses, _), local_handshake as (client_addresses, zmq_socket):
+                input_ctx, client_handshake_address, identity, True, False,
+                vllm_config)
+            with handshake as (addresses,
+                               _), local_handshake as (client_addresses, zmq_socket):
                 addresses.inputs = client_addresses.inputs
                 addresses.outputs = client_addresses.outputs
                 try:

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -825,7 +825,7 @@ def wait_for_engine_startup(
                     *start_pending,
                 )
             continue
-        if len(events) > 1 or (len(events) == 1 
+        if len(events) > 1 or (len(events) == 1
                                and events[0][0] != handshake_socket):
             # coord_process processes exited.
             finished = {}

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -825,7 +825,8 @@ def wait_for_engine_startup(
                     *start_pending,
                 )
             continue
-        if len(events) > 1 or (len(events) == 1 and events[0][0] != handshake_socket):
+        if len(events) > 1 or (len(events) == 1 
+                               and events[0][0] != handshake_socket):
             # coord_process processes exited.
             finished = {}
             if coord_process is not None and coord_process.exitcode is not None:

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -825,10 +825,11 @@ def wait_for_engine_startup(
                     *start_pending,
                 )
             continue
-        if len(events) > 1 or events[0][0] != handshake_socket:
+        if len(events) > 1 or (len(events) == 1 and events[0][0] != handshake_socket):
             # coord_process processes exited.
+            finished = {}
             if coord_process is not None and coord_process.exitcode is not None:
-                finished = {coord_process.name: coord_process.exitcode}
+                finished[coord_process.name] = coord_process.exitcode
             raise RuntimeError("Engine core initialization failed. "
                                "See root cause above. "
                                f"Failed core proc(s): {finished}")

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -825,15 +825,16 @@ def wait_for_engine_startup(
                     *start_pending,
                 )
             continue
-        if len(events) > 1 or (len(events) == 1
-                               and events[0][0] != handshake_socket):
+        if len(events) > 1 or (len(events) == 1 and events[0][0] != handshake_socket):
             # coord_process processes exited.
             finished = {}
             if coord_process is not None and coord_process.exitcode is not None:
                 finished[coord_process.name] = coord_process.exitcode
-            raise RuntimeError("Engine core initialization failed. "
-                               "See root cause above. "
-                               f"Failed core proc(s): {finished}")
+            raise RuntimeError(
+                "Engine core initialization failed. "
+                "See root cause above. "
+                f"Failed core proc(s): {finished}"
+            )
 
         # Receive HELLO and READY messages from the input socket.
         eng_identity, ready_msg_bytes = handshake_socket.recv_multipart()
@@ -928,11 +929,13 @@ def wait_for_engine_startup(
         elif status == "FAILED" and engine.state == CoreEngineState.CONNECTED:
             # One of the local core processes exited.
             finished = proc_manager.finished_procs() if proc_manager else {}
-            raise RuntimeError("Engine core initialization failed. "
-                               "See root cause above. "
-                               f"Failed core proc(s): {finished}. "
-                               "Recived error message from failed "
-                               f"engine {eng_index}: {msg['error_msg']}")
+            raise RuntimeError(
+                "Engine core initialization failed. "
+                "See root cause above. "
+                f"Failed core proc(s): {finished}. "
+                "Recived error message from failed "
+                f"engine {eng_index}: {msg['error_msg']}"
+            )
         else:
             raise RuntimeError(
                 f"Unexpected {status} message for "
@@ -943,9 +946,11 @@ def wait_for_engine_startup(
         if len(proc_manager_events) > 1:
             # One or more local core processes exited but we didn't receive any msg.
             finished = proc_manager.finished_procs() if proc_manager else {}
-            raise RuntimeError("Engine core initialization failed. "
-                               "See root cause above. "
-                               f"Failed core proc(s): {finished}")
+            raise RuntimeError(
+                "Engine core initialization failed. "
+                "See root cause above. "
+                f"Failed core proc(s): {finished}"
+            )
         logger.debug(
             "%s from %s core engine process %s.",
             status,

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -17,7 +17,10 @@ from vllm.utils import resolve_obj_by_qualname
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
+from vllm.logger import init_logger
 
+
+logger = init_logger(__name__)
 FailureCallback = Callable[[], None]
 
 
@@ -66,6 +69,8 @@ class Executor(ExecutorBase):
             raise ValueError(
                 f"Unknown distributed executor backend: {distributed_executor_backend}"
             )
+        logger.info(f"Using executor class: {executor_class.__name__} "
+                    f"for {distributed_executor_backend=}")
         return executor_class
 
     def initialize_from_config(self, kv_cache_configs: list[KVCacheConfig]) -> None:

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -68,8 +68,10 @@ class Executor(ExecutorBase):
             raise ValueError(
                 f"Unknown distributed executor backend: {distributed_executor_backend}"
             )
-        logger.info(f"Using executor class: {executor_class.__name__} "
-                    f"for {distributed_executor_backend=}")
+        logger.info(
+            f"Using executor class: {executor_class.__name__} "
+            f"for {distributed_executor_backend=}"
+        )
         return executor_class
 
     def initialize_from_config(self, kv_cache_configs: list[KVCacheConfig]) -> None:

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -68,10 +68,6 @@ class Executor(ExecutorBase):
             raise ValueError(
                 f"Unknown distributed executor backend: {distributed_executor_backend}"
             )
-        logger.info(
-            f"Using executor class: {executor_class.__name__} "
-            f"for {distributed_executor_backend=}"
-        )
         return executor_class
 
     def initialize_from_config(self, kv_cache_configs: list[KVCacheConfig]) -> None:

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -13,11 +13,11 @@ from vllm.executor.uniproc_executor import (  # noqa
     ExecutorWithExternalLauncher as ExecutorWithExternalLauncherV0,
 )
 from vllm.executor.uniproc_executor import UniProcExecutor as UniProcExecutorV0  # noqa
+from vllm.logger import init_logger
 from vllm.utils import resolve_obj_by_qualname
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
-from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 FailureCallback = Callable[[], None]

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -19,7 +19,6 @@ from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 from vllm.logger import init_logger
 
-
 logger = init_logger(__name__)
 FailureCallback = Callable[[], None]
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -508,8 +508,8 @@ class WorkerProc:
     ) -> list[WorkerProcHandle]:
 
         err_msg = ("WorkerProc initialization failed due to "
-                    "an exception {}in a background process. "
-                    "See stack trace for root cause.")
+                   "an exception {}in a background process. "
+                   "See stack trace for root cause.")
 
         pipes = {handle.ready_pipe: handle for handle in unready_proc_handles}
         ready_proc_handles: list[Optional[WorkerProcHandle]] = [None] * len(
@@ -525,7 +525,8 @@ class WorkerProc:
                     response: dict[str, Any] = pipe.recv()
                     status = response["status"]
                     if status == WorkerProc.FAILED_INIT_STR:
-                        raise Exception(err_msg.format(f"(err: {response['error_msg']}) "))
+                        raise Exception(
+                            err_msg.format(f"(err: {response['error_msg']}) "))
                     elif status != WorkerProc.READY_STR:
                         raise Exception(err_msg.format(""))
 
@@ -631,10 +632,8 @@ class WorkerProc:
 
             if ready_writer is not None:
                 ready_writer.send({
-                    "status":
-                    WorkerProc.FAILED_INIT_STR,
-                    "error_msg":
-                    str(e),
+                    "status": WorkerProc.FAILED_INIT_STR,
+                    "error_msg": str(e),
                 })
                 logger.exception("WorkerProc failed to start.")
             elif shutdown_event.is_set():

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -506,10 +506,11 @@ class WorkerProc:
     def wait_for_ready(
         unready_proc_handles: list[UnreadyWorkerProcHandle],
     ) -> list[WorkerProcHandle]:
-
-        err_msg = ("WorkerProc initialization failed due to "
-                   "an exception {}in a background process. "
-                   "See stack trace for root cause.")
+        err_msg = (
+            "WorkerProc initialization failed due to "
+            "an exception {}in a background process. "
+            "See stack trace for root cause."
+        )
 
         pipes = {handle.ready_pipe: handle for handle in unready_proc_handles}
         ready_proc_handles: list[Optional[WorkerProcHandle]] = [None] * len(
@@ -526,7 +527,8 @@ class WorkerProc:
                     status = response["status"]
                     if status == WorkerProc.FAILED_INIT_STR:
                         raise Exception(
-                            err_msg.format(f"(err: {response['error_msg']}) "))
+                            err_msg.format(f"(err: {response['error_msg']}) ")
+                        )
                     elif status != WorkerProc.READY_STR:
                         raise Exception(err_msg.format(""))
 
@@ -631,10 +633,12 @@ class WorkerProc:
             # TODO(rob): handle case where the MQ itself breaks.
 
             if ready_writer is not None:
-                ready_writer.send({
-                    "status": WorkerProc.FAILED_INIT_STR,
-                    "error_msg": str(e),
-                })
+                ready_writer.send(
+                    {
+                        "status": WorkerProc.FAILED_INIT_STR,
+                        "error_msg": str(e),
+                    }
+                )
                 logger.exception("WorkerProc failed to start.")
             elif shutdown_event.is_set():
                 logger.info("WorkerProc shutting down.")


### PR DESCRIPTION
## Purpose
Currently when engine core proc initialization fails, the frontend process will always throw the following error.
```
Engine core initialization failed. See root cause above. Failed core proc(s): {}
```
In our use cases, we want to be able to get the original error msg that causes the engine core proc to fail in the frontend process for some additional handling/loggings.

## Implementation
This is RFC so definitely let me know if I should do this in another way!

In this PR, the error msg will be sent via the `ready_writer` pipe from engine core proc to the multiproc executor process. And then using the zmq socket for handshake to send the error msg from executor process to the frontend process (this also works for uni executor).

Now the error thrown by the frontend process looks like the following
```
Engine core initialization failed. See root cause above. Failed core proc(s): {}. Recived error message from failed engine 1: this is an error msg xxxxxxx
```

Differential Revision: D83293058


