### PR TITLE
[Bench] Add decode-only profile support in bench serve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!vllm/benchmarks/lib/
 lib64/
 parts/
 sdist/

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -48,6 +48,7 @@ class RequestFuncOutput:
     tpot: float = 0.0  # avg next-token latencies
     prompt_len: int = 0
     error: str = ""
+    http_status: int = 200
 
 
 async def async_request_tgi(
@@ -89,6 +90,7 @@ async def async_request_tgi(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.http_status = response.status
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -164,6 +166,7 @@ async def async_request_trt_llm(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.http_status = response.status
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -238,6 +241,7 @@ async def async_request_deepspeed_mii(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.http_status = response.status
                 if response.status == 200:
                     parsed_resp = await response.json()
                     output.latency = time.perf_counter() - st
@@ -309,6 +313,7 @@ async def async_request_openai_completions(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.http_status = response.status
                 if response.status == 200:
                     first_chunk_received = False
                     async for chunk_bytes in response.content:
@@ -424,6 +429,7 @@ async def async_request_openai_chat_completions(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.http_status = response.status
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -538,6 +544,7 @@ async def async_request_openai_audio(
                 async with session.post(
                     url=api_url, data=form, headers=headers
                 ) as response:
+                    output.http_status = response.status
                     if response.status == 200:
                         async for chunk_bytes in response.content:
                             chunk_bytes = chunk_bytes.strip()

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -91,6 +91,7 @@ class RequestFuncOutput:
     prompt_len: int = 0
     error: str = ""
     start_time: float = 0.0
+    http_status: int = 200
 
 
 class RequestFunc(Protocol):
@@ -157,6 +158,7 @@ async def async_request_openai_completions(
     try:
         async with session.post(url=api_url, json=payload,
                                 headers=headers) as response:
+            output.http_status = response.status
             if response.status == 200:
                 first_chunk_received = False
                 handler = StreamedResponseHandler()
@@ -290,6 +292,7 @@ async def async_request_openai_chat_completions(
     try:
         async with session.post(url=api_url, json=payload,
                                 headers=headers) as response:
+            output.http_status = response.status
             if response.status == 200:
                 handler = StreamedResponseHandler()
                 async for chunk_bytes in response.content.iter_any():
@@ -416,6 +419,7 @@ async def async_request_openai_audio(
             async with session.post(url=api_url,
                                     data=form,
                                     headers=headers) as response:
+                output.http_status = response.status
                 if response.status == 200:
                     handler = StreamedResponseHandler()
 
@@ -497,6 +501,7 @@ async def async_request_openai_embeddings(
             headers=headers,
             json=payload
         ) as response:
+            output.http_status = response.status
             if response.status == 200:
                 output.latency = time.perf_counter() - st
                 data = await response.json()

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -447,8 +447,9 @@ def calculate_metrics(
     return metrics, actual_output_lens
 
 
-async def _fetch_metrics(base_url: str,
-                        session: aiohttp.ClientSession) -> Optional[MetricsSnapshot]:
+async def _fetch_metrics(
+    base_url: str, session: aiohttp.ClientSession
+) -> Optional[MetricsSnapshot]:
     """Fetch metrics from /metrics endpoint."""
     try:
         async with session.get(f"{base_url}/metrics") as response:
@@ -533,9 +534,9 @@ async def _start_profiler(request_func, base_url: str, model_id: str,
         return False
 
 
-async def _setup_decode_profiling(base_url: str, metrics_interval: float) -> tuple[
-    Optional[aiohttp.ClientSession], Optional[MetricsSnapshot]
-]:
+async def _setup_decode_profiling(
+    base_url: str, metrics_interval: float
+) -> tuple[Optional[aiohttp.ClientSession], Optional[MetricsSnapshot]]:
     """Set up decode profiling and test metrics endpoint availability."""
     print(f"Decode-only profiling enabled - monitoring metrics "
           f"every {metrics_interval}s")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This is to support profiling decode-only behavior by programmatically monitoring generation throughput vs. prompt throughput.

Followup/contribution welcome:
* [ ] support `nsys start` for decode-only profile

## Test Plan

`vllm bench serve --model deepseek-ai/DeepSeek-R1-0528 --port 8000  --dataset-name random --ignore-eos  --num-prompts 2048 --request-rate 2048  --random-input-len 2048  --random-output-len 1024 --max-concurrency 2048 --trust_remote_code --seed $RANDOM --ready-check-timeout-sec 0 --profile-decode-only --decode-profile-duration 10`

## Test Result

* verified profile starting/stopping as expected
* verified trace is decode-only

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

