### PR TITLE
[Models][Qwen] Replace `pad` with `cat` for better performance

### DIFF
--- a/vllm/model_executor/models/dots_ocr.py
+++ b/vllm/model_executor/models/dots_ocr.py
@@ -680,8 +680,7 @@ class DotsVisionTransformer(nn.Module):
             dim=0,
             dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
-        cu_seqlens = torch.cat([zeros, cu_seqlens])
+        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
 
         max_seqlen, seqlens = self.compute_attn_mask_seqlen(cu_seqlens)
         for blk in self.blocks:

--- a/vllm/model_executor/models/dots_ocr.py
+++ b/vllm/model_executor/models/dots_ocr.py
@@ -680,7 +680,8 @@ class DotsVisionTransformer(nn.Module):
             dim=0,
             dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+        cu_seqlens = torch.cat([zeros, cu_seqlens])
 
         max_seqlen, seqlens = self.compute_attn_mask_seqlen(cu_seqlens)
         for blk in self.blocks:

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -574,7 +574,7 @@ class Ernie4_5_VisionTransformer(nn.Module):
             grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
         ).cumsum(dim=0, dtype=torch.int32)
 
-        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+        zeros = cu_seqlens.new_zeros(1)
         if num_pad > 0:
             cu_seqlens = torch.cat([zeros, cu_seqlens, zeros])
             cu_seqlens[-1] = cu_seqlens[-2] + num_pad

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -574,11 +574,12 @@ class Ernie4_5_VisionTransformer(nn.Module):
             grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
         ).cumsum(dim=0, dtype=torch.int32)
 
+        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
         if num_pad > 0:
-            cu_seqlens = F.pad(cu_seqlens, (1, 1), value=0)
+            cu_seqlens = torch.cat([zeros, cu_seqlens, zeros])
             cu_seqlens[-1] = cu_seqlens[-2] + num_pad
         else:
-            cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+            cu_seqlens = torch.cat([zeros, cu_seqlens])
 
         # add batch size
         if hidden_states.ndim == 2:

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -539,8 +539,7 @@ class Qwen3_VisionTransformer(nn.Module):
             dim=0,
             dtype=grid_thw_tensor.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
-        cu_seqlens = torch.cat([zeros, cu_seqlens])
+        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
 
         hidden_states = hidden_states.unsqueeze(1)
         rotary_pos_emb = rotary_pos_emb.to(hidden_states.device)

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -539,7 +539,8 @@ class Qwen3_VisionTransformer(nn.Module):
             dim=0,
             dtype=grid_thw_tensor.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+        cu_seqlens = torch.cat([zeros, cu_seqlens])
 
         hidden_states = hidden_states.unsqueeze(1)
         rotary_pos_emb = rotary_pos_emb.to(hidden_states.device)

--- a/vllm/model_executor/models/siglip2navit.py
+++ b/vllm/model_executor/models/siglip2navit.py
@@ -592,8 +592,7 @@ class Siglip2Encoder(nn.Module):
             # for more information
             dtype=grid_thws.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
-        cu_seqlens = torch.cat([zeros, cu_seqlens])
+        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
 
         reverse_indices = torch.argsort(window_index)
 

--- a/vllm/model_executor/models/siglip2navit.py
+++ b/vllm/model_executor/models/siglip2navit.py
@@ -592,7 +592,8 @@ class Siglip2Encoder(nn.Module):
             # for more information
             dtype=grid_thws.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        zeros = torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+        cu_seqlens = torch.cat([zeros, cu_seqlens])
 
         reverse_indices = torch.argsort(window_index)
 


### PR DESCRIPTION
## Purpose

For simple cases using concatenation tends to be faster than padding.

## Test Plan

On a single H100
```
VLLM_TORCH_PROFILER_DIR=./vllm_profile vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --limit-mm-per-prompt.video 0
```

## Test Result
 **Before:**

<img width="868" height="233" alt="Screenshot 2025-10-09 at 13 30 39" src="https://github.com/user-attachments/assets/cb5c3bc5-8a9e-4349-9230-df83d7321ff0" />

 **After:**

<img width="419" height="187" alt="Screenshot 2025-10-09 at 13 31 30" src="https://github.com/user-attachments/assets/940387ae-5f0d-4254-a0c9-ae21f1314feb" />