### PR TITLE
Add Phi4FlashForCausalLM to _PREVIOUSLY_SUPPORTED_MODELS

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -332,6 +332,7 @@ _SUBPROCESS_COMMAND = [
 ]
 
 _PREVIOUSLY_SUPPORTED_MODELS = {
+    "Phi4FlashForCausalLM": "0.10.2",
     "Phi3SmallForCausalLM": "0.9.2",
     # encoder-decoder models except whisper
     # have been removed for V0 deprecation.

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -332,8 +332,8 @@ _SUBPROCESS_COMMAND = [
 ]
 
 _PREVIOUSLY_SUPPORTED_MODELS = {
-    "Phi4FlashForCausalLM": "0.10.2",
     "Phi3SmallForCausalLM": "0.9.2",
+    "Phi4FlashForCausalLM": "0.10.2",
     # encoder-decoder models except whisper
     # have been removed for V0 deprecation.
     "BartModel": "0.10.2",


### PR DESCRIPTION
## Purpose

Since we stripped out V0, the model `Phi4FlashForCausalLM` is no longer supported. There is an issue (https://github.com/vllm-project/vllm/issues/23957) open to track the work for porting this model to V1.

This PR adds the model to the `_PREVIOUSLY_SUPPORTED_MODELS` with the last version of vLLM that supported it. 

cc @youkaichao 

## Test Plan

n/a


## Test Result

n/a

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

