### PR TITLE
[Bugfix] Fix accuracy issue of TRTLLM FP8 MOE and improve logging

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -434,14 +434,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.weight_block_size = self.quant_config.weight_block_size
         self.block_quant = self.weight_block_size is not None
 
-        self.flashinfer_moe_backend: Optional[FlashinferMoeBackend] = None
         self.fused_experts: Optional[
             mk.FusedMoEModularKernel] = None  # type: ignore
-        if envs.VLLM_USE_FLASHINFER_MOE_FP8 and has_flashinfer_moe():
-            self.flashinfer_moe_backend = get_flashinfer_moe_backend()
-            logger.info_once(
-                f"Using FlashInfer {self.flashinfer_moe_backend.value} kernels"
-            )
+        
         # For GPUs that lack FP8 hardware support, we can leverage the Marlin
         # kernel for fast weight-only FP8 quantization
         self.use_marlin = (not current_platform.has_device_capability(89)
@@ -450,14 +445,28 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if current_platform.is_rocm():
             self.use_marlin = False
 
+        # First check for Flashinfer MOE on Blackwell GPUs
+        self.flashinfer_moe_backend: Optional[FlashinferMoeBackend] = None
+        if (current_platform.is_cuda() and 
+            current_platform.is_device_capability(100) and
+            envs.VLLM_USE_FLASHINFER_MOE_FP8 and has_flashinfer_moe()):
+                self.flashinfer_moe_backend = get_flashinfer_moe_backend()
+                logger.info_once(
+                  f"Detected Blackwell GPUs, using FlashInfer "
+                  f"{self.flashinfer_moe_backend.value} kernels for FP8 MOE."
+                )
+        
         # Check for DeepGemm support.
         self.allow_deep_gemm = False
         if envs.VLLM_USE_DEEP_GEMM:
             if not has_deep_gemm():
                 logger.warning_once("Failed to import DeepGemm kernels.")
             elif not self.block_quant:
-                logger.warning_once("Model is not block quantized. Not using "
-                                    "DeepGemm kernels")
+                logger.warning_once("Model is not block quantized. Not using"
+                                    " DeepGemm kernels")
+            elif self.flashinfer_moe_backend:
+                logger.info_once("DeepGemm disabled: FlashInfer MOE is"
+                                 " enabled.")
             elif (is_deep_gemm_supported()):
                 logger.info_once("Using DeepGemm kernels for Fp8MoEMethod.")
                 self.allow_deep_gemm = True
@@ -471,15 +480,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             logger.debug_once("Model is not block quantized. Not using "
                               "CutlassBlockScaledGroupedGemm kernels")
         elif (current_platform.is_cuda()
-              and current_platform.is_device_capability(100)):
-            logger.info_once(
-                "Using CutlassBlockScaledGroupedGemm kernels for Fp8MoEMethod."
-            )
-            self.allow_cutlass_block_scaled_grouped_gemm = True
-        else:
-            logger.warning_once(
-                "CutlassBlockScaledGroupedGemm not supported on the current "
-                "platform.")
+              and current_platform.is_device_capability(100)
+              and not self.flashinfer_moe_backend):
+                logger.info_once(
+                    "Using CutlassBlockScaledGroupedGemm kernels for Fp8 MOE "
+                    "on SM100."
+                )
+                self.allow_cutlass_block_scaled_grouped_gemm = True
 
     def create_weights(self, layer: Module, num_experts: int, hidden_size: int,
                        intermediate_size_per_partition: int,
@@ -934,7 +941,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: E501, F401
                 assert (renormalize and use_grouped_topk
                         and custom_routing_function is None)
-                result = torch.ops.vllm.flashinfer_fused_moe_blockscale_fp8(
+                e_score_correction_bias = (e_score_correction_bias.to(x.dtype)
+                            if e_score_correction_bias is not None else None)
+                return torch.ops.vllm.flashinfer_fused_moe_blockscale_fp8(
                     routing_logits=router_logits.to(torch.float32),
                     routing_bias=e_score_correction_bias,
                     x=x,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -436,7 +436,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         self.fused_experts: Optional[
             mk.FusedMoEModularKernel] = None  # type: ignore
-        
+
         # For GPUs that lack FP8 hardware support, we can leverage the Marlin
         # kernel for fast weight-only FP8 quantization
         self.use_marlin = (not current_platform.has_device_capability(89)
@@ -447,15 +447,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         # First check for Flashinfer MOE on Blackwell GPUs
         self.flashinfer_moe_backend: Optional[FlashinferMoeBackend] = None
-        if (current_platform.is_cuda() and 
-            current_platform.is_device_capability(100) and
-            envs.VLLM_USE_FLASHINFER_MOE_FP8 and has_flashinfer_moe()):
-                self.flashinfer_moe_backend = get_flashinfer_moe_backend()
-                logger.info_once(
-                  f"Detected Blackwell GPUs, using FlashInfer "
-                  f"{self.flashinfer_moe_backend.value} kernels for FP8 MOE."
-                )
-        
+        if (current_platform.is_cuda()
+                and current_platform.is_device_capability(100)
+                and envs.VLLM_USE_FLASHINFER_MOE_FP8 and has_flashinfer_moe()):
+            self.flashinfer_moe_backend = get_flashinfer_moe_backend()
+            logger.info_once(
+                f"Detected Blackwell GPUs, using FlashInfer "
+                f"{self.flashinfer_moe_backend.value} kernels for FP8 MOE.")
+
         # Check for DeepGemm support.
         self.allow_deep_gemm = False
         if envs.VLLM_USE_DEEP_GEMM:
@@ -482,11 +481,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         elif (current_platform.is_cuda()
               and current_platform.is_device_capability(100)
               and not self.flashinfer_moe_backend):
-                logger.info_once(
-                    "Using CutlassBlockScaledGroupedGemm kernels for Fp8 MOE "
-                    "on SM100."
-                )
-                self.allow_cutlass_block_scaled_grouped_gemm = True
+            logger.info_once(
+                "Using CutlassBlockScaledGroupedGemm kernels for Fp8 MOE "
+                "on SM100.")
+            self.allow_cutlass_block_scaled_grouped_gemm = True
 
     def create_weights(self, layer: Module, num_experts: int, hidden_size: int,
                        intermediate_size_per_partition: int,
@@ -941,8 +939,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: E501, F401
                 assert (renormalize and use_grouped_topk
                         and custom_routing_function is None)
-                e_score_correction_bias = (e_score_correction_bias.to(x.dtype)
-                            if e_score_correction_bias is not None else None)
+                e_score_correction_bias = (e_score_correction_bias.to(
+                    x.dtype) if e_score_correction_bias is not None else None)
                 return torch.ops.vllm.flashinfer_fused_moe_blockscale_fp8(
                     routing_logits=router_logits.to(torch.float32),
                     routing_bias=e_score_correction_bias,

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -27,8 +27,8 @@ def is_deep_gemm_supported() -> bool:
     is_supported_arch = current_platform.is_cuda() and (
         current_platform.is_device_capability(90)
         or current_platform.is_device_capability(100))
-    return (envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and
-            is_supported_arch and not envs.VLLM_USE_FLASHINFER_MOE_FP8)
+    return (envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch
+            and not envs.VLLM_USE_FLASHINFER_MOE_FP8)
 
 
 @functools.cache
@@ -46,7 +46,7 @@ def is_deep_gemm_e8m0_used() -> bool:
     if _fp8_gemm_nt_impl is None:
         logger.info_once("DeepGEMM E8M0 disabled: _fp8_gemm_nt_impl not found")
         return False
-    
+
     if envs.VLLM_USE_FLASHINFER_MOE_FP8:
         logger.info_once("DeepGEMM E8M0 disabled: FlashInfer MOE is enabled.")
         return False

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -27,7 +27,8 @@ def is_deep_gemm_supported() -> bool:
     is_supported_arch = current_platform.is_cuda() and (
         current_platform.is_device_capability(90)
         or current_platform.is_device_capability(100))
-    return envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch
+    return (envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and
+            is_supported_arch and not envs.VLLM_USE_FLASHINFER_MOE_FP8)
 
 
 @functools.cache
@@ -44,6 +45,10 @@ def is_deep_gemm_e8m0_used() -> bool:
 
     if _fp8_gemm_nt_impl is None:
         logger.info_once("DeepGEMM E8M0 disabled: _fp8_gemm_nt_impl not found")
+        return False
+    
+    if envs.VLLM_USE_FLASHINFER_MOE_FP8:
+        logger.info_once("DeepGEMM E8M0 disabled: FlashInfer MOE is enabled.")
         return False
 
     if current_platform.is_device_capability(100) and \


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fixes #25189: accuracy issues for TRTLLM DSR1 Latency kernels 
Bugs introduced in #23991 and #23640 

Also fixes incorrect logging prints for which kernels are used. When Flashinfer MOE is enabled, Deep Gemm is automatically disabled for SM100.

```
(EngineCore_DP0 pid=101213) (Worker_TP3 pid=101225) INFO 09-29 10:14:46 [fp8.py:454] Detected Blackwell GPUs, using FlashInfer TensorRT-LLM kernels for FP8 MOE.
(EngineCore_DP0 pid=101213) (Worker_TP3 pid=101225) INFO 09-29 10:14:46 [fp8.py:468] DeepGemm disabled: FlashInfer MOE is enabled.

```

## Test Plan
LM Eval with `VLLM_USE_FLASHINFER_MOE_FP8=1` and `VLLM_FLASHINFER_MOE_BACKEND="latency"`

```
root@umbriel-b200-017:/workspace/scratch-pmaj-1/gh-pm-vllm# ./run_lm_eval.sh                                                                        
+ export FORCE_NUM_KV_SPLITS=1                                                                                                                      
+ FORCE_NUM_KV_SPLITS=1                                                                                                                             
+ export VLLM_USE_FLASHINFER_MOE_FP8=1                                                                                                              
+ VLLM_USE_FLASHINFER_MOE_FP8=1                                                                                                                     
+ export VLLM_FLASHINFER_MOE_BACKEND=latency                                                                                                        
+ VLLM_FLASHINFER_MOE_BACKEND=latency                                                                                                               
+ echo 'Running lm_eval with:'                                                                                                                      
Running lm_eval with:                                                                                                                               
                     
  Model: /models/DSR1-FP8/models--deepseek-ai--DeepSeek-R1-0528/snapshots/4236a6af538feda4548eca9ab308586007567f52/                                 
  Tensor Parallel Size: 8                                                                                                                           
  Quantization: fp8                                                                                                                                 
  GPU Memory Utilization: 0.90                                                                                                                      
                                                                      
+ lm_eval --model vllm --model_args pretrained=/models/DSR1-FP8/models--deepseek-ai--DeepSeek-R1-0528/snapshots/4236a6af538feda4548eca9ab30858600756
7f52/,quantization=fp8,tensor_parallel_size=8,gpu_memory_utilization=0.90,add_bos_token=True --gen_kwargs temperature=0.0,max_gen_toks=32768 --trust
_remote_code --tasks gsm8k --num_fewshot 5 --batch_size 200 --limit 1319 --output_path results/4236a6af538feda4548eca9ab308586007567f52-gsm8k-1319sa
mples_20250929_101419 --log_samples
```


## Test Result
```
vllm (pretrained=/models/DSR1-FP8/models--deepseek-ai--DeepSeek-R1-0528/snapshots/4236a6af538feda4548eca9ab308586007567f52/,quantization=fp8,tensor_parallel_size=8,gpu_memory_utilization=0.90,add_bos_token=True,trust_remote_code=True), gen_kwargs: (temperature=0.0,max_gen_toks=32768), limit: 1319.0, num_fewshot: 5, batch_size: 200
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9666|±  |0.0049|
|     |       |strict-match    |     5|exact_match|↑  |0.9651|±  |0.0051|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [N/A] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

