### PR TITLE
[torch.compile] serialize cudagraph_mode as its enum name instead of value

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -76,9 +76,6 @@ class CUDAGraphMode(enum.Enum):
     def __str__(self) -> str:
         return self.name
 
-    def __repr__(self) -> str:
-        return self.name
-
 
 @config
 @dataclass


### PR DESCRIPTION
## Purpose
Serialize cudagraph_mode as its enum name (e.g., "FULL") instead of value.
before
```
"cudagraph_mode":[2,1]
```
after
```
"cudagraph_mode":"FULL_AND_PIECEWISE"
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

