### PR TITLE
[Bug] Fix Weight Loading for Block FP8 Cutlass SM90

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -911,15 +911,15 @@ def maybe_post_process_fp8_weight_block(layer: torch.nn.Module,
     # On Blackwell or Hopper, if E8M0 for DeepGemm is used, we need to
     # requantize the weight and input to the specific scale
     # at the same time.
-    if is_deep_gemm_e8m0_used():
+    should_use_deepgemm = should_use_deepgemm_for_fp8_linear(
+        torch.bfloat16, layer.weight)
+    if is_deep_gemm_e8m0_used() and should_use_deepgemm:
         block_sz = tuple(layer.weight_block_size)
         requant_weight_ue8m0_inplace(layer.weight.data,
                                      layer.weight_scale.data, block_sz)
     # SM90 Block FP8 CUTLASS requires row-major weight scales
     elif (current_platform.is_device_capability(90)
-          and cutlass_block_fp8_supported
-          and not should_use_deepgemm_for_fp8_linear(torch.bfloat16,
-                                                     layer.weight)):
+          and cutlass_block_fp8_supported and not should_use_deepgemm):
         layer.weight_scale = torch.nn.Parameter(
             layer.weight_scale.data.T.contiguous(), requires_grad=False)
 

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -912,7 +912,7 @@ def maybe_post_process_fp8_weight_block(layer: torch.nn.Module,
     # requantize the weight and input to the specific scale
     # at the same time.
     should_use_deepgemm = should_use_deepgemm_for_fp8_linear(
-        torch.bfloat16, layer.weight)
+        layer.orig_dtype, layer.weight)
     if is_deep_gemm_e8m0_used() and should_use_deepgemm:
         block_sz = tuple(layer.weight_block_size)
         requant_weight_ue8m0_inplace(layer.weight.data,


### PR DESCRIPTION
## Purpose

Fix Weight Loading for Cutlass SM90.

## Test Plan

`vllm serve deepseek-ai/DeepSeek-V3.2-Exp -tp 8  --max-num-seqs 128 --load-format dummy --enforce_eager`

Original

```bash
16:37:34 [multiproc_executor.py:671]     output = w8a8_blockscale_func(q_input, weight, x_scale, weight_scale,
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]   File "/opt/vllm-source/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 46, in cutlass_scaled_mm
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]     return ops.cutlass_scaled_mm(
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]            ^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]   File "/opt/vllm-source/vllm/_custom_ops.py", line 667, in cutlass_scaled_mm
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]     torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, bias)
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]   File "/opt/vllm/lib64/python3.12/site-packages/torch/_ops.py", line 1243, in __call__
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]     return self._op(*args, **kwargs)
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671] RuntimeError: b_scale_group_shape must be [128, 128].
(APIServer pid=1) (EngineCore_DP0 pid=293) (Worker_TP3 pid=305) ERROR 09-29 16:37:34 [multiproc_executor.py:671] 
```

Now

```bash
(APIServer pid=3511336) INFO 09-29 22:03:11 [launcher.py:42] Route: /invocations, Methods: POST
(APIServer pid=3511336) INFO 09-29 22:03:11 [launcher.py:42] Route: /metrics, Methods: GET
(APIServer pid=3511336) INFO:     Started server process [3511336]
(APIServer pid=3511336) INFO:     Waiting for application startup.
(APIServer pid=3511336) INFO:     Application startup complete.
```
