### PR TITLE
[Bugfix] Fix out of bound index issue for Jina-embedding-v3 RoPE with cuda graph

### DIFF
--- a/tests/models/language/pooling_mteb_test/test_jina.py
+++ b/tests/models/language/pooling_mteb_test/test_jina.py
@@ -25,10 +25,6 @@ EMBEDDING_MODELS = [
         mteb_score=0.824413164,
         architecture="XLMRobertaModel",
         is_matryoshka=True,
-        # The default max length of the model is 8194, which will crash
-        # CUDAGraph due to odd length for Gemm. We set it to 8192 to avoid
-        # avoid this issue.
-        max_model_len=8192,
         dtype="float32",
     )
 ]

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -7,7 +7,6 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.models import ModelRegistry
 from vllm.platforms import current_platform
-from vllm.triton_utils import triton
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, cdiv
 from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
 
@@ -75,8 +74,8 @@ class JinaRobertaModelConfig(VerifyAndUpdateConfig):
             # To deal with this, we increase max_position to multiple of n_warps,
             # so that triton kernel won't hit out-of-bound index in RoPE cache.
             if current_platform.is_cuda_alike() and not model_config.enforce_eager:
-                n_warps = getattr(triton.Config, "num_warps", 4)
-                max_position = cdiv(max_position, n_warps) * n_warps
+                n_warps_pad = 8
+                max_position = cdiv(max_position, n_warps_pad) * n_warps_pad
 
             config.rotary_kwargs = {
                 "head_size": head_dim,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Follow PR to fix https://github.com/vllm-project/vllm/pull/26638#discussion_r2423423702
- Make sure sin/cos cache a bit longer than seq_len=8194 for jina-embedding-v3 when enabling cuda graph, so that it won't hit the out-of-bound issue for long prompts due to odd max_model_len. 

## Test Plan
```
pytest -s -v tests/models/language/pooling_mteb_test/test_jina.py
```

## Test Result
Jina-embedding-v3 tests should still pass after removing `max_model_len=8192`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

