### PR TITLE
[BugFix][MM] Fix Nonetype error when video is cache in qwen2.5-omni-thinker

### DIFF
--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -325,11 +325,14 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
         self._validate_mm_kwargs(mm_kwargs, mm_item_counts)
 
         use_audio_in_video = False
-        video_items = [item for item in mm_kwargs["video"] if item is not None]
-        # only check video items (if there are any)
-        if video_items:
-            use_audio_in_video = all(item["use_audio_in_video"].data
-                                     for item in video_items)
+        if "video" in mm_kwargs:
+            video_items = [
+                item for item in mm_kwargs["video"] if item is not None
+            ]
+            # only check video items (if there are any)
+            if video_items:
+                use_audio_in_video = all(item["use_audio_in_video"].data
+                                         for item in video_items)
 
         if is_update_applied:
             mm_placeholders = self._find_mm_placeholders(

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -324,9 +324,12 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
         mm_item_counts = mm_items.get_all_counts()
         self._validate_mm_kwargs(mm_kwargs, mm_item_counts)
 
-        use_audio_in_video = (all(
-            item["use_audio_in_video"].data
-            for item in mm_kwargs["video"]) if "video" in mm_kwargs else False)
+        use_audio_in_video = False
+        video_items = [item for item in mm_kwargs["video"] if item is not None]
+        # only check video items (if there are any)
+        if video_items:
+            use_audio_in_video = all(item["use_audio_in_video"].data
+                                     for item in video_items)
 
         if is_update_applied:
             mm_placeholders = self._find_mm_placeholders(


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/25970

When omni is handling the cached video, it will produced `mm_kwargs: {'video': [None]}`. Then the error will occur when accessing `item["use_audio_in_video"].data` since `item` is `None`

CC: @ywang96 @DarkLight1337 @Isotr0py 

### Test script:
```
from PIL import Image
from vllm import LLM, SamplingParams
import traceback

def main():
    prompt = ("<|vision_bos|><|VIDEO|><|vision_eos|>")
    empty_image = Image.new("RGB", (224, 224), (0, 0, 0))
    model = LLM(model="Qwen/Qwen2.5-Omni-3B", enforce_eager=True)
    sampling_params = SamplingParams(max_tokens=10, temperature=0)
    inputs = [
        {
            "prompt": prompt,
            "multi_modal_data": {
                "video": [empty_image],
            }
        }
    ]
    generation = model.generate(inputs, sampling_params=sampling_params)
    print(generation[0].outputs[0].text)
    generation = model.generate(inputs, sampling_params=sampling_params)
    print(generation[0].outputs[0].text)

if __name__ == "__main__":
    main()
```
Before:
```
INFO 10-01 06:13:12 [llm.py:302] Supported_tasks: ['generate']
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.57s/it]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.53s/it, est. speed input: 57.70 toks/s, output: 3.95 toks/s]

A. 100000
Adding requests:   0%|                                                                                                                                  | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/cc/vllm/test_omni.py", line 24, in <module>
    main()
  File "/home/cc/vllm/test_omni.py", line 20, in main
    generation = model.generate(inputs, sampling_params=sampling_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/entrypoints/llm.py", line 389, in generate
    self._validate_and_add_requests(
  File "/home/cc/vllm/vllm/entrypoints/llm.py", line 1512, in _validate_and_add_requests
    self._add_request(
  File "/home/cc/vllm/vllm/entrypoints/llm.py", line 1565, in _add_request
    self.llm_engine.add_request(
  File "/home/cc/vllm/vllm/v1/engine/llm_engine.py", line 230, in add_request
    prompt_str, request = self.processor.process_inputs(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/v1/engine/processor.py", line 377, in process_inputs
    processed_inputs: ProcessorInputs = self.input_preprocessor.preprocess(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/inputs/preprocess.py", line 644, in preprocess
    return self._process_decoder_only_prompt(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/inputs/preprocess.py", line 614, in _process_decoder_only_prompt
    prompt_comps = self._prompt_to_llm_inputs(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/inputs/preprocess.py", line 393, in _prompt_to_llm_inputs
    return self._process_text(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/inputs/preprocess.py", line 343, in _process_text
    inputs = self._process_multimodal(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/inputs/preprocess.py", line 242, in _process_multimodal
    mm_input = mm_processor.apply(
               ^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/multimodal/processing.py", line 2045, in apply
    prompt_ids, prompt, mm_placeholders = self._maybe_apply_prompt_updates(
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/vllm/vllm/model_executor/models/qwen2_5_omni_thinker.py", line 327, in _maybe_apply_prompt_updates
    use_audio_in_video = (all(
                          ^^^^
  File "/home/cc/vllm/vllm/model_executor/models/qwen2_5_omni_thinker.py", line 328, in <genexpr>
    item["use_audio_in_video"].data
    ~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
ERROR 10-01 06:13:18 [core_client.py:564] Engine core proc EngineCore_DP0 died unexpectedly, shutting down client.
```
After:
```
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.44s/it]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.46s/it, est. speed input: 59.29 toks/s, output: 4.06 toks/s]

A. 100000
Adding requests:   0%|                                                                                                                                  | 0/1 [00:00<?, ?it/s]
Adding requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 214.35it/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.36s/it, est. speed input: 107.14 toks/s, output: 7.34 toks/s]

A. 100000
```

### Example script:
```
python examples/offline_inference/qwen2_5_omni/only_thinker.py

INFO 10-01 06:08:51 [llm.py:302] Supported_tasks: ['generate']
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.65s/it]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████| 1/1 [00:28<00:00, 28.87s/it, est. speed input: 190.99 toks/s, output: 2.22 toks/s]
The audio recites a little piece of practical poetry. It goes like this: "Mary had a little lamb, its fleece was white as snow. And everywhere that Mary went, the lamb was sure to go.".The image shows a baby wearing glasses, sitting on a bed and flipping through the pages of a book.
```