### PR TITLE
[Tests] conftest: Extending VllmRunner and HfRunner to accept token_ids as input

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,7 +420,7 @@ class HfRunner:
         if audios is not None:
             assert len(prompts) == len(audios)
 
-        all_inputs: list[Union[BatchFeature, BatchEncoding]] = []
+        all_inputs: list[Union[BatchFeature, BatchEncoding, dict[str, torch.Tensor]]] = []
         for i, prompt in enumerate(prompts):
             if isinstance(prompt, str):
                 processor_kwargs: dict[str, Any] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,7 +420,9 @@ class HfRunner:
         if audios is not None:
             assert len(prompts) == len(audios)
 
-        all_inputs: list[Union[BatchFeature, BatchEncoding, dict[str, torch.Tensor]]] = []
+        all_inputs: list[
+            Union[BatchFeature, BatchEncoding, dict[str, torch.Tensor]]
+        ] = []
         for i, prompt in enumerate(prompts):
             if isinstance(prompt, str):
                 processor_kwargs: dict[str, Any] = {
@@ -446,9 +448,16 @@ class HfRunner:
                     inputs = inputs.to(dtype=self.dtype)
                 all_inputs.append(inputs)
             else:
+                # check that prompt is (batched) list of integers (token ids)
                 assert isinstance(prompt, list) and all(
                     isinstance(x, int) for x in prompt
-                ), "prompt must be a list of ints corresponding to the prompt token ids"
+                ), (
+                    "Prompt must be a list of ints corresponding to the prompt token ids."
+                )
+                # check that no multimodal input is provided
+                assert not (images or videos or audios), (
+                    "When providing prompt token ids multimodal inputs are not supported."
+                )
                 input_dict: dict[str, torch.Tensor] = {
                     "input_ids": torch.tensor(prompt, dtype=torch.long).unsqueeze(0),
                 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -803,7 +803,7 @@ class VllmRunner:
 
     def generate(
         self,
-        prompts: Union[list[str], list[torch.Tensor]],
+        prompts: Union[list[str], list[torch.Tensor], list[list[int]]],
         sampling_params: SamplingParams,
         images: Optional[PromptImageInput] = None,
         videos: Optional[PromptVideoInput] = None,
@@ -873,7 +873,7 @@ class VllmRunner:
 
     def generate_greedy(
         self,
-        prompts: Union[list[str], list[torch.Tensor]],
+        prompts: Union[list[str], list[torch.Tensor], list[list[int]]],
         max_tokens: int,
         images: Optional[PromptImageInput] = None,
         videos: Optional[PromptVideoInput] = None,


### PR DESCRIPTION
## Purpose
So far, the `VllmRunner` and `HfRunner` in [tests/conftest.py](https://github.com/vllm-project/vllm/compare/main...yannicks1:vllm:improve-testing-use-conftest?expand=1#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) only accepted `prompts` of type `list[str]` corresponding to the (batched) textual prompts. 
This PR extends the argument `prompts` to be of type `list[list[int]]` which correspond to the (batched) list of `token_ids` of the prompt. 

The change makes the usage of `VllmRunner` and `HfRunner` more versatile, as demonstrated in [tests/v1/e2e/test_context_length.py](https://github.com/vllm-project/vllm/compare/main...yannicks1:vllm:improve-testing-use-conftest?expand=1#diff-c650fbd91c07e297886e25088c49fa2dc24c1b32bbd6f4e4f29e7a69f0137b13). 

## Test Plan
[tests/v1/e2e/test_context_length.py](https://github.com/vllm-project/vllm/compare/main...yannicks1:vllm:improve-testing-use-conftest?expand=1#diff-c650fbd91c07e297886e25088c49fa2dc24c1b32bbd6f4e4f29e7a69f0137b13) uses and tests above implementation. 

If required/wished, a separate unit test comparing outputs based on textual prompts vs. `token_ids` can be written.

## Test Result
[tests/v1/e2e/test_context_length.py](https://github.com/vllm-project/vllm/compare/main...yannicks1:vllm:improve-testing-use-conftest?expand=1#diff-c650fbd91c07e297886e25088c49fa2dc24c1b32bbd6f4e4f29e7a69f0137b13) passes. 


