### PR TITLE
[Benchmark] Support Infinity API

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -1584,7 +1584,7 @@ def get_samples(args, tokenizer) -> list[SampleRequest]:
 
         if dataset_class.IS_MULTIMODAL and not (
             args.backend in ("openai-chat", "openai-audio")
-            or "openai-embeddings-" in args.backend
+            or "embeddings-" in args.backend
         ):
             # multi-modal benchmark is only available on OpenAI Chat
             # endpoint-type.


### PR DESCRIPTION

## Purpose

Add Infinity API backend so it is easier for us to diagnose and close the performance gaps.

cc @noooop @maxdebayser 

## Test Plan

## Test Result

| Request Throughput (req/s)             | Infinity | vLLM | vLLM (`--api-server-count 8`) |
|----------------------------------------|----------|--------|---------------------------------|
| `BAAI/bge-base-en-v1.5` [text]           | 150.42   | 26.06 (-83%) | 77.26 (-49%) |
| `intfloat/e5-mistral-7b-instruct` [text] | 9.37     | 18.87 (+101%) | 19.25 (+105%) |
| `openai/clip-vit-base-patch32` [text]    | 210.32   | 156.89 (-25%) | 75.42 (-64%) |
| `openai/clip-vit-base-patch32` [image]   | 43.35    | 36.28  (-16%) | 59.42 (+37%) |

API server scale-out helps a lot, especially for small models (BGE v1.5 and CLIP image), but still doesn't fully close the gap. On the other hand, it actually worsened the performance of CLIP text.

More details below:

<details class="admonition abstract" markdown="1">
<summary>Text Embeddings (Encoder-only, CLS pooling) - BGE v1.5</summary>

Prefix caching and chunked prefill are not available for this model. KV cache is also not applicable.

### Infinity

```
$ CUDA_VISIBLE_DEVICES=0 infinity_emb v2 --model-id BAAI/bge-base-en-v1.5 --dtype float32 --port 8000 --no-bettertransformer
```

#### Text (ShareGPT)

```
$ vllm bench serve   --model BAAI/bge-base-en-v1.5   --backend infinity-embeddings --endpoint /embeddings   --dataset-name sharegpt   --dataset-path benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  6.65      
Total input tokens:                      948481    
Request throughput (req/s):              150.42    
Total Token throughput (tok/s):          142672.66 
==================================================
```

### vLLM

```
$ CUDA_VISIBLE_DEVICES=0 vllm serve BAAI/bge-base-en-v1.5 --dtype float32 --port 8000
```

#### Text (ShareGPT)

```
$ vllm bench serve   --model BAAI/bge-base-en-v1.5   --backend openai-embeddings --endpoint /v1/embeddings   --dataset-name sharegpt   --dataset-path benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     830       
Benchmark duration (s):                  31.85     
Total input tokens:                      109101    
Request throughput (req/s):              26.06     
Total Token throughput (tok/s):          3425.49   
==================================================
```

</details>

<details class="admonition abstract" markdown="1">
<summary>Text Embeddings (Decoder-only, LAST pooling) - E5 Mistral</summary>

Prefix caching and chunked prefill are available for this model.

I used `--dtype bfloat16` to avoid OOM on my testing setup.

### Infinity

```
$ CUDA_VISIBLE_DEVICES=0 infinity_emb v2 --model-id intfloat/e5-mistral-7b-instruct --dtype bfloat16 --port 8000 --no-bettertransformer
```

#### Text (ShareGPT)

```
$ vllm bench serve   --model intfloat/e5-mistral-7b-instruct   --backend infinity-embeddings --endpoint /embeddings   --dataset-name sharegpt   --dataset-path benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  106.73    
Total input tokens:                      929370    
Request throughput (req/s):              9.37      
Total Token throughput (tok/s):          8707.42   
==================================================
```

### vLLM

```
$ CUDA_VISIBLE_DEVICES=0 vllm serve intfloat/e5-mistral-7b-instruct --dtype bfloat16 --port 8000
```

#### Text (ShareGPT)

```
$ vllm bench serve   --model intfloat/e5-mistral-7b-instruct   --backend openai-embeddings --endpoint /v1/embeddings   --dataset-name sharegpt   --dataset-path benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  52.99     
Total input tokens:                      246435    
Request throughput (req/s):              18.87     
Total Token throughput (tok/s):          4650.88   
==================================================
```

</details>

<details class="admonition abstract" markdown="1">
<summary>Multimodal Embeddings (Decoder-only, LAST pooling) - CLIP</summary>

The vLLM implementation hangs towards the end of the text benchmark when `--dtype float32` is used, so I used `--dtype bfloat16` here. Interestingly, the timings were almost the same using either dtype -- `bfloat16` is even slightly worse for both Infinity and vLLM.

### Infinity

```
$ CUDA_VISIBLE_DEVICES=0 infinity_emb v2 --model-id openai/clip-vit-base-patch32 --dtype bfloat16 --port 8000 --no-bettertransformer
```

#### Text (ShareGPT)

```
$ vllm bench serve   --model openai/clip-vit-base-patch32   --backend infinity-embeddings-clip   --endpoint /embeddings   --dataset-name sharegpt   --dataset-path benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  4.75      
Total input tokens:                      954705    
Request throughput (req/s):              210.32    
Total Token throughput (tok/s):          200791.60 
==================================================
```

#### Image (VisionArena)

```
$ vllm bench serve   --model openai/clip-vit-base-patch32   --backend infinity-embeddings-clip   --endpoint /embeddings   --dataset-name hf  --dataset-path lmarena-ai/VisionArena-Chat
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  23.07     
Total input tokens:                      3192265   
Request throughput (req/s):              43.35     
Total Token throughput (tok/s):          138386.99 
==================================================
```

### vLLM

```
$ CUDA_VISIBLE_DEVICES=0 vllm serve openai/clip-vit-base-patch32 --dtype bfloat16 --port 8000
```

#### Text (ShareGPT)

```
$ vllm bench serve   --model openai/clip-vit-base-patch32   --backend openai-embeddings-clip   --endpoint /v1/embeddings   --dataset-name sharegpt   --dataset-path benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  6.37      
Total input tokens:                      51039     
Request throughput (req/s):              156.89    
Total Token throughput (tok/s):          8007.50   
=================================================
```

#### Image (VisionArena)

```
$ vllm bench serve   --model openai/clip-vit-base-patch32   --backend openai-embeddings-clip   --endpoint /v1/embeddings   --dataset-name hf  --dataset-path lmarena-ai/VisionArena-Chat
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  27.57     
Total input tokens:                      1000      
Request throughput (req/s):              36.28     
Total Token throughput (tok/s):          36.28     
==================================================
```

</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

