### PR TITLE
[WIP][CustomOp] Make deepseek indexer custom op.

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -47,6 +47,7 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.fused_moe import SharedFusedMoE
@@ -754,7 +755,8 @@ direct_register_custom_op(
 )
 
 
-class Indexer(nn.Module):
+@CustomOp.register("deepseek_indexer")
+class DeepseekIndexer(CustomOp):
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -985,7 +987,7 @@ class DeepseekV2MLAAttention(nn.Module):
         self.is_v32 = hasattr(config, "index_topk")
 
         if self.is_v32:
-            self.indexer = Indexer(
+            self.indexer = DeepseekIndexer(
                 vllm_config,
                 config,
                 hidden_size,


### PR DESCRIPTION

## Purpose
This PR tries to make indexer in deepseek also a custom op in order to support oot backends. Currently I don't move `Indexer` into some files in `model_executor/layers` because it is used for deepseek only and is coupled with deepseek. Although I know that it might not be a good idea to introduce CustomOp into modeling files, I haven't thought of a better solution yet. If any reviewers have any better ideas, welcome to comment and I will continue to work on this, thanks.
cc @wangxiyuan @LucasWilkinson @ProExpertProg @Yikun 
## Test Plan
No need to add new tests.
## Test Result
All current tests should pass.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

