### PR TITLE
[Bug][Benchmark] Fix duplicate req in oversampling

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -246,7 +246,7 @@ class BenchmarkDataset(ABC):
                         num_requests)
 
         ids = [req.request_id for req in requests]
-        if None not in ids and len(ids) != len(set(ids)):
+        if len(ids) != len(set(ids)):
             raise ValueError("Duplicate request_id found in the sampled "
                              "requests. Please ensure that each request_id "
                              "is unique.")

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -235,15 +235,21 @@ class BenchmarkDataset(ABC):
 
         if len(requests) < num_requests:
             random.seed(self.random_seed)
-            additional = deepcopy(
-                random.choices(requests, k=num_requests - len(requests))
-            )
-            for i in range(len(additional)):
-                req = additional[i]
+            needed = num_requests - len(requests)
+            additional = []
+            for i in range(needed):
+                req = deepcopy(random.choice(requests))
                 req.request_id = request_id_prefix + str(len(requests) + i)
+                additional.append(req)
             requests.extend(additional)
             logger.info("Oversampled requests to reach %d total samples.",
                         num_requests)
+
+        ids = [req.request_id for req in requests]
+        if None not in ids and len(ids) != len(set(ids)):
+            raise ValueError("Duplicate request_id found in the sampled "
+                             "requests. Please ensure that each request_id "
+                             "is unique.")
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
There are duplicate requests ids during oversampling in vllm bench serve which causes issue. The server throws these logs
```
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145] Error in chat completion stream generator.                                        
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145] Traceback (most recent call last):                                                
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]   File "/host/vllm-ekagra/vllm/vllm/entrypoints/openai/serving_chat.py", line 574,
 in chat_completion_stream_generator                                                                                                                
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]     async for res in result_generator:                                            
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]   File "/host/vllm-ekagra/vllm/vllm/v1/engine/async_llm.py", line 376, in generate
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]     q = await self.add_request(                                                   
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]         ^^^^^^^^^^^^^^^^^^^^^^^                                                   
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]   File "/host/vllm-ekagra/vllm/vllm/v1/engine/async_llm.py", line 289, in add_requ
est                                                                                                                                                 
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]     await self._add_request(request, prompt_str, None, 0, queue)                  
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]   File "/host/vllm-ekagra/vllm/vllm/v1/engine/async_llm.py", line 315, in _add_req
uest                                                                                                                                                
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]     self.output_processor.add_request(request, prompt, parent_req, index,         
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]   File "/host/vllm-ekagra/vllm/vllm/v1/engine/output_processor.py", line 366, in a
dd_request                                                                                                                                          
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145]     raise ValueError(f"Request id {request_id} already running.")                 
(APIServer pid=27557) ERROR 10-02 13:53:06 [serving_chat.py:1145] ValueError: Request id chatcmpl-benchmark-serving146 already running.
```

This is because the deepcopy on multiple elements selected by random.choices still share the same base address. If the random.choice samples 1 request multiple times then the request id set during the last iteration will be shared by all the instances of the same request. This PR fixes it by deepcopying it one at a time. The PR adds a assertion to confirm that no duplicate req are found. The same assertion fails when the changes in this PR are not made. 