### PR TITLE
Improve VllmConfig.__str__ to include all configuration fields

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -710,14 +710,18 @@ class VllmConfig:
             f"enforce_eager={self.model_config.enforce_eager}, "
             f"kv_cache_dtype={self.cache_config.cache_dtype}, "
             f"device_config={self.device_config.device}, "
+            f"lora_config={self.lora_config!r}, "
             f"structured_outputs_config={self.structured_outputs_config!r}, "
             f"observability_config={self.observability_config!r}, "
+            f"quant_config={self.quant_config!r}, "
             f"seed={self.model_config.seed}, "
             f"served_model_name={self.model_config.served_model_name}, "
             f"enable_prefix_caching={self.cache_config.enable_prefix_caching}, "
             f"chunked_prefill_enabled={self.scheduler_config.chunked_prefill_enabled}, "  # noqa
             f"pooler_config={self.model_config.pooler_config!r}, "
-            f"compilation_config={self.compilation_config!r}")
+            f"compilation_config={self.compilation_config!r}, "
+            f"kv_transfer_config={self.kv_transfer_config!r}, "
+            f"kv_events_config={self.kv_events_config!r}")
 
 
 _current_vllm_config: Optional[VllmConfig] = None


### PR DESCRIPTION
## Summary
- Add missing configuration fields to `VllmConfig.__str__` method for comprehensive logging
- Enhances debugging capabilities by showing complete vLLM configuration

## Changes Made
- Added `lora_config` to the output string
- Added `quant_config` to the output string  
- Added `kv_transfer_config` to the output string
- Added `kv_events_config` to the output string

Previously the `__str__` method only included a subset of the VllmConfig fields. This PR adds the missing fields so that when the config is logged, all relevant configuration information is visible for debugging and monitoring purposes.

## Test Plan
- The change is purely additive to the logging output
- All added fields use the `!r` repr format for proper display
- Fields follow the same pattern as existing config fields in the method

Fixes #26242