### PR TITLE
[CI] Add E2E Blackwell Quantized MoE Test

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -833,10 +833,11 @@ steps:
   working_dir: "/vllm-workspace/"
   gpu: b200
   source_file_dependencies:
-  - tests/evals/gpt_oss
+  - tests/quantization/test_blackwell_moe.py
   - vllm/model_executor/models/deepseek_v2.py
   - vllm/model_executor/models/gpt_oss.py
   - vllm/model_executor/models/llama4.py
+  - vllm/model_executor/layers/fused_moe
   - vllm/model_executor/layers/quantization/compressed_tensors
   - vllm/model_executor/layers/quantization/modelopt.py
   - vllm/model_executor/layers/quantization/mxfp4.py

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -520,7 +520,7 @@ steps:
   # https://github.com/pytorch/ao/issues/2919, we'll have to skip new torchao tests for now
   # we can only upgrade after this is resolved
   - pip install --pre torchao==0.13.0.dev20250814 --index-url https://download.pytorch.org/whl/nightly/cu128
-  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization
+  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/
 
 - label: LM Eval Small Models # 53min
   timeout_in_minutes: 75
@@ -827,6 +827,18 @@ steps:
   commands:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
     - pytest -s -v tests/evals/gpt_oss/test_gpqa_correctness.py --model openai/gpt-oss-20b --metric 0.58 --server-args '--tensor-parallel-size 2'
+
+- label: Blackwell Quantized MoE Test
+  timeout_in_minutes: 60
+  working_dir: "/vllm-workspace/"
+  gpu: b200
+  source_file_dependencies:
+  - tests/evals/gpt_oss
+  - vllm/model_executor/models/gpt_oss.py
+  - vllm/model_executor/layers/quantization/mxfp4.py
+  - vllm/v1/attention/backends/flashinfer.py
+  commands:
+    - pytest -s -v tests/quantization/test_blackwell_moe.py
 
 #####  1 GPU test  #####
 #####  multi gpus test  #####

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -834,7 +834,11 @@ steps:
   gpu: b200
   source_file_dependencies:
   - tests/evals/gpt_oss
+  - vllm/model_executor/models/deepseek_v2.py
   - vllm/model_executor/models/gpt_oss.py
+  - vllm/model_executor/models/llama4.py
+  - vllm/model_executor/layers/quantization/compressed_tensors
+  - vllm/model_executor/layers/quantization/modelopt.py
   - vllm/model_executor/layers/quantization/mxfp4.py
   - vllm/v1/attention/backends/flashinfer.py
   commands:

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -104,7 +104,7 @@ def test_deepseek_nvfp4_moe_flashinfer_cutlass(
     can_initialize("nvidia/DeepSeek-R1-0528-FP4-v2", [])
 
 
-@pytest.mark.skip(reason="RuntimeError: routing_bias must be bfloat16.")
+@pytest.mark.skip(reason="RuntimeError: No kernel found for the given options")
 def test_deepseek_nvfp4_moe_flashinfer_trtllm(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP4", "1")
     monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "latency")

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -37,10 +37,11 @@ def can_initialize(model: str, extra_args: list[str]):
     ]
 
     # Launch server and make a simple request
-    with RemoteOpenAIServer(model,
-                            server_args,
-                            max_wait_seconds=600, # Due to FlashInfer compile
-                            override_hf_configs=dummy_hf_overrides) as server:
+    with RemoteOpenAIServer(
+            model,
+            server_args,
+            max_wait_seconds=600,  # Due to FlashInfer compile
+            override_hf_configs=dummy_hf_overrides) as server:
         client = server.get_client()
         # Make a simple request to verify the server works
         completion = client.completions.create(

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from functools import partial
+from unittest.mock import patch
+
+import pytest
+from transformers import PretrainedConfig
+
+from vllm import LLM
+from vllm.sampling_params import SamplingParams
+from vllm.platforms import current_platform
+from tests.utils import create_new_process_for_each_test
+
+if not current_platform.is_device_capability(100):
+    pytest.skip("This test only runs on Blackwell GPUs (SM100).",
+                allow_module_level=True)
+
+def dummy_hf_overrides(hf_config: PretrainedConfig) -> PretrainedConfig:
+    """
+    Dummy HF overrides function used to create dummy model
+    with only minimum nums of layer.
+    """
+    text_config = hf_config.get_text_config()
+
+    # Do 4 backbone layers to include dense and MoE layers
+    text_config.update({
+        "num_layers": 4,
+        "num_hidden_layers": 4,
+    })
+
+    if hasattr(hf_config, "vision_config"):
+        hf_config.vision_config.update({
+            "num_layers": 1,
+            "num_hidden_layers": 1,
+        })
+    # e.g.: ibm-granite/granite-speech-3.3-2b
+    if hasattr(hf_config, "encoder_config"):
+        hf_config.encoder_config.update({
+            "num_layers": 1,
+            "num_hidden_layers": 1,
+        })
+    # e.g.: Qwen/Qwen2-Audio-7B-Instruct
+    if hasattr(hf_config, "audio_config"):
+        hf_config.audio_config.update({
+            "num_layers": 1,
+            "num_hidden_layers": 1,
+            "encoder_layers": 1,
+        })
+
+    return hf_config
+
+
+# @create_new_process_for_each_test()
+def can_initialize(vllm_runner, model_name: str, **model_kwargs):
+
+    default_model_kwargs = {
+        "enforce_eager": True,
+        "trust_remote_code": True,
+        "max_model_len": 1024,
+        "gpu_memory_utilization": 0.8,
+        "load_format": "dummy",
+        # "hf_overrides": dummy_hf_overrides,
+    }
+    default_model_kwargs.update(model_kwargs)
+
+    with vllm_runner(model_name, **default_model_kwargs) as llm:
+        sp = SamplingParams(temperature=0, max_tokens=2)
+        llm.generate("Hello, world!", sampling_params=sp)
+
+def test_blackwell_fp8_tensor_moe_flashinfer_trtllm(vllm_runner, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP8", "1")
+    can_initialize(vllm_runner, "nvidia/Llama-4-Scout-17B-16E-Instruct-FP8", tensor_parallel_size=1)
+
+def test_blackwell_fp8_block_moe_deep_gemm(vllm_runner, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_DEEP_GEMM", "1")
+    can_initialize(vllm_runner, "deepseek-ai/DeepSeek-V3.1", tensor_parallel_size=1)
+
+def test_blackwell_nvfp4_moe_flashinfer_cutlass(vllm_runner, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP4", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+    can_initialize(vllm_runner, "nvidia/Llama-4-Scout-17B-16E-Instruct-FP4", tensor_parallel_size=1)
+
+def test_blackwell_nvfp4_moe_flashinfer_trtllm(vllm_runner, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP4", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "latency")
+    can_initialize(vllm_runner, "nvidia/Llama-4-Scout-17B-16E-Instruct-FP4", tensor_parallel_size=1)
+    can_initialize(vllm_runner, "nvidia/DeepSeek-R1-0528-FP4-v2", tensor_parallel_size=1)
+

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -71,6 +71,7 @@ def test_llama4_fp8_tensor_moe_flashinfer_cutlass(
     can_initialize("nvidia/Llama-4-Scout-17B-16E-Instruct-FP8", [])
 
 
+@pytest.mark.skip(reason="Takes too long to run")
 def test_llama4_fp8_tensor_moe_flashinfer_trtllm(
         monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP8", "1")

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -43,27 +43,23 @@ def can_initialize(model: str, extra_args: list[str]):
                             override_hf_configs=dummy_hf_overrides) as server:
         client = server.get_client()
         # Make a simple request to verify the server works
-        completion = client.chat.completions.create(
+        completion = client.completions.create(
             model=model,
-            messages=[{
-                "role": "system",
-                "content": "You are a helpful assistant."
-            }, {
-                "role": "user",
-                "content": "Hello!"
-            }],
+            prompt=["Hello!"],
             temperature=0,
-            max_completion_tokens=2,
+            max_tokens=2,
         )
-        generated_text = completion.choices[0].message.content
-        assert generated_text is not None
+        print(completion)
+        assert completion.choices[0].text is not None
 
 
 ## Llama4 ##
 
 
-@pytest.mark.skip(
-    reason="This gets stuck during/after graph capture for some reason")
+@pytest.mark.skip(reason=(
+    "RuntimeError: run_moe() Expected a value of type "
+    "'Optional[List[Tensor]]' for argument '_9' but instead found type "
+    "'list'."))
 def test_llama4_fp8_tensor_moe_flashinfer_cutlass(
         monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP8", "1")
@@ -71,7 +67,7 @@ def test_llama4_fp8_tensor_moe_flashinfer_cutlass(
     can_initialize("nvidia/Llama-4-Scout-17B-16E-Instruct-FP8", [])
 
 
-@pytest.mark.skip(reason="Takes too long to run")
+@pytest.mark.skip(reason="Works, but takes too long to run")
 def test_llama4_fp8_tensor_moe_flashinfer_trtllm(
         monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP8", "1")
@@ -79,8 +75,7 @@ def test_llama4_fp8_tensor_moe_flashinfer_trtllm(
     can_initialize("nvidia/Llama-4-Scout-17B-16E-Instruct-FP8", [])
 
 
-@pytest.mark.skip(
-    reason="This gets stuck during/after graph capture for some reason")
+@pytest.mark.skip(reason="Works, but takes too long to run")
 def test_llama4_nvfp4_moe_flashinfer_cutlass(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP4", "1")
     monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -25,9 +25,9 @@ def can_initialize(model: str, extra_args: list[str]):
     # Server arguments
     server_args = [
         "--max-model-len",
-        "8192",
+        "2048",
         "--max-num-batched-tokens",
-        "1024",
+        "256",
         "--load-format",
         "dummy",
         "--trust-remote-code",
@@ -40,13 +40,13 @@ def can_initialize(model: str, extra_args: list[str]):
     with RemoteOpenAIServer(
             model,
             server_args,
-            max_wait_seconds=600,  # Due to FlashInfer compile
+            max_wait_seconds=1000,  # Due to FlashInfer compile
             override_hf_configs=dummy_hf_overrides) as server:
         client = server.get_client()
         # Make a simple request to verify the server works
         completion = client.completions.create(
             model=model,
-            prompt=["Hello!"],
+            prompt=["Hello, World!"],
             temperature=0,
             max_tokens=2,
         )

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -39,7 +39,7 @@ def can_initialize(model: str, extra_args: list[str]):
     # Launch server and make a simple request
     with RemoteOpenAIServer(model,
                             server_args,
-                            max_wait_seconds=480,
+                            max_wait_seconds=600, # Due to FlashInfer compile
                             override_hf_configs=dummy_hf_overrides) as server:
         client = server.get_client()
         # Make a simple request to verify the server works

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,8 +91,10 @@ class RemoteOpenAIServer:
         env['VLLM_WORKER_MULTIPROC_METHOD'] = 'spawn'
         if env_dict is not None:
             env.update(env_dict)
+        serve_cmd = ["vllm", "serve", model, *vllm_serve_args]
+        print(f"Launching RemoteOpenAIServer with: {' '.join(serve_cmd)}")
         self.proc: subprocess.Popen = subprocess.Popen(
-            ["vllm", "serve", model, *vllm_serve_args],
+            serve_cmd,
             env=env,
             stdout=sys.stdout,
             stderr=sys.stderr,

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -40,6 +40,8 @@ def flashinfer_fused_moe_blockscale_fp8(
     assert global_num_experts % 4 == 0
     assert top_k < (topk_group * global_num_experts / num_expert_group)
     assert block_shape == [128, 128]
+    # Routing kernel expects #experts <= #threads 256
+    assert global_num_experts <= 256
 
     a_q, a_sf = per_token_group_quant_fp8(x, block_shape[1])
     # NOTE: scales of hidden states have to be transposed!


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Adds a new "Blackwell Quantized MoE Test" job that is solely meant to run critical MoE models (Llama 4, Qwen, DeepSeek, GPT-OSS) that we have many ways of running on Blackwell, through various quantization backends.
It loads the model with dummy weights and for just a few layers to make sure we can pass `process_weights_after_loading`, torch.compile, cudagraph capture, and serve a request.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

