### PR TITLE
fix seed_oss_tool_call used Stream

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/seed_oss_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/seed_oss_tool_parser.py
@@ -412,17 +412,6 @@ class SeedOssToolParser(ToolParser):
                 # Continue processing next tool
                 return None
 
-        # Check if end thinking
-        if not self.is_thinking_end and (
-            self.think_end_token_id in delta_token_ids
-            or self.think_end_token in delta_text
-        ):
-            self.is_thinking_end = True
-
-        # If thinking hasn't ended yet, don't process any tool calls
-        if not self.is_thinking_end:
-            return DeltaMessage(content=delta_text)
-
         # Handle normal content before tool calls
         if not self.is_tool_call_started:
             # Check if tool call is starting


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Chinese：
服务启动时添加，--reasoning-parser seed_oss
当使用流式输出stream=True的时候， tool_calls结果一直为None

English：
Add --reasoning-parser seed_oss when the service starts.
When using the stream output stream=True, the tool_calls result is always None

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

