### PR TITLE
[CI Failure] fix_test_auto_prefix_cache_support

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1917,7 +1917,7 @@ def test_priority_scheduling_preemption_when_out_of_kv():
 def test_chunked_prefill_disabled_for_encoder_decoder(
         enable_chunked_prefill: bool, is_encoder_decoder: bool,
         expect_enabled: bool) -> None:
-    """Validate that chunked prefill is appropriately disabled for 
+    """Validate that chunked prefill is appropriately disabled for
     encoder-decoder models."""
     scheduler_config = SchedulerConfig(
         enable_chunked_prefill=enable_chunked_prefill,
@@ -1942,7 +1942,7 @@ def test_chunked_prefill_disabled_for_encoder_decoder(
 def _validate_chunked_prefill_settings_for_encoder_decoder(
         scheduler_config: SchedulerConfig, is_encoder_decoder: bool,
         expect_enabled: bool) -> None:
-    """Validate chunked prefill settings in the scheduler config for 
+    """Validate chunked prefill settings in the scheduler config for
     encoder-decoder models."""
     assert scheduler_config.chunked_prefill_enabled is expect_enabled
     assert scheduler_config.enable_chunked_prefill is expect_enabled


### PR DESCRIPTION
## Purpose

Recent changes from https://github.com/vllm-project/vllm/pull/25075 breaks two tests from `tests/models/language/pooling/test_auto_prefix_cache_support.py` (https://buildkite.com/vllm/ci/builds/33031/steps/canvas?sid=01999dee-5c62-422e-9c31-054b1091dc6b).

Per suggestion, the breaking change from previous PR is from https://github.com/vllm-project/vllm/blob/main/vllm/config/vllm.py#L399-L402 or
```
        if (self.scheduler_config.chunked_prefill_enabled is False
                or disable_chunked_prefill_reasons):
```
This PR is changing this predicate by considering `self.cache_config.enable_prefix_caching` as well.

## Test Plan

```
pytest -v -s tests/models/language/pooling/test_auto_prefix_cache_support.py

pytest -v -s tests/v1/core/test_scheduler.py
```

## Test Result

both succeed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

