### PR TITLE
[torch.compile] Fix tests for torch==2.9 inductor partition

### DIFF
--- a/tests/compile/piecewise/test_full_cudagraph.py
+++ b/tests/compile/piecewise/test_full_cudagraph.py
@@ -11,6 +11,7 @@ from tests.v1.attention.utils import full_cg_backend_configs as backend_configs
 from vllm import LLM, SamplingParams
 from vllm.config import CompilationConfig
 from vllm.platforms import current_platform
+from vllm.utils import is_torch_equal_or_newer
 
 
 @contextlib.contextmanager
@@ -56,14 +57,8 @@ def llm_pair(request):
         use_inductor_graph_partition
     )
 
-    # TODO(luka/boyuan): fix Inductor assert
-    if use_inductor_graph_partition:  # and not is_torch_equal_or_newer("2.9.0.dev"):
+    if use_inductor_graph_partition and not is_torch_equal_or_newer("2.9.0.dev"):
         pytest.skip("Inductor graph partition only supported in torch>=2.9")
-
-    # if use_inductor_graph_partition:
-    #     # TODO otherwise we reuse an unpartitioned graph
-    #     backend_config.comp_config["inductor_compile_config"] = \
-    #         {"force_disable_caches": True}
 
     # Dynamically skip test if GPU capability is not met
     if (

--- a/tests/compile/piecewise/test_multiple_graphs.py
+++ b/tests/compile/piecewise/test_multiple_graphs.py
@@ -190,6 +190,7 @@ def run_model(
         return output.cpu()
 
 
+# TODO use_inductor_cg_partition both true and false
 def test_multi_graph_piecewise_compile_outputs_equal():
     outputs = []
 
@@ -237,6 +238,7 @@ def test_multi_graph_piecewise_compile_outputs_equal():
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
             level=CompilationLevel.NO_COMPILATION,
+            use_inductor_graph_partition=False,
         )
     )
     cudagraph_runtime_mode = CUDAGraphMode.NONE

--- a/tests/compile/piecewise/test_multiple_graphs.py
+++ b/tests/compile/piecewise/test_multiple_graphs.py
@@ -5,6 +5,7 @@ Test (piecewise) compilation with a simple model where multiple submodules
 are compiled and graph captured separately.
 """
 
+import pytest
 import torch
 from torch import nn
 
@@ -190,8 +191,12 @@ def run_model(
         return output.cpu()
 
 
-# TODO use_inductor_cg_partition both true and false
-def test_multi_graph_piecewise_compile_outputs_equal():
+@pytest.mark.parametrize("use_inductor_graph_partition", [False, True])
+def test_multi_graph_piecewise_compile(use_inductor_graph_partition: bool):
+    if use_inductor_graph_partition:
+        # FIXME(luka/boyuan): this currently fails
+        pytest.skip("Inductor graph partition not supported with multi-graph")
+
     outputs = []
 
     # piecewise compile
@@ -201,6 +206,7 @@ def test_multi_graph_piecewise_compile_outputs_equal():
             use_cudagraph=True,
             splitting_ops=["silly::attention"],
             cudagraph_capture_sizes=[1, 2],
+            use_inductor_graph_partition=use_inductor_graph_partition,
         )
     )
     cudagraph_runtime_mode = CUDAGraphMode.PIECEWISE
@@ -221,16 +227,24 @@ def test_multi_graph_piecewise_compile_outputs_equal():
     # static tensor addresses
     inputs = torch.randn(BATCH_SIZE, MLP_SIZE).cuda()
 
-    with compilation_counter.expect(
-        num_graphs_seen=2,  # two graphs for the model
-        num_piecewise_graphs_seen=6,
+    if use_inductor_graph_partition:
+        # Splitting happens at Inductor lowering level,
+        # total piecewise fx graphs is equal to total graphs
+        num_piecewise_fx = 2
+        num_piecewise_capturable_fx = 2
+    else:
         # attn_one, attn_two each has 3 piecewise graphs
         # (pre attn, post attn, silly_attention) each
-        num_piecewise_capturable_graphs_seen=4,
+        num_piecewise_fx = 6
         # attn_one, attn_two has pre attn and post attn each, total=4
-        num_backend_compilations=4,  # num_piecewise_capturable_graphs_seen
-        num_cudagraph_captured=8,
-        # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
+        num_piecewise_capturable_fx = 4
+
+    with compilation_counter.expect(
+        num_graphs_seen=2,  # two graphs for the model
+        num_piecewise_graphs_seen=num_piecewise_fx,
+        num_piecewise_capturable_graphs_seen=num_piecewise_capturable_fx,
+        num_backend_compilations=num_piecewise_capturable_fx,
+        num_cudagraph_captured=8,  # num_cudagraph_sizes * num_partitions
     ):
         outputs.append(run_model(vllm_config, model, inputs, cudagraph_runtime_mode))
 
@@ -238,7 +252,6 @@ def test_multi_graph_piecewise_compile_outputs_equal():
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
             level=CompilationLevel.NO_COMPILATION,
-            use_inductor_graph_partition=False,
         )
     )
     cudagraph_runtime_mode = CUDAGraphMode.NONE
@@ -270,6 +283,7 @@ def test_multi_graph_piecewise_compile_outputs_equal():
             level=CompilationLevel.PIECEWISE,
             use_cudagraph=False,
             splitting_ops=["silly::attention"],
+            use_inductor_graph_partition=use_inductor_graph_partition,
         )
     )
     cudagraph_runtime_mode = CUDAGraphMode.PIECEWISE
@@ -288,9 +302,9 @@ def test_multi_graph_piecewise_compile_outputs_equal():
 
     with compilation_counter.expect(
         num_graphs_seen=2,
-        num_piecewise_graphs_seen=6,
-        num_piecewise_capturable_graphs_seen=4,
-        num_backend_compilations=4,
+        num_piecewise_graphs_seen=num_piecewise_fx,
+        num_piecewise_capturable_graphs_seen=num_piecewise_capturable_fx,
+        num_backend_compilations=num_piecewise_capturable_fx,
         num_cudagraph_captured=0,  # no cudagraph captured
     ):
         outputs.append(run_model(vllm_config, model, inputs, cudagraph_runtime_mode))

--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -265,6 +265,7 @@ def run_model(
             level=CompilationLevel.PIECEWISE,
             use_cudagraph=True,
             backend=backend,
+            use_inductor_graph_partition=False,  # TODO try both?
             cudagraph_capture_sizes=[1, 2],
         )
         if split_attn:

--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -9,6 +9,7 @@ if the config `tractable_init` is set to True. Otherwise, the weights are
 initialized randomly with a fixed seed.
 """
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
@@ -26,6 +27,7 @@ from vllm.config import (
     set_current_vllm_config,
 )
 from vllm.forward_context import BatchDescriptor, set_forward_context
+from vllm.utils import is_torch_equal_or_newer
 
 # This import automatically registers `torch.ops.silly.attention`
 from .. import silly_attention  # noqa: F401
@@ -257,28 +259,13 @@ def tractable_computation(
 
 
 @torch.inference_mode
-def run_model(
-    llama_config, use_compile: bool, backend: str, split_attn: bool = False
-) -> torch.Tensor:
-    if use_compile:
-        compilation_config = CompilationConfig(
-            level=CompilationLevel.PIECEWISE,
-            use_cudagraph=True,
-            backend=backend,
-            use_inductor_graph_partition=False,  # TODO try both?
-            cudagraph_capture_sizes=[1, 2],
-        )
-        if split_attn:
-            compilation_config.splitting_ops = ["silly::attention"]
-        cudagraph_runtime_mode = CUDAGraphMode.PIECEWISE
-    else:
-        compilation_config = CompilationConfig(
-            level=CompilationLevel.NO_COMPILATION,
-        )
-        cudagraph_runtime_mode = CUDAGraphMode.NONE
+def run_model(llama_config, compile_config: CompilationConfig) -> torch.Tensor:
+    # Start with a fresh copy to make sure there's no cache dir sharing
+    compile_config = deepcopy(compile_config)
+    cudagraph_runtime_mode = compile_config.cudagraph_mode
 
     vllm_config = VllmConfig(
-        compilation_config=compilation_config, additional_config=llama_config
+        compilation_config=compile_config, additional_config=llama_config
     )
     with set_current_vllm_config(vllm_config):
         model = (
@@ -339,8 +326,25 @@ def run_model(
             return output.cpu()
 
 
-@pytest.mark.parametrize("backend", ["inductor", "eager"])
-def test_toy_llama(backend: str):
+@pytest.mark.parametrize(
+    "backend, use_inductor_graph_partition",
+    [
+        ("eager", False),  # No inductor
+        ("inductor", False),  # Inductor, Dynamo partition
+        ("inductor", True),  # Inductor, Inductor partition
+    ],
+)
+def test_toy_llama(
+    backend: str, use_inductor_graph_partition: bool, monkeypatch, tmp_path
+):
+    # We disable the vLLM compile cache into a new tmp dir for 2 reasons:
+    # 1. To make sure we can properly track the number of Inductor compilations.
+    # 2. Inductor partitioning does not play nicely with Autograd cache (below)
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+    if use_inductor_graph_partition and not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("Inductor graph partition only supported in torch>=2.9")
+
     # compare output with and without piecewise compilation
 
     llama_config = LlamaConfig(
@@ -351,6 +355,32 @@ def test_toy_llama(backend: str):
         hidden_size=128, mlp_size=256, vocab_size=128, num_layers=2, tractable_init=True
     )
 
+    compile_config_no_compile = CompilationConfig(
+        level=CompilationLevel.NO_COMPILATION,
+        cudagraph_mode=CUDAGraphMode.NONE,
+        backend="eager",
+    )
+
+    compile_config_no_split = CompilationConfig(
+        level=CompilationLevel.PIECEWISE,
+        use_inductor_graph_partition=use_inductor_graph_partition,
+        cudagraph_mode=CUDAGraphMode.PIECEWISE,
+        backend=backend,
+        cudagraph_capture_sizes=[1, 2],
+    )
+
+    # FIXME(luka/boyuan): the graph from the previous test case
+    #  (no inductor partition) gets cached by AotAutograd so then the
+    #  compilation with inductor partitioning incorrectly loads an unpartitioned
+    #  graph and never partitions. I think this is a bug with custom inductor
+    #  partitioning but does not affect vLLM more generally as vLLM uses its own
+    #  cache (which takes inductor partitioning into account).
+    if use_inductor_graph_partition:
+        compile_config_no_split.inductor_compile_config["force_disable_caches"] = True
+
+    compile_config_split = deepcopy(compile_config_no_split)
+    compile_config_split.splitting_ops = ["silly::attention"]
+
     outputs = []
     with compilation_counter.expect(
         num_graphs_seen=0,
@@ -359,8 +389,9 @@ def test_toy_llama(backend: str):
         num_backend_compilations=0,
         num_cudagraph_captured=0,
     ):
-        outputs.append(run_model(llama_config, backend="eager", use_compile=False))
-    run_model(tractable_config, backend="eager", use_compile=False)
+        outputs.append(run_model(llama_config, compile_config_no_compile))
+
+    run_model(tractable_config, compile_config_no_compile)
 
     if backend == "inductor":
         kwargs = {"num_inductor_compiles": 1, "num_eager_compiles": 0}
@@ -368,35 +399,34 @@ def test_toy_llama(backend: str):
         kwargs = {"num_eager_compiles": 1, "num_inductor_compiles": 0}
 
     with compilation_counter.expect(
-        # One graph for the model
-        num_graphs_seen=1,
+        num_graphs_seen=1,  # one graph for the model
         num_piecewise_graphs_seen=1,
         num_piecewise_capturable_graphs_seen=1,
-        # num_piecewise_capturable_graphs_seen
-        num_backend_compilations=1,
-        # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
+        num_backend_compilations=1,  # num_piecewise_capturable_graphs_seen
         num_cudagraph_captured=2,
         **kwargs,
     ):
-        outputs.append(run_model(llama_config, backend=backend, use_compile=True))
-    run_model(tractable_config, backend=backend, use_compile=True)
+        outputs.append(run_model(llama_config, compile_config_no_split))
+
+    run_model(tractable_config, compile_config_no_split)
+
+    if use_inductor_graph_partition:
+        num_piecewise_fx = 1
+        num_piecewise_capturable_fx = 1
+    else:
+        num_piecewise_fx = 2 * llama_config.num_layers + 1
+        num_piecewise_capturable_fx = 1 + llama_config.num_layers
 
     with compilation_counter.expect(
         num_graphs_seen=1,  # one graph for the model
-        num_piecewise_graphs_seen=2 * llama_config.num_layers + 1,  # 2 * num_layers + 1
-        num_piecewise_capturable_graphs_seen=1
-        + llama_config.num_layers,  # 1 + num_layers
-        num_backend_compilations=1
-        + llama_config.num_layers,  # num_piecewise_capturable_graphs_seen
-        num_cudagraph_captured=2
-        * (
-            1 + llama_config.num_layers
-        ),  # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
+        num_piecewise_graphs_seen=num_piecewise_fx,
+        num_piecewise_capturable_graphs_seen=num_piecewise_capturable_fx,
+        num_backend_compilations=num_piecewise_capturable_fx,
+        # num_cudagraph_sizes * num_partitions
+        num_cudagraph_captured=2 * (1 + llama_config.num_layers),
     ):
-        outputs.append(
-            run_model(llama_config, backend=backend, use_compile=True, split_attn=True)
-        )
-    run_model(tractable_config, backend=backend, use_compile=True, split_attn=True)
+        outputs.append(run_model(llama_config, compile_config_split))
+    run_model(tractable_config, compile_config_split)
 
     for i in range(1, len(outputs)):
         assert torch.allclose(outputs[0], outputs[i])

--- a/tests/compile/silly_attention.py
+++ b/tests/compile/silly_attention.py
@@ -62,5 +62,4 @@ direct_register_custom_op(
     mutates_args=["out"],
     fake_impl=silly_attention_fake,
     target_lib=silly_lib,
-    tags=(torch._C.Tag.cudagraph_unsafe,),
 )

--- a/tests/compile/test_decorator.py
+++ b/tests/compile/test_decorator.py
@@ -73,6 +73,7 @@ def test_ignore_torch_compile_decorator():
             use_cudagraph=True,
             splitting_ops=["silly::attention"],
             cudagraph_capture_sizes=[1, 2],
+            use_inductor_graph_partition=False,  # TODO test both?
         )
     )
     cudagraph_runtime_mode = CUDAGraphMode.PIECEWISE
@@ -188,6 +189,7 @@ def test_conditional_compile_enable_if():
             use_cudagraph=True,
             splitting_ops=["silly::attention"],
             cudagraph_capture_sizes=[1, 2],
+            use_inductor_graph_partition=False,  # TODO test both
         ),
     )
     cudagraph_runtime_mode = CUDAGraphMode.PIECEWISE
@@ -220,6 +222,7 @@ def test_conditional_compile_enable_if():
             use_cudagraph=True,
             splitting_ops=["silly::attention"],
             cudagraph_capture_sizes=[1, 2],
+            use_inductor_graph_partition=False,  # TODO test both?
         ),
     )
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -38,10 +38,6 @@ from vllm.utils import GiB_bytes, direct_register_custom_op
 
 logger = init_logger(__name__)
 USE_XFORMERS_OPS = None
-try:
-    tag_cudagraph_unsafe = (torch._C.Tag.cudagraph_unsafe,)
-except AttributeError:
-    tag_cudagraph_unsafe = ()  # type: ignore[assignment]
 
 
 def check_xformers_availability():
@@ -879,7 +875,6 @@ direct_register_custom_op(
     op_name="unified_attention",
     op_func=unified_attention,
     fake_impl=unified_attention_fake,
-    tags=tag_cudagraph_unsafe,
 )
 
 
@@ -931,7 +926,6 @@ direct_register_custom_op(
     op_func=unified_attention_with_output,
     mutates_args=["output", "output_block_scale"],
     fake_impl=unified_attention_with_output_fake,
-    tags=tag_cudagraph_unsafe,
 )
 
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -201,7 +201,7 @@ class CompilationConfig:
     (it sees a part of the graph). The backend can not be custom for compilation
     level 3, i.e. the backend must be either eager or inductor. Furthermore,
     compilation is only piecewise if splitting ops is set accordingly and
-    use_inductor_cudagraphs_partition is off. Note that the default options for
+    use_inductor_graph_partition is off. Note that the default options for
     splitting ops are sufficient for piecewise compilation.
     """
     custom_ops: list[str] = field(default_factory=list)
@@ -346,7 +346,7 @@ class CompilationConfig:
     FULL_AND_PIECEWISE instead.
     """
 
-    use_inductor_graph_partition: bool = is_torch_equal_or_newer("2.9.0")
+    use_inductor_graph_partition: bool = False
     """Use inductor graph partition to split the graph at cudagraph_unsafe ops.
     This partition happens at inductor codegen time after all passes and fusions
     are finished. It generates a single `call` function which wraps

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -431,6 +431,7 @@ class CompilationConfig:
         factors.append(self.custom_ops)
         factors.append(self.splitting_ops)
         factors.append(self.use_inductor)
+        factors.append(self.use_inductor_graph_partition)
         factors.append(self.inductor_compile_config)
         factors.append(self.inductor_passes)
         factors.append(self.pass_config.uuid())

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -346,7 +346,7 @@ class CompilationConfig:
     FULL_AND_PIECEWISE instead.
     """
 
-    use_inductor_graph_partition: bool = False
+    use_inductor_graph_partition: bool = is_torch_equal_or_newer("2.9.0")
     """Use inductor graph partition to split the graph at cudagraph_unsafe ops.
     This partition happens at inductor codegen time after all passes and fusions
     are finished. It generates a single `call` function which wraps


### PR DESCRIPTION
## Purpose
Fix compilation tests for Inductor graph partitioning. Also remove a noisy warning and remove `cudagraph_unsafe` tags from attention ops to allow proper behavior with empty splitting ops.

To work this still requires #26735 and a spawn workaround. But for current main this should not change any behavior.

Remaining issues:
- nested fused_moe compilation
- test_full_cudagraph.py fails for one test case?
- test_multiple_graphs.py fails
- cache disabled for test_toy_llama.py

2.9 issues:
- have to force spawn due to CUDA init in parent.

## Test Plan
Tested with torch 2.9 in all of CI with #26738. Tested all tests locally.

## Test Result

1. Inductor error with fused_moe due to nested PIECEWISE wrappers
<details>
```
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|                                                                                                                             | 0/35 [00:00<?, ?it/s]
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] EngineCore failed to start.
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] Traceback (most recent call last):
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 173, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     output = self.runnable(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/.cache/vllm/torch_compile_cache/2bb3a64dcc/rank_0_0/backbone/artifact_shape_None_subgraph_0/4a/c4ak2drkbgkblf6yvpndkczodnjikhrpfbqmvqhhkdjfqkh66jb4.py", line 2331, in partition_2
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     buf33 = torch.ops.vllm.moe_forward_shared.default(buf31, buf32, 'model.layers.1.mlp.experts')
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_ops.py", line 841, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self._op(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 2409, in moe_forward_shared
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self.forward_impl(hidden_states, router_logits)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 2253, in forward_impl
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     final_hidden_states = self.quant_method.apply(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                           ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 552, in apply
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self.forward(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/custom_op.py", line 47, in forward
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self._forward_method(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 612, in forward_cuda
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     topk_weights, topk_ids, zero_expert_result = FusedMoE.select_experts(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                                                  ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 1901, in select_experts
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     topk_weights, topk_ids = grouped_topk(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                              ^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 832, in compile_wrapper
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return fn(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/fused_moe.py", line 1125, in grouped_topk
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1044, in _fn
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return fn(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/aot_autograd.py", line 1130, in forward
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return compiled_fn(full_args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 353, in runtime_wrapper
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     all_outs = call_func_at_runtime_with_args(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py", line 129, in call_func_at_runtime_with_args
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     out = normalize_as_list(f(args))
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                             ^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 526, in wrapper
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return compiled_fn(runtime_args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 613, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self.current_callable(inputs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/tmp/torchinductor_ProExpertProg/nm/cnmvad62od4mrfrbkaxpstu5cmdee7mlxriqfuleenmctsbky5gn.py", line 354, in call
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     (buf11, buf12) = self.partitions[0](partition0_args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 171, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     with torch.cuda.graph(cudagraph, pool=self.graph_pool):
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 242, in __enter__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     torch.cuda.synchronize()
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 1083, in synchronize
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return torch._C._cuda_synchronize()
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] Search for `cudaErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] 
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] 
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] During handling of the above exception, another exception occurred:
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] 
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] Traceback (most recent call last):
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 769, in run_engine_core
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 545, in __init__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     super().__init__(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 110, in __init__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 232, in _initialize_kv_caches
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/executor/abstract.py", line 77, in initialize_from_config
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     self.collective_rpc("compile_or_warm_up_model")
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/executor/uniproc_executor.py", line 81, in collective_rpc
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return [run_method(self.driver_worker, method, args, kwargs)]
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/utils/__init__.py", line 3230, in run_method
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return func(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_worker.py", line 361, in compile_or_warm_up_model
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     cuda_graph_memory_bytes = self.model_runner.capture_model()
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_model_runner.py", line 3820, in capture_model
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     self._capture_cudagraphs(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_model_runner.py", line 3923, in _capture_cudagraphs
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     self._dummy_run(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return func(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_model_runner.py", line 3518, in _dummy_run
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     outputs = self.model(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]               ^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 125, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self.runnable(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/models/deepseek_v2.py", line 1361, in forward
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     hidden_states = self.model(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                     ^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/compilation/decorators.py", line 316, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     model_output = self.forward(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/models/deepseek_v2.py", line 1219, in forward
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     def forward(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 414, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return super().__call__(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1044, in _fn
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return fn(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 837, in call_wrapped
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self._wrapped_call(self, *args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 413, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     raise e
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 400, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "<eval_with_key>.2", line 200, in forward
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     submod_0 = self.submod_0(l_input_ids_, s72, l_self_modules_embed_tokens_parameters_weight_, l_self_modules_layers_modules_0_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_rotary_emb_buffers_cos_sin_cache_, l_positions_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_0_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_0_modules_mlp_modules_gate_up_proj_parameters_weight_, l_self_modules_layers_modules_0_modules_mlp_modules_down_proj_parameters_weight_, l_self_modules_layers_modules_1_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_1_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_1_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_2_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_2_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_2_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_3_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_3_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_3_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_4_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_5_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_5_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_5_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_6_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_6_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_6_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_7_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_7_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_7_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_8_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_8_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_8_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_9_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_9_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_9_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_10_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_10_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_10_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_11_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_11_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_11_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_12_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_12_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_12_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_13_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_13_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_13_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_14_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_14_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_14_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_15_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_15_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_15_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_16_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_16_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_16_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_17_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_17_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_17_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_18_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_18_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_18_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_19_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_19_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_19_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_20_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_20_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_20_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_21_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_21_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_21_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_22_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_22_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_22_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_23_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_23_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_23_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_24_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_24_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_24_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_25_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_25_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_25_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_26_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_26_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_26_modules_mlp_modules_gate_parameters_weight_, l_self_modules_norm_parameters_weight_);  l_input_ids_ = s72 = l_self_modules_embed_tokens_parameters_weight_ = l_self_modules_layers_modules_0_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_rotary_emb_buffers_cos_sin_cache_ = l_positions_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_0_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_0_modules_mlp_modules_gate_up_proj_parameters_weight_ = l_self_modules_layers_modules_0_modules_mlp_modules_down_proj_parameters_weight_ = l_self_modules_layers_modules_1_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_1_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_1_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_2_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_2_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_2_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_3_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_3_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_3_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_4_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_5_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_5_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_5_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_6_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_6_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_6_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_7_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_7_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_7_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_8_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_8_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_8_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_9_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_9_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_9_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_10_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_10_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_10_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_11_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_11_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_11_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_12_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_12_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_12_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_13_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_13_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_13_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_14_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_14_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_14_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_15_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_15_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_15_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_16_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_16_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_16_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_17_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_17_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_17_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_18_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_18_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_18_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_19_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_19_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_19_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_20_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_20_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_20_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_21_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_21_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_21_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_22_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_22_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_22_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_23_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_23_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_23_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_24_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_24_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_24_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_25_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_25_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_25_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_26_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_26_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_26_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_norm_parameters_weight_ = None
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/compilation/piecewise_backend.py", line 98, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self.compiled_graph_for_general_shape(*args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/compilation/compiler_interface.py", line 248, in compiled_graph_wrapper
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     graph_output = inductor_compiled_graph(*args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py", line 63, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self._compiled_fn(*args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py", line 184, in <lambda>
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return CompiledArtifact(lambda *args: compiled_fn(list(args)), None)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                                           ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 353, in runtime_wrapper
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     all_outs = call_func_at_runtime_with_args(
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py", line 129, in call_func_at_runtime_with_args
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     out = normalize_as_list(f(args))
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                             ^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 526, in wrapper
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return compiled_fn(runtime_args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 613, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     return self.current_callable(inputs)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/.cache/vllm/torch_compile_cache/2bb3a64dcc/rank_0_0/backbone/artifact_shape_None_subgraph_0/4a/c4ak2drkbgkblf6yvpndkczodnjikhrpfbqmvqhhkdjfqkh66jb4.py", line 21772, in call
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     (buf29, buf35, buf36, buf44, buf42, buf43, buf45, arg8_1, arg7_1) = self.partitions[2](partition2_args)
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 171, in __call__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     with torch.cuda.graph(cudagraph, pool=self.graph_pool):
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 265, in __exit__
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     self.cuda_graph.capture_end()
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 128, in capture_end
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778]     super().capture_end()
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] torch.AcceleratorError: CUDA error: operation failed due to a previous error during capture
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] Search for `cudaErrorStreamCaptureInvalidated' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
(EngineCore_DP0 pid=978075) ERROR 10-06 17:06:10 [core.py:778] 
(EngineCore_DP0 pid=978075) Process EngineCore_DP0:
(EngineCore_DP0 pid=978075) Traceback (most recent call last):
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 173, in __call__
(EngineCore_DP0 pid=978075)     output = self.runnable(*args, **kwargs)
(EngineCore_DP0 pid=978075)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/.cache/vllm/torch_compile_cache/2bb3a64dcc/rank_0_0/backbone/artifact_shape_None_subgraph_0/4a/c4ak2drkbgkblf6yvpndkczodnjikhrpfbqmvqhhkdjfqkh66jb4.py", line 2331, in partition_2
(EngineCore_DP0 pid=978075)     buf33 = torch.ops.vllm.moe_forward_shared.default(buf31, buf32, 'model.layers.1.mlp.experts')
(EngineCore_DP0 pid=978075)             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_ops.py", line 841, in __call__
(EngineCore_DP0 pid=978075)     return self._op(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 2409, in moe_forward_shared
(EngineCore_DP0 pid=978075)     return self.forward_impl(hidden_states, router_logits)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 2253, in forward_impl
(EngineCore_DP0 pid=978075)     final_hidden_states = self.quant_method.apply(
(EngineCore_DP0 pid=978075)                           ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 552, in apply
(EngineCore_DP0 pid=978075)     return self.forward(
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/custom_op.py", line 47, in forward
(EngineCore_DP0 pid=978075)     return self._forward_method(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 612, in forward_cuda
(EngineCore_DP0 pid=978075)     topk_weights, topk_ids, zero_expert_result = FusedMoE.select_experts(
(EngineCore_DP0 pid=978075)                                                  ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/layer.py", line 1901, in select_experts
(EngineCore_DP0 pid=978075)     topk_weights, topk_ids = grouped_topk(
(EngineCore_DP0 pid=978075)                              ^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 832, in compile_wrapper
(EngineCore_DP0 pid=978075)     return fn(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/layers/fused_moe/fused_moe.py", line 1125, in grouped_topk
(EngineCore_DP0 pid=978075)     @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1044, in _fn
(EngineCore_DP0 pid=978075)     return fn(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/aot_autograd.py", line 1130, in forward
(EngineCore_DP0 pid=978075)     return compiled_fn(full_args)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 353, in runtime_wrapper
(EngineCore_DP0 pid=978075)     all_outs = call_func_at_runtime_with_args(
(EngineCore_DP0 pid=978075)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py", line 129, in call_func_at_runtime_with_args
(EngineCore_DP0 pid=978075)     out = normalize_as_list(f(args))
(EngineCore_DP0 pid=978075)                             ^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 526, in wrapper
(EngineCore_DP0 pid=978075)     return compiled_fn(runtime_args)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 613, in __call__
(EngineCore_DP0 pid=978075)     return self.current_callable(inputs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/tmp/torchinductor_ProExpertProg/nm/cnmvad62od4mrfrbkaxpstu5cmdee7mlxriqfuleenmctsbky5gn.py", line 354, in call
(EngineCore_DP0 pid=978075)     (buf11, buf12) = self.partitions[0](partition0_args)
(EngineCore_DP0 pid=978075)                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 171, in __call__
(EngineCore_DP0 pid=978075)     with torch.cuda.graph(cudagraph, pool=self.graph_pool):
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 242, in __enter__
(EngineCore_DP0 pid=978075)     torch.cuda.synchronize()
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 1083, in synchronize
(EngineCore_DP0 pid=978075)     return torch._C._cuda_synchronize()
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075) torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
(EngineCore_DP0 pid=978075) Search for `cudaErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(EngineCore_DP0 pid=978075) CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore_DP0 pid=978075) For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(EngineCore_DP0 pid=978075) Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
(EngineCore_DP0 pid=978075) 
(EngineCore_DP0 pid=978075) 
(EngineCore_DP0 pid=978075) During handling of the above exception, another exception occurred:
(EngineCore_DP0 pid=978075) 
(EngineCore_DP0 pid=978075) Traceback (most recent call last):
(EngineCore_DP0 pid=978075)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=978075)     self.run()
(EngineCore_DP0 pid=978075)   File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=978075)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 782, in run_engine_core
(EngineCore_DP0 pid=978075)     raise e
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 769, in run_engine_core
(EngineCore_DP0 pid=978075)     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=978075)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 545, in __init__
(EngineCore_DP0 pid=978075)     super().__init__(
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 110, in __init__
(EngineCore_DP0 pid=978075)     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=978075)                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/engine/core.py", line 232, in _initialize_kv_caches
(EngineCore_DP0 pid=978075)     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/executor/abstract.py", line 77, in initialize_from_config
(EngineCore_DP0 pid=978075)     self.collective_rpc("compile_or_warm_up_model")
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/executor/uniproc_executor.py", line 81, in collective_rpc
(EngineCore_DP0 pid=978075)     return [run_method(self.driver_worker, method, args, kwargs)]
(EngineCore_DP0 pid=978075)             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/utils/__init__.py", line 3230, in run_method
(EngineCore_DP0 pid=978075)     return func(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_worker.py", line 361, in compile_or_warm_up_model
(EngineCore_DP0 pid=978075)     cuda_graph_memory_bytes = self.model_runner.capture_model()
(EngineCore_DP0 pid=978075)                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_model_runner.py", line 3820, in capture_model
(EngineCore_DP0 pid=978075)     self._capture_cudagraphs(
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_model_runner.py", line 3923, in _capture_cudagraphs
(EngineCore_DP0 pid=978075)     self._dummy_run(
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=978075)     return func(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/v1/worker/gpu_model_runner.py", line 3518, in _dummy_run
(EngineCore_DP0 pid=978075)     outputs = self.model(
(EngineCore_DP0 pid=978075)               ^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 125, in __call__
(EngineCore_DP0 pid=978075)     return self.runnable(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=978075)     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=978075)     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/models/deepseek_v2.py", line 1361, in forward
(EngineCore_DP0 pid=978075)     hidden_states = self.model(
(EngineCore_DP0 pid=978075)                     ^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/compilation/decorators.py", line 316, in __call__
(EngineCore_DP0 pid=978075)     model_output = self.forward(*args, **kwargs)
(EngineCore_DP0 pid=978075)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/model_executor/models/deepseek_v2.py", line 1219, in forward
(EngineCore_DP0 pid=978075)     def forward(
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 414, in __call__
(EngineCore_DP0 pid=978075)     return super().__call__(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=978075)     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=978075)     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1044, in _fn
(EngineCore_DP0 pid=978075)     return fn(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 837, in call_wrapped
(EngineCore_DP0 pid=978075)     return self._wrapped_call(self, *args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 413, in __call__
(EngineCore_DP0 pid=978075)     raise e
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 400, in __call__
(EngineCore_DP0 pid=978075)     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=978075)     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=978075)     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "<eval_with_key>.2", line 200, in forward
(EngineCore_DP0 pid=978075)     submod_0 = self.submod_0(l_input_ids_, s72, l_self_modules_embed_tokens_parameters_weight_, l_self_modules_layers_modules_0_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_rotary_emb_buffers_cos_sin_cache_, l_positions_, l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_0_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_0_modules_mlp_modules_gate_up_proj_parameters_weight_, l_self_modules_layers_modules_0_modules_mlp_modules_down_proj_parameters_weight_, l_self_modules_layers_modules_1_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_1_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_1_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_2_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_2_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_2_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_3_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_3_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_3_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_4_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_5_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_5_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_5_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_6_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_6_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_6_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_7_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_7_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_7_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_8_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_8_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_8_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_9_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_9_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_9_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_10_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_10_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_10_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_11_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_11_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_11_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_12_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_12_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_12_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_13_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_13_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_13_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_14_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_14_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_14_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_15_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_15_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_15_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_16_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_16_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_16_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_17_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_17_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_17_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_18_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_18_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_18_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_19_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_19_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_19_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_20_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_20_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_20_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_21_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_21_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_21_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_22_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_22_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_22_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_23_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_23_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_23_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_24_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_24_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_24_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_25_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_25_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_25_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_26_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_, l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_26_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_26_modules_mlp_modules_gate_parameters_weight_, l_self_modules_norm_parameters_weight_);  l_input_ids_ = s72 = l_self_modules_embed_tokens_parameters_weight_ = l_self_modules_layers_modules_0_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_rotary_emb_buffers_cos_sin_cache_ = l_positions_ = l_self_modules_layers_modules_0_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_0_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_0_modules_mlp_modules_gate_up_proj_parameters_weight_ = l_self_modules_layers_modules_0_modules_mlp_modules_down_proj_parameters_weight_ = l_self_modules_layers_modules_1_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_1_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_1_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_1_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_2_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_2_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_2_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_2_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_3_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_3_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_3_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_3_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_4_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_5_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_5_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_5_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_5_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_6_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_6_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_6_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_6_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_7_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_7_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_7_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_7_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_8_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_8_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_8_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_8_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_9_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_9_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_9_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_9_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_10_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_10_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_10_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_10_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_11_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_11_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_11_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_11_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_12_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_12_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_12_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_12_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_13_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_13_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_13_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_13_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_14_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_14_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_14_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_14_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_15_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_15_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_15_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_15_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_16_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_16_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_16_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_16_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_17_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_17_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_17_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_17_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_18_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_18_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_18_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_18_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_19_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_19_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_19_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_19_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_20_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_20_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_20_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_20_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_21_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_21_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_21_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_21_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_22_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_22_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_22_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_22_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_23_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_23_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_23_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_23_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_24_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_24_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_24_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_24_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_25_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_25_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_25_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_25_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_26_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_q_proj_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_kv_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_26_modules_self_attn_modules_mla_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_26_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_26_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_norm_parameters_weight_ = None
(EngineCore_DP0 pid=978075)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/compilation/piecewise_backend.py", line 98, in __call__
(EngineCore_DP0 pid=978075)     return self.compiled_graph_for_general_shape(*args)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/compilation/compiler_interface.py", line 248, in compiled_graph_wrapper
(EngineCore_DP0 pid=978075)     graph_output = inductor_compiled_graph(*args)
(EngineCore_DP0 pid=978075)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py", line 63, in __call__
(EngineCore_DP0 pid=978075)     return self._compiled_fn(*args)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py", line 184, in <lambda>
(EngineCore_DP0 pid=978075)     return CompiledArtifact(lambda *args: compiled_fn(list(args)), None)
(EngineCore_DP0 pid=978075)                                           ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 353, in runtime_wrapper
(EngineCore_DP0 pid=978075)     all_outs = call_func_at_runtime_with_args(
(EngineCore_DP0 pid=978075)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py", line 129, in call_func_at_runtime_with_args
(EngineCore_DP0 pid=978075)     out = normalize_as_list(f(args))
(EngineCore_DP0 pid=978075)                             ^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 526, in wrapper
(EngineCore_DP0 pid=978075)     return compiled_fn(runtime_args)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 613, in __call__
(EngineCore_DP0 pid=978075)     return self.current_callable(inputs)
(EngineCore_DP0 pid=978075)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/.cache/vllm/torch_compile_cache/2bb3a64dcc/rank_0_0/backbone/artifact_shape_None_subgraph_0/4a/c4ak2drkbgkblf6yvpndkczodnjikhrpfbqmvqhhkdjfqkh66jb4.py", line 21772, in call
(EngineCore_DP0 pid=978075)     (buf29, buf35, buf36, buf44, buf42, buf43, buf45, arg8_1, arg7_1) = self.partitions[2](partition2_args)
(EngineCore_DP0 pid=978075)                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/vllm/compilation/cuda_graph.py", line 171, in __call__
(EngineCore_DP0 pid=978075)     with torch.cuda.graph(cudagraph, pool=self.graph_pool):
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 265, in __exit__
(EngineCore_DP0 pid=978075)     self.cuda_graph.capture_end()
(EngineCore_DP0 pid=978075)   File "/home/ProExpertProg/git/vllm2/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 128, in capture_end
(EngineCore_DP0 pid=978075)     super().capture_end()
(EngineCore_DP0 pid=978075) torch.AcceleratorError: CUDA error: operation failed due to a previous error during capture
(EngineCore_DP0 pid=978075) Search for `cudaErrorStreamCaptureInvalidated' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(EngineCore_DP0 pid=978075) CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore_DP0 pid=978075) For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(EngineCore_DP0 pid=978075) Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
(EngineCore_DP0 pid=978075) 
ERROR
```
</details>

2. `test_multiple_graphs.py` fails
3. `test_toy_llama.py` disables caching because otherwise AotAutograd cache hits from non-partitioned to partitioned graph.