### PR TITLE
[ResponseAPI] Simplify input/output message serialization

### DIFF
--- a/tests/entrypoints/openai/test_response_api_with_harmony.py
+++ b/tests/entrypoints/openai/test_response_api_with_harmony.py
@@ -12,6 +12,8 @@ from openai_harmony import (
     Message,
 )
 
+from vllm.entrypoints.openai.protocol import serialize_message, serialize_messages
+
 from ...utils import RemoteOpenAIServer
 
 MODEL_NAME = "openai/gpt-oss-20b"
@@ -758,3 +760,32 @@ async def test_output_messages_enabled(client: OpenAI, model_name: str, server):
     assert response.status == "completed"
     assert len(response.input_messages) > 0
     assert len(response.output_messages) > 0
+
+
+def test_serialize_message() -> None:
+    dict_value = {"a": 1, "b": "2"}
+    assert serialize_message(dict_value) == dict_value
+
+    msg_value = {
+        "role": "assistant",
+        "name": None,
+        "content": [{"type": "text", "text": "Test 1"}],
+        "channel": "analysis",
+    }
+    msg = Message.from_dict(msg_value)
+    assert serialize_message(msg) == msg_value
+
+
+def test_serialize_messages() -> None:
+    assert serialize_messages(None) is None
+    assert serialize_messages([]) is None
+
+    dict_value = {"a": 3, "b": "4"}
+    msg_value = {
+        "role": "assistant",
+        "name": None,
+        "content": [{"type": "text", "text": "Test 2"}],
+        "channel": "analysis",
+    }
+    msg = Message.from_dict(msg_value)
+    assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -2069,6 +2069,26 @@ class ResponseUsage(OpenAIBaseModel):
     total_tokens: int
 
 
+def serialize_message(msg):
+    """
+    Serializes a single message
+    """
+    if isinstance(msg, dict):
+        return msg
+    elif hasattr(msg, "__dict__"):
+        return msg.to_dict()
+    else:
+        # fallback to pyandic dump
+        return msg.model_dump_json()
+
+
+def serialize_messages(msgs):
+    """
+    Serializes multiple messages
+    """
+    return [serialize_message(msg) for msg in msgs] if msgs else None
+
+
 class ResponsesResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"resp_{random_uuid()}")
     created_at: int = Field(default_factory=lambda: int(time.time()))
@@ -2111,35 +2131,13 @@ class ResponsesResponse(OpenAIBaseModel):
     # https://github.com/openai/harmony/issues/78
     @field_serializer("output_messages", when_used="json")
     def serialize_output_messages(self, msgs, _info):
-        if msgs:
-            serialized = []
-            for m in msgs:
-                if isinstance(m, dict):
-                    serialized.append(m)
-                elif hasattr(m, "__dict__"):
-                    serialized.append(m.to_dict())
-                else:
-                    # fallback to pyandic dump
-                    serialized.append(m.model_dump_json())
-            return serialized
-        return None
+        return serialize_messages(msgs)
 
     # NOTE: openAI harmony doesn't serialize TextContent properly, this fixes it
     # https://github.com/openai/harmony/issues/78
     @field_serializer("input_messages", when_used="json")
     def serialize_input_messages(self, msgs, _info):
-        if msgs:
-            serialized = []
-            for m in msgs:
-                if isinstance(m, dict):
-                    serialized.append(m)
-                elif hasattr(m, "__dict__"):
-                    serialized.append(m.to_dict())
-                else:
-                    # fallback to pyandic dump
-                    serialized.append(m.model_dump_json())
-            return serialized
-        return None
+        return serialize_messages(msgs)
 
     @classmethod
     def from_request(


### PR DESCRIPTION
## Purpose

Simplify https://github.com/vllm-project/vllm/pull/26185 by moving serialization into utils which could be applied to both input/output messages.

## Test Plan & Test Result
```
HF_HUB_DISABLE_XET=1 pytest tests/entrypoints/openai/test_response_api_with_harmony.py
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

