### PR TITLE
Pass down metrics regarding RequestMetrics

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -38,13 +38,16 @@ class RequestMetrics:
     """
     arrival_time: float
     last_token_time: float
-    first_scheduled_time: Optional[float]
-    first_token_time: Optional[float]
-    time_in_queue: Optional[float]
+    first_scheduled_time: Optional[float] = None
+    first_token_time: Optional[float] = None
+    time_in_queue: Optional[float] = None
     finished_time: Optional[float] = None
     scheduler_time: Optional[float] = None
     model_forward_time: Optional[float] = None
     model_execute_time: Optional[float] = None
+    num_generation_tokens: Optional[int] = None
+    first_token_latency: Optional[float] = None
+
 
 
 # cannot use msgspec.Struct here because Dynamo does not support it

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -21,7 +21,7 @@ from vllm.v1.engine.logprobs import LogprobsProcessor
 from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.metrics.stats import (IterationStats, LoRARequestStates,
                                    RequestStateStats)
-
+from vllm.sequence import RequestMetrics
 
 class RequestOutputCollector:
     """
@@ -446,6 +446,13 @@ class OutputProcessor:
             if request_output := req_state.make_request_output(
                     new_token_ids, pooling_output, finish_reason, stop_reason,
                     kv_transfer_params):
+                request_output.metrics = RequestMetrics(
+                        arrival_time=req_state.stats.arrival_time,
+                        last_token_time=req_state.stats.last_token_ts,
+                        first_token_time=req_state.stats.first_token_ts,
+                        num_generation_tokens=req_state.stats.num_generation_tokens,
+                        first_token_latency=req_state.stats.first_token_latency,
+                    )
                 if req_state.queue is not None:
                     # AsyncLLM: put into queue for handling by generate().
                     req_state.queue.put(request_output)


### PR DESCRIPTION
Summary:
Support passing some inference metrics through request_output. Therefore, these metrics can be passed down through llm engine step().
It is very useful when users need to leverage these metrics

Test Plan: NA

Reviewed By: 22quinn

Differential Revision: D83576815
