### PR TITLE
[Renderer] Clean up renderer code

### DIFF
--- a/tests/entrypoints/openai/test_token_in_token_out.py
+++ b/tests/entrypoints/openai/test_token_in_token_out.py
@@ -54,7 +54,7 @@ async def test_token_in_token_out_and_logprobs(server):
             prompt=token_ids,
             max_tokens=20,
             temperature=0,
-            echo=True,
+            echo=False,
             extra_body={
                 "return_token_ids": True,
             },

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -4,7 +4,7 @@
 import pytest
 
 from vllm.inputs import zip_enc_dec_prompts
-from vllm.inputs.parse import parse_and_batch_prompt
+from vllm.inputs.parse import parse_raw_prompts
 
 pytestmark = pytest.mark.cpu_test
 
@@ -31,30 +31,30 @@ INPUTS_SLICES = [
 ]
 
 
-def test_parse_single_batch_empty():
+def test_parse_raw_single_batch_empty():
     with pytest.raises(ValueError, match="at least one prompt"):
-        parse_and_batch_prompt([])
+        parse_raw_prompts([])
 
     with pytest.raises(ValueError, match="at least one prompt"):
-        parse_and_batch_prompt([[]])
+        parse_raw_prompts([[]])
 
 
 @pytest.mark.parametrize('string_input', STRING_INPUTS)
-def test_parse_single_batch_string_consistent(string_input: str):
-    assert parse_and_batch_prompt(string_input) \
-        == parse_and_batch_prompt([string_input])
+def test_parse_raw_single_batch_string_consistent(string_input: str):
+    assert parse_raw_prompts(string_input) \
+        == parse_raw_prompts([string_input])
 
 
 @pytest.mark.parametrize('token_input', TOKEN_INPUTS)
-def test_parse_single_batch_token_consistent(token_input: list[int]):
-    assert parse_and_batch_prompt(token_input) \
-        == parse_and_batch_prompt([token_input])
+def test_parse_raw_single_batch_token_consistent(token_input: list[int]):
+    assert parse_raw_prompts(token_input) \
+        == parse_raw_prompts([token_input])
 
 
 @pytest.mark.parametrize('inputs_slice', INPUTS_SLICES)
-def test_parse_single_batch_string_slice(inputs_slice: slice):
-    assert parse_and_batch_prompt(STRING_INPUTS)[inputs_slice] \
-        == parse_and_batch_prompt(STRING_INPUTS[inputs_slice])
+def test_parse_raw_single_batch_string_slice(inputs_slice: slice):
+    assert parse_raw_prompts(STRING_INPUTS)[inputs_slice] \
+        == parse_raw_prompts(STRING_INPUTS[inputs_slice])
 
 
 # yapf: disable

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -691,6 +691,5 @@ class OpenAIServingCompletion(OpenAIServing):
             truncate_prompt_tokens=request.truncate_prompt_tokens,
             add_special_tokens=request.add_special_tokens,
             cache_salt=request.cache_salt,
-            needs_detokenization=bool(request.echo
-                                      and not request.return_token_ids),
+            needs_detokenization=bool(request.echo),
         )

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -42,6 +42,27 @@ class RenderConfig:
     needs_detokenization: Optional[bool] = False
     """If True, detokenize IDs back to text for inclusion in outputs."""
 
+    def verify_truncate_prompt_tokens(
+            self, model_config: ModelConfig) -> Optional[int]:
+        """Validate and normalize `truncate_prompt_tokens` parameter."""
+        truncate_prompt_tokens = self.truncate_prompt_tokens
+        if truncate_prompt_tokens is None:
+            return None
+
+        if truncate_prompt_tokens == 0:
+            return 0
+
+        if truncate_prompt_tokens < 0:
+            truncate_prompt_tokens = model_config.max_model_len
+
+        max_length = self.max_length
+        if max_length is not None and truncate_prompt_tokens > max_length:  # type: ignore[operator]
+            raise ValueError(
+                f"{truncate_prompt_tokens=} cannot be greater than "
+                f"{max_length=}. Please select a smaller truncation size.")
+
+        return truncate_prompt_tokens
+
 
 class BaseRenderer(ABC):
     """
@@ -75,7 +96,7 @@ class BaseRenderer(ABC):
         self,
         *,
         prompt_or_prompts: Union[str, list[str], list[int], list[list[int]]],
-        config: "RenderConfig",
+        config: RenderConfig,
     ) -> list[EngineTokensPrompt]:
         """
         Convert text or token inputs into engine-ready TokensPrompt objects.
@@ -108,7 +129,7 @@ class BaseRenderer(ABC):
         prompt_or_prompts: Optional[Union[str, list[str], list[int],
                                           list[list[int]]]] = None,
         prompt_embeds: Optional[Union[bytes, list[bytes]]] = None,
-        config: "RenderConfig",
+        config: RenderConfig,
     ) -> list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
         """
         Convert text/token and/or base64-encoded embeddings inputs into
@@ -190,15 +211,15 @@ class CompletionRenderer(BaseRenderer):
         self,
         *,
         prompt_or_prompts: Union[str, list[str], list[int], list[list[int]]],
-        config: "RenderConfig",
+        config: RenderConfig,
     ) -> list[EngineTokensPrompt]:
         """Implementation of prompt rendering for completion-style requests.
         
         Uses async tokenizer pooling for improved performance. See base class
         for detailed parameter documentation.
         """
-        truncate_prompt_tokens = self._validate_and_normalize_truncate_tokens(
-            config.truncate_prompt_tokens, config.max_length)
+        truncate_prompt_tokens = config.verify_truncate_prompt_tokens(
+            self.model_config)
         if truncate_prompt_tokens == 0:
             return []
 
@@ -216,14 +237,14 @@ class CompletionRenderer(BaseRenderer):
         prompt_or_prompts: Optional[Union[str, list[str], list[int],
                                           list[list[int]]]] = None,
         prompt_embeds: Optional[Union[bytes, list[bytes]]] = None,
-        config: "RenderConfig",
+        config: RenderConfig,
     ) -> list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
         """
         Render text/token prompts and/or precomputed embedding prompts. At
         least one of `prompt_or_prompts` or `prompt_embeds` must be provided.
         """
-        truncate_prompt_tokens = self._validate_and_normalize_truncate_tokens(
-            config.truncate_prompt_tokens, config.max_length)
+        truncate_prompt_tokens = config.verify_truncate_prompt_tokens(
+            self.model_config)
         if truncate_prompt_tokens == 0:
             return []
 
@@ -244,29 +265,6 @@ class CompletionRenderer(BaseRenderer):
 
         return rendered
 
-    def _validate_and_normalize_truncate_tokens(
-        self,
-        truncate_prompt_tokens: Optional[int],
-        max_length: Optional[int],
-    ) -> Optional[int]:
-        """Validate and normalize truncate_prompt_tokens parameter."""
-        if truncate_prompt_tokens is None:
-            return None
-
-        if truncate_prompt_tokens == 0:
-            return 0
-
-        if truncate_prompt_tokens < 0:
-            truncate_prompt_tokens = self.model_config.max_model_len
-
-        if max_length is not None and truncate_prompt_tokens > max_length:  # type: ignore[operator]
-            raise ValueError(
-                f"truncate_prompt_tokens ({truncate_prompt_tokens}) "
-                f"cannot be greater than max_length ({max_length}). "
-                f"Please select a smaller truncation size.")
-
-        return truncate_prompt_tokens
-
     def _maybe_apply_truncation(
             self, token_ids: list[int],
             truncate_prompt_tokens: Optional[int]) -> list[int]:
@@ -281,7 +279,7 @@ class CompletionRenderer(BaseRenderer):
     async def _create_prompt(
         self,
         prompt_input: Union[EngineTextPrompt, EngineTokensPrompt],
-        config: "RenderConfig",
+        config: RenderConfig,
         truncate_prompt_tokens: Optional[int],
     ) -> EngineTokensPrompt:
         prompt, prompt_token_ids, _ = get_prompt_components(prompt_input)

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -343,7 +343,7 @@ class CompletionRenderer(BaseRenderer):
                                                  truncate_prompt_tokens)
 
         prompt = None
-        if needs_detokenization is True:
+        if needs_detokenization:
             async_tokenizer = self._get_async_tokenizer()
             prompt = await async_tokenizer.decode(token_ids)
 

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -231,7 +231,6 @@ class CompletionRenderer(BaseRenderer):
 
             tasks.append(task)
 
-        # Wait for all text tokenization to finish
         return await asyncio.gather(*tasks)
 
     async def render_prompt_and_embeds(

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -4,6 +4,7 @@
 import asyncio
 import io
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Annotated, Optional, Union
 
@@ -14,7 +15,7 @@ from pydantic import Field
 from vllm.config import ModelConfig
 from vllm.inputs.data import EmbedsPrompt as EngineEmbedsPrompt
 from vllm.inputs.data import TokensPrompt as EngineTokensPrompt
-from vllm.inputs.parse import parse_and_batch_prompt
+from vllm.inputs.parse import get_prompt_components, parse_raw_prompts
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import AsyncMicrobatchTokenizer
 
@@ -201,35 +202,37 @@ class CompletionRenderer(BaseRenderer):
         if truncate_prompt_tokens == 0:
             return []
 
-        # Parse and batch the input prompts
-        batch_inputs = parse_and_batch_prompt(prompt_or_prompts)
+        tasks = list[Awaitable[EngineTokensPrompt]]()
+        for prompt_input in parse_raw_prompts(prompt_or_prompts):
+            prompt, prompt_token_ids, _ = get_prompt_components(prompt_input)
 
-        tasks = []
-        for prompt_input in batch_inputs:
-            if prompt_input["is_tokens"] is True:
+            if prompt_token_ids is not None:
                 # Token input
                 # Note: detokenization is needed when echo is enabled,
                 # where the input token IDs are decoded back to text.
-                task = self._maybe_detokenize(prompt_input["content"],
-                                              config.max_length,
-                                              truncate_prompt_tokens,
-                                              config.cache_salt,
-                                              config.needs_detokenization)
-            else:
+                task = self._create_prompt_from_token_ids(
+                    prompt_token_ids,
+                    config.max_length,
+                    truncate_prompt_tokens,
+                    config.cache_salt,
+                    config.needs_detokenization,
+                )
+            elif prompt is not None:
                 # Text input
-                task = self._tokenize(prompt_input["content"],
-                                      config.max_length,
-                                      truncate_prompt_tokens,
-                                      config.add_special_tokens,
-                                      config.cache_salt)
+                task = self._create_prompt_from_text(
+                    prompt,
+                    config.max_length,
+                    truncate_prompt_tokens,
+                    config.add_special_tokens,
+                    config.cache_salt,
+                )
+            else:
+                raise NotImplementedError
+
             tasks.append(task)
 
         # Wait for all text tokenization to finish
-        if tasks:
-            tokenized_text_prompts = await asyncio.gather(*tasks)
-            return tokenized_text_prompts
-
-        return []
+        return await asyncio.gather(*tasks)
 
     async def render_prompt_and_embeds(
         self,
@@ -299,7 +302,7 @@ class CompletionRenderer(BaseRenderer):
 
         return token_ids[-truncate_prompt_tokens:]
 
-    async def _tokenize(
+    async def _create_prompt_from_text(
         self,
         text: str,
         max_length: Optional[int],
@@ -330,7 +333,7 @@ class CompletionRenderer(BaseRenderer):
         return self._create_tokens_prompt(encoded.input_ids, max_length,
                                           cache_salt, text)
 
-    async def _maybe_detokenize(
+    async def _create_prompt_from_token_ids(
         self,
         token_ids: list[int],
         max_length: Optional[int],


### PR DESCRIPTION
## Purpose

- Remove unnecessary overloads in `vllm.inputs.parse` because it doesn't affect the type annotations in downstream code anyway
- Refactor `parse_and_batch_prompt` to `parse_raw_prompts` in order to reuse the existing `TextPrompt` and `TokensPrompt` instead of creating new `TypedDict` classes just for this method.
- Refactor task creation to `_create_prompt` method. This makes it easier for renderer to accept the same inputs as offline `LLM` class.
- Move `truncate_prompt_tokens` verification logic to `RenderConfig`
- Rename `renderer._maybe_detokenize -> renderer._create_prompt_from_token_ids` and `renderer._tokenize -> renderer._create_prompt_from_text` to be clearer
- Update `needs_detokenization` to not be affected by `request.return_token_ids`, because `request.return_token_ids` does not require text to be present in the output. (Edit: This actually does interact with `echo`, I have reverted it in #26238)

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

