### PR TITLE
[Bugfix] Convert untraceable GroupShape to list for AMD impl

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -360,7 +360,7 @@ class W8A8BlockFp8LinearOp:
             weight,
             input_scale,
             weight_scale,
-            self.weight_group_shape,
+            list(self.weight_group_shape),
             input_2d.dtype,
         )
 
@@ -377,7 +377,7 @@ class W8A8BlockFp8LinearOp:
             weight,
             input_scale,
             weight_scale,
-            self.weight_group_shape,
+            list(self.weight_group_shape),
             input_2d.dtype,
         )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
https://github.com/vllm-project/vllm/pull/25696 converts GroupShape to list where possible for cutlass custom ops; however, this was not done for the aiter or triton impl, which causes the code to fail in dynamo tracing

## Test Plan
Run DeepseekR1-0528 on AMD hardware with FP8 kernels
```
 FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE VLLM_USE_V1=1 VLLM_MLA_DISABLE=0 VLLM_FP8_PADDING=1 VLLM_USE_TRITON_FLASH_ATTN=1 VLLM_USE_ROCM_FP8_FLASH_ATTN=0 HSA_NO_SCRATCH_RECLAIM=1 
VLLM_USE_STANDALONE_COMPILE=1 with-proxy python examples/offline_inference/basic/generate.py --model=deepseek-ai/DeepSeek-R1-0528 --max-model-len=1024 -tp=8
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

