### PR TITLE
Draft: Add RequestErrorContext and error propagation infrastructure for request aborts

### DIFF
--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -103,6 +103,7 @@ class RequestOutput:
                                   None if decoder-only.
         num_cached_tokens: The number of tokens with prefix cache hit.
         kv_transfer_params: The params for remote K/V transfer.
+        error_context: Rich error context if request failed/aborted.
     """
 
     def __init__(
@@ -121,6 +122,7 @@ class RequestOutput:
         *,
         multi_modal_placeholders: Optional[MultiModalPlaceholderDict] = None,
         kv_transfer_params: Optional[dict[str, Any]] = None,
+        error_context: Optional[dict[str, Any]] = None,
         # Forward compatibility, code that uses args added in new release can
         # still run with older versions of vLLM without breaking.
         **kwargs: Any,
@@ -142,6 +144,7 @@ class RequestOutput:
         self.encoder_prompt_token_ids = encoder_prompt_token_ids
         self.num_cached_tokens = num_cached_tokens
         self.kv_transfer_params = kv_transfer_params
+        self.error_context = error_context
 
     def add(self, next_output: "RequestOutput", aggregate: bool) -> None:
         """Merge subsequent RequestOutput into this one"""


### PR DESCRIPTION
This ties in with: #26171 

PoC of an error context and propagation system that allows exposing rich error context and metadata back up through the API server.

### Example implementations

**1. KV Transfer Load Failures**
```python
# When remote KV cache blocks fail to load
error_ctx = RequestErrorContext(
    error_type=ErrorType.KV_TRANSFER_FAILURE,
    message="Failed to load KV cache from remote source",
    http_status=HTTPStatus.BAD_GATEWAY,
    metadata={"affected_tokens": num_tokens, "invalid_blocks": len(invalid_block_ids)} #in addition everything in kv_transfer_params, eg. remote_host_id for routing purposes
)
# Client receives 502 with actionable details instead of generic 500
```
2. Resource Exhaustion (scheduler preemption handling)
```py
# When request aborted after excessive preemptions
error_ctx = RequestErrorContext(
    error_type=ErrorType.RESOURCE_EXHAUSTION,
    message="Request aborted due to memory pressure",
    http_status=HTTPStatus.SERVICE_UNAVAILABLE,
    metadata={"num_preemptions": request.num_preemptions, "available_blocks": blocks}
)
# Client receives 503, can implement retry with backoff
```
3. Corrupted Model Output
```py
# When NaN detected in model logits
if request.is_output_corrupted:
    error_ctx = RequestErrorContext(
        error_type=ErrorType.MODEL_OUTPUT_CORRUPTED,
        message="Model generated corrupted output (NaN in logits)",
        http_status=HTTPStatus.INTERNAL_SERVER_ERROR,
        metadata={"num_nans": request.num_nans_in_logits, "position": request.num_output_tokens}
    )
```