### PR TITLE
[Bugfix] Fix block size for prefix caching when DCP is enabled

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -178,6 +178,12 @@ class EngineCore:
             or self.scheduler.get_kv_connector() is not None
         ):
             block_size = vllm_config.cache_config.block_size
+            
+            # Use logical block size for hashing when DCP is enabled.
+            dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
+            if dcp_world_size > 1:
+                block_size *= dcp_world_size
+            
             caching_hash_fn = get_hash_fn_by_name(
                 vllm_config.cache_config.prefix_caching_hash_algo
             )


### PR DESCRIPTION
## Purpose
Without this fix, I get responses that have clearly (from manual observation) retrieved and used the wrong context tokens from the prefix cache. This is the command I was using for testing:

```sh
vllm serve RedHatAI/DeepSeek-R1-0528-quantized.w4a16 --tensor-parallel-size 4 -dcp 4 --max-model-len 9216 --enforce-eager
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

