### PR TITLE
[MM][BugFix] Fix checking condition on `SupportsMRoPE `

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -858,7 +858,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if mm_input.get("use_audio_in_video") is True:
                 use_audio_in_video = True
 
-        if supports_mrope(self.model):
+        if supports_mrope(self.get_model()):
             req_state.mrope_positions, req_state.mrope_position_delta = (
                 self.model.get_mrope_input_positions(
                     req_state.prompt_token_ids,


### PR DESCRIPTION
A previous PR added an `SupportsMRoPE` interface (https://github.com/vllm-project/vllm/pull/24194), but it seems not valid as `self.model` would be wrapped by cuda graph. Then all models would fall to the else condition even if the model has its own `get_mrope_input_positions`. 

This PR uses `self.get_model()` to correctly checked the raw (unwrapped) model.

cc: @ywang96 @DarkLight1337 @Isotr0py @AzizCode92 @divyanshsinghvi (related to https://github.com/vllm-project/vllm/pull/24172)

Related issue: https://github.com/vllm-project/vllm/issues/24165

### Reproduction script
Add logging before  https://github.com/vllm-project/vllm/blob/a462331e367191d61414878072dcee8f23bb9214/vllm/v1/worker/gpu_model_runner.py#L869-L880 
```
python examples/offline_inference/vision_language.py -m qwen2_vl --num-prompts 1



(EngineCore_DP0 pid=1421211) INFO 10-09 20:19:48 [gpu_model_runner.py:861] self.model: <vllm.compilation.cuda_graph.CUDAGraphWrapper object at 0x7f27ad63c8c0>
(EngineCore_DP0 pid=1421211) INFO 10-09 20:19:48 [gpu_model_runner.py:862] supports_mrope(self.model): False
(EngineCore_DP0 pid=1421211) INFO 10-09 20:19:48 [gpu_model_runner.py:863] self.get_model(): Qwen2VLForConditionalGeneration(
(EngineCore_DP0 pid=1421211) INFO 10-09 20:19:48 [gpu_model_runner.py:863]   (visual): Qwen2VisionTransformer(
...
(EngineCore_DP0 pid=1421211) INFO 10-09 20:19:48 [gpu_model_runner.py:863] )
(EngineCore_DP0 pid=1421211) INFO 10-09 20:19:48 [gpu_model_runner.py:864] supports_mrope(self.get_model()): True
```