### PR TITLE
[Bugfix] Fix ovis2.5 pre-quant fp8 checkpoint loading

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -203,6 +203,15 @@ class Fp8Config(QuantizationConfig):
                 )
         self.weight_block_size = weight_block_size
 
+    def __repr__(self) -> str:
+        return (
+            f"Fp8Config("
+            f"is_checkpoint_fp8_serialized={self.is_checkpoint_fp8_serialized}, "
+            f"activation_scheme={self.activation_scheme}, "
+            f"ignored_layers={self.ignored_layers}, "
+            f"weight_block_size={self.weight_block_size})"
+        )
+
     @classmethod
     def get_name(cls) -> QuantizationMethods:
         return "fp8"

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -302,7 +302,10 @@ def is_layer_skipped(
 
         is_skipped = None
         for shard_prefix in shard_prefixes:
-            is_shard_skipped = shard_prefix in ignored_layers
+            is_shard_skipped = shard_prefix in ignored_layers or any(
+                shard_prefix.startswith(ignored_layer)
+                for ignored_layer in ignored_layers
+            )
 
             if is_skipped is None:
                 is_skipped = is_shard_skipped
@@ -321,7 +324,9 @@ def is_layer_skipped(
             ]
         )
     else:
-        is_skipped = prefix in ignored_layers
+        is_skipped = prefix in ignored_layers or any(
+            prefix.startswith(ignored_layer) for ignored_layer in ignored_layers
+        )
 
     assert is_skipped is not None
     return is_skipped

--- a/vllm/model_executor/models/ovis2_5.py
+++ b/vllm/model_executor/models/ovis2_5.py
@@ -445,7 +445,7 @@ class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
         super().__init__()
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
-        print(quant_config)
+
         self.config: PretrainedConfig = config
         self.llm = init_vllm_registered_model(
             vllm_config=vllm_config.with_hf_config(config.text_config),

--- a/vllm/model_executor/models/ovis2_5.py
+++ b/vllm/model_executor/models/ovis2_5.py
@@ -445,7 +445,7 @@ class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
         super().__init__()
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
-
+        print(quant_config)
         self.config: PretrainedConfig = config
         self.llm = init_vllm_registered_model(
             vllm_config=vllm_config.with_hf_config(config.text_config),
@@ -456,7 +456,7 @@ class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
             config=config.vit_config,
             visual_vocab_size=config.visual_vocab_size,
             quant_config=quant_config,
-            prefix=f"{prefix}.visual_tokenizer",
+            prefix=maybe_prefix(prefix, "visual_tokenizer"),
         )
 
         self.vte = VisualEmbedding(config.visual_vocab_size, config.hidden_size)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix https://github.com/vllm-project/vllm/issues/26182
- VLMs quantized by `ms-swift` will have  `modules_to_not_convert` field with only partial module prefix:
```
    "modules_to_not_convert": [
        "visual_tokenizer.vit",
        "vte",
        "visual_tokenizer.head",
        "lm_head"
    ],
```
- This PR makes `is_layer_skipped` used by fp8 to fit this case


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

