### PR TITLE
[Model] Support FP8 Mamba SSM Cache

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -23,7 +23,7 @@ logger = init_logger(__name__)
 
 BlockSize = Literal[1, 8, 16, 32, 64, 128]
 CacheDType = Literal["auto", "bfloat16", "fp8", "fp8_e4m3", "fp8_e5m2", "fp8_inc"]
-MambaDType = Literal["auto", "float32"]
+MambaDType = Literal["auto", "float32", "fp8", "fp8_e4m3"]
 PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor"]
 
 

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -51,6 +51,8 @@ class MambaStateDtypeCalculator:
         mamba_cache_dtype: MambaDType,
         mamba_ssm_cache_dtype: MambaDType,
     ) -> tuple[torch.dtype, ...]:
+        if mamba_cache_dtype.startswith("fp8"):
+            raise ValueError("fp8 mamba conv state is not supported")
         conv_state_dtype = get_kv_cache_torch_dtype(mamba_cache_dtype, model_dtype)
         if mamba_ssm_cache_dtype == "auto":
             temporal_state_dtype = conv_state_dtype


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR attempts to implement FP8 Mamba SSM Cache support incrementally. The cache management is already capable of allocating the right size when enabling fp8 by setting `mamba_ssm_cache_dtype=fp8`. However, naively enabling this results in the mamba state being casted (instead of scaled) to higher precision types for computations, and the store back is also forced type casts instead of scaling. This leads to output quality degradation.

We will add the support gradually:

### Basic requirements
- [ ] support static/dynamic per-tensor scale
- [ ] support finer grained (per-head, per-token, per-group) scales
- [ ] support dynamic scaling
- [ ] support fp8 in prefix-caching use cases
- [ ] memory footprint measurements to ensure correctness of the implementation
- [ ] performance (latency/throughput) measurements

### Further optimizations
- [ ] fuse dequantization/quantization into mamba kernels

## Test Plan
We will use a few hybrid model checkpoints 

## Test Result
To be added

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

