### PR TITLE
[V1] [Hybrid] Remove code to override default CUDA graph configuration

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import vllm.envs as envs
-from vllm.config.compilation import CUDAGraphMode
 from vllm.logger import init_logger
 from vllm.model_executor.models import ModelRegistry
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, cdiv
@@ -290,7 +289,6 @@ class MambaModelConfig(VerifyAndUpdateConfig):
 
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
-        compilation_config = vllm_config.compilation_config
 
         # Set mamba block size to max_model_len (this may get
         # override by prefix caching logic later)
@@ -319,19 +317,6 @@ class MambaModelConfig(VerifyAndUpdateConfig):
         logger.info("Disabling cascade attention since it is not supported "
                     "for hybrid models.")
         model_config.disable_cascade_attn = True
-
-        # TODO(tdoublep): remove as full cuda graph support is added
-        FCG_NOT_SUPPORTED_MODELS = [
-            "Lfm2ForCausalLM",
-            "MiniMaxText01ForCausalLM",
-        ]
-
-        if (model_config.architecture not in FCG_NOT_SUPPORTED_MODELS
-                and compilation_config.cudagraph_mode is None):
-            logger.info(
-                "Hybrid or mamba-based model detected: setting cudagraph mode "
-                "to FULL_AND_PIECEWISE in order to optimize performance.")
-            compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
 
 
 class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Removes some legacy code that enabled `FULL_AND_PIECEWISE` as the default for hybrid models. This code is now entirely redundant as this is now the global default.

## Test Plan

I verified that for MinimaxText-01 (which is the only hybrid remaining that doesn't support FCG) it still falls back to piecewise. 

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

