### PR TITLE
[compile] Fix inductor partition config

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -709,9 +709,7 @@ class CompilationConfig:
             return self.level == CompilationLevel.PIECEWISE
 
         # Inductor partition case
-        return (
-            self.level > CompilationLevel.NO_COMPILATION and self.backend == "inductor"
-        )
+        return self.level > CompilationLevel.NO_COMPILATION and self.use_inductor
 
     def custom_op_log_check(self):
         """


### PR DESCRIPTION
When trying to run the following cmd, I ran into [this assertion error](https://github.com/baonudesifeizhai/vllm/blob/5bc26c438d096bac6148b49f5aec7ac7736d72d0/vllm/v1/cudagraph_dispatcher.py#L43-L54) because [self.backend](https://github.com/baonudesifeizhai/vllm/blob/5bc26c438d096bac6148b49f5aec7ac7736d72d0/vllm/config/compilation.py#L713) is equal to `""`.

```
vllm bench latency \
    --model=RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8 \
    --output-len 1 --input-len 8192 --batch-size 1 \
    --tensor-parallel-size 8 --load-format dummy \
    --num_iters_warmup 5 --num_iters 15 \
    -O '{"level": 3, "pass_config": {"enable_async_tp": true, "enable_sequence_parallelism": true}, "use_inductor_graph_partition": true, "custom_ops":["+quant_fp8"], "cudagraph_mode":"FULL_AND_PIECEWISE"}' \
    --no-enable-prefix-caching
```

cc @ProExpertProg @zou3519 @BoyuanFeng @baonudesifeizhai 