### PR TITLE
Fix V1 engine serialization error with Ray distributed executor

### DIFF
--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -16,8 +16,8 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.sequence import ExecuteModelRequest, IntermediateTensors
 from vllm.utils import get_ip
-from vllm.v1.worker.worker_base import WorkerWrapperBase
 from vllm.v1.outputs import AsyncModelRunnerOutput
+from vllm.v1.worker.worker_base import WorkerWrapperBase
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -144,7 +144,8 @@ try:
                 assert not output or not output.req_ids
                 output = scheduler_output, None
             # Ensure outputs crossing Ray compiled DAG are serializable.
-            # AsyncModelRunnerOutput holds CUDA events/streams and cannot be pickled.
+            # AsyncModelRunnerOutput holds CUDA events and cannot be
+            # pickled.
             if isinstance(output, AsyncModelRunnerOutput):
                 output = output.get_output()
             return output


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
**Problem**: When using V1 engine with Ray distributed executor, inference crashes with `TypeError: cannot pickle Event object` during the first request after initialization.

**Fixes**
- [Ray #57039](https://github.com/ray-project/ray/issues/57039)
- [vLLM #25861](https://github.com/vllm-project/vllm/issues/25861)

**Root Cause:** `AsyncGPUModelRunnerOutput` contains `torch.cuda.Event` objects that cannot be serialized when Ray's compiled DAG attempts to send outputs between workers via shared memory channels.

**Solution**: Unwrap `AsyncModelRunnerOutput` to `ModelRunnerOutput` before returning from `RayWorkerWrapper.execute_model_ray()`. This ensures only serializable data crosses Ray process boundaries.

## Test Plan
Tested with Qwen3-30B model using TP=4 on Ray Serve with vLLM V1 engine, ray-llm nightly image, and 4xL40S GPUs

## Test Result

**Input**
`serve run config.yaml`

config.yaml
```
applications:
- name: app
  import_path: ray.serve.llm:build_openai_app
  route_prefix: "/"
  args:
    llm_configs:
    - model_loading_config:
        model_id: qwen3
        model_source: unsloth/Qwen3-30B-A3B-Instruct-2507
      accelerator_type: L40S
      engine_kwargs:
        tensor_parallel_size: 4
        gpu_memory_utilization: 0.85
        max_model_len: 8192
        async_scheduling: true
        trust_remote_code: true
        enable_prefix_caching: true
        enable_auto_tool_choice: true
        tool_call_parser: hermes
      deployment_config:
        autoscaling_config:
          min_replicas: 1
          max_replicas: 1
          target_ongoing_requests: 128
          upscale_delay_s: 30
          downscale_delay_s: 120
          look_back_period_s: 15
        max_ongoing_requests: 160
      runtime_env:
        pip:
          - flashinfer-python
        env_vars:
          VLLM_USE_V1: "1"
      log_engine_metrics: true
```

send request
```
~/default$ curl --location 'http://localhost:8000/v1/chat/completions' --header 'Conte
nt-Type: application/json' --data '{
    "model": "qwen3",
    "messages": [
        {
            "role": "user",
            "content": "Hi"
        }
    ]
}'
```

**Output**
```

{"id":"chatcmpl-88e48ff0-b36d-4933-8e13-
bbe939ecdd4b","object":"chat.completion","created":1759454921,"model":"qwen3","choices":[{"index":0,"message":
{"role":"assistant","content":"Hello! How can I assist you today? 
😊","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":
[],"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"s
ystem_fingerprint":null,"usage":
{"prompt_tokens":9,"total_tokens":21,"completion_tokens":12,"prompt_tokens_details":null},"prompt_logprobs":null,"promp
t_token_ids":null,"kv_transfer_params":null}(base) ray@ip-10-0-163-91:~/default$ 

```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

