### PR TITLE
[MISC] Fix triton import error

### DIFF
--- a/vllm/model_executor/layers/quantization/qutlass_utils.py
+++ b/vllm/model_executor/layers/quantization/qutlass_utils.py
@@ -14,9 +14,9 @@
 from typing import Literal
 
 import torch
-import triton
-import triton.language as tl
 from torch.library import wrap_triton
+
+from vllm.triton_utils import tl, triton
 
 
 @triton.jit


### PR DESCRIPTION
## Purpose
Fix triton import error in the scenario that triton is not installed. Actually we have make CI on this problem in https://github.com/vllm-project/vllm/pull/17716. However not sure why it is ineffective since this [commit](https://github.com/vllm-project/vllm/pull/24440/commits/72a78094f000cf96918390521c95c5a29e0008f1) in https://github.com/vllm-project/vllm/pull/24440/commits. This pr is a quick fix on this issue

## Test Plan
CI passed with pre-commit
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

