### PR TITLE
[Bugfix] Incorrect another MM data format in vllm bench throughput

### DIFF
--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -59,16 +59,16 @@ def run_vllm(
     prompts: list[Union[TextPrompt, TokensPrompt]] = []
     sampling_params: list[SamplingParams] = []
     for request in requests:
-        prompts.append(
-            TokensPrompt(
-                prompt_token_ids=request.prompt["prompt_token_ids"],
-                multi_modal_data=request.multi_modal_data,
-            )
+        prompt = (
+            TokensPrompt(prompt_token_ids=request.prompt["prompt_token_ids"])
             if "prompt_token_ids" in request.prompt
-            else TextPrompt(
-                prompt=request.prompt, multi_modal_data=request.multi_modal_data
-            )
+            else TextPrompt(prompt=request.prompt)
         )
+        if request.multi_modal_data:
+            assert isinstance(request.multi_modal_data, dict)
+            prompt["multi_modal_data"] = request.multi_modal_data
+        prompts.append(prompt)
+
         sampling_params.append(
             SamplingParams(
                 n=n,


### PR DESCRIPTION
## Purpose

Same as https://github.com/vllm-project/vllm/pull/26395, I think the PR missed another spot in `run_vllm` function as I still see the failure when running vllm bench throughput after the rebase in https://github.com/pytorch/pytorch-integration-testing/actions/runs/18361337410/job/52305453336#step:16:8356

cc @DarkLight1337 

## Test Plan

## Test Result
