### PR TITLE
[Bugfix][CI/Build] Fix build error when using QUTLASS_SRC_DIR to build vllm from source.

### DIFF
--- a/cmake/external_projects/qutlass.cmake
+++ b/cmake/external_projects/qutlass.cmake
@@ -13,7 +13,6 @@ if(QUTLASS_SRC_DIR)
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
   )
-  set(qutlass_SOURCE_DIR "${QUTLASS_SRC_DIR}")
 else()
   FetchContent_Declare(
     qutlass
@@ -23,10 +22,9 @@ else()
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
   )
-  FetchContent_Populate(qutlass)
-  set(qutlass_SOURCE_DIR "${qutlass_SOURCE_DIR}")
 endif()
 
+FetchContent_Populate(qutlass)
 if(NOT qutlass_SOURCE_DIR)
   message(FATAL_ERROR "[QUTLASS] source directory could not be resolved.")
 endif()

--- a/cmake/external_projects/qutlass.cmake
+++ b/cmake/external_projects/qutlass.cmake
@@ -13,6 +13,7 @@ if(QUTLASS_SRC_DIR)
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
   )
+  set(qutlass_SOURCE_DIR "${QUTLASS_SRC_DIR}")
 else()
   FetchContent_Declare(
     qutlass


### PR DESCRIPTION
## Purpose
https://github.com/vllm-project/vllm/pull/24440 brings in the QuTLASS library, and I found a small build issue here.
A FATAL_ERROR will be triggered when using QUTLASS_SRC_DIR to build vllm from source.
https://github.com/vllm-project/vllm/blob/98f30b8cba5bb7e16421ab4c75fc200357744310/cmake/external_projects/qutlass.cmake#L29-L31

This pull request fixes build error when use local qutlass source directory via environment variable. 
## Test Plan
`QUTLASS_SRC_DIR=/path/to/qutlass uv pip install -e .`
## Test Result
Build on SM90 and everything is ok (qutlass build is skipped).

cc @LopezCastroRoberto @mgoin 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
