### PR TITLE
[Model][Bugfix] Fix issues in MiDashengLM implementation for quantized models

### DIFF
--- a/vllm/model_executor/models/midashenglm.py
+++ b/vllm/model_executor/models/midashenglm.py
@@ -617,6 +617,17 @@ class MiDashengLMMultiModalProcessor(
     dummy_inputs=MiDashengLMDummyInputsBuilder,
 )
 class MiDashengLMModel(nn.Module, SupportsMultiModal, SupportsPP):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> Optional[str]:

--- a/vllm/model_executor/models/midashenglm.py
+++ b/vllm/model_executor/models/midashenglm.py
@@ -318,7 +318,7 @@ class DashengAudioTransformer(nn.Module):
                 qkv_bias=config.qkv_bias,
                 init_values=config.init_values,
                 quant_config=quant_config,
-                prefix=f"{prefix}.block{i}",
+                prefix=f"{prefix}.blocks.{i}",
             ) for i in range(config.depth))
         self.norm = nn.LayerNorm(config.embed_dim, eps=1e-6)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR addresses several issues discovered during the testing of MiDashengLM quantization.

1. **Add `packed_modules_mapping` to `MiDashengLMModel`:** The `MiDashengLMModel` was missing the `packed_modules_mapping` attribute, which caused an error when loading models quantized with `bitsandbytes`. This has been added to ensure compatibility.
2. **Fix Parameter Mismatch in `DashengAudioTransformer`:** The `DashengAudioTransformer` was providing an incorrect prefix to `DashengBlock`, resulting in a parameter mismatch error when loading quantized models. This PR provides the correct prefix to resolve the loading issue.
3. **Update Audio Encoder Frontend in vLLM:** The current vLLM implementation was using an outdated audio encoder frontend. It has been updated to align with the latest implementation from the Hugging Face version, ensuring consistency.
4. **Correct Audio Encoder Attention Mechanism:** The attention mechanism in the vLLM audio encoder was incorrectly implemented, leading to significant deviations in the encoder's output. This has been reverted to the manual implementation from the Hugging Face version to produce the correct output.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

