### PR TITLE
[CPU] fix the issue when the node is '-' cause json decode error.

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -337,11 +337,7 @@ class CpuPlatform(Platform):
         lscpu_output = subprocess.check_output(
             "lscpu -J -e=CPU,CORE,NODE", shell=True, text=True
         )
-        lscpu_output = re.sub(
-            r'"node":\s*-\s*(,|\n)', 
-            r'"node": 0\1', 
-            lscpu_output
-        )  
+        lscpu_output = re.sub(r'"node":\s*-\s*(,|\n)', r'"node": 0\1', lscpu_output)
         logical_cpu_list: list[LogicalCPUInfo] = json.loads(
             lscpu_output, object_hook=LogicalCPUInfo.json_decoder
         )["cpus"]

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -4,9 +4,9 @@
 import json
 import os
 import platform
-import re
 import subprocess
 import sys
+import re
 from dataclasses import dataclass
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Optional
@@ -45,6 +45,8 @@ class LogicalCPUInfo:
 
     @classmethod
     def _int(cls, value: str) -> int:
+        if value == "-":
+            return -1  # Temporarily retain and convert later
         try:
             int_value = int(value)
         except Exception:
@@ -53,16 +55,21 @@ class LogicalCPUInfo:
 
     @staticmethod
     def json_decoder(obj_dict: dict):
-        id = obj_dict.get("cpu")
+        id_val = obj_dict.get("cpu")
         physical_core = obj_dict.get("core")
         numa_node = obj_dict.get("node")
 
-        if not (id is None or physical_core is None or numa_node is None):
+        if not (id_val is None or physical_core is None or numa_node is None):
+            cpu_id = LogicalCPUInfo._int(str(id_val))
+            phys_core = LogicalCPUInfo._int(str(physical_core))
+            # Special handling of NUMA: -1 is treated as 0 (single node)
+            node_val = LogicalCPUInfo._int(str(numa_node))
+            if node_val == -1:
+                node_val = 0
             return LogicalCPUInfo(
-                id=LogicalCPUInfo._int(id),
-                physical_core=LogicalCPUInfo._int(physical_core),
-                numa_node=LogicalCPUInfo._int(numa_node),
-            )
+                id=cpu_id,
+                physical_core=phys_core,
+                numa_node=node_val)
         else:
             return obj_dict
 
@@ -334,44 +341,44 @@ class CpuPlatform(Platform):
         assert platform.system() == "Linux"
 
         # Init LogicalCPUInfo from lscpu
-        lscpu_output = subprocess.check_output(
-            "lscpu -J -e=CPU,CORE,NODE", shell=True, text=True
-        )
-        lscpu_output = re.sub(
-            r'"node":\s*-\s*(,|\n)', 
-            r'"node": 0\1', 
-            lscpu_output
-        )  
-        logical_cpu_list: list[LogicalCPUInfo] = json.loads(
-            lscpu_output, object_hook=LogicalCPUInfo.json_decoder
-        )["cpus"]
+        lscpu_output = subprocess.check_output("lscpu -J -e=CPU,CORE,NODE",
+                                               shell=True,
+                                               text=True)
 
-        # Filter CPUs with invalid attributes
+        # Preprocessing: Replace invalid "node": - with "node": -1 (decoder will process it further)
+        lscpu_output = re.sub(r'"node":\s*-\s*(,|\n)', r'"node": -1\1', lscpu_output)
+
+        logical_cpu_list: list[LogicalCPUInfo] = json.loads(
+            lscpu_output, object_hook=LogicalCPUInfo.json_decoder)['cpus']
+
+        # Filter CPUs with invalid attributes (relax NUMA checking)
         logical_cpu_list = [
-            x
-            for x in logical_cpu_list
-            if -1 not in (x.id, x.physical_core, x.numa_node)
+            x for x in logical_cpu_list
+            if -1 not in (x.id, x.physical_core)  # ignore x.numa_node
         ]
 
         # Filter allowed CPUs
-        if hasattr(os, "sched_getaffinity"):
-            allowed_cpu_id_list = os.sched_getaffinity(0)
-        else:
-            raise NotImplementedError("Unsupported OS")
-        logical_cpu_list = [x for x in logical_cpu_list if x.id in allowed_cpu_id_list]
+        allowed_cpu_id_list = os.sched_getaffinity(0)
+        logical_cpu_list = [
+            x for x in logical_cpu_list if x.id in allowed_cpu_id_list
+        ]
 
         # Get allowed NUMA nodes
         allowed_numa_nodes = set()
         for x in logical_cpu_list:
-            allowed_numa_nodes.add(x.numa_node)  # type: ignore
+            allowed_numa_nodes.add(x.numa_node)  # now it will include 0
         allowed_numa_nodes_list = sorted(allowed_numa_nodes)
 
         env_key = CpuPlatform.device_control_env_var
-        if env_key in os.environ and os.environ[env_key] != "":
-            visible_nodes = [int(s) for s in os.environ[env_key].split(",")]
+        if (env_key in os.environ and os.environ[env_key] != ""):
+            visible_nodes = [int(s) for s in os.environ[env_key].split(',')]
             allowed_numa_nodes_list = [
-                x for x in visible_nodes if x in allowed_cpu_id_list
+                x for x in visible_nodes if x in allowed_numa_nodes
             ]
+
+        # Additional safety check: if still empty, fallback to [0]
+        if not allowed_numa_nodes_list:
+            allowed_numa_nodes_list = [0]
 
         return allowed_numa_nodes_list, logical_cpu_list
 

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -6,6 +6,7 @@ import os
 import platform
 import subprocess
 import sys
+import re
 from dataclasses import dataclass
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Optional
@@ -44,6 +45,8 @@ class LogicalCPUInfo:
 
     @classmethod
     def _int(cls, value: str) -> int:
+        if value == "-":
+            return -1  # Temporarily retain and convert later
         try:
             int_value = int(value)
         except Exception:
@@ -52,16 +55,21 @@ class LogicalCPUInfo:
 
     @staticmethod
     def json_decoder(obj_dict: dict):
-        id = obj_dict.get("cpu")
+        id_val = obj_dict.get("cpu")
         physical_core = obj_dict.get("core")
         numa_node = obj_dict.get("node")
 
-        if not (id is None or physical_core is None or numa_node is None):
+        if not (id_val is None or physical_core is None or numa_node is None):
+            cpu_id = LogicalCPUInfo._int(str(id_val))
+            phys_core = LogicalCPUInfo._int(str(physical_core))
+            # Special handling of NUMA: -1 is treated as 0 (single node)
+            node_val = LogicalCPUInfo._int(str(numa_node))
+            if node_val == -1:
+                node_val = 0
             return LogicalCPUInfo(
-                id=LogicalCPUInfo._int(id),
-                physical_core=LogicalCPUInfo._int(physical_core),
-                numa_node=LogicalCPUInfo._int(numa_node),
-            )
+                id=cpu_id,
+                physical_core=phys_core,
+                numa_node=node_val)
         else:
             return obj_dict
 
@@ -333,39 +341,44 @@ class CpuPlatform(Platform):
         assert platform.system() == "Linux"
 
         # Init LogicalCPUInfo from lscpu
-        lscpu_output = subprocess.check_output(
-            "lscpu -J -e=CPU,CORE,NODE", shell=True, text=True
-        )
-        logical_cpu_list: list[LogicalCPUInfo] = json.loads(
-            lscpu_output, object_hook=LogicalCPUInfo.json_decoder
-        )["cpus"]
+        lscpu_output = subprocess.check_output("lscpu -J -e=CPU,CORE,NODE",
+                                               shell=True,
+                                               text=True)
 
-        # Filter CPUs with invalid attributes
+        # Preprocessing: Replace invalid "node": - with "node": -1 (decoder will process it further)
+        lscpu_output = re.sub(r'"node":\s*-\s*(,|\n)', r'"node": -1\1', lscpu_output)
+
+        logical_cpu_list: list[LogicalCPUInfo] = json.loads(
+            lscpu_output, object_hook=LogicalCPUInfo.json_decoder)['cpus']
+
+        # Filter CPUs with invalid attributes (relax NUMA checking)
         logical_cpu_list = [
-            x
-            for x in logical_cpu_list
-            if -1 not in (x.id, x.physical_core, x.numa_node)
+            x for x in logical_cpu_list
+            if -1 not in (x.id, x.physical_core)  # ignore x.numa_node
         ]
 
         # Filter allowed CPUs
-        if hasattr(os, "sched_getaffinity"):
-            allowed_cpu_id_list = os.sched_getaffinity(0)
-        else:
-            raise NotImplementedError("Unsupported OS")
-        logical_cpu_list = [x for x in logical_cpu_list if x.id in allowed_cpu_id_list]
+        allowed_cpu_id_list = os.sched_getaffinity(0)
+        logical_cpu_list = [
+            x for x in logical_cpu_list if x.id in allowed_cpu_id_list
+        ]
 
         # Get allowed NUMA nodes
         allowed_numa_nodes = set()
         for x in logical_cpu_list:
-            allowed_numa_nodes.add(x.numa_node)  # type: ignore
+            allowed_numa_nodes.add(x.numa_node)  # now it will include 0
         allowed_numa_nodes_list = sorted(allowed_numa_nodes)
 
         env_key = CpuPlatform.device_control_env_var
-        if env_key in os.environ and os.environ[env_key] != "":
-            visible_nodes = [int(s) for s in os.environ[env_key].split(",")]
+        if (env_key in os.environ and os.environ[env_key] != ""):
+            visible_nodes = [int(s) for s in os.environ[env_key].split(',')]
             allowed_numa_nodes_list = [
-                x for x in visible_nodes if x in allowed_cpu_id_list
+                x for x in visible_nodes if x in allowed_numa_nodes
             ]
+
+        # Additional safety check: if still empty, fallback to [0]
+        if not allowed_numa_nodes_list:
+            allowed_numa_nodes_list = [0]
 
         return allowed_numa_nodes_list, logical_cpu_list
 


### PR DESCRIPTION

Link to issue: #26560 

## Purpose
Fix AssertionError "No enough allowed NUMA nodes to bind threads" in single-NUMA or containerized environments where `lscpu -J` outputs invalid JSON ("node": -) for NUMA node fields, leading to empty `allowed_numa_nodes_list` after filtering. The fix preprocesses the JSON string to replace "-1" (post-conversion) and handles it in the JSON decoder by mapping invalid NUMA values to 0 (assuming single-node topology). Additionally, relaxes filtering to ignore NUMA -1 checks and adds a fallback to  if the list remains empty. This ensures thread binding proceeds without manual intervention in production setups like Kubernetes/AKS.

Resolves issue where all CPUs are filtered out due to numa_node = -1, common in non-multi-socket systems or isolated containers.

***
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".(https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

