### PR TITLE
[ROCm][Bugfix] Add missing parameter to ROCm backend

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -175,6 +175,7 @@ class RocmAttentionBackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")


### PR DESCRIPTION
Follow up to #25896 that skipped ROCm attention backend when adding the new parameter to get_kv_cache_shape