### PR TITLE
OffloadingConnector: Fix GPU block tracking bug

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -278,8 +278,9 @@ class OffloadingConnectorScheduler:
                 req, start_idx=start_block_idx, end_idx=num_blocks)
             store_output = self.manager.prepare_store(new_block_hashes)
             if store_output is None:
-                logger.warning("Cannot store %s blocks", num_new_blocks)
-                break
+                logger.warning("Request %s: cannot store %s blocks", req_id,
+                               num_new_blocks)
+                continue
 
             self._next_stored_block_idx[req_id] = num_blocks
 


### PR DESCRIPTION
This PR fixes a bug in the offloading connector that may result in incorrect GPU block tracking per request.
It occurs when blocks cannot be allocated on the offloaded medium (prepare_store fails), and the scheduler output has multiple requests, some of them with new GPU block IDs. Before this PR, the connector simply returned without processing the rest of the requests, and their GPU block IDs.

This resulted in a crash of the engine core:
```
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714] EngineCore encountered a fatal error.
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714] Traceback (most recent call last):
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/v1/engine/core.py", line 705, in run_engine_core
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     engine_core.run_busy_loop()
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/v1/engine/core.py", line 732, in run_busy_loop
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     self._process_engine_step()
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/v1/engine/core.py", line 758, in _process_engine_step
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     outputs, model_executed = self.step_fn()
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]                               ^^^^^^^^^^^^^^
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/v1/engine/core.py", line 290, in step
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     scheduler_output = self.scheduler.schedule()
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]                        ^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/v1/core/sched/scheduler.py", line 589, in schedule
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     meta = self.connector.build_connector_meta(scheduler_output)
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py", line 101, in build_connector_meta
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     return self.connector_scheduler.build_connector_meta(scheduler_output)
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py", line 323, in build_connector_meta
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     reqs_to_store=self._get_reqs_to_store(scheduler_output))
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]   File "/workspace/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py", line 305, in _get_reqs_to_store
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]     GPULoadStoreSpec(block_ids[gpu_block_idx + i]))
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714]                      ~~~~~~~~~^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_0 pid=271)^[[0;0m ERROR 09-21 17:33:21 [core.py:714] IndexError: list index out of range
```