### PR TITLE
[RFC] Default no plugin loading

### DIFF
--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -22,6 +22,8 @@ def load_plugins_by_group(group: str) -> dict[str, Callable[[], Any]]:
         from importlib.metadata import entry_points
 
     allowed_plugins = envs.VLLM_PLUGINS
+    if not allowed_plugins:
+        return {}
 
     discovered_plugins = entry_points(group=group)
     if len(discovered_plugins) == 0:
@@ -37,16 +39,10 @@ def load_plugins_by_group(group: str) -> dict[str, Callable[[], Any]]:
     for plugin in discovered_plugins:
         log_level("- %s -> %s", plugin.name, plugin.value)
 
-    if allowed_plugins is None:
-        log_level("All plugins in this group will be loaded. "
-                  "Set `VLLM_PLUGINS` to control which plugins to load.")
-
     plugins = dict[str, Callable[[], Any]]()
     for plugin in discovered_plugins:
-        if allowed_plugins is None or plugin.name in allowed_plugins:
-            if allowed_plugins is not None:
-                log_level("Loading plugin %s", plugin.name)
-
+        if plugin.name in allowed_plugins:
+            log_level("Loading plugin %s", plugin.name)
             try:
                 func = plugin.load()
                 plugins[plugin.name] = func


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
 
This is a user-facing breaking change, so RFC here.
There are a bunch of tests need to be fixed but I'll do those after the RFC is agreed.

Currently vLLM loads all general plugins by default, this makes it hard for us to distribute some packages. We do not want some plugins installed in our package to be loaded by default. Users should explicitly turn on plugins using `VLLM_PLUGINS` instead of vLLM turning it on by default. Current behavior of loading general plugins by default feels like a black box.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

