### PR TITLE
[Perf] Cache vllm.env.__getattr__ result to avoid recomputation

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -8,56 +8,52 @@ import pytest
 
 import vllm.envs as envs
 from vllm.envs import (
-    __getattr__,
+    enable_envs_cache,
     env_list_with_choices,
     env_with_choices,
     environment_variables,
-    refresh_envs_cache,
-    reset_envs_cache,
 )
 
 
-def test_reset_envs_cache(monkeypatch: pytest.MonkeyPatch):
-    assert envs.VLLM_PORT is None
-    # VLLM_PORT is still None after explictly
-    # updating "VLLM_PORT" to "1234" due to __getattr__ cache
-    monkeypatch.setenv("VLLM_PORT", "1234")
-    assert envs.VLLM_PORT is None
-    # VLLM_PORT is updated properly after invalidate the cache
-    reset_envs_cache()
-    assert envs.VLLM_PORT == 1234
-
-    # Reset envs cache to avoid data pollution to other tests
-    reset_envs_cache()
-
-
-def test_refresh_envs_cache(monkeypatch: pytest.MonkeyPatch):
+def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):
     assert envs.VLLM_HOST_IP == ""
     assert envs.VLLM_PORT is None
-
-    environment_variables_cnt = len(environment_variables)
-    # After environment variable refresh, ensure
-    # - values are udpated
-    # - values are all cached
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")
-    refresh_envs_cache()
-
-    # No more cache miss after environment variable refresh
-    # NOTE: We use misses over hits in the test, as some environment variable
-    # initializations calls the __getattr__ which messed up the hit counts
-    # (e.g. VLLM_DP_RANK_LOCAL).
-    assert __getattr__.cache_info().misses == environment_variables_cnt
     assert envs.VLLM_HOST_IP == "1.1.1.1"
     assert envs.VLLM_PORT == 1234
-    assert __getattr__.cache_info().misses == environment_variables_cnt
+    # __getattr__ is not decorated with functools.cache
+    assert not hasattr(envs.__getattr__, "cache_info")
+
+
+def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
+    monkeypatch.setenv("VLLM_PORT", "1234")
+    # __getattr__ is not decorated with functools.cache
+    assert not hasattr(envs.__getattr__, "cache_info")
+
+    # Enable envs cache and ignore ongoing environment changes
+    enable_envs_cache()
+
+    # __getattr__ is not decorated with functools.cache
+    assert hasattr(envs.__getattr__, "cache_info")
+    start_hits = envs.__getattr__.cache_info().hits
+
+    # 2 more hits due to VLLM_HOST_IP and VLLM_PORT accesses
+    assert envs.VLLM_HOST_IP == "1.1.1.1"
+    assert envs.VLLM_PORT == 1234
+    assert envs.__getattr__.cache_info().hits == start_hits + 2
+
     # All environment variables are cached
     for environment_variable in environment_variables:
-        __getattr__(environment_variable)
-    assert __getattr__.cache_info().misses == environment_variables_cnt
+        envs.__getattr__(environment_variable)
+    assert envs.__getattr__.cache_info().hits == start_hits + 2 + len(
+        environment_variables
+    )
 
-    # Reset envs cache to avoid data pollution to other tests
-    reset_envs_cache()
+    # Reset envs.__getattr__ back to none-cached version to
+    # avoid affecting other tests
+    envs.__getattr__ = envs.__getattr__.__wrapped__
 
 
 class TestEnvWithChoices:

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -44,8 +44,9 @@ def test_refresh_envs_cache(monkeypatch: pytest.MonkeyPatch):
     refresh_envs_cache()
 
     # No more cache miss after environment variable refresh
-    # NOTE: We can't directly use CacheInfo().hits, as some environment variable
-    # initialization calls the __getattr__ as well (e.g. VLLM_DP_RANK_LOCAL).
+    # NOTE: We use misses over hits in the test, as some environment variable
+    # initializations calls the __getattr__ which messed up the hit counts
+    # (e.g. VLLM_DP_RANK_LOCAL).
     assert __getattr__.cache_info().misses == environment_variables_cnt
     assert envs.VLLM_HOST_IP == "1.1.1.1"
     assert envs.VLLM_PORT == 1234

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1430,9 +1430,10 @@ def enable_envs_cache() -> None:
     runtime overhead. This also means that environment variables should NOT
     be updated after the service is initialized.
     """
-    # Tag __getattr__ with lru_cache
+    # Tag __getattr__ with functools.cache
     global __getattr__
     __getattr__ = functools.cache(__getattr__)
+
     # Cache all environment variables
     for key in environment_variables:
         __getattr__(key)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1409,7 +1409,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
 
 
 def __getattr__(name: str):
-    # lazy evaluation of environment variables
+    """
+    Gets environment variables lazily.
+
+    NOTE: After enable_envs_cache() invocation (which triggered after service
+    initialization), all environment variables will be cached.
+    """
     if name in environment_variables:
         return environment_variables[name]()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1416,6 +1416,18 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def reset_envs_cache() -> None:
+    """Resets the cache of vllm environment variables."""
+    __getattr__.cache_clear()
+
+
+def refresh_envs_cache() -> None:
+    """Refreshes the cache of vllm environment variables."""
+    reset_envs_cache()
+    for key in environment_variables:
+        __getattr__(key)
+
+
 def __dir__():
     return list(environment_variables.keys())
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import functools
 import hashlib
 import json
 import os
@@ -1407,6 +1408,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
 # --8<-- [end:env-vars-definition]
 
 
+@functools.cache
 def __getattr__(name: str):
     # lazy evaluation of environment variables
     if name in environment_variables:

--- a/vllm/utils/gc_utils.py
+++ b/vllm/utils/gc_utils.py
@@ -7,7 +7,7 @@ from collections import Counter
 from contextlib import suppress
 from typing import Any
 
-from vllm.envs import VLLM_GC_DEBUG
+import vllm.envs as envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -36,7 +36,7 @@ class GCDebugConfig:
                 self.top_objects = json_conf.get("top_objects", -1)
             except Exception:
                 self.enabled = False
-                logger.error("Failed to parse VLLM_GC_DEBUG(%s)", VLLM_GC_DEBUG)
+                logger.error("Failed to parse VLLM_GC_DEBUG(%s)", envs.VLLM_GC_DEBUG)
         logger.info("GC Debug Config. %s", str(self))
 
     def __repr__(self) -> str:
@@ -93,7 +93,7 @@ def maybe_attach_gc_debug_callback() -> None:
     """
     Attached a callback for GC debug when VLLM_GC_DEBUG is enabled.
     """
-    config = GCDebugConfig(VLLM_GC_DEBUG)
+    config = GCDebugConfig(envs.VLLM_GC_DEBUG)
     if config.enabled:
         debugger: GCDebugger = GCDebugger(config)
 

--- a/vllm/utils/gc_utils.py
+++ b/vllm/utils/gc_utils.py
@@ -7,7 +7,7 @@ from collections import Counter
 from contextlib import suppress
 from typing import Any
 
-import vllm.envs as envs
+from vllm.envs import VLLM_GC_DEBUG
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -36,7 +36,7 @@ class GCDebugConfig:
                 self.top_objects = json_conf.get("top_objects", -1)
             except Exception:
                 self.enabled = False
-                logger.error("Failed to parse VLLM_GC_DEBUG(%s)", envs.VLLM_GC_DEBUG)
+                logger.error("Failed to parse VLLM_GC_DEBUG(%s)", VLLM_GC_DEBUG)
         logger.info("GC Debug Config. %s", str(self))
 
     def __repr__(self) -> str:
@@ -93,7 +93,7 @@ def maybe_attach_gc_debug_callback() -> None:
     """
     Attached a callback for GC debug when VLLM_GC_DEBUG is enabled.
     """
-    config = GCDebugConfig(envs.VLLM_GC_DEBUG)
+    config = GCDebugConfig(VLLM_GC_DEBUG)
     if config.enabled:
         debugger: GCDebugger = GCDebugger(config)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -20,7 +20,7 @@ import zmq
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.distributed.parallel_state import is_global_first_rank
-from vllm.envs import refresh_envs_cache
+from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
 from vllm.logging_utils.dump_input import dump_engine_exception
 from vllm.lora.request import LoRARequest
@@ -602,9 +602,9 @@ class EngineCoreProc(EngineCore):
         # If enable, attach GC debugger after static variable freeze.
         maybe_attach_gc_debug_callback()
 
-        # Refresh environment variable cache (e.g. assume no more
+        # Enable environment variable cache (e.g. assume no more
         # environment variable overrides after this point)
-        refresh_envs_cache()
+        enable_envs_cache()
 
     @contextmanager
     def _perform_handshakes(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -20,6 +20,7 @@ import zmq
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.distributed.parallel_state import is_global_first_rank
+from vllm.envs import refresh_envs_cache
 from vllm.logger import init_logger
 from vllm.logging_utils.dump_input import dump_engine_exception
 from vllm.lora.request import LoRARequest
@@ -600,6 +601,10 @@ class EngineCoreProc(EngineCore):
 
         # If enable, attach GC debugger after static variable freeze.
         maybe_attach_gc_debug_callback()
+
+        # Refresh environment variable cache (e.g. assume no more
+        # environment variable overrides after this point)
+        refresh_envs_cache()
 
     @contextmanager
     def _perform_handshakes(

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -33,6 +33,7 @@ from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
 )
+from vllm.envs import refresh_envs_cache
 from vllm.logger import init_logger
 from vllm.utils import (
     _maybe_force_spawn,
@@ -454,6 +455,10 @@ class WorkerProc:
 
         # Load model
         self.worker.load_model()
+
+        # Refresh environment variable cache (e.g. assume no more
+        # environment variable overrides after this point)
+        refresh_envs_cache()
 
     @staticmethod
     def make_worker_process(

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -33,7 +33,7 @@ from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
 )
-from vllm.envs import refresh_envs_cache
+from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
 from vllm.utils import (
     _maybe_force_spawn,
@@ -456,9 +456,9 @@ class WorkerProc:
         # Load model
         self.worker.load_model()
 
-        # Refresh environment variable cache (e.g. assume no more
+        # Enable environment variable cache (e.g. assume no more
         # environment variable overrides after this point)
-        refresh_envs_cache()
+        enable_envs_cache()
 
     @staticmethod
     def make_worker_process(


### PR DESCRIPTION
## Purpose
We found quite some os.env stack in the trace dump. But ideally, those environment results are NOT changed after process starts, so we should be caching the results to avoid recomputation.

Environment variables cache will be refreshed after the process initialization to allow environment variable overrides during server startups.

## Test Plan & Test Result
_get_num_input_tokens took 11us without the PR and 5us with the caching.

**Before**
<img width="1255" height="531" alt="Screenshot 2025-10-02 at 4 35 23 PM" src="https://github.com/user-attachments/assets/b1dbfadc-c7fc-454e-8e57-c18dd03b8014" />

**After**
<img width="1115" height="440" alt="Screenshot 2025-10-02 at 4 35 36 PM" src="https://github.com/user-attachments/assets/d2e0e331-b2b6-4fd4-ad29-5b915b329df6" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

