### PR TITLE
fix(tests): Resolve late binding of loop variable in assert message lambda

### DIFF
--- a/tests/kernels/mamba/test_mamba_ssm_ssd.py
+++ b/tests/kernels/mamba/test_mamba_ssm_ssd.py
@@ -539,15 +539,15 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
             Y_ref_seq[: chunked_seqlens[i], ...],
             atol=atol,
             rtol=rtol,
-            msg=lambda x: f"seq{i} output part1 " + x,
-        )  # noqa: B023
+            msg=lambda x, i=i: f"seq{i} output part1 " + x,
+        )
         torch.testing.assert_close(
             Y_seq[chunked_seqlens[i] :, ...],
             Y_ref_seq[chunked_seqlens[i] :, ...],
             atol=atol,
             rtol=rtol,
-            msg=lambda x: f"seq{i} output part2 " + x,
-        )  # noqa: B023
+            msg=lambda x, i=i: f"seq{i} output part2 " + x,
+        )
 
         state_seq = state_chunked[i]
         state_seq_ref = state_ref[i]
@@ -556,5 +556,5 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
             state_seq_ref,
             atol=atol,
             rtol=rtol,
-            msg=lambda x: f"seq{i} state " + x,
-        )  # noqa: B023
+            msg=lambda x, i=i: f"seq{i} state " + x,
+        )


### PR DESCRIPTION
## Purpose

This PR resolves a latent bug in the Mamba SSD tests identified by the **Ruff linter (`B023`)**.
Ruff's `B023` rule, which originates from `flake8-bugbear`, flagged an issue in the `test_mamba_chunk_scan_cont_batch_prefill_chunking` function. The `msg` parameter for `torch.testing.assert_close` was assigned a `lambda` function created inside a `for` loop. This lambda captured the loop variable `i` by reference, not by value, creating a "late binding" issue.
While this might not cause incorrect behavior with the current test runner, it posed a significant risk: if the test framework's behavior were to change to defer error message generation, any assertion failure would incorrectly report the *final* value of `i`, making debugging difficult and misleading.
This change corrects the variable capture by using a default argument in the lambda (`lambda x, i=i: ...`), which ensures the value of `i` is captured at definition time. This makes the test code more robust, eliminates the potential for misleading error messages, and allows for the removal of the `# noqa: B023` suppressions.

## Test Plan
## Test Result