### PR TITLE
[Misc] Require `merge_by_field_config` argument

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -7,10 +7,9 @@ from typing import Optional, cast
 
 import numpy as np
 import torch
-from typing_extensions import deprecated
 
 from vllm.lora.request import LoRARequest
-from vllm.multimodal.inputs import MultiModalFeatureSpec, MultiModalKwargsItems
+from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.utils import length_from_prompt_token_ids_or_embeds, swap_dict_values
@@ -52,16 +51,6 @@ class CachedRequestState:
     @property
     def num_tokens(self) -> int:
         return self.num_prompt_tokens + len(self.output_token_ids)
-
-    # Temporary back-compatibility for plugins that define model runner
-    @property
-    @deprecated("`mm_inputs` is superseded by `mm_kwargs` and will be "
-                "removed in v0.13. Please use `mm_kwargs` instead.")
-    def mm_inputs(self) -> list[MultiModalKwargsItems]:
-        return [
-            MultiModalKwargsItems.from_seq([f.data]) for f in self.mm_features
-            if f.data is not None
-        ]
 
     def get_token_id(self, idx: int) -> int:
         if idx < self.num_prompt_tokens:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

According to https://github.com/vllm-project/vllm/issues/26149, some models now have `merge_by_field_config=True` while others still have `merge_by_field_config=False`. It is therefore now required for model runners to pass this argument explicitly in order for both sets of models to receive the correct input format.

Because of this, the old `mm_inputs` also doesn't work anymore, so I have removed the associated functions. Although they were originally supposed to be removed in v0.13 (not v0.12), it is too complicated for each model implementation to support both input formats, so I have decided to speed up the progress.

cc @xuechendi @Yikun 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

