### PR TITLE
chore: remove useless check to perform import for entry_points

### DIFF
--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -15,11 +15,7 @@ plugins_loaded = False
 
 
 def load_plugins_by_group(group: str) -> dict[str, Callable[[], Any]]:
-    import sys
-    if sys.version_info < (3, 10):
-        from importlib_metadata import entry_points
-    else:
-        from importlib.metadata import entry_points
+    from importlib.metadata import entry_points
 
     allowed_plugins = envs.VLLM_PLUGINS
 

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -45,12 +45,7 @@ BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
 def _load_logitsprocs_plugins() -> list[type[LogitsProcessor]]:
     """Load all installed logit processor plugins"""
 
-    import sys
-
-    if sys.version_info < (3, 10):
-        from importlib_metadata import entry_points
-    else:
-        from importlib.metadata import entry_points
+    from importlib.metadata import entry_points
 
     installed_logitsprocs_plugins = entry_points(group=LOGITSPROCS_GROUP)
     if len(installed_logitsprocs_plugins) == 0:


### PR DESCRIPTION
The check is was on sys.version to be < 3.10, but then an identical code was run. This change removes the superfluous check.
