### PR TITLE
Bump flashinfer to 0.4.0rc2 to support determinism

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -715,7 +715,7 @@ setup(
         ],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility
         # FlashInfer should be updated together with the Dockerfile
-        "flashinfer": ["flashinfer-python==0.3.1"],
+        "flashinfer": ["flashinfer-python==0.4.0rc4"],
         # Optional deps for AMD FP4 quantization support
         "petit-kernel": ["petit-kernel"],
     },


### PR DESCRIPTION
Previous attempt to land https://github.com/vllm-project/vllm/pull/25769 caused CI failures because the version for flashinfer was not bumped.

## Purpose

This PR tests and bumps a release candidate version of flashinfer.

## Test Plan

Run CI

## Test Result

[unknown]

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

