### PR TITLE
[Bugfix] fix Qwen3VLMoe load when pp > 1

### DIFF
--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -212,6 +212,8 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                     # attempted to load as other weights later
                     is_expert_weight = True
                     name_mapped = name.replace(weight_name, param_name)
+                    if is_pp_missing_parameter(name_mapped, self):
+                        continue
                     if is_fused_expert:
                         loaded_weight = loaded_weight.transpose(-1,
                                                                 -2)  # no bias
@@ -230,8 +232,6 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                                 name_mapped, params_dict, loaded_weight,
                                 shard_id, num_experts)
                     else:
-                        if is_pp_missing_parameter(name_mapped, self):
-                            continue
                         # Skip loading extra parameters for GPTQ/modelopt models
                         if name_mapped.endswith(
                                 ignore_suffixes


### PR DESCRIPTION
## Purpose

fix https://github.com/QwenLM/Qwen3-VL/issues/1523

## Test Plan

test with command

```bash
python3 -m vllm.entrypoints.openai.api_server   
  --model  /path/to/Qwen3-VL-235B-A22B-Instruct   
  --served-model-name Qwen3-VL-235B-A22B-Instruct   
  --tensor-parallel-size 4
  --pipeline-parallel-size 2   
  --mm-encoder-tp-mode data   
  --limit-mm-per-prompt.video 0   
  --mm-processor-cache-type shm   
  --enable-expert-parallel   
  --host 0.0.0.0   
  --port 22002   
  --dtype bfloat16   
  --gpu-memory-utilization 0.95   
  --distributed-executor-backend mp 
  --max-model-len 40960
```

## Test Result

before

```bash
(EngineCore_DP0 pid=9735) ERROR 09-28 20:05:29 [core.py:712] param = params_dict[name]
(EngineCore_DP0 pid=9735) ERROR 09-28 20:05:29 [core.py:712] ~~~~~~~~~~~^^^^^^
(EngineCore_DP0 pid=9735) ERROR 09-28 20:05:29 [core.py:712] KeyError: 'layers.0.mlp.experts.w2_weight'
```

now fixed!
