### PR TITLE
[Model][Bugfix] Fix MiDashengLM audio encoder mask by removing incorrect `logical_not`

### DIFF
--- a/vllm/model_executor/models/midashenglm.py
+++ b/vllm/model_executor/models/midashenglm.py
@@ -426,8 +426,7 @@ class DashengAudioTransformer(nn.Module):
             assert x_length.ndim == 1, "Lengths are of size (B,)"
             scaled_lengths = (x_length / (self.hop_length * 4)).long()
             mask = self._to_mask(max_length=t, lengths=scaled_lengths)
-            split_masks = mask.logical_not().split(target_length_in_patches,
-                                                   dim=-1)
+            split_masks = mask.split(target_length_in_patches, dim=-1)
         else:
             mask = None
             split_masks = [None] * len(input_splits)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

In PR #25854, we addressed an issue in MiDashengLM’s audio encoder attention. The initial fix used a hand-written attention implementation, which, per review feedback, was then replaced with an SDPA-based implementation before merge.

SDPA interprets attention masks in the opposite way compared to our original hand-written code. To stay consistent, the previous logical inversion of the mask should have been removed. However, that adjustment was inadvertently omitted in the submitted changes, causing the audio encoder to produce incorrect embeddings.

This PR removes the leftover inversion and restores correct outputs from the MiDashengLM encoder.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

