### PR TITLE
[Docs] Remove API Reference from search index

### DIFF
--- a/docs/api/vllm/.meta.yml
+++ b/docs/api/vllm/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 0.5
+  exclude: true


### PR DESCRIPTION
It was causing ~600MB of RAM usage (now ~50MB)
