### PR TITLE
[MISC] Fix misleading batch_size_capture_list when cuda_graph_sizes < 4

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -582,6 +582,8 @@ class VllmConfig:
             cuda_graph_sizes = self.scheduler_config.cuda_graph_sizes
             if len(cuda_graph_sizes) == 1:
                 max_graph_size = cuda_graph_sizes[0]
+                assert max_graph_size >= 1, "Maximum cudagraph size should be" \
+                                            " greater than or equal to 1."
                 batch_size_capture_list = [
                     i for i in [1, 2, 4] if i <= max_graph_size
                 ] + list(range(8, max_graph_size + 1, 8))

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -581,9 +581,10 @@ class VllmConfig:
             not self.model_config.enforce_eager:
             cuda_graph_sizes = self.scheduler_config.cuda_graph_sizes
             if len(cuda_graph_sizes) == 1:
-                batch_size_capture_list = [1, 2, 4] + [
-                    i for i in range(8, cuda_graph_sizes[0] + 1, 8)
-                ]
+                max_graph_size = cuda_graph_sizes[0]
+                batch_size_capture_list = [
+                    i for i in [1, 2, 4] if i <= max_graph_size
+                ] + list(range(8, max_graph_size + 1, 8))
             elif len(cuda_graph_sizes) > 1:
                 batch_size_capture_list = sorted(cuda_graph_sizes)
             else:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Previously, the logic for generating `batch_size_capture_list` always included [1, 2, 4] by default. Refer to https://github.com/vllm-project/vllm/blob/f4e4088c99020c9711e824096f013f89da54bb36/vllm/config/__init__.py#L619-L622

This was misleading when cuda_graph_sizes < 4 because the list contained batch sizes that exceeded the actual maximum.

## How to fix in this patch
Filtered out [1, 2, 4] values that are larger than cuda_graph_sizes[0].
The list now correctly reflects the allowed batch sizes, even for small values.

Examples:
- cuda_graph_sizes = [1] → [1]
- cuda_graph_sizes = [2] → [1, 2]
- cuda_graph_sizes = [17] → [1, 2, 4, 8, 16]


## Test Result

Before fix:
```python
vllm serve /models/DeepSeek-R1 --trust-remote-code --tensor-parallel-size 8 --cuda-graph-sizes 2

(EngineCore_DP0 pid=904192) INFO 09-28 02:11:36 [core.py:78] Initializing a V1 LLM engine (v0.11.0rc2.dev34+gda63274d9) with config: model='/models/DeepSeek-R1', speculative_config=None, tokenizer='/models/DeepSeek-R1', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=163840, download_dir=None, load_format=auto, tensor_parallel_size=8, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=fp8, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=/models/DeepSeek-R1, enable_prefix_caching=True, chunked_prefill_enabled=True, pooler_config=None, compilation_config={"level":3,"debug_dump_path":null,"cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output","vllm.mamba_mixer2","vllm.mamba_mixer","vllm.short_conv","vllm.linear_attention","vllm.plamo2_mamba_mixer","vllm.gdn_attention"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"cudagraph_mode":[2,1],"use_cudagraph":true,"cudagraph_num_of_warmups":1,
"cudagraph_capture_sizes":[4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":true,"use_inductor_graph_partition":false,"pass_config":{},"max_capture_size":4,"local_cache_dir":null}
```

After fix:
```python
vllm serve /models/DeepSeek-R1 --trust-remote-code --tensor-parallel-size 8 --cuda-graph-sizes 2

(EngineCore_DP0 pid=885683) INFO 09-28 01:52:41 [core.py:78] Initializing a V1 LLM engine (v0.11.0rc2.dev34+gda63274d9) with config: model='/models/DeepSeek-R1', speculative_config=None, tokenizer='/models/DeepSeek-R1', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=163840, download_dir=None, load_format=auto, tensor_parallel_size=8, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=fp8, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=/models/DeepSeek-R1, enable_prefix_caching=True, chunked_prefill_enabled=True, pooler_config=None, compilation_config={"level":3,"debug_dump_path":null,"cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output","vllm.mamba_mixer2","vllm.mamba_mixer","vllm.short_conv","vllm.linear_attention","vllm.plamo2_mamba_mixer","vllm.gdn_attention"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"cudagraph_mode":[2,1],"use_cudagraph":true,"cudagraph_num_of_warmups":1,
"cudagraph_capture_sizes":[2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":true,"use_inductor_graph_partition":false,"pass_config":{},"max_capture_size":2,"local_cache_dir":null}
```	


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

