### PR TITLE
[Easy] Add str repr for IterationStats

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from vllm.v1.metrics.stats import IterationStats
+
+
+def test_iteration_stats_repr():
+    iteration_stats = IterationStats()
+    iteration_stats.iteration_timestamp = 0
+    expected_repr = ("IterationStats("
+                     "iteration_timestamp=0, "
+                     "num_generation_tokens=0, "
+                     "num_prompt_tokens=0, "
+                     "num_preempted_reqs=0, "
+                     "finished_requests=[], "
+                     "max_num_generation_tokens_iter=[], "
+                     "n_params_iter=[], "
+                     "time_to_first_tokens_iter=[], "
+                     "inter_token_latencies_iter=[], "
+                     "waiting_lora_adapters={}, "
+                     "running_lora_adapters={})")
+    assert repr(iteration_stats) == expected_repr

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -111,6 +111,11 @@ class IterationStats:
         self.waiting_lora_adapters: dict[str, int] = {}
         self.running_lora_adapters: dict[str, int] = {}
 
+    def __repr__(self) -> str:
+        field_to_value_str = ", ".join(f"{k}={v}"
+                                       for k, v in vars(self).items())
+        return f"{self.__class__.__name__}({field_to_value_str})"
+
     def _time_since(self, start: float) -> float:
         """Calculate an interval relative to this iteration's timestamp."""
         return self.iteration_timestamp - start


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
for debugging

## Test Plan

```
>>> from vllm.v1.metrics.stats import IterationStats
INFO 10-04 15:05:08 [__init__.py:215] Automatically detected platform cuda.
>>> a = IterationStats()
>>> a
IterationStats(iteration_timestamp=1759615513.896626, num_generation_tokens=0, num_prompt_tokens=0, num_preempted_reqs=0, finished_requests=[], max_num_generation_tokens_iter=[], n_params_iter=[], time_to_first_tokens_iter=[], inter_token_latencies_iter=[], waiting_lora_adapters={}, running_lora_adapters={})
>>> 
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

