### PR TITLE
[Chore]: One pythonic tool parser test uses the wrong parser

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
@@ -210,7 +210,7 @@ def test_streaming_tool_call_with_large_steps():
 def test_regex_timeout_handling(streaming: bool):
     """test regex timeout is handled gracefully"""
     mock_tokenizer = MagicMock()
-    tool_parser: ToolParser = ToolParserManager.get_tool_parser("llama4_pythonic")(
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("pythonic")(
         mock_tokenizer
     )
 


### PR DESCRIPTION
## Purpose

This fixes an issue pointed out by Gemini on a separate PR, where the `test_pythonic_tool_parser.py` was accidentally testing against the `llama4_pythonic` parser instead of the `pythonic` parser in one of its tests.

## Test Plan

```
pytest tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
```

## Test Result

The test passed before and after this change, but now it's testing the right tool call parser.

