### PR TITLE
[Bugfix] Apply same sampling parameters for both `n=1` and `n>1`

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -290,7 +290,7 @@ class AsyncLLM(EngineClient):
             return queue
 
         # Fan out child requests (for n>1).
-        parent_request = ParentRequest(request_id, params)
+        parent_request = ParentRequest(request_id, request.sampling_params)
         for idx in range(params.n):
             request_id, params = parent_request.get_child_info(idx)
             child_request = request if idx == params.n - 1 else copy(request)


### PR DESCRIPTION
## Purpose

Closes #26002.

FIX https://github.com/vllm-project/vllm/issues/23438
FIX https://github.com/vllm-project/vllm/issues/23251

## Test Plan

Use the reproducer in the original issue.

## Test Result

Confirmed that same sampling parameters are used for both `n=1` and `n>1` cases.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
