### PR TITLE
[Perf] Optimize reshape_and_cache CUDA Kernel

### DIFF
--- a/benchmarks/kernels/benchmark_reshape_and_cache.py
+++ b/benchmarks/kernels/benchmark_reshape_and_cache.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import random
+import time
+
+import torch
+from tabulate import tabulate
+
+from vllm import _custom_ops as ops
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils import (
+    STR_DTYPE_TO_TORCH_DTYPE,
+    FlexibleArgumentParser,
+    create_kv_caches_with_random,
+)
+
+logger = init_logger(__name__)
+
+
+@torch.inference_mode()
+def run_benchmark(
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+    kv_cache_dtype: str,
+    num_iters: int,
+    benchmark_mode: str,
+    device: str = "cuda",
+) -> float:
+    """Return latency (seconds) for given num_tokens."""
+
+    if kv_cache_dtype == "fp8" and head_size % 16:
+        raise ValueError("fp8 kv-cache requires head_size to be a multiple of 16.")
+
+    current_platform.seed_everything(42)
+    torch.set_default_device(device)
+
+    # create random key / value tensors [T, H, D].
+    key = torch.randn(num_tokens, num_heads, head_size, dtype=dtype, device=device)
+    value = torch.randn_like(key)
+
+    # prepare the slot mapping.
+    # each token is assigned a unique slot in the KV-cache.
+    num_slots = block_size * num_blocks
+    if num_tokens > num_slots:
+        raise ValueError("num_tokens cannot exceed the total number of cache slots")
+    slot_mapping_lst = random.sample(range(num_slots), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+
+    key_caches, value_caches = create_kv_caches_with_random(
+        num_blocks,
+        block_size,
+        1,  # num_layers
+        num_heads,
+        head_size,
+        kv_cache_dtype,
+        dtype,
+        device=device,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+    # to free unused memory
+    del key_caches, value_caches
+
+    # compute per-kernel scaling factors for fp8 conversion (if used).
+    k_scale = (key.amax() / 64.0).to(torch.float32)
+    v_scale = (value.amax() / 64.0).to(torch.float32)
+
+    function_under_test = lambda: ops.reshape_and_cache(
+        key,  # noqa: F821
+        value,  # noqa: F821
+        key_cache,  # noqa: F821
+        value_cache,  # noqa: F821
+        slot_mapping,  # noqa: F821
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )
+
+    if benchmark_mode == "cudagraph":
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            function_under_test()
+        torch.cuda.synchronize()
+        function_under_test = lambda: g.replay()
+
+    def run_cuda_benchmark(n_iters: int) -> float:
+        nonlocal key, value, key_cache, value_cache, slot_mapping
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        for _ in range(n_iters):
+            function_under_test()
+            torch.cuda.synchronize()
+        end = time.perf_counter()
+        return (end - start) / n_iters
+
+    # warm-up
+    run_cuda_benchmark(3)
+
+    lat = run_cuda_benchmark(num_iters)
+
+    # free tensors to mitigate OOM when sweeping
+    del key, value, key_cache, value_cache, slot_mapping
+    torch.cuda.empty_cache()
+
+    return lat
+
+
+def main(args):
+    rows = []
+    for exp in range(1, 17):
+        n_tok = 2**exp
+        lat = run_benchmark(
+            num_tokens=n_tok,
+            num_heads=args.num_heads,
+            head_size=args.head_size,
+            block_size=args.block_size,
+            num_blocks=args.num_blocks,
+            dtype=STR_DTYPE_TO_TORCH_DTYPE[args.dtype],
+            kv_cache_dtype=args.kv_cache_dtype,
+            num_iters=args.iters,
+            benchmark_mode=args.mode,
+            device="cuda",
+        )
+        rows.append([n_tok, "HDN", f"{lat * 1e6:.3f}"])
+
+    print(
+        f"Benchmark results for implementation cuda"
+        f" (measuring with {args.mode}):"
+    )
+    print(tabulate(rows, headers=["num_tokens", "layout", "latency (µs)"]))
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser()
+
+    parser.add_argument("--num-heads", type=int, default=128)
+    parser.add_argument(
+        "--head-size",
+        type=int,
+        choices=[64, 80, 96, 112, 120, 128, 192, 256],
+        default=128,
+    )
+    parser.add_argument("--block-size", type=int, choices=[16, 32], default=16)
+    parser.add_argument("--num-blocks", type=int, default=128 * 512)
+
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        choices=["half", "bfloat16", "float"],
+        default="bfloat16",
+    )
+
+    parser.add_argument(
+        "--kv-cache-dtype",
+        type=str,
+        choices=["auto", "fp8"],
+        default="auto",
+    )
+
+    parser.add_argument("--iters", type=int, default=100)
+
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["cudagraph", "no_graph"],
+        default="cudagraph",
+    )
+
+    args = parser.parse_args()
+
+    main(args)

--- a/benchmarks/kernels/benchmark_reshape_and_cache.py
+++ b/benchmarks/kernels/benchmark_reshape_and_cache.py
@@ -129,10 +129,7 @@ def main(args):
         )
         rows.append([n_tok, "HDN", f"{lat * 1e6:.3f}"])
 
-    print(
-        f"Benchmark results for implementation cuda"
-        f" (measuring with {args.mode}):"
-    )
+    print(f"Benchmark results for implementation cuda (measuring with {args.mode}):")
     print(tabulate(rows, headers=["num_tokens", "layout", "latency (µs)"]))
 
 

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -225,10 +225,14 @@ struct CopyWithScaleOp {
 
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
 __global__ void reshape_and_cache_kernel(
-    const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size//x, x]
-    const scalar_t* __restrict__ value,  // [num_tokens, num_heads, head_size//x, x]
-    cache_t* __restrict__ key_cache,     // [num_blocks, num_heads, head_size//x, block_size, x]
-    cache_t* __restrict__ value_cache,   // [num_blocks, num_heads, head_size//x, x, block_size]
+    const scalar_t* __restrict__ key,  // [num_tokens, num_heads, head_size//x,
+                                       // x]
+    const scalar_t* __restrict__ value,  // [num_tokens, num_heads,
+                                         // head_size//x, x]
+    cache_t* __restrict__ key_cache,    // [num_blocks, num_heads, head_size//x,
+                                        // block_size, x]
+    cache_t* __restrict__ value_cache,  // [num_blocks, num_heads, head_size//x,
+                                        // x, block_size]
     const int64_t* __restrict__ slot_mapping,  // [num_tokens]
     const int key_stride, const int value_stride, const int num_heads,
     const int head_size, const int block_size, const int x,
@@ -251,30 +255,33 @@ __global__ void reshape_and_cache_kernel(
   const int head_idx = h_block_idx / h_block_count;
   const int h_block = h_block_idx % h_block_count;
 
-  const scalar_t* __restrict__ key_src = key + token_idx * key_stride + head_idx * head_size + h_block * x;
-  const int64_t src_value_start = token_idx * value_stride + head_idx * head_size + h_block * x;
+  const scalar_t* __restrict__ key_src =
+      key + token_idx * key_stride + head_idx * head_size + h_block * x;
+  const int64_t src_value_start =
+      token_idx * value_stride + head_idx * head_size + h_block * x;
 
-  cache_t* __restrict__ key_dst = key_cache + block_idx * num_heads * h_block_count * block_size * x
-                              + head_idx * h_block_count * block_size * x
-                              + h_block * block_size * x
-                              + block_offset * x;
-  const int64_t tgt_value_start = block_idx * num_heads * h_block_count * x * block_size
-                                + head_idx * h_block_count * x * block_size
-                                + h_block * x * block_size
-                                + block_offset;
+  cache_t* __restrict__ key_dst =
+      key_cache + block_idx * num_heads * h_block_count * block_size * x +
+      head_idx * h_block_count * block_size * x + h_block * block_size * x +
+      block_offset * x;
+  const int64_t tgt_value_start =
+      block_idx * num_heads * h_block_count * x * block_size +
+      head_idx * h_block_count * x * block_size + h_block * x * block_size +
+      block_offset;
 
   float k_scale_val = (kv_dt == Fp8KVCacheDataType::kAuto) ? 0.f : *k_scale;
   constexpr int VEC_SIZE = (sizeof(scalar_t) == 2) ? 8 : 4;
   CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
   vectorize_with_alignment<VEC_SIZE>(key_src, key_dst, x, 0, 1, k_op);
 
-  #pragma unroll
+#pragma unroll
   for (int i = 0; i < x; i++) {
     scalar_t value_val = value[src_value_start + i];
     if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
       value_cache[tgt_value_start + i * block_size] = value_val;
     } else {
-      value_cache[tgt_value_start + i * block_size] = fp8::scaled_convert<cache_t, scalar_t, kv_dt>(value_val, *v_scale);
+      value_cache[tgt_value_start + i * block_size] =
+          fp8::scaled_convert<cache_t, scalar_t, kv_dt>(value_val, *v_scale);
     }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
FIX #25705 

## Method
- the shape of  key/value is: num_tokens * num_heads * head_size
- the shape of key_cache is: num_blocks * num_heads * (head_size // x) * block_size * x
- the shape of value_cache is: num_blocks * num_heads * head_size * block_size

then i viewed them in shape as:
- the shape of  key/value is: num_tokens * num_heads * (head_size // x) * x
- the shape of key_cache is: num_blocks * num_heads * (head_size // x) * block_size * x
- the shape of value_cache is: num_blocks * num_heads * (head_size// x) * x * block_size

that is to say that if we start the kernel in config as grid(num_tokens), block(num_heads * head_size // x)
we process each token's kv_cache in a block
the block size is num_heads * head_size // x
so by the threadIdx we could read a contiguous x elements in key/value
then apply vectorize op in key_cache and use naive loop method for value_cache
that's how it worked

I doubt whether there are efficient scatter kernel in cuda that can speed up the value_cache's op, cause value_cache need's to 
fill in the data in a stride of block_size for every element, maybe there still potential for speeding up?

## Test Plan
for time cost test, i add a benchmark_reshape_and_cache.py into benchmark/kernels, which almost copy the benchmark/kernels/benchmark_reshape_and_cache_flash.py

for accuary test, it has been implemented in tests/kernels/attention/test_cache.py::test_reshape_and_cache
the kernel implemented can passed it fully

## Test Result
python benchmark/kernels/benckmark_reshape_and_cache.py --num-heads 64 --head-size 64
| num_tokens | latency_old (µs) | latency_new (µs) | Change (%) |
|------------|---------------------|---------------------|------------------------|
| 2          | 10.548              | 11.796              | +11.83%                |
| 4          | 10.297              | 11.178              | +8.56%                 |
| 8          | 10.355              | 11.196              | +8.12%                 |
| 16         | 10.087              | 12.026              | +19.22%                |
| 32         | 10.934              | 12.105              | +10.71%                |
| 64         | 12.617              | 15.353              | +21.68%                |
| 128        | 19.795              | 23.331              | +17.86%                |
| 256        | 49.896              | 52.235              | +4.69%                 |
| 512        | 134.205             | 124.531             | -7.21%              |
| 1024       | 280.939             | 250.043             | -11.00%            |
| 2048       | 596.014             | 529.813             | -11.11%             |
| 4096       | 1196.63             | 1057.45             | -11.63%             |
| 8192       | 2375.14             | 2096.88             | -11.72%             |
| 16384      | 4730.87             | 4178.63             | -11.67%             |
| 32768      | 9476.05             | 8334.58             | -12.05%             |
| 65536      | 18945               | 16653               | -12.10%           |
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x ] The test plan, such as providing test command.
- [ x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

