### PR TITLE
Fix issue of using only the part of video frame [Nemotron Nano]

### DIFF
--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -208,7 +208,7 @@ def video_to_pixel_values(
         )
         # dynamic_preprocess returns tensors already; take the single tile
         assert len(pil_frame) >= 1
-        frames_tensors.append(pil_frame[0])
+        frames_tensors.append(pil_frame[-1])
 
     return torch.stack(frames_tensors)
 


### PR DESCRIPTION
## Purpose

This MR fixes a bug in Nemotron Nano model which caused video modality to use only part of the video frame.
By mistake the preprocessing code used wrong tile (top-left tile instead of thumbnail one) when processing videos. A thumbnail that (which should be used for video frames) is the last one.

## Test Plan

Internal testing

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

