### PR TITLE
[CI/Build] allow setting GDRCOPY_VERSION during docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -388,13 +388,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     VLLM_DOCKER_BUILD_CONTEXT=1 TORCH_CUDA_ARCH_LIST="9.0a 10.0a" /tmp/install_deepgemm.sh --cuda-version "${CUDA_VERSION}" ${DEEPGEMM_GIT_REF:+--ref "$DEEPGEMM_GIT_REF"}
 
 COPY tools/install_gdrcopy.sh install_gdrcopy.sh
+ARG GDRCOPY_VERSION
 RUN set -eux; \
     case "${TARGETPLATFORM}" in \
       linux/arm64) UUARCH="aarch64" ;; \
       linux/amd64) UUARCH="x64" ;; \
       *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" >&2; exit 1 ;; \
     esac; \
-    ./install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "${GDRCOPY_CUDA_VERSION}" "${UUARCH}"; \
+    GDRCOPY_VERSION=${GDRCOPY_VERSION} ./install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "${GDRCOPY_CUDA_VERSION}" "${UUARCH}"; \
     rm ./install_gdrcopy.sh
 
 # Install EP kernels(pplx-kernels and DeepEP)


### PR DESCRIPTION
## Purpose
When building the docker image for a machine with CUDA 12.2 (and presumably other non-default CUDA versions), it is necessary to deviate from the default GDRCOPY_VERSION set in `tools/install_gdrcopy.sh`
```
GDRCOPY_PKG_VER="${GDRCOPY_VERSION:-2.5.1-1}"
```

The Dockerfile does not currently allow this environment variable to be set & passed through to the gdrcopy script. This PR adds the environment variable as an ARG to let it passthrough correctly.

## Test Plan
before fix: 
- Attempt to build docker image for an older CUDA version and note the failure resulting from an incorrect GDRCOPY_VERSION
- additionally note no way to set GDRCOPY_VERSION for the docker build step

after fix:
- passing GDRCOPY_VERSION to docker build should now successfully set the version and allow the build to succeed

## Test Result
it does indeed build successfully

---

This is my first contribution, sorry if I missed some part of the process or if there is a way to set this variable after all... i couldn't find a way without making this code change
