### PR TITLE
[Bug]: Set LD_LIBRARY_PATH to include the 'standard' CUDA location

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -461,6 +461,12 @@ ENV CUDA_HOME=/usr/local/cuda
 RUN export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-9.0a+PTX}" \
     && bash install_python_libraries.sh
 
+# CUDA image changed from /usr/local/nvidia to /usr/local/cuda in 12.8 but will
+# return to /usr/local/nvidia in 13.0 to allow container providers to mount drivers
+# consistently from the host (see https://github.com/vllm-project/vllm/issues/18859).
+# Until then, add /usr/local/nvidia/lib64 before the image cuda path to allow override.
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
 #################### vLLM installation IMAGE ####################
 
 #################### TEST IMAGE ####################


### PR DESCRIPTION
## Purpose

NVIDIA changed the CUDA library install path in their base
images in 12.8, but some container providers automount drivers
in the old location. After discussion with NVIDIA future CUDA
images (13.0+) will revert to the old path. Until then, reduce
the friction for new vLLM users running on GKE by including
the old / future mount path ahead of the built in CUDA to
allow automount logic to work out of the box.

Fixes #18859

## Test Plan

Verify the built image works with an automounted CUDA version
provided by the container platform at /usr/local/nvidia/lib64.
Start vLLM in a minimal config on GKE with automounted drivers.

## Test Result

In progress ...

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

