### PR TITLE
[BugFix][Core] Fix error when enable async-scheduling in multi-node env

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1433,13 +1433,6 @@ class EngineArgs:
         )
 
         if self.async_scheduling:
-            # Async scheduling does not work with the uniprocess backend.
-            if self.distributed_executor_backend is None:
-                self.distributed_executor_backend = "mp"
-                logger.info(
-                    "Defaulting to mp-based distributed executor "
-                    "backend for async scheduling."
-                )
             if self.pipeline_parallel_size > 1:
                 raise ValueError(
                     "Async scheduling is not supported with pipeline-parallel-size > 1."
@@ -1495,6 +1488,13 @@ class EngineArgs:
             _api_process_count=self._api_process_count,
             _api_process_rank=self._api_process_rank,
         )
+
+        if self.async_scheduling and (
+                parallel_config.distributed_executor_backend not in ("mp", "uni")):
+            raise ValueError(
+                "Currently, async scheduling is only support `mp` or `uni` "
+                "distributed executor backend, but you choose "
+                f"`{parallel_config.distributed_executor_backend}`.")
 
         speculative_config = self.create_speculative_config(
             target_model_config=model_config,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1490,11 +1490,13 @@ class EngineArgs:
         )
 
         if self.async_scheduling and (
-                parallel_config.distributed_executor_backend not in ("mp", "uni")):
+            parallel_config.distributed_executor_backend not in ("mp", "uni")
+        ):
             raise ValueError(
                 "Currently, async scheduling only supports `mp` or `uni` "
                 "distributed executor backend, but you choose "
-                f"`{parallel_config.distributed_executor_backend}`.")
+                f"`{parallel_config.distributed_executor_backend}`."
+            )
 
         speculative_config = self.create_speculative_config(
             target_model_config=model_config,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1492,7 +1492,7 @@ class EngineArgs:
         if self.async_scheduling and (
                 parallel_config.distributed_executor_backend not in ("mp", "uni")):
             raise ValueError(
-                "Currently, async scheduling is only support `mp` or `uni` "
+                "Currently, async scheduling only supports `mp` or `uni` "
                 "distributed executor backend, but you choose "
                 f"`{parallel_config.distributed_executor_backend}`.")
 


### PR DESCRIPTION
When launching in a multi-node environment (e.g., TP16), the ParallelConfig automatically selects `ray` as the distributed_executor_backend. However, when async scheduling is enabled, it prematurely sets the default value of distributed_executor_backendto to mp, causing a launch failure like bellow. This fix moves the check to after that the backend is auto-selected.

<img width="1500" height="419" alt="image" src="https://github.com/user-attachments/assets/28448d09-fcb3-4d95-9a1b-89a3685f2714" />

Currently, async scheduling (primarily the fully overlap feature) does not support Ray as a backend(error like bellow). Support for this can be added in a future PR.

<img width="1500" height="926" alt="image" src="https://github.com/user-attachments/assets/91a938cf-e1df-468e-8ded-8ce60a17c24b" />

