### PR TITLE
Change FLASHINFER_WORKSPACE_BUFFER_SIZE to be configurable by envvar

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from typing import ClassVar
-
+import os
 import numpy as np
 import torch
 from flashinfer import (
@@ -51,7 +51,7 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 
-FLASHINFER_WORKSPACE_BUFFER_SIZE = 256 * 1024 * 1024
+FLASHINFER_WORKSPACE_BUFFER_SIZE = int(os.environ.get("FLASHINFER_WORKSPACE_BUFFER_SIZE", 256 * 1024 * 1024)) 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 
 FP8_DTYPE = current_platform.fp8_dtype()


### PR DESCRIPTION
Summary: We start to see error on not enough allocated workplace buffer in flsahinfer when running long context with large bs. Add option to tune the buffer by envvar

Test Plan:
```
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
VLLM_DISABLE_COMPILE_CACHE=1 \
VLLM_GPU_MEMORY_UTILIZATION=0.90 \
VLLM_USE_V1=1 \
FLASHINFER_WORKSPACE_BUFFER_SIZE=$((1024*1024*1024))
buck2 run @//mode/opt \
  -m ovr_config//triton:trunk \
  -c fbcode.enable_vllm=true \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=h100a \
  //smart/inference_platform_sp/llm_predictor_gpu:service -- \
  --local_cache_dir "/data/local/models/Qwen3-VL-235B-A22B-Thinking" \
  --try_local_cache \
  --thrift_server_port 12345 \
  --max_seq_len=65536 \
  --max_num_batched_tokens 65536 \
  --max_concurrent_requests_multiplier=2 \
  --max_batch_size=64 \
  --enable_warmup=true \
  --model_mf_bucket=llm_inference \
  --model_mf_path=tree/oss/Qwen3-VL-235B-A22B-Thinking \
  --force_llm_format=true \
  --allow_custom_stop_tokens \
  --model_parallel_size 8 \
  --enable-expert-parallel \
  --vllm_engine \
  2>&1 | tee "/tmp/$USER/server_vllm.log"
```

Differential Revision: D83693814


