### PR TITLE
[Llama4] [multimodal] Fix misplaced dtype cast of `cos_sin_cache` in `Llama4VisionRotaryEmbedding`

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/llama4_vision_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/llama4_vision_rope.py
@@ -59,6 +59,8 @@ class Llama4VisionRotaryEmbedding(RotaryEmbedding):
         key: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         assert key is not None
+        # self.cos_sin_cache here is complex tensor so we cannot cast into
+        # query's dtype directly with self._match_cos_sin_cache_dtype
         self.cos_sin_cache: torch.Tensor = self.cos_sin_cache.to(query.device)
         query_ = torch.view_as_complex(query.float().reshape(
             *query.shape[:-1], -1, 2))

--- a/vllm/model_executor/layers/rotary_embedding/llama4_vision_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/llama4_vision_rope.py
@@ -59,7 +59,7 @@ class Llama4VisionRotaryEmbedding(RotaryEmbedding):
         key: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         assert key is not None
-        self._match_cos_sin_cache_dtype(query)
+        self.cos_sin_cache: torch.Tensor = self.cos_sin_cache.to(query.device)
         query_ = torch.view_as_complex(query.float().reshape(
             *query.shape[:-1], -1, 2))
         key_ = torch.view_as_complex(key.float().reshape(


### PR DESCRIPTION

## Purpose

Fix #25888.

Especially, this PR roll back the misplaced dtype cast introduced by #21126 which deteriorates the vision understanding performance of llama 4 family.

Note that the `cos_sin_cache` in `Llama4VisionRotaryEmbedding` is always complex (`torch.complex64`) but the query is always real (`torch.bfloat16`), so we cannot cast the trigonometric cache to query's dtype.

## Test Plan

Check that Llama 4 model families are correctly recognize the "4 dice" image used in the vllm multimodal test CI pipeline.

```python
import httpx
from openai import OpenAI

client = OpenAI(base_url="http://localhost:8080/v1", api_key="a")

# This is the 4 dice image used in the vllm multimodal test CI pipeline
image_url = "https://raw.githubusercontent.com/vllm-project/vllm/refs/heads/main/tests/multimodal/assets/rgba.png"

messages = [{"role": "user", "content": [{"type": "text", "text": "Explain the image."}, {"type": "image_url", "image_url": {"url": image_url}}]}]

for t in client.chat.completions.create(model="meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", messages=messages, stream=True):
    if t.choices:
        d = t.choices[0].delta
        print(getattr(d, "reasoning_content", "") or d.content or "", end="", flush=True)
```

## Test Result

```text
The image depicts four dice in mid-air, each with a distinct color and orientation.

*   The dice are arranged in a staggered formation, with the red die at the center and the other three dice positioned around it.
    *   The red die is in sharp focus, while the other three dice are slightly blurred.
    *   The blue die is located in the upper left corner of the image, the green die is in the upper right corner, and the yellow die is below the red die.
*   The dice have a reflective surface, giving them a shiny appearance.
    *   The dice are translucent, allowing the background to be visible through them.
    *   The dice have white dots on their faces, which represent the numbers 1-6.
*   The background of the image is solid white, providing a clean and simple backdrop for the dice.
    *   There are no other objects or features in the image besides the dice.

Overall, the image presents a visually appealing and dynamic representation of four dice in motion, with a focus on their colors and reflective surfaces.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

