### PR TITLE
docs: wrong command in structured_outputs README

### DIFF
--- a/examples/online_serving/structured_outputs/README.md
+++ b/examples/online_serving/structured_outputs/README.md
@@ -21,7 +21,7 @@ If you want to run this script standalone with `uv`, you can use the following:
 
 ```bash
 uvx --from git+https://github.com/vllm-project/vllm#subdirectory=examples/online_serving/structured_outputs \
-    structured-output
+    structured-outputs
 ```
 
 See [feature docs](https://docs.vllm.ai/en/latest/features/structured_outputs.html) for more information.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

as diff
before this patch

➜  vllm git:(main) vim examples/online_serving/structured_outputs/README.md
➜  vllm git:(main) uvx --from git+https://github.com/vllm-project/vllm#subdirectory=examples/online_serving/structured_outputs \
    structured-output
    Updated https://github.com/vllm-project/vllm (41f3884438c082c4cc2250eb800b8586e1a103d8)
      Built examples-online-structured-outputs @ git+https://github.com/vllm-project/vllm@41f3884438c082c4cc2250eb800b8586e1a103d8#subdirectory=examples/o
Installed 17 packages in 25ms
An executable named `structured-output` is not provided by package `examples-online-structured-outputs`.
The following executables are available:
- structured-outputs

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

