### PR TITLE
[Bugfix][DCP] Set default CUDAGraphMode to PIECEWISE for DCP

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -348,9 +348,7 @@ class VllmConfig:
                         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
                     # decode context parallel do not support full cudagraphs now.
-                    if self.parallel_config is not None and (
-                        self.parallel_config.decode_context_parallel_size > 1
-                    ):
+                    if self.parallel_config.decode_context_parallel_size > 1:
                         logger.warning(
                             "Decode context parallel (DCP) is enabled, which is "
                             "incompatible with full CUDA graphs. Set "

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -346,6 +346,10 @@ class VllmConfig:
                         or self.model_config.is_encoder_decoder
                     ):
                         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
+                    # decode context parallel do not support full cudagraphs now.
+                    if self.parallel_config.decode_context_parallel_size > 1:
+                        self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
                 else:
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -348,7 +348,13 @@ class VllmConfig:
                         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
                     # decode context parallel do not support full cudagraphs now.
-                    if self.parallel_config.decode_context_parallel_size > 1:
+                    if self.parallel_config is not None and (
+                        self.parallel_config.decode_context_parallel_size > 1
+                    ):
+                        logger.warning(
+                            "Decode context parallel (DCP) is enabled, which is "
+                            "incompatible with full CUDA graphs. Set "
+                            "cudagraph_mode to PIECEWISE.")
                         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
                 else:
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -354,7 +354,8 @@ class VllmConfig:
                         logger.warning(
                             "Decode context parallel (DCP) is enabled, which is "
                             "incompatible with full CUDA graphs. Set "
-                            "cudagraph_mode to PIECEWISE.")
+                            "cudagraph_mode to PIECEWISE."
+                        )
                         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
                 else:
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE


### PR DESCRIPTION
## Purpose
[#25444 ](https://github.com/vllm-project/vllm/pull/25444) change default CUDAGraphMode from PIECEWISE to FULL_AND_PIECEWISE. However, DCP do not support full cuda graphs now (https://github.com/vllm-project/vllm/issues/26022#issuecomment-3373068790). This PR change default CUDAGraphMode to PIECEWISE when enable DCP.

cc @youzhedian @youkaichao @LucasWilkinson 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

