### PR TITLE
Improve model accuracy by using F32 P*V with v_cache dot product

### DIFF
--- a/csrc/attention/attention_kernels.cuh
+++ b/csrc/attention/attention_kernels.cuh
@@ -390,9 +390,7 @@ __device__ void paged_attention_kernel(
         static_cast<int64_t>(block_table[block_idx]);
     const int physical_block_offset = (lane % NUM_V_VECS_PER_ROW) * V_VEC_SIZE;
     const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
-    // L_vec logits_vec;
-    // from_float(logits_vec, *reinterpret_cast<Float_L_vec*>(logits + token_idx -
-    //                                                        start_token_idx));
+
     //Avoid type conversion and use original F32 data for higher precision dot product
     Float_L_vec logits_vec = *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx);
 
@@ -425,7 +423,6 @@ __device__ void paged_attention_kernel(
             v_vec_ptr[j] = token_idx + j < seq_len ? v_vec_ptr[j] : zero_value;
           }
         }
-        // accs[i] += dot(logits_vec, v_vec);
         //Precision improvement: upgrade v_vec to F32 and dot product with F32 logits
         Float_L_vec v_vec_f32 = to_float(v_vec);
         accs[i] += dot(logits_vec, v_vec_f32);

--- a/csrc/attention/attention_kernels.cuh
+++ b/csrc/attention/attention_kernels.cuh
@@ -393,7 +393,7 @@ __device__ void paged_attention_kernel(
 
     // Avoid type conversion and use original F32 data for higher precision dot
     // product
-    Float_L_vec logits_vec = 
+    Float_L_vec logits_vec =
         *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx);
 
     const cache_t* v_ptr = v_cache + physical_block_number * kv_block_stride +

--- a/csrc/attention/attention_kernels.cuh
+++ b/csrc/attention/attention_kernels.cuh
@@ -391,8 +391,10 @@ __device__ void paged_attention_kernel(
     const int physical_block_offset = (lane % NUM_V_VECS_PER_ROW) * V_VEC_SIZE;
     const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
 
-    //Avoid type conversion and use original F32 data for higher precision dot product
-    Float_L_vec logits_vec = *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx);
+    // Avoid type conversion and use original F32 data for higher precision dot
+    // product
+    Float_L_vec logits_vec = 
+        *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx);
 
     const cache_t* v_ptr = v_cache + physical_block_number * kv_block_stride +
                            kv_head_idx * kv_head_stride;
@@ -423,7 +425,8 @@ __device__ void paged_attention_kernel(
             v_vec_ptr[j] = token_idx + j < seq_len ? v_vec_ptr[j] : zero_value;
           }
         }
-        //Precision improvement: upgrade v_vec to F32 and dot product with F32 logits
+        // Precision improvement: upgrade v_vec to F32 and dot product with F32
+        // logits
         Float_L_vec v_vec_f32 = to_float(v_vec);
         accs[i] += dot(logits_vec, v_vec_f32);
       }

--- a/csrc/attention/dtype_bfloat16.cuh
+++ b/csrc/attention/dtype_bfloat16.cuh
@@ -450,6 +450,15 @@ inline __device__ float to_float(__nv_bfloat16 u) {
   return __bfloat162float(u);
 }
 
+inline __device__ Float8_ to_float(bf16_8_t u) {
+  Float8_ tmp;
+  tmp.x = bf1622float2(u.x);
+  tmp.y = bf1622float2(u.y);
+  tmp.z = bf1622float2(u.z);
+  tmp.w = bf1622float2(u.w);
+  return tmp;
+}
+
 // Zero-out a variable.
 inline __device__ void zero(__nv_bfloat16& dst) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Use higher precision data type (F32) for P*V with v_cache dot product**

## Purpose

The existing paged attention kernel uses f16/bf16 (input data type) for computing P*V and v_cache dot products. This can sacrifice accuracy for certain models (including the Qwen3 series), particularly when dealing with long contexts, longer outputs, and quantized models.

This PR switches to F32 for the P*V with v_cache dot product, which significantly improves model accuracy.

## Test Plan

Because the full vLLM project is large, we validated the change using a migrated Rust project ([candle-vllm](https://github.com/EricLBuehler/candle-vllm)) that uses identical paged attention kernels with a simpler project structure.

Reproducible steps:

1. Clone and checkout repo before this PR (e.g. `git checkout f6b99f2`), then build candle-vllm without the `paged-attn` feature.
2. Run the Qwen3-MoE model:
```shell
   cargo run --features cuda,nccl --release -- --w /data/Qwen3-30B-A3B-Instruct-2507 --isq q4k --d 0,1
````

where `/data/Qwen3-30B-A3B-Instruct-2507` is the local model path.

3. Start the simple chatbot:

```shell
python3 examples/chat.py
```

Ask multi-turn questions and test scenarios requiring the model to maintain context across long outputs (e.g., >16k tokens). The current kernel often loses focus or fails to follow instructions.

4. Pull the latest commit (with this PR), rebuild candle-vllm, and re-run with the same command and inputs. Accuracy improves significantly.

## Test Results

* Applying this PR substantially improves Qwen3-30B-A3B accuracy on A100 GPUs (and other GPUs in theory).
* Other models are also expected to benefit from the higher precision.

There is another test on V100 which shows promising improvements by leveraging this PR:

https://github.com/guoqingbao/vllm.rs/pull/28

## Side Effects

We did not observe obvious decoding speed degradation, here's explain why?

* In the original code, `logits` were downcast from F32 to f16/bf16 `logits_vec`:

  ```c++
  // L_vec logits_vec;
  // from_float(logits_vec, *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx));
  ```

  In the proposed code, we directly use the F32 logits:

  ```c++
  Float_L_vec logits_vec = *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx);
  ```

  → This avoids unnecessary type conversion.

* For the dot product, the old code used f16/bf16:

  ```c++
  // accs[i] += dot(logits_vec, v_vec);
  ```

  Now we upcast `v_vec` to F32 before the dot product (minimal cost):

  ```c++
  Float_L_vec v_vec_f32 = to_float(v_vec);
  accs[i] += dot(logits_vec, v_vec_f32);
  ```

  → While F32 dot products may have slightly higher cost, GPU execution leverages both fp16/bf16 and F32 compute units in parallel, so we did not observe a slowdown.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

* [x] Fix accuracy degradation for paged attention kernel.
* [x] Validate with Rust version of vLLM for simplicity.
* [x] Provide reproducible steps and e2e test results.
* [ ] (Optional) Update documentation (e.g., `supported_models.md`, `examples`).
* [ ] (Optional) Update release notes if user-facing.

</details>

