### PR TITLE
[Misc] fix tests failure by using current_platform

### DIFF
--- a/vllm/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/attention/ops/triton_reshape_and_cache_flash.py
@@ -137,7 +137,7 @@ def triton_reshape_and_cache_flash(
 
     # heuristics instead of autotuning
     TILE_SIZE = min(2048, triton.next_power_of_2(n))
-    if torch.version.hip or torch.version.xpu:
+    if torch.version.hip or current_platform.is_xpu():
         num_stages = 4
         num_warps = 8
     else:  # cuda

--- a/vllm/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/attention/ops/triton_reshape_and_cache_flash.py
@@ -137,7 +137,7 @@ def triton_reshape_and_cache_flash(
 
     # heuristics instead of autotuning
     TILE_SIZE = min(2048, triton.next_power_of_2(n))
-    if torch.version.hip or current_platform.is_xpu():
+    if current_platform.is_rocm() or current_platform.is_xpu():
         num_stages = 4
         num_warps = 8
     else:  # cuda


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fix the local unit test error by using standard platform detection method in vllm

## Purpose
Fix the failing UTs.  Error msg:
```
        TILE_SIZE = min(2048, triton.next_power_of_2(n))
>       if torch.version.hip or torch.version.xpu:
E       AttributeError: module 'torch.version' has no attribute 'xpu'
```

## Test Plan
Re-run UT

## Test Result


tests/kernels/attention/test_cache.py::test_reshape_and_cache_flash[triton-NHD-auto-cuda:1-0-dtype1-1024-8-80-8-42] PASSED

---


