### PR TITLE
[Bugfix][Core]Fix block table out-of-range issue in priority scheduling

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -273,6 +273,9 @@ class Scheduler(SchedulerInterface):
                     self.running.remove(preempted_req)
                     if preempted_req in scheduled_running_reqs:
                         scheduled_running_reqs.remove(preempted_req)
+                        token_budget += num_scheduled_tokens[preempted_req.request_id]
+                        req_to_new_blocks.pop(preempted_req.request_id)
+                        num_scheduled_tokens.pop(preempted_req.request_id)
                 else:
                     preempted_req = self.running.pop()
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR fixes a block table out-of-range error that occurs when using priority scheduling

When a low-priority request that has already been added to scheduled_running_reqs is preempted,
the corresponding entries in req_to_new_blocks and num_scheduled_tokens are not updated synchronously.

As a result, when the same request is later re-scheduled and added back to scheduled_running_reqs,
the block table allocation does not start from index 0, leading to an index out-of-range error.

This PR ensures that:

When a request is preempted, related entries in req_to_new_blocks and num_scheduled_tokens are cleared or resynchronized.

Subsequent scheduling will always allocate new block IDs starting from 0.

Fixes [#23316](https://github.com/vllm-project/vllm/issues/23316)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

