### PR TITLE
[Bugfix] Fix triton import precommit failure

### DIFF
--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -7,8 +7,8 @@ from collections.abc import Callable
 from typing import Any, Union
 
 import torch
-import triton
-import triton.language as tl
+
+from vllm.triton_utils import tl, triton
 
 
 def _matmul_launch_metadata(grid: Callable[..., Any], kernel: Any,


### PR DESCRIPTION
Introduced in https://github.com/vllm-project/vllm/pull/25603, but not sure why the last commit passed the precommit there. I'm hitting precommit failures locally when merging main.