### PR TITLE
[Bugfix] Disable FlashInfer MLA prefill by default due to chunked prefill issues

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     VLLM_CONFIG_ROOT: str = os.path.expanduser("~/.config/vllm")
     VLLM_USAGE_STATS_SERVER: str = "https://stats.vllm.ai"
     VLLM_NO_USAGE_STATS: bool = False
-    VLLM_DISABLE_FLASHINFER_PREFILL: bool = False
+    VLLM_DISABLE_FLASHINFER_PREFILL: bool = True
     VLLM_DO_NOT_TRACK: bool = False
     VLLM_USAGE_SOURCE: str = ""
     VLLM_CONFIGURE_LOGGING: int = 1
@@ -557,7 +557,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_NO_USAGE_STATS":
     lambda: os.environ.get("VLLM_NO_USAGE_STATS", "0") == "1",
     "VLLM_DISABLE_FLASHINFER_PREFILL":
-    lambda: os.environ.get("VLLM_DISABLE_FLASHINFER_PREFILL", "0") == "1",
+    lambda: os.environ.get("VLLM_DISABLE_FLASHINFER_PREFILL", "1") == "1",
     "VLLM_DO_NOT_TRACK":
     lambda: (os.environ.get("VLLM_DO_NOT_TRACK", None) or os.environ.get(
         "DO_NOT_TRACK", None) or "0") == "1",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Address https://github.com/vllm-project/vllm/issues/26042 for now to unblock the release. We will take a performance regression on B200 due to falling back to FA2 prefill, but we need correctness first.

## Test Plan

## Test Result

```
Base commands:
vllm serve deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
python tests/evals/gsm8k/gsm8k_eval.py

# Hopper

vllm serve deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
Accuracy: 0.794

# Blackwell

## Default backends (FlashInfer prefill and CUTLASS MLA decode)
vllm serve deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
Accuracy: 0.216

## Using FA2 prefill and CUTLASS MLA decode
VLLM_DISABLE_FLASHINFER_PREFILL=1 vllm serve deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
Accuracy: 0.785
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

