### PR TITLE
[Qwen3 Attention]Update qwen3 models with new interface

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -199,7 +199,7 @@ class Qwen2Attention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k, v = torch.split_with_sizes_copy(qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -142,7 +142,7 @@ class Qwen3Attention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k, v = torch.split_with_sizes_copy(qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1)
         # Add qk-norm
         q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
         q_by_head = self.q_norm(q_by_head)

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -300,7 +300,7 @@ class Qwen3MoeAttention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k, v = torch.split_with_sizes_copy(qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1)
         # Add qk-norm
         q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
         q_by_head = self.q_norm(q_by_head)


### PR DESCRIPTION
Purpose

This PR improves the efficiency of the attention mechanism by replacing the qkv.split() function with torch.split_with_sizes_copy(qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1) in the forward method of the Attention class in the qwen3 moe.py file. The new method optimizes the splitting operation at the operator level, leading to potential performance improvements, especially on larger models or data.

Test Plan

Run existing unit tests and benchmarks to verify that the change does not introduce any regression.

Measure the performance (e.g., training time, inference time) before and after applying the change to confirm efficiency improvements.

Validate the correctness of the attention output by comparing it to the previous implementation on various test cases, ensuring the split behavior remains intact.

Test Result
The original interface calls the slice operator three times, with a total consumption time of 2.06 + 1.86 + 5.14. After the modification, the interface calls the splitv operator once, with a total consumption time of 2.16. This is the time taken for a single decode.

![alt](https://foruda.gitee.com/images/1760081128023076216/2d8e7fd9_13326179.jpeg "output.jpeg")
![alt](https://foruda.gitee.com/images/1760081527745102234/a24be468_13326179.jpeg "output2.jpeg")

Performance improvement: Test results show a reduction in the time required for the attention layer to process large inputs.

Correctness: All tests passed, and the attention layer's output remained consistent with the previous implementation across several scenarios.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

