### PR TITLE
[Attention] Add MLA prefill backend: trtllm_ragged_attention_deepseek

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -183,6 +183,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: int | None = None
     VLLM_NIXL_ABORT_REQUEST_TIMEOUT: int = 480
     VLLM_USE_CUDNN_PREFILL: bool = False
+    VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL: bool = False
     VLLM_ENABLE_CUDAGRAPH_GC: bool = False
     VLLM_LOOPBACK_IP: str = ""
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = False
@@ -1250,6 +1251,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_USE_CUDNN_PREFILL": lambda: bool(
         int(os.getenv("VLLM_USE_CUDNN_PREFILL", "0"))
     ),
+    # Controls whether to use TRT-LLM ragged DeepSeek prefill
+    "VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL":
+    lambda: bool(int(
+        os.getenv("VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL", "0"))),
+
     # If set to 1/True, use the TRTLLM attention backend in flashinfer.
     # If set to 0/False, use the default attention backend in flashinfer.
     # If not set, auto-detect the attention backend in flashinfer.
@@ -1481,6 +1487,7 @@ def compute_hash() -> str:
         "VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS",
         "VLLM_USE_FLASHINFER_MOE_MXFP4_BF16",
         "VLLM_USE_CUDNN_PREFILL",
+        "VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL",
         "VLLM_USE_TRTLLM_ATTENTION",
         "VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION",
         "VLLM_ROCM_USE_AITER",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1252,10 +1252,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_USE_CUDNN_PREFILL", "0"))
     ),
     # Controls whether to use TRT-LLM ragged DeepSeek prefill
-    "VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL":
-    lambda: bool(int(
-        os.getenv("VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL", "0"))),
-
+    "VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL", "0"))
+    ),
     # If set to 1/True, use the TRTLLM attention backend in flashinfer.
     # If set to 0/False, use the default attention backend in flashinfer.
     # If not set, auto-detect the attention backend in flashinfer.

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1510,7 +1510,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
             o_sf_scale=1.0,
-            batch_size=prefill.query_seq_lens.shape[0],
+            batch_size=prefill.chunked_context.seq_lens.shape[0],
             window_left=-1,
             cum_seq_lens_q=prefill.query_start_loc,
             cum_seq_lens_kv=prefill.chunked_context.cu_seq_lens[chunk_idx],

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1510,7 +1510,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
             o_sf_scale=1.0,
-            batch_size=prefill.chunked_context.seq_lens.shape[0],
+            batch_size=prefill.chunked_context.seq_lens[chunk_idx].shape[0],
             window_left=-1,
             cum_seq_lens_q=prefill.query_start_loc,
             cum_seq_lens_kv=prefill.chunked_context.cu_seq_lens[chunk_idx],

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1509,7 +1509,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             max_kv_len=prefill.chunked_context.max_seq_lens[chunk_idx],
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
-            o_sf_scale=-1.0,
+            o_sf_scale=1.0,
             batch_size=prefill.query_seq_lens.shape[0],
             window_left=-1,
             cum_seq_lens_q=prefill.query_start_loc,

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -457,6 +457,7 @@ def use_flashinfer_prefill() -> bool:
         not envs.VLLM_DISABLE_FLASHINFER_PREFILL
         and flashinfer_available
         and not envs.VLLM_USE_CUDNN_PREFILL
+        and not envs.VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL
         and current_platform.is_device_capability(100)
     )
 

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -473,9 +473,11 @@ def use_cudnn_prefill() -> bool:
 
 def use_trtllm_ragged_deepseek_prefill() -> bool:
     """Check if TRT-LLM ragged DeepSeek prefill should be used."""
-    return (flashinfer_available
-            and envs.VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL
-            and current_platform.is_device_capability(100))
+    return (
+        flashinfer_available
+        and envs.VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL
+        and current_platform.is_device_capability(100)
+    )
 
 
 # Currently 394MB, this can be tuned based on GEMM sizes used.
@@ -944,8 +946,9 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 prefill_metadata.cudnn_workspace = self.cudnn_workspace
 
             if self._use_trtllm_ragged_prefill:
-                prefill_metadata.query_seq_lens = prefill_query_start_loc[1:] \
-                    - prefill_query_start_loc[:-1]
+                prefill_metadata.query_seq_lens = (
+                    prefill_query_start_loc[1:] - prefill_query_start_loc[:-1]
+                )
 
         decode_metadata = None
         if num_decodes > 0:
@@ -1245,10 +1248,10 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             self._pad_v = False
         elif use_trtllm_ragged_deepseek_prefill():
             logger.debug_once("Using TRT-LLM ragged DeepSeek prefill for MLA")
-            self._run_prefill_context_chunk = \
+            self._run_prefill_context_chunk = (
                 self._run_prefill_context_chunk_trtllm_ragged
-            self._run_prefill_new_tokens = \
-                self._run_prefill_new_tokens_trtllm_ragged
+            )
+            self._run_prefill_new_tokens = self._run_prefill_new_tokens_trtllm_ragged
             self._pad_v = False
         elif use_cudnn_prefill():
             logger.debug_once("Using CUDNN prefill for MLA")
@@ -1439,10 +1442,11 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         )
 
     def _run_prefill_new_tokens_trtllm_ragged(
-            self, prefill: MLACommonPrefillMetadata, q, k, v,
-            return_softmax_lse):
+        self, prefill: MLACommonPrefillMetadata, q, k, v, return_softmax_lse
+    ):
         """TRT-LLM ragged attention for new tokens (causal)."""
         from flashinfer.prefill import trtllm_ragged_attention_deepseek
+
         assert prefill.query_seq_lens is not None
 
         return trtllm_ragged_attention_deepseek(
@@ -1467,9 +1471,9 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         )
 
     def _run_prefill_context_chunk_trtllm_ragged(
-            self, prefill: MLACommonPrefillMetadata, chunk_idx: int, q, k, v):
-        """TRT-LLM ragged attention for context chunks (non-causal).
-        """
+        self, prefill: MLACommonPrefillMetadata, chunk_idx: int, q, k, v
+    ):
+        """TRT-LLM ragged attention for context chunks (non-causal)."""
         from flashinfer.prefill import trtllm_ragged_attention_deepseek
 
         assert prefill.chunked_context is not None

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1356,36 +1356,6 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         assert isinstance(prefill, FlashInferPrefillMetadata)
         assert prefill.prefill_main is not None
 
-        logger.info("[FlashInfer] _run_prefill_new_tokens_fi called")
-
-        # Log input tensor shapes and dtypes
-        logger.info(
-            f"[FlashInfer] Input shapes - q: {q.shape}, k: {k.shape}, v: {v.shape}"
-        )
-        logger.info(
-            f"[FlashInfer] Input dtypes - q: {q.dtype}, k: {k.dtype}, v: {v.dtype}"
-        )
-
-        # Log input tensor statistics
-        logger.debug(
-            f"[FlashInfer] q stats - min: {q.min().item():.6f}, max: {q.max().item():.6f}, mean: {q.mean().item():.6f}, std: {q.std().item():.6f}"
-        )
-        logger.debug(
-            f"[FlashInfer] k stats - min: {k.min().item():.6f}, max: {k.max().item():.6f}, mean: {k.mean().item():.6f}, std: {k.std().item():.6f}"
-        )
-        logger.debug(
-            f"[FlashInfer] v stats - min: {v.min().item():.6f}, max: {v.max().item():.6f}, mean: {v.mean().item():.6f}, std: {v.std().item():.6f}"
-        )
-
-        # Log metadata information
-        logger.info(f"[FlashInfer] Metadata - max_query_len: {prefill.max_query_len}")
-        logger.info(
-            f"[FlashInfer] Metadata - query_start_loc: {prefill.query_start_loc.tolist()}"
-        )
-
-        # Log attention parameters
-        logger.info(f"[FlashInfer] Attention params - return_lse: {return_softmax_lse}")
-
         ret = prefill.prefill_main.run(
             q=q,
             k=k,
@@ -1396,28 +1366,8 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         # Log output statistics
         if isinstance(ret, tuple):
             out, lse = ret
-            logger.info(
-                f"[FlashInfer] Output shapes - out: {out.shape}, lse: {lse.shape}"
-            )
-            logger.debug(
-                f"[FlashInfer] Output stats - min: {out.min().item():.6f}, max: {out.max().item():.6f}, mean: {out.mean().item():.6f}, std: {out.std().item():.6f}"
-            )
-            logger.debug(
-                f"[FlashInfer] LSE stats - min: {lse.min().item():.6f}, max: {lse.max().item():.6f}, mean: {lse.mean().item():.6f}, std: {lse.std().item():.6f}"
-            )
-            # Convert from (q_len, num_heads) to (num_heads, q_len)
-            logger.info(
-                "[FlashInfer] _run_prefill_new_tokens_fi completed - returning tuple"
-            )
             return ret[0], ret[1].transpose(0, 1).contiguous()
         else:
-            logger.info(f"[FlashInfer] Output shape - out: {ret.shape}")
-            logger.debug(
-                f"[FlashInfer] Output stats - min: {ret.min().item():.6f}, max: {ret.max().item():.6f}, mean: {ret.mean().item():.6f}, std: {ret.std().item():.6f}"
-            )
-            logger.info(
-                "[FlashInfer] _run_prefill_new_tokens_fi completed - returning single tensor"
-            )
             return ret
 
     def _run_prefill_new_tokens_cudnn(
@@ -1467,77 +1417,11 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
     ):
         assert isinstance(prefill, FlashInferPrefillMetadata)
 
-        logger.info(
-            f"[FlashInfer] _run_prefill_context_chunk_fi called - chunk_idx: {chunk_idx}"
-        )
-
-        # Log input tensor shapes and dtypes
-        logger.info(
-            f"[FlashInfer] Chunk {chunk_idx} - Input shapes - q: {q.shape}, k: {k.shape}, v: {v.shape}"
-        )
-        logger.info(
-            f"[FlashInfer] Chunk {chunk_idx} - Input dtypes - q: {q.dtype}, k: {k.dtype}, v: {v.dtype}"
-        )
-
-        # Log input tensor statistics
-        logger.debug(
-            f"[FlashInfer] Chunk {chunk_idx} - q stats - min: {q.min().item():.6f}, max: {q.max().item():.6f}, mean: {q.mean().item():.6f}, std: {q.std().item():.6f}"
-        )
-        logger.debug(
-            f"[FlashInfer] Chunk {chunk_idx} - k stats - min: {k.min().item():.6f}, max: {k.max().item():.6f}, mean: {k.mean().item():.6f}, std: {k.std().item():.6f}"
-        )
-        logger.debug(
-            f"[FlashInfer] Chunk {chunk_idx} - v stats - min: {v.min().item():.6f}, max: {v.max().item():.6f}, mean: {v.mean().item():.6f}, std: {v.std().item():.6f}"
-        )
-
-        # Log chunk-specific metadata
-        if prefill.chunked_context is not None:
-            logger.info(
-                f"[FlashInfer] Chunk {chunk_idx} - seq_lens: {prefill.chunked_context.seq_lens[chunk_idx].tolist()}"
-            )
-            logger.info(
-                f"[FlashInfer] Chunk {chunk_idx} - max_seq_lens: {prefill.chunked_context.max_seq_lens[chunk_idx]}"
-            )
-            logger.info(
-                f"[FlashInfer] Chunk {chunk_idx} - cu_seq_lens: {prefill.chunked_context.cu_seq_lens[chunk_idx].tolist()}"
-            )
-            logger.info(
-                f"[FlashInfer] Chunk {chunk_idx} - seq_tot: {prefill.chunked_context.seq_tot[chunk_idx]}"
-            )
-        logger.info(
-            f"[FlashInfer] Chunk {chunk_idx} - Metadata - max_query_len: {prefill.max_query_len}"
-        )
-        logger.info(
-            f"[FlashInfer] Chunk {chunk_idx} - query_start_loc: {prefill.query_start_loc.tolist()}"
-        )
-
         attn_out, lse = prefill.prefill_chunks[chunk_idx].run(
             q=q,
             k=k,
             v=v,
             return_lse=True,
-        )
-
-        # Log output statistics
-        logger.info(
-            f"[FlashInfer] Chunk {chunk_idx} - Output shapes - attn_out: {attn_out.shape}, lse: {lse.shape}"
-        )
-        logger.debug(
-            f"[FlashInfer] Chunk {chunk_idx} - Output stats - min: {attn_out.min().item():.6f}, max: {attn_out.max().item():.6f}, mean: {attn_out.mean().item():.6f}, std: {attn_out.std().item():.6f}"
-        )
-        logger.info(f"[FlashInfer] Chunk {chunk_idx} - LSE values after attention:")
-        logger.info(
-            f"[FlashInfer] Chunk {chunk_idx} - LSE stats - min: {lse.min().item():.6f}, max: {lse.max().item():.6f}, mean: {lse.mean().item():.6f}, std: {lse.std().item():.6f}"
-        )
-        logger.info(
-            f"[FlashInfer] Chunk {chunk_idx} - LSE shape: {lse.shape}, dtype: {lse.dtype}"
-        )
-        logger.debug(
-            f"[FlashInfer] Chunk {chunk_idx} - LSE first 10 values: {lse.flatten()[:10].tolist()}"
-        )
-
-        logger.info(
-            f"[FlashInfer] _run_prefill_context_chunk_fi completed - chunk_idx: {chunk_idx}"
         )
 
         # Convert from (q_len, num_heads) to (num_heads, q_len)
@@ -1576,62 +1460,6 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
 
         assert prefill.query_seq_lens is not None
 
-        logger.info("[TRT-LLM Ragged] _run_prefill_new_tokens_trtllm_ragged called")
-
-        # Log input tensor shapes and dtypes
-        logger.info(
-            f"[TRT-LLM Ragged] Input shapes - q: {q.shape}, k: {k.shape}, v: {v.shape}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Input dtypes - q: {q.dtype}, k: {k.dtype}, v: {v.dtype}"
-        )
-
-        # Log input tensor statistics
-        logger.debug(
-            f"[TRT-LLM Ragged] q stats - min: {q.min().item():.6f}, max: {q.max().item():.6f}, mean: {q.mean().item():.6f}, std: {q.std().item():.6f}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] k stats - min: {k.min().item():.6f}, max: {k.max().item():.6f}, mean: {k.mean().item():.6f}, std: {k.std().item():.6f}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] v stats - min: {v.min().item():.6f}, max: {v.max().item():.6f}, mean: {v.mean().item():.6f}, std: {v.std().item():.6f}"
-        )
-
-        # Log metadata information
-        logger.info(
-            f"[TRT-LLM Ragged] Metadata - query_seq_lens: {prefill.query_seq_lens.tolist()}, max_query_len: {prefill.max_query_len}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Metadata - batch_size: {prefill.query_seq_lens.shape[0]}, query_start_loc: {prefill.query_start_loc.tolist()}"
-        )
-
-        # Log attention parameters
-        logger.info(
-            f"[TRT-LLM Ragged] Attention params - bmm1_scale: {self.scale:.6f}, is_causal: True, return_lse: {return_softmax_lse}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] Workspace buffer size: {self._workspace_buffer.shape[0]}"
-        )
-
-        out = torch.zeros(
-            q.shape[0],
-            q.shape[1],
-            v.shape[2],
-            device=q.device,
-            dtype=q.dtype,
-        )
-        lse = torch.full(
-            (q.shape[0], q.shape[1]),
-            float("-inf"),
-            device=q.device,
-            dtype=torch.float32,
-        )
-
-        logger.debug(
-            f"[TRT-LLM Ragged] Pre-allocated output shapes - out: {out.shape}, lse: {lse.shape}"
-        )
-
-
         ret = trtllm_ragged_attention_deepseek(
             query=q,
             key=k,
@@ -1650,32 +1478,11 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             enable_pdl=False,
             is_causal=True,
             return_lse=return_softmax_lse,
-            attention_sinks=None,
-            out=out,
-            lse=lse,
         )
-
-        # Log output statistics
-        logger.info(
-            f"[TRT-LLM Ragged] Output shapes - out: {out.shape}, lse: {lse.shape}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] Output stats - min: {out.min().item():.6f}, max: {out.max().item():.6f}, mean: {out.mean().item():.6f}, std: {out.std().item():.6f}"
-        )
-        if return_softmax_lse:
-            logger.debug(
-                f"[TRT-LLM Ragged] LSE stats - min: {lse.min().item():.6f}, max: {lse.max().item():.6f}, mean: {lse.mean().item():.6f}, std: {lse.std().item():.6f}"
-            )
 
         if isinstance(ret, tuple):
             # Convert from (q_len, num_heads) to (num_heads, q_len)
-            logger.info(
-                "[TRT-LLM Ragged] _run_prefill_new_tokens_trtllm_ragged completed - returning tuple"
-            )
             return ret[0], ret[1].transpose(0, 1).contiguous()
-        logger.info(
-            "[TRT-LLM Ragged] _run_prefill_new_tokens_trtllm_ragged completed - returning single tensor"
-        )
         return ret
 
     def _run_prefill_context_chunk_trtllm_ragged(
@@ -1687,57 +1494,6 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         assert prefill.chunked_context is not None
         assert prefill.chunked_context.seq_lens[chunk_idx] is not None
 
-        logger.info(
-            f"[TRT-LLM Ragged] _run_prefill_context_chunk_trtllm_ragged called - chunk_idx: {chunk_idx}"
-        )
-
-        # Log input tensor shapes and dtypes
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Input shapes - q: {q.shape}, k: {k.shape}, v: {v.shape}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Input dtypes - q: {q.dtype}, k: {k.dtype}, v: {v.dtype}"
-        )
-
-        # Log input tensor statistics
-        logger.debug(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - q stats - min: {q.min().item():.6f}, max: {q.max().item():.6f}, mean: {q.mean().item():.6f}, std: {q.std().item():.6f}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - k stats - min: {k.min().item():.6f}, max: {k.max().item():.6f}, mean: {k.mean().item():.6f}, std: {k.std().item():.6f}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - v stats - min: {v.min().item():.6f}, max: {v.max().item():.6f}, mean: {v.mean().item():.6f}, std: {v.std().item():.6f}"
-        )
-
-        # Log chunk-specific metadata
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - seq_lens: {prefill.chunked_context.seq_lens[chunk_idx].tolist()}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - max_seq_lens: {prefill.chunked_context.max_seq_lens[chunk_idx]}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - cu_seq_lens: {prefill.chunked_context.cu_seq_lens[chunk_idx].tolist()}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - seq_tot: {prefill.chunked_context.seq_tot[chunk_idx]}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Metadata - max_query_len: {prefill.max_query_len}, batch_size: {prefill.query_seq_lens.shape[0]}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - query_start_loc: {prefill.query_start_loc.tolist()}"
-        )
-
-        # Log attention parameters
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Attention params - bmm1_scale: {self.scale:.6f}, o_sf_scale: 1.0, is_causal: False"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Workspace buffer size: {self._workspace_buffer.shape[0]}"
-        )
-
         out = torch.zeros(
             q.shape[0],
             q.shape[1],
@@ -1745,20 +1501,6 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             device=q.device,
             dtype=q.dtype,
         )
-        lse = torch.full(
-            (q.shape[0], q.shape[1]),
-            float("-inf"),
-            device=q.device,
-            dtype=torch.float32,
-        )
-
-        logger.debug(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Pre-allocated output shapes - out: {out.shape}, lse: {lse.shape}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Initialized LSE with -inf - min: {lse.min().item():.6f}, max: {lse.max().item():.6f}"
-        )
-
         self._workspace_buffer.fill_(0)
 
         attn_out, lse = trtllm_ragged_attention_deepseek(
@@ -1780,48 +1522,6 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             is_causal=False,
             return_lse=True,
             out=out,
-            lse=lse,
-        )
-
-        # Log output statistics
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Output shapes - attn_out: {attn_out.shape}, lse: {lse.shape}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - Output stats - min: {attn_out.min().item():.6f}, max: {attn_out.max().item():.6f}, mean: {attn_out.mean().item():.6f}, std: {attn_out.std().item():.6f}"
-        )
-        logger.info(f"[TRT-LLM Ragged] Chunk {chunk_idx} - LSE values after attention:")
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - LSE stats - min: {lse.min().item():.6f}, max: {lse.max().item():.6f}, mean: {lse.mean().item():.6f}, std: {lse.std().item():.6f}"
-        )
-        logger.info(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - LSE shape: {lse.shape}, dtype: {lse.dtype}"
-        )
-        logger.debug(
-            f"[TRT-LLM Ragged] Chunk {chunk_idx} - LSE first 10 values: {lse.flatten()[:10].tolist()}"
-        )
-
-        # Set LSE to -inf for sequences where seq_lens is 0
-        #seq_lens = prefill.chunked_context.seq_lens[chunk_idx]
-        #zero_mask = seq_lens == 0
-        #if zero_mask.any():
-        #    logger.info(
-        #        f"[TRT-LLM Ragged] Chunk {chunk_idx} - Found {zero_mask.sum().item()} sequences with seq_lens=0, setting their LSE to -inf"
-        #    )
-        #    # Get query lengths for each sequence
-        #    query_start_loc = prefill.query_start_loc
-        #    for seq_idx in range(len(seq_lens)):
-        #        if zero_mask[seq_idx]:
-        #            q_start = query_start_loc[seq_idx].item()
-        #            q_end = query_start_loc[seq_idx + 1].item()
-        #            # Set LSE to -inf for all query tokens in this sequence
-        #            lse[q_start:q_end, :] = float("-inf")
-        #    logger.info(
-        #        f"[TRT-LLM Ragged] Chunk {chunk_idx} - LSE stats after masking - min: {lse.min().item():.6f}, max: {lse.max().item():.6f}, mean: {lse.mean().item():.6f}"
-        #    )
-
-        logger.info(
-            f"[TRT-LLM Ragged] _run_prefill_context_chunk_trtllm_ragged completed - chunk_idx: {chunk_idx}"
         )
 
         # Convert from (q_len, num_heads) to (num_heads, q_len)


### PR DESCRIPTION
## Purpose

Add MLA prefill backend: trtllm_ragged_attention_deepseek
* controlled by `VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL=1`

* [x] Need to fix accuracy issue
  * 0.54 -> 0.59 fixed by zeroing output tensor for context chunk prefill
  * 0.59 -> 0.61 (0.22 -> 0.64 w/ prefix caching) fixed by transposing lse
  * 0.61 -> 0.65 fixed by zeroing workspace
* [x] performance benchmark

## Test Plan

* [ ] microbenchmark
  * in follow-up work after refactoring
* [x] vllm bench serve
* [x] lm_eval gsm8k

## Test Result

### bench serve

12.7% qps improvement
-10.2% TTFT improvement

#### Baseline
```
CUDA_VISIBLE_DEVICES=0 VLLM_LOGGING_LEVEL=DEBUG VLLM_ATTENTION_BACKEND=FLASHINFER_MLA vllm serve --model="deepseek-ai/DeepSeek-V2-Lite-Chat" 2>&1 | tee /tmp/fi.log
```
```
============ Serving Benchmark Result ============
Successful requests:                     2048
Maximum request concurrency:             2048
Benchmark duration (s):                  200.42
Total input tokens:                      4192256
Total generated tokens:                  2097152
Request throughput (req/s):              10.22
Output token throughput (tok/s):         10463.54
Peak output token throughput (tok/s):    16094.00
Peak concurrent requests:                2048.00
Total Token throughput (tok/s):          31380.41
---------------Time to First Token----------------
Mean TTFT (ms):                          64511.82
Median TTFT (ms):                        55968.36
P99 TTFT (ms):                           132592.32
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          86.54
Median TPOT (ms):                        89.57
P99 TPOT (ms):                           93.98
---------------Inter-token Latency----------------
Mean ITL (ms):                           86.54
Median ITL (ms):                         70.26
P99 ITL (ms):                            208.33
==================================================
```
#### This PR
```
CUDA_VISIBLE_DEVICES=0 VLLM_LOGGING_LEVEL=DEBUG VLLM_ATTENTION_BACKEND=FLASHINFER_MLA VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL=1 vllm serve --model="deepseek-ai/DeepSeek-V2-Lite-Chat" 2>&1 | tee /tmp/ragged.log
```

```
============ Serving Benchmark Result ============
Successful requests:                     2048
Maximum request concurrency:             2048
Benchmark duration (s):                  177.74
Total input tokens:                      4192256
Total generated tokens:                  2097152
Request throughput (req/s):              11.52
Output token throughput (tok/s):         11799.21
Peak output token throughput (tok/s):    18098.00
Peak concurrent requests:                2048.00
Total Token throughput (tok/s):          35386.10
---------------Time to First Token----------------
Mean TTFT (ms):                          57924.67
Median TTFT (ms):                        49533.53
P99 TTFT (ms):                           118626.18
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          76.15
Median TPOT (ms):                        78.87
P99 TPOT (ms):                           83.38
---------------Inter-token Latency----------------
Mean ITL (ms):                           76.16
Median ITL (ms):                         60.18
P99 ITL (ms):                            181.91
==================================================
```

### gsm8k

#### Baseline
```
CUDA_VISIBLE_DEVICES=0 VLLM_LOGGING_LEVEL=DEBUG VLLM_ATTENTION_BACKEND=FLASHINFER_MLA vllm serve --model="deepseek-ai/DeepSeek-V2-Lite-Chat" --enforce-eager 2>&1 | tee /tmp/fi.log

local-completions (model=deepseek-ai/DeepSeek-V2-Lite-Chat,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=256), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 1
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.6520|±  |0.0131|
|     |       |strict-match    |     8|exact_match|↑  |0.6482|±  |0.0132|

#### This PR
```
CUDA_VISIBLE_DEVICES=0 VLLM_LOGGING_LEVEL=DEBUG VLLM_ATTENTION_BACKEND=FLASHINFER_MLA VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL=1 vllm serve --model="deepseek-ai/DeepSeek-V2-Lite-Chat" --enforce-eager 2>&1 | tee /tmp/ragged.log

local-completions (model=deepseek-ai/DeepSeek-V2-Lite-Chat,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=256), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 1
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.655|±  |0.0131|
|     |       |strict-match    |     8|exact_match|↑  |0.649|±  |0.0131|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

