### PR TITLE
[Feat][EPLB] Enable Round-robin expert placement strategy while eplb is enabled.

### DIFF
--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -40,8 +40,6 @@ from vllm.distributed.parallel_state import (get_ep_group, get_node_count,
                                              in_the_same_node_as)
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe.utils import (
-    determine_expert_placement_strategy)
 from vllm.model_executor.models.interfaces import MixtureOfExperts
 
 from .rebalance_algo import rebalance_experts
@@ -219,10 +217,7 @@ class EplbState:
         """
         Build the initial EPLB state.
         """
-        expert_placement_strategy = determine_expert_placement_strategy(
-            num_redundant_experts=\
-                parallel_config.eplb_config.num_redundant_experts,
-        )
+        expert_placement_strategy = parallel_config.expert_placement_strategy
 
         physical_to_logical_map_list = (
             cls.build_initial_global_physical_to_logical_map(

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -34,6 +34,8 @@ from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
     is_rocm_aiter_moe_enabled)
 from vllm.model_executor.layers.fused_moe.routing_simulator import (
     RoutingSimulator)
+from vllm.model_executor.layers.fused_moe.utils import (
+    determine_expert_placement_strategy)
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
 from vllm.model_executor.utils import set_weight_attrs
@@ -1023,22 +1025,15 @@ class FusedMoE(CustomOp):
                 assert num_redundant_experts == 0, \
                     "Redundant experts are only supported with EPLB."
 
-            expert_placement_strategy = (
-                vllm_config.parallel_config.expert_placement_strategy)
-            if expert_placement_strategy == "round_robin":
-                # TODO(Bruce): will support round robin expert placement with
-                # EPLB enabled in the future.
-                round_robin_supported = ((num_expert_group is not None
-                                          and num_expert_group > 1)
-                                         and num_redundant_experts == 0
-                                         and not self.enable_eplb)
-
-                if not round_robin_supported:
-                    logger.warning(
-                        "Round-robin expert placement is only supported for "
-                        "models with multiple expert groups and no redundant "
-                        "experts. Falling back to linear expert placement.")
-                    expert_placement_strategy = "linear"
+            expert_placement_strategy = determine_expert_placement_strategy(
+                num_expert_group=num_expert_group,
+                num_redundant_experts=num_redundant_experts,
+            )
+            if expert_placement_strategy == "round_robin" and self.enable_eplb:
+                # When eplb is enabled, it assumes that the expert_map is
+                # linear, so we keep it unchanged and apply the
+                # round_robin logic elsewhere.
+                expert_placement_strategy = "linear"
 
             self.expert_map: Optional[torch.Tensor]
             local_num_experts, expert_map = determine_expert_map(
@@ -2071,14 +2066,19 @@ class FusedMoE(CustomOp):
 
     @classmethod
     def make_expert_params_mapping(
-            cls,
-            ckpt_gate_proj_name: str,
-            ckpt_down_proj_name: str,
-            ckpt_up_proj_name: str,
-            num_experts: int,
-            num_redundant_experts: int = 0) -> list[tuple[str, str, int, str]]:
+        cls,
+        ckpt_gate_proj_name: str,
+        ckpt_down_proj_name: str,
+        ckpt_up_proj_name: str,
+        num_experts: int,
+        num_redundant_experts: int = 0,
+        expert_placement_strategy: ExpertPlacementStrategy = None,
+    ) -> list[tuple[str, str, int, str]]:
 
         num_physical_experts = num_experts + num_redundant_experts
+        if expert_placement_strategy is None:
+            expert_placement_strategy = determine_expert_placement_strategy(
+                num_redundant_experts=num_redundant_experts)
 
         # In the returned mapping:
         # - `expert_id` is the physical expert id
@@ -2086,7 +2086,7 @@ class FusedMoE(CustomOp):
         # So that we should map the expert id to logical in `weight_name`
         physical_to_logical_map = \
             EplbState.build_initial_global_physical_to_logical_map(
-            num_experts, num_redundant_experts)
+            num_experts, num_redundant_experts, expert_placement_strategy)
 
         return [
             # (param_name, weight_name, expert_id, shard_id)


### PR DESCRIPTION
**TL;DR:** Round-robin now serves as a better initial condition for EPLB, providing more balanced expert distribution before the first EPLB balancing step and helping it reach a steady load-balanced state faster.

This PR extends the round-robin expert placement introduced in [PR-23745](https://github.com/vllm-project/vllm/pull/23745) to support EPLB. Round-robin now serves as a better initial condition for EPLB, helping it reach a steady load-balanced state faster and improving overall utilization stability and performance consistency across expert groups.


## Performance
Conclusion: With configurations list below, when eplb is enabled, the round-robin strategy improves avg. throughput and end-to-end latency by approximately 3% than default linear strategy.

Test Platform:
Vllm version: vllm/vllm-openai:nightly-8c546102658f97b10d13bcf25193b65edc6ea6ff
Model: DeepSeek-V2-Chat-0628, 
GPU: H20 * 8
Serving mode config :
    python3 -u -m vllm.entrypoints.openai.api_server \
            --model ${MODEL_PATH} \
            --trust-remote-code \
            --gpu-memory-utilization 0.85 \
            -tp 8 \ 
            --enable-expert-parallel \
            --enable-eplb \
            --expert-placement-strategy "round_robin"

Benchmark config: input_len=1024, output_len=128, request_rate=4, max_concurrency=4, num_prompts=32:
    python3 ./bench_serving.py
        --backend vllm
        --dataset-name random
        --model ${MODEL_PATH}
        --random-input-len 1024 
        --random-output-len 128
        --random-range-ratio 0.5
        --tokenizer ./tokenizer
        --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json
        --request-rate 4
        --max-concurrency 4
        --num-prompts 32
        --base-url http://127.0.0.1:8000
        --port 8000

<img width="1488" height="909" alt="Clipboard_Screenshot_1759048641" src="https://github.com/user-attachments/assets/7279cccf-2ab7-4383-8654-54d7499bf866" />

## Accuracy Test
Tested with Deepseek-v2-chat-0628 on h20*8 with following serving cmd:
```python
python3 -u -m vllm.entrypoints.openai.api_server \
            --model ${model_path} \
            --trust-remote-code \
            --gpu-memory-utilization 0.85 \
            -tp 8 \ 
            --enable-expert-parallel \
            --enable-eplb \
            --expert-placement-strategy "round_robin" \
```
Note: Deepseek-v2 has a bad behavior on our chosen dataset, just to make sure this PR has no impact on accuracy.
| Dataset  | vllm v0.10.1.1 |  This PR |
|----------|-------------------|-----------------------|
| Aime24   | 13.33%            |  20.00%               |
| Gpqa     | 41.91%            |  44.44%                |
| Math500  | 72.20%            | 72.40%                |
<img width="1855" height="517" alt="Clipboard_Screenshot_1759050538" src="https://github.com/user-attachments/assets/5199750b-fb4e-4de3-a469-544e3c22f38d" />
```