### PR TITLE
[Misc] Add penalties sampling parameters to serve tool

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1077,6 +1077,27 @@ def add_cli_args(parser: argparse.ArgumentParser):
         "openai-compatible backends. If not specified, default to greedy "
         "decoding (i.e. temperature==0.0).",
     )
+    sampling_group.add_argument(
+        "--frequency-penalty",
+        type=float,
+        default=None,
+        help="Frequency penalty sampling parameter. Only has effect on "
+        "openai-compatible backends.",
+    )
+    sampling_group.add_argument(
+        "--presence-penalty",
+        type=float,
+        default=None,
+        help="Presence penalty sampling parameter. Only has effect on "
+        "openai-compatible backends.",
+    )
+    sampling_group.add_argument(
+        "--repetition-penalty",
+        type=float,
+        default=None,
+        help="Repetition penalty sampling parameter. Only has effect on "
+        "openai-compatible backends.",
+    )
 
     parser.add_argument(
         '--tokenizer-mode',
@@ -1211,6 +1232,9 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
             "top_k": args.top_k,
             "min_p": args.min_p,
             "temperature": args.temperature,
+            "frequency_penalty": args.frequency_penalty,
+            "presence_penalty": args.presence_penalty,
+            "repetition_penalty": args.repetition_penalty,
         }.items() if v is not None
     }
 


### PR DESCRIPTION

## Purpose
Adding the frequency_penalty, presence_penalty, and repetition_penalty sampling parameters to the serve tool. It allows enabling them for performance measurement.

## Test Plan
Example for `frequency_penalty`:
```
vllm bench serve --model $MODEL_NAME --dataset-name sharegpt --num-prompts 200 --dataset-path $DATASET_PATH --seed 0 --frequency-penalty 1.0
```

## Test Result
