### PR TITLE
Add plugin registry and callbacks for AI model validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1259,6 +1259,7 @@ def num_gpus_available():
 
 temp_dir = tempfile.gettempdir()
 _dummy_opt_path = os.path.join(temp_dir, "dummy_opt")
+_dummy_opt_unmodified_path = os.path.join(temp_dir, "dummy_opt_unmodified")
 _dummy_llava_path = os.path.join(temp_dir, "dummy_llava")
 _dummy_gemma2_embedding_path = os.path.join(temp_dir, "dummy_gemma2_embedding")
 
@@ -1279,6 +1280,19 @@ def dummy_opt_path():
         with open(json_path, "w") as f:
             json.dump(config, f)
     return _dummy_opt_path
+
+
+@pytest.fixture
+def dummy_opt_unmodified_path():
+    json_path = os.path.join(_dummy_opt_unmodified_path, "config.json")
+    if not os.path.exists(_dummy_opt_unmodified_path):
+        snapshot_download(
+            repo_id="facebook/opt-125m",
+            local_dir=_dummy_opt_unmodified_path,
+            ignore_patterns=["*.bin", "*.bin.index.json", "*.pt", "*.h5", "*.msgpack"],
+        )
+        assert os.path.exists(json_path)
+    return _dummy_opt_unmodified_path
 
 
 @pytest.fixture

--- a/tests/model_executor/model_loader/test_model_validation.py
+++ b/tests/model_executor/model_loader/test_model_validation.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import pytest
+from torch import nn
+
+from vllm.config import DeviceConfig, ModelConfig, VllmConfig
+from vllm.config.load import LoadConfig
+from vllm.model_executor.model_loader import get_model_loader, register_model_loader
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader, DownloadType
+from vllm.validation.plugins import (
+    ModelType,
+    ModelValidationPlugin,
+    ModelValidationPluginRegistry,
+)
+
+
+@register_model_loader("custom_load_format")
+class CustomModelLoader(BaseModelLoader):
+    def __init__(self, load_config: LoadConfig) -> None:
+        super().__init__(load_config)
+        self.download_type = None
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        pass
+
+    def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        pass
+
+    def set_download_type(self, download_type: DownloadType) -> None:
+        """Allow changing download_type"""
+        self.download_type = download_type
+
+    def get_download_type(self, model_name_or_path: str) -> DownloadType | None:
+        return self.download_type
+
+
+class MyModelValidator(ModelValidationPlugin):
+    def model_validation_needed(self, model_type: ModelType, model_path: str) -> bool:
+        return True
+
+    def validate_model(
+        self, model_type: ModelType, model_path: str, model: str | None = None
+    ) -> None:
+        raise BaseException("Model did not validate")
+
+
+def test_register_model_loader(dist_init):
+    load_config = LoadConfig(load_format="custom_load_format")
+    custom_model_loader = get_model_loader(load_config)
+    assert isinstance(custom_model_loader, CustomModelLoader)
+
+    my_model_validator = MyModelValidator()
+    ModelValidationPluginRegistry.register_plugin("test", my_model_validator)
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(),
+        device_config=DeviceConfig("auto"),
+        load_config=LoadConfig(),
+    )
+    with pytest.raises(RuntimeError):
+        custom_model_loader.load_model(vllm_config, vllm_config.model_config)
+
+    # have validate_model() called
+    custom_model_loader.set_download_type(DownloadType.LOCAL_FILE)
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(),
+        device_config=DeviceConfig("cpu"),
+        load_config=LoadConfig(),
+    )
+    with pytest.raises(BaseException, match="Model did not validate"):
+        custom_model_loader.load_model(vllm_config, vllm_config.model_config)

--- a/tests/v1/engine/test_engine_core_model_validation.py
+++ b/tests/v1/engine/test_engine_core_model_validation.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+from vllm.utils.torch_utils import set_default_torch_num_threads
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.executor.abstract import Executor
+from vllm.validation.plugins import (
+    ModelType,
+    ModelValidationPlugin,
+    ModelValidationPluginRegistry,
+)
+
+
+class MyModelValidator(ModelValidationPlugin):
+    def model_validation_needed(self, model_type: ModelType, model_path: str) -> bool:
+        return True
+
+    def validate_model(
+        self, model_type: ModelType, model_path: str, model: str | None = None
+    ) -> None:
+        raise BaseException("Model did not validate")
+
+
+def test_engine_core_model_validation(
+    monkeypatch: pytest.MonkeyPatch, dummy_opt_unmodified_path
+):
+    my_model_validator = MyModelValidator()
+    ModelValidationPluginRegistry.register_plugin("test", my_model_validator)
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+
+        engine_args = EngineArgs(model=dummy_opt_unmodified_path)
+        vllm_config = engine_args.create_engine_config()
+        executor_class = Executor.get_class(vllm_config)
+
+        with (
+            set_default_torch_num_threads(1),
+            pytest.raises(BaseException, match="Model did not validate"),
+        ):
+            EngineCore(
+                vllm_config=vllm_config,
+                executor_class=executor_class,
+                log_stats=False,
+            )

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -247,6 +247,7 @@ class OpenAIServingModels:
             base_model_name = self.model_config.model
             unique_id = self.lora_id_counter.inc(1)
             found_adapter = False
+            reason = ""
 
             # Try to resolve using available resolvers
             for resolver in self.lora_resolvers:
@@ -273,13 +274,15 @@ class OpenAIServingModels:
                             resolver.__class__.__name__,
                             e,
                         )
+                        reason = str(e)
                         continue
 
             if found_adapter:
                 # An adapter was found, but all attempts to load it failed.
                 return create_error_response(
                     message=(
-                        f"LoRA adapter '{lora_name}' was found but could not be loaded."
+                        f"LoRA adapter '{lora_name}' was found "
+                        f"but could not be loaded: {reason}"
                     ),
                     err_type="BadRequestError",
                     status_code=HTTPStatus.BAD_REQUEST,

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -4,6 +4,8 @@
 
 import msgspec
 
+from vllm.validation.plugins import ModelType, ModelValidationPluginRegistry
+
 
 class LoRARequest(
     msgspec.Struct,
@@ -64,3 +66,9 @@ class LoRARequest(
         identified by their names across engines.
         """
         return hash(self.lora_name)
+
+    def validate(self) -> None:
+        """Validate the LoRA adapter given its path."""
+        ModelValidationPluginRegistry.validate_model(
+            ModelType.MODEL_TYPE_LORA, self.lora_path
+        )

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -105,6 +105,10 @@ class WorkerLoRAManager:
                 lora_request.tensorizer_config_dict,
             )
 
+            # Security-validate the LoRA adapter (e.g. signature verification),
+            # throwing an exception if validation fails.
+            lora_request.validate()
+
             # Validates the LoRA configuration against requirements before
             # loading weights, throwing an exception if validation fails.
             peft_helper.validate_legal(self.lora_config)

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import enum
 from abc import ABC, abstractmethod
 
+import huggingface_hub
 import torch
 import torch.nn as nn
 
@@ -14,8 +16,16 @@ from vllm.model_executor.model_loader.utils import (
     process_weights_after_loading,
 )
 from vllm.utils.torch_utils import set_default_torch_dtype
+from vllm.validation.plugins import ModelType, ModelValidationPluginRegistry
 
 logger = init_logger(__name__)
+
+
+class DownloadType(int, enum.Enum):
+    HUGGINGFACE_HUB = 1
+    LOCAL_FILE = 2
+    S3 = 3  # not currently supported
+    UNKNOWN = 4
 
 
 class BaseModelLoader(ABC):
@@ -35,6 +45,45 @@ class BaseModelLoader(ABC):
         inplace weights loading for an already-initialized model"""
         raise NotImplementedError
 
+    def get_download_type(self, model_name_or_path: str) -> DownloadType | None:
+        """Subclass must override this and return the download type it needs"""
+        return None
+
+    def download_all_files(
+        self, model: nn.Module, model_config: ModelConfig, load_config: LoadConfig
+    ) -> str | None:
+        """Download all files. Ask the subclass for what type of download
+        it does; Huggingface is used so often, so download all files here."""
+        dt = self.get_download_type(model_config.model)
+        if dt == DownloadType.HUGGINGFACE_HUB:
+            return huggingface_hub.snapshot_download(
+                model_config.model,
+                allow_patterns=["*"],
+                cache_dir=self.load_config.download_dir,
+                revision=model_config.revision,
+                local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
+            )
+        elif dt == DownloadType.LOCAL_FILE:
+            return model_config.model
+        return None
+
+    def validate_model(
+        self, model: nn.Module, model_config: ModelConfig, load_config: LoadConfig
+    ) -> None:
+        """If needed, validate the model after downloading _all_ its files."""
+        if ModelValidationPluginRegistry.model_validation_needed(
+            ModelType.MODEL_TYPE_AI_MODEL, model_config.model
+        ):
+            folder = self.download_all_files(model, model_config, load_config)
+            if folder is None:
+                raise RuntimeError(
+                    "Model validation could not be done due to "
+                    "an unsupported download method."
+                )
+            ModelValidationPluginRegistry.validate_model(
+                ModelType.MODEL_TYPE_AI_MODEL, folder, model_config.model
+            )
+
     def load_model(
         self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""
     ) -> nn.Module:
@@ -52,6 +101,8 @@ class BaseModelLoader(ABC):
                 )
 
             log_model_inspection(model)
+
+            self.validate_model(model, model_config, vllm_config.load_config)
 
             logger.debug("Loading weights on %s ...", load_device)
             # Quantization does not happen in `load_weights` but after it

--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -31,7 +31,7 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
     RowParallelLinear,
 )
-from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader, DownloadType
 from vllm.model_executor.model_loader.utils import ParamMapping
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
@@ -815,3 +815,8 @@ class BitsAndBytesModelLoader(BaseModelLoader):
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config.model, model_config.revision)
+
+    def get_download_type(self, model_name_or_path: str) -> DownloadType:
+        if os.path.isdir(model_name_or_path):
+            return DownloadType.LOCAL_FILE
+        return DownloadType.HUGGINGFACE_HUB

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -15,7 +15,7 @@ from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.torchao import torchao_version_at_least
-from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader, DownloadType
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
@@ -302,3 +302,8 @@ class DefaultModelLoader(BaseModelLoader):
                     "Following weights were not initialized from "
                     f"checkpoint: {weights_not_loaded}"
                 )
+
+    def get_download_type(self, model_name_or_path: str) -> DownloadType:
+        if os.path.isdir(model_name_or_path):
+            return DownloadType.LOCAL_FILE
+        return DownloadType.HUGGINGFACE_HUB

--- a/vllm/model_executor/model_loader/runai_streamer_loader.py
+++ b/vllm/model_executor/model_loader/runai_streamer_loader.py
@@ -9,7 +9,7 @@ from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
-from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader, DownloadType
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
@@ -113,3 +113,10 @@ class RunaiModelStreamerLoader(BaseModelLoader):
         model.load_weights(
             self._get_weights_iterator(model_weights, model_config.revision)
         )
+
+    def get_download_type(self, model_name_or_path: str) -> DownloadType:
+        if os.path.isdir(model_name_or_path):
+            return DownloadType.LOCAL_FILE
+        if is_runai_obj_uri(model_name_or_path):
+            return DownloadType.S3
+        return DownloadType.HUGGINGFACE_HUB

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -14,7 +14,7 @@ from torch import nn
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
-from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader, DownloadType
 from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf,
     runai_safetensors_weights_iterator,
@@ -212,3 +212,10 @@ class ShardedStateLoader(BaseModelLoader):
                 state_dict_part,
                 os.path.join(path, filename),
             )
+
+    def get_download_type(self, model_name_or_path: str) -> DownloadType:
+        if os.path.isdir(model_name_or_path):
+            return DownloadType.LOCAL_FILE
+        if is_s3(model_name_or_path):
+            return DownloadType.S3
+        return DownloadType.HUGGINGFACE_HUB

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -65,6 +65,7 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import compute_iteration_details
+from vllm.validation.plugins import ModelType, ModelValidationPluginRegistry
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
@@ -99,6 +100,11 @@ class EngineCore:
                 vllm_config,
             )
 
+        if os.path.isdir(vllm_config.model_config.model):
+            ModelValidationPluginRegistry.validate_model(
+                ModelType.MODEL_TYPE_AI_MODEL, vllm_config.model_config.model
+            )
+
         self.log_stats = log_stats
 
         # Setup Model.
@@ -116,6 +122,16 @@ class EngineCore:
         vllm_config.cache_config.num_gpu_blocks = num_gpu_blocks
         vllm_config.cache_config.num_cpu_blocks = num_cpu_blocks
         self.collective_rpc("initialize_cache", args=(num_gpu_blocks, num_cpu_blocks))
+
+        if ModelValidationPluginRegistry.model_validation_needed(
+            ModelType.MODEL_TYPE_AI_MODEL, vllm_config.model_config.model
+        ):
+            raise Exception(
+                "Model validation was requested for "
+                f"{vllm_config.model_config.model} but was not "
+                "done since a code path was taken that is not yet "
+                "instrumented for model validation."
+            )
 
         self.structured_output_manager = StructuredOutputManager(vllm_config)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1036,8 +1036,11 @@ class EngineCoreProc(EngineCore):
                 output.result = UtilityResult(result)
             except BaseException as e:
                 logger.exception("Invocation of %s method failed", method_name)
+                message = str(e)
+                if e.__cause__:
+                    message += f" caused by {e.__cause__}"
                 output.failure_message = (
-                    f"Call to {method_name} method failed: {str(e)}"
+                    f"Call to {method_name} method failed: {message}"
                 )
             self.output_queue.put_nowait(
                 (client_idx, EngineCoreOutputs(utility_output=output))

--- a/vllm/validation/plugins.py
+++ b/vllm/validation/plugins.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import enum
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class ModelType(int, enum.Enum):
+    MODEL_TYPE_AI_MODEL = 1
+    MODEL_TYPE_LORA = 2
+
+
+class ModelValidationPlugin(ABC):
+    """Base class for all model validation plugins"""
+
+    @abstractmethod
+    def model_validation_needed(self, model_type: ModelType, model_path: str) -> bool:
+        """Have the plugin check whether it already validated the model
+        at the given model_path."""
+        return False
+
+    @abstractmethod
+    def validate_model(
+        self, model_type: ModelType, model_path: str, model: str | None = None
+    ) -> None:
+        """Validate the model at the given model_path."""
+        pass
+
+
+@dataclass
+class _ModelValidationPluginRegistry:
+    plugins: dict[str, ModelValidationPlugin] = field(default_factory=dict)
+
+    def register_plugin(self, plugin_name: str, plugin: ModelValidationPlugin):
+        """Register a security plugin."""
+        if plugin_name in self.plugins:
+            logger.warning(
+                "Model validation plugin %s is already registered, and will be "
+                "overwritten by the new plugin %s.",
+                plugin_name,
+                plugin,
+            )
+
+        self.plugins[plugin_name] = plugin
+
+    def model_validation_needed(self, model_type: ModelType, model_path: str) -> bool:
+        """Check whether model validation was requested but was not done, yet.
+        Returns False in case no model validation was requested or it is already
+        done. Returns True if model validation was request but not done yet."""
+        for plugin in self.plugins.values():
+            if plugin.model_validation_needed(model_type, model_path):
+                return True
+        return False
+
+    def validate_model(
+        self, model_type: ModelType, model_path: str, model: str | None = None
+    ) -> None:
+        """Have all plugins validate the model at the given path. Any plugin
+        that cannot validate it will throw an exception."""
+        plugins = self.plugins.values()
+        if plugins:
+            for plugin in plugins:
+                plugin.validate_model(model_type, model_path, model)
+            logger.info("Successfully validated %s", model_path)
+
+
+ModelValidationPluginRegistry = _ModelValidationPluginRegistry()


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR adds a plugin registry for AI model validation plugins and sets callbacks from which the plugins are invoked. The model validation can be used on AI models and LoRA adapters and therefore the plugin points are set to verify:

- AI models available in the filesystem
- AI models that are downloaded from Huggingface hub
- LoRA adapters when they are loaded

The first plugin to use this new infrastructure will be used for integrity and provenance verification of AI models and LoRA adapters and will be hosted outside the vLLM repository.

The plugin for signature enforcement is *currently* available here: https://github.com/stefanberger/vllm-plugin-signature-enforcement

## Test Plan

The following new tests have been added:
```bash
pytest tests/v1/engine/test_engine_core_model_validation.py
pytest tests/model_executor/model_loader/test_model_validation.py
```

The following existing test have been extended:
```bash
pytest tests/lora/test_lora_manager.py
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

