### PR TITLE
[dependency] Add conditional dependency for gpt-oss to maintain Python 3.10 minimum version requirement.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -49,4 +49,4 @@ pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects
 setproctitle # Used to set process names for better debugging and monitoring
 openai-harmony >= 0.0.3  # Required for gpt-oss
-gpt-oss >= 0.0.7
+gpt-oss >= 0.0.7; python_version >= '3.12'


### PR DESCRIPTION
## Summary

Add conditional dependency for gpt-oss to maintain Python 3.10 minimum version requirement.
Issue is introduced by https://github.com/vllm-project/vllm/pull/24315

## Problem

The gpt-oss package requires Python >= 3.12, but vLLM currently supports Python >= 3.10. Adding gpt-oss as an unconditional dependency would break compatibility for Python 3.10 and 3.11 users.

## Solution

Make the gpt-oss dependency conditional on Python version >= 3.12:

```
gpt-oss >= 0.0.7; python_version >= '3.12'
```


## Impact

- **Python 3.10-3.11 users**: Can install and use vLLM with core functionality. gpt-oss features are gracefully disabled with warning logs, as handled by existing `validate_gpt_oss_install()` logic.

- **Python 3.12+ users**: Get full gpt-oss functionality including browser and code interpreter tools.

- **Minimum Python version**: Remains unchanged at 3.10.