### PR TITLE
Update Dockerfile and install runai-model-streamer[gcs] package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -542,7 +542,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     else \
         BITSANDBYTES_VERSION="0.46.1"; \
     fi; \
-    uv pip install --system accelerate hf_transfer modelscope "bitsandbytes>=${BITSANDBYTES_VERSION}" 'timm>=1.0.17' 'runai-model-streamer[s3]>=0.14.0'
+    uv pip install --system accelerate hf_transfer modelscope "bitsandbytes>=${BITSANDBYTES_VERSION}" 'timm>=1.0.17' 'runai-model-streamer[s3,gcs]>=0.14.0'
 
 ENV VLLM_USAGE_SOURCE production-docker-image
 


### PR DESCRIPTION
## Purpose
 * Install the runai-model-streamer[gcs] pip package in Dockerfile creation, to enable GCS support in the nightly / published image.
 * GCS support and tests added in #24909

## Test Result

Validated by running Dockerfile locally