### PR TITLE
CP: make correct_attn_out robust to 4‑D views and fix Triton arg binding

### DIFF
--- a/vllm/attention/ops/common.py
+++ b/vllm/attention/ops/common.py
@@ -117,14 +117,52 @@ def correct_attn_out(
     if ctx is None:
         ctx = CPTritonContext()
 
-    lse = torch.empty_like(lses[0])
+    # --- Normalize to 3D views ---
+    if out.ndim == 4 and out.shape[1] == 1:
+        out = out.squeeze(1)
+    assert out.ndim == 3, f"expected out [B,H,D] or [B,1,H,D], got {tuple(out.shape)}"
 
-    grid = (out.shape[0], out.shape[1], 1)
-    regular_args = (out, out, lses, lse, *out.stride(), *lses.stride(), cp_rank)
-    const_args = {
-        "HEAD_DIM": out.shape[-1],
-        "N_ROUNDED": lses.shape[0],
-    }
+    if lses.ndim == 4 and lses.shape[-1] == 1:
+        lses = lses.squeeze(-1)
+    if lses.ndim == 4 and lses.shape[1] == 1:
+        lses = lses.squeeze(1)
+    assert lses.ndim == 3, (
+        f"expected lses [N,B,H] (optionally with a 1-sized extra dim), "
+        f"got {tuple(lses.shape)}"
+    )
+
+    B, H, D = out.shape
+    N = lses.shape[0]
+
+    # Strides after we normalized shapes to 3-D views.  The kernel computes
+    # offsets for `vlse_ptr` using lses_stride_B/H, so the output buffer must
+    # have the same B/H stride layout as a slice of `lses`.
+    o_sB, o_sH, o_sD = out.stride()
+    l_sN, l_sB, l_sH = lses.stride()
+
+    # Allocate LSE with the same B/H strides as `lses` so writes land correctly
+    # even when `lses` is a non-contiguous view (e.g., 4-D to 3-D squeeze).
+    lse = torch.empty_strided(
+        (B, H), (l_sB, l_sH), device=lses.device, dtype=lses.dtype
+    )
+
+    # Kernel launch config
+    grid = (B, H, 1)
+
+    regular_args = (
+        out,
+        out,
+        lses,
+        lse,
+        o_sB,
+        o_sH,
+        o_sD,
+        l_sN,
+        l_sB,
+        l_sH,
+        cp_rank,
+    )
+    const_args = {"HEAD_DIM": D, "N_ROUNDED": N}
 
     ctx.call_kernel(_correct_attn_cp_out_kernel, grid, *regular_args, **const_args)
     return out, lse


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The issue is found from @simon-mo where we want to bring up H100 resources for CI https://github.com/vllm-project/vllm/pull/26396 , and there is a failure https://buildkite.com/vllm/ci/builds/33954/steps/canvas?sid=0199c256-fc49-4e2d-afd6-c54961f0ffb0 with the error msg

```
(Worker_TP0 pid=3232) ERROR 10-07 22:59:10 [multiproc_executor.py:706] TypeError: dynamic_func() got multiple values for argument 'HEAD_DIM'
```
After some investigation on both H100 and B200, I find this error is only showing up on H100 where `out` and `lses` can arrive as 4‑D views:
* out.stride() = (8192, 8192, 512, 1) ⇒ shape like [B, 1, H, D]
* lses.stride() = (128, 16, 1, 1) ⇒ shape like [N, B, H, 1]

so the original impl unpacks `*out.stride()` and `*lses.stride()` blindly, which in this case yields 4 + 4 stride values instead of the 3 + 3 the kernel signature expects. Triton then binds one of those “extra” stride values positionally into the `HEAD_DIM` slot, and we also pass `HEAD_DIM` via `**const_args`, hence:
```
TypeError: dynamic_func() got multiple values for argument 'HEAD_DIM'
```

## Test Plan
```
pytest tests/distributed/test_context_parallel.py
export VLLM_ATTENTION_BACKEND=TRITON_MLA pytest tests/distributed/test_context_parallel.py
```
on both H100 and B200

## Test Result
all 4 tests passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

