### PR TITLE
Fix test_mamba_ssm_ssd.py due to missing _query_start_loc_to_chunk_indices_offsets

### DIFF
--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import itertools
 from dataclasses import dataclass
 from typing import Optional
 
@@ -15,6 +16,75 @@ from vllm.v1.attention.backends.utils import (PAD_SLOT_ID,
                                               compute_causal_conv1d_metadata,
                                               split_decodes_and_prefills)
 from vllm.v1.kv_cache_interface import AttentionSpec
+
+
+def compute_varlen_chunk_metadata(
+    query_start_loc: torch.Tensor,
+    chunk_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Build chunk-aligned, variable-length metadata used by Mamba2 SSD kernels.
+
+    Given per-sequence cumulative token starts `query_start_loc` of shape [B+1]
+    and a physical `chunk_size`, returns three tensors on the same device:
+      - cu_chunk_seqlens:  (nchunks+1,) int32   exclusive prefix-sum of
+        logical-chunk lengths (each logical chunk never crosses a sequence or
+        physical-chunk boundary).
+      - last_chunk_indices: (B,)       int32   index of the last logical chunk
+        for each sequence (=-1 for empty sequences).
+      - seq_idx_chunks:     (nchunks,) int32   sequence index for each logical
+        chunk in order.
+
+    This is intentionally lightweight and CPU-side; it mirrors the metadata
+    produced by the V1 Mamba2 meta-data builder and is exported so tests
+    (and other callers) can avoid duplicating the logic.
+    """
+    assert query_start_loc.ndim == 1, "query_start_loc must be 1-D [B+1]"
+    assert int(query_start_loc[0].item()) == 0, "query_start_loc[0] must be 0"
+    device = query_start_loc.device
+
+    qsl64 = query_start_loc.to(torch.int64)
+    starts = qsl64[:-1].tolist()
+    ends = qsl64[1:].tolist()
+    total = int(qsl64[-1].item())
+
+    chunk_lens: list[int] = []
+    seq_idx_chunks: list[int] = []
+    last_chunk_indices: list[int] = [-1] * len(starts)
+
+    for b, (s, e) in enumerate(zip(starts, ends)):
+        if e <= s:
+            # empty sequence
+            continue
+        pos = s
+        while pos < e:
+            # split at both sequence boundaries and physical chunk boundaries
+            room = chunk_size - (pos % chunk_size)
+            take = min(room, e - pos)
+            chunk_lens.append(int(take))
+            seq_idx_chunks.append(b)
+            last_chunk_indices[b] = len(chunk_lens) - 1
+            pos += take
+
+    # Exclusive prefix sum over logical-chunk lengths
+    if chunk_lens:
+        cu_chunk_seqlens = torch.tensor([0] +
+                                        list(itertools.accumulate(chunk_lens)),
+                                        device=device,
+                                        dtype=torch.int32)
+        # Final boundary must equal total tokens
+        assert int(cu_chunk_seqlens[-1].item()) == total
+    else:
+        cu_chunk_seqlens = torch.tensor([0], device=device, dtype=torch.int32)
+
+    last_chunk_indices_t = (torch.tensor(
+        last_chunk_indices, device=device, dtype=torch.int32)
+                            if len(starts) > 0 else torch.empty(
+                                (0, ), device=device, dtype=torch.int32))
+    seq_idx_chunks_t = torch.tensor(seq_idx_chunks,
+                                    device=device,
+                                    dtype=torch.int32)
+    return cu_chunk_seqlens, last_chunk_indices_t, seq_idx_chunks_t
 
 
 class Mamba2AttentionBackend(AttentionBackend):


### PR DESCRIPTION

## Purpose
https://github.com/vllm-project/vllm/pull/24683 removed the helper function _query_start_loc_to_chunk_indices_offsets and breaks the tests/kernels/mamba/test_mamba_ssm_ssd.py (sample job https://buildkite.com/vllm/ci/builds/32891/steps/canvas?sid=019998c8-1682-4e2d-8161-55a772c16cde) from v1.attention.backends.mamba2_attn as part of the chunk‑aligned Mamba2 changes. This made tests/kernels/mamba/test_mamba_ssm_ssd.py fail at import time. This patch removes the import and computes the small piece of chunk metadata directly in the test, also providing cu_chunk_seqlens and last_chunk_indices expected by the new kernels. No runtime changes.

This PR
## Test Plan
```
pytest tests/kernels/mamba/test_mamba_ssm_ssd.py -v -s
```
## Test Result
```
======================================================= 348 passed, 1 warning in 823.24s (0:13:43) ========================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

