### PR TITLE
Add more tests for batch invariant kernel-override logic [3/n]

### DIFF
--- a/tests/v1/generation/batch_invariance/test_multi_gpu_ops.py
+++ b/tests/v1/generation/batch_invariance/test_multi_gpu_ops.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import random
+from functools import reduce
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+
+from tests.utils import multi_gpu_test
+from vllm.distributed.parallel_state import (init_distributed_environment,
+                                             initialize_model_parallel)
+from vllm.model_executor.layers.batch_invariant import init_batch_invariance
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (ColumnParallelLinear,
+                                               RowParallelLinear)
+from vllm.platforms import current_platform
+from vllm.utils import update_environment_variables
+
+
+def get_open_port():
+    """Get an available port for distributed testing."""
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        return s.getsockname()[1]
+
+
+def run_parallel_op_test_worker(local_rank: int, world_size: int,
+                                master_port: int, test_config: dict, fn):
+    """Worker function that runs on each GPU process."""
+    # Set up distributed environment
+    device = f"cuda:{local_rank}"
+    current_platform.set_device(device)
+    torch.cuda.set_device(device)
+    torch.set_default_device(device)
+
+    update_environment_variables({
+        'RANK': str(local_rank),
+        'LOCAL_RANK': str(local_rank),
+        'WORLD_SIZE': str(world_size),
+        'MASTER_ADDR': 'localhost',
+        'MASTER_PORT': str(master_port),
+    })
+
+    # Initialize distributed
+    init_distributed_environment()
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    # Set seed for reproducibility
+    current_platform.seed_everything(42)
+    init_batch_invariance()
+
+    # Run the specific test based on op_name
+    fn(local_rank, world_size, test_config)
+
+
+class ULPChecker:
+    FP_SPECS = {
+        torch.float8_e4m3fn: {
+            'mantissa_bits': 3,
+            'exponent_bits': 4,
+            'total_bits': 8,
+            'int_dtype': torch.uint8
+        },
+        torch.float8_e5m2: {
+            'mantissa_bits': 2,
+            'exponent_bits': 5,
+            'total_bits': 8,
+            'int_dtype': torch.uint8
+        },
+        torch.bfloat16: {
+            'mantissa_bits': 7,
+            'exponent_bits': 8,
+            'total_bits': 16,
+            'int_dtype': torch.int16
+        },
+        torch.float16: {
+            'mantissa_bits': 10,
+            'exponent_bits': 5,
+            'total_bits': 16,
+            'int_dtype': torch.int16
+        },
+        torch.float32: {
+            'mantissa_bits': 23,
+            'exponent_bits': 8,
+            'total_bits': 32,
+            'int_dtype': torch.int32
+        },
+        torch.float64: {
+            'mantissa_bits': 52,
+            'exponent_bits': 11,
+            'total_bits': 64,
+            'int_dtype': torch.int64
+        },
+    }
+
+    @staticmethod
+    def to_int_bits(tensor: torch.Tensor) -> torch.Tensor:
+        dtype = tensor.dtype
+        if dtype not in ULPChecker.FP_SPECS:
+            raise ValueError(f"Unsupported dtype: {dtype}")
+
+        spec = ULPChecker.FP_SPECS[dtype]
+        int_dtype = spec['int_dtype']
+
+        return tensor.view(int_dtype)
+
+    @staticmethod
+    def ulp_distance_int(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        if a.dtype != b.dtype:
+            raise ValueError(f"Dtype mismatch: {a.dtype} vs {b.dtype}")
+
+        if a.shape != b.shape:
+            raise ValueError(f"Shape mismatch: {a.shape} vs {b.shape}")
+
+        spec = ULPChecker.FP_SPECS[a.dtype]
+        total_bits = spec['total_bits']
+
+        a_int = ULPChecker.to_int_bits(a)
+        b_int = ULPChecker.to_int_bits(b)
+
+        sign_bit = 1 << (total_bits - 1)
+
+        a_ordered = torch.where(
+            (a_int & sign_bit) != 0,
+            sign_bit - (a_int & ~sign_bit),  # Negative: flip magnitude bits
+            a_int + sign_bit  # Positive: offset by sign bit
+        )
+        b_ordered = torch.where((b_int & sign_bit) != 0,
+                                sign_bit - (b_int & ~sign_bit),
+                                b_int + sign_bit)
+
+        ulp_dist = torch.abs(a_ordered - b_ordered)
+        return ulp_dist
+
+
+def create_needle_tensor(
+        batch_size: int,
+        shape: list[int],
+        device: torch.device,
+        dtype: torch.dtype,
+        needle_idx: int = 0) -> torch.Tensor:
+    input_tensor = torch.randn(batch_size, *shape, device=device, dtype=dtype)
+
+    numel = reduce(lambda x, y: x * y, shape)
+    needle_pattern = torch.sin(
+        torch.arange(numel, device=device).float().view(*shape) *
+        0.1).to(dtype)
+
+    assert needle_idx < input_tensor.shape[0]
+    input_tensor[needle_idx] = needle_pattern
+
+    return input_tensor
+
+
+def verify(outputs: list[torch.Tensor],
+                              needle_idxs: list[int]) -> bool:
+    if len(outputs) < 2:
+        return True
+
+    needle_outputs = []
+    for output, needle_idx in zip(outputs, needle_idxs):
+        needle_outputs.append(output[needle_idx])
+
+    reference = needle_outputs[0]
+    for i, needle_output in enumerate(needle_outputs[1:], 1):
+        dist_t = ULPChecker.ulp_distance_int(reference, needle_output)
+        if torch.max(dist_t) != 0:
+            print(f"Needle consistency failed at batch size comparison {i}")
+            print(f"Max difference (ULP): {torch.max(dist_t)}")
+            print(f"Max difference: {torch.max(reference - needle_output)}")
+            return False
+
+    return True
+
+
+def validate(func, batch_sizes, shape, device, dtype):
+    random.seed(123)
+    outputs = []
+    needle_idxs = []
+
+    for batch_size in batch_sizes:
+        needle_idx = random.randint(0, batch_size - 1)
+        input_tensor = create_needle_tensor(batch_size, shape, device, dtype,
+                                            needle_idx)
+
+        with torch.no_grad():
+            output = func(input_tensor)
+            assert isinstance(output, torch.Tensor)
+            outputs.append(output)
+            needle_idxs.append(needle_idx)
+
+    assert verify(outputs, needle_idxs), \
+        "Needle consistency failed"
+
+
+def _test_column_parallel_linear(local_rank: int, world_size: int,
+                                 config: dict):
+    device = torch.device(f"cuda:{local_rank}")
+    batch_sizes = [1, 8, 32]
+    dtype = config['dtype']
+    hidden_size = config['reduction_size']
+    seq_len = 4096
+    input_size = hidden_size
+    output_size = hidden_size * 2
+    layer = ColumnParallelLinear(
+        input_size=input_size,
+        output_size=output_size,
+        bias=True,
+        gather_output=False,
+        params_dtype=dtype,
+    )
+    layer = layer.to(device)
+    validate(lambda x: layer(x)[0], batch_sizes, (seq_len, hidden_size),
+             device, dtype)
+
+
+def _test_row_parallel_linear(local_rank: int, world_size: int, config: dict):
+    device = torch.device(f"cuda:{local_rank}")
+    batch_sizes = [1, 8, 32]
+    dtype = config['dtype']
+    hidden_size = config['reduction_size']
+    seq_len = 4096
+    input_size = hidden_size * 2
+    output_size = hidden_size
+    layer = RowParallelLinear(
+        input_size=input_size,
+        output_size=output_size,
+        bias=True,
+        reduce_results=True,
+        params_dtype=dtype,
+    )
+    layer = layer.to(device)
+    validate(lambda x: layer(x)[0], batch_sizes,
+             (seq_len, input_size // world_size), device, dtype)
+
+
+def _test_rms_norm(local_rank: int, world_size: int,
+                                      config: dict):
+    """Test RMSNorm with needle consistency."""
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = config['dtype']
+    hidden_size = config['reduction_size']
+    batch_sizes = [1, 32, 1024]
+
+    layer = RMSNorm(hidden_size, eps=1e-6)
+    layer = layer.to(device).to(dtype)
+    validate(layer, batch_sizes, (hidden_size, ), device, dtype)
+
+
+def _test_fused_rms_norm(local_rank: int, world_size: int,
+                                            config: dict):
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = config['dtype']
+    hidden_size = config['reduction_size']
+    batch_sizes = [1, 32, 1024]
+
+    layer = RMSNorm(hidden_size, eps=1e-6)
+    layer = layer.to(device).to(dtype)
+    validate(lambda x: layer(x, x)[0], batch_sizes, (hidden_size, ), device,
+             dtype)
+
+
+def _test_fused_moe(local_rank: int, world_size: int,
+                                       config: dict):
+    """Test FusedMoE with needle consistency."""
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = config['dtype']
+    hidden_size = config['reduction_size']
+    batch_sizes = [1, 8, 32]
+
+    # MoE configuration parameters
+    num_experts = 8
+    top_k = 2
+    intermediate_size = hidden_size * 4
+
+    from vllm.config import VllmConfig
+    from vllm.forward_context import get_forward_context, set_forward_context
+    from vllm.model_executor.layers.fused_moe import FusedMoE
+
+    vllm_config = VllmConfig()
+
+    # Create FusedMoE layer similar to how it's used in models
+    layer = FusedMoE(
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        params_dtype=dtype,
+        reduce_results=True,
+        renormalize=True,
+        use_grouped_topk=False,
+    )
+    layer = layer.to(device)
+
+    # Test function that takes hidden states and generates router logits
+    def test_func(hidden_states):
+        # Generate router logits (this would normally come from a router layer)
+        router_logits = torch.randn(hidden_states.shape[0],
+                                    hidden_states.shape[1],
+                                    num_experts,
+                                    device=device,
+                                    dtype=dtype)
+
+        # Set forward context with minimal required parameters
+        # attn_metadata can be None for testing purposes
+        with set_forward_context(attn_metadata=None,
+                                 vllm_config=vllm_config,
+                                 num_tokens=hidden_states.shape[0] *
+                                 hidden_states.shape[1]):
+            fwdctx = get_forward_context()
+            fwdctx.no_compile_layers[''] = layer
+            return layer(hidden_states, router_logits)
+
+    validate(test_func, batch_sizes, (hidden_size, ), device, dtype)
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize("world_size", [2])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("reduction_size", [1, 5, 1024, 1024 + 1])
+@pytest.mark.parametrize("func", [
+    _test_column_parallel_linear,
+    _test_row_parallel_linear,
+    _test_rms_norm,
+    _test_fused_rms_norm,
+    _test_fused_moe,
+])
+def test_parallel_reduction_batch_invariance(world_size: int,
+                                             dtype: torch.dtype,
+                                             reduction_size: int, func):
+    """Test parallel operators on 2 GPUs."""
+    test_config = {
+        "dtype": dtype,
+        "reduction_size": reduction_size,
+    }
+
+    mp.spawn(run_parallel_op_test_worker,
+             args=(world_size, get_open_port(), test_config, func),
+             nprocs=world_size)

--- a/tests/v1/generation/test_batch_invariance.py
+++ b/tests/v1/generation/test_batch_invariance.py
@@ -76,18 +76,22 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle():
       seed.
     - Keep max_tokens and max_model_len bounded for speed and memory use.
     """
-    random.seed(12345)
+    seed = int(os.getenv("VLLM_TEST_SEED", "12345"))
+    random.seed(seed)
 
     # Allow overrides from environment (useful for CI tuning)
     # "facebook/opt-125m" is too small, doesn't reliably test determinism
     model = os.getenv("VLLM_TEST_MODEL", "Qwen/Qwen3-1.7B")
+    #model = os.getenv("VLLM_TEST_MODEL", "ibm-research/PowerMoE-3b")
     num_trials = int(os.getenv("VLLM_NEEDLE_TRIALS", "5"))
-    batch_size = int(os.getenv("VLLM_NEEDLE_BATCH_SIZE", "64"))
-    assert batch_size >= 2, "Batch size should be >= 2 to mix needle."
+    max_batch_size = int(os.getenv("VLLM_NEEDLE_BATCH_SIZE", "128"))
+    min_random_prompt = int(os.getenv("VLLM_MIN_PROMPT", "1024"))
+    max_random_prompt = int(os.getenv("VLLM_MAX_PROMPT", "2048"))
+    assert max_batch_size >= 2, "Batch size should be >= 2 to mix needle."
 
     # Keep GPU memory usage low to avoid startup allocation failures.
-    gpu_mem_util = float(os.getenv("VLLM_GPU_MEMORY_UTILIZATION", "0.3"))
-    max_model_len = int(os.getenv("VLLM_MAX_MODEL_LEN", "4096"))
+    gpu_mem_util = float(os.getenv("VLLM_GPU_MEMORY_UTILIZATION", "0.4"))
+    max_model_len = int(os.getenv("VLLM_MAX_MODEL_LEN", "5120"))
     swap_space_gb = int(os.getenv("VLLM_SWAP_SPACE_GB", "4"))
 
     # Sampling parameters: longer outputs with a more random-sounding
@@ -111,7 +115,7 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle():
         # Engine with bs=1 behavior
         llm_bs1 = LLM_with_max_seqs(
             model=model,
-            max_num_seqs=1,
+            max_num_seqs=128,
             gpu_memory_utilization=gpu_mem_util,
             max_model_len=max_model_len,
             swap_space=swap_space_gb,
@@ -126,7 +130,7 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle():
         # Engine with larger batch limit (e.g., 64)
         llm_bsN = LLM_with_max_seqs(
             model=model,
-            max_num_seqs=batch_size,
+            max_num_seqs=128,
             gpu_memory_utilization=gpu_mem_util,
             max_model_len=max_model_len,
             swap_space=swap_space_gb,
@@ -135,15 +139,17 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle():
         mismatches = 0
 
         for trial in range(num_trials):
-            # Create a batch of size `batch_size` and insert the needle at
+            # Create a batch of size `max_batch_size` and insert the needle at
             # a random index
             prompts: list[str] = []
+            batch_size = random.randint(max_batch_size // 2, max_batch_size)
             needle_pos = random.randint(0, batch_size - 1)
             for i in range(batch_size):
                 if i == needle_pos:
                     prompts.append(needle_prompt)
                 else:
-                    prompts.append(_random_prompt())
+                    prompts.append(
+                        _random_prompt(min_random_prompt, max_random_prompt))
 
             # Generate with the larger-batch engine
             outputs = llm_bsN.generate(prompts, sampling)
@@ -154,17 +160,19 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle():
             text = needle_output.outputs[0].text
 
             if text != baseline_text:
+                print(
+                    f"{text}\n\n== Not the same as ==\n\n{baseline_text}\n\n")
                 mismatches += 1
 
         passes = num_trials - mismatches
         # Dump how many passed vs failed
         print(f"[determinism] total={num_trials}, passed={passes}, "
-              f"failed={mismatches}, batch_size={batch_size}")
+              f"failed={mismatches}, max_batch_size={max_batch_size}")
 
         if mismatches > 0:
             pytest.fail(
                 f"Nondeterministic outputs detected: {mismatches} failed out "
-                f"of {num_trials} trials (batch_size={batch_size}).")
+                f"of {num_trials} trials (max_batch_size={max_batch_size}).")
 
     finally:
         # Ensure engines are shutdown to free GPU/VRAM across test sessions
@@ -196,9 +204,10 @@ def _extract_step_logprobs(request_output):
     not torch.cuda.is_available(),
     reason="Requires CUDA to match production inference path.",
 )
-def test_logprobs_bitwise_batch_invariance_bs1_vs_bs2():
+def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN():
 
-    #model_name = os.getenv("VLLM_TEST_MODEL", "facebook/opt-125m")
+    seed = int(os.getenv("VLLM_TEST_SEED", "12345"))
+    random.seed(seed)
     model_name = os.getenv("VLLM_TEST_MODEL", "Qwen/Qwen3-1.7B")
     tp_size = int(os.getenv("VLLM_TEST_TP_SIZE", "1"))
 
@@ -212,10 +221,15 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bs2():
     prompts = [
         "The capital of France is",
         "The capital of Germany is",
+        _random_prompt(10, 10),
+        _random_prompt(10, 10),
+        _random_prompt(10, 10),
+        _random_prompt(10, 10),
+        _random_prompt(10, 10),
     ]
 
     sp = SamplingParams(
-        temperature=0.0,
+        temperature=0.6,
         top_p=1.0,
         max_tokens=8,
         # Seed shouldn't matter at temperature=0, but keeping it stable anyway.
@@ -234,25 +248,25 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bs2():
                         "enable logprobs return to run this test.")
         bs1_logprobs_per_prompt.append(step_logprobs)
 
-    # BS=2: run prompts in a batch and collect logprobs per step for each
+    # BS=N: run prompts in a batch and collect logprobs per step for each
     # prompt.
     outs_batched = llm.generate(prompts, sp, use_tqdm=False)
     assert len(outs_batched) == len(prompts)
-    bs2_logprobs_per_prompt = []
+    bsN_logprobs_per_prompt = []
     for o in outs_batched:
         step_logprobs = _extract_step_logprobs(o)
         if step_logprobs is None:
             pytest.skip("Logits are not available on RequestOutput; "
                         "enable logprobs return to run this test.")
-        bs2_logprobs_per_prompt.append(step_logprobs)
+        bsN_logprobs_per_prompt.append(step_logprobs)
 
-    # Compare step-by-step logprobs for each prompt between BS=1 and BS=2 runs.
-    for i, (logprobs_bs1, logprobs_bs2) in enumerate(
-            zip(bs1_logprobs_per_prompt, bs2_logprobs_per_prompt)):
-        assert len(logprobs_bs1) == len(logprobs_bs2), (
+    # Compare step-by-step logprobs for each prompt between BS=1 and BS=N runs.
+    for i, (logprobs_bs1, logprobs_bsN) in enumerate(
+            zip(bs1_logprobs_per_prompt, bsN_logprobs_per_prompt)):
+        assert len(logprobs_bs1) == len(logprobs_bsN), (
             f"Different number of generation steps for prompt index {i}: "
-            f"{len(logprobs_bs1)} (BS=1) vs {len(logprobs_bs2)} (BS=2)")
-        for t, (a, b) in enumerate(zip(logprobs_bs1, logprobs_bs2)):
+            f"{len(logprobs_bs1)} (BS=1) vs {len(logprobs_bsN)} (BS=N)")
+        for t, (a, b) in enumerate(zip(logprobs_bs1, logprobs_bsN)):
             assert a.shape == b.shape, (
                 f"Logits shape mismatch at prompt {i}, step {t}: "
                 f"{a.shape} vs {b.shape}")

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -8,6 +8,7 @@ from typing import Any, Union
 
 import torch
 
+import vllm.envs as envs
 from vllm.triton_utils import tl, triton
 
 
@@ -557,5 +558,7 @@ def vllm_kernel_override_batch_invariant():
 def init_batch_invariance():
     # this will hit all the csrc overrides as well
     if vllm_kernel_override_batch_invariant():
-        os.environ["VLLM_ATTENTION_BACKEND"] = "FLEX_ATTENTION"
+        curr_attn_backend = envs.VLLM_ATTENTION_BACKEND
+        if curr_attn_backend not in ["FLEX_ATTENTION", "FLASHINFER"]:
+            os.environ["VLLM_ATTENTION_BACKEND"] = "FLEX_ATTENTION"
         enable_batch_invariant_mode()

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -20,6 +20,8 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionType)
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.logger import init_logger
+from vllm.model_executor.layers.batch_invariant import (
+    vllm_kernel_override_batch_invariant)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey, kFp8StaticTensorSym, kNvfp4Quant)
 from vllm.platforms import current_platform
@@ -43,6 +45,7 @@ from vllm.v1.attention.backends.utils import (AttentionCGSupport,
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE = 256 * 1024 * 1024
+FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
@@ -263,6 +266,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._prefill_wrapper = None  # Wrapper for prefill/append
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
+        if vllm_kernel_override_batch_invariant():
+            self.decode_fixed_split_size = 2048
+            self.prefill_fixed_split_size = 4096
+            self.disable_split_kv = True
+
         self.compilation_config = vllm_config.compilation_config
         max_num_pages_per_req = cdiv(self.model_config.max_model_len,
                                      self.kv_cache_spec.block_size)
@@ -356,10 +364,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
     def _get_workspace_buffer(self):
         if self._workspace_buffer is None:
-            self._workspace_buffer = torch.zeros(
-                FLASHINFER_WORKSPACE_BUFFER_SIZE,
-                dtype=torch.uint8,
-                device=self.device)
+            buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE
+            if vllm_kernel_override_batch_invariant():
+                buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT
+            self._workspace_buffer = torch.zeros(buffer_size,
+                                                 dtype=torch.uint8,
+                                                 device=self.device)
         return self._workspace_buffer
 
     def _get_prefill_wrapper(self):
@@ -615,6 +625,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         logits_soft_cap=self.logits_soft_cap,
                         q_data_type=self.q_data_type,
                         kv_data_type=self.kv_cache_dtype,
+                        fixed_split_size=self.prefill_fixed_split_size,
+                        disable_split_kv=self.disable_split_kv,
                     )
                 else:
                     attn_metadata.qo_indptr_gpu = qo_indptr_cpu.to(
@@ -668,6 +680,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         logits_soft_cap=self.logits_soft_cap,
                         q_data_type=self.q_data_type,
                         kv_data_type=self.kv_cache_dtype,
+                        fixed_split_size=self.decode_fixed_split_size,
+                        disable_split_kv=self.disable_split_kv,
                     )
         return attn_metadata
 
@@ -1046,6 +1060,8 @@ def fast_plan_decode(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     non_blocking: bool = True,
+    fixed_split_size: int = -1,
+    disable_split_kv: bool = False,
 ) -> None:
     """
     A faster version of BatchDecodeWithPagedKVCacheWrapper::plan used for
@@ -1083,6 +1099,10 @@ def fast_plan_decode(
             rope_scale,
             rope_theta,
             non_blocking,
+            None,  # block_tables
+            None,  # seq_lens
+            fixed_split_size,
+            disable_split_kv,
         )
         self.vllm_first_call = False
         return
@@ -1145,6 +1165,9 @@ def fast_plan_decode(
             head_dim,
             head_dim,
             False,  # causal
+            window_left,
+            fixed_split_size,
+            disable_split_kv,
         )
     except Exception as e:
         raise RuntimeError(f"Error in tensor core plan: {e}") from e


### PR DESCRIPTION
Following #25769, This change adds additional unit tests for the batch invariant kernel-overrides.

## Purpose

We want more rigorous testing across kernels to ensure batch invariance. This PR lays out a test set to that end.

## Test Plan

```
VLLM_KERNEL_OVERRIDE_BATCH_INVARIANT=1 pytest -s -v tests/v1/generation/batch_invariance/test_multi_gpu_ops.py
```

## Test Result

Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

