### PR TITLE
[CI] Only capture a single CUDA graph size in CI by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -731,7 +731,7 @@ class VllmRunner:
         init_ctx = (nullcontext() if default_torch_num_threads is None else
                     set_default_torch_num_threads(default_torch_num_threads))
 
-        if "compilation_config" not in kwargs:
+        if not kwargs.get("compilation_config", None):
             kwargs["compilation_config"] = {"cudagraph_capture_sizes": [8]}
 
         with init_ctx:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -731,6 +731,9 @@ class VllmRunner:
         init_ctx = (nullcontext() if default_torch_num_threads is None else
                     set_default_torch_num_threads(default_torch_num_threads))
 
+        if "compilation_config" not in kwargs:
+            kwargs["compilation_config"] = {"cudagraph_capture_sizes": [8]}
+
         with init_ctx:
             self.llm = LLM(
                 model=model_name,


### PR DESCRIPTION
Should reduce the time taken for all tests which don't specify `enforce_eager=True` or their own `compilation_config`