### PR TITLE
[Bugfix] Always apply MM processor even when no MM items are passed

### DIFF
--- a/tests/multimodal/test_inputs.py
+++ b/tests/multimodal/test_inputs.py
@@ -105,6 +105,32 @@ def test_multimodal_input_batch_mixed_stacking_depths():
 
 
 @pytest.mark.parametrize("model_id", [
+    "facebook/opt-125m",
+])
+@pytest.mark.parametrize("prompt", [
+    {
+        "prompt": "",
+        "multi_modal_data": {
+            "dummy": []
+        },
+    },
+    {
+        "prompt_token_ids": [],
+        "multi_modal_data": {
+            "dummy": []
+        },
+    },
+])
+def test_preprocessor_text_no_mm_inputs(model_id, prompt):
+    model_config = ModelConfig(model=model_id)
+    tokenizer = init_tokenizer_from_configs(model_config)
+    input_preprocessor = InputPreprocessor(model_config, tokenizer)
+
+    with pytest.raises(ValueError, match="does not support multimodal inputs"):
+        input_preprocessor.preprocess(prompt)
+
+
+@pytest.mark.parametrize("model_id", [
     "facebook/chameleon-7b",
 ])
 @pytest.mark.parametrize("prompt", [

--- a/tests/multimodal/test_inputs.py
+++ b/tests/multimodal/test_inputs.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 
 from vllm.config import ModelConfig
-from vllm.inputs import PromptType
 from vllm.inputs.preprocess import InputPreprocessor
 from vllm.multimodal.inputs import MultiModalKwargs, NestedTensors
 from vllm.transformers_utils.tokenizer import init_tokenizer_from_configs
@@ -108,19 +107,16 @@ def test_multimodal_input_batch_mixed_stacking_depths():
 @pytest.mark.parametrize("model_id", [
     "facebook/chameleon-7b",
 ])
-@pytest.mark.parametrize("prompt_type", ["text", "tokens"])
-def test_preprocessor_always_mm_code_path(model_id, prompt_type):
+@pytest.mark.parametrize("prompt", [
+    "",
+    {
+        "prompt_token_ids": []
+    },
+])
+def test_preprocessor_always_mm_code_path(model_id, prompt):
     model_config = ModelConfig(model=model_id)
     tokenizer = init_tokenizer_from_configs(model_config)
     input_preprocessor = InputPreprocessor(model_config, tokenizer)
-
-    prompt: PromptType
-    if prompt_type == "text":
-        prompt = ""
-    elif prompt_type == "tokens":
-        prompt = {"prompt_token_ids": []}
-    else:
-        raise NotImplementedError(prompt_type)
 
     # HF processor adds sep token
     sep_token_id = tokenizer.vocab[tokenizer.sep_token]

--- a/tests/multimodal/test_inputs.py
+++ b/tests/multimodal/test_inputs.py
@@ -4,10 +4,7 @@
 import pytest
 import torch
 
-from vllm.config import ModelConfig
-from vllm.inputs.preprocess import InputPreprocessor
 from vllm.multimodal.inputs import MultiModalKwargs, NestedTensors
-from vllm.transformers_utils.tokenizer import init_tokenizer_from_configs
 
 pytestmark = pytest.mark.cpu_test
 
@@ -102,50 +99,3 @@ def test_multimodal_input_batch_mixed_stacking_depths():
 
     result = MultiModalKwargs.batch([{"image": [a]}, {"image": [b, c]}])
     assert_multimodal_inputs_equal(result, {"image": [a.unsqueeze(0), [b, c]]})
-
-
-@pytest.mark.parametrize("model_id", [
-    "facebook/opt-125m",
-])
-@pytest.mark.parametrize("prompt", [
-    {
-        "prompt": "",
-        "multi_modal_data": {
-            "dummy": []
-        },
-    },
-    {
-        "prompt_token_ids": [],
-        "multi_modal_data": {
-            "dummy": []
-        },
-    },
-])
-def test_preprocessor_text_no_mm_inputs(model_id, prompt):
-    model_config = ModelConfig(model=model_id)
-    tokenizer = init_tokenizer_from_configs(model_config)
-    input_preprocessor = InputPreprocessor(model_config, tokenizer)
-
-    with pytest.raises(ValueError, match="does not support multimodal inputs"):
-        input_preprocessor.preprocess(prompt)
-
-
-@pytest.mark.parametrize("model_id", [
-    "facebook/chameleon-7b",
-])
-@pytest.mark.parametrize("prompt", [
-    "",
-    {
-        "prompt_token_ids": []
-    },
-])
-def test_preprocessor_always_mm_code_path(model_id, prompt):
-    model_config = ModelConfig(model=model_id)
-    tokenizer = init_tokenizer_from_configs(model_config)
-    input_preprocessor = InputPreprocessor(model_config, tokenizer)
-
-    # HF processor adds sep token
-    sep_token_id = tokenizer.vocab[tokenizer.sep_token]
-
-    processed_inputs = input_preprocessor.preprocess(prompt)
-    assert sep_token_id in processed_inputs["prompt_token_ids"]

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -323,7 +323,7 @@ class InputPreprocessor:
                 mm_uuids=mm_uuids,
             )
         else:
-            if "multi_modal_data" in parsed_content:
+            if parsed_content.get("multi_modal_data"):
                 raise ValueError(
                     "This model does not support multimodal inputs")
 
@@ -353,7 +353,7 @@ class InputPreprocessor:
                 mm_uuids=mm_uuids,
             )
         else:
-            if "multi_modal_data" in parsed_content:
+            if parsed_content.get("multi_modal_data"):
                 raise ValueError(
                     "This model does not support multimodal inputs")
 

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -322,6 +322,10 @@ class InputPreprocessor:
                 mm_uuids=mm_uuids,
             )
         else:
+            if "multi_modal_data" in parsed_content:
+                raise ValueError(
+                    "This model does not support multimodal inputs")
+
             inputs = token_inputs(prompt_token_ids)
 
         if cache_salt := parsed_content.get("cache_salt"):
@@ -348,6 +352,10 @@ class InputPreprocessor:
                 mm_uuids=mm_uuids,
             )
         else:
+            if "multi_modal_data" in parsed_content:
+                raise ValueError(
+                    "This model does not support multimodal inputs")
+
             prompt_token_ids = self._tokenize_prompt(
                 prompt_text,
                 tokenization_kwargs=tokenization_kwargs,

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -313,11 +313,10 @@ class InputPreprocessor:
         prompt_token_ids = self._truncate_inputs(
             parsed_content["prompt_token_ids"], tokenization_kwargs)
 
-        inputs: Union[TokenInputs, MultiModalInputs]
-        if multi_modal_data := parsed_content.get("multi_modal_data"):
+        if self.model_config.is_multimodal_model:
             inputs = self._process_multimodal(
                 prompt_token_ids,
-                multi_modal_data,
+                parsed_content.get("multi_modal_data", {}),
                 parsed_content.get("mm_processor_kwargs"),
                 tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=mm_uuids,
@@ -340,10 +339,10 @@ class InputPreprocessor:
         prompt_text = parsed_content["prompt"]
 
         inputs: Union[TokenInputs, MultiModalInputs]
-        if multi_modal_data := parsed_content.get("multi_modal_data"):
+        if self.model_config.is_multimodal_model:
             inputs = self._process_multimodal(
                 prompt_text,
-                multi_modal_data,
+                parsed_content.get("multi_modal_data", {}),
                 parsed_content.get("mm_processor_kwargs"),
                 tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=mm_uuids,

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -313,6 +313,7 @@ class InputPreprocessor:
         prompt_token_ids = self._truncate_inputs(
             parsed_content["prompt_token_ids"], tokenization_kwargs)
 
+        inputs: Union[TokenInputs, MultiModalInputs]
         if self.model_config.is_multimodal_model:
             inputs = self._process_multimodal(
                 prompt_token_ids,

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -507,8 +507,8 @@ class Phi3VMultiModalProcessor(BaseMultiModalProcessor[Phi3VProcessingInfo]):
         )
 
         # Keep the behavior in line with HF processor
-        if token_ids[:2] == tokenizer.encode("<s> <|image|>",
-                                             add_special_tokens=False):
+        if len(mm_prompt_updates) and (token_ids[:2] == tokenizer.encode(
+                "<s> <|image|>", add_special_tokens=False)):
             token_ids = [token_ids[0], *token_ids[2:]]
             placeholders = {
                 modality: [

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -331,6 +331,7 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
         """
         mm_item_counts = mm_items.get_all_counts()
         self._validate_mm_kwargs(mm_kwargs, mm_item_counts)
+        self._validate_mm_updates(mm_prompt_updates, mm_item_counts)
 
         use_audio_in_video = False
         if "video" in mm_kwargs:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

- Always run MM code path for text-only or token-only inputs if the model supports MM. This aligns the behavior with calling `AutoProcessor` instead of calling just `AutoTokenizer`.
- Separate the error message for prompt update and placeholder validations for easier debugging.

## Test Plan

Added `test_preprocessor_always_mm_code_path` to test the first point. The test fails prior to this PR.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

