### PR TITLE
[Bugfix] Catch and log invalid token ids in detokenizer #2

### DIFF
--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -227,7 +227,7 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
     def _protected_step(self, next_token_id: int) -> Optional[str]:
         try:
             token = self.stream.step(self.tokenizer, next_token_id)
-        except OverflowError:
+        except (OverflowError, TypeError):
             # Handle rare observed overflow, still to be diagnosed.
             # See https://github.com/vllm-project/vllm/issues/21951.
             logger.exception("Encountered invalid token id: %d", next_token_id)

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -230,7 +230,7 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
         except (OverflowError, TypeError):
             # Handle rare observed overflow, still to be diagnosed.
             # See https://github.com/vllm-project/vllm/issues/21951.
-            logger.exception("Encountered invalid token id: %d", next_token_id)
+            logger.exception("Encountered invalid token id: %r", next_token_id)
             token = None
         except Exception as e:
             if not str(e).startswith(INVALID_PREFIX_ERR_MSG):


### PR DESCRIPTION
This is an update to the "workaround" added in https://github.com/vllm-project/vllm/pull/24351.

That PR insulates against occasional negative token ids that can be produced occasionally, though we still don't know the root cause (see https://github.com/vllm-project/vllm/issues/21951).

With the update to `tokenizers` 0.22.1, this error manifests as a `TypeError` rather than an `OverflowError`, so the patch needs to be updated to account for this.

Mitigates https://github.com/vllm-project/vllm/issues/26438, https://github.com/vllm-project/vllm/issues/26071, https://github.com/vllm-project/vllm/issues/25821.