### PR TITLE
[Bugfix] Fix import `gemm_afp4wfp4` failure on AMD

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -97,7 +97,7 @@ try:
         dispatch_key=current_platform.dispatch_key,
     )
 
-except ImportError:
+except (ImportError, AttributeError):
     dynamic_mxfp4_quant = gemm_afp4wfp4 = None
 
 __all__ = ["QuarkW4A4MXFP4"]


### PR DESCRIPTION
## Purpose
We are seeing these error after #25135 on AMD MI300X:
```
  File "vllm/v1/engine/async_llm.py", line 231, in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
  File "vllm/engine/arg_utils.py", line 1142, in create_engine_config
    model_config = self.create_model_config()
  File "vllm/engine/arg_utils.py", line 994, in create_model_config
    return ModelConfig(
  File "pydantic/_internal/_dataclasses.py", line 123, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  File "vllm/config/model.py", line 648, in __post_init__
    self._verify_quantization()
  File "vllm/config/model.py", line 935, in _verify_quantization
    method = me_quant.get_quantization_config(name)
  File "vllm/model_executor/layers/quantization/__init__.py", line 86, in get_quantization_config
    from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
  File "vllm/model_executor/layers/quantization/quark/quark.py", line 19, in <module>
    from vllm.model_executor.layers.quantization.quark.schemes import (
  File "vllm/model_executor/layers/quantization/quark/schemes/__init__.py", line 5, in <module>
    from .quark_w4a4_mxfp4 import QuarkW4A4MXFP4
  File "vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py", line 28, in <module>
    from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4
  File "aiter/ops/triton/gemm_afp4wfp4.py", line 40, in <module>
    def _gemm_afp4_wfp4_kernel(
  File "triton/runtime/jit.py", line 852, in jit
    return decorator(fn)
  File "triton/runtime/jit.py", line 840, in decorator
    return JITFunction(
  File "triton/runtime/jit.py", line 667, in __init__
    src = src[re.search(r"^def\s+\w+\s*\(", src, re.MULTILINE).start():]
AttributeError: 'NoneType' object has no attribute 'start'
```
`gemm_afp4wfp4` is a CUDA only triton kernel, so it will crash under JIT-compile with ROCM

## Test Plan
