### PR TITLE
Rename max_long_partial_prefills to max_long_prefills for clarity

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -50,7 +50,7 @@ class SchedulerConfig:
     """For chunked prefill, the maximum number of sequences that can be
     partially prefilled concurrently."""
 
-    max_long_partial_prefills: int = 1
+    max_long_prefills: int = 1
     """For chunked prefill, the maximum number of prompts longer than
     long_prefill_token_threshold that will be prefilled concurrently. Setting
     this less than max_num_partial_prefills will allow shorter prompts to jump
@@ -214,9 +214,9 @@ class SchedulerConfig:
 
             logger.info(
                 "Concurrent partial prefills enabled with "
-                "max_num_partial_prefills=%d, max_long_partial_prefills=%d, "
+                "max_num_partial_prefills=%d, max_long_prefills=%d, "
                 "long_prefill_token_threshold=%d",
-                self.max_num_partial_prefills, self.max_long_partial_prefills,
+                self.max_num_partial_prefills, self.max_long_prefills,
                 self.long_prefill_token_threshold)
 
         # NOTE: Default set cuda_graph_sizes to [min(max_num_seqs * 2, 512)].
@@ -276,11 +276,10 @@ class SchedulerConfig:
                     f"({self.long_prefill_token_threshold}) cannot be greater "
                     f"than the max_model_len ({self.max_model_len}).")
 
-        if (self.max_long_partial_prefills
-                < 1) or (self.max_long_partial_prefills
-                         > self.max_num_partial_prefills):
+        if (self.max_long_prefills < 1) or (self.max_long_prefills
+                                            > self.max_num_partial_prefills):
             raise ValueError(
-                f"max_long_partial_prefills ({self.max_long_partial_prefills}) "
+                f"max_long_prefills ({self.max_long_prefills}) "
                 "must be greater than or equal to 1 and less than or equal to "
                 f"max_num_partial_prefills ({self.max_num_partial_prefills}).")
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -357,7 +357,7 @@ class EngineArgs:
     max_num_batched_tokens: Optional[
         int] = SchedulerConfig.max_num_batched_tokens
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
-    max_long_partial_prefills: int = SchedulerConfig.max_long_partial_prefills
+    max_long_prefills: int = SchedulerConfig.max_long_prefills
     long_prefill_token_threshold: int = \
         SchedulerConfig.long_prefill_token_threshold
     max_num_seqs: Optional[int] = SchedulerConfig.max_num_seqs
@@ -879,9 +879,8 @@ class EngineArgs:
         scheduler_group.add_argument(
             "--max-num-partial-prefills",
             **scheduler_kwargs["max_num_partial_prefills"])
-        scheduler_group.add_argument(
-            "--max-long-partial-prefills",
-            **scheduler_kwargs["max_long_partial_prefills"])
+        scheduler_group.add_argument("--max-long-prefills",
+                                     **scheduler_kwargs["max_long_prefills"])
         scheduler_group.add_argument('--cuda-graph-sizes',
                                      **scheduler_kwargs["cuda_graph_sizes"])
         scheduler_group.add_argument(
@@ -1362,7 +1361,7 @@ class EngineArgs:
             policy=self.scheduling_policy,
             scheduler_cls=self.scheduler_cls,
             max_num_partial_prefills=self.max_num_partial_prefills,
-            max_long_partial_prefills=self.max_long_partial_prefills,
+            max_long_prefills=self.max_long_prefills,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
             disable_hybrid_kv_cache_manager=self.
             disable_hybrid_kv_cache_manager,
@@ -1457,9 +1456,8 @@ class EngineArgs:
 
         # No Concurrent Partial Prefills so far.
         if (self.max_num_partial_prefills
-                != SchedulerConfig.max_num_partial_prefills
-                or self.max_long_partial_prefills
-                != SchedulerConfig.max_long_partial_prefills):
+                != SchedulerConfig.max_num_partial_prefills or
+                self.max_long_prefills != SchedulerConfig.max_long_prefills):
             _raise_or_fallback(feature_name="Concurrent Partial Prefill",
                                recommend_to_remove=False)
             return False


### PR DESCRIPTION
## Purpose
1）Problem
The current parameter name `max_long_partial_prefills` is confusing and misleading:
Unclear semantics: The word "partial" confuses users about whether it means "partial long prefills" or "long partial prefills"
Inconsistent naming: Doesn't align with the naming style of related parameter `long_prefill_token_threshold`
Poor developer experience: Developers frequently get confused about this parameter's meaning during configuration

2）Solution
Rename `max_long_partial_prefills` to `max_long_prefills` for the following reasons:
Clearer: Directly expresses "maximum number of long prompts"
Consistent: Aligns with `long_prefill_token_threshold` naming style
Simpler: Removes the confusing "partial" terminology
Intuitive: Parameter meaning is self-evident

3）CLI argument changes
```
# Before
--max-long-partial-prefills 2

# After
--max-long-prefills 2
```

4）Backward Compatibility
Compatibility is not needed because this parameter `max_long_partial_prefills` has not been implemented yet

## Test Plan
Not needed

## Test Result
None

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

