### PR TITLE
[Kernel] FA4 Integration. 

### DIFF
--- a/vllm/attention/utils/fa_utils.py
+++ b/vllm/attention/utils/fa_utils.py
@@ -38,11 +38,7 @@ def get_flash_attn_version(requires_alibi: bool = False) -> int | None:
 
         # 1. default version depending on platform
         fa_version = (
-            4
-            if (device_capability.major == 10 and is_fa_version_supported(4))
-            else 3
-            if (device_capability.major == 9 and is_fa_version_supported(3))
-            else 2
+            3 if (device_capability.major == 9 and is_fa_version_supported(3)) else 2
         )
 
         # 2. override if passed by environment

--- a/vllm/attention/utils/fa_utils.py
+++ b/vllm/attention/utils/fa_utils.py
@@ -38,23 +38,19 @@ def get_flash_attn_version(requires_alibi: bool = False) -> int | None:
 
         # 1. default version depending on platform
         fa_version = (
-            3 if (device_capability.major == 9 and is_fa_version_supported(3)) else 2
+            4
+            if (device_capability.major == 10 and is_fa_version_supported(4))
+            else 3
+            if (device_capability.major == 9 and is_fa_version_supported(3))
+            else 2
         )
 
         # 2. override if passed by environment
         if envs.VLLM_FLASH_ATTN_VERSION is not None:
-            assert envs.VLLM_FLASH_ATTN_VERSION in [2, 3]
+            assert envs.VLLM_FLASH_ATTN_VERSION in [2, 3, 4]
             fa_version = envs.VLLM_FLASH_ATTN_VERSION
 
-        # 3. fallback for unsupported combinations
-        if device_capability.major == 10 and fa_version == 3:
-            logger.warning_once(
-                "Cannot use FA version 3 on Blackwell platform "
-                "defaulting to FA version 2."
-            )
-            fa_version = 2
-
-        if requires_alibi and fa_version == 3:
+        if requires_alibi and fa_version in [3, 4]:
             logger.warning_once(
                 "Cannot use FA version 3 with ALiBi, defaulting to FA version 2."
             )

--- a/vllm/attention/utils/fa_utils.py
+++ b/vllm/attention/utils/fa_utils.py
@@ -52,7 +52,8 @@ def get_flash_attn_version(requires_alibi: bool = False) -> int | None:
 
         if requires_alibi and fa_version in [3, 4]:
             logger.warning_once(
-                "Cannot use FA version 3 with ALiBi, defaulting to FA version 2."
+                "Cannot use FA version %d with ALiBi, defaulting to FA version 2.",
+                fa_version,
             )
             fa_version = 2
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -374,14 +374,11 @@ class CudaPlatformBase(Platform):
             # Default backends for V1 engine
             # Prefer FlashInfer for Blackwell GPUs if installed
             if cls.is_device_capability(100):
-                if envs.VLLM_FLASH_ATTN_VERSION == 4:
-                    if is_default_backend_supported := is_attn_backend_supported(
-                        FLASH_ATTN_V1, head_size, dtype, allow_import_error=False
-                    ):
-                        logger.info_once(
-                            "Using Flash Attention 4 backend on V1 engine."
-                        )
-                        return FLASH_ATTN_V1
+                if envs.VLLM_FLASH_ATTN_VERSION == 4 and is_attn_backend_supported(
+                    FLASH_ATTN_V1, head_size, dtype, allow_import_error=False
+                ):
+                    logger.info_once("Using Flash Attention 4 backend on V1 engine.")
+                    return FLASH_ATTN_V1
 
                 if is_default_backend_supported := is_attn_backend_supported(
                     FLASHINFER_V1, head_size, dtype

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -374,6 +374,15 @@ class CudaPlatformBase(Platform):
             # Default backends for V1 engine
             # Prefer FlashInfer for Blackwell GPUs if installed
             if cls.is_device_capability(100):
+                if envs.VLLM_FLASH_ATTN_VERSION == 4:
+                    if is_default_backend_supported := is_attn_backend_supported(
+                        FLASH_ATTN_V1, head_size, dtype, allow_import_error=False
+                    ):
+                        logger.info_once(
+                            "Using Flash Attention 4 backend on V1 engine."
+                        )
+                        return FLASH_ATTN_V1
+
                 if is_default_backend_supported := is_attn_backend_supported(
                     FLASHINFER_V1, head_size, dtype
                 ):

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -492,8 +492,6 @@ class FlashAttentionImpl(AttentionImpl):
 
         if attn_metadata is None:
             # Profiling run.
-            if envs.VLLM_FLASH_ATTN_VERSION == 4:
-                return torch.empty_like(query).contiguous()
             return output
 
         attn_type = self.attn_type

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -448,8 +448,8 @@ class FlashAttentionImpl(AttentionImpl):
 
         self.sinks = sinks
         if self.sinks is not None:
-            assert self.vllm_flash_attn_version == 3, (
-                "Sinks are only supported in FlashAttention 3"
+            assert self.vllm_flash_attn_version in [3, 4], (
+                "Sinks are only supported in FlashAttention 3 and 4"
             )
             assert self.sinks.shape[0] == num_heads, (
                 "Sinks must have the same number of heads as the number of "

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -590,7 +590,7 @@ class FlashAttentionImpl(AttentionImpl):
                     learnable_sink=self.sinks,
                     softcap=self.logits_soft_cap,
                     return_lse=False,
-                    out=output,
+                    out=output[:num_actual_tokens],
                 )
             else:
                 flash_attn_varlen_func(

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -63,7 +63,7 @@ class FlashAttentionBackend(AttentionBackend):
     @staticmethod
     def get_supported_kernel_block_size() -> list[int | MultipleOf]:
         if envs.VLLM_FLASH_ATTN_VERSION == 4:
-            return [MultipleOf(128)]
+            return [128]
         return [MultipleOf(16)]
 
     @classmethod

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -611,7 +611,7 @@ class FlashAttentionImpl(AttentionImpl):
             descale_shape = (cu_seqlens_q.shape[0] - 1, self.num_kv_heads)
 
             if self.dcp_world_size > 1:
-                assert envs.VLLM_FLASH_ATTN_VERSION != 4, (
+                assert get_flash_attn_version() != 4, (
                     "Distributed Context Parallel doesn't support FA4 yet"
                 )
                 self._forward_with_dcp(


### PR DESCRIPTION
Ongoing integration for [Flash Attention 4](https://github.com/Dao-AILab/flash-attention/tree/main/flash_attn/cute). 

How to run
```
# Clone FA repo and install FA4
git clone https://github.com/Dao-AILab/flash-attention.git
cd flash-attention/flash_attn/cute
uv pip install -v . --no-build-isolation
# run on vllm
VLLM_FLASH_ATTN_VERSION=4 vllm serve Qwen/Qwen3-0.6B --block-size 128
```

Accuracy bench
openai/gpt-oss-20b, GPQA:
| Reasoning effort | Score |
|:--------|:-----:|
| Low | 56.6  | 
| Medium  | 67.0  | 

Perf Benchmark, flashinfer is significantly better than FA4 for now, probably because splitkv hasn't been implemented yet:
Qwen3-0.6B, 1000:1000x256
FA4:
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  31.72     
Total input tokens:                      256000    
Total generated tokens:                  256000    
Request throughput (req/s):              8.07      
Output token throughput (tok/s):         8071.34   
Peak output token throughput (tok/s):    10261.00  
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          16142.67  
---------------Time to First Token----------------
Mean TTFT (ms):                          562.07    
Median TTFT (ms):                        526.62    
P99 TTFT (ms):                           1021.21   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.93     
Median TPOT (ms):                        30.97     
P99 TPOT (ms):                           31.03     
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.94     
Median ITL (ms):                         30.77     
P99 ITL (ms):                            39.04     
==================================================
```

FlashInfer
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  12.12     
Total input tokens:                      256000    
Total generated tokens:                  256000    
Request throughput (req/s):              21.13     
Output token throughput (tok/s):         21129.71  
Peak output token throughput (tok/s):    26496.00  
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          42259.43  
---------------Time to First Token----------------
Mean TTFT (ms):                          501.19    
Median TTFT (ms):                        483.11    
P99 TTFT (ms):                           806.13    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.49     
Median TPOT (ms):                        11.52     
P99 TPOT (ms):                           11.61     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.50     
Median ITL (ms):                         11.40     
P99 ITL (ms):                            18.56     
==================================================
```

8000:1x256
FA4
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  5.52      
Total input tokens:                      2048000   
Total generated tokens:                  256       
Request throughput (req/s):              46.36     
Output token throughput (tok/s):         46.36     
Peak output token throughput (tok/s):    51.00     
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          370944.79 
---------------Time to First Token----------------
Mean TTFT (ms):                          2922.54   
Median TTFT (ms):                        2938.03   
P99 TTFT (ms):                           5372.98   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================
```
Flashinfer
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  5.80      
Total input tokens:                      2048000   
Total generated tokens:                  256       
Request throughput (req/s):              44.14     
Output token throughput (tok/s):         44.14     
Peak output token throughput (tok/s):    49.00     
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          353135.59 
---------------Time to First Token----------------
Mean TTFT (ms):                          3049.76   
Median TTFT (ms):                        3049.41   
P99 TTFT (ms):                           5666.89   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================
```