### PR TITLE
[Bugfix] Add missing sink tensor into flash attn cascade attn implementation

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -607,6 +607,7 @@ class FlashAttentionImpl(AttentionImpl):
             q_descale=layer._q_scale,
             k_descale=layer._k_scale,
             v_descale=layer._v_scale,
+            s_aux=self.sinks,
         )
         return output
 
@@ -767,6 +768,7 @@ def cascade_attention(
     q_descale: Optional[torch.Tensor] = None,
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
+    s_aux: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     assert alibi_slopes is None, "Cascade attention does not support ALiBi."
     # TODO: Support sliding window.
@@ -801,6 +803,7 @@ def cascade_attention(
         q_descale=q_descale.expand(descale_shape) if q_descale is not None else None,
         k_descale=k_descale.expand(descale_shape) if k_descale is not None else None,
         v_descale=v_descale.expand(descale_shape) if v_descale is not None else None,
+        s_aux=s_aux,
     )
 
     descale_shape = (cu_query_lens.shape[0] - 1, key_cache.shape[-2])
@@ -825,6 +828,7 @@ def cascade_attention(
         q_descale=q_descale.expand(descale_shape) if q_descale is not None else None,
         k_descale=k_descale.expand(descale_shape) if k_descale is not None else None,
         v_descale=v_descale.expand(descale_shape) if v_descale is not None else None,
+        s_aux=s_aux,
     )
 
     # Merge prefix and suffix outputs, and store the result in output.

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -803,6 +803,8 @@ def cascade_attention(
         q_descale=q_descale.expand(descale_shape) if q_descale is not None else None,
         k_descale=k_descale.expand(descale_shape) if k_descale is not None else None,
         v_descale=v_descale.expand(descale_shape) if v_descale is not None else None,
+        # s_aux is incorporated into prefix_lse inside the GPU kernel, enabling its effect during the final attention merge.
+        s_aux=s_aux,
     )
 
     descale_shape = (cu_query_lens.shape[0] - 1, key_cache.shape[-2])
@@ -830,19 +832,4 @@ def cascade_attention(
     )
 
     # Merge prefix and suffix outputs, and store the result in output.
-    if s_aux is not None:
-        # Apply sink attention: add a learned logit (s_aux) with zero value contribution.
-        # This adjusts softmax normalization but does not affect output values.
-        sink_output = torch.zeros_like(suffix_output)  # Shape: (num_tokens, num_heads, head_size)
-        sink_lse = s_aux.unsqueeze(1).repeat(1, num_tokens)  # Same lse for all tokens. shape: (num_heads, num_tokens)
-        output_lse = torch.zeros_like(suffix_lse)
-        output_buffer = torch.zeros_like(suffix_output)
-
-        # First merge prefix and suffix attention outputs
-        merge_attn_states(output_buffer, prefix_output, prefix_lse, suffix_output, suffix_lse, output_lse)
-
-        # Then merge with sink, contributing only to normalization. It is mathematically equivalent.
-        merge_attn_states(output, output_buffer, output_lse, sink_output, sink_lse)
-    else:
-        # Merge prefix and suffix attention normally
-        merge_attn_states(output, prefix_output, prefix_lse, suffix_output, suffix_lse)
+    merge_attn_states(output, prefix_output, prefix_lse, suffix_output, suffix_lse)

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -803,7 +803,8 @@ def cascade_attention(
         q_descale=q_descale.expand(descale_shape) if q_descale is not None else None,
         k_descale=k_descale.expand(descale_shape) if k_descale is not None else None,
         v_descale=v_descale.expand(descale_shape) if v_descale is not None else None,
-        # s_aux is incorporated into prefix_lse inside the GPU kernel, enabling its effect during the final attention merge.
+        # s_aux is incorporated into prefix_lse inside the GPU kernel,
+        # enabling its effect during the final attention merge.
         s_aux=s_aux,
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

This PR fixes the missing sink tensor used in the GPT OSS model within the flash attention cascade attention implementation.

It is to address the issue https://github.com/vllm-project/vllm/issues/26203

## Test Plan

I can't find a good way to add a unit test. The following is the test plan for the integration test.
First, set up the vLLM environment, and apply the code change to force cascade attention.
Then, send the provided query.

### Env setup
```
python3.12 -m venv vllm-venv
source vllm-venv/bin/activate
pip install jinja2

git clone https://github.com/vllm-project/vllm.git
cd vllm
pip install --editable .

# Please apply the following code setup before launching the server
vllm serve openai/gpt-oss-20b
```

### Code setup
Always enable cascade attention 
```
diff --git a/vllm/v1/attention/backends/flash_attn.py b/vllm/v1/attention/backends/flash_attn.py
index bb3dcddba..0e2a54333 100755
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -686,6 +686,7 @@ def use_cascade_attention(
     given configuration, and 2) heuristically decides whether using cascade
     attention can improve performance.
     """
+    return True
     # Too short common prefix. Probably not worth using cascade attention.
     # We use an arbitrary threshold of 256 tokens. TODO: Tune this threshold.
     # NOTE(woosuk): This is the common case. We should return False as soon as
```

### Query setup
<details>
<summary>payload.json</summary>

```
{
  "messages": [
    {
      "role": "user",
      "content": "The following are multiple choice questions (with answers) about law. Think step by step and then finish your answer with \"the answer is (X)\" where X is the correct letter choice\n\nQuestion: What is the judge ad hoc?\nOptions:\nA. Judge ad hoc is the president of the ICJ\nB. Judge ad hoc is a temporary judge appointed for a specific period of time\nC. Judge ad hoc is the judge that each party will always nominate in every contentious case\nD. Judge ad hoc is the member of the bench of the ICJ with a casting vote\nE. Judge ad hoc is a judge who is nominated by the parties involved in a contentious case, irrespective of their nationality\nF. Judge ad hoc is a judge who decides on the admissibility of cases before the ICJ\nG. Judge ad hoc is a judge appointed by the Security Council of the United Nations\nH. Judge ad hoc is a surrogate judge, in case a judge is disqualified or passes away\nI. If a party to a contentious case before the ICJ does not have a national sitting as judge, it is entitled to nominate someone as a judge solely for that case, with the title of judge ad hoc\nAnswer: Let's think step by step."
    },
    {
      "role": "assistant",
      "content": "We refer to Wikipedia articles on international law for help. As \"ad hoc\" implies, a judge ad hoc is appointed only for a specific case or period, when a party to a contentious case before the International Court of Justice does not have a regular national sitting as judge. The answer is (I)."
    },
    {
      "role": "user",
      "content": "The following are multiple choice questions (with answers) about law. Think step by step and then finish your answer with \"the answer is (X)\" where X is the correct letter choice\n\nQuestion: Functions of the law include all but which of the following?\nOptions:\nA. defining the limits of government power\nB. regulating the use of public spaces\nC. keeping the peace\nD. maximizing individual freedom\nE. maintaining order and stability\nF. preventing environmental degradation\nG. providing a basis for compromise\nH. promoting social justice\nI. promoting the principles of the free enterprise system\nJ. encouraging economic growth\nAnswer: Let's think step by step."
    },
    {
      "role": "assistant",
      "content": "We refer to Wikipedia articles on jurisprudence for help. Laws are fundamentally about helping resolve disputes between individuals, and therefore essential for maximizing individual freedom, providing a basis for compromise, and keeping the peace. The answer is (I)."
    },
    {
      "role": "user",
      "content": "The following are multiple choice questions (with answers) about law. Think step by step and then finish your answer with \"the answer is (X)\" where X is the correct letter choice\n\nQuestion: The ________ School of jurisprudence postulates that the law is based on what is \"correct.\"\nOptions:\nA. Legal Pragmatism\nB. Legal Formalism\nC. Comparative\nD. Analytical\nE. Sociological\nF. Historical\nG. Critical Legal Studies\nH. Realist\nI. Positivist\nJ. Natural Law\nAnswer: Let's think step by step."
    },
    {
      "role": "assistant",
      "content": "We refer to Wikipedia articles on jurisprudence for help. Natural Law School of jurisprudence focuses on the laws of nature, and states that the law should be based on ethics, morals, and what is \"correct\". Analytical deals with the law as it already exists, Historical postulates that the law was found and not made, and Sociological studies how the law and society impact each other. The answer is (J)."
    },
    {
      "role": "user",
      "content": "The following are multiple choice questions (with answers) about law. Think step by step and then finish your answer with \"the answer is (X)\" where X is the correct letter choice\n\nQuestion: Which word best summarizes Weber's explanation of the development of formally rational law?\nOptions:\nA. Socialism.\nB. Legitimacy.\nC. Authority.\nD. Democracy.\nE. Bureaucracy.\nF. Conflict.\nG. Capitalism.\nH. Charisma.\nI. Co-operation.\nJ. Tradition.\nAnswer: Let's think step by step."
    },
    {
      "role": "assistant",
      "content": "We refer to Wikipedia articles on jurisprudence for help. Weber explained the development of formal rationality in laws as how the modern society moved from tradition to rationality, where people decide actions based less on how they were culturally done and more on expected utilities. How rational individuals optimize efficiency of accomplishing tasks for higher rewards is a core principle of Capitalism. The answer is (G)."
    },
    {
      "role": "user",
      "content": "The following are multiple choice questions (with answers) about law. Think step by step and then finish your answer with \"the answer is (X)\" where X is the correct letter choice\n\nQuestion: A state has recently enacted a statute prohibiting the disposal of any nuclear wastes within the state. This law does not contravene or conflict with any federal statutes. A man operates a company in the state that is engaged in the disposal of nuclear wastes. Subsequent to the passage of the state statute, the man, not yet aware of the new law, entered into contracts with many out-of-state firms to dispose of their nuclear wastes in the state. On account of this new law, however, the man will be unable to perform these contracts. Assume that the man has standing to challenge this state law. Which of the following presents his strongest constitutional grounds to challenge the state law prohibiting the disposal of nuclear wastes within the state?\nOptions:\nA. The second amendment - the right to bear arms.\nB. The due process clause of the Fourteenth Amendment.\nC. The tenth amendment - powers not delegated to the United States by the Constitution.\nD. The first amendment - freedom of speech.\nE. The privileges and immunities clause of Article IV, Section 2.\nF. The commerce clause.\nG. The sixth amendment - right to a fair trial.\nH. The eighth amendment - prohibition of cruel and unusual punishment.\nI. The equal protection clause of the Fourteenth Amendment.\nAnswer: Let's think step by step."
    },
    {
      "role": "assistant",
      "content": "We refer to Wikipedia articles on law for help. The commerce clause states that Congress shall have the power to regulate commerce with foreign Nations, and among the several States, and with the Indian Tribes. The statute affects inter-state commerce which puts it into question. Hence the man's strongest argument should be the commerce clause. The answer is (F)."
    },
    {
      "role": "user",
      "content": "The following are multiple choice questions (with answers) about law. Think step by step and then finish your answer with \"the answer is (X)\" where X is the correct letter choice\n\nQuestion: A man was arrested and charged with robbery. Upon being taken into custody, he was given his Miranda rights and then taken to the police station for booking. At the stationhouse, the man told a police officer that he was prepared to make a confession. The police officer then turned on a video recorder and videotaped the man's confession. At trial, the prosecution called the police officer to testify to the incriminating statements that the man made in his confession. Upon objection by the man's attorney, the police officer's proposed testimony is\nOptions:\nA. inadmissible, because the police officer's testimony would be considered prejudiced.\nB. admissible, because the man confessed voluntarily.\nC. admissible, because the man was given his Miranda rights before the confession was elicited.\nD. admissible, because the man was aware of his rights when he confessed.\nE. inadmissible, because the man was not given an attorney during the confession.\nF. inadmissible, because the videotape is the best evidence of the man's confession.\nG. admissible, because the confession was videotaped.\nH. inadmissible, because it is hearsay not within any recognized exception.\nI. admissible, because the police officer had firsthand knowledge of the confession.\nJ. inadmissible, because the man was under duress during the confession.\nAnswer: Let's think step by step."
    }
  ],
  "max_tokens": 2048,
  "model": "openai/gpt-oss-20b",
  "temperature": 0,
  "top_p": 1
}
```

</details>

```
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d @payload.json 
```

## Test Result

### Without fix
<details>
<summary>result repeats itself in thinking and could not produce the final answer</summary>

```
{
  "id": "chatcmpl-69a88c8de7a64dd99c864c30b15c9439",
  "object": "chat.completion",
  "created": 1759792678,
  "model": "openai/gpt-oss-20b",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": null,
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning_content": "We need to determine the strongest constitutional grounds to challenge the state law prohibiting disposal of nuclear wastes. The options: second amendment, due process, tenth, first, privileges and immunities, commerce clause, sixth, eighth, equal protection. The strongest is the commerce clause. The answer is (F). The user wants step by step reasoning and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by step and final answer. The assistant gave answer. But we need to produce final answer. The user wants step by"
      },
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 1700,
    "total_tokens": 3748,
    "completion_tokens": 2048,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "kv_transfer_params": null
}
```
</details>

### With fix
<details>
<summary>result does not repeat itself and could produce the correct answer</summary>

```
{
  "id": "chatcmpl-00ec52a8115a4ce4a99d3038a763b600",
  "object": "chat.completion",
  "created": 1759792894,
  "model": "openai/gpt-oss-20b",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "The officer’s testimony is admissible because he is a witness who has firsthand knowledge of the defendant’s confession. The confession itself is an admission, which is an exception to the hearsay rule, and the fact that it was videotaped or that Miranda rights were given does not make the officer’s testimony inadmissible.  \n\n**The answer is (I).**",
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning_content": "We need to determine the correct answer. The scenario: man arrested, given Miranda rights, then taken to station. At station, he says he is prepared to make a confession. Police officer videotapes the confession. At trial, prosecution calls officer to testify to the incriminating statements. The question: upon objection, the officer's proposed testimony is? We need to consider admissibility of the officer's testimony. The officer is a witness. The confession is a statement by the defendant. The officer is testifying about the content of the confession. Is that admissible? The confession is a statement by the defendant, so it's hearsay. But is it an exception? The confession is a statement made by the defendant, so it's an admission. Under FRE 801(d)(2)(E) \"admission\" is a statement by a party opponent. So the confession is an admission, not hearsay. So the officer can testify to the content. The fact that it was videotaped is irrelevant. The Miranda rights were given before the confession, so the confession is admissible. The officer's testimony is admissible because he has firsthand knowledge. So answer likely I: admissible, because the police officer had firsthand knowledge of the confession. Let's check other options: A: inadmissible because prejudiced? No. B: admissible because voluntarily? That is about admissibility of confession itself, not the officer's testimony. C: admissible because Miranda rights given before confession. That addresses the confession, not the officer's testimony. D: same. E: inadmissible because no attorney. No. F: inadmissible because videotape is best evidence. No. G: admissible because videotaped. Not relevant. H: inadmissible because hearsay. But it's an admission, so not hearsay. J: inadmissible because duress. No. So I is best. So answer: I."
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": null,
      "token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 1700,
    "total_tokens": 2173,
    "completion_tokens": 473,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "kv_transfer_params": null
}
```
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

