### PR TITLE
[PERF] Qwen3-next MTP speedup (change bool mask indexing to index_select / index_copy to reduce d2h)

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -45,7 +45,7 @@ def tensor_cache(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]
     """
 
     cache_entries: tuple[tuple | None, dict | None, Any] = []
-    cache_size = 4
+    cache_size = 8
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -455,7 +455,6 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         spec_query_start_loc = attn_metadata.spec_query_start_loc
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
         spec_sequence_masks = attn_metadata.spec_sequence_masks
-        spec_token_masks = attn_metadata.spec_token_masks
         spec_token_indx = attn_metadata.spec_token_indx
         non_spec_token_indx = attn_metadata.non_spec_token_indx
         spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
@@ -465,8 +464,6 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         ssm_state = self_kv_cache[1]
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
-        if spec_token_masks is not None:
-            spec_token_masks = spec_token_masks[:num_actual_tokens]
 
         # 1. Set up dimensions for reshapes later
         projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states[:num_actual_tokens])

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -423,7 +423,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             (query, key),
         )
         value = rearrange(value, "l (h d) -> 1 l h d", d=self.head_v_dim)
-        return query, key, value
+        return query.contiguous(), key.contiguous(), value.contiguous()
 
     def forward(
         self,
@@ -456,6 +456,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
         spec_sequence_masks = attn_metadata.spec_sequence_masks
         spec_token_masks = attn_metadata.spec_token_masks
+        spec_token_indx = attn_metadata.spec_token_indx
+        non_spec_token_indx = attn_metadata.non_spec_token_indx
         spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
         self_kv_cache = self.kv_cache[forward_context.virtual_engine]
@@ -487,8 +489,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 mixed_qkv_spec = mixed_qkv
                 mixed_qkv_non_spec = None
             else:
-                mixed_qkv_spec = mixed_qkv[spec_token_masks]
-                mixed_qkv_non_spec = mixed_qkv[~spec_token_masks]
+                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
+                mixed_qkv_non_spec = mixed_qkv.index_select(0, non_spec_token_indx)
         else:
             mixed_qkv_spec = None
             mixed_qkv_non_spec = mixed_qkv
@@ -558,10 +560,10 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 g_non_spec = None
                 beta_non_spec = None
             else:
-                g_spec = g[:, spec_token_masks]
-                beta_spec = beta[:, spec_token_masks]
-                g_non_spec = g[:, ~spec_token_masks]
-                beta_non_spec = beta[:, ~spec_token_masks]
+                g_spec = g.index_select(1, spec_token_indx)
+                beta_spec = beta.index_select(1, spec_token_indx)
+                g_non_spec = g.index_select(1, non_spec_token_indx)
+                beta_non_spec = beta.index_select(1, non_spec_token_indx)
         else:
             g_spec = None
             beta_spec = None
@@ -638,8 +640,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 dtype=core_attn_out_non_spec.dtype,
                 device=core_attn_out_non_spec.device,
             )
-            core_attn_out[:, spec_token_masks] = core_attn_out_spec
-            core_attn_out[:, ~spec_token_masks] = core_attn_out_non_spec
+            core_attn_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
+            core_attn_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
+
         elif spec_sequence_masks is not None:
             core_attn_out = core_attn_out_spec
         else:

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -50,6 +50,9 @@ class GDNAttentionMetadata:
     spec_token_masks: torch.Tensor | None = (
         None  # shape: [num_prefill_tokens + num_decode_tokens,]
     )
+    spec_token_indx: torch.Tensor | None = None
+    non_spec_token_indx: torch.Tensor | None = None
+
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
 
     # The following attributes are for triton implementation of causal_conv1d
@@ -110,6 +113,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             dtype=torch.bool,
             device=device,
         )
+        self.spec_token_indx = torch.empty(
+            (self.decode_cudagraph_max_bs * (self.num_spec + 1),),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.non_spec_token_indx = torch.empty(
+            (self.decode_cudagraph_max_bs * (self.num_spec + 1),),
+            dtype=torch.int32,
+            device=device,
+        )
         self.spec_query_start_loc = torch.empty(
             (self.decode_cudagraph_max_bs + 1,),
             dtype=torch.int32,
@@ -167,6 +180,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             )
             num_spec_decode_tokens = 0
             spec_token_masks = None
+            spec_token_indx = None
+            non_spec_token_indx = None
             spec_state_indices_tensor = None
             non_spec_state_indices_tensor = m.block_table_tensor[:, 0]
             spec_query_start_loc = None
@@ -180,6 +195,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             num_prefills = non_spec_query_lens.size(0) - num_decodes
             num_decode_tokens = num_decodes
             num_prefill_tokens = non_spec_query_lens.sum().item() - num_decode_tokens
+            num_spec_decode_tokens = (
+                query_lens.sum().item() - num_prefill_tokens - num_decode_tokens
+            )
 
             if num_prefills == 0 and num_decodes == 0:
                 spec_token_masks = torch.ones(
@@ -192,6 +210,14 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     dtype=torch.bool,
                     device=query_start_loc.device,
                 )
+                spec_token_indx = torch.arange(
+                    spec_token_masks.size(0),
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                non_spec_token_indx = torch.empty(
+                    0, dtype=torch.int32, device=query_start_loc.device
+                )
                 spec_state_indices_tensor = m.block_table_tensor[:, : self.num_spec + 1]
                 non_spec_state_indices_tensor = None
                 spec_query_start_loc = query_start_loc
@@ -200,6 +226,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_token_masks = torch.repeat_interleave(
                     spec_sequence_masks, query_lens
                 )
+                index = torch.argsort(spec_token_masks)
+                num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+                non_spec_token_indx = index[:num_non_spec_tokens]
+                spec_token_indx = index[num_non_spec_tokens:]
+
                 spec_state_indices_tensor = m.block_table_tensor[
                     spec_sequence_masks, : self.num_spec + 1
                 ]
@@ -226,9 +257,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     out=non_spec_query_start_loc[1:],
                 )
 
-            num_spec_decode_tokens = (
-                query_lens.sum().item() - num_prefill_tokens - num_decode_tokens
-            )
             assert num_accepted_tokens is not None
             num_accepted_tokens = num_accepted_tokens[spec_sequence_masks]
 
@@ -280,6 +308,19 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             )
             spec_token_masks = self.spec_token_masks[:num_actual_tokens]
             spec_token_masks[spec_token_masks.size(0) :].fill_(False)
+
+            assert non_spec_token_indx is not None and spec_token_indx is not None
+            self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(
+                non_spec_token_indx, non_blocking=True
+            )
+            non_spec_token_indx = self.non_spec_token_indx[
+                : non_spec_token_indx.size(0)
+            ]
+
+            self.spec_token_indx[: spec_token_indx.size(0)].copy_(
+                spec_token_indx, non_blocking=True
+            )
+            spec_token_indx = self.spec_token_indx[: spec_token_indx.size(0)]
 
             self.spec_query_start_loc[: num_spec_decodes + 1].copy_(
                 spec_query_start_loc, non_blocking=True
@@ -333,6 +374,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_state_indices_tensor=non_spec_state_indices_tensor,
             spec_sequence_masks=spec_sequence_masks,
             spec_token_masks=spec_token_masks,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,


### PR DESCRIPTION
## Purpose
Qwen3-next MTP suffered from d<->h memory transfers on prefill phase. That makes MTP slower than STM (at least for some inputs). 

This PR fixes the following
1. Remove boolean indexing from GDN. Change it on direct indexing. (`tensor[bool_mask]` cause d2h transfer of number of `True` element needed for creation resulting tensor).
2. Increase cache size in `@tensor_cache`. There are 2 calls for every GDN attn, they are grouped by 3. We need at least 2*3 cache entry. 
3. Make early `.contiguous()` for q,k,v in GDN. This is not help right now but helps with `torch.compile` to make better fusion. 


## Test Result
B200. Test MTP with 512 concurrency. 
```
VLLM_ATTENTION_BACKEND=FLASH_ATTN vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp 4 --no-enable-prefix-caching --speculative-config '{"method": "qwen3_next_mtp", "num_speculative_tokens": 2}' --cuda-graph-sizes=2048
```
```
vllm bench serve --backend vllm --model Qwen/Qwen3-Next-80B-A3B-Instruct --endpoint /v1/completions --dataset-name random --random-input 1024 --random-output 1024 --max-concurrency 512 --num-prompt 512 --ignore-eos
```

Before
```
============ Serving Benchmark Result ============
Successful requests:                     512
Maximum request concurrency:             512
Benchmark duration (s):                  32.88
Total input tokens:                      524288
Total generated tokens:                  524288
Request throughput (req/s):              15.57
Output token throughput (tok/s):         15947.50
Peak output token throughput (tok/s):    9216.00
Peak concurrent requests:                512.00
Total Token throughput (tok/s):          31894.99
---------------Time to First Token----------------
Mean TTFT (ms):                          5594.84
Median TTFT (ms):                        5429.04
P99 TTFT (ms):                           11260.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.89
Median TPOT (ms):                        22.99
P99 TPOT (ms):                           29.52
---------------Inter-token Latency----------------
Mean ITL (ms):                           64.31
Median ITL (ms):                         56.32
P99 ITL (ms):                            165.80
==================================================
```

After
```
============ Serving Benchmark Result ============
Successful requests:                     512
Maximum request concurrency:             512
Benchmark duration (s):                  29.34
Total input tokens:                      524288
Total generated tokens:                  524288
Request throughput (req/s):              17.45
Output token throughput (tok/s):         17872.27
Peak output token throughput (tok/s):    9727.00
Peak concurrent requests:                512.00
Total Token throughput (tok/s):          35744.55
---------------Time to First Token----------------
Mean TTFT (ms):                          3953.48
Median TTFT (ms):                        3795.80
P99 TTFT (ms):                           7914.50
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.12
Median TPOT (ms):                        21.04
P99 TPOT (ms):                           26.59
---------------Inter-token Latency----------------
Mean ITL (ms):                           59.34
Median ITL (ms):                         56.31
P99 ITL (ms):                            117.85
==================================================
```

Speedup of Output token throughput is **12%**


For comparison STP mode:
```
VLLM_ATTENTION_BACKEND=FLASH_ATTN vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp 4 --no-enable-prefix-caching --cuda-graph-sizes=2048
```
```
vllm bench serve --backend vllm --model Qwen/Qwen3-Next-80B-A3B-Instruct --endpoint /v1/completions --dataset-name random --random-input 1024 --random-output 1024 --max-concurrency 512 --num-prompt 512 --ignore-eos
```

```
============ Serving Benchmark Result ============
Successful requests:                     512
Maximum request concurrency:             512
Benchmark duration (s):                  37.51
Total input tokens:                      524288
Total generated tokens:                  524288
Request throughput (req/s):              13.65
Output token throughput (tok/s):         13976.35
Peak output token throughput (tok/s):    17920.00
Peak concurrent requests:                512.00
Total Token throughput (tok/s):          27952.70
---------------Time to First Token----------------
Mean TTFT (ms):                          3698.59
Median TTFT (ms):                        3467.95
P99 TTFT (ms):                           7608.89
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          32.47
Median TPOT (ms):                        32.75
P99 TPOT (ms):                           34.83
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.47
Median ITL (ms):                         29.54
P99 ITL (ms):                            131.08
==================================================
```
