### PR TITLE
fix: handle missing parameters in qwen3_next weight loading

### DIFF
--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -783,6 +783,15 @@ def sequence_parallel_chunk_impl_fake(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def should_skip_bias_param(name: str) -> bool:
+    """Check if a parameter name should be skipped as an extra bias parameter.
+    
+    Handles both standard (.bias) and expert layer (_bias) naming conventions.
+    Used for GPTQ models where extra bias parameters may be present.
+    """
+    return name.endswith(".bias") or name.endswith("_bias")
+
+
 direct_register_custom_op(
     op_name="sequence_parallel_chunk_impl",
     op_func=sequence_parallel_chunk_impl,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`qwen3_next.py` add a check to skip parameters not present in params_dict 

from issue: https://github.com/vllm-project/vllm/issues/25797


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

