### PR TITLE
[Perf][Easy] Early stop in request_block_hasher

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -585,6 +585,10 @@ def get_request_block_hasher(
         start_token_idx = len(request.block_hashes) * block_size
         num_tokens = request.num_tokens
 
+        if start_token_idx + block_size > num_tokens:
+            # Early stop when there no new full blocks created.
+            return []
+
         curr_mm_idx = 0
         if start_token_idx > 0:
             # Set curr_mm_idx = -1 to indicate the last mm input.


### PR DESCRIPTION
## Purpose
Most request_block_hasher will NOT introduce new blocks, early stop in request_block_hasher to avoid unnecessary computations.

## Test Plan & Test Result
**Before**
<img width="1056" height="157" alt="Screenshot 2025-10-02 at 9 46 34 AM" src="https://github.com/user-attachments/assets/7f56f67c-c2ac-42f0-b457-50dcbcee1dae" />

**After**
<img width="589" height="150" alt="Screenshot 2025-10-02 at 9 48 04 AM" src="https://github.com/user-attachments/assets/366a68d9-74fb-43ab-bba8-ccb05b920541" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

