### PR TITLE
[TPU] Fix tpu torch compile error

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -330,9 +330,12 @@ class VllmConfig:
             + self.compilation_config.custom_ops.count("all")
             == 0
         ):
+            from vllm.platforms import current_platform
+
             if (
                 self.compilation_config.level > 0
                 and self.compilation_config.backend != "eager"
+                and not current_platform.is_tpu()
             ):
                 self.compilation_config.custom_ops.append("none")
             else:

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -139,8 +139,9 @@ class TpuPlatform(Platform):
             )
             compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
-        if compilation_config.backend == "":
-            compilation_config.backend = "openxla"
+        # Note: the default backend is set to inductor now
+        # we want to overwrite to openxla to execute the ops properly on TPU.
+        compilation_config.backend = "openxla"
 
         assert vllm_config.speculative_config is None, (
             "TPU does not support speculative decoding"


### PR DESCRIPTION
Fix TPU torch [compile error](https://buildkite.com/vllm/ci/builds/33886#0199c03d-a2d4-461a-b604-ab2aa8c362a8) after https://github.com/vllm-project/vllm/pull/26113

This pr includes:
1. Set compilation backend to `openxla` on TPU platform
2. Make sure TPU is using `forward_tpu` when dispatching in custom ops
3. Bypass some backend checks which require either `eager` or `inductor` for non-tpu platforms.