### PR TITLE
[FrontEnd] UNREVERT CompilationConfig overhaul (#20283): deprecate use_inductor in favor of backend, simplify custom_ops 

### DIFF
--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -257,14 +257,16 @@ def tractable_computation(
 
 
 @torch.inference_mode
-def run_model(
-    llama_config, use_compile: bool, use_inductor: bool, split_attn: bool = False
-) -> torch.Tensor:
+def run_model(llama_config,
+              use_compile: bool,
+              backend: str,
+              split_attn: bool = False) -> torch.Tensor:
+
     if use_compile:
         compilation_config = CompilationConfig(
             level=CompilationLevel.PIECEWISE,
             use_cudagraph=True,
-            use_inductor=use_inductor,
+            backend=backend,
             cudagraph_capture_sizes=[1, 2],
         )
         if split_attn:
@@ -338,8 +340,8 @@ def run_model(
             return output.cpu()
 
 
-@pytest.mark.parametrize("use_inductor", [True, False])
-def test_toy_llama(use_inductor: bool):
+@pytest.mark.parametrize("backend", ["inductor", "eager"])
+def test_toy_llama(backend: str):
     # compare output with and without piecewise compilation
 
     llama_config = LlamaConfig(
@@ -358,10 +360,11 @@ def test_toy_llama(use_inductor: bool):
         num_backend_compilations=0,
         num_cudagraph_captured=0,
     ):
-        outputs.append(run_model(llama_config, use_inductor=False, use_compile=False))
-    run_model(tractable_config, use_inductor=False, use_compile=False)
+        outputs.append(
+            run_model(llama_config, backend="eager", use_compile=False))
+    run_model(tractable_config, backend="eager", use_compile=False)
 
-    if use_inductor:
+    if backend == "inductor":
         kwargs = {"num_inductor_compiles": 1, "num_eager_compiles": 0}
     else:
         kwargs = {"num_eager_compiles": 1, "num_inductor_compiles": 0}
@@ -378,9 +381,8 @@ def test_toy_llama(use_inductor: bool):
         **kwargs,
     ):
         outputs.append(
-            run_model(llama_config, use_inductor=use_inductor, use_compile=True)
-        )
-    run_model(tractable_config, use_inductor=use_inductor, use_compile=True)
+            run_model(llama_config, backend=backend, use_compile=True))
+    run_model(tractable_config, backend=backend, use_compile=True)
 
     with compilation_counter.expect(
         num_graphs_seen=1,  # one graph for the model
@@ -395,16 +397,14 @@ def test_toy_llama(use_inductor: bool):
         ),  # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
     ):
         outputs.append(
-            run_model(
-                llama_config,
-                use_inductor=use_inductor,
-                use_compile=True,
-                split_attn=True,
-            )
-        )
-    run_model(
-        tractable_config, use_inductor=use_inductor, use_compile=True, split_attn=True
-    )
+            run_model(llama_config,
+                      backend=backend,
+                      use_compile=True,
+                      split_attn=True))
+    run_model(tractable_config,
+              backend=backend,
+              use_compile=True,
+              split_attn=True)
 
     for i in range(1, len(outputs)):
         assert torch.allclose(outputs[0], outputs[i])

--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -257,11 +257,9 @@ def tractable_computation(
 
 
 @torch.inference_mode
-def run_model(llama_config,
-              use_compile: bool,
-              backend: str,
-              split_attn: bool = False) -> torch.Tensor:
-
+def run_model(
+    llama_config, use_compile: bool, backend: str, split_attn: bool = False
+) -> torch.Tensor:
     if use_compile:
         compilation_config = CompilationConfig(
             level=CompilationLevel.PIECEWISE,
@@ -360,8 +358,7 @@ def test_toy_llama(backend: str):
         num_backend_compilations=0,
         num_cudagraph_captured=0,
     ):
-        outputs.append(
-            run_model(llama_config, backend="eager", use_compile=False))
+        outputs.append(run_model(llama_config, backend="eager", use_compile=False))
     run_model(tractable_config, backend="eager", use_compile=False)
 
     if backend == "inductor":
@@ -380,8 +377,7 @@ def test_toy_llama(backend: str):
         num_cudagraph_captured=2,
         **kwargs,
     ):
-        outputs.append(
-            run_model(llama_config, backend=backend, use_compile=True))
+        outputs.append(run_model(llama_config, backend=backend, use_compile=True))
     run_model(tractable_config, backend=backend, use_compile=True)
 
     with compilation_counter.expect(
@@ -397,14 +393,9 @@ def test_toy_llama(backend: str):
         ),  # num_cudagraph_sizes * num_piecewise_capturable_graphs_seen
     ):
         outputs.append(
-            run_model(llama_config,
-                      backend=backend,
-                      use_compile=True,
-                      split_attn=True))
-    run_model(tractable_config,
-              backend=backend,
-              use_compile=True,
-              split_attn=True)
+            run_model(llama_config, backend=backend, use_compile=True, split_attn=True)
+        )
+    run_model(tractable_config, backend=backend, use_compile=True, split_attn=True)
 
     for i in range(1, len(outputs)):
         assert torch.allclose(outputs[0], outputs[i])

--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -146,7 +146,7 @@ def test_compile_correctness(
             CompilationLevel.DYNAMO_ONCE,
             CompilationLevel.PIECEWISE,
         ]:
-            all_args.append(final_args + [f"-O.{level}", "-O.backend=eager"])
+            all_args.append(final_args + [f"-O.level={level}", "-O.backend=eager"])
             all_envs.append({})
             all_envs.append({})
 

--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -127,7 +127,9 @@ def test_compile_correctness(
             CompilationLevel.PIECEWISE,
         ]:
             for level in [CompilationLevel.NO_COMPILATION, comp_level]:
-                all_args.append(final_args + [f"-O.level={level}", "-O.backend=inductor"])
+                all_args.append(
+                    final_args + [f"-O.level={level}", "-O.backend=inductor"]
+                )
 
             # inductor will change the output, so we only compare if the output
             # is close, not exactly the same.

--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -127,7 +127,7 @@ def test_compile_correctness(
             CompilationLevel.PIECEWISE,
         ]:
             for level in [CompilationLevel.NO_COMPILATION, comp_level]:
-                all_args.append(final_args + [f"-O.{level}", "-O.backend=inductor"])
+                all_args.append(final_args + [f"-O.level={level}", "-O.backend=inductor"])
 
             # inductor will change the output, so we only compare if the output
             # is close, not exactly the same.

--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -127,7 +127,7 @@ def test_compile_correctness(
             CompilationLevel.PIECEWISE,
         ]:
             for level in [CompilationLevel.NO_COMPILATION, comp_level]:
-                all_args.append(final_args + [f"-O{level}", "-O.backend=inductor"])
+                all_args.append(final_args + [f"-O.{level}", "-O.backend=inductor"])
                 all_envs.append({})
 
             # inductor will change the output, so we only compare if the output
@@ -147,7 +147,7 @@ def test_compile_correctness(
             CompilationLevel.DYNAMO_ONCE,
             CompilationLevel.PIECEWISE,
         ]:
-            all_args.append(final_args + [f"-O{level}", "-O.backend=eager"])
+            all_args.append(final_args + [f"-O.{level}", "-O.backend=eager"])
             all_envs.append({})
             all_envs.append({})
 

--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -76,7 +76,8 @@ class TestSetting:
             attn_backend="FLASH_ATTN",
             method="encode",
         ),
-        # # vision language model
+        # vision language model
+        # See https://github.com/vllm-project/vllm/issues/26716.
         # TestSetting(
         #     model="microsoft/Phi-3.5-vision-instruct",
         #     model_args=["--trust-remote-code", "--max-model-len", "2048"],
@@ -114,8 +115,7 @@ def test_compile_correctness(
             str(pp_size),
             "-tp",
             str(tp_size),
-            "--compilation-config",
-            '{"cudagraph_mode": "none"}',
+            "-O.cudagraph_mode=none",
         ]
 
         all_args: list[list[str]] = []
@@ -128,7 +128,6 @@ def test_compile_correctness(
         ]:
             for level in [CompilationLevel.NO_COMPILATION, comp_level]:
                 all_args.append(final_args + [f"-O.{level}", "-O.backend=inductor"])
-                all_envs.append({})
 
             # inductor will change the output, so we only compare if the output
             # is close, not exactly the same.

--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -88,7 +88,6 @@ def test_enabled_ops(
             backend=backend, level=torch_level, custom_ops=custom_ops
         )
     )
-    # breakpoint()
     with set_current_vllm_config(vllm_config):
         assert CustomOp.default_on() == default_on
 

--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -41,14 +41,15 @@ class Relu3(ReLUSquaredActivation):
         # Default values based on compile level
         # - All by default (no Inductor compilation)
         (None, 0, "eager", [True] * 4, True),
-        (None, 1, "inductor", [True] * 4, True),
+        (None, 1, "eager", [True] * 4, True),
         (None, 2, "eager", [True] * 4, True),
-        # - None by default (with Inductor)
-        (None, 3, "inductor", [True] * 4, True),
-        (None, 4, "inductor", [True] * 4, True),
-        # - All by default (without Inductor)
         (None, 3, "eager", [True] * 4, True),
-        (None, 4, "eager", [True] * 4, True),
+        # - None by default (with Inductor)
+        (None, 0, "inductor", [True] * 4, True),
+        # - None by default (with Inductor)
+        (None, 1, "inductor", [False] * 4, False),
+        (None, 2, "inductor", [False] * 4, False),
+        (None, 3, "inductor", [False] * 4, False),
         # Explicitly enabling/disabling
         #
         # Default: all
@@ -62,7 +63,7 @@ class Relu3(ReLUSquaredActivation):
         # All but ReLU3 (even if ReLU2 is on)
         ("-relu3,+relu2", 3, "eager", [1, 1, 1, 0], True),
         # RMSNorm and SiluAndMul
-        ("none,-relu3,+rms_norm,+silu_and_mul", 4, "eager", [1, 1, 0, 0], False
+        ("none,-relu3,+rms_norm,+silu_and_mul", 3, "eager", [1, 1, 0, 0], False
          ),
         # All but RMSNorm
         ("-rms_norm", 3, "eager", [0, 1, 1, 1], True),
@@ -72,13 +73,14 @@ class Relu3(ReLUSquaredActivation):
         # Only ReLU3
         ("none,+relu3", 3, "inductor", [0, 0, 0, 1], False),
         # All but RMSNorm
-        ("all,-rms_norm", 4, "inductor", [0, 1, 1, 1], True),
+        ("all,-rms_norm", 3, "inductor", [0, 1, 1, 1], True),
     ])
 def test_enabled_ops(env: str | None, torch_level: int, backend: str,
                      ops_enabled: list[int], default_on: bool):
     custom_ops = env.split(',') if env else []
     vllm_config = VllmConfig(compilation_config=CompilationConfig(
         backend=backend, level=torch_level, custom_ops=custom_ops))
+    # breakpoint()
     with set_current_vllm_config(vllm_config):
 
         assert CustomOp.default_on() == default_on

--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -62,7 +62,8 @@ class Relu3(ReLUSquaredActivation):
         # All but ReLU3 (even if ReLU2 is on)
         ("-relu3,+relu2", 3, "eager", [1, 1, 1, 0], True),
         # RMSNorm and SiluAndMul
-        ("none,-relu3,+rms_norm,+silu_and_mul", 4, "eager", [1, 1, 0, 0], False),
+        ("none,-relu3,+rms_norm,+silu_and_mul", 4, "eager", [1, 1, 0, 0], False
+         ),
         # All but RMSNorm
         ("-rms_norm", 3, "eager", [0, 1, 1, 1], True),
         #
@@ -71,22 +72,13 @@ class Relu3(ReLUSquaredActivation):
         # Only ReLU3
         ("none,+relu3", 3, "inductor", [0, 0, 0, 1], False),
         # All but RMSNorm
-        ("all,-rms_norm", 4, True, [0, 1, 1, 1], True),
-    ],
-)
-def test_enabled_ops(
-    env: str | None,
-    torch_level: int,
-    use_inductor: bool,
-    ops_enabled: list[int],
-    default_on: bool,
-):
-    custom_ops = env.split(",") if env else []
-    vllm_config = VllmConfig(
-        compilation_config=CompilationConfig(
-            use_inductor=bool(use_inductor), level=torch_level, custom_ops=custom_ops
-        )
-    )
+        ("all,-rms_norm", 4, "inductor", [0, 1, 1, 1], True),
+    ])
+def test_enabled_ops(env: str | None, torch_level: int, backend: str,
+                     ops_enabled: list[int], default_on: bool):
+    custom_ops = env.split(',') if env else []
+    vllm_config = VllmConfig(compilation_config=CompilationConfig(
+        backend=backend, level=torch_level, custom_ops=custom_ops))
     with set_current_vllm_config(vllm_config):
 
         assert CustomOp.default_on() == default_on

--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -36,40 +36,40 @@ class Relu3(ReLUSquaredActivation):
 
 
 @pytest.mark.parametrize(
-    "env, torch_level, use_inductor, ops_enabled, default_on",
+    "env, torch_level, backend, ops_enabled, default_on",
     [
         # Default values based on compile level
         # - All by default (no Inductor compilation)
-        (None, 0, False, [True] * 4, True),
-        (None, 1, True, [True] * 4, True),
-        (None, 2, False, [True] * 4, True),
+        (None, 0, "eager", [True] * 4, True),
+        (None, 1, "inductor", [True] * 4, True),
+        (None, 2, "eager", [True] * 4, True),
         # - None by default (with Inductor)
-        (None, 3, True, [False] * 4, False),
-        (None, 4, True, [False] * 4, False),
+        (None, 3, "inductor", [True] * 4, True),
+        (None, 4, "inductor", [True] * 4, True),
         # - All by default (without Inductor)
-        (None, 3, False, [True] * 4, True),
-        (None, 4, False, [True] * 4, True),
+        (None, 3, "eager", [True] * 4, True),
+        (None, 4, "eager", [True] * 4, True),
         # Explicitly enabling/disabling
         #
         # Default: all
         #
         # All but SiluAndMul
-        ("+rms_norm,-silu_and_mul", 0, True, [1, 0, 1, 1], True),
+        ("+rms_norm,-silu_and_mul", 0, "inductor", [1, 0, 1, 1], True),
         # Only ReLU3
-        ("none,-rms_norm,+relu3", 1, False, [0, 0, 0, 1], False),
+        ("none,-rms_norm,+relu3", 1, "eager", [0, 0, 0, 1], False),
         # All but SiluAndMul
-        ("all,-silu_and_mul", 2, True, [1, 0, 1, 1], True),
+        ("all,-silu_and_mul", 2, "inductor", [1, 0, 1, 1], True),
         # All but ReLU3 (even if ReLU2 is on)
-        ("-relu3,+relu2", 3, False, [1, 1, 1, 0], True),
+        ("-relu3,+relu2", 3, "eager", [1, 1, 1, 0], True),
         # RMSNorm and SiluAndMul
-        ("none,-relu3,+rms_norm,+silu_and_mul", 4, False, [1, 1, 0, 0], False),
+        ("none,-relu3,+rms_norm,+silu_and_mul", 4, "eager", [1, 1, 0, 0], False),
         # All but RMSNorm
-        ("-rms_norm", 3, False, [0, 1, 1, 1], True),
+        ("-rms_norm", 3, "eager", [0, 1, 1, 1], True),
         #
         # Default: none
         #
         # Only ReLU3
-        ("-silu_and_mul,+relu3", 3, True, [0, 0, 0, 1], False),
+        ("none,+relu3", 3, "inductor", [0, 0, 0, 1], False),
         # All but RMSNorm
         ("all,-rms_norm", 4, True, [0, 1, 1, 1], True),
     ],
@@ -88,6 +88,7 @@ def test_enabled_ops(
         )
     )
     with set_current_vllm_config(vllm_config):
+
         assert CustomOp.default_on() == default_on
 
         ops_enabled = [bool(x) for x in ops_enabled]

--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -63,8 +63,7 @@ class Relu3(ReLUSquaredActivation):
         # All but ReLU3 (even if ReLU2 is on)
         ("-relu3,+relu2", 3, "eager", [1, 1, 1, 0], True),
         # RMSNorm and SiluAndMul
-        ("none,-relu3,+rms_norm,+silu_and_mul", 3, "eager", [1, 1, 0, 0], False
-         ),
+        ("none,-relu3,+rms_norm,+silu_and_mul", 3, "eager", [1, 1, 0, 0], False),
         # All but RMSNorm
         ("-rms_norm", 3, "eager", [0, 1, 1, 1], True),
         #
@@ -74,15 +73,23 @@ class Relu3(ReLUSquaredActivation):
         ("none,+relu3", 3, "inductor", [0, 0, 0, 1], False),
         # All but RMSNorm
         ("all,-rms_norm", 3, "inductor", [0, 1, 1, 1], True),
-    ])
-def test_enabled_ops(env: str | None, torch_level: int, backend: str,
-                     ops_enabled: list[int], default_on: bool):
-    custom_ops = env.split(',') if env else []
-    vllm_config = VllmConfig(compilation_config=CompilationConfig(
-        backend=backend, level=torch_level, custom_ops=custom_ops))
+    ],
+)
+def test_enabled_ops(
+    env: str | None,
+    torch_level: int,
+    backend: str,
+    ops_enabled: list[int],
+    default_on: bool,
+):
+    custom_ops = env.split(",") if env else []
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            backend=backend, level=torch_level, custom_ops=custom_ops
+        )
+    )
     # breakpoint()
     with set_current_vllm_config(vllm_config):
-
         assert CustomOp.default_on() == default_on
 
         ops_enabled = [bool(x) for x in ops_enabled]

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -56,8 +56,7 @@ def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
             return InductorAdaptor()
     else:
         assert compilation_config.backend == "eager", (
-            "Custom backends not \
-            supported with CompilationLevel.PIECEWISE"
+            "Custom backends not supported with CompilationLevel.PIECEWISE"
         )
 
         logger.debug("Using EagerAdaptor")

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -55,7 +55,9 @@ def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
             logger.debug("Using InductorAdaptor")
             return InductorAdaptor()
     else:
-        assert backend == "eager", "Custom backends not supported with CompilationLevel.PIECEWISE"
+        assert compilation_config.backend == "eager", "Custom backends not \
+            supported with CompilationLevel.PIECEWISE"
+
         logger.debug("Using EagerAdaptor")
         return EagerAdaptor()
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -55,6 +55,7 @@ def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
             logger.debug("Using InductorAdaptor")
             return InductorAdaptor()
     else:
+        assert backend == "eager", "Custom backends not supported with CompilationLevel.PIECEWISE"
         logger.debug("Using EagerAdaptor")
         return EagerAdaptor()
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -55,8 +55,10 @@ def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
             logger.debug("Using InductorAdaptor")
             return InductorAdaptor()
     else:
-        assert compilation_config.backend == "eager", "Custom backends not \
+        assert compilation_config.backend == "eager", (
+            "Custom backends not \
             supported with CompilationLevel.PIECEWISE"
+        )
 
         logger.debug("Using EagerAdaptor")
         return EagerAdaptor()

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -41,7 +41,7 @@ logger = init_logger(__name__)
 
 
 def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
-    if compilation_config.use_inductor:
+    if compilation_config.backend == "inductor":
         # Use standalone compile only if requested, version is new enough,
         # and the symbol actually exists in this PyTorch build.
         if (

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -187,7 +187,8 @@ class CompilationConfig:
     backend: str = "inductor"
     """The backend for compilation. It needs to be a string:
 
-    - "" (empty string): use the default backend ("inductor" on CUDA-alike platforms).
+    - "" (empty string): use the default backend ("inductor" on CUDA-alike
+    platforms).
     - "eager"/"openxla"/...: use the specified backend registered in PyTorch.
     - "full.module.name": a qualified name which can be used to import the
 
@@ -197,7 +198,7 @@ class CompilationConfig:
     used for the compilation directly (it sees the whole graph). When the
     compilation level is 3, the backend is used for the piecewise compilation
     (it sees a part of the graph)."""
-    custom_ops: list[str] = field(default_factory=lambda: list())
+    custom_ops: list[str] = field(default_factory=list)
     """Fine-grained control over which custom ops to enable/disable. Use 'all'
     to enable all, 'none' to disable all. Also specify a list of custom op
     names to enable (prefixed with a '+'), or disable (prefixed with a '-').
@@ -557,13 +558,16 @@ class CompilationConfig:
             raise ValueError(
                 f"Invalid backend for piecewise compilation: {self.backend}")
 
-        if self.backend == "":
-            self.backend = "inductor"
         if self.use_inductor is not None:
             logger.warning_once(
                 "The 'use_inductor' flag is deprecated and will be\
                     removed in a future release."
                 "Please use the 'backend' option instead.", )
+            self.backend = "inductor" if self.use_inductor else "eager"
+
+        if self.backend == "":
+            self.backend = "inductor"
+
         if count_none + count_all == 0:
             if self.level > 0 and self.backend != "eager":
                 self.custom_ops.insert(0, "none")

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -233,7 +233,8 @@ class CompilationConfig:
     """
     Whether to use inductor compilation.
 
-    This flag is deprecated and will be removed. Please use the 'backend' option instead.
+    This flag is deprecated and will be removed.
+    Please use the 'backend' option instead.
 
     - False: inductor compilation is not used. graph runs in eager
         (custom_ops enabled by default).
@@ -551,17 +552,22 @@ class CompilationConfig:
                     "(where 'op' is the registered op name)"
                 )
 
-        # Currently only eager and inductor backend are supported for piecewise compilation. 
-        # Update when more backends are supported.
-        if self.level == CompilationLevel.PIECEWISE and self.backend not in ["", "eager", "inductor"]:
-            raise ValueError(f"Invalid backend for piecewise compilation: {self.backend}")
+        # Currently only eager and inductor backend are supported
+        # for piecewise compilation. Update when more backends are supported.
+        if self.level == CompilationLevel.PIECEWISE and self.backend not in [
+                "", "eager", "inductor"
+        ]:
+            raise ValueError(
+                f"Invalid backend for piecewise compilation: {self.backend}")
+
+        if self.backend == "":
+            self.backend = "inductor"
 
         logger.warning_once(
-            "The 'use_inductor' flag is deprecated and will be removed in a future release. "
-            "Please use the 'backend' option instead.",
-        )
-    
-   
+            "The 'use_inductor' flag is deprecated and will be\
+                 removed in a future release."
+            "Please use the 'backend' option instead.", )
+
     def init_backend(self, vllm_config: "VllmConfig") -> Union[str, Callable]:
         """
         Initialize the backend for the compilation config from a vllm config.
@@ -571,7 +577,10 @@ class CompilationConfig:
             The backend for the compilation config.
         """
         if self.level is None:
-            raise ValueError("No compilation level is set. This method should only be called via vllm config where the level is set if none is provided.")
+            raise ValueError(
+                "No compilation level is set. This method should only be \
+                called via vllm config where the level is set if none is \
+                provided.")
         if self.level == CompilationLevel.NO_COMPILATION:
             raise ValueError("No compilation level is set.")
 
@@ -590,8 +599,10 @@ class CompilationConfig:
             elif self.backend in ["eager", "inductor"]:
                 vllm_config.compilation_config.backend = self.backend
             else:
-                raise ValueError(f"Invalid backend for piecewise compilation: {self.backend}")
-       
+                raise ValueError(
+                    f"Invalid backend for piecewise compilation: {self.backend}"
+                )
+
         assert self.level == CompilationLevel.PIECEWISE
 
         from vllm.compilation.backends import VllmBackend

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -197,8 +197,8 @@ class CompilationConfig:
     distributed setting. When the compilation level is 1 or 2, the backend is
     used for the compilation directly (it sees the whole graph). When the
     compilation level is 3, the backend is used for the piecewise compilation
-    (it sees a part of the graph). The backend can not be custor for compilation
-    level 3. Furthermore, compiliation is only piecewise if splitting ops is set
+    (it sees a part of the graph). The backend can not be custom for compilation
+    level 3. Furthermore, compilation is only piecewise if splitting ops is set
     accordingly and use_inductor_cudagraphs_partition is off. Note that the
     default options for splitting ops are sufficient for piecewise compilation.
     """

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -15,6 +15,7 @@ from pydantic.dataclasses import dataclass
 from vllm.compilation.inductor_pass import CallableInductorPass, InductorPass
 from vllm.config.utils import config
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.utils import is_torch_equal_or_newer, resolve_obj_by_qualname
 
 if TYPE_CHECKING:
@@ -184,7 +185,7 @@ class CompilationConfig:
     """The directory to store the compiled graph, to accelerate Inductor
     compilation. By default, it will use model-related information to generate
     a cache directory."""
-    backend: str = "inductor"
+    backend: str = ""
     """The backend for compilation. It needs to be a string:
 
     - "" (empty string): use the default backend ("inductor" on CUDA-alike
@@ -579,7 +580,7 @@ class CompilationConfig:
             self.backend = "inductor" if self.use_inductor else "eager"
 
         if self.backend == "":
-            self.backend = "inductor"
+            self.backend = current_platform.simple_compile_backend
 
     def init_backend(self, vllm_config: "VllmConfig") -> str | Callable:
         """

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -187,7 +187,7 @@ class CompilationConfig:
     backend: str = "inductor"
     """The backend for compilation. It needs to be a string:
 
-    - "" (empty string): use the default backend.
+    - "" (empty string): use the default backend ("inductor" on CUDA-alike platforms).
     - "eager"/"openxla"/...: use the specified backend registered in PyTorch.
     - "full.module.name": a qualified name which can be used to import the
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -199,9 +199,10 @@ class CompilationConfig:
     used for the compilation directly (it sees the whole graph). When the
     compilation level is 3, the backend is used for the piecewise compilation
     (it sees a part of the graph). The backend can not be custom for compilation
-    level 3. Furthermore, compilation is only piecewise if splitting ops is set
-    accordingly and use_inductor_cudagraphs_partition is off. Note that the
-    default options for splitting ops are sufficient for piecewise compilation.
+    level 3, i.e. the backend must be either eager or inductor. Furthermore,
+    compilation is only piecewise if splitting ops is set accordingly and
+    use_inductor_cudagraphs_partition is off. Note that the default options for
+    splitting ops are sufficient for piecewise compilation.
     """
     custom_ops: list[str] = field(default_factory=list)
     """Fine-grained control over which custom ops to enable/disable. Use 'all'
@@ -239,8 +240,7 @@ class CompilationConfig:
     """
     Whether to use inductor compilation.
 
-    This flag is deprecated and will be removed in the next release
-    either 0.12.0 or 0.11.2, whichever is first.
+    This flag is deprecated and will be removed in the next release 0.12.0.
     Please use the 'backend' option instead.
 
     - False: inductor compilation is not used. graph runs in eager
@@ -761,8 +761,9 @@ class CompilationConfig:
             return self.level == CompilationLevel.PIECEWISE
 
         # Inductor partition case
-        return (self.backend == "inductor" and 
-                self.level > CompilationLevel.NO_COMPILATION)
+        return (
+            self.backend == "inductor" and self.level > CompilationLevel.NO_COMPILATION
+        )
 
     def custom_op_log_check(self):
         """

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -197,7 +197,7 @@ class CompilationConfig:
     used for the compilation directly (it sees the whole graph). When the
     compilation level is 3, the backend is used for the piecewise compilation
     (it sees a part of the graph)."""
-    custom_ops: list[str] = field(default_factory=list)
+    custom_ops: list[str] = ['all']
     """Fine-grained control over which custom ops to enable/disable. Use 'all'
     to enable all, 'none' to disable all. Also specify a list of custom op
     names to enable (prefixed with a '+'), or disable (prefixed with a '-').

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -197,7 +197,7 @@ class CompilationConfig:
     used for the compilation directly (it sees the whole graph). When the
     compilation level is 3, the backend is used for the piecewise compilation
     (it sees a part of the graph)."""
-    custom_ops: list[str] = ['all']
+    custom_ops: list[str] = field(default_factory=lambda: ['all'])
     """Fine-grained control over which custom ops to enable/disable. Use 'all'
     to enable all, 'none' to disable all. Also specify a list of custom op
     names to enable (prefixed with a '+'), or disable (prefixed with a '-').
@@ -467,6 +467,9 @@ class CompilationConfig:
         count_none = self.custom_ops.count("none")
         count_all = self.custom_ops.count("all")
         assert count_none + count_all <= 1, "Can only specify 'none' or 'all'"
+
+        if len(self.custom_ops) == 0:
+            self.custom_ops = ['all']
 
         # TODO(zou3519/luka): There are 2 issues with auto-functionalization V2:
         # 1. A bug in PyTorch, fixed in 2.7:

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -574,8 +574,8 @@ class CompilationConfig:
 
         if self.use_inductor is not None:
             logger.warning_once(
-                "The 'use_inductor' flag is deprecated and will be\
-                    removed in a future release."
+                "The 'use_inductor' flag is deprecated and will be "
+                "removed in the next release (v0.12.0). "
                 "Please use the 'backend' option instead.",
             )
             self.backend = "inductor" if self.use_inductor else "eager"

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -464,7 +464,7 @@ class CompilationConfig:
             return CUDAGraphMode[value.upper()]
         return value
 
-    def __post_init__(self, **kwargs) -> None:
+    def __post_init__(self) -> None:
         count_none = self.custom_ops.count("none")
         count_all = self.custom_ops.count("all")
         assert count_none + count_all <= 1, "Can only specify 'none' or 'all'"

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -761,10 +761,8 @@ class CompilationConfig:
             return self.level == CompilationLevel.PIECEWISE
 
         # Inductor partition case
-        if self.backend == "inductor":
-            return self.level > CompilationLevel.NO_COMPILATION
-
-        return False
+        return (self.backend == "inductor" and 
+                self.level > CompilationLevel.NO_COMPILATION)
 
     def custom_op_log_check(self):
         """

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -562,16 +562,20 @@ class CompilationConfig:
         # for piecewise compilation. Custom backends are not suppported for
         # piecewise compilation. Update when more backends are supported.
         if self.level == CompilationLevel.PIECEWISE and self.backend not in [
-                "", "eager", "inductor"
+            "",
+            "eager",
+            "inductor",
         ]:
             raise ValueError(
-                f"Invalid backend for piecewise compilation: {self.backend}")
+                f"Invalid backend for piecewise compilation: {self.backend}"
+            )
 
         if self.use_inductor is not None:
             logger.warning_once(
                 "The 'use_inductor' flag is deprecated and will be\
                     removed in a future release."
-                "Please use the 'backend' option instead.", )
+                "Please use the 'backend' option instead.",
+            )
             self.backend = "inductor" if self.use_inductor else "eager"
 
         if self.backend == "":
@@ -589,16 +593,15 @@ class CompilationConfig:
             raise ValueError(
                 "No compilation level is set. This method should only be \
                 called via vllm config where the level is set if none is \
-                provided.")
+                provided."
+            )
         if self.level == CompilationLevel.NO_COMPILATION:
             raise ValueError("No compilation level is set.")
 
         from torch._dynamo.backends.registry import list_backends
 
         torch_backends = list_backends(exclude_tags=tuple())
-        if self.level in [
-                CompilationLevel.DYNAMO_AS_IS, CompilationLevel.DYNAMO_ONCE
-        ]:
+        if self.level in [CompilationLevel.DYNAMO_AS_IS, CompilationLevel.DYNAMO_ONCE]:
             if self.backend in torch_backends:
                 return self.backend
             return resolve_obj_by_qualname(self.backend)
@@ -606,7 +609,8 @@ class CompilationConfig:
         assert self.level == CompilationLevel.PIECEWISE
         if self.backend not in ["eager", "inductor"]:
             raise ValueError(
-                f"Invalid backend for piecewise compilation: {self.backend}")
+                f"Invalid backend for piecewise compilation: {self.backend}"
+            )
 
         from vllm.compilation.backends import VllmBackend
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -239,7 +239,8 @@ class CompilationConfig:
     """
     Whether to use inductor compilation.
 
-    This flag is deprecated and will be removed.
+    This flag is deprecated and will be removed in the next release
+    either 0.12.0 or 0.11.2, whichever is first.
     Please use the 'backend' option instead.
 
     - False: inductor compilation is not used. graph runs in eager

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -7,8 +7,8 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import asdict, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
-
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
+from warnings import warn
 from pydantic import TypeAdapter, field_validator
 from pydantic.dataclasses import dataclass
 
@@ -460,7 +460,7 @@ class CompilationConfig:
             return CUDAGraphMode[value.upper()]
         return value
 
-    def __post_init__(self) -> None:
+    def __post_init__(self, **kwargs) -> None:
         count_none = self.custom_ops.count("none")
         count_all = self.custom_ops.count("all")
         assert count_none + count_all <= 1, "Can only specify 'none' or 'all'"
@@ -545,7 +545,12 @@ class CompilationConfig:
                     "(where 'op' is the registered op name)"
                 )
 
-    def init_backend(self, vllm_config: "VllmConfig") -> str | Callable:
+        logger.warning_once(
+            "The 'use_inductor' flag is deprecated and will be removed in a future release. "
+            "Please use the 'backend' option instead.",
+        )
+            
+    def init_backend(self, vllm_config: "VllmConfig") -> Union[str, Callable]:
         if self.level == CompilationLevel.NO_COMPILATION:
             raise ValueError("No compilation level is set.")
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -323,7 +323,8 @@ class VllmConfig:
                 # in V0 means the compilation level wins out.
                 self.compilation_config.level = CompilationLevel.NO_COMPILATION
         else:
-            assert self.compilation_config.level >= 0
+            assert self.compilation_config.level >= CompilationLevel.NO_COMPILATION
+            assert self.compilation_config.level <= CompilationLevel.PIECEWISE
             assert self.compilation_config.level <= 3
 
         # If user does not set custom ops via none or all set it here based on

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -334,7 +334,7 @@ class VllmConfig:
             == 0
         ):
             if (
-                self.compilation_config.backend != "eager"
+                self.compilation_config.backend == "inductor"
                 and self.compilation_config.level > CompilationLevel.NO_COMPILATION
             ):
                 self.compilation_config.custom_ops.append("none")

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -323,6 +323,16 @@ class VllmConfig:
                 # in V0 means the compilation level wins out.
                 self.compilation_config.level = CompilationLevel.NO_COMPILATION
 
+        # If user does not set custom ops via none or all set it here based on
+        # compilation level and backend.
+        if self.compilation_config.custom_ops.count(
+                "none") + self.compilation_config.custom_ops.count("all") == 0:
+            if self.compilation_config.level > 0 \
+                and self.compilation_config.backend != "eager":
+                self.compilation_config.custom_ops.insert(0, "none")
+            else:
+                self.compilation_config.custom_ops.insert(0, "all")
+
         # async tp is built on top of sequence parallelism
         # and requires it to be enabled.
         if self.compilation_config.pass_config.enable_async_tp:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -325,7 +325,6 @@ class VllmConfig:
         else:
             assert self.compilation_config.level >= CompilationLevel.NO_COMPILATION
             assert self.compilation_config.level <= CompilationLevel.PIECEWISE
-            assert self.compilation_config.level <= 3
 
         # If user does not set custom ops via none or all set it here based on
         # compilation level and backend.
@@ -334,7 +333,10 @@ class VllmConfig:
             + self.compilation_config.custom_ops.count("all")
             == 0
         ):
-            if self.compilation_config.backend == "inductor":
+            if (
+                self.compilation_config.backend != "eager"
+                and self.compilation_config.level > CompilationLevel.NO_COMPILATION
+            ):
                 self.compilation_config.custom_ops.append("none")
             else:
                 self.compilation_config.custom_ops.append("all")

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -328,11 +328,7 @@ class VllmConfig:
 
         # If user does not set custom ops via none or all set it here based on
         # compilation level and backend.
-        if (
-            self.compilation_config.custom_ops.count("none")
-            + self.compilation_config.custom_ops.count("all")
-            == 0
-        ):
+        if none(s in self.compilation_config.custom_ops for s in ("all", "none")):
             if (
                 self.compilation_config.backend == "inductor"
                 and self.compilation_config.level > CompilationLevel.NO_COMPILATION

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -328,7 +328,7 @@ class VllmConfig:
 
         # If user does not set custom ops via none or all set it here based on
         # compilation level and backend.
-        if none(s in self.compilation_config.custom_ops for s in ("all", "none")):
+        if all(s not in self.compilation_config.custom_ops for s in ("all", "none")):
             if (
                 self.compilation_config.backend == "inductor"
                 and self.compilation_config.level > CompilationLevel.NO_COMPILATION

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -334,10 +334,7 @@ class VllmConfig:
             + self.compilation_config.custom_ops.count("all")
             == 0
         ):
-            if (
-                self.compilation_config.level > 0
-                and self.compilation_config.backend != "eager"
-            ):
+            if self.compilation_config.backend == "inductor":
                 self.compilation_config.custom_ops.append("none")
             else:
                 self.compilation_config.custom_ops.append("all")

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -322,6 +322,9 @@ class VllmConfig:
                 # NB: Passing both --enforce-eager and a compilation level
                 # in V0 means the compilation level wins out.
                 self.compilation_config.level = CompilationLevel.NO_COMPILATION
+        else:
+            assert self.compilation_config.level >= 0
+            assert self.compilation_config.level <= 3
 
         # If user does not set custom ops via none or all set it here based on
         # compilation level and backend.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -329,13 +329,18 @@ class VllmConfig:
 
         # If user does not set custom ops via none or all set it here based on
         # compilation level and backend.
-        if self.compilation_config.custom_ops.count(
-                "none") + self.compilation_config.custom_ops.count("all") == 0:
-            if self.compilation_config.level > 0 \
-                and self.compilation_config.backend != "eager":
-                self.compilation_config.custom_ops.insert(0, "none")
+        if (
+            self.compilation_config.custom_ops.count("none")
+            + self.compilation_config.custom_ops.count("all")
+            == 0
+        ):
+            if (
+                self.compilation_config.level > 0
+                and self.compilation_config.backend != "eager"
+            ):
+                self.compilation_config.custom_ops.append("none")
             else:
-                self.compilation_config.custom_ops.insert(0, "all")
+                self.compilation_config.custom_ops.append("all")
 
         # async tp is built on top of sequence parallelism
         # and requires it to be enabled.

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -113,9 +113,9 @@ class CustomOp(nn.Module):
         custom_ops = compilation_config.custom_ops
         if not hasattr(cls, "name"):
             logger.warning_once(
-                "Custom op %s was not registered, which means it won't appear\
-                 in the op registry. It will be enabled/disabled based on the\
-                 global settings.",  # noqa: E501
+                "Custom op %s was not registered, which means it won't appear "
+                "in the op registry. It will be enabled/disabled based on the "
+                "global settings.",
                 cls.__name__,
             )
             return CustomOp.default_on()

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -129,10 +129,10 @@ class CustomOp(nn.Module):
     @staticmethod
     def default_on() -> bool:
         """
-       Behavior controlled by `CompilationConfig.custom_ops`: On by default if
-       'all', off by default if 'none'.
-       When PyTorch Inductor is used, 'none' is the default value,
-       otherwise 'all'.
+        Behavior controlled by `CompilationConfig.custom_ops`: On by default if
+        'all', off by default if 'none'.
+        When PyTorch Inductor is used, 'none' is the default value,
+        otherwise 'all'.
         """
         compilation_config = get_cached_compilation_config()
         count_none = compilation_config.custom_ops.count("none")

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -127,8 +127,8 @@ class CustomOp(nn.Module):
     @staticmethod
     def default_on() -> bool:
         """
-        On by default if PyTorch Inductor is not used.
-        Specifying 'all' or 'none' in custom_op takes precedence.
+       Behavior controlled by `CompilationConfig.custom_ops`: On by default if 'all', off by default if 'none'.
+       When PyTorch Inductor is used, 'none' is the default value, otherwise 'all'.
         """
         compilation_config = get_cached_compilation_config()
         count_none = compilation_config.custom_ops.count("none")

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -113,7 +113,9 @@ class CustomOp(nn.Module):
         custom_ops = compilation_config.custom_ops
         if not hasattr(cls, "name"):
             logger.warning_once(
-                "Custom op %s was not registered, which means it won't appear in the op registry. It will be enabled/disabled based on the global settings.",  # noqa: E501
+                "Custom op %s was not registered, which means it won't appear\
+                 in the op registry. It will be enabled/disabled based on the\
+                 global settings.",  # noqa: E501
                 cls.__name__,
             )
             return CustomOp.default_on()
@@ -127,12 +129,15 @@ class CustomOp(nn.Module):
     @staticmethod
     def default_on() -> bool:
         """
-       Behavior controlled by `CompilationConfig.custom_ops`: On by default if 'all', off by default if 'none'.
-       When PyTorch Inductor is used, 'none' is the default value, otherwise 'all'.
+       Behavior controlled by `CompilationConfig.custom_ops`: On by default if
+       'all', off by default if 'none'.
+       When PyTorch Inductor is used, 'none' is the default value,
+       otherwise 'all'.
         """
         compilation_config = get_cached_compilation_config()
         count_none = compilation_config.custom_ops.count("none")
         count_all = compilation_config.custom_ops.count("all")
+        assert count_none + count_all == 1
 
         return not count_none > 0 or count_all > 0
 

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -135,7 +135,7 @@ class CustomOp(nn.Module):
         compilation_config = get_cached_compilation_config()
         default_on = (
             compilation_config.level < CompilationLevel.PIECEWISE
-            or not compilation_config.use_inductor
+            or not compilation_config.backend == "inductor"
         )
         count_none = compilation_config.custom_ops.count("none")
         count_all = compilation_config.custom_ops.count("all")

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -130,16 +130,11 @@ class CustomOp(nn.Module):
         On by default if PyTorch Inductor is not used.
         Specifying 'all' or 'none' in custom_op takes precedence.
         """
-        from vllm.config import CompilationLevel
-
         compilation_config = get_cached_compilation_config()
-        default_on = (
-            compilation_config.level < CompilationLevel.PIECEWISE
-            or not compilation_config.backend == "inductor"
-        )
         count_none = compilation_config.custom_ops.count("none")
         count_all = compilation_config.custom_ops.count("all")
-        return default_on and not count_none > 0 or count_all > 0
+
+        return not count_none > 0 or count_all > 0
 
     # Dictionary of all custom ops (classes, indexed by registered name).
     # To check if an op with a name is enabled, call .enabled() on the class.

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -267,16 +267,16 @@ class CpuPlatform(Platform):
 
             compilation_config.level = CompilationLevel.DYNAMO_ONCE
             compilation_config.backend = backend
-            compilation_config.inductor_compile_config.update(
-                {
-                    "dce": True,
-                    "size_asserts": False,
-                    "nan_asserts": False,
-                    "epilogue_fusion": True,
-                }
-            )
-            if compilation_config.use_inductor:
-                compilation_config.custom_ops = ["none"]
+            compilation_config.inductor_compile_config.update({
+                "dce":
+                True,
+                "size_asserts":
+                False,
+                "nan_asserts":
+                False,
+                "epilogue_fusion":
+                True,
+            })
 
         if vllm_config.lora_config is not None:
             compilation_config.level = CompilationLevel.NO_COMPILATION

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -267,16 +267,14 @@ class CpuPlatform(Platform):
 
             compilation_config.level = CompilationLevel.DYNAMO_ONCE
             compilation_config.backend = backend
-            compilation_config.inductor_compile_config.update({
-                "dce":
-                True,
-                "size_asserts":
-                False,
-                "nan_asserts":
-                False,
-                "epilogue_fusion":
-                True,
-            })
+            compilation_config.inductor_compile_config.update(
+                {
+                    "dce": True,
+                    "size_asserts": False,
+                    "nan_asserts": False,
+                    "epilogue_fusion": True,
+                }
+            )
 
         if vllm_config.lora_config is not None:
             compilation_config.level = CompilationLevel.NO_COMPILATION


### PR DESCRIPTION
Original PR: #26113
Revert of original PR: #26472

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

