### PR TITLE
[FEAT] [AITER] [ROCm] integrate aiter sampling ops

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -432,76 +432,6 @@ def _rocm_aiter_rmsnorm2d_fwd_with_add_fake(
     return torch.empty_like(x), torch.empty_like(residual)
 
 
-def _rocm_aiter_top_k_renorm_probs_impl(
-    probs: torch.Tensor,
-    k_tensor: torch.Tensor | None = None,
-    k_scalar: int = 0,
-) -> torch.Tensor:
-    from aiter.ops.sampling import top_k_renorm_probs
-
-    return top_k_renorm_probs(probs, k_tensor, k_scalar)
-
-
-def _rocm_aiter_top_k_renorm_probs_fake(
-    probs: torch.Tensor,
-    k_tensor: torch.Tensor | None = None,
-    k_scalar: int = 0,
-) -> torch.Tensor:
-    return torch.empty_like(probs)
-
-
-def _rocm_aiter_top_p_sampling_from_probs_impl(
-    probs: torch.Tensor,
-    rand_values: torch.Tensor | None = None,
-    p_tensor: torch.Tensor | None = None,
-    p_scalar: float = 0.0,
-    deterministic: bool = True,
-) -> torch.Tensor:
-    from aiter.ops.sampling import top_p_sampling_from_probs
-
-    return top_p_sampling_from_probs(
-        probs, rand_values, p_tensor, p_scalar, deterministic
-    )
-
-
-def _rocm_aiter_top_p_sampling_from_probs_fake(
-    probs: torch.Tensor,
-    rand_values: torch.Tensor | None = None,
-    p_tensor: torch.Tensor | None = None,
-    p_scalar: float = 0.0,
-    deterministic: bool = True,
-) -> torch.Tensor:
-    return torch.empty((probs.shape[0],), dtype=torch.int64, device=probs.device)
-
-
-def _rocm_aiter_top_k_top_p_sampling_from_probs_impl(
-    probs: torch.Tensor,
-    rand_values: torch.Tensor | None = None,
-    k_tensor: torch.Tensor | None = None,
-    k_scalar: int = 0,
-    p_tensor: torch.Tensor | None = None,
-    p_scalar: float = 0.0,
-    deterministic: bool = True,
-) -> torch.Tensor:
-    from aiter.ops.sampling import top_k_top_p_sampling_from_probs
-
-    return top_k_top_p_sampling_from_probs(
-        probs, rand_values, k_tensor, k_scalar, p_tensor, p_scalar, deterministic
-    )
-
-
-def _rocm_aiter_top_k_top_p_sampling_from_probs_fake(
-    probs: torch.Tensor,
-    rand_values: torch.Tensor | None = None,
-    k_tensor: torch.Tensor | None = None,
-    k_scalar: int = 0,
-    p_tensor: torch.Tensor | None = None,
-    p_scalar: float = 0.0,
-    deterministic: bool = True,
-) -> torch.Tensor:
-    return torch.empty((probs.shape[0],), dtype=torch.int64, device=probs.device)
-
-
 def _aiter_to_tensor_scalar_tuple(x):
     if isinstance(x, torch.Tensor):
         return (x, 0)
@@ -704,30 +634,6 @@ class rocm_aiter_ops:
                 op_func=_rocm_aiter_rmsnorm2d_fwd_with_add_impl,
                 mutates_args=[],
                 fake_impl=_rocm_aiter_rmsnorm2d_fwd_with_add_fake,
-                dispatch_key=current_platform.dispatch_key,
-            )
-
-            direct_register_custom_op(
-                op_name="rocm_aiter_top_k_renorm_probs",
-                op_func=_rocm_aiter_top_k_renorm_probs_impl,
-                mutates_args=[],
-                fake_impl=_rocm_aiter_top_k_renorm_probs_fake,
-                dispatch_key=current_platform.dispatch_key,
-            )
-
-            direct_register_custom_op(
-                op_name="rocm_aiter_top_p_sampling_from_probs",
-                op_func=_rocm_aiter_top_p_sampling_from_probs_impl,
-                mutates_args=[],
-                fake_impl=_rocm_aiter_top_p_sampling_from_probs_fake,
-                dispatch_key=current_platform.dispatch_key,
-            )
-
-            direct_register_custom_op(
-                op_name="rocm_aiter_top_k_top_p_sampling_from_probs",
-                op_func=_rocm_aiter_top_k_top_p_sampling_from_probs_impl,
-                mutates_args=[],
-                fake_impl=_rocm_aiter_top_k_top_p_sampling_from_probs_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
 
@@ -1086,7 +992,9 @@ class rocm_aiter_ops:
         k_tensor: torch.Tensor | None = None,
         k_scalar: int = 0,
     ) -> torch.Tensor:
-        return torch.ops.vllm.rocm_aiter_top_k_renorm_probs(probs, k_tensor, k_scalar)
+        from aiter.ops.sampling import top_k_renorm_probs
+
+        return top_k_renorm_probs(probs, k_tensor, k_scalar)
 
     @staticmethod
     def top_p_sampling_from_probs(
@@ -1096,7 +1004,9 @@ class rocm_aiter_ops:
         p_scalar: float = 0.0,
         deterministic: bool = True,
     ) -> torch.Tensor:
-        return torch.ops.vllm.rocm_aiter_top_p_sampling_from_probs(
+        from aiter.ops.sampling import top_p_sampling_from_probs
+
+        return top_p_sampling_from_probs(
             probs, rand_values, p_tensor, p_scalar, deterministic
         )
 
@@ -1110,7 +1020,9 @@ class rocm_aiter_ops:
         p_scalar: float = 0.0,
         deterministic: bool = True,
     ) -> torch.Tensor:
-        return torch.ops.vllm.rocm_aiter_top_k_top_p_sampling_from_probs(
+        from aiter.ops.sampling import top_k_top_p_sampling_from_probs
+
+        return top_k_top_p_sampling_from_probs(
             probs, rand_values, k_tensor, k_scalar, p_tensor, p_scalar, deterministic
         )
 

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -471,7 +471,6 @@ def _rocm_aiter_top_p_sampling_from_probs_fake(
     p_scalar: float = 0.0,
     deterministic: bool = True,
 ) -> torch.Tensor:
-    # 返回 token id，形状为 [batch_size]
     return torch.empty((probs.shape[0],), dtype=torch.int64, device=probs.device)
 
 
@@ -607,12 +606,6 @@ class rocm_aiter_ops:
     @if_aiter_supported
     def is_triton_gemm_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._TRITON_UNQUANT_GEMM
-
-    @classmethod
-    @if_aiter_supported
-    def is_sampler_enabled(cls) -> bool:
-        """Verifies device specs and availability of env variable."""
-        return cls._AITER_ENABLED
 
     @staticmethod
     @if_aiter_supported

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -21,6 +21,9 @@ try:
 except ImportError:
     is_flashinfer_available = False
 
+_aiter_ops = None
+_triton_topk = None
+
 
 class TopKTopPSampler(nn.Module):
     """

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -21,9 +21,6 @@ try:
 except ImportError:
     is_flashinfer_available = False
 
-_aiter_ops = None
-_triton_topk = None
-
 
 class TopKTopPSampler(nn.Module):
     """
@@ -245,6 +242,82 @@ class TopKTopPSampler(nn.Module):
         raise RuntimeError(
             "aiter_sample was called with no active top-k or top-p.")
 
+    def aiter_sample(
+        self,
+        logits: torch.Tensor,
+        k: Optional[torch.Tensor],
+        p: Optional[torch.Tensor],
+        generators: dict[int, torch.Generator],
+    ) -> torch.Tensor:
+        """Sample from logits using aiter ops."""
+        B = logits.size(0)
+        device = logits.device
+
+        # Normalize k (support scalar or per-batch) - This part is necessary
+        maybe_k_arr: Optional[torch.Tensor] = None
+        top_k_val: int = 0
+        if k is not None:
+            if torch.is_tensor(k):
+                k = k.view(-1)
+                if k.numel() not in [1, B]:
+                    raise RuntimeError("top-k tensor size must be 1")
+                maybe_k_arr = k.to(device=device, dtype=torch.int32)
+            else:
+                top_k_val = int(k)
+
+        # Normalize p (support scalar or per-batch) - This part is necessary
+        maybe_p_arr: Optional[torch.Tensor] = None
+        top_p_val: float = 0.0
+        if p is not None:
+            if torch.is_tensor(p):
+                p = p.view(-1)
+                if p.numel() == 1:
+                    maybe_p_arr = p.to(device=device,
+                                       dtype=torch.float32).expand(B)
+                else:
+                    assert p.numel() == B
+                    maybe_p_arr = p.to(device=device, dtype=torch.float32)
+            else:
+                top_p_val = float(p)
+
+        use_top_k = top_k_val > 0 or maybe_k_arr is not None
+        use_top_p = (maybe_p_arr is not None) or (0.0 < top_p_val < 1.0)
+
+        # Joint k+p path
+        if use_top_p and use_top_k:
+            logger.info_once("k+p path")
+            probs = logits.softmax(dim=-1, dtype=torch.float32).contiguous()
+            next_token_ids = self.aiter_ops.top_k_top_p_sampling_from_probs(
+                probs,
+                None,
+                maybe_k_arr,
+                top_k_val,
+                maybe_p_arr,
+                top_p_val,
+                deterministic=True,
+            )
+            return next_token_ids.view(-1)
+
+        # Top-p only path
+        elif use_top_p:
+            logger.info_once("p path")
+            # This path needs probs, so we compute it here.
+            probs = logits.softmax(dim=-1, dtype=torch.float32).contiguous()
+            next_token_ids = self.aiter_ops.top_p_sampling_from_probs(
+                probs, None, maybe_p_arr, top_p_val, deterministic=True)
+            return next_token_ids.view(-1)
+
+        # Top-k only path
+        elif use_top_k:
+            logger.info_once("k path")
+            probs = logits.softmax(dim=-1, dtype=torch.float32).contiguous()
+            renorm_probs = self.aiter_ops.top_k_renorm_probs(
+                probs, maybe_k_arr, top_k_val)
+            return torch.multinomial(renorm_probs, num_samples=1).view(-1)
+
+        raise RuntimeError(
+            "aiter_sample was called with no active top-k or top-p.")
+
 
 # Note: this is a workaround for
 # https://github.com/pytorch/pytorch/pull/151218
@@ -395,7 +468,6 @@ def flashinfer_sample(
         )
 
     return next_token_ids.view(-1)
-
 
 def _to_tensor_scalar_tuple(x):
     if isinstance(x, torch.Tensor):

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -86,7 +86,7 @@ class TopKTopPSampler(nn.Module):
             self.forward = self.forward_cpu
         elif (
             logprobs_mode not in ("processed_logits", "processed_logprobs")
-            and rocm_aiter_ops.is_sampler_enabled()
+            and rocm_aiter_ops.is_enabled()
         ):
             logger.info_once("Using rocm_aiter_ops for top-p & top-k sampling.")
             self.forward = self.forward_hip

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import os
 from typing import Optional
 
 import torch


### PR DESCRIPTION
## Purpose

To significantly improve the performance of top-k/top-p sampling on AMD ROCm GPUs, this PR integrates the optimized aiter sampling operator, replacing the default PyTorch native implementation.

The new aiter path is activated when the VLLM_ROCM_USE_AITER_SAMPLER environment variable is set to 1. The core changes are located in vllm/v1/sample/ops/topk_topp_sampler.py.

Validated on aiter commit: `6b586ae`

## Test Plan
Comprehensive correctness and performance tests were conducted on AMD MI300X GPUs to validate the feat and analyze its performance impact.

Server Configuration
The aiter sampling kernel on the ROCm platform is controlled by the VLLM_ROCM_USE_AITER master switch. The behavior is as follows:

PyTorch Native (Default): The PyTorch native implementation is used by default. This occurs if the VLLM_ROCM_USE_AITER environment variable is not set, or is explicitly set to 0.

Aiter Sampling (Enabled): To enable the optimized aiter sampler, the environment variable must be set: 
`export VLLM_ROCM_USE_AITER=1`

Part A Correctness Test (lm_eval):
Used the lm_eval suite to test the gsm8k task.
Goal: Further verify the accuracy of the new operator

Part B Performance Test (benchserver)
Used an vLLM benchmark script to end-to-end conduct stress tests.
Goal: Compare throughput (tok/s) and latency (TPOT) between the pytorch native and the aiter sampling.

The following command was used, with sampling flags (--top-p, --top-k) adjusted for each scenario:

Server startup:

```
export TORCHDYNAMO_DISABLE=1
export VLLM_USE_V1=1
# aiter
export VLLM_ROCM_USE_AITER=1
# pytorch native
export VLLM_ROCM_USE_AITER=0 or no set

export HIP_VISIBLE_DEVICES=1,2
vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
    --tensor-parallel-size 2 \
    --trust-remote-code \
    --swap-space 16 \
    --disable-log-requests \
    --distributed-executor-backend mp \
    --quantization fp8 \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.9 \
    --max-num-seqs 128 \
    --max-num-batched-tokens 131072 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --port 8001

```


Client startup:

top-p example

```
vllm bench serve \
    --backend vllm \
    --model "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8" \
    --dataset-name random \
    --random-input-len 1000 \
    --random-output-len 1000 \
    --num-prompts 640 \
    --max-concurrency 64 \
    --save-result \
    --trust-remote-code \
    --port 8001 \
    --endpoint /v1/completions \
    --top-p 0.95 \
    --top-k 0 \
    --temperature 0.1
```
top-k and top p+k can be adjusted flexibly


## Test Result
Part A: Using lm_eval test
We conducted detailed tests on AMD MI300X GPUs, using the Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 model, and performed three-way comparison tests of top-p, top-k, and top-p+k for PyTorch native and aiter sampling, as shown in the following figure, and then Figure 1

<img width="1461" height="652" alt="Screenshot 2025-10-04 at 22 58 57" src="https://github.com/user-attachments/assets/b559536e-a9e0-4abf-a04b-7cff2a27789e" />


Accuracy (gsm8k)
The accuracy difference between aiter and pytorch native is negligible, falling within the expected range of variance for different low-level sampling implementations.


Part B: Using vLLM Benchmarks
At the same time, we also conducted end-to-end testing and saw significant performance improvements.

<img width="562" height="652" alt="Screenshot 2025-10-04 at 22 59 10" src="https://github.com/user-attachments/assets/f3d06588-9dc0-4c2d-afb0-ae9c224be90b" />


The aiter operator provides a substantial performance uplift. On average, it achieves an ~1.6x increase in total throughput and a ~50% reduction in Time To First Token (TTFT).



