### PR TITLE
Fix tensor device and dtype placement in Qwen2VL model

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -720,7 +720,7 @@ class Qwen2VisionTransformer(nn.Module):
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
 
         # compute cu_seqlens
-        grid_thw_ = torch.tensor(grid_thw)
+        grid_thw_ = torch.tensor(grid_thw, device=x.device, dtype=torch.long) 
         cu_seqlens = torch.repeat_interleave(grid_thw_[:, 1] * grid_thw_[:, 2],
                                              grid_thw_[:, 0]).cumsum(
                                                  dim=0, dtype=torch.int32)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -720,7 +720,7 @@ class Qwen2VisionTransformer(nn.Module):
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
 
         # compute cu_seqlens
-        grid_thw_ = torch.tensor(grid_thw, device=x.device, dtype=torch.long) 
+        grid_thw_ = torch.tensor(grid_thw, device=x.device, dtype=torch.long)
         cu_seqlens = torch.repeat_interleave(grid_thw_[:, 1] * grid_thw_[:, 2],
                                              grid_thw_[:, 0]).cumsum(
                                                  dim=0, dtype=torch.int32)


### PR DESCRIPTION
Summary:
Signed-off-by: Yuanfeng Li [yuanfengli@meta.com](mailto:yuanfengli@meta.com)

Fix device placement issue in Qwen2-VL model by explicitly specifying device and dtype when creating `grid_thw_` tensor to prevent device mismatch errors during GPU inference.

Test Plan:
Tested with Qwen2-VL model inference on GPU to verify the tensor device placement issue is resolved.


Differential Revision: D83903654


