### PR TITLE
debug test_shared_storage_connector_hashes

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -284,6 +284,7 @@ steps:
 
 - label: V1 Test others # 42min
   timeout_in_minutes: 60
+  fast_check: true
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
     - vllm/

--- a/tests/v1/kv_connector/unit/test_shared_storage_connector.py
+++ b/tests/v1/kv_connector/unit/test_shared_storage_connector.py
@@ -8,6 +8,8 @@ from PIL import Image
 from vllm import LLM, EngineArgs, SamplingParams
 from vllm.assets.image import ImageAsset
 from vllm.config import KVTransferConfig
+from vllm.distributed.kv_transfer.kv_transfer_state import (
+    ensure_kv_transfer_shutdown)
 from vllm.multimodal.utils import encode_image_base64
 
 MODEL_NAME = "RedHatAI/Qwen2.5-VL-3B-Instruct-quantized.w8a8"
@@ -114,9 +116,12 @@ def process_prompt(processor, llm: LLM, question: str,
 def test_shared_storage_connector_hashes(tmp_path):
     """
     Tests that SharedStorageConnector saves KV to the storage locations
-    with proper hashes; that are unique for inputs with identical text but 
+    with proper hashes; that are unique for inputs with identical text but
     different images (same size), or same multiple images but different orders.
     """
+    # Shutdown the KV transfer process if it is still running
+    ensure_kv_transfer_shutdown()
+
     # Using tmp_path as the storage path to store KV
     print(f"KV storage path at: {str(tmp_path)}")
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests/7b01abb7-8064-8f64-9362-7eceb5b9280e is failing with error message 
```

[2025-09-26T06:26:34Z]         assert image_1 != image_2, "The images should not be identical"
--
  | [2025-09-26T06:26:34Z]
  | [2025-09-26T06:26:34Z]         # Create the LLM instance
  | [2025-09-26T06:26:34Z]         engine_args = asdict(engine_args)
  | [2025-09-26T06:26:34Z] >       llm = LLM(**engine_args)
  | [2025-09-26T06:26:34Z]
  | [2025-09-26T06:26:34Z] v1/kv_connector/unit/test_shared_storage_connector.py:156:
  | [2025-09-26T06:26:34Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | [2025-09-26T06:26:34Z] /usr/local/lib/python3.12/dist-packages/vllm/entrypoints/llm.py:293: in __init__
  | [2025-09-26T06:26:34Z]     self.llm_engine = LLMEngine.from_engine_args(
  | [2025-09-26T06:26:34Z] /usr/local/lib/python3.12/dist-packages/vllm/v1/engine/llm_engine.py:177: in from_engine_args
  | [2025-09-26T06:26:34Z]     return cls(vllm_config=vllm_config,
  | [2025-09-26T06:26:34Z] /usr/local/lib/python3.12/dist-packages/vllm/v1/engine/llm_engine.py:124: in __init__
  | [2025-09-26T06:26:34Z]     self.logger_manager = StatLoggerManager(
  | [2025-09-26T06:26:34Z] /usr/local/lib/python3.12/dist-packages/vllm/v1/metrics/loggers.py:707: in __init__
  | [2025-09-26T06:26:34Z]     loggers.append(logger_factory(vllm_config,
  | [2025-09-26T06:26:34Z] /usr/local/lib/python3.12/dist-packages/vllm/v1/metrics/loggers.py:65: in __init__
  | [2025-09-26T06:26:34Z]     self.kv_transfer_logging = KVConnectorLogging(kv_tranfer_config)
  | [2025-09-26T06:26:34Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | [2025-09-26T06:26:34Z]
  | [2025-09-26T06:26:34Z] self = <vllm.distributed.kv_transfer.kv_connector.v1.metrics.KVConnectorLogging object at 0x7f35840da090>
  | [2025-09-26T06:26:34Z] kv_tranfer_config = KVTransferConfig(kv_connector='SharedStorageConnector', engine_id='20bee06b-94d9-43db-b284-cb7d016da665', kv_buffer_de...{'shared_storage_path': '/tmp/pytest-of-root/pytest-1/test_shared_storage_connector_0'}, kv_connector_module_path=None)
  | [2025-09-26T06:26:34Z]
  | [2025-09-26T06:26:34Z]     def __init__(self, kv_tranfer_config: KVTransferConfig):
  | [2025-09-26T06:26:34Z]         # This should be called on frontend process.
  | [2025-09-26T06:26:34Z] >       assert not has_kv_transfer_group()
  | [2025-09-26T06:26:34Z] E       AssertionError
  | [2025-09-26T06:26:34Z]
  | [2025-09-26T06:26:34Z] /usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py:54: AssertionError
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

