### PR TITLE
fix(benchmark): Prevent OOV error for small tokenizers in latency test

### DIFF
--- a/vllm/benchmarks/latency.py
+++ b/vllm/benchmarks/latency.py
@@ -108,7 +108,7 @@ def main(args: argparse.Namespace):
         detokenize=not args.disable_detokenize,
     )
     dummy_prompt_token_ids = np.random.randint(
-        10000, size=(args.batch_size, args.input_len)
+        llm.get_tokenizer().vocab_size, size=(args.batch_size, args.input_len)
     )
     dummy_prompts: list[PromptType] = [
         {"prompt_token_ids": batch} for batch in dummy_prompt_token_ids.tolist()


### PR DESCRIPTION
## Purpose

This PR fixes a bug in the latency benchmark script (`vllm/benchmarks/latency.py`) where a hardcoded upper bound of 10,000 was used for sampling token IDs. This caused an `OutOfVocabulary` (OOV) error when running the benchmark with a tokenizer whose vocabulary size is smaller than this value.
The fix replaces the hardcoded `10000` with the actual vocabulary size obtained dynamically from the tokenizer using `llm.get_tokenizer().vocab_size`. This makes the benchmark robust and compatible with tokenizers of any size.
Fixes \#26576

## Test Plan

## Test Result