### PR TITLE
[Bug] Fix AttributeError: 'QKVParallelLinear' object has no attribute 'orig_dtype'

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -66,6 +66,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
         output_size_per_partition = sum(output_partition_sizes)
         layer.logical_widths = output_partition_sizes
         layer.weight_block_size = None
+        layer.orig_dtype = params_dtype
 
         if self.strategy == QuantizationStrategy.BLOCK:
             assert self.weight_block_size is not None


### PR DESCRIPTION
## Purpose

Fix AttributeError: 'QKVParallelLinear' object has no attribute 'orig_dtype'

This fix is appropriate since `CompressedTensorsW8A8Fp8MoEMethod` `CompressedTensorsW8A16Fp8` etc has the same pattern.

## Test

`vllm bench throughput --model RedHatAI/Qwen3-0.6B-FP8-BLOCK  --load-format dummy --input-len 1000 --output-len 100 --trust_remote_code --enforce_eager`

Origin 

```bash
(EngineCore_DP0 pid=2423289)   File "/data/vllm-community-homes/vllm-user-6/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1962, in __getattr__
(EngineCore_DP0 pid=2423289)     raise AttributeError(
(EngineCore_DP0 pid=2423289) AttributeError: 'QKVParallelLinear' object has no attribute 'orig_dtype'
```

Now

```bash
Throughput: 21.99 requests/s, 24189.80 total tokens/s, 2199.07 output tokens/s
Total num prompt tokens:  1000000
Total num output tokens:  100000
```