### PR TITLE
[Models][Qwen3VL] Speedup `fast_pos_embed_interpolate`

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -467,8 +467,6 @@ class Qwen3_VisionTransformer(nn.Module):
             dh_grid, dw_grid = torch.meshgrid(dh, dw, indexing="ij")
             h_floor_grid, w_floor_grid = torch.meshgrid(h_floor, w_floor, indexing="ij")
             h_ceil_grid, w_ceil_grid = torch.meshgrid(h_ceil, w_ceil, indexing="ij")
-            h_floor_grid_idx = h_floor_grid * num_grid_per_side
-            h_ceil_grid_idx = h_ceil_grid * num_grid_per_side
 
             # original computation of weights
             # w00 = (1 - dh_grid) * (1 - dw_grid)
@@ -482,12 +480,11 @@ class Qwen3_VisionTransformer(nn.Module):
             w01 = dw_grid - w11
             w00 = 1 - dh_grid - w01
 
-            idx00 = h_floor_grid_idx + w_floor_grid
-            idx01 = h_floor_grid_idx + w_ceil_grid
-            idx10 = h_ceil_grid_idx + w_floor_grid
-            idx11 = h_ceil_grid_idx + w_ceil_grid
+            h_grid = torch.stack([h_floor_grid, h_floor_grid, h_ceil_grid, h_ceil_grid])
+            w_grid = torch.stack([w_floor_grid, w_ceil_grid, w_floor_grid, w_ceil_grid])
+            h_grid_idx = h_grid * num_grid_per_side
 
-            indices = torch.stack([idx00, idx01, idx10, idx11], dim=0).reshape(4, -1)
+            indices = (h_grid_idx + w_grid).reshape(4, -1)
             weights = torch.stack([w00, w01, w10, w11], dim=0).reshape(4, -1, 1)
             weights = weights.to(dtype=self.dtype)
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -492,12 +492,11 @@ class Qwen3_VisionTransformer(nn.Module):
             weighted_embeds = embeds * weights
             combined = weighted_embeds.sum(dim=0)
 
-            combined = combined.view(h * w, hidden_dim)
-            repeated = combined.unsqueeze(0).expand(t, -1, -1).contiguous()
-            repeated = repeated.view(
-                t, h // m_size, m_size, w // m_size, m_size, hidden_dim
+            combined = combined.reshape(
+                h // m_size, m_size, w // m_size, m_size, hidden_dim
             )
-            repeated = repeated.permute(0, 1, 3, 2, 4, 5).reshape(-1, hidden_dim)
+            combined = combined.permute(0, 2, 1, 3, 4).reshape(1, -1, hidden_dim)
+            repeated = combined.expand(t, -1, -1).reshape(-1, hidden_dim)
             outputs.append(repeated)
 
         return torch.cat(outputs, dim=0)


### PR DESCRIPTION
## Purpose

Followup on #25337 and #25347. `fast_pos_embed_interpolate` launches many small cuda ops so this PR slightly simplifies and optimised the implementation.
/cc @ywang96 @Isotr0py

## Test Plan & Results

I verified that the new implementation doesn't change the computation.

A quick micro benchmark on an H100 shows a 15% speedup of `fast_pos_embed_interpolate` and I don't think it reduces readability of the code.

```python
import torch
import torch.nn as nn


class Qwen3_VisionTransformer(nn.Module):
    def __init__(self, hidden_size, num_position_embeddings, spatial_merge_size):
        super().__init__()
        self.spatial_merge_size = spatial_merge_size
        self.num_grid_per_side = int(num_position_embeddings**0.5)
        self.dtype = torch.bfloat16
        self.device = torch.device("cuda:0")
        self.pos_embed = nn.Embedding(
            num_position_embeddings, hidden_size, dtype=self.dtype, device=self.device
        )

    def fast_pos_embed_interpolate(self, grid_thw: list[list[int]]) -> torch.Tensor:
        ...

    def bench_fast_pos_embed_interpolate(self, grid_thw: list[list[int]]):
        self.fast_pos_embed_interpolate(grid_thw)
        torch.cuda.synchronize()


model = Qwen3_VisionTransformer(
    hidden_size=1152, num_position_embeddings=2304, spatial_merge_size=2
)

grid_thw = [[1, 64, 48], [1, 64, 48], [1, 64, 48], [1, 64, 48], [1, 64, 48]]

model.bench_fast_pos_embed_interpolate(grid_thw)
%timeit model.bench_fast_pos_embed_interpolate(grid_thw)
```

```
main:    1.33 ms ± 30.9 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
This PR: 1.13 ms ± 3.85 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

