### PR TITLE
[Bugfix] Don't use FULL_AND_PIECEWISE cudagraph for Llama4

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -329,11 +329,12 @@ class VllmConfig:
                     self.compilation_config.cudagraph_mode = \
                         CUDAGraphMode.FULL_AND_PIECEWISE
 
-                    # pooling models and encoder-decoder models
-                    # do not support full cudagraphs
+                    # pooling models, encoder-decoder models, and models with
+                    # chunked attention do not support full cudagraphs
                     if self.model_config is not None and \
                         (self.model_config.pooler_config is not None
-                         or self.model_config.is_encoder_decoder):
+                         or self.model_config.is_encoder_decoder
+                         or self.model_config.attention_chunk_size is not None):
                         self.compilation_config.cudagraph_mode = \
                             CUDAGraphMode.PIECEWISE
                 else:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

FIX https://github.com/vllm-project/vllm/issues/25960

## Test Plan

## Test Result

```
vllm serve RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16 --load-format dummy --max-model-len 32K
...
... 'cudagraph_mode': <CUDAGraphMode.PIECEWISE: 1>, ...
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

