### PR TITLE
[BugFix][QWEN-VL]fix wrong apply_rotary_emb_torch selection introduced by #24642

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -73,7 +73,7 @@ def apply_rotary_emb_dispatch(x: torch.Tensor, cos: torch.Tensor,
 
 @cache
 def dispatch_rotary_emb_function(
-    apply_rotary_emb_torch_: Optional[Callable[..., torch.Tensor]] = None
+    func_override: Optional[Callable[..., torch.Tensor]] = None
 ) -> Callable[..., torch.Tensor]:
     if current_platform.is_cuda():
         return apply_rotary_emb
@@ -87,8 +87,8 @@ def dispatch_rotary_emb_function(
                 "flash_attn is not installed. Falling back to PyTorch "
                 "implementation for rotary embeddings.")
 
-    if apply_rotary_emb_torch_ is not None:
-        return apply_rotary_emb_torch_
+    if func_override is not None:
+        return func_override
     else:
         return apply_rotary_emb_torch
 

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -73,7 +73,7 @@ def apply_rotary_emb_dispatch(x: torch.Tensor, cos: torch.Tensor,
 
 @cache
 def dispatch_rotary_emb_function(
-    func_override: Optional[Callable[..., torch.Tensor]] = None
+    default: Optional[Callable[..., torch.Tensor]] = None
 ) -> Callable[..., torch.Tensor]:
     if current_platform.is_cuda():
         return apply_rotary_emb
@@ -87,8 +87,8 @@ def dispatch_rotary_emb_function(
                 "flash_attn is not installed. Falling back to PyTorch "
                 "implementation for rotary embeddings.")
 
-    if func_override is not None:
-        return func_override
+    if default is not None:
+        return default
     else:
         return apply_rotary_emb_torch
 

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -4,7 +4,7 @@
 import math
 from functools import cache
 from importlib.util import find_spec
-from typing import Callable
+from typing import Callable, Optional
 
 import torch
 
@@ -72,7 +72,9 @@ def apply_rotary_emb_dispatch(x: torch.Tensor, cos: torch.Tensor,
 
 
 @cache
-def dispatch_rotary_emb_function() -> Callable[..., torch.Tensor]:
+def dispatch_rotary_emb_function(
+    apply_rotary_emb_torch_: Optional[Callable[..., torch.Tensor]] = None
+) -> Callable[..., torch.Tensor]:
     if current_platform.is_cuda():
         return apply_rotary_emb
 
@@ -85,7 +87,10 @@ def dispatch_rotary_emb_function() -> Callable[..., torch.Tensor]:
                 "flash_attn is not installed. Falling back to PyTorch "
                 "implementation for rotary embeddings.")
 
-    return apply_rotary_emb_torch
+    if apply_rotary_emb_torch_ is not None:
+        return apply_rotary_emb_torch_
+    else:
+        return apply_rotary_emb_torch
 
 
 # yarn functions

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -276,7 +276,7 @@ def apply_rotary_emb_torch(x: torch.Tensor,
 
 def apply_rotary_pos_emb_vision(t: torch.Tensor,
                                 freqs: torch.Tensor) -> torch.Tensor:
-    rotary_emb_function = dispatch_rotary_emb_function(apply_rotary_emb_torch)
+    rotary_emb_function = dispatch_rotary_emb_function(func_override=apply_rotary_emb_torch)
     t_ = t.float()
     cos = freqs.cos()
     sin = freqs.sin()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -276,7 +276,8 @@ def apply_rotary_emb_torch(x: torch.Tensor,
 
 def apply_rotary_pos_emb_vision(t: torch.Tensor,
                                 freqs: torch.Tensor) -> torch.Tensor:
-    rotary_emb_function = dispatch_rotary_emb_function(func_override=apply_rotary_emb_torch)
+    rotary_emb_function = dispatch_rotary_emb_function(
+        func_override=apply_rotary_emb_torch)
     t_ = t.float()
     cos = freqs.cos()
     sin = freqs.sin()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -277,7 +277,7 @@ def apply_rotary_emb_torch(x: torch.Tensor,
 def apply_rotary_pos_emb_vision(t: torch.Tensor,
                                 freqs: torch.Tensor) -> torch.Tensor:
     rotary_emb_function = dispatch_rotary_emb_function(
-        func_override=apply_rotary_emb_torch)
+        default=apply_rotary_emb_torch)
     t_ = t.float()
     cos = freqs.cos()
     sin = freqs.sin()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -276,7 +276,7 @@ def apply_rotary_emb_torch(x: torch.Tensor,
 
 def apply_rotary_pos_emb_vision(t: torch.Tensor,
                                 freqs: torch.Tensor) -> torch.Tensor:
-    rotary_emb_function = dispatch_rotary_emb_function()
+    rotary_emb_function = dispatch_rotary_emb_function(apply_rotary_emb_torch)
     t_ = t.float()
     cos = freqs.cos()
     sin = freqs.sin()


### PR DESCRIPTION

## Purpose

#24642 introduced dispatch_rotary_emb_function method in common.py while for non_cuda or non_rocm, apply_rotary_emb_torch is differently defined in some modeling codes, so providing an argument to fix

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

