### PR TITLE
[EAGLE] [Quantization] turn quantization off for draft model initialization

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -899,6 +899,8 @@ class EagleProposer:
                     "Quantization is not supported for draft model, "
                     "disabling quantization for draft model"
                 )
+            else:
+                target_model_quant_config = None
             self.model = get_model(
                 vllm_config=self.vllm_config, model_config=draft_model_config
             )

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -892,9 +892,18 @@ class EagleProposer:
         from vllm.compilation.backends import set_model_tag
 
         with set_model_tag("eagle_head"):
+            if self.vllm_config.quant_config is not None:
+                target_model_quant_config = self.vllm_config.quant_config
+                self.vllm_config.quant_config = None
+                logger.warning(
+                    "Quantization is not supported for draft model, "
+                    "disabling quantization for draft model"
+                )
             self.model = get_model(
                 vllm_config=self.vllm_config, model_config=draft_model_config
             )
+            # restore the quant config
+            self.vllm_config.quant_config = target_model_quant_config
 
         draft_attn_layer_names = (
             get_layers_from_vllm_config(self.vllm_config, Attention).keys()


### PR DESCRIPTION
## Purpose
Fixes https://github.com/vllm-project/vllm/issues/26402

As an alternative, I have also considered creating a deepcopy of the `VllmConfig` to the drafter, but then this results in errors, as the drafter makes some modifications that would not be flushed back in this case.



## Test Plan
I ran the same commands as detailed in https://github.com/vllm-project/vllm/issues/26402 and verified that now the drafting works correctly also if the target model is quantized.

## Test Result
Fixes the issue.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

