### PR TITLE
[Core] NIXL/Segment-tree encoder cache based EPD-disaggregation

### DIFF
--- a/benchmarks/disagg_benchmarks/disagg_encode_route.py
+++ b/benchmarks/disagg_benchmarks/disagg_encode_route.py
@@ -1,0 +1,326 @@
+# api_proxy.py
+import asyncio
+import json
+import time
+import uuid
+from typing import AsyncIterator, Optional, Dict, Any
+from fastapi import FastAPI, Request, HTTPException
+import aiohttp
+from fastapi.responses import StreamingResponse, JSONResponse
+import uvicorn
+import argparse
+import logging
+import random
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+
+encode_session: Optional[aiohttp.ClientSession] = None
+decode_session: Optional[aiohttp.ClientSession] = None
+
+
+@app.on_event("startup")
+async def startup_event():
+    global encode_session, decode_session
+    encode_session = aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=0),
+        timeout=aiohttp.ClientTimeout(total=100000))
+    decode_session = aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=0),
+        timeout=aiohttp.ClientTimeout(total=100000))
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    global encode_session, decode_session
+    if encode_session:
+        await encode_session.close()
+    if decode_session:
+        await decode_session.close()
+
+
+def has_mm_input(request_data: dict):
+    if "messages" not in request_data:
+        return False
+    for message in request_data["messages"]:
+        if not isinstance(message.get("content"), list):
+            continue
+        for content_item in message["content"]:
+            if content_item.get("type") in [
+                    "image_url", "audio_url", "input_audio"
+            ]:
+                return True
+    return False
+
+
+async def forward_streaming_request(
+    request_data: dict,
+    request_id: str,
+    e_server_url: str,
+    pd_server_url: str,
+) -> AsyncIterator[str]:
+    max_tokens = request_data.get('max_tokens', None)
+    stream = request_data.get('stream', None)
+    stream_options = request_data.get('stream_options', None)
+
+    headers = {"x-request-id": request_id}
+    request_data['max_tokens'] = 1
+    request_data['stream'] = False
+    request_data['stream_options'] = {}
+    request_data['kv_transfer_params'] = {"do_remote_decode": True}
+
+    # Skip request to encoder instance if we don't have mm input
+    if has_mm_input(request_data):
+        task1 = asyncio.create_task(
+            encode_session.post(f"{e_server_url}/v1/chat/completions",
+                                json=request_data,
+                                headers=headers))
+        try:
+            response = await task1
+            if response.status != 200:
+                error_text = await response.text()
+                raise HTTPException(status_code=response.status,
+                                    detail={
+                                        "error": "Request failed",
+                                        "message": error_text
+                                    })
+        except Exception as e:
+            raise HTTPException(status_code=500,
+                                detail={
+                                    "error": "Internal server error",
+                                    "message": str(e)
+                                })
+
+    try:
+        resp = await response.json()
+        request_data['stream'] = stream
+        request_data['stream_options'] = stream_options
+        request_data['max_tokens'] = max_tokens
+        request_data['kv_transfer_params'] = resp['kv_transfer_params']
+
+        async with decode_session.post(f"{pd_server_url}/v1/chat/completions",
+                                       json=request_data,
+                                       headers=headers) as response:
+            response.raise_for_status()
+            async for chunk in response.content.iter_chunked(128):
+                if chunk:
+                    yield chunk.decode('utf-8', errors='ignore')
+    except Exception as e:
+        logger.error(f"Error in streaming: {e}")
+        raise
+
+
+async def forward_non_streaming_request(
+    request_data: dict,
+    request_id: str,
+    e_server_url: str,
+    pd_server_url: str,
+) -> dict:
+    headers = {"x-request-id": request_id}
+    max_tokens = request_data.get('max_tokens', None)
+    stream = request_data.get('stream', None)
+    stream_options = request_data.get('stream_options', None)
+
+    headers = {"x-request-id": request_id}
+    request_data['max_tokens'] = 1
+    request_data['stream'] = False
+    request_data['stream_options'] = {}
+    request_data['kv_transfer_params'] = {"do_remote_decode": True}
+
+    # Skip request to encoder instance if we don't have mm input
+    if has_mm_input(request_data):
+        # Start request to encode server
+        task1 = asyncio.create_task(
+            encode_session.post(f"{e_server_url}/v1/chat/completions",
+                                json=request_data,
+                                headers=headers))
+
+        try:
+            response = await task1
+            if response.status != 200:
+                error_text = await response.text()
+                raise HTTPException(status_code=response.status,
+                                    detail={
+                                        "error": "Request failed",
+                                        "message": error_text
+                                    })
+        except Exception as e:
+            raise HTTPException(status_code=500,
+                                detail={
+                                    "error": "Internal server error",
+                                    "message": str(e)
+                                })
+
+    try:
+        # Make request to decode server
+        resp = await response.json()
+        request_data['stream'] = stream
+        request_data['stream_options'] = stream_options
+        request_data['max_tokens'] = max_tokens
+        request_data['kv_transfer_params'] = resp['kv_transfer_params']
+        async with decode_session.post(f"{pd_server_url}/v1/chat/completions",
+                                       json=request_data,
+                                       headers=headers) as response2:
+            response2.raise_for_status()
+            result = await response2.json()
+        return result
+    except Exception as e:
+        logger.error(f"Error in non-streaming: {e}")
+        raise
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    """Handle chat completion requests."""
+    try:
+        e_instance = random.randint(0, len(app.state.e_urls) - 1)
+        pd_instance = random.randint(0, len(app.state.pd_urls) - 1)
+        e_rank = app.state.e_ranks[e_instance]
+        pd_rank = app.state.pd_ranks[pd_instance]
+        e_server_url = app.state.e_urls[e_instance]
+        pd_server_url = app.state.pd_urls[pd_instance]
+
+        logger.info(f"Matched: E-{e_rank}, PD-{pd_rank}")
+
+        request_data = await request.json()
+        request_id = request.headers.get("x-request-id")
+
+        if not request_id:
+            request_id = str(uuid.uuid4())
+        request_id = f"{request_id}|{e_rank}|{pd_rank}"
+        is_streaming = request_data.get("stream", False)
+        if is_streaming:
+            return StreamingResponse(forward_streaming_request(
+                request_data, request_id, e_server_url, pd_server_url),
+                                     media_type="text/event-stream")
+        else:
+            result = await forward_non_streaming_request(
+                request_data, request_id, e_server_url, pd_server_url)
+            return JSONResponse(content=result)
+    except Exception as e:
+        logger.error(f"Error processing request: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/v1/models")
+async def list_models():
+    try:
+        async with decode_session.get(
+                f"{app.state.pd_urls[0]}/v1/models") as response:
+            response.raise_for_status()
+            return await response.json()
+    except Exception as e:
+        logger.error(f"Error fetching models: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    try:
+
+        async def check_encode():
+            try:
+                for e_url in app.state.e_urls:
+                    async with encode_session.get(
+                            f"{e_url}/health") as response:
+                        response.raise_for_status()
+                return True
+            except Exception:
+                return False
+
+        async def check_decode():
+            try:
+                for pd_url in app.state.pd_urls:
+                    async with encode_session.get(
+                            f"{pd_url}/health") as response:
+                        response.raise_for_status()
+                return True
+            except Exception:
+                return False
+
+        encode_healthy, decode_healthy = await asyncio.gather(
+            check_encode(), check_decode(), return_exceptions=True)
+
+        health_status = {
+            "proxy":
+            "healthy",
+            "encode_servers":
+            "healthy" if encode_healthy is True else "unhealthy",
+            "prefill_decode_servers":
+            "healthy" if decode_healthy is True else "unhealthy"
+        }
+
+        if not (encode_healthy is True and decode_healthy is True):
+            return JSONResponse(content=health_status, status_code=503)
+
+        return health_status
+
+    except Exception as e:
+        logger.error(f"Health check error: {e}")
+        return JSONResponse(content={
+            "proxy": "unhealthy",
+            "error": str(e)
+        },
+                            status_code=503)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="API Proxy for distributed vLLM servers")
+    parser.add_argument("--host",
+                        type=str,
+                        default="localhost",
+                        help="Proxy host")
+    parser.add_argument("--port", type=int, default=8000, help="Proxy port")
+
+    parser.add_argument(
+        "--encode-servers-urls",
+        type=str,
+        default="http://localhost:8100",
+        help="URLs of the encode server in comma separated format"
+        "(e.g., \"http://localhost:8001,http://localhost:8002\")")
+
+    parser.add_argument(
+        "--encode-servers-ranks",
+        type=str,
+        default="0",
+        help="Respective EPD ranks for encode servers in comma-separated format"
+        "(e.g., \"0,1\")")
+
+    parser.add_argument(
+        "--prefill-decode-servers-urls",
+        type=str,
+        default="http://localhost:8200",
+        help="URLs of the prefill/decode servers in comma separated format"
+        "(e.g., \"http://localhost:8003,http://localhost:8004\")")
+
+    parser.add_argument(
+        "--prefill-decode-servers-ranks",
+        type=str,
+        default="1",
+        help="Respective EPD ranks for encode servers in comma-separated format"
+        "(e.g., \"2,3\")")
+
+    args = parser.parse_args()
+    app.state.e_urls = args.encode_servers_urls.split(",")
+    app.state.pd_urls = args.prefill_decode_servers_urls.split(",")
+    app.state.e_ranks = args.encode_servers_ranks.split(",")
+    app.state.pd_ranks = args.prefill_decode_servers_ranks.split(",")
+
+    logger.info(f"Starting API proxy on {args.host}:{args.port} with 1 worker")
+    logger.info(
+        f"Encode servers: {app.state.e_urls} (respective ranks {app.state.e_ranks})"
+    )
+    logger.info(
+        f"Prefill/Decode server: {app.state.pd_urls} (respective ranks {app.state.pd_ranks})"
+    )
+
+    uvicorn.run(app,
+                host=args.host,
+                port=args.port,
+                log_level="info",
+                access_log=False,
+                loop="uvloop")

--- a/benchmarks/disagg_benchmarks/disagg_epd_route.py
+++ b/benchmarks/disagg_benchmarks/disagg_epd_route.py
@@ -1,0 +1,405 @@
+# api_proxy.py
+import asyncio
+import json
+import time
+import uuid
+from typing import AsyncIterator, Optional, Dict, Any
+from fastapi import FastAPI, Request, HTTPException
+import aiohttp
+from fastapi.responses import StreamingResponse, JSONResponse
+import uvicorn
+import argparse
+import logging
+import random
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+
+encode_session: Optional[aiohttp.ClientSession] = None
+decode_session: Optional[aiohttp.ClientSession] = None
+
+
+@app.on_event("startup")
+async def startup_event():
+    global encode_session, decode_session
+    encode_session = aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=0),
+        timeout=aiohttp.ClientTimeout(total=100000))
+    decode_session = aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=0),
+        timeout=aiohttp.ClientTimeout(total=100000))
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    global encode_session, decode_session
+    if encode_session:
+        await encode_session.close()
+    if decode_session:
+        await decode_session.close()
+
+
+def has_mm_input(request_data: dict):
+    if "messages" not in request_data:
+        return False
+    for message in request_data["messages"]:
+        if not isinstance(message.get("content"), list):
+            continue
+        for content_item in message["content"]:
+            if content_item.get("type") in [
+                    "image_url", "audio_url", "input_audio"
+            ]:
+                return True
+    return False
+
+
+async def forward_streaming_request(request_data: dict, request_id: str,
+                                    e_server_url: str, p_server_url: str,
+                                    d_server_url: str) -> AsyncIterator[str]:
+    max_tokens = request_data.get('max_tokens', None)
+    stream = request_data.get('stream', None)
+    stream_options = request_data.get('stream_options', None)
+
+    headers = {"x-request-id": request_id}
+    request_data['max_tokens'] = 1
+    request_data['stream'] = False
+    request_data['stream_options'] = {}
+    request_data['kv_transfer_params'] = {"do_remote_decode": True}
+
+    # Skip request to encoder instance if we don't have mm input
+    if has_mm_input(request_data):
+        task1 = asyncio.create_task(
+            encode_session.post(f"{e_server_url}/v1/chat/completions",
+                                json=request_data,
+                                headers=headers))
+        try:
+            response = await task1
+            if response.status != 200:
+                error_text = await response.text()
+                raise HTTPException(status_code=response.status,
+                                    detail={
+                                        "error": "Request failed",
+                                        "message": error_text
+                                    })
+        except Exception as e:
+            raise HTTPException(status_code=500,
+                                detail={
+                                    "error": "Internal server error",
+                                    "message": str(e)
+                                })
+
+    try:
+        resp = await response.json()
+
+        request_data['max_tokens'] = 1
+        request_data['stream'] = False
+        request_data['stream_options'] = {}
+        request_data['kv_transfer_params'] = resp['kv_transfer_params']
+        request_data['kv_transfer_params']['do_remote_decode'] = True
+
+        task2 = asyncio.create_task(
+            decode_session.post(f"{p_server_url}/v1/chat/completions",
+                                json=request_data,
+                                headers=headers))
+        try:
+            response = await task2
+            if response.status != 200:
+                error_text = await response.text()
+                raise HTTPException(status_code=response.status,
+                                    detail={
+                                        "error": "Request failed",
+                                        "message": error_text
+                                    })
+        except Exception as e:
+            raise HTTPException(status_code=500,
+                                detail={
+                                    "error": "Internal server error",
+                                    "message": str(e)
+                                })
+
+        resp = await response.json()
+
+        request_data['stream'] = stream
+        request_data['stream_options'] = stream_options
+        request_data['max_tokens'] = max_tokens
+        request_data['kv_transfer_params'] = resp['kv_transfer_params']
+
+        async with decode_session.post(f"{d_server_url}/v1/chat/completions",
+                                       json=request_data,
+                                       headers=headers) as response:
+            response.raise_for_status()
+            async for chunk in response.content.iter_chunked(128):
+                if chunk:
+                    yield chunk.decode('utf-8', errors='ignore')
+    except Exception as e:
+        logger.error(f"Error in streaming: {e}")
+        raise
+
+
+async def forward_non_streaming_request(
+    request_data: dict,
+    request_id: str,
+    e_server_url: str,
+    p_server_url: str,
+    d_server_url: str,
+) -> dict:
+    headers = {"x-request-id": request_id}
+    max_tokens = request_data.get('max_tokens', None)
+    stream = request_data.get('stream', None)
+    stream_options = request_data.get('stream_options', None)
+
+    headers = {"x-request-id": request_id}
+    request_data['max_tokens'] = 1
+    request_data['stream'] = False
+    request_data['stream_options'] = {}
+    request_data['kv_transfer_params'] = {"do_remote_decode": True}
+
+    # Skip request to encoder instance if we don't have mm input
+    if has_mm_input(request_data):
+        # Start request to encode server
+        task1 = asyncio.create_task(
+            encode_session.post(f"{e_server_url}/v1/chat/completions",
+                                json=request_data,
+                                headers=headers))
+
+        try:
+            response = await task1
+            if response.status != 200:
+                error_text = await response.text()
+                raise HTTPException(status_code=response.status,
+                                    detail={
+                                        "error": "Request failed",
+                                        "message": error_text
+                                    })
+        except Exception as e:
+            raise HTTPException(status_code=500,
+                                detail={
+                                    "error": "Internal server error",
+                                    "message": str(e)
+                                })
+
+    try:
+        # Make request to decode server
+        resp = await response.json()
+        request_data['max_tokens'] = 1
+        request_data['stream'] = False
+        request_data['stream_options'] = {}
+        request_data['kv_transfer_params'] = resp['kv_transfer_params']
+        request_data['kv_transfer_params']['do_remote_decode'] = True
+
+        task2 = asyncio.create_task(
+            decode_session.post(f"{p_server_url}/v1/chat/completions",
+                                json=request_data,
+                                headers=headers))
+
+        try:
+            response2 = await task2
+            if response2.status != 200:
+                error_text = await response2.text()
+                raise HTTPException(status_code=response2.status,
+                                    detail={
+                                        "error": "Request failed",
+                                        "message": error_text
+                                    })
+        except Exception as e:
+            raise HTTPException(status_code=500,
+                                detail={
+                                    "error": "Internal server error",
+                                    "message": str(e)
+                                })
+
+        resp = await response2.json()
+        request_data['stream'] = stream
+        request_data['stream_options'] = stream_options
+        request_data['max_tokens'] = max_tokens
+        request_data['kv_transfer_params'] = resp['kv_transfer_params']
+        async with decode_session.post(f"{d_server_url}/v1/chat/completions",
+                                       json=request_data,
+                                       headers=headers) as response2:
+            response2.raise_for_status()
+            result = await response2.json()
+        return result
+    except Exception as e:
+        logger.error(f"Error in non-streaming: {e}")
+        raise
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    """Handle chat completion requests."""
+    try:
+        e_instance = random.randint(0, len(app.state.e_urls) - 1)
+        p_instance = random.randint(0, len(app.state.p_urls) - 1)
+        d_instance = random.randint(0, len(app.state.d_urls) - 1)
+        e_rank = app.state.e_ranks[e_instance]
+        p_rank = app.state.p_ranks[p_instance]
+        d_rank = app.state.d_ranks[d_instance]
+        e_server_url = app.state.e_urls[e_instance]
+        p_server_url = app.state.p_urls[p_instance]
+        d_server_url = app.state.d_urls[d_instance]
+
+        logger.info(f"Matched: E-{e_rank}, P-{p_rank} D-{d_rank}")
+
+        request_data = await request.json()
+        request_id = request.headers.get("x-request-id")
+
+        if not request_id:
+            request_id = str(uuid.uuid4())
+        request_id = f"{request_id}|{e_rank}|{p_rank}|{d_rank}"
+        is_streaming = request_data.get("stream", False)
+        if is_streaming:
+            return StreamingResponse(forward_streaming_request(
+                request_data, request_id, e_server_url, p_server_url,
+                d_server_url),
+                                     media_type="text/event-stream")
+        else:
+            result = await forward_non_streaming_request(
+                request_data, request_id, e_server_url, p_server_url,
+                d_server_url)
+            return JSONResponse(content=result)
+    except Exception as e:
+        logger.error(f"Error processing request: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/v1/models")
+async def list_models():
+    try:
+        async with decode_session.get(
+                f"{app.state.pd_urls[0]}/v1/models") as response:
+            response.raise_for_status()
+            return await response.json()
+    except Exception as e:
+        logger.error(f"Error fetching models: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    try:
+
+        async def check_encode():
+            try:
+                for e_url in app.state.e_urls:
+                    async with encode_session.get(
+                            f"{e_url}/health") as response:
+                        response.raise_for_status()
+                return True
+            except Exception:
+                return False
+
+        async def check_decode():
+            try:
+                for pd_url in app.state.pd_urls:
+                    async with encode_session.get(
+                            f"{pd_url}/health") as response:
+                        response.raise_for_status()
+                return True
+            except Exception:
+                return False
+
+        encode_healthy, decode_healthy = await asyncio.gather(
+            check_encode(), check_decode(), return_exceptions=True)
+
+        health_status = {
+            "proxy":
+            "healthy",
+            "encode_servers":
+            "healthy" if encode_healthy is True else "unhealthy",
+            "prefill_decode_servers":
+            "healthy" if decode_healthy is True else "unhealthy"
+        }
+
+        if not (encode_healthy is True and decode_healthy is True):
+            return JSONResponse(content=health_status, status_code=503)
+
+        return health_status
+
+    except Exception as e:
+        logger.error(f"Health check error: {e}")
+        return JSONResponse(content={
+            "proxy": "unhealthy",
+            "error": str(e)
+        },
+                            status_code=503)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="API Proxy for distributed vLLM servers")
+    parser.add_argument("--host",
+                        type=str,
+                        default="localhost",
+                        help="Proxy host")
+    parser.add_argument("--port", type=int, default=8000, help="Proxy port")
+
+    parser.add_argument(
+        "--encode-servers-urls",
+        type=str,
+        default="http://localhost:8100",
+        help="URLs of the encode server in comma separated format"
+        "(e.g., \"http://localhost:8001,http://localhost:8002\")")
+
+    parser.add_argument(
+        "--encode-servers-ranks",
+        type=str,
+        default="0",
+        help="Respective EPD ranks for encode servers in comma-separated format"
+        "(e.g., \"0,1\")")
+
+    parser.add_argument(
+        "--prefill-servers-urls",
+        type=str,
+        default="http://localhost:8200",
+        help="URLs of the prefill servers in comma separated format"
+        "(e.g., \"http://localhost:8003,http://localhost:8004\")")
+
+    parser.add_argument(
+        "--prefill-servers-ranks",
+        type=str,
+        default="1",
+        help="Respective EPD ranks for prefill servers in comma-separated format"
+        "(e.g., \"2,3\")")
+
+    parser.add_argument(
+        "--decode-servers-urls",
+        type=str,
+        default="http://localhost:8300",
+        help="URLs of the decode servers in comma separated format"
+        "(e.g., \"http://localhost:8003,http://localhost:8004\")")
+
+    parser.add_argument(
+        "--decode-servers-ranks",
+        type=str,
+        default="2",
+        help="Respective EPD ranks for decode servers in comma-separated format"
+    )
+
+    args = parser.parse_args()
+    app.state.e_urls = args.encode_servers_urls.split(",")
+    app.state.p_urls = args.prefill_servers_urls.split(",")
+    app.state.d_urls = args.decode_servers_urls.split(",")
+    app.state.e_ranks = args.encode_servers_ranks.split(",")
+    app.state.p_ranks = args.prefill_servers_ranks.split(",")
+    app.state.d_ranks = args.decode_servers_ranks.split(",")
+
+    logger.info(f"Starting API proxy on {args.host}:{args.port} with 1 worker")
+    logger.info(
+        f"Encode servers: {app.state.e_urls} (respective ranks {app.state.e_ranks})"
+    )
+    logger.info(
+        f"Prefill server: {app.state.p_urls} (respective ranks {app.state.p_ranks})"
+    )
+    logger.info(
+        f"Decode server: {app.state.d_urls} (respective ranks {app.state.d_ranks})"
+    )
+
+    uvicorn.run(app,
+                host=args.host,
+                port=args.port,
+                log_level="info",
+                access_log=False,
+                loop="uvloop")

--- a/benchmarks/disagg_benchmarks/disagg_nixl_epd_benchmark.sh
+++ b/benchmarks/disagg_benchmarks/disagg_nixl_epd_benchmark.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# Requirement: 3x GPUs.
+
+# Model: Qwen/Qwen2.5-VL-3B-Instruct
+# Query:  QPS 2/4/6/8, 100 requests
+# Resource: 3x GPU
+# Approaches:
+# 1. Disaggregated Encode - Prefill+Decode: 1 encode instance, 1 prefill+decode instance
+# 2. Disaggregated Encode - Prefill - Decode: 1 encode instance, 1 prefill instance, 1 decode instance
+
+set -ex
+
+kill_gpu_processes() {
+  # kill all processes on GPU.
+  pgrep pt_main_thread | xargs -r kill -9
+  pgrep python3 | xargs -r kill -9
+  # vLLM now names the process with VLLM prefix after https://github.com/vllm-project/vllm/pull/21445
+  pgrep VLLM | xargs -r kill -9
+  for port in 8000 8100 8200 8300; do lsof -t -i:$port | xargs -r kill -9; done
+  sleep 1
+}
+
+wait_for_server() {
+  # wait for vllm server to start
+  # return 1 if vllm server crashes
+  local port=$1
+  timeout 1200 bash -c "
+    until curl -s localhost:${port}/v1/completions > /dev/null; do
+      sleep 1
+    done" && return 0 || return 1
+}
+
+
+launch_e_pd_benchmark() {
+  model="Qwen/Qwen2.5-VL-3B-Instruct"
+  
+  # disagg encode
+  CUDA_VISIBLE_DEVICES=0 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5560 vllm serve $model \
+    --port 8100 \
+    --trust-remote-code --enable-request-id-headers \
+    --kv-transfer-config \
+    '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_encoder_mode":"encoder_only"}' &
+
+  # disagg prefill + decode
+  CUDA_VISIBLE_DEVICES=1 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5561 vllm serve $model \
+    --port 8200 \
+    --trust-remote-code --enable-request-id-headers \
+    --kv-transfer-config \
+    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
+
+  wait_for_server 8100
+  wait_for_server 8200
+  python3 disagg_encode_route.py &
+  sleep 1
+}
+
+
+launch_e_p_d_benchmark() {
+  model="Qwen/Qwen2.5-VL-3B-Instruct"
+
+  # disagg encode
+  CUDA_VISIBLE_DEVICES=0 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5560 vllm serve $model \
+    --port 8100 \
+    --trust-remote-code --enable-request-id-headers \
+    --kv-transfer-config \
+    '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_encoder_mode":"encoder_only"}' &
+
+  # disagg prefill
+  CUDA_VISIBLE_DEVICES=1 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5561 vllm serve $model \
+    --port 8200 \
+    --trust-remote-code --enable-request-id-headers \
+    --kv-transfer-config \
+    '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_encoder_mode":"ep_encoder"}' &
+  
+  # disagg decode
+  CUDA_VISIBLE_DEVICES=2 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5562 vllm serve $model \
+    --port 8300 \
+    --trust-remote-code --enable-request-id-headers \
+    --kv-transfer-config \
+    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
+
+  wait_for_server 8100
+  wait_for_server 8200
+  wait_for_server 8300
+  python3 disagg_epd_route.py &
+  sleep 1
+}
+
+
+benchmark() {
+  results_folder="./results"
+  model="Qwen/Qwen2.5-VL-3B-Instruct"
+  dataset_name="hf"
+  dataset_path="lmarena-ai/VisionArena-Chat"
+  num_prompts=100
+  qps=$1
+  tag=$2
+
+  vllm bench serve \
+    --backend vllm \
+    --model $model \
+    --dataset-name $dataset_name \
+    --dataset-path $dataset_path \
+    --hf-split train \
+    --endpoint-type openai-chat \
+    --endpoint /v1/chat/completions \
+    --num-prompts $num_prompts \
+    --port 8000 \
+    --save-result \
+    --result-dir $results_folder \
+    --result-filename "$tag"-qps-"$qps".json \
+    --request-rate "$qps"
+
+  sleep 2
+}
+
+
+main() {
+
+  (which wget && which curl) || (apt-get update && apt-get install -y wget curl)
+  (which jq) || (apt-get -y install jq)
+  (which socat) || (apt-get -y install socat)
+  (which lsof) || (apt-get -y install lsof)
+
+  pip install quart httpx matplotlib aiohttp datasets
+
+  cd "$(dirname "$0")"
+
+  rm -rf results
+  mkdir results
+
+  export VLLM_HOST_IP=$(hostname -I | awk '{print $1}')
+
+  launch_e_pd_benchmark
+  for qps in 2; do
+  benchmark $qps chunked_prefill
+  done
+  kill_gpu_processes
+
+  launch_e_p_d_benchmark
+  for qps in 2; do
+  benchmark $qps disagg_prefill
+  done
+  kill_gpu_processes
+
+  python3 visualize_benchmark_results.py
+}
+
+
+main "$@"

--- a/examples/online_serving/disaggregated_encode.sh
+++ b/examples/online_serving/disaggregated_encode.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# This file demonstrates the example usage of disaggregated multi-modal encoding with NIXLConnector.
+# We will launch 2 vllm instances (1 for encode and 1 for decode),
+# and then transfer the KV cache between them.
+
+set -xe
+
+echo "🚧🚧 Warning: The usage of disaggregated encoding is experimental and subject to change 🚧🚧"
+sleep 1
+
+MODEL_NAME=${HF_MODEL_NAME:-Qwen/Qwen2.5-VL-3B-Instruct}
+
+# Trap the SIGINT signal (triggered by Ctrl+C)
+trap 'cleanup' INT
+
+# Cleanup function
+cleanup() {
+    echo "Caught Ctrl+C, cleaning up..."
+    # Cleanup commands
+    pgrep python | xargs kill -9
+    pkill -f python
+    echo "Cleanup complete. Exiting."
+    exit 0
+}
+
+export VLLM_HOST_IP=$(hostname -I | awk '{print $1}')
+
+# install quart first -- required for disagg encode proxy serve
+if python3 -c "import quart" &> /dev/null; then
+    echo "Quart is already installed."
+else
+    echo "Quart is not installed. Installing..."
+    python3 -m pip install quart
+fi 
+
+# a function that waits vLLM server to start
+wait_for_server() {
+  local port=$1
+  timeout 1200 bash -c "
+    until curl -s localhost:${port}/v1/chat/completions > /dev/null; do
+      sleep 1
+    done" && return 0 || return 1
+}
+
+
+# You can also adjust --kv-ip and --kv-port for distributed inference.
+
+# prefilling instance, which is the KV producer
+CUDA_VISIBLE_DEVICES=0 VLLM_NIXL_SIDE_CHANNEL_PORT=5557 vllm serve Qwen/Qwen2.5-VL-3B-Instruct \
+    --port 8100 \
+    --max-model-len 256 \
+    --trust-remote-code \
+    --enforce-eager \
+    --kv-transfer-config \
+    '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_encoder_mode":"epd_encoder"}' &
+
+# decoding instance, which is the KV consumer
+CUDA_VISIBLE_DEVICES=1 VLLM_NIXL_SIDE_CHANNEL_PORT=5558 vllm serve Qwen/Qwen2.5-VL-3B-Instruct \
+    --port 8200 \
+    --max-model-len 256 \
+    --trust-remote-code \
+    --enforce-eager \
+    --kv-transfer-config \
+    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
+
+# wait until prefill and decode instances are ready
+wait_for_server 8100
+wait_for_server 8200
+
+# launch a proxy server that opens the service at port 8000
+# the workflow of this proxy:
+# - send the request to encode vLLM instance (port 8100), change max_tokens 
+#   to 1 and add "do_remote_decode": true in kv_transfer_params
+# - after the encode vLLM finishes encoding, send the request to decode vLLM 
+#   instance
+# NOTE: the usage of this API is subject to change --- in the future we will 
+# introduce "vllm connect" to connect between encode and decode instances
+python3 ../../tests/v1/kv_connector/nixl_integration/toy_epd_proxy_server.py &
+sleep 1
+
+# serve two example requests
+output1=$(curl -X POST -s http://localhost:8000/v1/chat/completions \
+-H "Content-Type: application/json" \
+-d '{
+"model": "'"$MODEL_NAME"'",
+"messages": [{
+  "role": "user",
+    "content": [
+      {"type": "text", "text": "Describe the image."},
+      {"type": "image_url", "image_url": {"url": "https://picsum.photos/id/238/200/300"}}
+    ]
+  }]
+}')
+
+output2=$(curl -X POST -s http://localhost:8000/v1/chat/completions \
+-H "Content-Type: application/json" \
+-d '{
+"model": "'"$MODEL_NAME"'",
+"messages": [{
+  "role": "user",
+    "content": [
+      {"type": "text", "text": "Compare two images."},
+      {"type": "image_url", "image_url": {"url": "https://picsum.photos/id/200/300/300"}},
+      {"type": "image_url", "image_url": {"url": "https://picsum.photos/id/201/300/300"}}
+    ]
+  }]
+}')
+
+
+# Cleanup commands
+pgrep python | xargs kill -9
+pkill -f python
+
+echo ""
+
+sleep 1
+
+# Print the outputs of the curl requests
+echo ""
+echo "Output of first request: $output1"
+echo "Output of second request: $output2"
+
+echo "🎉🎉 Successfully finished 2 test requests! 🎉🎉"
+echo ""

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -49,3 +49,4 @@ pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects
 setproctitle # Used to set process names for better debugging and monitoring
 openai-harmony >= 0.0.3  # Required for gpt-oss
+sortedcontainers

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -14,6 +14,9 @@ KVProducer = Literal["kv_producer", "kv_both"]
 KVConsumer = Literal["kv_consumer", "kv_both"]
 KVRole = Literal[KVProducer, KVConsumer]
 
+# E-node / E-P node, respectively.
+KVEncoderRole = Literal["encoder_only", "ep_encoder"]
+
 
 @config
 @dataclass
@@ -61,6 +64,10 @@ class KVTransferConfig:
     """The Python module path to dynamically load the KV connector from.
     Only supported in V1."""
 
+    kv_encoder_mode: Optional[KVEncoderRole] = None
+    """The role for EPD-disaggeregation. Choices are 'encoder_only' and
+    'ep_encoder'."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -106,6 +113,15 @@ class KVTransferConfig:
     def is_kv_consumer(self) -> bool:
         return self.kv_connector is not None and \
             self.kv_role in get_args(KVConsumer)
+
+    @property
+    def is_encoder_only(self) -> bool:
+        return self.kv_encoder_mode is not None and \
+            self.kv_encoder_mode == "encoder_only"
+
+    @property
+    def is_encode_sender(self) -> bool:
+        return self.kv_encoder_mode is not None
 
     def get_from_extra_config(self, key, default) -> Any:
         return self.kv_connector_extra_config.get(key, default)

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from vllm.multimodal.inputs import MultiModalKwargsItem, PlaceholderRange
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams
+    from vllm.v1.core.encoder_cache_manager import MemorySegment
     from vllm.v1.request import Request
 
 
@@ -140,6 +141,13 @@ class SchedulerOutput:
     # E.g., if a request has [0, 1], it could mean the vision encoder needs
     # to process that the request's 0-th and 1-th images in the current step.
     scheduled_encoder_inputs: dict[str, list[int]]
+    # mm_hash -> list of new allocated memory segments for encoded multimodal inputs
+    # Only used for remote prefill or decode.
+    scheduled_encoder_segments: dict[str, list[MemorySegment]]
+    # mm_hash -> (token length, list of local memory segments to receive remote multimodal inputs).
+    # If the list is empty, there is no pre-allocated segment but new target tensor
+    # will be allocated. Only used for remote encode.
+    local_encoder_segments: dict[str, tuple[int, list[MemorySegment]]]
     # Number of common prefix blocks for all requests in each KV cache group.
     # This can be used for cascade attention.
     num_common_prefix_blocks: list[int]

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -203,6 +203,7 @@ class RequestStatus(enum.IntEnum):
     WAITING = enum.auto()
     WAITING_FOR_FSM = enum.auto()
     WAITING_FOR_REMOTE_KVS = enum.auto()
+    WAITING_FOR_REMOTE_MMS = enum.auto()
     RUNNING = enum.auto()
     PREEMPTED = enum.auto()
     # Note: anything after PREEMPTED will be considered


### PR DESCRIPTION
# Purpose

Recently, several multi-node inference/orchestration engines such as llm-d and dynamo have emerged, and they natively supports Prefill-Decode disaggregation. To improve them, we can imagine Encode-Prefill-Decode disaggregation that is introduced in several RFCs and PRs: https://github.com/vllm-project/vllm/issues/20799, https://github.com/hsliuustc0106/vllm/issues/18, https://github.com/vllm-project/vllm/pull/25233.

However, llm-d and dynamo rely on the NIXL communicator, which wraps fast transfer layers like UCX or other RDMA drivers. Instead of using external embedding cache pool servers (such as Redis) as implemented in the prototype (https://github.com/vllm-project/vllm/issues/20799), we can enable direct communication between the encoder and other workers using the NIXL communicator proposed in the original RFC (https://github.com/vllm-project/vllm/issues/20799).

To implement NIXL-based encoder cache transfer, we must first pre-allocate the entire encoder cache region in a device and register it to its NIXL agent, and then share the metadata (size and pointer) of the memory region with prefill and decode workers before inference begins.

We added these parts:

1. Segment-tree based encoder cache manager: 
    - Allocate encoded multi-modal embedding tokens to the best-fit segment in a segment tree. If there is no segment that can contain the tokens, the tokens can be stored in multiple segments. The encoder worker only sends the pointers and lengths of the  segments.
    - Upgrade current encoder cache manager which only tracks remaining encoder token budget.
2. Native dynamic role-switching between P, D, EP, PD and EPD worker following [1].
    - Specifically, the role is determined by the request (i.e. `do_remote_[encode/prefill/decode]` values in `kv_transfer_params`) rather than the worker instantiation phase.
    - Encoder-only worker must be defined before instantiating it, because we don’t want to allocate KV cache and worker
3. Encoder-only scheduler and GPU model runner that skip KV-cache block allocation and LLM inference.

**References**

[1] Huawei: Efficiently Serving Large Multimodal Models Using EPD Disaggregation, https://arxiv.org/pdf/2501.05460v4

# File Changes

## `kv_transfer.py`

- Added `kv_encoder_mode` in `KVTransferConfig`
    - `encoder_only`: Set this worker as an encoder-only worker. Do not load weights for LLM and instantiate KV-cache.
    - `ep_encoder`: Enable segment-tree based encoder cache so that it works as a prefill worker (i.e. receives embedding tokens and sends embedding+prefill tokens)

## Scheduler

- Added `schedule_encoder_only(self)` for encoder-only worker. It does not allocate KV-cache blocks for a request.
- Defer any requests that use a same multi-modal input (determined by same `mm_hash` value) which will be received from a remote encoder worker.
    - To enable it, added `WAITING_FOR_REMOTE_MMS` value to `RequestStatus`.

## Segment-tree based encoder cache

### `encoder_cache_manager.py`

- Added `EncoderBlockCacheManager` that inherits `EncoderCacheManager`. `EncoderBlockCacheManager`
    - Receives `mm_hash` and expected multi-modal token length. Returns segment indices and their lengths to store its multi-modal tokens.
- When a request requires a remote encode worker, it first allocates segments for the multi-modal inputs and store its `mm_hash` to a `self.receiving` set. When the encoded tokens are received from the remote worker, its`mm_hash` will be removed from the set.
    - All the requests that uses the same `mm_hash` in the `self.receiving` set will be deferred.

### `gpu_model_runner.py`

- Allocates a monolithic memory block for an encoder pool if `kv_encoder_mode` is set in `kv_transfer_config`.
- Skips KV cache allocation and the main LLM execution if the worker sets `encoder_only`.

## Router and NIXL worker

A router is the endpoint for a whole inference and exchanges `kv_transfer_params` between encode-prefill-decode workers.

Along to existing the NIXL KV-cache communication, metadata of encoded embedding data must be composed into `kv_transfer_params` value in the request to the following worker. NIXL worker (`nixl_connector.py`) automatically builds `kv_transfer_params` for the following workers, and the router forwards it to the next worker.

There are two simple routers which are taken and fixed from https://github.com/vllm-project/vllm/pull/25233.

- `disagg_encode_route.py`: a router for encode - prefill+decode workers
- `disagg_epd_route.py`: a router for encode - prefill - decode workers

Prior to any data transfer, all workers in a single transfer path must exchange metadata (pointer and size information) for their encoder cache and KV caches through a side-channel.

While the data transfer, each request must contain special flags in `kv_transfer_params` that indicate how the request should be handled. For example in E-PD disaggreagtion, the initial request to the encoder worker contains `{ "do_remote_decode": True }` and the forwarded request to the prefill-decoder worker will contain `{ "do_remote_encode": True }`. The exact formats are written below. When we don’t want to use disaggregated inference, we can send a normal request to prefill or decode workers without `kv_transfer_params`.

The below timelines depict what data will be transferred and what tensors will be created.

### E-PD

- `kv_transfer_params` format

```jsx
// Request to encoder
{ 
	"do_remote_encode": False, 
	"do_remote_prefill": False,
	"do_remote_decode": True 
}

// Request to PD
{
	"do_remote_encode": True,
	"do_remote_prefill": False,
	"do_remote_decode": False
}
```

- Timeline

```mermaid
sequenceDiagram
	autonumber
	participant R as Router
	participant RW as EncodeWorker
	participant RX as EncodeNIXLWorker
	participant LW as PDWorker
	participant LX as PDNIXLAgent
	
	RW ->> RX : Create & Register <br/> Encoder Cache <br/> to the NIXL context
	R ->> RW : Send an image request
	
	opt mm_hash not <br/> in the cache
	RW ->> RW : Calculate encoder tokens <br/> & register it to the cache
	end
	RW ->> R : Send encoded tokens' <br> segment metadata
	R ->> LW : Forward the request <br> with the segment metadata <br> & remote server IP:port
	
	opt handshaking is not executed
		LW ->> LX : Send (remote server id, <br> remote encoder cache ptr & length)
		RX <<->> LX : Handshake & exchange memory <br> descriptor of the encoder cache <br> (e.g. memory raw ptr) through TCP/zmq
	end
	
	LW ->> LX : Create tensors to store <br> the remote encoder tokens
	LX ->> LX : Register the tensors to the NIXL agent
	LX -> RX : Execute transfer	
	LX ->> LW : Notify the transfer ended <br> to the local scheduler
	LX ->> RX : Notify the transfer ended (automatic)
	LX ->> LX : Deregister the tensors to the NIXL agent
	
	RX ->> RW : Notify the token is freeable.
	RW ->> RW : Decrease reference count <br>  of the tokens. Evict the segment <br>  if there is not enough space.
	
	LW ->> LW : Execute prefill & decode
	LW ->> R : Send decoded tokens
```

### EP-D

- `kv_transfer_params` format

```jsx
// Request to EP
{ 
	"do_remote_encode": False,
	"do_remote_prefill": False,
	"do_remote_decode": True
}

// Request to Decoder
{
	"do_remote_encode": True,
	"do_remote_prefill": True,
	"do_remote_decode": False
}
```

- Timeline

```mermaid
sequenceDiagram
	autonumber
	participant R as Router
	participant RW as EPWorker
	participant RX as EPNIXLWorker
	participant LW as DecodeWorker
	participant LX as DecodeNIXLWorker
	
	RW ->> RX : Create & Register <br/> Encoder & KV Cache <br/> to the NIXL context
  LW ->> LX : Create & Register <br/> KV Cache <br/> to the NIXL context	
	R ->> RW : Send a request
	
	opt mm_hash not <br/> in the cache
	RW ->> RW : Calculate encoder tokens <br/> & register it to the cache
	end
	RW ->> RW : Execute Prefill
	RW ->> R : Send encoded tokens' <br> segment metadata <br> & KV cache block ids
	R ->> LW : Forward the request <br> with the KV cache <br> & segment metadata <br> & remote server IP:port
	
	opt handshaking is not executed
		LW ->> LX : Send (remote server id, <br> remote encoder & <br> KV cache ptr & length)
		RX <<->> LX : Handshake & exchange memory <br> descriptor of the encoder cache <br> (e.g. memory raw ptr) through TCP/zmq
	end
	
	LW ->> LX : Create tensors to store <br> the remote encoder tokens
	LX ->> LX : Register the tensors to the NIXL agent
	LX -> RX : Execute encoder token transfer	
	LX -> RX : Execute KV cache transfer	
	LX ->> LW : Notify the transfer ended <br> to the local scheduler
	LX ->> RX : Notify the transfer ended (automatic)
	LX ->> LX : Deregister the encoder tensors to the NIXL agent
	
	RX ->> RW : Notify the token is freeable.
	RW ->> RW : Decrease reference count <br>  of the tokens. Evict the segment <br>  if there is not enough space.
	
	LW ->> LW : Execute prefill & decode
	LW ->> R : Send decoded tokens
```

### E-P-D

- `kv_transfer_params` format

```jsx
// Request to Encoder
{ 
	"do_remote_encode": False,
	"do_remote_prefill": False,
	"do_remote_decode": True
}

// Request to Prefiller
{
	"do_remote_encode": True,
	"do_remote_prefill": False,
	"do_remote_decode": True
}

// Request to Decoder
{
	"do_remote_encode": True,
	"do_remote_prefill": True,
	"do_remote_decode": False
}
```

- Timeline

```mermaid
sequenceDiagram
	autonumber
	participant R as Router
	participant RW as EncodeWorker
	participant RX as EncodeNIXLWorker
	participant CW as PrefillWorker
	participant CX as PrefillNIXLWorker
	participant LW as DecodeWorker
	participant LX as DecodeNIXLWorker
	
	RW ->> RX : Create & Register <br/> Encoder cache <br/> to the NIXL context
	CW ->> CX : Create & Register <br/> Encoder & KV cache <br/> to the NIXL context
  LW ->> LX : Create & Register KV cache <br/> to the NIXL context	
	R ->> RW : Send a request
	
	opt mm_hash not <br/> in the cache
	RW ->> RW : Calculate encoder tokens <br/> & register it to the cache
	end
	RW ->> R : Send encoded tokens' <br> segment metadata 
	R ->> CW : Forward the request <br> with the segment metadata <br> & remote server IP:port
	
	opt handshaking is not executed
		CW ->> CX : Send (remote server id, <br> remote encoder cache ptr & length)
		RX <<->> CX : Handshake & exchange memory <br> descriptor of the encoder cache <br> (e.g. memory raw ptr) through TCP/zmq
	end
	
	CW ->> CX : Notify which local segments <br> should be used to <br>store the remote tokens
	RX ->> CX : Execute encoder token transfer <br> from remote encoder segments <br> to local encoder segments
	CX ->> CW : Notify the transfer ended <br> to the local scheduler
	CX ->> RX : Notify the transfer ended (automatic)
	CW ->> CW : Do prefill
	CW ->> R : Send encoded tokens' <br> segment metadata <br> & KV cache block ids
	R ->> LW : Forward the request <br> with the segment metadata <br> & remote server IP:port
	
	RX ->> RW : Notify the token is freeable.
	RW ->> RW : Decrease reference count <br> of the tokens. Evict the segment <br> if there is not enough space.
	
	opt handshaking is not executed
		LW ->> LX : Send (remote server id, <br> remote encoder & <br> KV cache ptr & length)
		CX <<->> LX : Handshake & exchange memory <br> descriptor of the encoder & KV cache <br> (e.g. memory raw ptr) through TCP/zmq
	end
	
	LW ->> LX : Create tensors to store <br> the remote encoder tokens
	LX ->> LX : Register the tensors to the NIXL agent
	LX -> CX : Execute encoder token transfer	
	LX -> CX : Execute KV cache transfer	
	LX ->> LW : Notify the transfer ended <br> to the local scheduler
	LX ->> CX : Notify the transfer ended (automatic)
	LX ->> LX : Deregister the encoder tensors to the NIXL agent
	
	CX ->> CW : Notify the token is freeable.
	CW ->> CW : Decrease reference count <br>  of the tokens. Evict the segment <br>  if there is not enough space.
	
	LW ->> LW : Execute decode
	LW ->> R : Send decoded tokens
```

# Test Plan

The benchmark script is placed in `visualize_benchmark_results.py`. To run a manual inference, try the below script.

```bash
model="Qwen/Qwen2.5-VL-3B-Instruct"

# disagg encode
CUDA_VISIBLE_DEVICES=0 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5560 vllm serve $model \
	--port 8100 \
	--trust-remote-code --enable-request-id-headers \
	--kv-transfer-config \
	'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_encoder_mode":"encoder_only"}' &

# disagg prefill
CUDA_VISIBLE_DEVICES=2 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5561 vllm serve $model \
	--port 8200 \
	--trust-remote-code --enable-request-id-headers \
	--kv-transfer-config \
	'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_encoder_mode":"ep_encoder"}' &

# disagg decode
CUDA_VISIBLE_DEVICES=3 VLLM_NIXL_SIDE_CHANNEL_HOST=localhost VLLM_NIXL_SIDE_CHANNEL_PORT=5562 vllm serve $model \
	--port 8300 \
	--trust-remote-code --enable-request-id-headers \
	--kv-transfer-config \
	'{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
	
# router
python benchmarks/disagg_benchmarks/disagg_epd_route.py &

# workload
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
   -d '{
    "model": "Qwen/Qwen2.5-VL-3B-Instruct",
    "messages": [{
        "role": "user",
        "content": [
            {
                "type": "text",
                "text": "How many things are in the image? Describe each object."
            },
            {
                "type": "image_url",
                "image_url": {
                    "url": "https://picsum.photos/id/237/200/300"
                }
            }
        ]
    }]
}'
```

# Test Result

- Environment: 2x A4500 with NVLink
- Dataset: Random dataset (`vllm bench serve --dataset-name random-mm`)
- Inputs: 32 / 1024 tokens, Outputs: 32 tokens, Image: 512x512 (324 toks) / 1024x1024 (1369 toks) per request
- Query per second (QPS): 2 to 6 or 8 queries
- Model: Qwen/Qwen2.5-VL-3B-Instruct
- Baseline: E-PD disaggregation vs Monolith (single GPU, no disaggregation)

## Mean TTFT

- In: 1024 / Out: 32 / Image: 512x512
<img width="1100" height="700" alt="mean_ttft_ms-inl-1024-outl-32-imgl-512" src="https://github.com/user-attachments/assets/900575cf-d855-499c-89c2-69a063dfd588" />

- In: 32 / Out: 32 / Image: 1024x1024
<img width="1100" height="700" alt="mean_ttft_ms-inl-32-outl-32-imgl-1024" src="https://github.com/user-attachments/assets/70419c36-4bb0-491c-9b7f-fbf211d46b75" />

- In: 1024 / Out: 32 / Image: 1024x1024
<img width="1100" height="700" alt="mean_ttft_ms-inl-1024-outl-32-imgl-1024" src="https://github.com/user-attachments/assets/70794c1a-ec7a-4054-afcc-776668de7d5b" />

For the case above QPS 5 with 1024px image, half of the requests (~150 reqs) were unsuccessful due to the timeout.

## Mean ITL

- In: 1024 / Out: 32 / Image: 512x512
<img width="1100" height="700" alt="mean_itl_ms-inl-1024-outl-32-imgl-512" src="https://github.com/user-attachments/assets/519aa287-9ed7-4fb3-bdde-5723d1f363a7" />

- In: 32 / Out: 32 / Image: 1024x1024
<img width="1100" height="700" alt="mean_itl_ms-inl-32-outl-32-imgl-1024" src="https://github.com/user-attachments/assets/38699ef7-7f7b-4b4c-b211-6cc9542b665d" />

- In: 1024 / Out: 32 / Image: 1024x1024
<img width="1100" height="700" alt="mean_itl_ms-inl-1024-outl-32-imgl-1024" src="https://github.com/user-attachments/assets/b63cec43-e801-40d7-b6d3-74decf735c6f" />

## Goodput

- In: 1024 / Out: 32 / Image: 512x512 / SLO: TTFT < 1000ms, TPOT: 80ms
    
<img width="1100" height="700" alt="goodput_percentage-inl-1024-outl-32-imgl-512" src="https://github.com/user-attachments/assets/c775107b-2b9c-4ef1-9bc6-6a3e934d1d93" />

- In: 32 / Out: 32 / Image: 1024x1024 / SLO: TTFT < 4000ms, TPOT: 200ms
<img width="1100" height="700" alt="goodput_percentage-inl-32-outl-32-imgl-1024" src="https://github.com/user-attachments/assets/cec39c59-282f-41c3-a529-f64121b55cdf" />

- In: 32 / Out: 32 / Image: 1024x1024 / SLO: TTFT < 4000ms, TPOT: 600ms
<img width="1100" height="700" alt="goodput_percentage-inl-1024-outl-32-imgl-1024" src="https://github.com/user-attachments/assets/45d15105-e7bd-4eba-af99-517953a7205e" />

# Current problems

- LLM weights are allocated in GPU even if the worker is set to encoder-only. We need to make it load only encoder weights.
- Two separated NIXL transfer (KV cache + encoder tokens) requests from a decoder worker will be executed when using EP-D and E-P-D disaggregation.
    - This is necessary since we cannot combine source transfer descriptors (`xfer_descs`) of encoder token tensors and KV cache.
    - Currently, `notif_id` is set to `{request_id}:{kv_cache_tp_ratio}${multi_modal_tp_ratio}`.  (`multi_modal_tp_radio` is set to 0 when the request does not require remote encoder).
        - The sender will be notified for `kv_cache_tp_ratio` + `multi_modal_tp_ratio` times.
- NIXL P-D disaggregation is 15x slower than NCCL connector.
  - This is also observed in the main branch in my environment. We should check whether there is an environmental problem