### PR TITLE
[Bugfix][Speculative Decoding] Extend Eagle quantization config fix to llama_eagle.py

### DIFF
--- a/vllm/model_executor/models/llama_eagle.py
+++ b/vllm/model_executor/models/llama_eagle.py
@@ -38,7 +38,7 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
             del self.input_layernorm
             self.input_layernorm = nn.Identity()
 
-    def get_quant_config(self, vllm_config: VllmConfig) -> Optional[QuantizationConfig]:
+    def get_quant_config(self, vllm_config: VllmConfig) -> QuantizationConfig | None:
         """Use drafter's quantization config instead of verifier's."""
         draft_model_config = vllm_config.speculative_config.draft_model_config
         draft_load_config = vllm_config.load_config

--- a/vllm/model_executor/models/llama_eagle.py
+++ b/vllm/model_executor/models/llama_eagle.py
@@ -12,6 +12,7 @@ from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.llama import LlamaDecoderLayer, LlamaForCausalLM
@@ -36,6 +37,17 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
         if disable_input_layernorm:
             del self.input_layernorm
             self.input_layernorm = nn.Identity()
+
+    def get_quant_config(self, vllm_config: VllmConfig) -> Optional[QuantizationConfig]:
+        """Use drafter's quantization config instead of verifier's."""
+        draft_model_config = vllm_config.speculative_config.draft_model_config
+        draft_load_config = vllm_config.load_config
+
+        return (
+            VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
+            if draft_model_config
+            else None
+        )
 
 
 @support_torch_compile


### PR DESCRIPTION
This PR extends the quantization config fix from #25883 to `llama_eagle.py` 

### Background

PR #25883 fixed an issue where Eagle3 drafter models were incorrectly using the verifier model's quantization config instead of their own. This caused problems when the drafter and verifier models had different quantization configurations.

The fix introduced a `get_quant_config()` method in `LlamaDecoderLayer` that can be overridden by Eagle subclasses to use the draft model's quantization config.

### Changes
This PR applies the same pattern to additional Eagle drafters:

#### llama_eagle.py
- Adds `get_quant_config()` method to the `LlamaDecoderLayer` subclass in `llama_eagle.py`
- The method retrieves the quantization config from the draft model instead of the verifier model
- Uses `VllmConfig.get_quantization_config()` to properly obtain the draft model's quantization config



### Impact
The fix ensures that Eagle drafter models correctly use their own quantization configuration, preventing quantization mismatches when used with differently quantized verifier models.

### Notes
- `llama_eagle3.py` was already fixed in #25883
- `llama4_eagle.py` handles this differently by explicitly passing quantization config as a parameter, so no changes are needed there
- `minicpm_eagle.py` accepts a separate `quant_config` parameter in its decoder layer, so it doesn't need this fix

---

**Fixes:** Extends fix from #25883
**Related:** #25883

## Verification

```bash
CUDA_VISIBLE_DEVICES=0 python examples/offline_inference/spec_decode.py \
  --method "eagle" \
  --tp 1 \
  --print-output \
  --model-dir "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic" \
  --eagle-dir "yuhuili/EAGLE-LLaMA3.1-Instruct-8B" \
  --dataset_name "hf" \
  --dataset_path "philschmid/mt-bench" \
  --num-spec-tokens 5 2>&1 | tee local/acceptance-rates-eagle.txt
```

Output:

```bash
--------------------------------------------------
--------------------------------------------------
total_num_output_tokens: 210113
num_drafts: 87017
num_draft_tokens: 435085
num_accepted_tokens: 123333
mean acceptance length: 2.42
--------------------------------------------------
acceptance at token 0: 0.68
acceptance at token 1: 0.38
acceptance at token 2: 0.20
acceptance at token 3: 0.10
acceptance at token 4: 0.06
```