### PR TITLE
[Bugfix] Check flashinfer availability using flashinfer.sampling.get_sampling_module

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -17,8 +17,13 @@ logger = init_logger(__name__)
 try:
     import flashinfer.sampling
 
+    flashinfer.sampling.get_sampling_module()
     is_flashinfer_available = True
-except ImportError:
+except (ImportError, RuntimeError, AttributeError) as e:
+    logger.warning("FlashInfer is not available. for an known error: %s", e)
+    is_flashinfer_available = False
+except Exception as e:
+    logger.warning("Failed to import FlashInfer. for an unknown error: %s", e)
     is_flashinfer_available = False
 
 


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm/issues/26565

Currently, we set is_flashinfer_available if importing flashinfer succeeds. However, flashinfer can still fail during execution on older CUDA architectures like sm70. To address this, I'm now calling flashinfer.sampling.get_sampling_module upfront to actually execute the module. Since it's a functools.cache function, this won't introduce additional overhead.

```flashinfer.sampling.get_sampling_module```  finally call check_cuda_arch to validates runtime environment.


flashinfer code snippet:
https://github.com/flashinfer-ai/flashinfer/blob/c3ff7e76e67d7ca6875ed6137322eedf5c356f32/flashinfer/sampling.py#L47-L50

https://github.com/flashinfer-ai/flashinfer/blob/c3ff7e76e67d7ca6875ed6137322eedf5c356f32/flashinfer/jit/core.py#L67C1-L79

```python
def check_cuda_arch():
    # Collect all detected CUDA architectures
    eligible = False
    for major, minor in current_compilation_context.TARGET_CUDA_ARCHS:
        if major >= 8:
            eligible = True
        elif major == 7 and minor.isdigit():
            if int(minor) >= 5:
                eligible = True


    # Raise error only if all detected architectures are lower than sm75
    if not eligible:
        raise RuntimeError("FlashInfer requires GPUs with sm75 or higher")
```

## Test Plan
I used the #26565 mini repro command on v100.
```bash
python -m vllm.entrypoints.openai.api_server \
    --model ../merged-model-path \
    --served-model-name glm-4-9b-chat \
    --host 0.0.0.0 \
    --port 8800 \
```
## Test Result
with fix code, it worked fine
```bash
(EngineCore_DP0 pid=7801) WARNING 10-10 20:42:56 [topk_topp_sampler.py:23] FlashInfer is not available. for an known error: FlashInfer requires GPUs with sm75 or higher
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=7801) INFO 10-10 20:42:57 [parallel_state.py:1208] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=7801) WARNING 10-10 20:42:57 [topk_topp_sampler.py:71] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

