### PR TITLE
[Bugfix] Fix MTP+FlashInfer crash when trtllm kernels are available but disabled

### DIFF
--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -220,6 +220,9 @@ def force_use_trtllm_attention() -> bool | None:
 
 def can_use_trtllm_attention(num_qo_heads: int, num_kv_heads: int) -> bool:
     """Check if the current configuration supports TRTLLM attention."""
+    force_use_trtllm = force_use_trtllm_attention()
+    if force_use_trtllm is not None and not force_use_trtllm:
+        return False
     has_trtllm = supports_trtllm_attention()
     return has_trtllm and (num_qo_heads % num_kv_heads == 0)
 

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -220,8 +220,7 @@ def force_use_trtllm_attention() -> bool | None:
 
 def can_use_trtllm_attention(num_qo_heads: int, num_kv_heads: int) -> bool:
     """Check if the current configuration supports TRTLLM attention."""
-    force_use_trtllm = force_use_trtllm_attention()
-    if force_use_trtllm is not None and not force_use_trtllm:
+    if force_use_trtllm_attention() is False:
         return False
     has_trtllm = supports_trtllm_attention()
     return has_trtllm and (num_qo_heads % num_kv_heads == 0)


### PR DESCRIPTION
## Purpose

The `reorder_batch_threshold` is set based on `can_use_trtllm_attention`, assuming that `use_trtllm_attention` will return True if spec is enabled and it can be used.

There is a missing edge-case here for the force disable trtllm attention flag. In this case `can_use_trtllm_attention` says True, but `use_trtllm_attention`  says False, and the mismatch causes incorrect padding leading to the crash observed in #26312
