### PR TITLE
[Kernel] Make moe_forward and moe_forward_shared into inplace ops

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
@@ -20,7 +20,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate,
     TopKWeightAndReduceNoOP,
 )
-from vllm.model_executor.layers.fused_moe.utils import _resize_cache, disable_inplace
+from vllm.model_executor.layers.fused_moe.utils import _resize_cache
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_make_workspace_new,
     marlin_moe_intermediate_size,
@@ -329,10 +329,7 @@ def fused_marlin_moe(
     ).view(-1, topk, K)
 
     if output is None:
-        if inplace and not disable_inplace():
-            output = hidden_states
-        else:
-            output = torch.empty_like(hidden_states)
+        output = hidden_states if inplace else torch.empty_like(hidden_states)
 
     if moe_sum is None:
         return torch.sum(moe_output.view(-1, topk, K), dim=1, out=output)

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -2174,6 +2174,7 @@ class FusedMoE(CustomOp):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        og_size = hidden_states.shape
         og_hidden_states = hidden_states.shape[-1]
         if self.hidden_size != og_hidden_states:
             hidden_states = F.pad(
@@ -2187,28 +2188,25 @@ class FusedMoE(CustomOp):
             if current_platform.is_tpu():
                 # TODO: Once the OOM issue for the TPU backend is resolved, we
                 # will switch to using the moe_forward custom op.
-                fused_output = self.forward_impl(hidden_states, router_logits)
-                assert not isinstance(fused_output, tuple)
+                self.forward_impl(hidden_states, router_logits)
             else:
-                fused_output = torch.ops.vllm.moe_forward(
+                torch.ops.vllm.moe_forward(
                     hidden_states, router_logits, self.layer_name
                 )
-            return fused_output[..., :og_hidden_states]
+                hidden_states.resize_(og_size)
+            return hidden_states
         else:
             if current_platform.is_tpu():
                 # TODO: Once the OOM issue for the TPU backend is resolved, we
                 # will switch to using the moe_forward custom op.
-                shared_output, fused_output = self.forward_impl(
-                    hidden_states, router_logits
-                )
+                shared_output = self.forward_impl(hidden_states, router_logits)
             else:
-                shared_output, fused_output = torch.ops.vllm.moe_forward_shared(
+                shared_output = torch.ops.vllm.moe_forward_shared(
                     hidden_states, router_logits, self.layer_name
                 )
-            return (
-                shared_output[..., :og_hidden_states],
-                fused_output[..., :og_hidden_states],
-            )
+            hidden_states.resize_(og_size)
+            assert shared_output is not None
+            return (hidden_states, shared_output[..., :og_hidden_states])
 
     def forward_cuda(
         self,
@@ -2222,7 +2220,7 @@ class FusedMoE(CustomOp):
         full_hidden_states: torch.Tensor,
         full_router_logits: torch.Tensor,
         has_separate_shared_experts: bool,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor | None:
         assert self.batched_hidden_states is not None
         assert self.batched_router_logits is not None
         assert self.batched_hidden_states.dtype == full_hidden_states.dtype
@@ -2377,15 +2375,34 @@ class FusedMoE(CustomOp):
                 )
 
         if self.shared_experts is None:
-            return full_fused_final_hidden_states
+            full_hidden_states.copy_(full_fused_final_hidden_states)
+            return None
         else:
-            return (full_shared_final_hidden_states, full_fused_final_hidden_states)
+            full_hidden_states.copy_(full_fused_final_hidden_states)
+            return full_shared_final_hidden_states
+
+    def _reduce_output(
+        self,
+        states: torch.Tensor,
+        do_combine: bool,
+    ) -> torch.Tensor:
+        if do_combine:
+            states = get_ep_group().combine(states, self.is_sequence_parallel)
+
+        if (
+            not self.is_sequence_parallel
+            and self.reduce_results
+            and (self.tp_size > 1 or self.ep_size > 1)
+        ):
+            states = self.maybe_all_reduce_tensor_model_parallel(states)
+
+        return states
 
     def forward_impl(
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor | None:
         assert self.quant_method is not None
 
         self.ensure_moe_quant_config_init()
@@ -2494,31 +2511,26 @@ class FusedMoE(CustomOp):
                 assert isinstance(final_hidden_states, tuple)
                 final_hidden_states, zero_expert_result = final_hidden_states
 
-            def reduce_output(
-                states: torch.Tensor, do_combine: bool = True
-            ) -> torch.Tensor:
-                if do_naive_dispatch_combine and do_combine:
-                    states = get_ep_group().combine(states, self.is_sequence_parallel)
-
-                if (
-                    not self.is_sequence_parallel
-                    and self.reduce_results
-                    and (self.tp_size > 1 or self.ep_size > 1)
-                ):
-                    states = self.maybe_all_reduce_tensor_model_parallel(states)
-
-                return states
-
             if self.shared_experts is not None:
-                return (
-                    reduce_output(final_hidden_states[0], do_combine=False),
-                    reduce_output(final_hidden_states[1]),
+                hidden_states.copy_(
+                    self._reduce_output(
+                        final_hidden_states[1], do_naive_dispatch_combine
+                    )
                 )
+                return self._reduce_output(final_hidden_states[0], False)
             elif self.zero_expert_num is not None and self.zero_expert_num > 0:
                 assert isinstance(final_hidden_states, torch.Tensor)
-                return reduce_output(final_hidden_states) + zero_expert_result
+                hidden_states.copy_(
+                    self._reduce_output(final_hidden_states, do_naive_dispatch_combine)
+                    + zero_expert_result
+                )
+                return None
             else:
-                return reduce_output(final_hidden_states)
+                assert isinstance(final_hidden_states, torch.Tensor)
+                hidden_states.copy_(
+                    self._reduce_output(final_hidden_states, do_naive_dispatch_combine)
+                )
+                return None
 
     @classmethod
     def make_expert_params_mapping(
@@ -2584,26 +2596,17 @@ def moe_forward(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
     layer_name: str,
-) -> torch.Tensor:
+):
     forward_context: ForwardContext = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
     assert self.shared_experts is None
-    return self.forward_impl(hidden_states, router_logits)
-
-
-def moe_forward_fake(
-    hidden_states: torch.Tensor,
-    router_logits: torch.Tensor,
-    layer_name: str,
-) -> torch.Tensor:
-    return torch.empty_like(hidden_states)
+    self.forward_impl(hidden_states, router_logits)
 
 
 direct_register_custom_op(
     op_name="moe_forward",
     op_func=moe_forward,
     mutates_args=["hidden_states"],
-    fake_impl=moe_forward_fake,
     tags=(torch.Tag.needs_fixed_stride_order,),
 )
 
@@ -2612,7 +2615,7 @@ def moe_forward_shared(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
     layer_name: str,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     forward_context: ForwardContext = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
     assert self.shared_experts is not None
@@ -2623,10 +2626,9 @@ def moe_forward_shared_fake(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
     layer_name: str,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     shared_out = torch.empty_like(hidden_states)
-    fused_out = torch.empty_like(hidden_states)
-    return shared_out, fused_out
+    return shared_out
 
 
 direct_register_custom_op(

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -2596,7 +2596,7 @@ def moe_forward(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
     layer_name: str,
-):
+) -> None:
     forward_context: ForwardContext = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
     assert self.shared_experts is None

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -2193,7 +2193,8 @@ class FusedMoE(CustomOp):
                 torch.ops.vllm.moe_forward(
                     hidden_states, router_logits, self.layer_name
                 )
-                hidden_states.resize_(og_size)
+            # hidden_states.resize_(og_size)
+            hidden_states.copy_(hidden_states.narrow(-1, 0, og_hidden_states))
             return hidden_states
         else:
             if current_platform.is_tpu():
@@ -2204,7 +2205,8 @@ class FusedMoE(CustomOp):
                 shared_output = torch.ops.vllm.moe_forward_shared(
                     hidden_states, router_logits, self.layer_name
                 )
-            hidden_states.resize_(og_size)
+            # hidden_states.resize_(og_size)
+            hidden_states.copy_(hidden_states.narrow(-1, 0, og_hidden_states))
             assert shared_output is not None
             return (hidden_states, shared_output[..., :og_hidden_states])
 

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -2206,8 +2206,8 @@ class FusedMoE(CustomOp):
                 )
             assert shared_output is not None
             return (
-                padded_hidden_states[..., :og_hidden_states],
                 shared_output[..., :og_hidden_states],
+                padded_hidden_states[..., :og_hidden_states],
             )
 
     def forward_cuda(

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -14,7 +14,6 @@ from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache,
     count_expert_num_tokens,
-    disable_inplace,
 )
 from vllm.utils import cdiv
 from vllm.v1.worker.ubatching import (
@@ -1147,7 +1146,7 @@ class FusedMoEModularKernel(torch.nn.Module):
         - torch.Tensor: The output tensor after applying the MoE layer.
         """
 
-        if inplace and self.shared_experts is None and not disable_inplace():
+        if inplace and self.shared_experts is None:
             output = hidden_states
         else:
             output = torch.zeros_like(hidden_states)

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import functools
 from math import prod
 
 import torch
@@ -25,7 +24,6 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
 from vllm.triton_utils import tl, triton
 from vllm.utils import cdiv
 from vllm.utils.flashinfer import flashinfer_fp4_quantize
-from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 
 @triton.jit

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -322,11 +322,3 @@ def _validate_scale_shape(
 
 def activation_without_mul(activation: str) -> str:
     return activation + "_no_mul"
-
-
-# Torch custom ops can't deal with outputs aliasing inputs so we need to
-# disable inplace for torch >= 2.9.
-# See https://github.com/vllm-project/vllm/issues/26378
-@functools.cache
-def disable_inplace() -> bool:
-    return is_torch_equal_or_newer("2.9")


### PR DESCRIPTION
## Purpose
Make the `moe_forward` methods inplace rather than just mutating the input arguments.  This will reduce memory usage but increase copying.

## Test Plan
CI tests
Benchmarks

## Test Result
TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

cc @ProExpertProg , @varun-sundar-rabindranath 