### PR TITLE
[CI] Pooling models mteb test disable enforce_eager 

### DIFF
--- a/tests/models/language/generation_ppl_test/ppl_utils.py
+++ b/tests/models/language/generation_ppl_test/ppl_utils.py
@@ -51,7 +51,6 @@ def wikitext_ppl_test(
         gpu_memory_utilization=0.7,
         max_model_len=max_length,
         max_num_seqs=1,
-        enforce_eager=True,
         **vllm_extra_kwargs,
     ) as vllm_model:
         # Use max_num_seqs=1 to avoid OOM,

--- a/tests/models/language/pooling_mteb_test/mteb_utils.py
+++ b/tests/models/language/pooling_mteb_test/mteb_utils.py
@@ -192,7 +192,6 @@ def mteb_test_embed_models(
         model_info.name,
         runner="pooling",
         max_model_len=None,
-        enforce_eager=True,
         **vllm_extra_kwargs,
     ) as vllm_model:
         model_config = vllm_model.llm.llm_engine.model_config
@@ -349,7 +348,6 @@ def mteb_test_rerank_models(
         runner="pooling",
         max_model_len=None,
         max_num_seqs=8,
-        enforce_eager=True,
         **vllm_extra_kwargs,
     ) as vllm_model:
         model_config = vllm_model.llm.llm_engine.model_config


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Related to https://github.com/vllm-project/vllm/issues/22862
- #22862 (flaky test finded)
- #22878 (uses enforce_eager)
- #24088 (Since https://github.com/vllm-project/vllm/pull/22878 Pooling models mteb test uses enforce_eager, mteb_test_embed_models has become less (never) flaky.)
- #24634

Let's re-disable enforce_eager and check if the flaky test has been fixed.
- If it has already been fixed, everyone is happy.
- If it hasn't been fixed yet, error logs can help experts debug during the new release cycle.

The mteb test has been separated from Language Models Test in #24634, so the Nightly Test keeps failing, it won't confuse anyone.

cc @DarkLight1337 @robertgshaw2-redhat @zou3519



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

