### PR TITLE
[Bugfix] Disable cascade attention with FlashInfer

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -29,7 +29,6 @@ from vllm.utils.flashinfer import (can_use_trtllm_attention,
                                    flashinfer_disable_q_quantization,
                                    supports_trtllm_attention,
                                    use_trtllm_attention)
-from vllm.v1.attention.backends.flash_attn import use_cascade_attention
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm.v1.attention.backends.utils import (AttentionCGSupport,
@@ -436,7 +435,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         num_blocks_np = (seq_lens_np + (page_size - 1)) // page_size
 
-        use_cascade = common_prefix_len > 0
+        # TODO: Cascade attention doesn't work, disable it for now
+        # use_cascade = common_prefix_len > 0
+        use_cascade = False
         if use_cascade:
             # Grab the blocks of the shared prefix from the first request.
             assert common_prefix_len % page_size == 0
@@ -677,7 +678,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # TODO: The cascade wrapper currently does not support setting
             # kv cache dtype to something different from query dtype.
             return False
-        return use_cascade_attention(*args, **kwargs)
+        # TODO: Cascade attention doesn't work, disable it for now
+        # return use_cascade_attention(*args, **kwargs)
+        return False
 
 
 class FlashInferImpl(AttentionImpl):

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -435,9 +435,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         num_blocks_np = (seq_lens_np + (page_size - 1)) // page_size
 
-        # TODO: Cascade attention doesn't work, disable it for now
-        # use_cascade = common_prefix_len > 0
-        use_cascade = False
+        use_cascade = common_prefix_len > 0
         if use_cascade:
             # Grab the blocks of the shared prefix from the first request.
             assert common_prefix_len % page_size == 0


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Using cascade attention with FlashInfer on Blackwell seems to break when prefix caching is hit.

This eval hangs on the first batch of requests
```
vllm serve Qwen/Qwen3-0.6B
python tests/evals/gsm8k/gsm8k_eval.py
(APIServer pid=2318591) INFO 10-02 12:38:13 [loggers.py:127] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 100 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 89.9%
```
Adding `--no-enable-prefix-caching` or `--disable-cascade-attn` works fine.
It happens with both the flashinfer and trtllm backends, with cudagraphs and eager.

We haven't tracked down the issue yet, so for now we will disable cascade attention

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

