### PR TITLE
[Model][Qwen3VL] Compute `cu_seqlens` on CPU to remove 

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -546,7 +546,7 @@ class Qwen3_VisionTransformer(nn.Module):
 
         hidden_states = hidden_states.unsqueeze(1)
         max_seqlen, seqlens = self.compute_attn_mask_seqlen(cu_seqlens)
-        cu_seqlens.to(self.device, non_blocking=True)
+        cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
 
         deepstack_feature_lists = []
         for layer_num, blk in enumerate(self.blocks):

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -488,7 +488,9 @@ class Qwen3_VisionTransformer(nn.Module):
 
             indices = torch.stack([idx00, idx01, idx10, idx11], dim=0).reshape(4, -1)
             weights = torch.stack([w00, w01, w10, w11], dim=0).reshape(4, -1, 1)
-            weights = weights.to(dtype=self.dtype, device=self.device)
+            weights = weights.to(
+                dtype=self.dtype, device=self.device, non_blocking=True
+            )
 
             embeds = self.pos_embed(indices)
             weighted_embeds = embeds * weights
@@ -524,7 +526,7 @@ class Qwen3_VisionTransformer(nn.Module):
         x: torch.Tensor,
         grid_thw: list[list[int]],
     ) -> torch.Tensor:
-        hidden_states = x.to(device=self.device, dtype=self.dtype)
+        hidden_states = x.to(device=self.device, dtype=self.dtype, non_blocking=True)
         hidden_states = self.patch_embed(hidden_states)
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
@@ -542,7 +544,7 @@ class Qwen3_VisionTransformer(nn.Module):
         cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
 
         hidden_states = hidden_states.unsqueeze(1)
-        rotary_pos_emb = rotary_pos_emb.to(hidden_states.device)
+        rotary_pos_emb = rotary_pos_emb.to(hidden_states.device, non_blocking=True)
         max_seqlen, seqlens = self.compute_attn_mask_seqlen(cu_seqlens)
 
         deepstack_feature_lists = []


### PR DESCRIPTION
## Purpose

The current code does 5 `cudaStreamSynchronize`( 3 syncs due to CPU-GPU weight copy and 2 syncs inside `torch.repeat_interleave`) which isn't idea.
This PR removes the blocking weight copy and moves the `cu_seqlens` to the CPU which is faster and doesn't require any CPU-GPU syncs.

**Before:**

<img width="1248" height="340" alt="Screenshot 2025-10-09 at 15 36 12" src="https://github.com/user-attachments/assets/6f35ca5d-3b75-4ca6-8ac4-3f3d3875122a" />

**After:**

<img width="713" height="283" alt="Screenshot 2025-10-09 at 15 35 59" src="https://github.com/user-attachments/assets/de3a8fb3-e954-4184-a356-a99f0bd66b19" />

## Test Plan

On a single H100
```shell
vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --limit-mm-per-prompt.video 0 --no-enable-prefix-caching
```
```shell
vllm bench serve --backend openai-chat --model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/VisionArena-Chat --hf-split train --num-prompts 1000
```

## Test Result

**Before:**
```
============ Serving Benchmark Result ============
Successful requests:                     984
Benchmark duration (s):                  31.49
Total input tokens:                      93876
Total generated tokens:                  118504
Request throughput (req/s):              31.25
Output token throughput (tok/s):         3763.75
Peak output token throughput (tok/s):    10155.00
Peak concurrent requests:                984.00
Total Token throughput (tok/s):          6745.30
---------------Time to First Token----------------
Mean TTFT (ms):                          12682.91
Median TTFT (ms):                        11258.48
P99 TTFT (ms):                           26015.58
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          111.32
Median TPOT (ms):                        121.03
P99 TPOT (ms):                           257.56
---------------Inter-token Latency----------------
Mean ITL (ms):                           105.87
Median ITL (ms):                         63.28
P99 ITL (ms):                            447.10
==================================================
```

**After:**

```
============ Serving Benchmark Result ============
Successful requests:                     984
Benchmark duration (s):                  31.47
Total input tokens:                      93720
Total generated tokens:                  118619
Request throughput (req/s):              31.27
Output token throughput (tok/s):         3769.80
Peak output token throughput (tok/s):    10951.00
Peak concurrent requests:                984.00
Total Token throughput (tok/s):          6748.29
---------------Time to First Token----------------
Mean TTFT (ms):                          12383.31
Median TTFT (ms):                        11419.97
P99 TTFT (ms):                           26081.61
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          112.25
Median TPOT (ms):                        121.49
P99 TPOT (ms):                           248.47
---------------Inter-token Latency----------------
Mean ITL (ms):                           107.45
Median ITL (ms):                         61.96
P99 ITL (ms):                            486.04
==================================================
```

This reduces Mean TTFT by **1 - 2 %**.