### PR TITLE
[Core] Enable decode of context length equal to max model length

### DIFF
--- a/tests/entrypoints/llm/test_generate.py
+++ b/tests/entrypoints/llm/test_generate.py
@@ -82,10 +82,11 @@ def test_max_model_len():
     for output in outputs:
         num_total_tokens = len(output.prompt_token_ids) + len(
             output.outputs[0].token_ids)
-        # Total tokens must not exceed max_model_len.
+        # Total tokens must not exceed max_model_len + 1 (the last token can be
+        # generated with the context length equal to the max model length)
         # It can be less if generation finishes due to other reasons (e.g., EOS)
         # before reaching the absolute model length limit.
-        assert num_total_tokens <= max_model_len
+        assert num_total_tokens <= max_model_len + 1
 
 
 def test_log_stats():

--- a/tests/v1/e2e/test_context_length.py
+++ b/tests/v1/e2e/test_context_length.py
@@ -8,7 +8,7 @@ This test verifies the following behavior: allow prefill and decodes on the
 model's maximum context length ``max_model_len`` and get one more token.
 
 Test strategy
-- Build a textual prompt that tokenizes to exactly ``max_model_len`` tokens.
+- Build a textual prompt that tokenizes to exactly ``prompt_len`` tokens.
 - Run vLLM generation requesting ``max_tokens`` new tokens.
 - Run HF generation on the same prompt requesting the same number of tokens.
 - Assert both return the same number of generated tokens and the same ids.
@@ -35,15 +35,15 @@ from vllm.inputs import TokensPrompt
 @create_new_process_for_each_test()
 @pytest.mark.parametrize("model", ["JackFram/llama-160m"])
 @pytest.mark.parametrize(
-    "max_model_len, max_tokens",
+    "prompt_len, max_tokens",
     [
-        (2048, 1),
-        (2047, 2),
+        (2048, 1),  # prompt_len = max_model_len
+        (2047, 2),  # prompt_len = max_model_len - 1
     ],
 )
 def test_max_context_length(
     model: str,
-    max_model_len: int,
+    prompt_len: int,
     max_tokens: int,
 ) -> None:
     """Compare vLLM and HuggingFace when the prompt already fills the
@@ -54,8 +54,8 @@ def test_max_context_length(
     single token when given the same inputs.
     """
 
-    # Construct a prompt of size max_model_len
-    prompt_ids = [[43] * max_model_len]
+    # Construct a prompt of size prompt_len
+    prompt_ids = [[43] * prompt_len]
 
     # Generate max_tokens new tokens deterministically.
     sampling_params = [

--- a/tests/v1/e2e/test_context_length.py
+++ b/tests/v1/e2e/test_context_length.py
@@ -93,6 +93,9 @@ def test_max_context_length(
         # HF returns the prompt + generated tokens. Slice off the prompt.
         hf_output_ids = hf_generated.cpu().tolist()[0][len(prompt_ids[0]):]
 
+    # check that exactly max_tokens tokens were generated with vLLM and HF
+    assert len(vllm_output_ids) == len(hf_output_ids) == max_tokens
+
     # check that vLLM outputs (token ids) match HF outputs
     # Note: for simplicity don't pass detokenized string
     check_outputs_equal(

--- a/tests/v1/e2e/test_context_length.py
+++ b/tests/v1/e2e/test_context_length.py
@@ -8,7 +8,7 @@ This test verifies the following behavior: allow prefill and decodes on the
 model's maximum context length ``max_model_len`` and get one more token.
 
 Test strategy
-- Build a textual prompt that tokenizes to exactly ``prompt_len`` tokens.
+- Build a prompt consisting of exactly ``prompt_len`` tokens.
 - Run vLLM generation requesting ``max_tokens`` new tokens.
 - Run HF generation on the same prompt requesting the same number of tokens.
 - Assert both return the same number of generated tokens and the same ids.
@@ -66,6 +66,7 @@ def test_max_context_length(
     llm = LLM(
         model=model,
         tokenizer=model,
+        max_model_len=2048,
         max_num_seqs=1,
         tensor_parallel_size=1,
     )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -224,7 +224,7 @@ class Scheduler(SchedulerInterface):
             # This is necessary when using spec decoding.
             num_new_tokens = min(
                 num_new_tokens,
-                self.max_model_len - 1 - request.num_computed_tokens)
+                self.max_model_len - request.num_computed_tokens)
 
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -43,7 +43,7 @@ def remove_all(lst: list, items_to_remove: set) -> list:
 def check_stop(request: Request,
                max_model_len: int,
                pooler_output: Optional[torch.Tensor] = None) -> bool:
-    if (request.num_tokens >= max_model_len
+    if (request.num_tokens > max_model_len
             or request.num_output_tokens >= request.max_tokens):
         request.status = RequestStatus.FINISHED_LENGTH_CAPPED
         return True


### PR DESCRIPTION
## Purpose

On the current main branch, the stopping criterion does not allow a decode on context length `max_model_len`, the last decode happens at context length `max_model_len - 1` (one token before the actual limit). 

## Proposed change
Relax the assertion/check such that a last token can be generated and sampled when the context length exactly equals `max_model_len`.

changes needed:
- [vllm/v1/core/sched/scheduler.py](https://github.com/vllm-project/vllm/compare/main...yannicks1:vllm:enable-decode-of-max-model-len?expand=1#diff-9eeca590fd99f15621897e559dba39b3ec4e7c2c65ec3c3229711689e008b5f4)
- [vllm/v1/core/sched/utils.py](https://github.com/vllm-project/vllm/compare/main...yannicks1:vllm:enable-decode-of-max-model-len?expand=1#diff-d62daddf89a3f4abaf0f507a93ac2364c0fea3a31643c9bd2c0915662c2545fa)

This restores parity with the HuggingFace [transformers](https://github.com/huggingface/transformers) behavior (see [this](https://github.com/huggingface/transformers/pull/40775) PR) and avoids rejecting otherwise-valid generation requests.

## Test Plan
Extend the existing end-to-end context length test that compares vLLM to HuggingFace Transformers:
- Test file: tests/v1/e2e/test_context_length.py
- Test logic: build a textual prompt that tokenizes to exactly `prompt_len=max_model_len - 1`, then:
  - Run vLLM generation requesting `max_tokens=2`.
  - Run HF .generate(...) requesting `max_tokens=2`.
  - Assert both return the same number of generated tokens (equaling `max_tokens`) and the same token ids.

### Failing behavior (before this PR)

Without the change the unit test fails with:

```
============================================================================================== FAILURES ==============================================================================================
________________________________________________________________________ test_max_context_length[2047-2-JackFram/llama-160m] _________________________________________________________________________

>   assert len(vllm_output_ids) == len(hf_output_ids) == max_tokens
      ^^^^^^^^^^^^^^^^^
E   assert 1 == 2
E    +  where 1 = len([15898])
E    +  and   2 = len([15898, 11587])

tests/v1/e2e/test_context_length.py:98: AssertionError
```

### Test result (after this PR)

both tests pass:
```
=========================================================================== 2 passed in 36.51s ===========================================================================
```



