### PR TITLE
[Bugfix] Add missing `image_size` for phi4_multimodal

### DIFF
--- a/vllm/model_executor/models/phi4_multimodal.py
+++ b/vllm/model_executor/models/phi4_multimodal.py
@@ -786,6 +786,7 @@ class Phi4MMProcessingInfo(BaseProcessingInfo):
                 target_ratios,
                 orig_width,
                 orig_height,
+                image_size,
             )
 
             # calculate the target width and height


### PR DESCRIPTION
## Purpose

Add missing `image_size` argument to [`model_executor/models/phi4_multimodal.py`](https://github.com/vllm-project/vllm/blob/92da847cf5f4eedf0bc9fed45d7c076be78b8c1f/vllm/model_executor/models/phi4_multimodal.py#L784-L789)'s `image_processor.find_closest_aspect_ratio()`
