### PR TITLE
[CI/Build] Fix type errors to make pre-commit pass

### DIFF
--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -366,7 +366,7 @@ class MultiModalDataParser:
         if isinstance(data, torch.Tensor):
             return data.ndim == 3
         if is_list_of(data, torch.Tensor):
-            return data[0].ndim == 2
+            return data[0].ndim == 2  # type: ignore[index]
 
         return False
 
@@ -434,7 +434,7 @@ class MultiModalDataParser:
         elif isinstance(data, (np.ndarray, torch.Tensor)):
             data_items = [elem for elem in data]
         else:
-            data_items = data
+            data_items = data  # type: ignore[assignment]
 
         new_audios = list[np.ndarray]()
         for data_item in data_items:
@@ -498,7 +498,7 @@ class MultiModalDataParser:
         elif isinstance(data, tuple) and len(data) == 2:
             data_items = [data]
         else:
-            data_items = data
+            data_items = data  # type: ignore[assignment]
 
         new_videos = list[tuple[np.ndarray, Optional[dict[str, Any]]]]()
         metadata_lst: list[Optional[dict[str, Any]]] = []

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -351,15 +351,15 @@ class MistralTokenizer(TokenizerBase):
         if is_list_of(text, str):
             input_ids_: list[list[int]] = []
             for p in text:
-                each_input_ids = self.encode_one(p, truncation, max_length)
+                each_input_ids = self.encode_one(p, truncation, max_length)  # type: ignore[arg-type]
                 input_ids_.append(each_input_ids)
             input_ids = input_ids_
         # For list[int], apply chat template output, already tokens.
         elif is_list_of(text, int):
-            input_ids = text
+            input_ids = text  # type: ignore[assignment]
         # For str, single prompt text
         else:
-            input_ids = self.encode_one(text, truncation, max_length)
+            input_ids = self.encode_one(text, truncation, max_length)  # type: ignore[arg-type]
         return BatchEncoding({"input_ids": input_ids})
 
     def get_vocab(self) -> dict[str, int]:


### PR DESCRIPTION
Currently pre-commit is failing from type interpretation errors. The vllm_utils handle types correctly and this should be ignored. See use of is_list_of
