### PR TITLE
Fix relative file paths in coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -37,3 +37,5 @@ output = coverage.xml
 
 
 
+
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -41,3 +41,5 @@ output = coverage.xml
 
 
 
+
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -39,3 +39,5 @@ output = coverage.xml
 
 
 
+
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -32,3 +32,5 @@ directory = htmlcov
 [xml]
 output = coverage.xml
 
+
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [run]
 source = vllm
-relative_files = True
 omit =
     */tests/*
     */test_*
@@ -13,13 +12,6 @@ omit =
     */benchmarks/*
     */docs/*
 
-[paths]
-# Normalize all variants of the vllm package location to the single canonical "vllm" path
-source =
-    vllm
-    /vllm-workspace/vllm
-    */site-packages/vllm
-    */dist-packages/vllm
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -35,3 +35,5 @@ output = coverage.xml
 
 
 
+
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -34,3 +34,4 @@ output = coverage.xml
 
 
 
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 source = vllm
+relative_files = True
 omit =
     */tests/*
     */test_*
@@ -11,6 +12,14 @@ omit =
     */examples/*
     */benchmarks/*
     */docs/*
+
+[paths]
+# Normalize all variants of the vllm package location to the single canonical "vllm" path
+source =
+    vllm
+    /vllm-workspace/vllm
+    */site-packages/vllm
+    */dist-packages/vllm
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -39,3 +39,4 @@ directory = htmlcov
 
 [xml]
 output = coverage.xml
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: false
+
+fixes:
+  - "^/usr/.*/site-packages/vllm/::vllm/"
+  - "^/usr/.*/dist-packages/vllm/::vllm/"
+  - "^/vllm-workspace/vllm/::vllm/"
+
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-codecov:
-  require_ci_to_pass: false
-
-fixes:
-  - "^/usr/.*/site-packages/vllm/::vllm/"
-  - "^/usr/.*/dist-packages/vllm/::vllm/"
-  - "^/vllm-workspace/vllm/::vllm/"
-
-


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This is to fix coverage results not being merged correctly due to tests having differing working_dirs.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

