### PR TITLE
[compile] Enable sequence parallelism for full cuda graph without specifying compile sizes

### DIFF
--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -435,7 +435,10 @@ class AsyncTPPass(VllmPatternMatcherPass):
         # This pass is applied on top of the sequence parallelism pass.
         # It inherits the same applicability condition as `SequenceParallelismPass`.
         # See `SequenceParallelismPass.is_applicable` for more details.
-        if self.splitting_ops is None or self.splitting_ops == []:
+        if (
+            not self.compilation_config.splitting_ops
+            or self.compilation_config.use_inductor_graph_partition
+        ):
             return True
         tp_size = get_tensor_model_parallel_world_size()
         return shape is not None and shape % tp_size == 0

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -431,8 +431,12 @@ class AsyncTPPass(VllmPatternMatcherPass):
 
         self.dump_patterns(config, self.patterns)
 
-    def is_applicable_for_shape(self, shape: int | None) -> bool:
-        # only do replace for specific shapes
+    def is_applicable(self, shape: int | None) -> bool:
+        # This pass is applied on top of the sequence parallelism pass.
+        # It inherits the same applicability condition as `SequenceParallelismPass`.
+        # See `SequenceParallelismPass.is_applicable` for more details.
+        if self.splitting_ops is None or self.splitting_ops == []:
+            return True
         tp_size = get_tensor_model_parallel_world_size()
         return shape is not None and shape % tp_size == 0
 

--- a/vllm/compilation/inductor_pass.py
+++ b/vllm/compilation/inductor_pass.py
@@ -96,7 +96,7 @@ class InductorPass(CustomGraphPass):
         encoded = json.dumps(dict_, sort_keys=True).encode("utf-8")
         return hashlib.sha256(encoded).hexdigest()
 
-    def is_applicable_for_shape(self, shape: int | None):
+    def is_applicable(self, shape: int | None):
         return True
 
 

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -71,7 +71,7 @@ class PostGradPassManager(CustomGraphPass):
 
         shape = get_pass_context().runtime_shape
         for pass_ in self.passes:
-            if pass_.is_applicable_for_shape(shape):
+            if pass_.is_applicable(shape):
                 pass_(graph)
                 VllmInductorPass.dump_prefix += 1
 

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -74,6 +74,8 @@ class PostGradPassManager(CustomGraphPass):
             if pass_.is_applicable(shape):
                 pass_(graph)
                 VllmInductorPass.dump_prefix += 1
+            else:
+                logger.debug("Skipping %s with shape %s", pass_, shape)
 
         # post-cleanup goes before fix_functionalization
         # because it requires a functional graph

--- a/vllm/compilation/sequence_parallelism.py
+++ b/vllm/compilation/sequence_parallelism.py
@@ -482,7 +482,22 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
             ).register(self.patterns)
         self.dump_patterns(config, self.patterns)
 
-    def is_applicable_for_shape(self, shape: int | None) -> bool:
+    def is_applicable(self, shape: int | None) -> bool:
+        # When sequence parallelism is enabled, the residual tensor from RMSNorm
+        # needs to be split along the sequence dimension. However, this dimension
+        # is symbolic during piecewise compilation, and splitting symbolic shapes
+        # is not supported.
+        #
+        # This pass is therefore only applied when the sequence dimension is
+        # concrete:
+        # 1. In full-graph compilation mode (no splitting ops are used).
+        #   For this case we always pad num_tokens to be a multiple of
+        #   tensor_parallel_size, so there's no need to check shape % tp_size == 0.
+        # 2. For specific shape provided during compilation (e.g., from
+        #    `compile_sizes`), which must be divisible by the tensor-parallel
+        #    size.
+        if self.splitting_ops is None or self.splitting_ops == []:
+            return True
         tp_size = get_tensor_model_parallel_world_size()
         return shape is not None and shape % tp_size == 0
 

--- a/vllm/compilation/sequence_parallelism.py
+++ b/vllm/compilation/sequence_parallelism.py
@@ -490,13 +490,16 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
         #
         # This pass is therefore only applied when the sequence dimension is
         # concrete:
-        # 1. In full-graph compilation mode (no splitting ops are used).
+        # 1. In full-graph compilation mode (no Dynamo splitting ops are used).
         #   For this case we always pad num_tokens to be a multiple of
         #   tensor_parallel_size, so there's no need to check shape % tp_size == 0.
         # 2. For specific shape provided during compilation (e.g., from
         #    `compile_sizes`), which must be divisible by the tensor-parallel
         #    size.
-        if self.splitting_ops is None or self.splitting_ops == []:
+        if (
+            not self.compilation_config.splitting_ops
+            or self.compilation_config.use_inductor_graph_partition
+        ):
             return True
         tp_size = get_tensor_model_parallel_world_size()
         return shape is not None and shape % tp_size == 0

--- a/vllm/compilation/vllm_inductor_pass.py
+++ b/vllm/compilation/vllm_inductor_pass.py
@@ -3,6 +3,7 @@
 import functools
 import operator
 import time
+import weakref
 from typing import ClassVar
 
 import regex as re
@@ -28,12 +29,10 @@ class VllmInductorPass(InductorPass):
     """Keep track of pass index for debug dump ordering."""
 
     def __init__(self, config: VllmConfig):
+        self.compilation_config = weakref.proxy(config.compilation_config)
         self.pass_config = config.compilation_config.pass_config
-        self.splitting_ops = config.compilation_config.splitting_ops
-        self.model_dtype = config.model_config.dtype if config.model_config \
-            else None
-        self.device = config.device_config.device if config.device_config \
-            else None
+        self.model_dtype = config.model_config.dtype if config.model_config else None
+        self.device = config.device_config.device if config.device_config else None
         self.pass_name = self.__class__.__name__
 
     @staticmethod

--- a/vllm/compilation/vllm_inductor_pass.py
+++ b/vllm/compilation/vllm_inductor_pass.py
@@ -29,8 +29,11 @@ class VllmInductorPass(InductorPass):
 
     def __init__(self, config: VllmConfig):
         self.pass_config = config.compilation_config.pass_config
-        self.model_dtype = config.model_config.dtype if config.model_config else None
-        self.device = config.device_config.device if config.device_config else None
+        self.splitting_ops = config.compilation_config.splitting_ops
+        self.model_dtype = config.model_config.dtype if config.model_config \
+            else None
+        self.device = config.device_config.device if config.device_config \
+            else None
         self.pass_name = self.__class__.__name__
 
     @staticmethod


### PR DESCRIPTION
## Purpose

Addresses https://github.com/vllm-project/vllm/issues/25277
Porting over the changes from @cascade812 in https://github.com/vllm-project/vllm/pull/21031 which enabled SP without needing to specify compile_sizes in CompilationConfig, + adding some special handling so that async TP/SP can be enabled if just `use_inductor_graph_partition=True`

## Test Result

Here are the updated numbers:

For meta-llama/Llama-3.1-70B-Instruct, updated the command:
```
vllm bench latency --model=meta-llama/Llama-3.1-70B-Instruct --output-len 1 --input-len 8192 --batch-size 1 --tensor-parallel-size 8 --load-format dummy --num_iters_warmup 5 --num_iters 15 -O '{"level": 3, "pass_config": {"enable_async_tp": true, "enable_sequence_parallelism": true}, "use_inductor_graph_partition": false, "splitting_ops":[], "cudagraph_mode": FULL}' --no-enable-prefix-caching --gpu_memory_utilization 0.6
```

<img width="1201" height="729" alt="Image" src="https://github.com/user-attachments/assets/065068f1-922d-4c2b-b53b-680d9fc4aee3" />

For RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8:

```
vllm bench latency --model=RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8 --output-len 1 --input-len 8192 --batch-size 1 --tensor-parallel-size 8 --load-format dummy --num_iters_warmup 5 --num_iters 15 -O '{"level": 3, "pass_config": {"enable_async_tp": true, "enable_sequence_parallelism": true}, "use_inductor_graph_partition": false, "splitting_ops":[], "custom_ops":["+quant_fp8"], "cudagraph_mode": FULL}' --no-enable-prefix-caching
```

<img width="1201" height="732" alt="Image" src="https://github.com/user-attachments/assets/2bf4bfe9-d993-43da-a0c8-8ae6fd0a01fb" />

For nvidia/Llama-3.3-70B-Instruct-FP8:

<img width="1201" height="710" alt="Image" src="https://github.com/user-attachments/assets/3ee218ab-e966-4f66-a148-b4a89ba3d72d" />
