### PR TITLE
[Kernel] Optimize Triton Fused MoE kernel by splitting k-dim

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -811,14 +811,14 @@ def main(args: argparse.Namespace):
 if __name__ == "__main__":
     parser = FlexibleArgumentParser()
     parser.add_argument(
-        "--model", type=str, default="mistralai/Mixtral-8x7B-Instruct-v0.1"
+        "--model", type=str, default="deepseek-ai/DeepSeek-R1"
     )
     parser.add_argument(
-        "--tp-size", "-tp", "--tensor-parallel-size", type=int, default=2
+        "--tp-size", "-tp", "--tensor-parallel-size", type=int, default=8
     )
     parser.add_argument("--enable-expert-parallel", "-enable-ep", action="store_true")
     parser.add_argument(
-        "--dtype", type=str, choices=["auto", "fp8_w8a8", "int8_w8a16"], default="auto"
+        "--dtype", type=str, choices=["auto", "fp8_w8a8", "int8_w8a16"], default="fp8_w8a8"
     )
     parser.add_argument("--use-deep-gemm", action="store_true")
     parser.add_argument(

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -24,6 +24,9 @@ from vllm.transformers_utils.config import get_config
 from vllm.triton_utils import triton
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
+torch.manual_seed(0)
+torch.cuda.manual_seed_all(0)  # For multi-GPU
+
 FP8_DTYPE = current_platform.fp8_dtype()
 
 
@@ -244,6 +247,7 @@ def get_configs_compute_bound(use_fp16, block_quant_shape) -> list[dict[str, int
         block_n_range = [32, 64, 128, 256]
         block_k_range = [64, 128, 256]
         num_warps_range = [4, 8]
+        split_k_range = [1, 4, 8, 16]
         group_m_range = [1, 16, 32, 64]
         num_stage_range = [2, 3, 4, 5]
 
@@ -251,6 +255,7 @@ def get_configs_compute_bound(use_fp16, block_quant_shape) -> list[dict[str, int
             "BLOCK_SIZE_M": block_m_range,
             "BLOCK_SIZE_N": block_n_range,
             "BLOCK_SIZE_K": block_k_range,
+            "SPLIT_K": split_k_range,
             "GROUP_SIZE_M": group_m_range,
             "num_warps": num_warps_range,
             "num_stages": num_stage_range,
@@ -274,6 +279,30 @@ def get_configs_compute_bound(use_fp16, block_quant_shape) -> list[dict[str, int
                 configs.remove(config)
     return configs
 
+
+def prune_cuda_search_space(
+    num_tokens, shard_intermediate_size, hidden_size, search_space, is_fp16, topk
+):
+    N1, K1 = shard_intermediate_size, hidden_size
+
+    # Currently we only prune mm1 split_k configs for cuda
+    # We should add more heuristics here in future and
+    # expand original search space
+    pruned_space_1 = prune_cuda_configs(
+        num_tokens * topk, N1, K1, search_space
+    )
+    search_space = merge_unique_dicts(pruned_space_1, []) # placeholder for mm2
+    return search_space
+
+
+def prune_cuda_configs(M, N, K, configs):
+    pruned_configs = []
+    for config in configs:
+        SPLIT_K = config.get("SPLIT_K", 1)
+        if SPLIT_K != 1 and not need_split_k_cuda(M, N, K):
+            continue
+        pruned_configs.append(config)
+    return pruned_configs
 
 def prune_rocm_search_space(
     num_tokens, shard_intermediate_size, hidden_size, search_space, is_fp16, topk
@@ -370,6 +399,10 @@ def prune_rocm_configs(M, N, K, configs, is_fp16=True):
         pruned_configs.append(config)
 
     return pruned_configs
+
+
+def need_split_k_cuda(SIZE_M, SIZE_N, SIZE_K):
+    return (SIZE_M < 64 or SIZE_N < 64) and SIZE_K > 1024
 
 
 def need_split_k(SIZE_M, SIZE_N, SIZE_K):
@@ -475,6 +508,16 @@ class BenchmarkWorker:
                 is_fp16,
                 topk,
             )
+        else:
+            is_fp16 = not (use_fp8_w8a8 or use_int8_w8a16)
+            search_space = prune_cuda_search_space(
+                num_tokens,
+                shard_intermediate_size,
+                hidden_size,
+                search_space,
+                is_fp16,
+                topk,
+            )
 
         need_device_guard = False
         if current_platform.is_rocm():
@@ -517,6 +560,7 @@ def sort_config(config: BenchmarkConfig) -> BenchmarkConfig:
         "BLOCK_SIZE_M": config["BLOCK_SIZE_M"],
         "BLOCK_SIZE_N": config["BLOCK_SIZE_N"],
         "BLOCK_SIZE_K": config["BLOCK_SIZE_K"],
+        "SPLIT_K": config["SPLIT_K"],
         "GROUP_SIZE_M": config["GROUP_SIZE_M"],
         "num_warps": config["num_warps"],
         "num_stages": config["num_stages"],

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -288,10 +288,8 @@ def prune_cuda_search_space(
     # Currently we only prune mm1 split_k configs for cuda
     # We should add more heuristics here in future and
     # expand original search space
-    pruned_space_1 = prune_cuda_configs(
-        num_tokens * topk, N1, K1, search_space
-    )
-    search_space = merge_unique_dicts(pruned_space_1, []) # placeholder for mm2
+    pruned_space_1 = prune_cuda_configs(num_tokens * topk, N1, K1, search_space)
+    search_space = merge_unique_dicts(pruned_space_1, [])  # placeholder for mm2
     return search_space
 
 
@@ -303,6 +301,7 @@ def prune_cuda_configs(M, N, K, configs):
             continue
         pruned_configs.append(config)
     return pruned_configs
+
 
 def prune_rocm_search_space(
     num_tokens, shard_intermediate_size, hidden_size, search_space, is_fp16, topk

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -811,14 +811,14 @@ def main(args: argparse.Namespace):
 if __name__ == "__main__":
     parser = FlexibleArgumentParser()
     parser.add_argument(
-        "--model", type=str, default="deepseek-ai/DeepSeek-R1"
+        "--model", type=str, default="mistralai/Mixtral-8x7B-Instruct-v0.1"
     )
     parser.add_argument(
-        "--tp-size", "-tp", "--tensor-parallel-size", type=int, default=8
+        "--tp-size", "-tp", "--tensor-parallel-size", type=int, default=2
     )
     parser.add_argument("--enable-expert-parallel", "-enable-ep", action="store_true")
     parser.add_argument(
-        "--dtype", type=str, choices=["auto", "fp8_w8a8", "int8_w8a16"], default="fp8_w8a8"
+        "--dtype", type=str, choices=["auto", "fp8_w8a8", "int8_w8a16"], default="auto"
     )
     parser.add_argument("--use-deep-gemm", action="store_true")
     parser.add_argument(

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -26,6 +26,7 @@ from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.parallel_state import init_distributed_environment
 from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers.fused_moe import override_config
 from vllm.model_executor.layers.fused_moe.config import (
     FUSED_MOE_UNQUANTIZED_CONFIG,
     int4_w4a16_moe_quant_config,
@@ -37,6 +38,7 @@ from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import (
     fused_topk,
+    get_default_config,
     modular_triton_fused_moe,
 )
 from vllm.model_executor.layers.fused_moe.moe_torch_iterative import (
@@ -64,6 +66,7 @@ from vllm.scalar_type import ScalarType, scalar_types
 NUM_EXPERTS = [8, 64, 192]
 EP_SIZE = [1, 4]
 TOP_KS = [2, 6]
+SPLIT_K_SIZE = [1, 2, 16]
 
 MOE_MARLIN_QUANT_TEST_CONFIGS = [
     # AWQ-INT4
@@ -456,6 +459,97 @@ def test_fused_moe_wn16(
         torch_output = torch_moe(a, w1_ref, w2_ref, score, topk, expert_map=e_map)
 
     torch.testing.assert_close(triton_output, torch_output, atol=2e-2, rtol=0)
+
+
+@pytest.mark.parametrize("m,n,k", FUSED_MOE_MNK_FACTORS)
+@pytest.mark.parametrize("e", [256])
+@pytest.mark.parametrize("topk", [8])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("split_k_size", SPLIT_K_SIZE)
+def test_fused_moe_splitk(
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    dtype: torch.dtype,
+    split_k_size: int,
+    monkeypatch,
+):
+    current_platform.seed_everything(7)
+
+    monkeypatch.setenv("VLLM_FUSED_MOE_CHUNK_SIZE", str(8192))
+
+    a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+    w1 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
+    w2 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 10
+    score = torch.randn((m, e), device="cuda", dtype=dtype)
+    e_map = None
+
+    #
+    # Setup test functions
+    #
+    quant_config = FUSED_MOE_UNQUANTIZED_CONFIG
+
+    m_fused_moe_fn = modular_triton_fused_moe(quant_config)
+
+    def m_fused_moe(
+        a: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        score: torch.Tensor,
+        topk: int,
+        global_num_experts: int = -1,
+        expert_map: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        topk_weights, topk_ids, _ = fused_topk(a, score, topk, False)
+        return m_fused_moe_fn(
+            a,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+        )
+
+    fused_moe_fn = functools.partial(fused_moe, renormalize=False)
+
+    #
+    # Run tests
+    #
+    runner = functools.partial(
+        run_moe_test,
+        a=a,
+        w1=w1,
+        w2=w2,
+        score=score,
+        topk=topk,
+        global_num_experts=e,
+        expert_map=e_map,
+    )
+
+    use_compile = False
+
+    use_cudagraph = n >= 1024 and k >= 1024 and current_platform.is_cuda_alike()
+
+    fused_moe_config = get_default_config(m, e, n, k, topk, a.dtype)
+    fused_moe_config["SPLIT_K"] = split_k_size
+
+    with set_current_vllm_config(vllm_config), override_config(fused_moe_config):
+        baseline_output = runner(torch_moe, iterative_moe)
+        runner(
+            baseline_output,
+            fused_moe_fn,
+            use_compile=use_compile,
+            use_cudagraph=use_cudagraph,
+        )
+        runner(
+            baseline_output,
+            m_fused_moe,
+            use_compile=use_compile,
+            use_cudagraph=use_cudagraph,
+        )
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])

--- a/vllm/model_executor/layers/fused_moe/configs/E=128,N=192,device_name=NVIDIA_H200,dtype=fp8_w8a8.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=128,N=192,device_name=NVIDIA_H200,dtype=fp8_w8a8.json
@@ -3,38 +3,38 @@
     "1": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_K": 128,
         "SPLIT_K": 16,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 2
     },
     "2": {
-        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "SPLIT_K": 4,
+        "SPLIT_K": 8,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 3
     },
     "4": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 256,
-        "SPLIT_K": 4,
+        "BLOCK_SIZE_K": 128,
+        "SPLIT_K": 16,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 2
+        "num_stages": 3
     },
     "8": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "SPLIT_K": 1,
+        "SPLIT_K": 16,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 3
     },
     "16": {
         "BLOCK_SIZE_M": 16,
@@ -52,13 +52,13 @@
         "SPLIT_K": 1,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 3
     },
     "32": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 256,
-        "SPLIT_K": 4,
+        "BLOCK_SIZE_K": 128,
+        "SPLIT_K": 1,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 3
@@ -70,7 +70,7 @@
         "SPLIT_K": 1,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 3
     },
     "64": {
         "BLOCK_SIZE_M": 16,
@@ -99,30 +99,22 @@
         "num_warps": 4,
         "num_stages": 3
     },
-    "128": {
-        "BLOCK_SIZE_M": 16,
+    "256": {
+        "BLOCK_SIZE_M": 32,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
-        "num_warps": 4,
-        "num_stages": 3
-    },
-    "256": {
-        "BLOCK_SIZE_M": 16,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 256,
         "SPLIT_K": 1,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 3
     },
     "512": {
-        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
         "SPLIT_K": 1,
         "GROUP_SIZE_M": 1,
-        "num_warps": 4,
+        "num_warps": 8,
         "num_stages": 3
     },
     "1024": {
@@ -130,44 +122,44 @@
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
         "SPLIT_K": 1,
-        "GROUP_SIZE_M": 16,
+        "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 3
     },
     "1536": {
-        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_K": 128,
         "SPLIT_K": 1,
-        "GROUP_SIZE_M": 32,
-        "num_warps": 4,
-        "num_stages": 4
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
     },
     "2048": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_K": 128,
         "SPLIT_K": 1,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 16,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 2
     },
     "3072": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 256,
-        "SPLIT_K": 1,
-        "GROUP_SIZE_M": 32,
-        "num_warps": 4,
-        "num_stages": 3
-    },
-    "4096": {
-        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
         "SPLIT_K": 1,
-        "GROUP_SIZE_M": 64,
-        "num_warps": 4,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "SPLIT_K": 1,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
         "num_stages": 3
     }
 }

--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=256,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=256,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -99,14 +99,6 @@
         "num_warps": 4,
         "num_stages": 3
     },
-    "128": {
-        "BLOCK_SIZE_M": 16,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
-        "num_warps": 4,
-        "num_stages": 3
-    },
     "256": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,

--- a/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
+++ b/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
@@ -177,7 +177,7 @@ def moe_permute(
         m_indices,
     )
 
-    if a1q_scale is not None and a1q_scale.dim() > 1:
+    if a1q_scale is not None and a1q_scale.numel() > 1:
         a1q_scale = a1q_scale[permuted_idx.clamp(max=n_token * topk - 1) // topk]
     return (
         permuted_hidden_states,


### PR DESCRIPTION
## Purpose
When doing TP MoE, N dim of MM1 is very small with large K dim, resulting in low SM util especially in decode scenario (i.e. M is also small). Therefore we can parallelize the K dim between thread blocks. 

This PR introduces additional triton fused moe config `SPLIT_K` indicating how many splits along K dimension. And add to the benchmark_moe.py space search. The search space is huge so I added heuristics to only tune split K when M/N <=64 and K > 1024.

## MoE layer Latency Comparison (hopper h200)

### DeepSeek-R1

| Batch Size | Before (μs) | After (μs) | Improvement |
|------------|-------------|------------|-------------|
| 1          | 54.59       | 38.55      | -29.4%      |
| 2          | 71.95       | 60.64      | -15.7%      |
| 4          | 88.49       | 83.09      | -6.1%       |
| 8          | 120.22      | 120.05     | -0.1%       |
| 16         | 180.59      | 179.84     | -0.4%       |
| 24         | 235.17      | 235.38     | +0.1%       |
| 32         | 282.91      | 264.97     | -6.3%       |

### Qwen3-235B

| Batch Size | Before (μs) | After (μs) | Improvement |
|------------|-------------|------------|-------------|
| 1          | 33.67       | 28.00      | -16.8%      |
| 2          | 40.47       | 34.34      | -15.1%      |
| 4          | 50.21       | 47.21      | -6.0%       |
| 8          | 63.80       | 62.00      | -2.8%       |

## Test Plan
1. regression test: Generate triton config with SplitK==1 comparing to current baseline to ensure 0 latency regression.
2. Correctness test (by forcing SPLIT_K> 1):
tests/kernels/moe/test_moe.py
pytest tests/kernels/moe/test_cutlass_moe.py
3. quality test: run lm_eval 

## Test Result
1. latency numbers matched within 1us before and after this change
2. unit tests passed
3. quality test:
```
lm_eval --model vllm --model_args pretrained=mistralai/Mixtral-8x7B-v0.1,tensor_parallel_size=8,max_model_len=2048,gpu_memory_utilization=0.9 --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto
```
Baseline:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5739|±  |0.0136|
|     |       |strict-match    |     5|exact_match|↑  |0.5709|±  |0.0136|

Force SPLIT_K = 2 for all configs:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5807|±  |0.0136|
|     |       |strict-match    |     5|exact_match|↑  |0.5777|±  |0.0136|


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
