### PR TITLE
[Model] Pass param prefix to VocabParallelEmbedding in hunyuan_v1

### DIFF
--- a/vllm/model_executor/models/hunyuan_v1.py
+++ b/vllm/model_executor/models/hunyuan_v1.py
@@ -604,7 +604,7 @@ class HunYuanModel(nn.Module):
                 config.hidden_size,
                 org_num_embeddings=config.vocab_size,
                 quant_config=quant_config,
-            )
+                prefix=maybe_prefix(prefix, "embed_tokens"))
         else:
             self.embed_tokens = PPMissingLayer()
         self.start_layer, self.end_layer, self.layers = make_layers(


### PR DESCRIPTION

## Purpose
Some custom quantization methods, such as `w4a8 dynamic` in `vllm-ascend`, need to determine whether specific modules like embedding layers should be quantized. This is often done by checking a configuration dictionary using a key constructed from the module's `prefix` and its parameter name (e.g., `model.embed_tokens.weight`).

In the `HunyuanModel` implementation, the `prefix` parameter was not being passed down during the instantiation of `VocabParallelEmbedding`. This resulted in an empty prefix, leading to an incorrect key (`.weight`) being used for the lookup and causing a `KeyError`.

This PR resolves the issue by correctly forwarding the `prefix` to the `VocabParallelEmbedding` module. This change is non-disruptive to existing quantization methods and improves compatibility with current and future custom quantization frameworks.

## Test Plan
I have tested this change by loading the Hunyuan-1.8B-instruct model with the w4a8 dynamic quantization from vllm-ascend

## Test Result

**Before Fix: Model loading fails with `KeyError`**

When the `prefix` is not passed correctly, the program terminates with the following traceback:
```
Traceback (most recent call last):
  File "/root/miniconda3/envs/infer/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/root/miniconda3/envs/infer/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 712, in run_engine_core
    raise e
  File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 699, in run_engine_core
    engine_core = EngineCoreProc(*args, **kwargs)
  File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 498, in __init__
    super().__init__(vllm_config, executor_class, log_stats,
  File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 83, in __init__
    self.model_executor = executor_class(vllm_config)
  File "/root/autodl-tmp/vllm/vllm/executor/executor_base.py", line 54, in __init__
    self._init_executor()
  File "/root/autodl-tmp/vllm/vllm/executor/uniproc_executor.py", line 55, in _init_executor
    self.collective_rpc("load_model")
  File "/root/autodl-tmp/vllm/vllm/executor/uniproc_executor.py", line 83, in collective_rpc
    return [run_method(self.driver_worker, method, args, kwargs)]
  File "/root/autodl-tmp/vllm/vllm/utils/__init__.py", line 3121, in run_method
    return func(*args, **kwargs)
  File "/root/autodl-tmp/vllm-ascend/vllm_ascend/worker/worker_v1.py", line 291, in load_model
    self.model_runner.load_model()
  File "/root/autodl-tmp/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2639, in load_model
    self.model = get_model(vllm_config=self.vllm_config)
  File "/root/autodl-tmp/vllm/vllm/model_executor/model_loader/__init__.py", line 119, in get_model
    return loader.load_model(vllm_config=vllm_config,
  File "/root/autodl-tmp/vllm/vllm/model_executor/model_loader/base_loader.py", line 45, in load_model
    model = initialize_model(vllm_config=vllm_config,
  File "/root/autodl-tmp/vllm/vllm/model_executor/model_loader/utils.py", line 63, in initialize_model
    return model_class(vllm_config=vllm_config, prefix=prefix)
  File "/root/autodl-tmp/vllm/vllm/model_executor/models/hunyuan_v1.py", line 1076, in __init__
    super().__init__(vllm_config=vllm_config, prefix=prefix)
  File "/root/autodl-tmp/vllm/vllm/model_executor/models/hunyuan_v1.py", line 918, in __init__
    self.model = HunYuanModel(vllm_config=vllm_config, prefix="model")
  File "/root/autodl-tmp/vllm/vllm/compilation/decorators.py", line 201, in __init__
    old_init(self, vllm_config=vllm_config, prefix=prefix, **kwargs)
  File "/root/autodl-tmp/vllm/vllm/model_executor/models/hunyuan_v1.py", line 603, in __init__
    self.embed_tokens = VocabParallelEmbedding(
  File "/root/autodl-tmp/vllm-ascend/vllm_ascend/ops/vocab_parallel_embedding.py", line 81, in __init__
    quant_method = quant_config.get_quant_method(self, prefix=prefix)
  File "/root/autodl-tmp/vllm-ascend/vllm_ascend/quantization/quant_config.py", line 120, in get_quant_method
    if self.is_layer_skipped_ascend(prefix,
  File "/root/autodl-tmp/vllm-ascend/vllm_ascend/quantization/quant_config.py", line 153, in is_layer_skipped_ascend
    is_skipped = self.quant_description[prefix + '.weight'] == "FLOAT"
KeyError: '.weight'
```

**After Fix: Model loading is successful**

After passing the `prefix` parameter correctly, the model loads and initializes without issue.
```
WARNING 10-03 10:13:23 [_custom_ops.py:20] Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
INFO 10-03 10:13:23 [importing.py:63] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 10-03 10:13:23 [core.py:644] Waiting for init message from front-end.
...
INFO 10-03 10:13:42 [parallel_state.py:1208] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
INFO 10-03 10:13:42 [model_runner_v1.py:2636] Starting to load model ./models/Hunyuan-1.8B-Instruct-quantized...
INFO 10-03 10:13:43 [utils.py:60] Using the vLLM Ascend Quantization now!
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.09it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.08it/s]
...
INFO 10-03 10:13:45 [model_runner_v1.py:2670] Loading model weights took 1.2984 GB
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

