### PR TITLE
[Bugfix] Enable padded FP4 quantization

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1374,7 +1374,7 @@ def scaled_fp4_quant(
     )
 
     # Two fp4 values will be packed into an uint8.
-    output = torch.empty((m, n // 2), device=device, dtype=torch.uint8)
+    output = torch.zeros((m, n // 2), device=device, dtype=torch.uint8)
 
     # We use the rounded values to store the swizzled values. Due to the
     # requirement of the Tensor Core, the minimum tile is 128x4 for the scales.
@@ -1385,7 +1385,7 @@ def scaled_fp4_quant(
     rounded_m = round_up(m, 128)
     scale_n = n // block_size
     rounded_n = round_up(scale_n, 4)
-    output_scale = torch.empty(
+    output_scale = torch.zeros(
         (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
     )
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1374,7 +1374,7 @@ def scaled_fp4_quant(
     )
 
     # Two fp4 values will be packed into an uint8.
-    output = torch.zeros((m, n // 2), device=device, dtype=torch.uint8)
+    output = torch.empty((m, n // 2), device=device, dtype=torch.uint8)
 
     # We use the rounded values to store the swizzled values. Due to the
     # requirement of the Tensor Core, the minimum tile is 128x4 for the scales.

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -386,8 +386,6 @@ def flashinfer_scaled_fp4_mm(
     assert block_scale_a.ndim == 2 and block_scale_b.ndim == 2
     assert a.stride(-1) == 1 and b.stride(-1) == 1
     assert a.shape[1] == b.shape[1]
-    assert block_scale_a.shape[1] == a.shape[1] // 8
-    assert block_scale_b.shape[1] == b.shape[1] // 8
 
     if backend == "cutlass":
         block_scale_a = block_scale_a.view(torch.uint8)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR fixes an issue with padded FP4 quantization, where previously initialized values in the allocated tensors aren't overwritten properly when quantizing to FP a tensor which requires padding.

This issue prevents running NVIDIA's new Nemotron-Nano-9B-v2 with TP2, as some of the tensor sizes in such cases do not divide evenly by 128.

Note that this specific model doesn't work with TP>2, and this PR doesn't solve issues that come up in those scenarios. For TP4 the issue comes from inside the FP4 GEMM kernel, where it expects some matrix size to be divisible by 32, and for TP8 the issue happens when creating the model weights, where some layers' in features are not divisible by 16. The same issues happen in TensorRT-LLM as well.

## Test Plan
No need for new tests, as tests are already in place to verify FP4 quantization, both with and without padding.

## Test Result
All existing FP4 quantization tests passed locally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

