### PR TITLE
[Bugfix][Spec Decode] Fix DP hang when some ranks do dummy runs

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -585,6 +585,16 @@ class EagleProposer:
 
         return spec_common_attn_metadata, token_indices, token_indices_to_sample
 
+    def _is_tree_attention(self) -> bool:
+        if not hasattr(self.runner,
+                       "attn_groups") or not self.runner.attn_groups:
+            return False
+
+        tree_attn_metadata_builder = \
+            self.runner.attn_groups[0][0].get_metadata_builder()
+        return isinstance(tree_attn_metadata_builder,
+                          TreeAttentionMetadataBuilder)
+
     def propose_tree(
         self,
         batch_size: int,
@@ -980,21 +990,26 @@ class EagleProposer:
         self,
         num_tokens: int,
     ) -> None:
-        with set_forward_context(None, self.vllm_config,
-                                 num_tokens=num_tokens):
-            if self.supports_mm_inputs:
-                input_ids = None
-                inputs_embeds = self.inputs_embeds[:num_tokens]
-            else:
-                input_ids = self.input_ids[:num_tokens]
-                inputs_embeds = None
+        assert not self._is_tree_attention(
+        ), "Dummy run for tree attention not implemented"
 
-            self.model(
-                input_ids=input_ids,
-                positions=self._get_positions(num_tokens),
-                hidden_states=self.hidden_states[:num_tokens],
-                inputs_embeds=inputs_embeds,
-            )
+        for _ in range(self.num_speculative_tokens):
+            with set_forward_context(None,
+                                     self.vllm_config,
+                                     num_tokens=num_tokens):
+                if self.supports_mm_inputs:
+                    input_ids = None
+                    inputs_embeds = self.inputs_embeds[:num_tokens]
+                else:
+                    input_ids = self.input_ids[:num_tokens]
+                    inputs_embeds = None
+
+                self.model(
+                    input_ids=input_ids,
+                    positions=self._get_positions(num_tokens),
+                    hidden_states=self.hidden_states[:num_tokens],
+                    inputs_embeds=inputs_embeds,
+                )
 
     def _get_attention_metadata_builder(
             self) -> list[AttentionMetadataBuilder]:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

When using `EagleProposer` with DP, vllm hangs because of mismatch communication behavior between DP ranks. The communications for non-tree proposing have the pattern below:

```python
class EagleProposer:
    def propose(...):
        with set_forward_context(...):   # First comm.
            ... = self.model(...)

        for token_index in range(self.num_speculative_tokens - 1):
            with set_forward_context(...):  # Next n-1 comms.
                ... = self.model(...)
```

where `set_forward_context` eventually leads to an `all_reduce` among the DP group.

https://github.com/vllm-project/vllm/blob/d3d649efec8161b62e8db576f8d1d02a77d22897/vllm/forward_context.py#L108-L114

Therefore, the root cause is that `EagleProposer` implements `dummy_run` as a single forward invocation, but the actual runner does it `self.num_speculative_tokens` times. We should simply align its behavior with `propose` method here.

---

Since end-to-end tree sampler is still WIP #22752 , we don't eagerly integrate its logic into `dummy_run` now. An assersion about it is added. It should be easy to align with it similarily after its landing.

## Test Plan

```sh
vllm serve \
    meta-llama/Meta-Llama-3-8B-Instruct \
    --host 0.0.0.0 \
    --port 7000 \
    --seed 42 \
    --disable-log-requests \
    --no-enable-prefix-caching \
    -dp 2 \
    --max-model-len 8192 \
    --max-num-seqs 64 \
    --gpu_memory_utilization 0.8 \
    --speculative-config '{"model":"yuhuili/EAGLE-LLaMA3-Instruct-8B","num_speculative_tokens":8,"max_model_len": 2048}'
```

### Basic functionality

```sh
vllm bench serve \
  --backend vllm --model meta-llama/Meta-Llama-3-8B-Instruct \
  --dataset-name sharegpt \
  --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
  --num-prompts 200 \
  --host localhost --port 7000
```

### Correctness

```sh
lm_eval --model local-completions \
  --tasks gsm8k \
  --model_args model=meta-llama/Meta-Llama-3-8B-Instruct,base_url=http://0.0.0.0:7000/v1/completions,num_concurrent=1,max_retries=3,tokenized_requests=False
```

## Test Result

### Basic functionality

```
============ Serving Benchmark Result ============
Successful requests:                     200       
Benchmark duration (s):                  12.97     
Total input tokens:                      42659     
Total generated tokens:                  40258     
Request throughput (req/s):              15.42     
Output token throughput (tok/s):         3104.04   
Peak output token throughput (tok/s):    2533.00   
Peak concurrent requests:                200.00    
Total Token throughput (tok/s):          6393.21   
---------------Time to First Token----------------
Mean TTFT (ms):                          1647.35   
Median TTFT (ms):                        1490.01   
P99 TTFT (ms):                           3865.45   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          31.44     
Median TPOT (ms):                        23.57     
P99 TPOT (ms):                           161.47    
---------------Inter-token Latency----------------
Mean ITL (ms):                           44.05     
Median ITL (ms):                         40.25     
P99 ITL (ms):                            87.76     
==================================================
```

No more hang.

### Correctness

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7551|±  |0.0118|
|     |       |strict-match    |     5|exact_match|↑  |0.7589|±  |0.0118|

Reasonable results for LLaMA3 8B.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
