### PR TITLE
[BugFix] Pad input buffers in _dummy_run

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3401,26 +3401,30 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         with self.maybe_dummy_run_with_lora(
             self.lora_config, num_scheduled_tokens, remove_lora
         ):
-            model_kwargs = self._init_model_kwargs(num_tokens)
+            model_kwargs = self._init_model_kwargs(num_tokens_after_padding)
             if self.supports_mm_inputs and not self.model_config.is_encoder_decoder:
                 input_ids = None
-                inputs_embeds = self.inputs_embeds.gpu[:num_tokens]
+                inputs_embeds = self.inputs_embeds.gpu[:
+                                                       num_tokens_after_padding]
                 model_kwargs = {
                     **model_kwargs,
                     **self._dummy_mm_kwargs(num_reqs),
                 }
             elif self.enable_prompt_embeds:
                 input_ids = None
-                inputs_embeds = self.inputs_embeds.gpu[:num_tokens]
-                model_kwargs = self._init_model_kwargs(num_tokens)
+                inputs_embeds = self.inputs_embeds.gpu[:
+                                                       num_tokens_after_padding]
+                model_kwargs = self._init_model_kwargs(
+                    num_tokens_after_padding)
             else:
-                input_ids = self.input_ids.gpu[:num_tokens]
+                input_ids = self.input_ids.gpu[:num_tokens_after_padding]
                 inputs_embeds = None
 
             if self.uses_mrope:
-                positions = self.mrope_positions.gpu[:, :num_tokens]
+                positions = self.mrope_positions.gpu[:, :
+                                                     num_tokens_after_padding]
             else:
-                positions = self.positions.gpu[:num_tokens]
+                positions = self.positions.gpu[:num_tokens_after_padding]
 
             if get_pp_group().is_first_rank:
                 intermediate_tensors = None
@@ -3435,8 +3439,12 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
 
                 intermediate_tensors = self.sync_and_slice_intermediate_tensors(
+<<<<<<< HEAD
                     num_tokens, None, False
                 )
+=======
+                    num_tokens_after_padding, None, False)
+>>>>>>> f38a17972 (pad input buffers)
 
             # filter out the valid batch descriptor
             _cg_mode, batch_descriptor = (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3401,30 +3401,26 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         with self.maybe_dummy_run_with_lora(
             self.lora_config, num_scheduled_tokens, remove_lora
         ):
-        # Make sure padding doesn't exceed max_num_tokens
-        assert num_tokens_after_padding <= self.max_num_tokens
+            # Make sure padding doesn't exceed max_num_tokens
+            assert num_tokens_after_padding <= self.max_num_tokens
             model_kwargs = self._init_model_kwargs(num_tokens_after_padding)
             if self.supports_mm_inputs and not self.model_config.is_encoder_decoder:
                 input_ids = None
-                inputs_embeds = self.inputs_embeds.gpu[:
-                                                       num_tokens_after_padding]
+                inputs_embeds = self.inputs_embeds.gpu[:num_tokens_after_padding]
                 model_kwargs = {
                     **model_kwargs,
                     **self._dummy_mm_kwargs(num_reqs),
                 }
             elif self.enable_prompt_embeds:
                 input_ids = None
-                inputs_embeds = self.inputs_embeds.gpu[:
-                                                       num_tokens_after_padding]
-                model_kwargs = self._init_model_kwargs(
-                    num_tokens_after_padding)
+                inputs_embeds = self.inputs_embeds.gpu[:num_tokens_after_padding]
+                model_kwargs = self._init_model_kwargs(num_tokens_after_padding)
             else:
                 input_ids = self.input_ids.gpu[:num_tokens_after_padding]
                 inputs_embeds = None
 
             if self.uses_mrope:
-                positions = self.mrope_positions.gpu[:, :
-                                                     num_tokens_after_padding]
+                positions = self.mrope_positions.gpu[:, :num_tokens_after_padding]
             else:
                 positions = self.positions.gpu[:num_tokens_after_padding]
 
@@ -3441,12 +3437,8 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
 
                 intermediate_tensors = self.sync_and_slice_intermediate_tensors(
-<<<<<<< HEAD
-                    num_tokens, None, False
+                    num_tokens_after_padding, None, False
                 )
-=======
-                    num_tokens_after_padding, None, False)
->>>>>>> f38a17972 (pad input buffers)
 
             # filter out the valid batch descriptor
             _cg_mode, batch_descriptor = (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3401,6 +3401,8 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         with self.maybe_dummy_run_with_lora(
             self.lora_config, num_scheduled_tokens, remove_lora
         ):
+        # Make sure padding doesn't exceed max_num_tokens
+        assert num_tokens_after_padding <= self.max_num_tokens
             model_kwargs = self._init_model_kwargs(num_tokens_after_padding)
             if self.supports_mm_inputs and not self.model_config.is_encoder_decoder:
                 input_ids = None


### PR DESCRIPTION
## Purpose
Fixes https://github.com/vllm-project/vllm/issues/26137

PR https://github.com/vllm-project/vllm/pull/24845 removed the padding. This PR re-introduce the padding. 

## Test Plan

server: 
ALL2ALL Backend Naive:
```
vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat     --disable-log-requests --no-enable-prefix-caching -tp 1 -dp 2 --max-num-seqs 256     --enable-expert-parallel --load-format dummy --gpu-memory-utilization 0.85
```

DBO:
```
NCCL_P2P_DISABLE=1 VLLM_ALL2ALL_BACKEND=deepep_low_latency  vllm serve --model="deepseek-ai/DeepSeek-V2-Lite" --max-num-seqs 512 --trust-remote-code --data-parallel-size 2 --enable-expert-parallel --gpu-memory-utilization 0.75 --disable-log-requests --enable-dbo --dbo-decode-token-threshold 4
```

DBO + small cudagraph size:
```
NCCL_P2P_DISABLE=1 VLLM_ALL2ALL_BACKEND=deepep_low_latency  vllm serve --model="deepseek-ai/DeepSeek-V2-Lite" --max-num-seqs 512 --trust-remote-code --data-parallel-size 2 --enable-expert-parallel --gpu-memory-utilization 0.75 --disable-log-requests --enable-dbo --dbo-decode-token-threshold 4 --cuda-graph-sizes 4
```

client 
```
vllm bench serve --port 8000 --model ${MODEL} --dataset-name random --num-prompts 512 --random-input-len 1024 --random-output-len 512 --trust-remote-code 
```

## Test Result

`ALL2ALL Backend Naive`, `DBO` and `DBO + small cudagraph size` doesn't deadlock.
