### PR TITLE
[Bug] Fix Shape Validation for Fallback while Enabling E8M0 for DeepGEMM

### DIFF
--- a/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
@@ -143,7 +143,7 @@ class TritonOrDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         apply_router_weight_on_input: bool,
     ):
         use_deep_gemm = self.allow_deep_gemm and (
-            _valid_deep_gemm(hidden_states, w1, w2) or is_deep_gemm_e8m0_used()
+            is_deep_gemm_e8m0_used() or _valid_deep_gemm(hidden_states, w1, w2)
         )
 
         experts = self.deep_gemm_expert if use_deep_gemm else self.triton_expert


### PR DESCRIPTION
## Purpose

@smarterclayton met unexpected log in blackwell

```bash
(EngineCore_DP1 pid=896) DEBUG 10-06 17:54:16 [model_executor/.../fused_moe/deep_gemm_moe.py:51] DeepGemm disabled due to unaligned problem size. M: 14, N: 2048, K: 7168. M should >= 128 and N and K must be multiples of 128. This is not an error and we will fall back to triton.
```

This shape validation shouldn't be triggered since we enable e8m0 by default in blackwell, no fallback will be actually used.

## Test

No shape validation now if e8m0 is enabled