### PR TITLE
[Bug] Fix DeepGEMM Attention Test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ ba = "ba"
 
 [tool.typos.type.py.extend-words]
 ba = "ba"
+nd = "nd"
 
 [tool.typos.type.cpp]
 extend-glob = ["*.cu"]

--- a/tests/kernels/attention/test_deepgemm_attention.py
+++ b/tests/kernels/attention/test_deepgemm_attention.py
@@ -82,8 +82,7 @@ def _ref_fp8_mqa_logits(
         torch.arange(0, seq_len_kv, device="cuda")[None, :] < cu_seqlen_ke[:, None]
     )
     mask = mask_lo & mask_hi
-
-    score = torch.einsum("mhd,and->hmn", q, k)
+    score = torch.einsum("mhd,nd->hmn", q, k)
     logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
     logits = logits.masked_fill(~mask, float("-inf"))
 


### PR DESCRIPTION
## Purpose

Fix DeepGEMM Attention Test

## Test

Originally:

```bash
tests/kernels/attention/test_deepgemm_attention.py::test_deepgemm_fp8_mqa_logits - RuntimeError: einsum(): the number of subscripts in the equation (3) does not match the number of dimensions (2) for operand 1 and no ellipsis was given
```

Now

```bash
collected 2 items                                                                                                    

test_deepgemm_attention.py ..                                                                                  [100%]

================================================== warnings summary ==================================================
../../../../.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:63
  /home/wentao/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
    import pynvml  # type: ignore[import]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 2 passed, 1 warning in 9.10s ============================================
Warning: please use at least NVCC 12.9 for the best DeepGEMM performance
```

