### PR TITLE
[Core] Bookkeeping optimization: Batchify updates 1D numpy arrays (e.g. num_tokens, num_tokens_no_spec)

### DIFF
--- a/benchmarks/benchmark_bookkeep.py
+++ b/benchmarks/benchmark_bookkeep.py
@@ -25,8 +25,10 @@ def update_one_by_one(
 ) -> None:
     for i in range(len(update_values)):
         if update_tags[i]:
+            # Access a single value from numpy array
             start_idx = num_tokens_no_spec_np[i]
             end_idx = start_idx + update_values[i]
+            # Update a single value to 2 numpy arrays
             num_tokens_no_spec_np[i] = end_idx
             num_tokens_np[i] = end_idx
 
@@ -37,6 +39,7 @@ def update_by_batch(
     update_tags: list[bool],
     update_values: list[int],
 ) -> None:
+    # Convert numpy array to list once before for loop
     num_tokens_no_spec = num_tokens_no_spec_np.tolist()
     num_tokens_indices_to_update: list[int] = []
     num_tokens_values_to_update: list[int] = []
@@ -46,6 +49,7 @@ def update_by_batch(
             end_idx = start_idx + update_values[i]
             num_tokens_indices_to_update.append(i)
             num_tokens_values_to_update.append(end_idx)
+    # Batch update numpy arrays after for loop
     if num_tokens_indices_to_update:
         num_tokens_no_spec_np[num_tokens_indices_to_update] = (
             num_tokens_values_to_update

--- a/benchmarks/benchmark_bookkeep.py
+++ b/benchmarks/benchmark_bookkeep.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import gc
+from random import randint, shuffle
+
+import numpy as np
+from benchmark_utils import TimeCollector, throughput_change
+from tabulate import tabulate
+from tqdm import trange
+
+from vllm.utils import FlexibleArgumentParser
+
+"""
+Example Usage:
+
+buck run @mode/opt scripts/jialino/llm/python:np_update
+"""
+
+
+def update_one_by_one(
+    num_tokens_no_spec_np: np.ndarray[np.int32, np.dtype[np.int32]],
+    num_tokens_np: np.ndarray[np.int32, np.dtype[np.int32]],
+    update_tags: list[bool],
+    update_values: list[int],
+) -> None:
+    for i in range(len(update_values)):
+        if update_tags[i]:
+            start_idx = num_tokens_no_spec_np[i]
+            end_idx = start_idx + update_values[i]
+            num_tokens_no_spec_np[i] = end_idx
+            num_tokens_np[i] = end_idx
+
+
+def update_by_batch(
+    num_tokens_no_spec_np: np.ndarray[np.int32, np.dtype[np.int32]],
+    num_tokens_np: np.ndarray[np.int32, np.dtype[np.int32]],
+    update_tags: list[bool],
+    update_values: list[int],
+) -> None:
+    num_tokens_no_spec = num_tokens_no_spec_np.tolist()
+    num_tokens_indices_to_update: list[int] = []
+    num_tokens_values_to_update: list[int] = []
+    for i in range(len(update_values)):
+        if update_tags[i]:
+            start_idx = num_tokens_no_spec[i]
+            end_idx = start_idx + update_values[i]
+            num_tokens_indices_to_update.append(i)
+            num_tokens_values_to_update.append(end_idx)
+    if num_tokens_indices_to_update:
+        num_tokens_no_spec_np[num_tokens_indices_to_update] = (
+            num_tokens_values_to_update
+        )
+        num_tokens_np[num_tokens_indices_to_update] = num_tokens_values_to_update
+
+
+def main(args) -> None:
+    testsets = []
+    for num_element in args.num_elements:
+        update_element = num_element
+        while update_element > 0:
+            testsets.append((num_element, update_element))
+            update_element = update_element // 10
+        testsets.append((num_element, 0))
+    testsets.sort()
+
+    data_rows = []
+    TIME_SCALE = TimeCollector.US
+
+    for i in trange(len(testsets), desc="Testsets"):
+        num_element, update_element = testsets[i]
+        num_tokens_no_spec_np = np.empty((num_element,), dtype=np.int32)
+        num_tokens_np = np.empty((num_element,), dtype=np.int32)
+        one_by_one_times = TimeCollector(TIME_SCALE)
+        batch_times = TimeCollector(TIME_SCALE)
+        # Only update update_element per iterations
+        update_tags = [True] * update_element + [False] * (num_element - update_element)
+        gc.collect()
+        for _ in trange(args.num_iteration, desc="Iterations per testset"):
+            shuffle(update_tags)
+            update_values = [randint(0, 100) for _ in range(num_element)]
+            with one_by_one_times:
+                update_one_by_one(
+                    num_tokens_no_spec_np, num_tokens_np, update_tags, update_values
+                )
+            with batch_times:
+                update_by_batch(
+                    num_tokens_no_spec_np, num_tokens_np, update_tags, update_values
+                )
+
+        one_by_one_avg = one_by_one_times.avg_v()
+        batch_metric_avg = batch_times.avg_v()
+        data_rows.append(
+            [
+                num_element,
+                update_element,
+                one_by_one_times.avg(),
+                batch_times.avg(),
+                throughput_change(batch_metric_avg, one_by_one_avg),
+            ]
+        )
+
+    print(
+        tabulate(
+            data_rows,
+            headers=[
+                "Total\nElements",
+                "Update\nElements",
+                "One by One\nAvg (us)",
+                "Batch\nAvg (us)",
+                "Throughput\nChange",
+            ],
+            tablefmt="pipe",
+            floatfmt=".3f",
+            colalign=["right"] * len(data_rows[0]),
+        )
+    )
+
+
+def invoke_main() -> None:
+    parser = FlexibleArgumentParser(
+        description="Benchmark the performance of Bookkeeping "
+        "(i.e. GPUModelRunner._bookkeeping_sync)"
+    )
+    parser.add_argument(
+        "--num-iteration",
+        type=int,
+        default=1000,
+        help="Number of iterations to run to stabilize final data readings",
+    )
+    parser.add_argument(
+        "--num_elements",
+        type=int,
+        nargs="+",
+        default=[10, 100, 1000, 10000],
+    )
+    main(parser.parse_args())
+
+
+if __name__ == "__main__":
+    invoke_main()  # pragma: no cover

--- a/benchmarks/benchmark_bookkeep.py
+++ b/benchmarks/benchmark_bookkeep.py
@@ -10,12 +10,6 @@ from tqdm import trange
 
 from vllm.utils import FlexibleArgumentParser
 
-"""
-Example Usage:
-
-buck run @mode/opt scripts/jialino/llm/python:np_update
-"""
-
 
 def update_one_by_one(
     num_tokens_no_spec_np: np.ndarray[np.int32, np.dtype[np.int32]],

--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -8,6 +8,8 @@ import time
 from types import TracebackType
 from typing import Any
 
+from multi_turn.bench_utils import Color
+
 
 def convert_to_pytorch_benchmark_format(
     args: argparse.Namespace, metrics: dict[str, list], extra_info: dict[str, Any]
@@ -75,21 +77,13 @@ def write_to_json(filename: str, records: list) -> None:
         )
 
 
-TERM_GREEN: str = "\033[92m"
-TERM_RED: str = "\033[91m"
-
-
-def throughput_change(
-    test_avg_elpased_time: float, baseline_avg_elpased_time: float
-) -> str:
-    color = (
-        TERM_GREEN if test_avg_elpased_time < baseline_avg_elpased_time else TERM_RED
-    )
-    return (
-        f"{color}"
-        f"{baseline_avg_elpased_time / test_avg_elpased_time * 100 - 100:.2f}%"
-        "\033[0m"
-    )
+def throughput_change(test_elpased_time: float, baseline_elpased_time: float) -> str:
+    """
+    Generates throughput change between test and baseline elapsed time
+    with proper colors.
+    """
+    color = Color.GREEN if test_elpased_time < baseline_elpased_time else Color.RED
+    return f"{color}{baseline_elpased_time / test_elpased_time * 100 - 100:.2f}%\033[0m"
 
 
 # Collect time and generate time metrics

--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -75,6 +75,23 @@ def write_to_json(filename: str, records: list) -> None:
         )
 
 
+TERM_GREEN: str = "\033[92m"
+TERM_RED: str = "\033[91m"
+
+
+def throughput_change(
+    test_avg_elpased_time: float, baseline_avg_elpased_time: float
+) -> str:
+    color = (
+        TERM_GREEN if test_avg_elpased_time < baseline_avg_elpased_time else TERM_RED
+    )
+    return (
+        f"{color}"
+        f"{baseline_avg_elpased_time / test_avg_elpased_time * 100 - 100:.2f}%"
+        "\033[0m"
+    )
+
+
 # Collect time and generate time metrics
 #
 # Example Usage:
@@ -104,8 +121,11 @@ class TimeCollector:
         else:
             self._max = max(self._max, v)
 
+    def avg_v(self) -> float:
+        return self._sum * 1.0 / self.cnt / self.scale
+
     def avg(self) -> float | str:
-        return self._sum * 1.0 / self.cnt / self.scale if self.cnt > 0 else "N/A"
+        return self.avg_v() if self.cnt > 0 else "N/A"
 
     def max(self) -> float | str:
         return self._max / self.scale if self._max else "N/A"


### PR DESCRIPTION
## Purpose
Currently, GPUModelRunner._bookkeeping_sync interleaves numpy updates and python logics which is inefficient, and we could see scattered tensor and numpy array updates which consumes significant amount of times.

In this change, we simply vectorize the tensor and numpy updates
- compute update indexes and values in for loop in Python
- apply buck updates to tensor and numpy for vectorization

**Update**
We only apply batchify to 1D array in this PR, will do the 2D array/tensor updates as followup.

<img width="1196" height="384" alt="Screenshot 2025-09-26 at 11 40 03 AM" src="https://github.com/user-attachments/assets/3b0ad3e1-b50a-419b-a711-bff379a01a78" />

## Test Plan & Test Result

**Benchmark**
We introduced a benchmark script to measure the win. It's a clear performance boost when all rows are updated (5x throughput boost), but a regression when <10% of rows are updated). But in real work scenarios, we believe most of the rows are updated, so it should still be a consistent improvement to the system.

<img width="505" height="306" alt="Screenshot 2025-10-09 at 2 20 31 PM" src="https://github.com/user-attachments/assets/039bd871-d289-4fb9-8841-a6eaa2b4fc36" />


**Correctness**
```
VLLM_USE_V1=1 python3 examples/offline_inference/spec_decode.py  --method ngram  --model-dir meta-llama/Llama-3.1-8B-Instruct  --prompt_lookup_min 2  --prompt_lookup_max 5  --num_spec_tokens 5  --dataset-name hf  --dataset-path philschmid/mt-bench  --num-prompts 80  --print-output

Output is exactly the same before and after the change
--------------------------------------------------
total_num_output_tokens: 17069
num_drafts: 2548
num_draft_tokens: 12711
num_accepted_tokens: 2587
mean acceptance length: 2.02
--------------------------------------------------
acceptance at token 0: 0.43
acceptance at token 1: 0.25
acceptance at token 2: 0.15
acceptance at token 3: 0.10
acceptance at token 4: 0.07
```

**Optimization**
~3x speedup with the change per trace
<img width="1393" height="595" alt="Screenshot 2025-09-26 at 2 36 37 PM" src="https://github.com/user-attachments/assets/5af16445-2a71-4c3b-876c-46d645e09f47" />

Per gptoss AIME 2025 eval runs
- bookkeeping total elapsed time reduced by 60%+
- bookkeeping elapsed time distribution is less skewed
<img width="761" height="115" alt="Screenshot 2025-09-26 at 11 36 11 PM" src="https://github.com/user-attachments/assets/dfc430cd-e143-4931-9b78-52c79ac383d7" />
<img width="1030" height="585" alt="Screenshot 2025-09-26 at 11 35 31 PM" src="https://github.com/user-attachments/assets/ddc0d1fa-f0ae-48a6-a82b-b5e715a2d669" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

