### PR TITLE
[CI/Build] fix doc build warning: Failed to get 'name: description' pair

### DIFF
--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -71,8 +71,8 @@ class NgramProposer:
         Args:
             valid_ngram_requests: 
                 Set of indices of requests that need ngram proposals.
-                num_tokens_no_spec: 
-            Numpy array of shape (batch_size,) representing the number 
+            num_tokens_no_spec: 
+                Numpy array of shape (batch_size,) representing the number 
                 of tokens without speculative tokens for each request.
             token_ids_cpu: 
                 Numpy array of shape (batch_size, max_model_len) 


### PR DESCRIPTION
Follow up https://github.com/vllm-project/vllm/pull/24986

Fix doc build waring:

<img width="1135" height="338" alt="image" src="https://github.com/user-attachments/assets/e41db6c5-b18b-4fc1-9b2c-ccbbd1e2a8eb" />


## Purpose
 if this warning exists, other pr cannot doc validation cannot passed

https://app.readthedocs.org/projects/vllm/builds/29726695/

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

