### PR TITLE
[CI Bugfix] Make sure TRTLLM attention is available in test_blackwell_moe

### DIFF
--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -14,6 +14,9 @@ if not current_platform.is_device_capability(100):
     pytest.skip("This test only runs on Blackwell GPUs (SM100).",
                 allow_module_level=True)
 
+# Make sure TRTLLM attention is available
+os.environ["VLLM_HAS_FLASHINFER_CUBIN"] = "1"
+# Set compilation threads to 16 to speed up startup
 os.environ["FLASHINFER_NVCC_THREADS"] = "16"
 
 # dummy_hf_overrides = {"num_layers": 4, "num_hidden_layers": 4,

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -14,13 +14,15 @@ if not current_platform.is_device_capability(100):
     pytest.skip("This test only runs on Blackwell GPUs (SM100).",
                 allow_module_level=True)
 
+
 @pytest.fixture(scope="module", autouse=True)
-def set_test_environment(monkeypatch):
+def set_test_environment():
     """Sets environment variables required for this test module."""
     # Make sure TRTLLM attention is available
-    monkeypatch.setenv("VLLM_HAS_FLASHINFER_CUBIN", "1")
+    os.environ["VLLM_HAS_FLASHINFER_CUBIN"] = "1"
     # Set compilation threads to 16 to speed up startup
-    monkeypatch.setenv("FLASHINFER_NVCC_THREADS", "16")
+    os.environ["FLASHINFER_NVCC_THREADS"] = "16"
+
 
 # dummy_hf_overrides = {"num_layers": 4, "num_hidden_layers": 4,
 # "text_config": {"num_layers": 4, "num_hidden_layers": 4}}

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -14,10 +14,13 @@ if not current_platform.is_device_capability(100):
     pytest.skip("This test only runs on Blackwell GPUs (SM100).",
                 allow_module_level=True)
 
-# Make sure TRTLLM attention is available
-os.environ["VLLM_HAS_FLASHINFER_CUBIN"] = "1"
-# Set compilation threads to 16 to speed up startup
-os.environ["FLASHINFER_NVCC_THREADS"] = "16"
+@pytest.fixture(scope="module", autouse=True)
+def set_test_environment(monkeypatch):
+    """Sets environment variables required for this test module."""
+    # Make sure TRTLLM attention is available
+    monkeypatch.setenv("VLLM_HAS_FLASHINFER_CUBIN", "1")
+    # Set compilation threads to 16 to speed up startup
+    monkeypatch.setenv("FLASHINFER_NVCC_THREADS", "16")
 
 # dummy_hf_overrides = {"num_layers": 4, "num_hidden_layers": 4,
 # "text_config": {"num_layers": 4, "num_hidden_layers": 4}}


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Sometimes the Blackwell Quantized MoE Test CI fails due to connectivity problems with NVIDIA's artifactory. In the case of GPT-OSS, we need TRTLLM attention in order to run, so force availability

```
(EngineCore_DP0 pid=3728) WARNING 10-03 10:13:32 [flashinfer.py:180] Failed to connect to NVIDIA artifactory: HTTPSConnectionPool(host='edge.urm.nvidia.com', port=443): Read timed out. (read timeout=5)
```
https://buildkite.com/vllm/ci/builds/33421/steps/canvas?sid=0199aac3-cb53-4c8f-a99b-7f24c012fae3#0199aac3-cb53-4c8f-a99b-7f24c012fae3/58-499

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

