### PR TITLE
Fix error in find_library when ldconfig returns garbage or non decodeable characters

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -1105,7 +1105,9 @@ def find_library(lib_name: str) -> str:
     # According to https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
     # `/sbin/ldconfig` should exist in all Linux systems.
     # `/sbin/ldconfig` searches the library in the system
-    libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode()
+    # errors="ignore" as is not guaranteed that there isn't going to be invalid
+    # byte sequences in the default encoding.
+    libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode(errors="ignore")
     # each line looks like the following:
     # libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1
     locs = [line.split()[-1] for line in libs.splitlines() if lib_name in line]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

With old versions of nvidia-container-toolkit there's a bug where ldconfig returns some garbage resulting in a crash during find_library. This happens for example in ubuntu 18 or Amazon Linux 2 as ldconfig in the container is somehow affected and there's garbage on the output for some library entries.

This fix prevents vllm from crashing when it can't decode the output of the ldconfig command with the default encoding.

See also https://github.com/triton-lang/triton/blob/09f1aa40fbd369d5c7497f85d07da300df50b9c3/third_party/nvidia/backend/driver.py#L26

## Test Plan

Added a unit test


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

