### PR TITLE
[ci] Rename `test_mxfp4_moe.py` to `test_ocp_mx_moe.py`

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -829,7 +829,7 @@ steps:
     - pytest -v -s tests/kernels/quantization/test_flashinfer_scaled_mm.py
     - pytest -v -s tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
     - pytest -v -s tests/kernels/moe/test_nvfp4_moe.py
-    - pytest -v -s tests/kernels/moe/test_mxfp4_moe.py
+    - pytest -v -s tests/kernels/moe/test_ocp_mx_moe.py
     # Fusion
     - pytest -v -s tests/compile/test_fusion_all_reduce.py
     - pytest -v -s tests/compile/test_fusion_attn.py::test_attention_quant_pattern

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -4,7 +4,7 @@
 
 Run `pytest tests/quantization/test_quark.py`.
 
-See also `tests/kernels/moe/test_mxfp4_moe.py`.
+See also `tests/kernels/moe/test_ocp_mx_moe.py`.
 """
 
 import importlib.metadata


### PR DESCRIPTION
As per title, as reported in https://github.com/vllm-project/vllm/pull/21166#issuecomment-3377626487

`test_mxfp4_moe.py` was renamed, but not in `.buildkite/test-pipeline.yaml`.

Not sure why the CI was green on the above PR.