### PR TITLE
[NIXL] support user defined VLLM_KV_CACHE_LAYOUT

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -178,6 +178,9 @@ class NixlConnector(KVConnectorBase_V1):
             # as the layout should not matter in that case,
             # which fallback to the default behavior.
             return None
+        if envs.VLLM_KV_CACHE_LAYOUT is not None:
+            # honor user specified layout
+            return envs.VLLM_KV_CACHE_LAYOUT
         logger.info_once(
             "NixlConnector setting KV cache layout to HND for better xfer performance."
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

For PxDx which is when prefill and Decode are with same TP_size, we don't need HND as must.
For Gaudi platform, NHD is the only stride order for attn impl, in order to avoid permute, would like to add an option here.

If test with `bash run_accuracy_test.sh`
```
inv_order=[0, 1, 3, 2, 4]
```

if test with `VLLM_KV_CACHE_LAYOUT=NHD bash run_accuracy_test.sh`
```
inv_order=[0, 1, 2, 3, 4]
```


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

