### PR TITLE
[Bugfix] Properly abort pooling request.

### DIFF
--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -330,18 +330,16 @@ class OutputProcessor:
         for request_id in request_ids:
             req_state = self.request_states.pop(request_id, None)
             if req_state is not None:
-                # Set pooling_output is not None to
-                # correctly enter the abort pooling branch
-                pooling_output = torch.randn(
-                    0, device="cpu") if req_state.detokenizer is None else None
-
                 self.lora_states.abort_request(req_state)
                 request_ids_to_abort.append(request_id)
                 # Produce final abort output.
                 if req_state.queue is not None and (
                         request_output := req_state.make_request_output(
                             new_token_ids=[],
-                            pooling_output=pooling_output,
+                            # Set pooling_output is not None to
+                            # correctly enter the abort pooling branch
+                            pooling_output=torch.randn(0, device="cpu")
+                            if req_state.detokenizer is None else None,
                             finish_reason=FinishReason.ABORT,
                             stop_reason=None,
                             kv_transfer_params=None)):


### PR DESCRIPTION

## Purpose

Fix #25568
Related to #24704

Set pooling_output is not None to correctly enter the abort pooling branch

## Test Plan

pytest -s -vvv tests/v1/engine/test_output_processor.py::test_abort_requests

## Test Result

test_abort_requests can guard this feature

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

