### PR TITLE
[Bugfix] Fix SHM cache initialization

### DIFF
--- a/tests/entrypoints/openai/test_lora_resolvers.py
+++ b/tests/entrypoints/openai/test_lora_resolvers.py
@@ -113,15 +113,17 @@ def mock_serving_setup():
     mock_engine.generate.reset_mock()
     mock_engine.add_lora.reset_mock()
 
-    mock_model_config = MockModelConfig()
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+
     models = OpenAIServingModels(
         engine_client=mock_engine,
         base_model_paths=BASE_MODEL_PATHS,
-        model_config=mock_model_config,
     )
 
     serving_completion = OpenAIServingCompletion(
-        mock_engine, mock_model_config, models, request_logger=None
+        mock_engine, models, request_logger=None
     )
 
     serving_completion._process_inputs = AsyncMock(

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -280,18 +280,15 @@ def _build_serving_chat(
 
 @dataclass
 class MockEngine:
-    async def get_model_config(self):
-        return MockModelConfig()
+    model_config: MockModelConfig = MockModelConfig()
 
 
 async def _async_serving_chat_init():
     engine = MockEngine()
-    model_config = await engine.get_model_config()
 
-    models = OpenAIServingModels(engine, model_config, BASE_MODEL_PATHS)
+    models = OpenAIServingModels(engine, BASE_MODEL_PATHS)
     serving_completion = OpenAIServingChat(
         engine,
-        model_config,
         models,
         response_role="assistant",
         chat_template=CHAT_TEMPLATE,

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -245,17 +245,13 @@ class MockModelConfig:
         return self.diff_sampling_param or {}
 
 
-def _build_serving_chat(
-    engine: AsyncLLM, model_config: MockModelConfig
-) -> OpenAIServingChat:
+def _build_serving_chat(engine: AsyncLLM) -> OpenAIServingChat:
     models = OpenAIServingModels(
         engine_client=engine,
         base_model_paths=BASE_MODEL_PATHS,
-        model_config=model_config,
     )
     serving_chat = OpenAIServingChat(
         engine,
-        model_config,
         models,
         response_role="assistant",
         chat_template=CHAT_TEMPLATE,
@@ -281,6 +277,8 @@ def _build_serving_chat(
 @dataclass
 class MockEngine:
     model_config: MockModelConfig = field(default_factory=MockModelConfig)
+    processor: MagicMock = field(default_factory=MagicMock)
+    io_processor: MagicMock = field(default_factory=MagicMock)
 
 
 async def _async_serving_chat_init():
@@ -308,8 +306,11 @@ async def test_serving_chat_returns_correct_model_name():
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.get_tokenizer.return_value = get_tokenizer(MODEL_NAME)
     mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
 
-    serving_chat = _build_serving_chat(mock_engine, MockModelConfig())
+    serving_chat = _build_serving_chat(mock_engine)
     messages = [{"role": "user", "content": "what is 1+1?"}]
 
     async def return_model_name(*args):
@@ -335,8 +336,11 @@ async def test_serving_chat_should_set_correct_max_tokens():
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.get_tokenizer.return_value = get_tokenizer(MODEL_NAME)
     mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
 
-    serving_chat = _build_serving_chat(mock_engine, MockModelConfig())
+    serving_chat = _build_serving_chat(mock_engine)
 
     req = ChatCompletionRequest(
         model=MODEL_NAME,
@@ -365,9 +369,12 @@ async def test_serving_chat_should_set_correct_max_tokens():
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.get_tokenizer.return_value = get_tokenizer(MODEL_NAME)
     mock_engine.errored = False
+    mock_engine.model_config = mock_model_config
+    mock_engine.processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
 
     # Initialize the serving chat
-    serving_chat = _build_serving_chat(mock_engine, mock_model_config)
+    serving_chat = _build_serving_chat(mock_engine)
 
     # Test Case 1: No max_tokens specified in request
     req = ChatCompletionRequest(
@@ -407,9 +414,12 @@ async def test_serving_chat_should_set_correct_max_tokens():
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.get_tokenizer.return_value = get_tokenizer(MODEL_NAME)
     mock_engine.errored = False
+    mock_engine.model_config = mock_model_config
+    mock_engine.processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
 
     # Initialize the serving chat
-    serving_chat = _build_serving_chat(mock_engine, mock_model_config)
+    serving_chat = _build_serving_chat(mock_engine)
 
     # Test case 1: No max_tokens specified, defaults to context_window
     req = ChatCompletionRequest(
@@ -450,9 +460,12 @@ async def test_serving_chat_could_load_correct_generation_config():
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.get_tokenizer.return_value = get_tokenizer(MODEL_NAME)
     mock_engine.errored = False
+    mock_engine.model_config = mock_model_config
+    mock_engine.processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
 
     # Initialize the serving chat
-    serving_chat = _build_serving_chat(mock_engine, mock_model_config)
+    serving_chat = _build_serving_chat(mock_engine)
 
     req = ChatCompletionRequest(
         model=MODEL_NAME,
@@ -493,8 +506,11 @@ async def test_serving_chat_did_set_correct_cache_salt(model_type):
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.get_tokenizer.return_value = get_tokenizer(MODEL_NAME)
     mock_engine.errored = False
+    mock_engine.model_config = mock_model_config
+    mock_engine.processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
 
-    serving_chat = _build_serving_chat(mock_engine, mock_model_config)
+    serving_chat = _build_serving_chat(mock_engine)
 
     # Test cache_salt
     req = ChatCompletionRequest(

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -280,7 +280,7 @@ def _build_serving_chat(
 
 @dataclass
 class MockEngine:
-    model_config: MockModelConfig = MockModelConfig()
+    model_config: MockModelConfig = field(default_factory=MockModelConfig)
 
 
 async def _async_serving_chat_init():

--- a/tests/entrypoints/openai/test_serving_engine.py
+++ b/tests/entrypoints/openai/test_serving_engine.py
@@ -22,10 +22,12 @@ def serving() -> OpenAIServing:
     model_config = Mock(spec=ModelConfig)
     model_config.max_model_len = 32768
     models = Mock(spec=OpenAIServingModels)
+    models.model_config = model_config
+    models.processor = Mock()
+    models.io_processor = Mock()
 
     serving = OpenAIServing(
         engine_client=engine_client,
-        model_config=model_config,
         models=models,
         request_logger=None,
     )

--- a/tests/entrypoints/openai/test_serving_models.py
+++ b/tests/entrypoints/openai/test_serving_models.py
@@ -25,15 +25,17 @@ LORA_UNLOADING_SUCCESS_MESSAGE = (
 
 
 async def _async_serving_models_init() -> OpenAIServingModels:
-    mock_model_config = MagicMock(spec=ModelConfig)
     mock_engine_client = MagicMock(spec=EngineClient)
     # Set the max_model_len attribute to avoid missing attribute
+    mock_model_config = MagicMock(spec=ModelConfig)
     mock_model_config.max_model_len = 2048
+    mock_engine_client.model_config = mock_model_config
+    mock_engine_client.processor = MagicMock()
+    mock_engine_client.io_processor = MagicMock()
 
     serving_models = OpenAIServingModels(
         engine_client=mock_engine_client,
         base_model_paths=BASE_MODEL_PATHS,
-        model_config=mock_model_config,
         lora_modules=None,
     )
     await serving_models.init_static_loras()

--- a/tests/entrypoints/openai/test_serving_responses.py
+++ b/tests/entrypoints/openai/test_serving_responses.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from contextlib import AsyncExitStack
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
@@ -70,11 +70,14 @@ class TestInitializeToolSessions:
         """Create a real OpenAIServingResponses instance for testing"""
         # Create minimal mocks for required dependencies
         engine_client = MagicMock()
-        engine_client.get_model_config = AsyncMock()
 
         model_config = MagicMock()
         model_config.hf_config.model_type = "test"
         model_config.get_diff_sampling_param.return_value = {}
+        engine_client.model_config = model_config
+
+        engine_client.processor = MagicMock()
+        engine_client.io_processor = MagicMock()
 
         models = MagicMock()
 
@@ -83,7 +86,6 @@ class TestInitializeToolSessions:
         # Create the actual instance
         instance = OpenAIServingResponses(
             engine_client=engine_client,
-            model_config=model_config,
             models=models,
             request_logger=None,
             chat_template=None,
@@ -132,18 +134,20 @@ class TestValidateGeneratorInput:
         """Create a real OpenAIServingResponses instance for testing"""
         # Create minimal mocks for required dependencies
         engine_client = MagicMock()
-        engine_client.get_model_config = AsyncMock()
 
         model_config = MagicMock()
         model_config.hf_config.model_type = "test"
         model_config.get_diff_sampling_param.return_value = {}
+        engine_client.model_config = model_config
+
+        engine_client.processor = MagicMock()
+        engine_client.io_processor = MagicMock()
 
         models = MagicMock()
 
         # Create the actual instance
         instance = OpenAIServingResponses(
             engine_client=engine_client,
-            model_config=model_config,
             models=models,
             request_logger=None,
             chat_template=None,

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -7,6 +7,7 @@ from vllm.config import ModelConfig
 from vllm.inputs import zip_enc_dec_prompts
 from vllm.inputs.parse import parse_raw_prompts
 from vllm.inputs.preprocess import InputPreprocessor
+from vllm.transformers_utils.tokenizer import init_tokenizer_from_configs
 
 pytestmark = pytest.mark.cpu_test
 
@@ -106,7 +107,8 @@ def test_zip_enc_dec_prompts(mm_processor_kwargs, expected_mm_kwargs):
 )
 def test_preprocessor_text_no_mm_inputs(model_id, prompt):
     model_config = ModelConfig(model=model_id)
-    input_preprocessor = InputPreprocessor(model_config)
+    tokenizer = init_tokenizer_from_configs(model_config)
+    input_preprocessor = InputPreprocessor(model_config, tokenizer)
 
     with pytest.raises(ValueError, match="does not support multimodal inputs"):
         input_preprocessor.preprocess(prompt)
@@ -127,8 +129,8 @@ def test_preprocessor_text_no_mm_inputs(model_id, prompt):
 )
 def test_preprocessor_always_mm_code_path(model_id, prompt):
     model_config = ModelConfig(model=model_id)
-    input_preprocessor = InputPreprocessor(model_config)
-    tokenizer = input_preprocessor.tokenizer
+    tokenizer = init_tokenizer_from_configs(model_config)
+    input_preprocessor = InputPreprocessor(model_config, tokenizer)
 
     # HF processor adds sep token
     sep_token_id = tokenizer.vocab[tokenizer.sep_token]

--- a/tests/v1/engine/test_processor_multi_modal_uuids.py
+++ b/tests/v1/engine/test_processor_multi_modal_uuids.py
@@ -65,7 +65,7 @@ def _mk_processor(
         device_config=DeviceConfig(device="cpu"),
     )
 
-    return Processor(vllm_config)
+    return Processor(vllm_config, tokenizer=None)
 
 
 def test_multi_modal_uuids_length_mismatch_raises(monkeypatch):

--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -459,7 +459,7 @@ def test_all_logprobs(example_prompts):
     results_logprobs_all = runner.llm.generate(
         example_prompts, sampling_params=sampling_params_logprobs_all
     )
-    vocab_size = runner.llm.llm_engine.get_model_config().get_vocab_size()
+    vocab_size = runner.llm.llm_engine.model_config.get_vocab_size()
 
     for i in range(len(results_logprobs_all)):
         logprobs = results_logprobs_all[i].outputs[0].logprobs

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -186,7 +186,7 @@ async def run_vllm_async(
         engine_args,
         disable_frontend_multiprocessing=disable_frontend_multiprocessing,
     ) as llm:
-        model_config = await llm.model_config
+        model_config = llm.model_config
         assert all(
             model_config.max_model_len
             >= (request.prompt_len + request.expected_output_len)

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -186,7 +186,7 @@ async def run_vllm_async(
         engine_args,
         disable_frontend_multiprocessing=disable_frontend_multiprocessing,
     ) as llm:
-        model_config = await llm.get_model_config()
+        model_config = await llm.model_config
         assert all(
             model_config.max_model_len
             >= (request.prompt_len + request.expected_output_len)

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -5,17 +5,19 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from typing import Any, Optional, Union
 
-from vllm.config import VllmConfig
+from vllm.config import ModelConfig, VllmConfig
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.outputs import PoolingRequestOutput, RequestOutput
+from vllm.plugins.io_processors import IOProcessor
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import Device
 from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -24,7 +26,10 @@ class EngineClient(ABC):
     """Protocol class for Clients to Engine"""
 
     vllm_config: VllmConfig
+    model_config: ModelConfig
     tokenizer: Optional[AnyTokenizer]
+    processor: Processor
+    io_processor: Optional[IOProcessor]
 
     @property
     @abstractmethod

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -10,7 +10,6 @@ from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.outputs import PoolingRequestOutput, RequestOutput
-from vllm.plugins.io_processors.interface import IOProcessor
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
@@ -95,9 +94,6 @@ class EngineClient(ABC):
     async def get_tokenizer(self) -> AnyTokenizer:
         """Get the tokenizer"""
         ...
-
-    async def get_io_processor(self) -> IOProcessor:
-        raise NotImplementedError
 
     @abstractmethod
     async def is_tracing_enabled(self) -> bool: ...

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from typing import Any, Optional, Union
 
-from vllm.config import ModelConfig, VllmConfig
+from vllm.config import VllmConfig
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -26,8 +26,6 @@ class EngineClient(ABC):
     """Protocol class for Clients to Engine"""
 
     vllm_config: VllmConfig
-    model_config: ModelConfig
-    tokenizer: Optional[AnyTokenizer]
     processor: Processor
     io_processor: Optional[IOProcessor]
 

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -1,25 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from typing import Any, Optional, Union
 
-from vllm.beam_search import BeamSearchSequence, create_sort_beams_key_function
 from vllm.config import ModelConfig, VllmConfig
-from vllm.inputs.data import PromptType, TokensPrompt
-from vllm.inputs.parse import is_explicit_encoder_decoder_prompt
-from vllm.inputs.preprocess import InputPreprocessor
+from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.outputs import CompletionOutput, PoolingRequestOutput, RequestOutput
+from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.plugins.io_processors.interface import IOProcessor
 from vllm.pooling_params import PoolingParams
-from vllm.sampling_params import BeamSearchParams, SamplingParams
+from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
 from vllm.transformers_utils.tokenizer import AnyTokenizer
-from vllm.utils import Device, collect_from_async_generator, random_uuid
+from vllm.utils import Device
 from vllm.v1.engine import EngineCoreRequest
 
 logger = init_logger(__name__)
@@ -61,180 +57,6 @@ class EngineClient(ABC):
         """Generate outputs for a request."""
         ...
 
-    async def beam_search(
-        self,
-        prompt: PromptType,
-        request_id: str,
-        params: BeamSearchParams,
-        lora_request: Optional[LoRARequest] = None,
-    ) -> AsyncGenerator[RequestOutput, None]:
-        beam_width = params.beam_width
-        max_tokens = params.max_tokens
-        ignore_eos = params.ignore_eos
-        temperature = params.temperature
-        length_penalty = params.length_penalty
-        include_stop_str_in_output = params.include_stop_str_in_output
-
-        preprocessor = await self.get_input_preprocessor()
-        tokenizer = preprocessor.get_tokenizer()
-        eos_token_id = tokenizer.eos_token_id
-
-        if is_explicit_encoder_decoder_prompt(prompt):
-            raise NotImplementedError
-        else:
-            processed_inputs = preprocessor._prompt_to_llm_inputs(prompt)
-
-        if processed_inputs["type"] == "embeds":
-            raise NotImplementedError
-
-        # This is a workaround to fix multimodal beam search; this is a
-        # bandaid fix for 2 small problems:
-        # 1. Multi_modal_data on the processed_inputs currently resolves to
-        #    `None`.
-        # 2. preprocessing above expands the multimodal placeholders. However,
-        #    this happens again in generation, so the double expansion causes
-        #    a mismatch.
-        # TODO - would be ideal to handle this more gracefully.
-        if isinstance(prompt, str):
-            prompt_text = prompt
-            prompt_token_ids = []
-            multi_modal_data = None
-        else:
-            prompt_text = prompt.get("prompt")
-            prompt_token_ids = prompt.get("prompt_token_ids", [])
-            multi_modal_data = prompt.get("multi_modal_data")
-
-        mm_processor_kwargs = processed_inputs.get("mm_processor_kwargs")
-
-        tokenized_length = len(prompt_token_ids)
-
-        sort_beams_key = create_sort_beams_key_function(eos_token_id, length_penalty)
-
-        beam_search_params = SamplingParams(
-            logprobs=2 * beam_width,
-            max_tokens=1,
-            temperature=temperature,
-        )
-        all_beams = [
-            BeamSearchSequence(
-                tokens=prompt_token_ids,
-                cum_logprob=0,
-                logprobs=[],
-                multi_modal_data=multi_modal_data,
-                mm_processor_kwargs=mm_processor_kwargs,
-                lora_request=lora_request,
-            )
-        ]
-        completed = []
-
-        for _ in range(max_tokens):
-            prompts_batch, lora_req_batch = zip(
-                *[
-                    (
-                        TokensPrompt(
-                            prompt_token_ids=beam.tokens,
-                            multi_modal_data=beam.multi_modal_data,
-                            mm_processor_kwargs=beam.mm_processor_kwargs,
-                        ),
-                        beam.lora_request,
-                    )
-                    for beam in all_beams
-                ]
-            )
-
-            tasks = []
-
-            request_id = f"beam_search-{random_uuid()}"
-            for i, (individual_prompt, lora_req) in enumerate(
-                zip(prompts_batch, lora_req_batch)
-            ):
-                request_id_item = f"{request_id}-{i}"
-                task = asyncio.create_task(
-                    collect_from_async_generator(
-                        self.generate(
-                            individual_prompt,
-                            beam_search_params,
-                            request_id_item,
-                            lora_request=lora_req,
-                        )
-                    )
-                )
-                tasks.append(task)
-
-            output = await asyncio.gather(*tasks)
-
-            output = [x[0] for x in output]
-
-            new_beams = []
-            for i, current_beam in enumerate(all_beams):
-                result = output[i]
-
-                if result.outputs[0].logprobs is not None:
-                    logprobs = result.outputs[0].logprobs[0]
-                    for token_id, logprob_obj in logprobs.items():
-                        if token_id == eos_token_id and not ignore_eos:
-                            completed.append(
-                                BeamSearchSequence(
-                                    tokens=current_beam.tokens + [token_id]
-                                    if include_stop_str_in_output
-                                    else current_beam.tokens,
-                                    logprobs=current_beam.logprobs + [logprobs],
-                                    cum_logprob=current_beam.cum_logprob
-                                    + logprob_obj.logprob,
-                                    finish_reason="stop",
-                                    stop_reason=eos_token_id,
-                                )
-                            )
-                        else:
-                            new_beams.append(
-                                BeamSearchSequence(
-                                    tokens=current_beam.tokens + [token_id],
-                                    logprobs=current_beam.logprobs + [logprobs],
-                                    lora_request=current_beam.lora_request,
-                                    cum_logprob=current_beam.cum_logprob
-                                    + logprob_obj.logprob,
-                                    multi_modal_data=current_beam.multi_modal_data,
-                                    mm_processor_kwargs=current_beam.mm_processor_kwargs,
-                                )
-                            )
-
-            sorted_beams = sorted(new_beams, key=sort_beams_key, reverse=True)
-            all_beams = sorted_beams[:beam_width]
-
-        completed.extend(all_beams)
-        sorted_completed = sorted(completed, key=sort_beams_key, reverse=True)
-        best_beams = sorted_completed[:beam_width]
-
-        for beam in best_beams:
-            if beam.tokens[-1] == eos_token_id and not ignore_eos:
-                # Skip the eos token in the text.
-                tokens = beam.tokens[tokenized_length:-1]
-            else:
-                tokens = beam.tokens[tokenized_length:]
-            beam.text = tokenizer.decode(tokens)
-
-        yield RequestOutput(
-            request_id=request_id,
-            prompt=prompt_text,
-            outputs=[
-                CompletionOutput(
-                    text=beam.text,
-                    cumulative_logprob=beam.cum_logprob,
-                    token_ids=beam.tokens[tokenized_length:],
-                    index=i,
-                    logprobs=beam.logprobs,
-                    finish_reason=beam.finish_reason
-                    if beam.finish_reason is not None
-                    else "length",
-                    stop_reason=beam.stop_reason,
-                )
-                for (i, beam) in enumerate(best_beams)
-            ],
-            finished=True,
-            prompt_token_ids=prompt_token_ids,
-            prompt_logprobs=None,
-        )
-
     @abstractmethod
     def encode(
         self,
@@ -267,11 +89,6 @@ class EngineClient(ABC):
     @abstractmethod
     async def get_model_config(self) -> ModelConfig:
         """Get the model configuration of the vLLM engine."""
-        ...
-
-    @abstractmethod
-    async def get_input_preprocessor(self) -> InputPreprocessor:
-        """Get the input processor of the vLLM engine."""
         ...
 
     @abstractmethod

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from typing import Any, Optional, Union
 
-from vllm.config import ModelConfig, VllmConfig
+from vllm.config import VllmConfig
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -22,6 +22,9 @@ logger = init_logger(__name__)
 
 class EngineClient(ABC):
     """Protocol class for Clients to Engine"""
+
+    vllm_config: VllmConfig
+    tokenizer: Optional[AnyTokenizer]
 
     @property
     @abstractmethod
@@ -78,16 +81,6 @@ class EngineClient(ABC):
             request_id: The unique id of the request,
                         or an iterable of such ids.
         """
-        ...
-
-    @abstractmethod
-    async def get_vllm_config(self) -> VllmConfig:
-        """Get the vllm configuration of the vLLM engine."""
-        ...
-
-    @abstractmethod
-    async def get_model_config(self) -> ModelConfig:
-        """Get the model configuration of the vLLM engine."""
         ...
 
     @abstractmethod

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from typing import Any, Optional, Union
 
-from vllm.config import VllmConfig
+from vllm.config import ModelConfig, VllmConfig
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -26,6 +26,7 @@ class EngineClient(ABC):
     """Protocol class for Clients to Engine"""
 
     vllm_config: VllmConfig
+    model_config: ModelConfig
     processor: Processor
     io_processor: Optional[IOProcessor]
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -476,15 +476,11 @@ class LLM:
         if (
             not default_mm_loras
             or not isinstance(prompt, dict)
-            or "multi_modal_data" not in prompt
+            or not (mm_data := prompt.get("multi_modal_data") or {})
         ):
             return lora_request
 
-        prompt = cast(Union[TextPrompt, TokensPrompt], prompt)
-
-        intersection = set(prompt["multi_modal_data"].keys()).intersection(
-            default_mm_loras.keys()
-        )
+        intersection = set(mm_data.keys()).intersection(default_mm_loras.keys())
         if not intersection:
             return lora_request
         if len(intersection) > 1:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -66,7 +66,6 @@ from vllm.outputs import (
     RequestOutput,
     ScoringRequestOutput,
 )
-from vllm.plugins.io_processors import get_io_processor
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import BeamSearchParams, RequestOutputKind, SamplingParams
 from vllm.tasks import PoolingTask
@@ -79,7 +78,6 @@ from vllm.usage.usage_lib import UsageContext
 from vllm.utils import Counter, Device, as_iter, is_list_of
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.llm_engine import LLMEngine
-from vllm.v1.engine.processor import Processor
 from vllm.v1.sample.logits_processor import LogitsProcessor
 
 if TYPE_CHECKING:
@@ -337,18 +335,11 @@ class LLM:
 
         supported_tasks = self.llm_engine.get_supported_tasks()
         logger.info("Supported tasks: %s", supported_tasks)
-
-        self.vllm_config = self.llm_engine.vllm_config
-        self.tokenizer = self.llm_engine.tokenizer
-        self.model_config = self.llm_engine.model_config
         self.supported_tasks = supported_tasks
-        self.processor = Processor(self.vllm_config, self.tokenizer)
 
-        # Load the Input/Output processor plugin if any
-        io_processor_plugin = self.model_config.io_processor_plugin
-        self.io_processor = get_io_processor(
-            self.llm_engine.vllm_config, io_processor_plugin
-        )
+        self.model_config = self.llm_engine.model_config
+        self.processor = self.llm_engine.processor
+        self.io_processor = self.llm_engine.io_processor
 
     def get_tokenizer(self) -> AnyTokenizer:
         return self.llm_engine.get_tokenizer()

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -480,7 +480,9 @@ class LLM:
         ):
             return lora_request
 
-        intersection = set(mm_data.keys()).intersection(default_mm_loras.keys())
+        intersection = set(
+            mm_data.keys()  # type: ignore
+        ).intersection(default_mm_loras.keys())
         if not intersection:
             return lora_request
         if len(intersection) > 1:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -367,7 +367,8 @@ class LLM:
     def _get_processor(self) -> Processor:
         if not hasattr(self, "_processor"):
             vllm_config = self.llm_engine.vllm_config
-            self._processor = Processor(vllm_config)
+            tokenizer = self.llm_engine.get_tokenizer()
+            self._processor = Processor(vllm_config, tokenizer)
 
         return self._processor
 

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -343,7 +343,7 @@ async def run_batch(
         BaseModelPath(name=name, model_path=args.model) for name in served_model_names
     ]
 
-    model_config = engine_client.vllm_config.model_config
+    model_config = engine_client.model_config
     supported_tasks = await engine_client.get_supported_tasks()
     logger.info("Supported tasks: %s", supported_tasks)
 

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -349,7 +349,7 @@ async def run_batch(
     model_config = vllm_config.model_config
 
     supported_tasks = await engine_client.get_supported_tasks()
-    logger.info("Supported_tasks: %s", supported_tasks)
+    logger.info("Supported tasks: %s", supported_tasks)
 
     vllm_config = await engine_client.get_vllm_config()
     tokenizer = await engine_client.get_tokenizer()

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -34,6 +34,7 @@ from vllm.entrypoints.openai.serving_models import BaseModelPath, OpenAIServingM
 from vllm.entrypoints.openai.serving_score import ServingScores
 from vllm.logger import init_logger
 from vllm.utils import FlexibleArgumentParser, random_uuid
+from vllm.v1.engine.processor import Processor
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
@@ -350,6 +351,10 @@ async def run_batch(
     supported_tasks = await engine_client.get_supported_tasks()
     logger.info("Supported_tasks: %s", supported_tasks)
 
+    vllm_config = await engine_client.get_vllm_config()
+    tokenizer = await engine_client.get_tokenizer()
+    processor = Processor(vllm_config, tokenizer)
+
     # Create the openai serving objects.
     openai_serving_models = OpenAIServingModels(
         engine_client=engine_client,
@@ -361,6 +366,7 @@ async def run_batch(
         OpenAIServingChat(
             engine_client,
             model_config,
+            processor,
             openai_serving_models,
             args.response_role,
             request_logger=request_logger,
@@ -375,6 +381,7 @@ async def run_batch(
         OpenAIServingEmbedding(
             engine_client,
             model_config,
+            processor,
             openai_serving_models,
             request_logger=request_logger,
             chat_template=None,
@@ -393,6 +400,7 @@ async def run_batch(
         ServingScores(
             engine_client,
             model_config,
+            processor,
             openai_serving_models,
             request_logger=request_logger,
         )

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -73,6 +73,7 @@ from vllm.transformers_utils.tokenizers import (
     validate_request_params,
 )
 from vllm.utils import as_list
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -82,6 +83,7 @@ class OpenAIServingChat(OpenAIServing):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         response_role: str,
         *,
@@ -102,6 +104,7 @@ class OpenAIServingChat(OpenAIServing):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -15,7 +15,6 @@ from fastapi import Request
 from openai_harmony import Message as OpenAIMessage
 from pydantic import TypeAdapter
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
@@ -73,7 +72,6 @@ from vllm.transformers_utils.tokenizers import (
     validate_request_params,
 )
 from vllm.utils import as_list
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -82,8 +80,6 @@ class OpenAIServingChat(OpenAIServing):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         response_role: str,
         *,
@@ -103,8 +99,6 @@ class OpenAIServingChat(OpenAIServing):
     ) -> None:
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
@@ -141,7 +135,7 @@ class OpenAIServingChat(OpenAIServing):
         self.tool_parser: Optional[Callable[[AnyTokenizer], ToolParser]] = None
         if self.enable_auto_tools:
             try:
-                if tool_parser == "pythonic" and model_config.model.startswith(
+                if tool_parser == "pythonic" and self.model_config.model.startswith(
                     "meta-llama/Llama-3.2"
                 ):
                     logger.warning(
@@ -172,7 +166,7 @@ class OpenAIServingChat(OpenAIServing):
         else:
             self.tool_call_id_type = "random"
 
-        self.use_harmony = model_config.hf_config.model_type == "gpt_oss"
+        self.use_harmony = self.model_config.hf_config.model_type == "gpt_oss"
         if self.use_harmony:
             if "stop_token_ids" not in self.default_sampling_params:
                 self.default_sampling_params["stop_token_ids"] = []

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -338,7 +338,7 @@ class OpenAIServingChat(OpenAIServing):
                 )
 
                 if isinstance(sampling_params, BeamSearchParams):
-                    generator = self.engine_client.beam_search(
+                    generator = self.beam_search(
                         prompt=engine_prompt,
                         request_id=request_id,
                         params=sampling_params,

--- a/vllm/entrypoints/openai/serving_classification.py
+++ b/vllm/entrypoints/openai/serving_classification.py
@@ -8,7 +8,6 @@ import numpy as np
 from fastapi import Request
 from typing_extensions import override
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.protocol import (
@@ -128,7 +127,6 @@ class ServingClassification(ClassificationMixin):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -136,7 +134,6 @@ class ServingClassification(ClassificationMixin):
     ) -> None:
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -10,7 +10,6 @@ from typing import Optional, Union, cast
 import jinja2
 from fastapi import Request
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.protocol import (
@@ -36,7 +35,6 @@ from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import as_list, merge_async_iterators
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -45,8 +43,6 @@ class OpenAIServingCompletion(OpenAIServing):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -57,8 +53,6 @@ class OpenAIServingCompletion(OpenAIServing):
     ):
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -201,7 +201,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 # but pre-commit in CI fails without it.
                 engine_prompt = cast(Union[EmbedsPrompt, TokensPrompt], engine_prompt)
                 if isinstance(sampling_params, BeamSearchParams):
-                    generator = self.engine_client.beam_search(
+                    generator = self.beam_search(
                         prompt=engine_prompt,
                         request_id=request_id,
                         params=sampling_params,

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -36,6 +36,7 @@ from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import as_list, merge_async_iterators
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -45,6 +46,7 @@ class OpenAIServingCompletion(OpenAIServing):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -56,6 +58,7 @@ class OpenAIServingCompletion(OpenAIServing):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -42,6 +42,7 @@ from vllm.outputs import (
 )
 from vllm.pooling_params import PoolingParams
 from vllm.utils import chunk_list
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -598,6 +599,7 @@ class OpenAIServingEmbedding(EmbeddingMixin):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -609,6 +611,7 @@ class OpenAIServingEmbedding(EmbeddingMixin):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -10,7 +10,6 @@ import torch
 from fastapi import Request
 from typing_extensions import assert_never, override
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
 from vllm.entrypoints.logger import RequestLogger
@@ -42,7 +41,6 @@ from vllm.outputs import (
 )
 from vllm.pooling_params import PoolingParams
 from vllm.utils import chunk_list
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -598,8 +596,6 @@ class OpenAIServingEmbedding(EmbeddingMixin):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -610,8 +606,6 @@ class OpenAIServingEmbedding(EmbeddingMixin):
     ) -> None:
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -290,7 +290,7 @@ class OpenAIServing:
 
         processor = self.processor
         tokenizer = processor.tokenizer
-        eos_token_id = tokenizer.eos_token_id
+        eos_token_id: int = tokenizer.eos_token_id  # type: ignore
 
         if is_explicit_encoder_decoder_prompt(prompt):
             raise NotImplementedError
@@ -310,14 +310,17 @@ class OpenAIServing:
         #    this happens again in generation, so the double expansion causes
         #    a mismatch.
         # TODO - would be ideal to handle this more gracefully.
+        prompt_text: Optional[str]
+        prompt_token_ids: list[int]
+        multi_modal_data: Optional[MultiModalDataDict]
         if isinstance(prompt, str):
             prompt_text = prompt
             prompt_token_ids = []
             multi_modal_data = None
         else:
-            prompt_text = prompt.get("prompt")
-            prompt_token_ids = prompt.get("prompt_token_ids", [])
-            multi_modal_data = prompt.get("multi_modal_data")
+            prompt_text = prompt.get("prompt")  # type: ignore
+            prompt_token_ids = prompt.get("prompt_token_ids", [])  # type: ignore
+            multi_modal_data = prompt.get("multi_modal_data")  # type: ignore
 
         mm_processor_kwargs = processed_inputs.get("mm_processor_kwargs")
 

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -458,10 +458,6 @@ class OpenAIServing:
             prompt_logprobs=None,
         )
 
-    async def reset_mm_cache(self) -> None:
-        self.processor.clear_cache()
-        await self.engine_client.reset_mm_cache()
-
     def _get_renderer(self, tokenizer: Optional[AnyTokenizer]) -> BaseRenderer:
         """
         Get a Renderer instance with the provided tokenizer.

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -386,9 +386,7 @@ class OpenAIServing:
                 )
                 tasks.append(task)
 
-            output = await asyncio.gather(*tasks)
-
-            output = [x[0] for x in output]
+            output = [x[0] for x in await asyncio.gather(*tasks)]
 
             new_beams = []
             for i, current_beam in enumerate(all_beams):

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -41,7 +41,6 @@ from vllm.entrypoints.openai.protocol import (
     ChatCompletionResponse,
     ClassificationRequest,
     ClassificationResponse,
-    CompletionOutput,
     CompletionRequest,
     CompletionResponse,
     DetokenizeRequest,
@@ -82,7 +81,7 @@ from vllm.multimodal import (  # noqa: F401 - Required to resolve Pydantic error
     MultiModalDataDict,
     MultiModalUUIDDict,
 )
-from vllm.outputs import PoolingRequestOutput, RequestOutput
+from vllm.outputs import CompletionOutput, PoolingRequestOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tracing import (

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -269,9 +269,8 @@ class OpenAIServing:
         self._async_tokenizer_pool: dict[AnyTokenizer, AsyncMicrobatchTokenizer] = {}
         self.log_error_stack = log_error_stack
 
-        self.vllm_config = self.models.vllm_config
-        self.tokenizer = self.models.tokenizer
         self.processor = self.models.processor
+        self.io_processor = self.models.io_processor
         self.model_config = self.models.model_config
         self.max_model_len = self.model_config.max_model_len
 

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -290,6 +290,11 @@ class OpenAIServing:
 
         processor = self.processor
         tokenizer = processor.tokenizer
+        if tokenizer is None:
+            raise ValueError(
+                "You cannot use beam search when `skip_tokenizer_init` is True"
+            )
+
         eos_token_id: int = tokenizer.eos_token_id  # type: ignore
 
         if is_explicit_encoder_decoder_prompt(prompt):

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -23,7 +23,6 @@ else:
 
 import vllm.envs as envs
 from vllm.beam_search import BeamSearchSequence, create_sort_beams_key_function
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -99,7 +98,6 @@ from vllm.utils import (
     random_uuid,
 )
 from vllm.v1.engine import EngineCoreRequest
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -246,8 +244,6 @@ class OpenAIServing:
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -258,9 +254,6 @@ class OpenAIServing:
         super().__init__()
 
         self.engine_client = engine_client
-        self.model_config = model_config
-        self.max_model_len = model_config.max_model_len
-        self.processor = processor
 
         self.models = models
 
@@ -275,6 +268,12 @@ class OpenAIServing:
 
         self._async_tokenizer_pool: dict[AnyTokenizer, AsyncMicrobatchTokenizer] = {}
         self.log_error_stack = log_error_stack
+
+        self.vllm_config = self.models.vllm_config
+        self.tokenizer = self.models.tokenizer
+        self.processor = self.models.processor
+        self.model_config = self.models.model_config
+        self.max_model_len = self.model_config.max_model_len
 
     async def beam_search(
         self,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -297,7 +297,9 @@ class OpenAIServing:
         if is_explicit_encoder_decoder_prompt(prompt):
             raise NotImplementedError
         else:
-            processed_inputs = processor._prompt_to_llm_inputs(prompt)
+            processed_inputs = processor.input_preprocessor._prompt_to_llm_inputs(
+                prompt
+            )
 
         if processed_inputs["type"] == "embeds":
             raise NotImplementedError

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -365,11 +365,10 @@ class OpenAIServing:
 
             tasks = []
 
-            request_id = f"beam_search-{random_uuid()}"
             for i, (individual_prompt, lora_req) in enumerate(
                 zip(prompts_batch, lora_req_batch)
             ):
-                request_id_item = f"{request_id}-{i}"
+                request_id_item = f"{request_id}-beam-{i}"
                 task = asyncio.create_task(
                     collect_from_async_generator(
                         self.engine_client.generate(

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -327,7 +327,9 @@ class OpenAIServing:
             prompt_token_ids = prompt.get("prompt_token_ids", [])  # type: ignore
             multi_modal_data = prompt.get("multi_modal_data")  # type: ignore
 
-        mm_processor_kwargs = processed_inputs.get("mm_processor_kwargs")
+        mm_processor_kwargs: Optional[dict[str, Any]] = processed_inputs.get(
+            "mm_processor_kwargs"
+        )  # type: ignore
 
         tokenized_length = len(prompt_token_ids)
 
@@ -441,7 +443,7 @@ class OpenAIServing:
             prompt=prompt_text,
             outputs=[
                 CompletionOutput(
-                    text=beam.text,
+                    text=beam.text,  # type: ignore
                     cumulative_logprob=beam.cum_logprob,
                     token_ids=beam.tokens[tokenized_length:],
                     index=i,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -359,11 +359,12 @@ class OpenAIServing:
             )
 
             tasks = []
+            request_id_batch = f"{request_id}-{random_uuid()}"
 
             for i, (individual_prompt, lora_req) in enumerate(
                 zip(prompts_batch, lora_req_batch)
             ):
-                request_id_item = f"{request_id}-beam-{i}"
+                request_id_item = f"{request_id_batch}-beam-{i}"
                 task = asyncio.create_task(
                     collect_from_async_generator(
                         self.engine_client.generate(

--- a/vllm/entrypoints/openai/serving_models.py
+++ b/vllm/entrypoints/openai/serving_models.py
@@ -21,7 +21,6 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
 from vllm.utils import AtomicCounter
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -71,10 +70,9 @@ class OpenAIServingModels:
             )
         self.lora_resolver_lock: dict[str, Lock] = defaultdict(Lock)
 
-        self.vllm_config = self.engine_client.vllm_config
-        self.tokenizer = self.engine_client.tokenizer
-        self.processor = Processor(self.vllm_config, self.tokenizer)
-        self.model_config = self.vllm_config.model_config
+        self.processor = self.engine_client.processor
+        self.io_processor = self.engine_client.io_processor
+        self.model_config = self.engine_client.vllm_config.model_config
         self.max_model_len = self.model_config.max_model_len
 
     async def init_static_loras(self):

--- a/vllm/entrypoints/openai/serving_models.py
+++ b/vllm/entrypoints/openai/serving_models.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Optional, Union
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.openai.protocol import (
     ErrorInfo,
@@ -22,6 +21,7 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
 from vllm.utils import AtomicCounter
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -51,18 +51,14 @@ class OpenAIServingModels:
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
         base_model_paths: list[BaseModelPath],
         *,
         lora_modules: Optional[list[LoRAModulePath]] = None,
     ):
         super().__init__()
 
-        self.base_model_paths = base_model_paths
-
-        self.max_model_len = model_config.max_model_len
         self.engine_client = engine_client
-        self.model_config = model_config
+        self.base_model_paths = base_model_paths
 
         self.static_lora_modules = lora_modules
         self.lora_requests: dict[str, LoRARequest] = {}
@@ -74,6 +70,12 @@ class OpenAIServingModels:
                 LoRAResolverRegistry.get_resolver(lora_resolver_name)
             )
         self.lora_resolver_lock: dict[str, Lock] = defaultdict(Lock)
+
+        self.vllm_config = self.engine_client.vllm_config
+        self.tokenizer = self.engine_client.tokenizer
+        self.processor = Processor(self.vllm_config, self.tokenizer)
+        self.model_config = self.vllm_config.model_config
+        self.max_model_len = self.model_config.max_model_len
 
     async def init_static_loras(self):
         """Loads all static LoRA modules.

--- a/vllm/entrypoints/openai/serving_models.py
+++ b/vllm/entrypoints/openai/serving_models.py
@@ -72,7 +72,7 @@ class OpenAIServingModels:
 
         self.processor = self.engine_client.processor
         self.io_processor = self.engine_client.io_processor
-        self.model_config = self.engine_client.vllm_config.model_config
+        self.model_config = self.engine_client.model_config
         self.max_model_len = self.model_config.max_model_len
 
     async def init_static_loras(self):

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -36,6 +36,7 @@ from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
 from vllm.plugins.io_processors import get_io_processor
 from vllm.utils import merge_async_iterators
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -61,6 +62,7 @@ class OpenAIServingPooling(OpenAIServing):
         self,
         engine_client: EngineClient,
         vllm_config: VllmConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -72,6 +74,7 @@ class OpenAIServingPooling(OpenAIServing):
         super().__init__(
             engine_client=engine_client,
             model_config=vllm_config.model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -13,7 +13,6 @@ import torch
 from fastapi import Request
 from typing_extensions import assert_never
 
-from vllm.config import VllmConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
 from vllm.entrypoints.logger import RequestLogger
@@ -36,7 +35,6 @@ from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
 from vllm.plugins.io_processors import get_io_processor
 from vllm.utils import merge_async_iterators
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -61,8 +59,6 @@ class OpenAIServingPooling(OpenAIServing):
     def __init__(
         self,
         engine_client: EngineClient,
-        vllm_config: VllmConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -73,8 +69,6 @@ class OpenAIServingPooling(OpenAIServing):
     ) -> None:
         super().__init__(
             engine_client=engine_client,
-            model_config=vllm_config.model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,
@@ -84,7 +78,7 @@ class OpenAIServingPooling(OpenAIServing):
         self.chat_template_content_format: Final = chat_template_content_format
         self.trust_request_chat_template = trust_request_chat_template
         io_processor_plugin = self.model_config.io_processor_plugin
-        self.io_processor = get_io_processor(vllm_config, io_processor_plugin)
+        self.io_processor = get_io_processor(self.vllm_config, io_processor_plugin)
 
     async def create_pooling(
         self,

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -33,7 +33,6 @@ from vllm.entrypoints.renderer import RenderConfig
 from vllm.entrypoints.utils import _validate_truncation_size
 from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
-from vllm.plugins.io_processors import get_io_processor
 from vllm.utils import merge_async_iterators
 
 logger = init_logger(__name__)
@@ -77,8 +76,6 @@ class OpenAIServingPooling(OpenAIServing):
         self.chat_template = chat_template
         self.chat_template_content_format: Final = chat_template_content_format
         self.trust_request_chat_template = trust_request_chat_template
-        io_processor_plugin = self.model_config.io_processor_plugin
-        self.io_processor = get_io_processor(self.vllm_config, io_processor_plugin)
 
     async def create_pooling(
         self,

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -101,6 +101,7 @@ from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import SamplingParams
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import random_uuid
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -110,6 +111,7 @@ class OpenAIServingResponses(OpenAIServing):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -128,6 +130,7 @@ class OpenAIServingResponses(OpenAIServing):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -49,7 +49,6 @@ from openai.types.responses.response_reasoning_item import (
 from openai_harmony import Message as OpenAIHarmonyMessage
 
 from vllm import envs
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -101,7 +100,6 @@ from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import SamplingParams
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import random_uuid
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -110,8 +108,6 @@ class OpenAIServingResponses(OpenAIServing):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -129,8 +125,6 @@ class OpenAIServingResponses(OpenAIServing):
     ) -> None:
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
@@ -179,7 +173,7 @@ class OpenAIServingResponses(OpenAIServing):
                 "the store."
             )
 
-        self.use_harmony = model_config.hf_config.model_type == "gpt_oss"
+        self.use_harmony = self.model_config.hf_config.model_type == "gpt_oss"
         if self.use_harmony:
             logger.warning(
                 "For gpt-oss, we ignore --enable-auto-tool-choice "

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -39,6 +39,7 @@ from vllm.lora.request import LoRARequest
 from vllm.outputs import PoolingRequestOutput, ScoringRequestOutput
 from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 from vllm.utils import make_async, merge_async_iterators
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -48,6 +49,7 @@ class ServingScores(OpenAIServing):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -56,6 +58,7 @@ class ServingScores(OpenAIServing):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -7,7 +7,6 @@ from typing import Any, Optional, Union
 
 from fastapi import Request
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.protocol import (
@@ -39,7 +38,6 @@ from vllm.lora.request import LoRARequest
 from vllm.outputs import PoolingRequestOutput, ScoringRequestOutput
 from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 from vllm.utils import make_async, merge_async_iterators
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -48,8 +46,6 @@ class ServingScores(OpenAIServing):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -57,8 +53,6 @@ class ServingScores(OpenAIServing):
     ) -> None:
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_tokenization.py
+++ b/vllm/entrypoints/openai/serving_tokenization.py
@@ -6,7 +6,6 @@ from typing import Any, Final, Optional, Union
 import jinja2
 from fastapi import Request
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
 from vllm.entrypoints.logger import RequestLogger
@@ -24,7 +23,6 @@ from vllm.entrypoints.openai.serving_models import OpenAIServingModels
 from vllm.entrypoints.renderer import RenderConfig
 from vllm.logger import init_logger
 from vllm.transformers_utils.tokenizer import AnyTokenizer
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -33,8 +31,6 @@ class OpenAIServingTokenization(OpenAIServing):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -45,8 +41,6 @@ class OpenAIServingTokenization(OpenAIServing):
     ) -> None:
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_tokenization.py
+++ b/vllm/entrypoints/openai/serving_tokenization.py
@@ -24,6 +24,7 @@ from vllm.entrypoints.openai.serving_models import OpenAIServingModels
 from vllm.entrypoints.renderer import RenderConfig
 from vllm.logger import init_logger
 from vllm.transformers_utils.tokenizer import AnyTokenizer
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -33,6 +34,7 @@ class OpenAIServingTokenization(OpenAIServing):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -44,6 +46,7 @@ class OpenAIServingTokenization(OpenAIServing):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             log_error_stack=log_error_stack,

--- a/vllm/entrypoints/openai/serving_transcription.py
+++ b/vllm/entrypoints/openai/serving_transcription.py
@@ -24,6 +24,7 @@ from vllm.entrypoints.openai.serving_models import OpenAIServingModels
 from vllm.entrypoints.openai.speech_to_text import OpenAISpeechToText
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
+from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -35,6 +36,7 @@ class OpenAIServingTranscription(OpenAISpeechToText):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -44,6 +46,7 @@ class OpenAIServingTranscription(OpenAISpeechToText):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
@@ -96,6 +99,7 @@ class OpenAIServingTranslation(OpenAISpeechToText):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -105,6 +109,7 @@ class OpenAIServingTranslation(OpenAISpeechToText):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,

--- a/vllm/entrypoints/openai/serving_transcription.py
+++ b/vllm/entrypoints/openai/serving_transcription.py
@@ -5,7 +5,6 @@ from typing import Optional, Union
 
 from fastapi import Request
 
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.protocol import (
@@ -24,7 +23,6 @@ from vllm.entrypoints.openai.serving_models import OpenAIServingModels
 from vllm.entrypoints.openai.speech_to_text import OpenAISpeechToText
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
-from vllm.v1.engine.processor import Processor
 
 logger = init_logger(__name__)
 
@@ -35,8 +33,6 @@ class OpenAIServingTranscription(OpenAISpeechToText):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -45,8 +41,6 @@ class OpenAIServingTranscription(OpenAISpeechToText):
     ):
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
@@ -98,8 +92,6 @@ class OpenAIServingTranslation(OpenAISpeechToText):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -108,8 +100,6 @@ class OpenAIServingTranslation(OpenAISpeechToText):
     ):
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,

--- a/vllm/entrypoints/openai/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text.py
@@ -12,7 +12,6 @@ import numpy as np
 from fastapi import Request
 
 import vllm.envs as envs
-from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.protocol import (
@@ -34,7 +33,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.models import SupportsTranscription
 from vllm.outputs import RequestOutput
 from vllm.utils import PlaceholderModule
-from vllm.v1.engine.processor import Processor
 
 try:
     import librosa
@@ -54,8 +52,6 @@ class OpenAISpeechToText(OpenAIServing):
     def __init__(
         self,
         engine_client: EngineClient,
-        model_config: ModelConfig,
-        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -65,8 +61,6 @@ class OpenAISpeechToText(OpenAIServing):
     ):
         super().__init__(
             engine_client=engine_client,
-            model_config=model_config,
-            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
@@ -77,7 +71,7 @@ class OpenAISpeechToText(OpenAIServing):
         self.task_type = task_type
 
         self.asr_config = self.model_cls.get_speech_to_text_config(
-            model_config, task_type
+            self.model_config, task_type
         )
 
         self.max_audio_filesize_mb = envs.VLLM_MAX_AUDIO_CLIP_FILESIZE_MB

--- a/vllm/entrypoints/openai/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text.py
@@ -34,6 +34,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.models import SupportsTranscription
 from vllm.outputs import RequestOutput
 from vllm.utils import PlaceholderModule
+from vllm.v1.engine.processor import Processor
 
 try:
     import librosa
@@ -54,6 +55,7 @@ class OpenAISpeechToText(OpenAIServing):
         self,
         engine_client: EngineClient,
         model_config: ModelConfig,
+        processor: Processor,
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
@@ -64,6 +66,7 @@ class OpenAISpeechToText(OpenAIServing):
         super().__init__(
             engine_client=engine_client,
             model_config=model_config,
+            processor=processor,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -61,13 +61,13 @@ class TokensPrompt(TypedDict):
     token_type_ids: NotRequired[list[int]]
     """A list of token type IDs to pass to the cross encoder model."""
 
-    multi_modal_data: NotRequired["MultiModalDataDict"]
+    multi_modal_data: NotRequired[Optional["MultiModalDataDict"]]
     """
     Optional multi-modal data to pass to the model,
     if the model supports it.
     """
 
-    mm_processor_kwargs: NotRequired[dict[str, Any]]
+    mm_processor_kwargs: NotRequired[Optional[dict[str, Any]]]
     """
     Optional multi-modal processor kwargs to be forwarded to the
     multimodal input mapper & processor. Note that if multiple modalities

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -20,13 +20,13 @@ class TextPrompt(TypedDict):
     prompt: str
     """The input text to be tokenized before passing to the model."""
 
-    multi_modal_data: NotRequired["MultiModalDataDict"]
+    multi_modal_data: NotRequired[Optional["MultiModalDataDict"]]
     """
     Optional multi-modal data to pass to the model,
     if the model supports it.
     """
 
-    mm_processor_kwargs: NotRequired[dict[str, Any]]
+    mm_processor_kwargs: NotRequired[Optional[dict[str, Any]]]
     """
     Optional multi-modal processor kwargs to be forwarded to the
     multimodal input mapper & processor. Note that if multiple modalities

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -17,7 +17,7 @@ from vllm.multimodal.inputs import (
     MultiModalUUIDDict,
 )
 from vllm.multimodal.processing import BaseMultiModalProcessor
-from vllm.transformers_utils.tokenizer import AnyTokenizer, init_tokenizer_from_configs
+from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils.jsontree import json_iter_leaves
 
 from .data import (
@@ -45,19 +45,16 @@ class InputPreprocessor:
     def __init__(
         self,
         model_config: ModelConfig,
+        tokenizer: Optional[AnyTokenizer],
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
         mm_processor_cache: Optional[BaseMultiModalProcessorCache] = None,
     ) -> None:
         super().__init__()
 
         self.model_config = model_config
+        self.tokenizer = tokenizer
         self.mm_registry = mm_registry
         self.mm_processor_cache = mm_processor_cache
-
-        if model_config.skip_tokenizer_init:
-            self.tokenizer = None
-        else:
-            self.tokenizer = init_tokenizer_from_configs(model_config)
 
     def get_tokenizer(self) -> AnyTokenizer:
         if self.tokenizer is None:

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -348,8 +348,8 @@ class InputPreprocessor:
         if self.model_config.is_multimodal_model:
             inputs = self._process_multimodal(
                 prompt_token_ids,
-                parsed_content.get("multi_modal_data", {}),
-                parsed_content.get("mm_processor_kwargs"),
+                parsed_content.get("multi_modal_data") or {},
+                parsed_content.get("mm_processor_kwargs") or {},
                 tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=mm_uuids,
             )
@@ -377,8 +377,8 @@ class InputPreprocessor:
         if self.model_config.is_multimodal_model:
             inputs = self._process_multimodal(
                 prompt_text,
-                parsed_content.get("multi_modal_data", {}),
-                parsed_content.get("mm_processor_kwargs"),
+                parsed_content.get("multi_modal_data") or {},
+                parsed_content.get("mm_processor_kwargs") or {},
                 tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=mm_uuids,
             )

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -105,11 +105,11 @@ class AsyncLLM(EngineClient):
             )
 
         if self.model_config.skip_tokenizer_init:
-            self.tokenizer = None
+            tokenizer = None
         else:
-            self.tokenizer = init_tokenizer_from_configs(self.model_config)
+            tokenizer = init_tokenizer_from_configs(self.model_config)
 
-        self.processor = Processor(self.vllm_config, self.tokenizer)
+        self.processor = Processor(self.vllm_config, tokenizer)
         self.io_processor = get_io_processor(
             self.vllm_config,
             self.model_config.io_processor_plugin,
@@ -618,6 +618,14 @@ class AsyncLLM(EngineClient):
             if self.log_requests:
                 logger.info("Request %s failed.", request_id)
             raise EngineGenerateError() from e
+
+    @property
+    def tokenizer(self) -> Optional[AnyTokenizer]:
+        return self.processor.tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, tokenizer: Optional[AnyTokenizer]) -> None:
+        self.processor.tokenizer = tokenizer
 
     async def get_tokenizer(self) -> AnyTokenizer:
         if self.tokenizer is None:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 
 import vllm.envs as envs
-from vllm.config import ModelConfig, VllmConfig
+from vllm.config import VllmConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.utils import _validate_truncation_size
@@ -619,12 +619,6 @@ class AsyncLLM(EngineClient):
             if self.log_requests:
                 logger.info("Request %s failed.", request_id)
             raise EngineGenerateError() from e
-
-    async def get_vllm_config(self) -> VllmConfig:
-        return self.vllm_config
-
-    async def get_model_config(self) -> ModelConfig:
-        return self.model_config
 
     async def get_tokenizer(self) -> AnyTokenizer:
         if self.tokenizer is None:

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -97,11 +97,11 @@ class LLMEngine:
         self.should_execute_dummy_batch = False
 
         if self.model_config.skip_tokenizer_init:
-            self.tokenizer = None
+            tokenizer = None
         else:
-            self.tokenizer = init_tokenizer_from_configs(self.model_config)
+            tokenizer = init_tokenizer_from_configs(self.model_config)
 
-        self.processor = Processor(self.vllm_config, self.tokenizer)
+        self.processor = Processor(self.vllm_config, tokenizer)
         self.io_processor = get_io_processor(
             self.vllm_config,
             self.model_config.io_processor_plugin,
@@ -339,6 +339,14 @@ class LLMEngine:
     def get_metrics(self) -> list[Metric]:
         assert self.log_stats, "Stat logging disabled"
         return get_metrics_snapshot()
+
+    @property
+    def tokenizer(self) -> Optional[AnyTokenizer]:
+        return self.processor.tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, tokenizer: Optional[AnyTokenizer]) -> None:
+        self.processor.tokenizer = tokenizer
 
     def get_tokenizer(self) -> AnyTokenizer:
         if self.tokenizer is None:

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -315,12 +315,6 @@ class LLMEngine:
 
         return processed_outputs.request_outputs
 
-    def get_vllm_config(self):
-        return self.vllm_config
-
-    def get_model_config(self):
-        return self.model_config
-
     def start_profile(self):
         self.engine_core.profile(True)
 

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -37,6 +37,7 @@ class Processor:
     def __init__(
         self,
         vllm_config: VllmConfig,
+        tokenizer: Optional[AnyTokenizer],
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
     ) -> None:
         self.vllm_config = vllm_config
@@ -52,6 +53,7 @@ class Processor:
 
         self.input_preprocessor = InputPreprocessor(
             self.model_config,
+            tokenizer,
             mm_registry,
             mm_processor_cache=self.mm_processor_cache,
         )


### PR DESCRIPTION
## Purpose

SHM cache was broken by `Renderer` refactor because of two reasons:
- The receiver cache in `EngineCore` is initialized before sender cache in `OpenAIServing`, causing missing shared memory error.
- Multiple sender cache instances are initialized: one in `LLMEngine`/`AsyncLLM`, and another one for each instance of `LLM`/`OpenAIServing` (note that one instance of each `OpenAIServing` subclass is created in the OpenAI entrypoint).

To fix this, the following changes have been made:

- Partially revert #23869 in order to ensure that the sender cache is initialized only once, and before the receiver cache is initialized. Non-async attributes, particularly `EngineClient.model_config` and `EngineClient.processor`, have been added so that they can still be directly accessed in API Server.
- Partially revert #26276, we now again pass `tokenizer` explicitly to `Processor`.

Other fixes:
- Fix typo in the startup log of supported tasks.
- Fix unintentional overwriting of `request_id` in `beam_search`.
- Fix beam search not working for multimodal models by allowing `TextPrompt` and `TokensPrompt` to accept `multi_modal_data` and `mm_processor_kwargs` as `None` values.

Other miscellaneous changes that help clean up the code:

- Add `model_config` attribute to `LLM` to simplify attribute access, similar to how it is done in `OpenAIServing`.
- Remove unnecessary `model_config` argument from `OpenAIServing` classes since we can now access it from `EngineClient` wihtout async.
- Remove `EngineClient.get_input_preprocessor` and move `EngineClient.beam_search` into `OpenAIServing` to be consistent with `LLM` class.
- Consolidate IO processor initialization and access code to follow similar logic as `Processor`.

cc @dongluw 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

