### PR TITLE
[Spec-Decode] Add DynamicProposer for per-sequence dynamic speculative decoding

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,7 +38,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 4695e6bed5366c41e28c06cd86170166e4f43d00
+          GIT_TAG 8f468e7da54a8e2f98abfa7c38636aac91c0cba1
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -13,7 +13,7 @@ protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
 openai >= 1.99.1  # For Responses API with reasoning content
-pydantic >= 2.11.7
+pydantic >= 2.12.0
 prometheus_client >= 0.18.0
 pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -44,4 +44,4 @@ numba == 0.61.2 # Required for N-gram speculative decoding
 numpy
 runai-model-streamer[s3,gcs]==0.14.0
 fastsafetensors>=0.1.10
-pydantic>=2.10 # 2.9 leads to error on python 3.10
+pydantic>=2.12 # 2.11 leads to error on python 3.13

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -52,7 +52,7 @@ numba == 0.61.2 # Required for N-gram speculative decoding
 numpy
 runai-model-streamer[s3,gcs]==0.14.0
 fastsafetensors>=0.1.10
-pydantic>=2.10 # 2.9 leads to error on python 3.10
+pydantic>=2.12 # 2.11 leads to error on python 3.13
 decord==0.6.0
 terratorch @ git+https://github.com/IBM/terratorch.git@1.1.rc3 # required for PrithviMAE test
 gpt-oss >= 0.0.7; python_version > '3.11'

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -783,7 +783,7 @@ pycparser==2.22
     # via cffi
 pycryptodomex==3.22.0
     # via blobfile
-pydantic==2.11.7
+pydantic==2.12.0
     # via
     #   -r requirements/test.in
     #   albumentations
@@ -797,7 +797,7 @@ pydantic==2.11.7
     #   openai-harmony
     #   pydantic-extra-types
     #   ray
-pydantic-core==2.33.2
+pydantic-core==2.41.1
     # via pydantic
 pydantic-extra-types==2.10.5
     # via mistral-common
@@ -1224,7 +1224,7 @@ types-python-dateutil==2.9.0.20241206
     # via arrow
 typeshed-client==2.8.2
     # via jsonargparse
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   aiosignal
     #   albumentations
@@ -1253,7 +1253,7 @@ typing-extensions==4.12.2
     #   typer
     #   typeshed-client
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via pydantic
 tzdata==2024.2
     # via pandas

--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -258,13 +258,13 @@ def tractable_computation(
 
 @torch.inference_mode
 def run_model(
-    llama_config, use_compile: bool, backend: str, split_attn: bool = False
+    llama_config, use_compile: bool, use_inductor: bool, split_attn: bool = False
 ) -> torch.Tensor:
     if use_compile:
         compilation_config = CompilationConfig(
             level=CompilationLevel.PIECEWISE,
             use_cudagraph=True,
-            backend=backend,
+            use_inductor=use_inductor,
             cudagraph_capture_sizes=[1, 2],
         )
         if split_attn:
@@ -338,8 +338,8 @@ def run_model(
             return output.cpu()
 
 
-@pytest.mark.parametrize("backend", ["inductor", "eager"])
-def test_toy_llama(backend: str):
+@pytest.mark.parametrize("use_inductor", [True, False])
+def test_toy_llama(use_inductor: bool):
     # compare output with and without piecewise compilation
 
     llama_config = LlamaConfig(
@@ -358,10 +358,10 @@ def test_toy_llama(backend: str):
         num_backend_compilations=0,
         num_cudagraph_captured=0,
     ):
-        outputs.append(run_model(llama_config, backend="eager", use_compile=False))
-    run_model(tractable_config, backend="eager", use_compile=False)
+        outputs.append(run_model(llama_config, use_inductor=False, use_compile=False))
+    run_model(tractable_config, use_inductor=False, use_compile=False)
 
-    if backend == "inductor":
+    if use_inductor:
         kwargs = {"num_inductor_compiles": 1, "num_eager_compiles": 0}
     else:
         kwargs = {"num_eager_compiles": 1, "num_inductor_compiles": 0}
@@ -377,8 +377,10 @@ def test_toy_llama(backend: str):
         num_cudagraph_captured=2,
         **kwargs,
     ):
-        outputs.append(run_model(llama_config, backend=backend, use_compile=True))
-    run_model(tractable_config, backend=backend, use_compile=True)
+        outputs.append(
+            run_model(llama_config, use_inductor=use_inductor, use_compile=True)
+        )
+    run_model(tractable_config, use_inductor=use_inductor, use_compile=True)
 
     with compilation_counter.expect(
         num_graphs_seen=1,  # one graph for the model
@@ -393,9 +395,16 @@ def test_toy_llama(backend: str):
         ),  # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
     ):
         outputs.append(
-            run_model(llama_config, backend=backend, use_compile=True, split_attn=True)
+            run_model(
+                llama_config,
+                use_inductor=use_inductor,
+                use_compile=True,
+                split_attn=True,
+            )
         )
-    run_model(tractable_config, backend=backend, use_compile=True, split_attn=True)
+    run_model(
+        tractable_config, use_inductor=use_inductor, use_compile=True, split_attn=True
+    )
 
     for i in range(1, len(outputs)):
         assert torch.allclose(outputs[0], outputs[i])

--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -37,59 +37,57 @@ class Relu3(ReLUSquaredActivation):
 
 
 @pytest.mark.parametrize(
-    "env, torch_level, backend, ops_enabled, default_on",
+    "env, torch_level, use_inductor, ops_enabled, default_on",
     [
         # Default values based on compile level
         # - All by default (no Inductor compilation)
-        (None, 0, "eager", [True] * 4, True),
-        (None, 1, "eager", [True] * 4, True),
-        (None, 2, "eager", [True] * 4, True),
-        (None, 3, "eager", [True] * 4, True),
+        (None, 0, False, [True] * 4, True),
+        (None, 1, True, [True] * 4, True),
+        (None, 2, False, [True] * 4, True),
         # - None by default (with Inductor)
-        (None, 0, "inductor", [True] * 4, True),
-        # - None by default (with Inductor)
-        (None, 1, "inductor", [False] * 4, False),
-        (None, 2, "inductor", [False] * 4, False),
-        (None, 3, "inductor", [False] * 4, False),
+        (None, 3, True, [False] * 4, False),
+        (None, 4, True, [False] * 4, False),
+        # - All by default (without Inductor)
+        (None, 3, False, [True] * 4, True),
+        (None, 4, False, [True] * 4, True),
         # Explicitly enabling/disabling
         #
         # Default: all
         #
         # All but SiluAndMul
-        ("+rms_norm,-silu_and_mul", 0, "inductor", [1, 0, 1, 1], True),
+        ("+rms_norm,-silu_and_mul", 0, True, [1, 0, 1, 1], True),
         # Only ReLU3
-        ("none,-rms_norm,+relu3", 1, "eager", [0, 0, 0, 1], False),
+        ("none,-rms_norm,+relu3", 1, False, [0, 0, 0, 1], False),
         # All but SiluAndMul
-        ("all,-silu_and_mul", 2, "inductor", [1, 0, 1, 1], True),
+        ("all,-silu_and_mul", 2, True, [1, 0, 1, 1], True),
         # All but ReLU3 (even if ReLU2 is on)
-        ("-relu3,+relu2", 3, "eager", [1, 1, 1, 0], True),
+        ("-relu3,+relu2", 3, False, [1, 1, 1, 0], True),
         # RMSNorm and SiluAndMul
-        ("none,-relu3,+rms_norm,+silu_and_mul", 3, "eager", [1, 1, 0, 0], False),
+        ("none,-relu3,+rms_norm,+silu_and_mul", 4, False, [1, 1, 0, 0], False),
         # All but RMSNorm
-        ("-rms_norm", 3, "eager", [0, 1, 1, 1], True),
+        ("-rms_norm", 3, False, [0, 1, 1, 1], True),
         #
         # Default: none
         #
         # Only ReLU3
-        ("none,+relu3", 3, "inductor", [0, 0, 0, 1], False),
+        ("-silu_and_mul,+relu3", 3, True, [0, 0, 0, 1], False),
         # All but RMSNorm
-        ("all,-rms_norm", 3, "inductor", [0, 1, 1, 1], True),
+        ("all,-rms_norm", 4, True, [0, 1, 1, 1], True),
     ],
 )
 def test_enabled_ops(
     env: Optional[str],
     torch_level: int,
-    backend: str,
+    use_inductor: bool,
     ops_enabled: list[int],
     default_on: bool,
 ):
     custom_ops = env.split(",") if env else []
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
-            backend=backend, level=torch_level, custom_ops=custom_ops
+            use_inductor=bool(use_inductor), level=torch_level, custom_ops=custom_ops
         )
     )
-    # breakpoint()
     with set_current_vllm_config(vllm_config):
         assert CustomOp.default_on() == default_on
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -34,7 +34,7 @@ logger = init_logger(__name__)
 
 
 def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
-    if compilation_config.backend == "inductor":
+    if compilation_config.use_inductor:
         # Use standalone compile only if requested, version is new enough,
         # and the symbol actually exists in this PyTorch build.
         if (
@@ -48,10 +48,6 @@ def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
             logger.debug("Using InductorAdaptor")
             return InductorAdaptor()
     else:
-        assert compilation_config.backend == "eager", (
-            "Custom backends not supported with CompilationLevel.PIECEWISE"
-        )
-
         logger.debug("Using EagerAdaptor")
         return EagerAdaptor()
 

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -111,17 +111,7 @@ def get_attr_docs(cls: type[Any]) -> dict[str, str]:
     https://davidism.com/mit-license/
     """
 
-    try:
-        cls_node = ast.parse(textwrap.dedent(inspect.getsource(cls))).body[0]
-    except (OSError, KeyError, TypeError):
-        # HACK: Python 3.13+ workaround - set missing __firstlineno__
-        # Workaround can be removed after we upgrade to pydantic==2.12.0
-        with open(inspect.getfile(cls)) as f:
-            for i, line in enumerate(f):
-                if f"class {cls.__name__}" in line and ":" in line:
-                    cls.__firstlineno__ = i + 1
-                    break
-        cls_node = ast.parse(textwrap.dedent(inspect.getsource(cls))).body[0]
+    cls_node = ast.parse(textwrap.dedent(inspect.getsource(cls))).body[0]
 
     if not isinstance(cls_node, ast.ClassDef):
         raise TypeError("Given object was not a class.")

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -318,25 +318,6 @@ class VllmConfig:
                 # NB: Passing both --enforce-eager and a compilation level
                 # in V0 means the compilation level wins out.
                 self.compilation_config.level = CompilationLevel.NO_COMPILATION
-        else:
-            assert self.compilation_config.level >= CompilationLevel.NO_COMPILATION
-            assert self.compilation_config.level <= CompilationLevel.PIECEWISE
-            assert self.compilation_config.level <= 3
-
-        # If user does not set custom ops via none or all set it here based on
-        # compilation level and backend.
-        if (
-            self.compilation_config.custom_ops.count("none")
-            + self.compilation_config.custom_ops.count("all")
-            == 0
-        ):
-            if (
-                self.compilation_config.level > 0
-                and self.compilation_config.backend != "eager"
-            ):
-                self.compilation_config.custom_ops.append("none")
-            else:
-                self.compilation_config.custom_ops.append("all")
 
         # async tp is built on top of sequence parallelism
         # and requires it to be enabled.

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -114,9 +114,7 @@ class CustomOp(nn.Module):
         custom_ops = compilation_config.custom_ops
         if not hasattr(cls, "name"):
             logger.warning_once(
-                "Custom op %s was not registered, which means it won't appear\
-                 in the op registry. It will be enabled/disabled based on the\
-                 global settings.",  # noqa: E501
+                "Custom op %s was not registered, which means it won't appear in the op registry. It will be enabled/disabled based on the global settings.",  # noqa: E501
                 cls.__name__,
             )
             return CustomOp.default_on()
@@ -130,17 +128,19 @@ class CustomOp(nn.Module):
     @staticmethod
     def default_on() -> bool:
         """
-        Behavior controlled by `CompilationConfig.custom_ops`: On by default if
-        'all', off by default if 'none'.
-        When PyTorch Inductor is used, 'none' is the default value,
-        otherwise 'all'.
+        On by default if PyTorch Inductor is not used.
+        Specifying 'all' or 'none' in custom_op takes precedence.
         """
+        from vllm.config import CompilationLevel
+
         compilation_config = get_cached_compilation_config()
+        default_on = (
+            compilation_config.level < CompilationLevel.PIECEWISE
+            or not compilation_config.use_inductor
+        )
         count_none = compilation_config.custom_ops.count("none")
         count_all = compilation_config.custom_ops.count("all")
-        assert count_none + count_all == 1
-
-        return not count_none > 0 or count_all > 0
+        return default_on and not count_none > 0 or count_all > 0
 
     # Dictionary of all custom ops (classes, indexed by registered name).
     # To check if an op with a name is enabled, call .enabled() on the class.

--- a/vllm/model_executor/models/dots_ocr.py
+++ b/vllm/model_executor/models/dots_ocr.py
@@ -680,7 +680,7 @@ class DotsVisionTransformer(nn.Module):
             dim=0,
             dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
 
         max_seqlen, seqlens = self.compute_attn_mask_seqlen(cu_seqlens)
         for blk in self.blocks:

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -574,11 +574,12 @@ class Ernie4_5_VisionTransformer(nn.Module):
             grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
         ).cumsum(dim=0, dtype=torch.int32)
 
+        zeros = cu_seqlens.new_zeros(1)
         if num_pad > 0:
-            cu_seqlens = F.pad(cu_seqlens, (1, 1), value=0)
+            cu_seqlens = torch.cat([zeros, cu_seqlens, zeros])
             cu_seqlens[-1] = cu_seqlens[-2] + num_pad
         else:
-            cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+            cu_seqlens = torch.cat([zeros, cu_seqlens])
 
         # add batch size
         if hidden_states.ndim == 2:

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -539,7 +539,7 @@ class Qwen3_VisionTransformer(nn.Module):
             dim=0,
             dtype=grid_thw_tensor.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
 
         hidden_states = hidden_states.unsqueeze(1)
         rotary_pos_emb = rotary_pos_emb.to(hidden_states.device)

--- a/vllm/model_executor/models/siglip2navit.py
+++ b/vllm/model_executor/models/siglip2navit.py
@@ -592,7 +592,7 @@ class Siglip2Encoder(nn.Module):
             # for more information
             dtype=grid_thws.dtype if torch.jit.is_tracing() else torch.int32,
         )
-        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
 
         reverse_indices = torch.argsort(window_index)
 

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -274,6 +274,8 @@ class CpuPlatform(Platform):
                     "epilogue_fusion": True,
                 }
             )
+            if compilation_config.use_inductor:
+                compilation_config.custom_ops = ["none"]
 
         if vllm_config.lora_config is not None:
             compilation_config.level = CompilationLevel.NO_COMPILATION

--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -106,6 +106,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
         query_start_loc_cpu: torch.Tensor,
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
+        dcp_tot_seq_lens_device: Optional[torch.Tensor],
     ) -> FlashMLADecodeMetadata:
         tile_scheduler_metadata, num_splits = get_mla_metadata(
             seq_lens_device,
@@ -146,6 +147,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
             seq_lens=seq_lens_device,
             tile_scheduler_metadata=tile_scheduler_metadata,
             num_splits=num_splits,
+            dcp_tot_seq_lens=dcp_tot_seq_lens_device,
         )
 
 

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -116,6 +116,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         query_start_loc_cpu: torch.Tensor,
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
+        dcp_tot_seq_lens_device: Optional[torch.Tensor],
     ) -> AiterMLADecodeMetadata:
         page_size = self.kv_cache_spec.block_size
         block_table_bounds = (seq_lens_device + page_size - 1) // page_size
@@ -174,6 +175,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             paged_kv_indices=paged_kv_indices,
             paged_kv_last_page_len=paged_kv_last_page_len,
             qo_indptr=qo_indptr,
+            dcp_tot_seq_lens=dcp_tot_seq_lens_device,
         )
 
         return attn_metadata

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -93,6 +93,9 @@ class CommonAttentionMetadata:
     # Needed by CrossAttentionBuilder
     encoder_seq_lens: Optional[np.ndarray] = None
 
+    dcp_local_seq_lens: Optional[torch.Tensor] = None
+    """Sequence lengths of the local rank in decode context parallelism world"""
+
 
 def slice_query_start_locs(
     query_start_loc: torch.Tensor,

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -130,6 +130,7 @@ class ModelRunnerOutput:
     # req_id -> num_nans_in_logits
     num_nans_in_logits: Optional[dict[str, int]] = None
 
+    num_draft_tokens_per_seq: Optional[list[int]] = None
 
 # ModelRunnerOutput wrapper for async scheduling.
 class AsyncModelRunnerOutput(ABC):

--- a/vllm/v1/spec_decode/dynamic_proposer.py
+++ b/vllm/v1/spec_decode/dynamic_proposer.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import deque
+from collections.abc import Sequence
+from typing import List, Dict, Optional
+
+import numpy as np
+import torch
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+logger = init_logger(__name__)
+
+# Constants for dynamic k adjustment
+MAX_SPEC_TOKENS = 10
+MIN_SPEC_TOKENS = 2
+ACCEPTANCE_HISTORY_LEN = 10
+ACCEPTANCE_RATE_HYSTERESIS = 0.05
+MIN_HISTORY_FOR_ADJUSTMENT = 3
+
+
+class SequenceState:
+    """Data class to store the speculative decoding state for each sequence."""
+
+    def __init__(self, initial_spec_tokens: int):
+        self.num_spec_tokens = initial_spec_tokens
+        self.acceptance_rate_history = deque(maxlen=ACCEPTANCE_HISTORY_LEN)
+
+
+class DynamicProposer(EagleProposer):
+    """
+    A proposer that dynamically adjusts the number of speculative tokens (k)
+    for each sequence based on its historical acceptance rate.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ) -> None:
+        super().__init__(vllm_config, device, runner)
+
+        self.seq_states: Dict[str, SequenceState] = {}
+        self.last_proposed_k_per_seq: Dict[str, int] = {}
+        self._initial_spec_tokens = max(
+            MIN_SPEC_TOKENS,
+            min(self.num_speculative_tokens, MAX_SPEC_TOKENS))
+
+        self.acceptance_rate_threshold = (
+            vllm_config.speculative_config.acceptance_rate_threshold
+        )
+
+        logger.info("DynamicProposer initialized for adaptive k.")
+
+    def update_sequence_states(
+        self,
+        req_ids: Sequence[Optional[str]],
+        num_accepted_tokens: Sequence[int],
+    ) -> None:
+        """
+        Updates sequence states with acceptance information from the previous step.
+        """
+        if not self.last_proposed_k_per_seq:
+            return
+
+        for req_id, num_accepted in zip(req_ids, num_accepted_tokens):
+            if req_id is None:
+                continue
+            num_proposed = self.last_proposed_k_per_seq.get(req_id)
+            if num_proposed is None or num_proposed <= 0:
+                continue
+
+            acc = max(int(num_accepted), 0)
+            acceptance_rate = (acc / num_proposed) if num_proposed > 0 else 0.0
+            state = self._get_or_create_state(req_id)
+            state.acceptance_rate_history.append(acceptance_rate)
+
+        self.last_proposed_k_per_seq.clear()
+
+    def cleanup_finished_seqs(
+        self,
+        req_ids_in_batch: Sequence[Optional[str]],
+    ) -> None:
+        """Cleans up the state for sequences that are no longer in the batch."""
+        active_req_ids = {req_id for req_id in req_ids_in_batch if req_id}
+        finished_req_ids = set(self.seq_states.keys()) - active_req_ids
+        for req_id in finished_req_ids:
+            del self.seq_states[req_id]
+            self.last_proposed_k_per_seq.pop(req_id, None)
+
+    def _get_or_create_state(self, req_id: str) -> SequenceState:
+        """Retrieves or creates the state for a given sequence."""
+        state = self.seq_states.get(req_id)
+        if state is None:
+            state = SequenceState(self._initial_spec_tokens)
+            self.seq_states[req_id] = state
+        return state
+
+    def _adjust_and_get_spec_tokens_for_batch(
+        self,
+        req_ids: Sequence[Optional[str]],
+    ) -> List[int]:
+        """
+        Calculates the number of speculative tokens for each sequence based on
+        its average acceptance rate.
+        """
+        spec_tokens_for_batch: List[int] = []
+        for req_id in req_ids:
+            if req_id is None:
+                spec_tokens_for_batch.append(MIN_SPEC_TOKENS)
+                continue
+
+            state = self._get_or_create_state(req_id)
+            history = state.acceptance_rate_history
+            if len(history) < MIN_HISTORY_FOR_ADJUSTMENT:
+                spec_tokens_for_batch.append(state.num_spec_tokens)
+                continue
+
+            avg_acceptance_rate = float(np.mean(history))
+            upper_bound = self.acceptance_rate_threshold + ACCEPTANCE_RATE_HYSTERESIS
+            lower_bound = self.acceptance_rate_threshold - ACCEPTANCE_RATE_HYSTERESIS
+
+            new_k = state.num_spec_tokens
+            if avg_acceptance_rate >= upper_bound:
+                new_k = min(state.num_spec_tokens + 1, MAX_SPEC_TOKENS)
+            elif avg_acceptance_rate <= lower_bound:
+                new_k = max(state.num_spec_tokens - 1, MIN_SPEC_TOKENS)
+
+            if new_k != state.num_spec_tokens:
+                logger.debug(
+                    "Accept rate %.2f -> req %s: k %d -> %d",
+                    avg_acceptance_rate,
+                    req_id,
+                    state.num_spec_tokens,
+                    new_k,
+                )
+                state.num_spec_tokens = new_k
+
+            spec_tokens_for_batch.append(state.num_spec_tokens)
+            
+        return spec_tokens_for_batch
+
+    @torch.inference_mode()
+    def propose(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        common_attn_metadata: CommonAttentionMetadata,
+        sampling_metadata: SamplingMetadata,
+        mm_embeds: Optional[List[torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        if self.runner is None:
+            raise RuntimeError("DynamicProposer requires GPUModelRunner")
+
+        batch_size = next_token_ids.shape[0]
+        req_ids = self.runner.input_batch.req_ids[:batch_size]
+
+        # 1. Update states with acceptance results from the previous step.
+        accepted_tokens = (
+            self.runner.input_batch.num_accepted_tokens_cpu[:batch_size].tolist())
+        self.update_sequence_states(req_ids, accepted_tokens)
+        self.cleanup_finished_seqs(req_ids)
+
+        # 2. Determine and record k for each sequence for the current step.
+        per_sequence_k = self._adjust_and_get_spec_tokens_for_batch(req_ids)
+        self.last_proposed_k_per_seq = {
+            req_id: k
+            for req_id, k in zip(req_ids, per_sequence_k) if req_id is not None
+        }
+
+        self.runner._true_draft_lengths = per_sequence_k
+
+        # Safeguard against potential length mismatch, though unlikely.
+        if len(per_sequence_k) != batch_size:
+            fixed_k = [0] * batch_size
+            for i in range(min(len(per_sequence_k), batch_size)):
+                fixed_k[i] = int(per_sequence_k[i])
+            per_sequence_k = fixed_k
+            
+        max_k_in_batch = max(per_sequence_k) if per_sequence_k else 0
+        if max_k_in_batch == 0:
+            # If no drafts are proposed in this step, return an empty tensor.
+            return torch.empty((batch_size, 0),
+                               dtype=torch.long,
+                               device=self.device)
+
+        # 3. Get draft tokens from the parent (EagleProposer), requesting up to max_k.
+        original_num_tokens = self.num_speculative_tokens
+        self.num_speculative_tokens = max_k_in_batch
+        try:
+            full_draft_token_ids = super().propose(
+                target_token_ids=target_token_ids,
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                next_token_ids=next_token_ids,
+                common_attn_metadata=common_attn_metadata,
+                sampling_metadata=sampling_metadata,
+                mm_embeds=mm_embeds,
+            )
+        finally:
+            self.num_speculative_tokens = original_num_tokens
+
+        if full_draft_token_ids.numel() == 0:
+            return full_draft_token_ids
+
+        # 4. Pad the draft tensor to be rectangular using valid token IDs.
+        #    This ensures that all tokens have valid embeddings.
+        B, K = full_draft_token_ids.shape
+        if K != max_k_in_batch:
+            raise RuntimeError(f"Unexpected draft shape: {full_draft_token_ids.shape}")
+
+        device = full_draft_token_ids.device
+        dtype = full_draft_token_ids.dtype
+
+        k_vec = torch.tensor(per_sequence_k, device=device, dtype=torch.long)
+        col_indices = torch.arange(K, device=device).unsqueeze(0)
+        padding_mask = col_indices >= k_vec.unsqueeze(1)
+
+        # For rows with k > 0, pad with the last valid draft token.
+        last_valid_indices = torch.clamp(k_vec - 1, min=0).view(-1, 1).expand(-1, K)
+        last_valid_tokens = full_draft_token_ids.gather(1, last_valid_indices)
+
+        # For rows with k = 0, pad with the next_token_id to ensure validity.
+        next_token_padding = next_token_ids.to(device=device,
+                                               dtype=dtype).view(-1, 1).expand(-1, K)
+                                               
+        # Select padding values based on whether k is positive.
+        padding_values = torch.where(k_vec.view(-1, 1) > 0, last_valid_tokens,
+                                     next_token_padding)
+
+        safe_drafts = full_draft_token_ids.clone()
+        safe_drafts[padding_mask] = padding_values[padding_mask]
+
+        # NOTE:
+        # - `safe_drafts` contains no invalid token IDs, preventing embedding
+        #   out-of-bounds errors.
+        # - The scheduler is aware of the true `k` for each row via separate
+        #   metadata (`num_draft_tokens`), so the padded values are ignored
+        #   during verification, preventing indexing errors.
+        return safe_drafts

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -597,6 +597,7 @@ class EagleProposer:
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=common_attn_metadata.slot_mapping[token_indices],
             causal=True,
+            dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
         )
 
         token_indices_to_sample = (
@@ -868,6 +869,7 @@ class EagleProposer:
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=common_attn_metadata.slot_mapping[token_indices],
             causal=True,
+            dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
         )
 
         return spec_common_attn_metadata, token_indices

--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -41,7 +41,7 @@ class SpecDecodingStats:
         self.num_draft_tokens += num_draft_tokens
         self.num_accepted_tokens += num_accepted_tokens
         assert num_accepted_tokens <= self.num_spec_tokens
-        #For dynamic_spec_decode
+        # For dynamic_spec_decode
         if num_accepted_tokens > len(self.num_accepted_tokens_per_pos):
             self.num_accepted_tokens_per_pos.extend(
                 [0] * (num_accepted_tokens - len(self.num_accepted_tokens_per_pos))
@@ -99,8 +99,23 @@ class SpecDecodingLogging:
         # Conventionally, mean acceptance length includes the bonus token
         mean_acceptance_length = 1 + (num_accepted_tokens / num_drafts)
 
-        pos_matrix = np.array(self.accepted_tokens_per_pos_lists)
-        acceptance_rates = np.sum(pos_matrix, axis=0) / num_drafts
+        # [FIX] Handle ragged lists by finding max_length and summing manually.
+        if not self.accepted_tokens_per_pos_lists or num_drafts == 0:
+            acceptance_rates = np.array([])
+        else:
+            max_len = max(
+                len(inner_list)
+                for inner_list in self.accepted_tokens_per_pos_lists
+                if inner_list
+            )
+            summed_pos = np.zeros(max_len, dtype=np.int64)
+            for pos_list in self.accepted_tokens_per_pos_lists:
+                # Convert the inner list to a NumPy array for vectorized addition
+                pos_array = np.array(pos_list)
+                summed_pos[: len(pos_array)] += pos_array
+
+            acceptance_rates = summed_pos / num_drafts
+
         rates_str = ", ".join(f"{p:.3f}" for p in acceptance_rates)
 
         log_fn(

--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -41,6 +41,11 @@ class SpecDecodingStats:
         self.num_draft_tokens += num_draft_tokens
         self.num_accepted_tokens += num_accepted_tokens
         assert num_accepted_tokens <= self.num_spec_tokens
+        #For dynamic_spec_decode
+        if num_accepted_tokens > len(self.num_accepted_tokens_per_pos):
+            self.num_accepted_tokens_per_pos.extend(
+                [0] * (num_accepted_tokens - len(self.num_accepted_tokens_per_pos))
+            )
         for i in range(num_accepted_tokens):
             self.num_accepted_tokens_per_pos[i] += 1
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -402,6 +402,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.max_num_reqs + 1, dtype=torch.int32
         )
         self.seq_lens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
+        if self.dcp_world_size > 1:
+            self.dcp_local_seq_lens = self._make_buffer(
+                self.max_num_reqs, dtype=torch.int32
+            )
         # Because inputs_embeds may be bfloat16 and we don't need a numpy
         # version of this tensor, avoid a RuntimeError by not creating a
         # numpy buffer.
@@ -585,7 +589,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # NOTE(lucas): currently no backend supports the custom masking
             #  required for DCP with q_len > 1, so we assert here. Remove this
             #  assert once the custom mask is support is added to FA3.
-            if self.dcp_world_size > 1:
+            if (
+                self.dcp_world_size > 1
+                and envs.VLLM_ATTENTION_BACKEND != "FLASH_ATTN_MLA"
+            ):
                 assert self.reorder_batch_threshold == 1, (
                     "DCP not support reorder_batch_threshold > 1 now."
                 )
@@ -1432,6 +1439,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 num_logits_indices=logits_indices.size(0),
                 causal=True,
                 encoder_seq_lens=encoder_seq_lens,
+                dcp_local_seq_lens=self.dcp_local_seq_lens.gpu[:num_reqs]
+                if self.dcp_world_size > 1
+                else None,
             )
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
@@ -3423,6 +3433,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         kv_cache_group_id
                     ].slot_mapping.gpu[:num_tokens],
                     causal=True,
+                    dcp_local_seq_lens=self.dcp_local_seq_lens.gpu[:num_reqs]
+                    if self.dcp_world_size > 1
+                    else None,
                 )
                 for attn_group in self.attn_groups[kv_cache_group_id]:
                     if ubatch_slices is not None:


### PR DESCRIPTION
## Purpose

This PR introduces a new speculative decoding method, `eagle_dynamic`, which enables adaptive adjustment of the number of speculative tokens (`k`). This addresses the idea of adaptive speculation discussed in issue dynamic SL in \#17984.

The existing speculative decoding methods in vLLM use a fixed `k` for all sequences. This can be inefficient, as a high `k` is wasteful for sequences with low acceptance rates, while a low `k` misses opportunities on highly predictable sequences.

This implementation introduces a `DynamicProposer` that monitors the historical acceptance rate for each request. It then dynamically increases or decreases `k` to keep the rate around a user-configurable target threshold. This aims to optimize throughput by tailoring the speculation length to the difficulty of the content being generated.

**Key Changes:**

  - Adds a new speculative method: `eagle_dynamic`.
  - Implements `DynamicProposer` which adjusts `k` per-sequence.
  - Introduces a new engine argument, `--acceptance-rate-threshold` to allow users to tune the target acceptance rate.
  - The data pipeline between the `GPUModelRunner` and the `Scheduler` has been updated to correctly handle variable-length draft proposals, ensuring accurate statistics and stable operation even when `k` differs between sequences in the same batch.

## Test Plan

The feature was tested end-to-end to observe the behavior in a live environment by running the vLLM engine with the `eagle_dynamic` method enabled. The dynamic adjustment of `k` can be observed in the logs.

**Command to run an E2E test:**

```bash
# The following command reflects the models used in testing.
python -m vllm.entrypoints.openai.api_server \
    --model meta-llama/Meta-Llama-3-8B-Instruct \
    --speculative-model yuhuili/EAGLE-LLaMA3-Instruct-8B \
    --speculative-method eagle_dynamic \
    --acceptance-rate-threshold 0.3
```

## Test Result

End-to-end testing confirms that the `k` value (the denominator in `accepted/k`) adapts dynamically and independently for each request based on its performance.

The logs below show `req=7` increasing its `k` from 9 to 10 due to high acceptance, while `req=5` decreases its `k` from 8 to 7 after a poor acceptance step.

```log
# k values are different for each request (req=5 has k=8, req=7 has k=9)
INFO [gpu_model_runner.py:949] EAGLE acceptance step: req=5 accepted=1/8 emitted=[123977, 627] | req=7 accepted=3/9 emitted=[11879, 374, 264, 27626]
INFO [gpu_model_runner.py:949] EAGLE acceptance step: req=5 accepted=1/8 emitted=[9, 116453] | req=7 accepted=3/9 emitted=[430, 1524, 279, 25655]

# req=7 has a good acceptance rate, so its k increases from 9 to 10
INFO [gpu_model_runner.py:949] EAGLE acceptance step: req=5 accepted=0/8 emitted=[118917] | req=7 accepted=4/10 emitted=[6299, 649, 1304, 264, 2466]

# req=5 has a poor acceptance rate, so its k decreases from 8 to 7
INFO [gpu_model_runner.py:949] EAGLE acceptance step: req=5 accepted=3/7 emitted=[114564, 104554, 18918, 86422] | req=7 accepted=3/10 emitted=[6811, 11, 323, 430]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

