### PR TITLE
[Chore]: Stream tokens vs characters in tool call parser tests

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/conftest.py
+++ b/tests/entrypoints/openai/tool_parsers/conftest.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from transformers import AutoTokenizer
+
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+
+
+@pytest.fixture(scope="function")
+def default_tokenizer() -> AnyTokenizer:
+    return AutoTokenizer.from_pretrained("gpt2")

--- a/tests/entrypoints/openai/tool_parsers/test_llama3_json_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_llama3_json_tool_parser.py
@@ -2,17 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from transformers import AutoTokenizer
 
 from vllm.entrypoints.openai.protocol import ExtractedToolCallInformation
 from vllm.entrypoints.openai.tool_parsers.llama_tool_parser import Llama3JsonToolParser
+from vllm.transformers_utils.tokenizer import AnyTokenizer
 
 
 @pytest.fixture
-def parser():
-    # Use a small tokenizer for testing
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
-    return Llama3JsonToolParser(tokenizer)
+def parser(default_tokenizer: AnyTokenizer):
+    return Llama3JsonToolParser(default_tokenizer)
 
 
 def test_extract_tool_calls_simple(parser):

--- a/tests/entrypoints/openai/tool_parsers/test_llama4_pythonic_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_llama4_pythonic_tool_parser.py
@@ -11,6 +11,7 @@ from tests.entrypoints.openai.tool_parsers.utils import (
 )
 from vllm.entrypoints.openai.protocol import FunctionCall
 from vllm.entrypoints.openai.tool_parsers import ToolParser, ToolParserManager
+from vllm.transformers_utils.tokenizer import AnyTokenizer
 
 # Test cases similar to pythonic parser but with Llama4 specific format
 SIMPLE_FUNCTION_OUTPUT = "[get_weather(city='LA', metric='C')]"
@@ -63,10 +64,9 @@ PYTHON_TAG_FUNCTION_OUTPUT = (
 
 
 @pytest.mark.parametrize("streaming", [True, False])
-def test_no_tool_call(streaming: bool):
-    mock_tokenizer = MagicMock()
+def test_no_tool_call(streaming: bool, default_tokenizer: AnyTokenizer):
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("llama4_pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
     model_output = "How can I help you today?"
 
@@ -205,11 +205,13 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("streaming, model_output, expected_tool_calls", TEST_CASES)
 def test_tool_call(
-    streaming: bool, model_output: str, expected_tool_calls: list[FunctionCall]
+    streaming: bool,
+    model_output: str,
+    expected_tool_calls: list[FunctionCall],
+    default_tokenizer: AnyTokenizer,
 ):
-    mock_tokenizer = MagicMock()
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("llama4_pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
 
     content, tool_calls = run_tool_extraction(
@@ -222,10 +224,9 @@ def test_tool_call(
         assert actual.function == expected
 
 
-def test_streaming_tool_call_with_large_steps():
-    mock_tokenizer = MagicMock()
+def test_streaming_tool_call_with_large_steps(default_tokenizer: AnyTokenizer):
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("llama4_pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
     model_output_deltas = [
         "<|python_start|>[get_weather(city='LA', metric='C'), "
@@ -245,11 +246,10 @@ def test_streaming_tool_call_with_large_steps():
 
 
 @pytest.mark.parametrize("streaming", [False])
-def test_regex_timeout_handling(streaming: bool):
+def test_regex_timeout_handling(streaming: bool, default_tokenizer: AnyTokenizer):
     """test regex timeout is handled gracefully"""
-    mock_tokenizer = MagicMock()
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("llama4_pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
 
     fake_problematic_input = "hello world[A(A=" + "\t)A(A=,\t" * 2

--- a/tests/entrypoints/openai/tool_parsers/test_olmo3_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_olmo3_tool_parser.py
@@ -11,6 +11,7 @@ from tests.entrypoints.openai.tool_parsers.utils import (
 )
 from vllm.entrypoints.openai.protocol import FunctionCall
 from vllm.entrypoints.openai.tool_parsers import ToolParser, ToolParserManager
+from vllm.transformers_utils.tokenizer import AnyTokenizer
 
 # https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/text_prompt_format.md#model-response-format-1
 SIMPLE_FUNCTION_OUTPUT = "get_weather(city='San Francisco', metric='celsius')"
@@ -68,9 +69,10 @@ ESCAPED_STRING_FUNCTION_CALL = FunctionCall(
 
 
 @pytest.mark.parametrize("streaming", [True, False])
-def test_no_tool_call(streaming: bool):
-    mock_tokenizer = MagicMock()
-    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(mock_tokenizer)
+def test_no_tool_call(streaming: bool, default_tokenizer: AnyTokenizer):
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(
+        default_tokenizer
+    )
     model_output = "How can I help you today?"
 
     content, tool_calls = run_tool_extraction(
@@ -183,10 +185,14 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("streaming, model_output, expected_tool_calls", TEST_CASES)
 def test_tool_call(
-    streaming: bool, model_output: str, expected_tool_calls: list[FunctionCall]
+    streaming: bool,
+    model_output: str,
+    expected_tool_calls: list[FunctionCall],
+    default_tokenizer: AnyTokenizer,
 ):
-    mock_tokenizer = MagicMock()
-    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(mock_tokenizer)
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(
+        default_tokenizer
+    )
 
     content, tool_calls = run_tool_extraction(
         tool_parser, model_output, streaming=streaming
@@ -199,9 +205,10 @@ def test_tool_call(
         assert actual.function == expected
 
 
-def test_streaming_tool_call_with_large_steps():
-    mock_tokenizer = MagicMock()
-    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(mock_tokenizer)
+def test_streaming_tool_call_with_large_steps(default_tokenizer: AnyTokenizer):
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(
+        default_tokenizer
+    )
     model_output_deltas = [
         "<function_calls>get_weather(city='San",
         " Francisco', metric='celsius')\n"
@@ -221,10 +228,11 @@ def test_streaming_tool_call_with_large_steps():
 
 
 @pytest.mark.parametrize("streaming", [False])
-def test_regex_timeout_handling(streaming: bool):
+def test_regex_timeout_handling(streaming: bool, default_tokenizer: AnyTokenizer):
     """test regex timeout is handled gracefully"""
-    mock_tokenizer = MagicMock()
-    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(mock_tokenizer)
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("olmo3")(
+        default_tokenizer
+    )
 
     fake_problematic_input = "hello world[A(A=" + "\t)A(A=,\t" * 2
 

--- a/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
@@ -11,6 +11,7 @@ from tests.entrypoints.openai.tool_parsers.utils import (
 )
 from vllm.entrypoints.openai.protocol import FunctionCall
 from vllm.entrypoints.openai.tool_parsers import ToolParser, ToolParserManager
+from vllm.transformers_utils.tokenizer import AnyTokenizer
 
 # https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/text_prompt_format.md#model-response-format-1
 SIMPLE_FUNCTION_OUTPUT = "get_weather(city='San Francisco', metric='celsius')"
@@ -60,10 +61,9 @@ ESCAPED_STRING_FUNCTION_CALL = FunctionCall(
 
 
 @pytest.mark.parametrize("streaming", [True, False])
-def test_no_tool_call(streaming: bool):
-    mock_tokenizer = MagicMock()
+def test_no_tool_call(streaming: bool, default_tokenizer: AnyTokenizer):
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
     model_output = "How can I help you today?"
 
@@ -165,11 +165,13 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("streaming, model_output, expected_tool_calls", TEST_CASES)
 def test_tool_call(
-    streaming: bool, model_output: str, expected_tool_calls: list[FunctionCall]
+    streaming: bool,
+    model_output: str,
+    expected_tool_calls: list[FunctionCall],
+    default_tokenizer: AnyTokenizer,
 ):
-    mock_tokenizer = MagicMock()
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
 
     content, tool_calls = run_tool_extraction(
@@ -183,10 +185,9 @@ def test_tool_call(
         assert actual.function == expected
 
 
-def test_streaming_tool_call_with_large_steps():
-    mock_tokenizer = MagicMock()
+def test_streaming_tool_call_with_large_steps(default_tokenizer: AnyTokenizer):
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
     model_output_deltas = [
         "[get_weather(city='San",
@@ -207,11 +208,10 @@ def test_streaming_tool_call_with_large_steps():
 
 
 @pytest.mark.parametrize("streaming", [False])
-def test_regex_timeout_handling(streaming: bool):
+def test_regex_timeout_handling(streaming: bool, default_tokenizer: AnyTokenizer):
     """test regex timeout is handled gracefully"""
-    mock_tokenizer = MagicMock()
     tool_parser: ToolParser = ToolParserManager.get_tool_parser("pythonic")(
-        mock_tokenizer
+        default_tokenizer
     )
 
     fake_problematic_input = "hello world[A(A=" + "\t)A(A=,\t" * 2


### PR DESCRIPTION
## Purpose

In the `run_tool_extraction_streaming` test function that helps us test streaming tool call scenarios, we were streaming individual characters at a time into the extract_tool_calls_streaming methods of tool call parsers when the `model_deltas` passed in was just a string. This is incorrect, as we should be streaming at least 1 token in with every request instead of individual characters.

This is laying the groundwork for a future PR where I'm adding tests to all the tool call parsers that do not have any tests. But, since this requires tweaking a couple of the existing parser tests to pass in real tokenizers instead of a simple mock, I broke this out into its own PR so that the one that adds more tool call tests can be a purely additive change.

This is marked as a chore because it's just making our streaming tests more true to what really happens, and is required before I can add working tests for some of the untested parsers today.

## Test Plan

```
pytest tests/entrypoints/openai/tool_parsers/
```

## Test Result

All tests passed (or xfailed) before and after this change, with no change in number passing or xfailing.
