### PR TITLE
[Bugfix][DeepSeek Fix config used for DeepseekV2 Eagle

### DIFF
--- a/vllm/model_executor/models/deepseek_eagle.py
+++ b/vllm/model_executor/models/deepseek_eagle.py
@@ -50,6 +50,7 @@ class DeepseekV2Model(nn.Module):
             DeepseekV2DecoderLayer(
                 vllm_config,
                 prefix=maybe_prefix(prefix, f"layers.{i + start_layer_id}"),
+                config=self.config,
             ) for i in range(self.config.num_hidden_layers)
         ])
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -990,10 +990,11 @@ class DeepseekV2DecoderLayer(nn.Module):
     def __init__(self,
                  vllm_config: VllmConfig,
                  prefix: str,
+                 config: Optional[DeepseekV2Config] = None,
                  topk_indices_buffer: Optional[torch.Tensor] = None) -> None:
         super().__init__()
 
-        config = vllm_config.model_config.hf_config
+        config = config or vllm_config.model_config.hf_config
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config


### PR DESCRIPTION
We are using the verifier model's config instead of the draft model's config when using Eagle for Deepseek.

Introduced in https://github.com/vllm-project/vllm/pull/24134. Similar issue for llama3 was fixed in https://github.com/vllm-project/vllm/pull/25883.