### PR TITLE
[test utils] correct wrong typing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -756,7 +756,7 @@ class VllmRunner:
 
     def get_inputs(
         self,
-        prompts: Union[list[str], list[torch.Tensor], list[int]],
+        prompts: Union[list[str], list[torch.Tensor], list[list[int]]],
         images: Optional[PromptImageInput] = None,
         videos: Optional[PromptVideoInput] = None,
         audios: Optional[PromptAudioInput] = None,


### PR DESCRIPTION
## Purpose
Fixing the wrong type annotation. 

For the function `get_inputs()` the argument `prompts` accepts a list of strings, tensors or a **list!** of integers. 

The type annotation should therefore be changed from:
`prompts: Union[list[str], list[torch.Tensor], list[int]],`
to 
`prompts: Union[list[str], list[torch.Tensor], list[list[int]]],`
. 

in the subsequent lines 771 - 793: 
```
        inputs = []
        for i, prompt in enumerate(prompts):
            multi_modal_data = {}
            if images is not None and (image := images[i]) is not None:
                multi_modal_data["image"] = image
            if videos is not None and (video := videos[i]) is not None:
                multi_modal_data["video"] = video
            if audios is not None and (audio := audios[i]) is not None:
                multi_modal_data["audio"] = audio
            text_prompt_kwargs: dict[str, Any] = {
                "multi_modal_data": multi_modal_data or None
            }
            if isinstance(prompt, str):
                text_prompt_kwargs["prompt"] = prompt
            elif isinstance(prompt, list):
                text_prompt_kwargs["prompt_token_ids"] = prompt
            else:
                text_prompt_kwargs["prompt_embeds"] = prompt
            inputs.append(TextPrompt(**text_prompt_kwargs))
        return inputs

```
the unpacked prompt in `prompts` is checked if it is an instance of `str` or a `list` (and defaults to the tensor case). Hence, `prompts` consisting of token ids are provided as list of list of integers. 


## Test Plan
No testing needed. 

## Test Result
No change in logic, all tests still pass. 
