### PR TITLE
vllm bench serve shows num of failed requests

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -97,6 +97,7 @@ class BenchmarkMetrics:
 @dataclass
 class EmbedBenchmarkMetrics:
     completed: int
+    failed: int
     total_input: int
     request_throughput: float
     total_token_throughput: float
@@ -239,12 +240,15 @@ def calculate_metrics_for_embeddings(
     """
     total_input = 0
     completed = 0
+    failed = 0
     e2els: list[float] = []
     for i in range(len(outputs)):
         if outputs[i].success:
             e2els.append(outputs[i].latency)
             completed += 1
             total_input += outputs[i].prompt_len
+        else:
+            failed += 1
 
     if completed == 0:
         warnings.warn(
@@ -254,6 +258,7 @@ def calculate_metrics_for_embeddings(
         )
     metrics = EmbedBenchmarkMetrics(
         completed=completed,
+        failed=failed,
         total_input=total_input,
         request_throughput=completed / dur_s,
         total_token_throughput=total_input / dur_s,


### PR DESCRIPTION
## Purpose
The `vllm bench serve` command is used to benchmark inference metrics. However, when the server fails, the benchmarking report is not quite explicit about this, which can lead to misleading results. This PR explicitly reports the number of failed requests.

## Test Plan
Start the server
```shell
vllm serve Qwen/Qwen3-0.6B
```

Launch the benchmark:
```shell
vllm bench serve --model Qwen/Qwen3-0.6B --dataset-name hf --dataset-path philschmid/mt-bench
```

## Test Result

```shell
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0          <<<<<<< New line
Benchmark duration (s):                  23.73     
Total input tokens:                      79807     
Total generated tokens:                  255726    
Request throughput (req/s):              42.15     
Output token throughput (tok/s):         10777.64  
Peak output token throughput (tok/s):    14046.00  
Peak concurrent requests:                1000.00   
Total Token throughput (tok/s):          14141.12  
---------------Time to First Token----------------
Mean TTFT (ms):                          9408.20   
Median TTFT (ms):                        6866.08   
P99 TTFT (ms):                           18164.16  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.92     
Median TPOT (ms):                        22.33     
P99 TPOT (ms):                           22.52     
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.93     
Median ITL (ms):                         21.79     
P99 ITL (ms):                            44.63     
==================================================
``` 