### PR TITLE
Stop mergify from keeping stale PRs alive

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,10 +2,11 @@ pull_request_rules:
 - name: label-documentation
   description: Automatically apply documentation label
   conditions:
+    - label != stale
     - or:
-      - files~=^[^/]+\.md$
-      - files~=^docs/
-      - files~=^examples/
+      - files ~= ^[^/]+\.md$
+      - files ~= ^docs/
+      - files ~= ^examples/
   actions:
     label:
       add:
@@ -14,14 +15,15 @@ pull_request_rules:
 - name: label-ci-build
   description: Automatically apply ci/build label
   conditions:
+    - label != stale
     - or:
-      - files~=^\.github/
-      - files~=\.buildkite/
-      - files~=^cmake/
-      - files=CMakeLists.txt
-      - files~=^docker/Dockerfile
-      - files~=^requirements.*\.txt
-      - files=setup.py
+      - files ~= ^\.github/
+      - files ~= \.buildkite/
+      - files ~= ^cmake/
+      - files = CMakeLists.txt
+      - files ~= ^docker/Dockerfile
+      - files ~= ^requirements.*\.txt
+      - files = setup.py
   actions:
     label:
       add:
@@ -30,14 +32,15 @@ pull_request_rules:
 - name: label-deepseek
   description: Automatically apply deepseek label
   conditions:
+    - label != stale
     - or:
-      - files~=^examples/.*deepseek.*\.py
-      - files~=^tests/.*deepseek.*\.py
-      - files~=^vllm/entrypoints/openai/tool_parsers/.*deepseek.*\.py
-      - files~=^vllm/model_executor/models/.*deepseek.*\.py
-      - files~=^vllm/reasoning/.*deepseek.*\.py
-      - files~=^vllm/transformers_utils/.*deepseek.*\.py
-      - title~=(?i)DeepSeek
+      - files ~= ^examples/.*deepseek.*\.py
+      - files ~= ^tests/.*deepseek.*\.py
+      - files ~= ^vllm/entrypoints/openai/tool_parsers/.*deepseek.*\.py
+      - files ~= ^vllm/model_executor/models/.*deepseek.*\.py
+      - files ~= ^vllm/reasoning/.*deepseek.*\.py
+      - files ~= ^vllm/transformers_utils/.*deepseek.*\.py
+      - title ~= (?i)DeepSeek
   actions:
     label:
       add:
@@ -46,7 +49,8 @@ pull_request_rules:
 - name: label-frontend
   description: Automatically apply frontend label
   conditions:
-    - files~=^vllm/entrypoints/
+    - label != stale
+    - files ~= ^vllm/entrypoints/
   actions:
     label:
       add:
@@ -55,13 +59,14 @@ pull_request_rules:
 - name: label-llama
   description: Automatically apply llama label
   conditions:
+    - label != stale
     - or:
-      - files~=^examples/.*llama.*\.py
-      - files~=^tests/.*llama.*\.py
-      - files~=^vllm/entrypoints/openai/tool_parsers/llama.*\.py
-      - files~=^vllm/model_executor/models/.*llama.*\.py
-      - files~=^vllm/transformers_utils/configs/.*llama.*\.py
-      - title~=(?i)llama
+      - files ~= ^examples/.*llama.*\.py
+      - files ~= ^tests/.*llama.*\.py
+      - files ~= ^vllm/entrypoints/openai/tool_parsers/llama.*\.py
+      - files ~= ^vllm/model_executor/models/.*llama.*\.py
+      - files ~= ^vllm/transformers_utils/configs/.*llama.*\.py
+      - title ~= (?i)llama
   actions:
     label:
       add:
@@ -70,11 +75,12 @@ pull_request_rules:
 - name: label-multi-modality
   description: Automatically apply multi-modality label
   conditions:
+    - label != stale
     - or:
-      - files~=^vllm/multimodal/
-      - files~=^tests/multimodal/
-      - files~=^tests/models/multimodal/
-      - files=tests/models/test_vision.py
+      - files ~= ^vllm/multimodal/
+      - files ~= ^tests/multimodal/
+      - files ~= ^tests/models/multimodal/
+      - files = tests/models/test_vision.py
   actions:
     label:
       add:
@@ -83,9 +89,10 @@ pull_request_rules:
 - name: label-new-model
   description: Automatically apply new-model label
   conditions:
+    - label != stale
     - and:
-      - files~=^vllm/model_executor/models/
-      - files=vllm/model_executor/models/registry.py
+      - files ~= ^vllm/model_executor/models/
+      - files = vllm/model_executor/models/registry.py
   actions:
     label:
       add:
@@ -94,11 +101,12 @@ pull_request_rules:
 - name: label-performance
   description: Automatically apply performance label
   conditions:
+    - label != stale
     - or:
-      - files~=^benchmarks/
-      - files~=^vllm/benchmarks/
-      - files~=^tests/benchmarks/
-      - files~=^\.buildkite/nightly-benchmarks/
+      - files ~= ^benchmarks/
+      - files ~= ^vllm/benchmarks/
+      - files ~= ^tests/benchmarks/
+      - files ~= ^\.buildkite/nightly-benchmarks/
   actions:
     label:
       add:
@@ -107,12 +115,13 @@ pull_request_rules:
 - name: label-qwen
   description: Automatically apply qwen label
   conditions:
+    - label != stale
     - or:
-      - files~=^examples/.*qwen.*\.py
-      - files~=^tests/.*qwen.*\.py
-      - files~=^vllm/model_executor/models/.*qwen.*\.py
-      - files~=^vllm/reasoning/.*qwen.*\.py
-      - title~=(?i)Qwen
+      - files ~= ^examples/.*qwen.*\.py
+      - files ~= ^tests/.*qwen.*\.py
+      - files ~= ^vllm/model_executor/models/.*qwen.*\.py
+      - files ~= ^vllm/reasoning/.*qwen.*\.py
+      - title ~= (?i)Qwen
   actions:
     label:
       add:
@@ -121,19 +130,20 @@ pull_request_rules:
 - name: label-gpt-oss
   description: Automatically apply gpt-oss label
   conditions:
+    - label != stale
     - or:
-      - files~=^examples/.*gpt[-_]?oss.*\.py
-      - files~=^tests/.*gpt[-_]?oss.*\.py
-      - files~=^tests/entrypoints/openai/test_response_api_with_harmony.py
-      - files~=^tests/entrypoints/test_context.py
-      - files~=^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
-      - files~=^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
-      - files~=^vllm/entrypoints/harmony_utils.py
-      - files~=^vllm/entrypoints/tool_server.py
-      - files~=^vllm/entrypoints/tool.py
-      - files~=^vllm/entrypoints/context.py
-      - title~=(?i)gpt[-_]?oss
-      - title~=(?i)harmony
+      - files ~= ^examples/.*gpt[-_]?oss.*\.py
+      - files ~= ^tests/.*gpt[-_]?oss.*\.py
+      - files ~= ^tests/entrypoints/openai/test_response_api_with_harmony.py
+      - files ~= ^tests/entrypoints/test_context.py
+      - files ~= ^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
+      - files ~= ^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
+      - files ~= ^vllm/entrypoints/harmony_utils.py
+      - files ~= ^vllm/entrypoints/tool_server.py
+      - files ~= ^vllm/entrypoints/tool.py
+      - files ~= ^vllm/entrypoints/context.py
+      - title ~= (?i)gpt[-_]?oss
+      - title ~= (?i)harmony
   actions:
     label:
       add:
@@ -142,18 +152,19 @@ pull_request_rules:
 - name: label-rocm
   description: Automatically apply rocm label
   conditions:
+    - label != stale
     - or:
-      - files~=^csrc/rocm/
-      - files~=^docker/Dockerfile.rocm
-      - files~=^requirements/rocm.*\.txt
-      - files~=^vllm/attention/backends/rocm.*\.py
-      - files~=^vllm/attention/ops/rocm.*\.py
-      - files~=^vllm/model_executor/layers/fused_moe/rocm.*\.py
-      - files~=^vllm/v1/attention/backends/mla/rocm.*\.py
-      - files~=^tests/kernels/.*_rocm.*\.py
-      - files=vllm/platforms/rocm.py
-      - title~=(?i)AMD
-      - title~=(?i)ROCm
+      - files ~= ^csrc/rocm/
+      - files ~= ^docker/Dockerfile.rocm
+      - files ~= ^requirements/rocm.*\.txt
+      - files ~= ^vllm/attention/backends/rocm.*\.py
+      - files ~= ^vllm/attention/ops/rocm.*\.py
+      - files ~= ^vllm/model_executor/layers/fused_moe/rocm.*\.py
+      - files ~= ^vllm/v1/attention/backends/mla/rocm.*\.py
+      - files ~= ^tests/kernels/.*_rocm.*\.py
+      - files = vllm/platforms/rocm.py
+      - title ~= (?i)AMD
+      - title ~= (?i)ROCm
   actions:
     label:
       add:
@@ -162,17 +173,18 @@ pull_request_rules:
 - name: label-structured-output
   description: Automatically apply structured-output label
   conditions:
+    - label != stale
     - or:
-      - files~=^benchmarks/structured_schemas/
-      - files=benchmarks/benchmark_serving_structured_output.py
-      - files=benchmarks/run_structured_output_benchmark.sh
-      - files=docs/features/structured_outputs.md
-      - files=examples/offline_inference/structured_outputs.py
-      - files=examples/online_serving/openai_chat_completion_structured_outputs.py
-      - files=examples/online_serving/openai_chat_completion_structured_outputs_with_reasoning.py
-      - files~=^tests/v1/structured_output/
-      - files=tests/v1/entrypoints/llm/test_struct_output_generate.py
-      - files~=^vllm/v1/structured_output/
+      - files ~= ^benchmarks/structured_schemas/
+      - files = benchmarks/benchmark_serving_structured_output.py
+      - files = benchmarks/run_structured_output_benchmark.sh
+      - files = docs/features/structured_outputs.md
+      - files = examples/offline_inference/structured_outputs.py
+      - files = examples/online_serving/openai_chat_completion_structured_outputs.py
+      - files = examples/online_serving/openai_chat_completion_structured_outputs_with_reasoning.py
+      - files ~= ^tests/v1/structured_output/
+      - files = tests/v1/entrypoints/llm/test_struct_output_generate.py
+      - files ~= ^vllm/v1/structured_output/
   actions:
     label:
       add:
@@ -181,13 +193,14 @@ pull_request_rules:
 - name: label-speculative-decoding
   description: Automatically apply speculative-decoding label
   conditions:
+    - label != stale
     - or:
-      - files~=^vllm/v1/spec_decode/
-      - files~=^tests/v1/spec_decode/
-      - files~=^examples/.*(spec_decode|mlpspeculator|eagle|speculation).*\.py
-      - files~=^vllm/model_executor/models/.*eagle.*\.py
-      - files=vllm/model_executor/models/mlp_speculator.py
-      - files~=^vllm/transformers_utils/configs/(eagle|medusa|mlp_speculator)\.py
+      - files ~= ^vllm/v1/spec_decode/
+      - files ~= ^tests/v1/spec_decode/
+      - files ~= ^examples/.*(spec_decode|mlpspeculator|eagle|speculation).*\.py
+      - files ~= ^vllm/model_executor/models/.*eagle.*\.py
+      - files = vllm/model_executor/models/mlp_speculator.py
+      - files ~= ^vllm/transformers_utils/configs/(eagle|medusa|mlp_speculator)\.py
   actions:
     label:
       add:
@@ -196,9 +209,10 @@ pull_request_rules:
 - name: label-v1
   description: Automatically apply v1 label
   conditions:
+    - label != stale
     - or:
-      - files~=^vllm/v1/
-      - files~=^tests/v1/
+      - files ~= ^vllm/v1/
+      - files ~= ^tests/v1/
   actions:
     label:
       add:
@@ -208,12 +222,13 @@ pull_request_rules:
   description: Automatically apply tpu label
   # Keep this list in sync with `label-tpu-remove` conditions
   conditions:
+    - label != stale
     - or:
-      - files~=tpu.py
-      - files~=_tpu
-      - files~=tpu_
-      - files~=/tpu/
-      - files~=pallas
+      - files ~= tpu.py
+      - files ~= _tpu
+      - files ~= tpu_
+      - files ~= /tpu/
+      - files ~= pallas
   actions:
     label:
       add:
@@ -223,12 +238,13 @@ pull_request_rules:
   description: Automatically remove tpu label
   # Keep this list in sync with `label-tpu` conditions
   conditions:
+    - label != stale
     - and:
-      - -files~=tpu.py
-      - -files~=_tpu
-      - -files~=tpu_
-      - -files~=/tpu/
-      - -files~=pallas
+      - -files ~= tpu.py
+      - -files ~= _tpu
+      - -files ~= tpu_
+      - -files ~= /tpu/
+      - -files ~= pallas
   actions:
     label:
       remove:
@@ -237,17 +253,18 @@ pull_request_rules:
 - name: label-tool-calling
   description: Automatically add tool-calling label
   conditions:
+    - label != stale
     - or:
-      - files~=^tests/tool_use/
-      - files~=^tests/entrypoints/openai/tool_parsers/
-      - files=tests/entrypoints/openai/test_chat_with_tool_reasoning.py
-      - files~=^vllm/entrypoints/openai/tool_parsers/
-      - files=docs/features/tool_calling.md
-      - files~=^examples/tool_chat_*
-      - files=examples/offline_inference/chat_with_tools.py
-      - files=examples/online_serving/openai_chat_completion_client_with_tools_required.py
-      - files=examples/online_serving/openai_chat_completion_tool_calls_with_reasoning.py
-      - files=examples/online_serving/openai_chat_completion_client_with_tools.py
+      - files ~= ^tests/tool_use/
+      - files ~= ^tests/entrypoints/openai/tool_parsers/
+      - files = tests/entrypoints/openai/test_chat_with_tool_reasoning.py
+      - files ~= ^vllm/entrypoints/openai/tool_parsers/
+      - files = docs/features/tool_calling.md
+      - files ~= ^examples/tool_chat_*
+      - files = examples/offline_inference/chat_with_tools.py
+      - files = examples/online_serving/openai_chat_completion_client_with_tools_required.py
+      - files = examples/online_serving/openai_chat_completion_tool_calls_with_reasoning.py
+      - files = examples/online_serving/openai_chat_completion_client_with_tools.py
   actions:
     label:
       add:
@@ -255,8 +272,9 @@ pull_request_rules:
 
 - name: ping author on conflicts and add 'needs-rebase' label
   conditions:
-      - conflict
-      - -closed
+    - label != stale
+    - conflict
+    - -closed
   actions:
     label:
       add:
@@ -270,10 +288,12 @@ pull_request_rules:
 
 - name: assign reviewer for tensorizer changes
   conditions:
-      - files~=^vllm/model_executor/model_loader/tensorizer.py
-      - files~=^vllm/model_executor/model_loader/tensorizer_loader.py
-      - files~=^tests/entrypoints/openai/test_tensorizer_entrypoint.py
-      - files~=^tests/model_executor/model_loader/tensorizer_loader/
+    - label != stale
+    - or:
+      - files ~= ^vllm/model_executor/model_loader/tensorizer.py
+      - files ~= ^vllm/model_executor/model_loader/tensorizer_loader.py
+      - files ~= ^tests/entrypoints/openai/test_tensorizer_entrypoint.py
+      - files ~= ^tests/model_executor/model_loader/tensorizer_loader/
   actions:
     assign:
       users:
@@ -281,13 +301,14 @@ pull_request_rules:
 
 - name: assign reviewer for modelopt changes
   conditions:
+    - label != stale
     - or:
-        - files~=^vllm/model_executor/layers/quantization/modelopt\.py$
-        - files~=^vllm/model_executor/layers/quantization/__init__\.py$
-        - files~=^tests/models/quantization/test_modelopt\.py$
-        - files~=^tests/quantization/test_modelopt\.py$
-        - files~=^tests/models/quantization/test_nvfp4\.py$
-        - files~=^docs/features/quantization/modelopt\.md$
+        - files ~= ^vllm/model_executor/layers/quantization/modelopt\.py$
+        - files ~= ^vllm/model_executor/layers/quantization/__init__\.py$
+        - files ~= ^tests/models/quantization/test_modelopt\.py$
+        - files ~= ^tests/quantization/test_modelopt\.py$
+        - files ~= ^tests/models/quantization/test_nvfp4\.py$
+        - files ~= ^docs/features/quantization/modelopt\.md$
   actions:
     assign:
       users:
@@ -295,8 +316,8 @@ pull_request_rules:
 
 - name: remove 'needs-rebase' label when conflict is resolved
   conditions:
-      - -conflict
-      - -closed
+    - -conflict
+    - -closed
   actions:
     label:
       remove:
@@ -305,15 +326,16 @@ pull_request_rules:
 - name: label-kv-connector
   description: Automatically apply kv-connector label
   conditions:
+    - label != stale
     - or:
-      - files~=^examples/online_serving/disaggregated[^/]*/.*
-      - files~=^examples/offline_inference/disaggregated[^/]*/.*
-      - files~=^examples/others/lmcache/
-      - files~=^tests/v1/kv_connector/
-      - files~=^vllm/distributed/kv_transfer/
-      - title~=(?i)\bP/?D\b
-      - title~=(?i)NIXL
-      - title~=(?i)LMCache
+      - files ~= ^examples/online_serving/disaggregated[^/]*/.*
+      - files ~= ^examples/offline_inference/disaggregated[^/]*/.*
+      - files ~= ^examples/others/lmcache/
+      - files ~= ^tests/v1/kv_connector/
+      - files ~= ^vllm/distributed/kv_transfer/
+      - title ~= (?i)\bP/?D\b
+      - title ~= (?i)NIXL
+      - title ~= (?i)LMCache
   actions:
     label:
       add:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,9 +4,9 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^[^/]+\.md$
-      - files ~= ^docs/
-      - files ~= ^examples/
+      - files~=^[^/]+\.md$
+      - files~=^docs/
+      - files~=^examples/
   actions:
     label:
       add:
@@ -17,13 +17,13 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^\.github/
-      - files ~= \.buildkite/
-      - files ~= ^cmake/
-      - files = CMakeLists.txt
-      - files ~= ^docker/Dockerfile
-      - files ~= ^requirements.*\.txt
-      - files = setup.py
+      - files~=^\.github/
+      - files~=\.buildkite/
+      - files~=^cmake/
+      - files=CMakeLists.txt
+      - files~=^docker/Dockerfile
+      - files~=^requirements.*\.txt
+      - files=setup.py
   actions:
     label:
       add:
@@ -34,13 +34,13 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^examples/.*deepseek.*\.py
-      - files ~= ^tests/.*deepseek.*\.py
-      - files ~= ^vllm/entrypoints/openai/tool_parsers/.*deepseek.*\.py
-      - files ~= ^vllm/model_executor/models/.*deepseek.*\.py
-      - files ~= ^vllm/reasoning/.*deepseek.*\.py
-      - files ~= ^vllm/transformers_utils/.*deepseek.*\.py
-      - title ~= (?i)DeepSeek
+      - files~=^examples/.*deepseek.*\.py
+      - files~=^tests/.*deepseek.*\.py
+      - files~=^vllm/entrypoints/openai/tool_parsers/.*deepseek.*\.py
+      - files~=^vllm/model_executor/models/.*deepseek.*\.py
+      - files~=^vllm/reasoning/.*deepseek.*\.py
+      - files~=^vllm/transformers_utils/.*deepseek.*\.py
+      - title~=(?i)DeepSeek
   actions:
     label:
       add:
@@ -50,7 +50,7 @@ pull_request_rules:
   description: Automatically apply frontend label
   conditions:
     - label != stale
-    - files ~= ^vllm/entrypoints/
+    - files~=^vllm/entrypoints/
   actions:
     label:
       add:
@@ -61,12 +61,12 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^examples/.*llama.*\.py
-      - files ~= ^tests/.*llama.*\.py
-      - files ~= ^vllm/entrypoints/openai/tool_parsers/llama.*\.py
-      - files ~= ^vllm/model_executor/models/.*llama.*\.py
-      - files ~= ^vllm/transformers_utils/configs/.*llama.*\.py
-      - title ~= (?i)llama
+      - files~=^examples/.*llama.*\.py
+      - files~=^tests/.*llama.*\.py
+      - files~=^vllm/entrypoints/openai/tool_parsers/llama.*\.py
+      - files~=^vllm/model_executor/models/.*llama.*\.py
+      - files~=^vllm/transformers_utils/configs/.*llama.*\.py
+      - title~=(?i)llama
   actions:
     label:
       add:
@@ -77,10 +77,10 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^vllm/multimodal/
-      - files ~= ^tests/multimodal/
-      - files ~= ^tests/models/multimodal/
-      - files = tests/models/test_vision.py
+      - files~=^vllm/multimodal/
+      - files~=^tests/multimodal/
+      - files~=^tests/models/multimodal/
+      - files=tests/models/test_vision.py
   actions:
     label:
       add:
@@ -91,8 +91,8 @@ pull_request_rules:
   conditions:
     - label != stale
     - and:
-      - files ~= ^vllm/model_executor/models/
-      - files = vllm/model_executor/models/registry.py
+      - files~=^vllm/model_executor/models/
+      - files=vllm/model_executor/models/registry.py
   actions:
     label:
       add:
@@ -103,10 +103,10 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^benchmarks/
-      - files ~= ^vllm/benchmarks/
-      - files ~= ^tests/benchmarks/
-      - files ~= ^\.buildkite/nightly-benchmarks/
+      - files~=^benchmarks/
+      - files~=^vllm/benchmarks/
+      - files~=^tests/benchmarks/
+      - files~=^\.buildkite/nightly-benchmarks/
   actions:
     label:
       add:
@@ -117,11 +117,11 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^examples/.*qwen.*\.py
-      - files ~= ^tests/.*qwen.*\.py
-      - files ~= ^vllm/model_executor/models/.*qwen.*\.py
-      - files ~= ^vllm/reasoning/.*qwen.*\.py
-      - title ~= (?i)Qwen
+      - files~=^examples/.*qwen.*\.py
+      - files~=^tests/.*qwen.*\.py
+      - files~=^vllm/model_executor/models/.*qwen.*\.py
+      - files~=^vllm/reasoning/.*qwen.*\.py
+      - title~=(?i)Qwen
   actions:
     label:
       add:
@@ -132,18 +132,18 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^examples/.*gpt[-_]?oss.*\.py
-      - files ~= ^tests/.*gpt[-_]?oss.*\.py
-      - files ~= ^tests/entrypoints/openai/test_response_api_with_harmony.py
-      - files ~= ^tests/entrypoints/test_context.py
-      - files ~= ^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
-      - files ~= ^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
-      - files ~= ^vllm/entrypoints/harmony_utils.py
-      - files ~= ^vllm/entrypoints/tool_server.py
-      - files ~= ^vllm/entrypoints/tool.py
-      - files ~= ^vllm/entrypoints/context.py
-      - title ~= (?i)gpt[-_]?oss
-      - title ~= (?i)harmony
+      - files~=^examples/.*gpt[-_]?oss.*\.py
+      - files~=^tests/.*gpt[-_]?oss.*\.py
+      - files~=^tests/entrypoints/openai/test_response_api_with_harmony.py
+      - files~=^tests/entrypoints/test_context.py
+      - files~=^vllm/model_executor/models/.*gpt[-_]?oss.*\.py
+      - files~=^vllm/model_executor/layers/.*gpt[-_]?oss.*\.py
+      - files~=^vllm/entrypoints/harmony_utils.py
+      - files~=^vllm/entrypoints/tool_server.py
+      - files~=^vllm/entrypoints/tool.py
+      - files~=^vllm/entrypoints/context.py
+      - title~=(?i)gpt[-_]?oss
+      - title~=(?i)harmony
   actions:
     label:
       add:
@@ -154,17 +154,17 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^csrc/rocm/
-      - files ~= ^docker/Dockerfile.rocm
-      - files ~= ^requirements/rocm.*\.txt
-      - files ~= ^vllm/attention/backends/rocm.*\.py
-      - files ~= ^vllm/attention/ops/rocm.*\.py
-      - files ~= ^vllm/model_executor/layers/fused_moe/rocm.*\.py
-      - files ~= ^vllm/v1/attention/backends/mla/rocm.*\.py
-      - files ~= ^tests/kernels/.*_rocm.*\.py
-      - files = vllm/platforms/rocm.py
-      - title ~= (?i)AMD
-      - title ~= (?i)ROCm
+      - files~=^csrc/rocm/
+      - files~=^docker/Dockerfile.rocm
+      - files~=^requirements/rocm.*\.txt
+      - files~=^vllm/attention/backends/rocm.*\.py
+      - files~=^vllm/attention/ops/rocm.*\.py
+      - files~=^vllm/model_executor/layers/fused_moe/rocm.*\.py
+      - files~=^vllm/v1/attention/backends/mla/rocm.*\.py
+      - files~=^tests/kernels/.*_rocm.*\.py
+      - files=vllm/platforms/rocm.py
+      - title~=(?i)AMD
+      - title~=(?i)ROCm
   actions:
     label:
       add:
@@ -175,16 +175,16 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^benchmarks/structured_schemas/
-      - files = benchmarks/benchmark_serving_structured_output.py
-      - files = benchmarks/run_structured_output_benchmark.sh
-      - files = docs/features/structured_outputs.md
-      - files = examples/offline_inference/structured_outputs.py
-      - files = examples/online_serving/openai_chat_completion_structured_outputs.py
-      - files = examples/online_serving/openai_chat_completion_structured_outputs_with_reasoning.py
-      - files ~= ^tests/v1/structured_output/
-      - files = tests/v1/entrypoints/llm/test_struct_output_generate.py
-      - files ~= ^vllm/v1/structured_output/
+      - files~=^benchmarks/structured_schemas/
+      - files=benchmarks/benchmark_serving_structured_output.py
+      - files=benchmarks/run_structured_output_benchmark.sh
+      - files=docs/features/structured_outputs.md
+      - files=examples/offline_inference/structured_outputs.py
+      - files=examples/online_serving/openai_chat_completion_structured_outputs.py
+      - files=examples/online_serving/openai_chat_completion_structured_outputs_with_reasoning.py
+      - files~=^tests/v1/structured_output/
+      - files=tests/v1/entrypoints/llm/test_struct_output_generate.py
+      - files~=^vllm/v1/structured_output/
   actions:
     label:
       add:
@@ -195,12 +195,12 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^vllm/v1/spec_decode/
-      - files ~= ^tests/v1/spec_decode/
-      - files ~= ^examples/.*(spec_decode|mlpspeculator|eagle|speculation).*\.py
-      - files ~= ^vllm/model_executor/models/.*eagle.*\.py
-      - files = vllm/model_executor/models/mlp_speculator.py
-      - files ~= ^vllm/transformers_utils/configs/(eagle|medusa|mlp_speculator)\.py
+      - files~=^vllm/v1/spec_decode/
+      - files~=^tests/v1/spec_decode/
+      - files~=^examples/.*(spec_decode|mlpspeculator|eagle|speculation).*\.py
+      - files~=^vllm/model_executor/models/.*eagle.*\.py
+      - files=vllm/model_executor/models/mlp_speculator.py
+      - files~=^vllm/transformers_utils/configs/(eagle|medusa|mlp_speculator)\.py
   actions:
     label:
       add:
@@ -211,8 +211,8 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^vllm/v1/
-      - files ~= ^tests/v1/
+      - files~=^vllm/v1/
+      - files~=^tests/v1/
   actions:
     label:
       add:
@@ -224,11 +224,11 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= tpu.py
-      - files ~= _tpu
-      - files ~= tpu_
-      - files ~= /tpu/
-      - files ~= pallas
+      - files~=tpu.py
+      - files~=_tpu
+      - files~=tpu_
+      - files~=/tpu/
+      - files~=pallas
   actions:
     label:
       add:
@@ -240,11 +240,11 @@ pull_request_rules:
   conditions:
     - label != stale
     - and:
-      - -files ~= tpu.py
-      - -files ~= _tpu
-      - -files ~= tpu_
-      - -files ~= /tpu/
-      - -files ~= pallas
+      - -files~=tpu.py
+      - -files~=_tpu
+      - -files~=tpu_
+      - -files~=/tpu/
+      - -files~=pallas
   actions:
     label:
       remove:
@@ -255,16 +255,16 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^tests/tool_use/
-      - files ~= ^tests/entrypoints/openai/tool_parsers/
-      - files = tests/entrypoints/openai/test_chat_with_tool_reasoning.py
-      - files ~= ^vllm/entrypoints/openai/tool_parsers/
-      - files = docs/features/tool_calling.md
-      - files ~= ^examples/tool_chat_*
-      - files = examples/offline_inference/chat_with_tools.py
-      - files = examples/online_serving/openai_chat_completion_client_with_tools_required.py
-      - files = examples/online_serving/openai_chat_completion_tool_calls_with_reasoning.py
-      - files = examples/online_serving/openai_chat_completion_client_with_tools.py
+      - files~=^tests/tool_use/
+      - files~=^tests/entrypoints/openai/tool_parsers/
+      - files=tests/entrypoints/openai/test_chat_with_tool_reasoning.py
+      - files~=^vllm/entrypoints/openai/tool_parsers/
+      - files=docs/features/tool_calling.md
+      - files~=^examples/tool_chat_*
+      - files=examples/offline_inference/chat_with_tools.py
+      - files=examples/online_serving/openai_chat_completion_client_with_tools_required.py
+      - files=examples/online_serving/openai_chat_completion_tool_calls_with_reasoning.py
+      - files=examples/online_serving/openai_chat_completion_client_with_tools.py
   actions:
     label:
       add:
@@ -290,10 +290,10 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^vllm/model_executor/model_loader/tensorizer.py
-      - files ~= ^vllm/model_executor/model_loader/tensorizer_loader.py
-      - files ~= ^tests/entrypoints/openai/test_tensorizer_entrypoint.py
-      - files ~= ^tests/model_executor/model_loader/tensorizer_loader/
+      - files~=^vllm/model_executor/model_loader/tensorizer.py
+      - files~=^vllm/model_executor/model_loader/tensorizer_loader.py
+      - files~=^tests/entrypoints/openai/test_tensorizer_entrypoint.py
+      - files~=^tests/model_executor/model_loader/tensorizer_loader/
   actions:
     assign:
       users:
@@ -303,12 +303,12 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-        - files ~= ^vllm/model_executor/layers/quantization/modelopt\.py$
-        - files ~= ^vllm/model_executor/layers/quantization/__init__\.py$
-        - files ~= ^tests/models/quantization/test_modelopt\.py$
-        - files ~= ^tests/quantization/test_modelopt\.py$
-        - files ~= ^tests/models/quantization/test_nvfp4\.py$
-        - files ~= ^docs/features/quantization/modelopt\.md$
+        - files~=^vllm/model_executor/layers/quantization/modelopt\.py$
+        - files~=^vllm/model_executor/layers/quantization/__init__\.py$
+        - files~=^tests/models/quantization/test_modelopt\.py$
+        - files~=^tests/quantization/test_modelopt\.py$
+        - files~=^tests/models/quantization/test_nvfp4\.py$
+        - files~=^docs/features/quantization/modelopt\.md$
   actions:
     assign:
       users:
@@ -328,14 +328,14 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
-      - files ~= ^examples/online_serving/disaggregated[^/]*/.*
-      - files ~= ^examples/offline_inference/disaggregated[^/]*/.*
-      - files ~= ^examples/others/lmcache/
-      - files ~= ^tests/v1/kv_connector/
-      - files ~= ^vllm/distributed/kv_transfer/
-      - title ~= (?i)\bP/?D\b
-      - title ~= (?i)NIXL
-      - title ~= (?i)LMCache
+      - files~=^examples/online_serving/disaggregated[^/]*/.*
+      - files~=^examples/offline_inference/disaggregated[^/]*/.*
+      - files~=^examples/others/lmcache/
+      - files~=^tests/v1/kv_connector/
+      - files~=^vllm/distributed/kv_transfer/
+      - title~=(?i)\bP/?D\b
+      - title~=(?i)NIXL
+      - title~=(?i)LMCache
   actions:
     label:
       add:


### PR DESCRIPTION
Prevents the following vicious cycle:
- PR goes stale and stale bot labels it `stale`
- Mergify sees this activity and checks its rules. It will most likely:
  - Add `needs-rebase`
  - Add a new label which didn't exist when the PR was opened
- Stale bot now marks the PR as `unstale` keeping it alive another 3 months
- Repeat
