### PR TITLE
[Bugfix] Fix `__syncwarp` on ROCM

### DIFF
--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -536,7 +536,9 @@ __global__ void indexer_k_quant_and_cache_kernel(
   for (int i = 0; i < VEC_SIZE; i++) {
     amax = fmaxf(amax, fabsf(float(k_val_ptr[i])));
   }
+#ifndef USE_ROCM
   __syncwarp();
+#endif
 
   // Reduced amax
   for (int mask = 16; mask > 0; mask /= 2) {
@@ -546,7 +548,9 @@ __global__ void indexer_k_quant_and_cache_kernel(
     amax = fmaxf(amax, __shfl_xor_sync(unsigned(-1), amax, mask));
 #endif
   }
+#ifndef USE_ROCM
   __syncwarp();
+#endif
   float scale = fmaxf(amax, 1e-4) / 448.0f;
   if (use_ue8m0) {
     scale = exp2f(ceilf(log2f(scale)));


### PR DESCRIPTION
## Purpose
We are seeing failure on AMD due to __syncwarp is exclusively on CUDA but not on HIP
```
__vllm_cpp_lib_hipify_gen__/out/csrc/cache_kernels.hip:541:3: error: use of undeclared identifier '__syncwarp'; did you mean '__sync_swap'?
  541 |   __syncwarp();
      |   ^~~~~~~~~~
      |   __sync_swap
```
## Test Plan
CI