### PR TITLE
Refactor/understanding prepare inputs padded

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -514,6 +514,24 @@ class EagleProposer:
             causal=True,
         )
 
+        # NOTE(Tomas Ruiz): The update has no effect?
+        # Before and after are always the same
+        # Is the update only a shallow object copy?
+        b = common_attn_metadata
+        a = spec_common_attn_metadata
+        assert b.query_start_loc.eq(a.query_start_loc).all()
+        assert b.query_start_loc_cpu.eq(a.query_start_loc_cpu).all()
+        assert b.seq_lens.eq(a.seq_lens).all()
+        assert b.seq_lens_cpu.eq(a.seq_lens_cpu).all()
+        assert b.num_computed_tokens_cpu.eq(a.num_computed_tokens_cpu).all()
+        assert b.num_reqs == a.num_reqs
+        assert b.num_actual_tokens == a.num_actual_tokens
+        assert b.max_query_len == a.max_query_len
+        assert b.max_seq_len == a.max_seq_len
+        assert b.block_table_tensor.eq(a.block_table_tensor).all()
+        assert b.slot_mapping.eq(a.slot_mapping).all()
+        assert b.causal == a.causal
+
         token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1 \
             - num_rejected_tokens_gpu
 

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -535,7 +535,7 @@ class EagleProposer:
         token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1 \
             - num_rejected_tokens_gpu
 
-        return spec_common_attn_metadata, token_indices, token_indices_to_sample
+        return common_attn_metadata, token_indices, token_indices_to_sample
 
     def propose_tree(
         self,


### PR DESCRIPTION
I'm trying to understand how prepare_inputs() works.
* `prepare_inputs_padded()` states that it updates `common_attn_metadata`. However, the code seems rather to make a copy only.
* I introduced assertions checking that all content is the same, and even make the method return the unmodified `common_attn_metadata`. Its has no negative impact.
* I run `pytest tests/v1/spec_decode/test_eagle.py` all tests pass (some are skipped).
```shell
=== 29 passed, 20 skipped, 2 warnings in 44.02s ===
```
* I run `pytest tests/v1/e2e/test_spec_decode.py -k test_eagle_correctness -s`, all tests pass (some are skipped).
<img width="629" height="32" alt="image" src="https://github.com/user-attachments/assets/b736a3cd-090d-4af9-bee1-3d6b4dd91ea5" />

Am I missing something? If not this is an opportunity to simplify the `prepare_inputs_padded()` method.