### PR TITLE
[BUG] Fix file parsing for load_format runai_streamer_sharded

### DIFF
--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -121,7 +121,7 @@ class ShardedStateLoader(BaseModelLoader):
 
         filepaths = []
         if is_s3(local_model_path):
-            file_pattern = f"*{self.pattern.format(rank=rank, part=' * ')}"
+            file_pattern = f"*{self.pattern.format(rank=rank, part='*')}"
             filepaths = s3_glob(path=local_model_path, allow_pattern=[file_pattern])
         else:
             filepaths = glob.glob(pattern)


### PR DESCRIPTION

## Purpose
RunAI streamer sharded does not work due to a minor bug in file parsing. 
## Test Plan
I can load a sharded model from disk or s3 with something like `vllm serve /home/ray/default/Qwen3-235B-A22B-sharded --tensor-parallel-size 8 --load-format runai_streamer_sharded`
## Test Result
I was able to do so.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

