### PR TITLE
[BUG] Reorder model config creation

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1131,6 +1131,10 @@ class EngineArgs:
         device_config = DeviceConfig(
             device=cast(Device, current_platform.device_type))
 
+        model_config = self.create_model_config()
+        self.model = model_config.model
+        self.tokenizer = model_config.tokenizer
+
         (self.model, self.tokenizer,
          self.speculative_config) = maybe_override_with_speculators(
              model=self.model,
@@ -1139,7 +1143,6 @@ class EngineArgs:
              trust_remote_code=self.trust_remote_code,
              vllm_speculative_config=self.speculative_config,
          )
-        model_config = self.create_model_config()
 
         # * If VLLM_USE_V1 is unset, we enable V1 for "supported features"
         #   and fall back to V0 for experimental or unsupported features.


### PR DESCRIPTION

## Purpose
Fixes bug with initializing using a s3 source, updates self.model and self.tokenizer so maybe_override_with_speculators does not try to read from s3. 

## Test Plan
Can start server with s3 url without failing during engine initialization

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

