### PR TITLE
[Bugfix] Fallback ViT attn backend to SDPA for blackwell

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -66,7 +66,7 @@ from vllm.multimodal.processing import (BaseMultiModalProcessor,
                                         PromptReplacement, PromptUpdate,
                                         PromptUpdateDetails)
 from vllm.multimodal.profiling import BaseDummyInputsBuilder
-from vllm.platforms import _Backend, current_platform
+from vllm.platforms import _Backend
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import uses_mrope
 from vllm.utils import is_list_of
@@ -336,14 +336,6 @@ class Qwen3_VisionTransformer(nn.Module):
         }:
             raise RuntimeError(
                 f"Qwen3-VL does not support {self.attn_backend} backend now.")
-        if current_platform.is_device_capability(
-                100) and self.attn_backend != _Backend.TORCH_SDPA:
-            # TODO(Roger/Wentao): remove this after FA
-            # or XFORMERS's issue fixed on Blackwell
-            logger.info_once("Qwen3-VL vision attention does not support "
-                             f"{self.attn_backend} backend on Blackwell now. "
-                             "Vision attention backend is set to TORCH_SDPA.")
-            self.attn_backend = _Backend.TORCH_SDPA
 
         self.blocks = nn.ModuleList([
             Qwen3_VisionBlock(

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -205,6 +205,11 @@ class CudaPlatformBase(Platform):
     @classmethod
     def get_vit_attn_backend(cls, head_size: int,
                              dtype: torch.dtype) -> _Backend:
+
+        # For Blackwell GPUs, force TORCH_SDPA for now.
+        if cls.has_device_capability(100):
+            return _Backend.TORCH_SDPA
+
         if dtype not in (torch.float16, torch.bfloat16):
             return _Backend.XFORMERS
 
@@ -218,9 +223,6 @@ class CudaPlatformBase(Platform):
             else:
                 # Fallback to XFORMERS
                 return _Backend.XFORMERS
-        # For Blackwell GPUs, force TORCH_SDPA for now.
-        if cls.has_device_capability(100):
-            return _Backend.TORCH_SDPA
         else:
             # Fallback for Volta/Turing GPUs or FA not supported
             return _Backend.XFORMERS

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -218,6 +218,9 @@ class CudaPlatformBase(Platform):
             else:
                 # Fallback to XFORMERS
                 return _Backend.XFORMERS
+        # For Blackwell GPUs, force TORCH_SDPA for now.
+        if cls.has_device_capability(100):
+            return _Backend.TORCH_SDPA
         else:
             # Fallback for Volta/Turing GPUs or FA not supported
             return _Backend.XFORMERS

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -207,6 +207,7 @@ class CudaPlatformBase(Platform):
                              dtype: torch.dtype) -> _Backend:
 
         # For Blackwell GPUs, force TORCH_SDPA for now.
+        # See https://github.com/facebookresearch/xformers/issues/1317#issuecomment-3199392579 # noqa: E501
         if cls.has_device_capability(100):
             return _Backend.TORCH_SDPA
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
https://github.com/vllm-project/vllm/pull/25788 Fixed the issue for Qwen3-VL - while we don't know if xformers is going to work with other head sizes, it's not officially supported yet according to https://github.com/facebookresearch/xformers/issues/1317#issuecomment-3199392579. Therefore it's probably safer for us to force ViT backend to SDPA for all models on blackwell for now.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

