### PR TITLE
[Hardware][CPU] Disable torch.compile for RISC-V to prevent APIError

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -178,6 +178,10 @@ class CpuPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        if cls.get_cpu_architecture() == CpuArchEnum.RISCV:
+            # Disable torch.compile to prevent Inductor from compiling C++ code
+            # with -march=native, which causes APIError during inference
+            os.environ["TORCH_COMPILE_DISABLE"] = "1"
         model_config = vllm_config.model_config
 
         if model_config is not None:

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -178,10 +178,6 @@ class CpuPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
-        if cls.get_cpu_architecture() == CpuArchEnum.RISCV:
-            # Disable torch.compile to prevent Inductor from compiling C++ code
-            # with -march=native, which causes APIError during inference
-            os.environ["TORCH_COMPILE_DISABLE"] = "1"
         model_config = vllm_config.model_config
 
         if model_config is not None:

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -9,7 +9,7 @@ from packaging import version
 from vllm import envs
 from vllm.config.model import LogprobsMode
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
+from vllm.platforms import CpuArchEnum, current_platform
 
 logger = init_logger(__name__)
 
@@ -73,7 +73,10 @@ class TopKTopPSampler(nn.Module):
                 )
                 self.forward = self.forward_native
         elif current_platform.is_cpu():
-            self.forward = self.forward_cpu
+            if current_platform.get_cpu_architecture() == CpuArchEnum.RISCV:
+                self.forward = self.forward_native
+            else:
+                self.forward = self.forward_cpu
         else:
             self.forward = self.forward_native
 


### PR DESCRIPTION
## Purpose

Fix `openai.APIError: EngineCore encountered an issue` on RISC-V platforms by automatically disabling `torch.compile`.
On RISC-V platforms, PyTorch's Inductor backend attempts to compile C++ code at runtime with the `-march=native` flag, which is incompatible with RISC-V architecture and causes inference to fail with APIError. This PR automatically sets `TORCH_COMPILE_DISABLE=1` environment variable for RISC-V platforms in `vllm/platforms/cpu.py`, eliminating the need for users to manually set this variable.

## Test Plan

Tested on RISC-V hardware (Sophgo SG2044):
1. Run vLLM inference without manually setting `TORCH_COMPILE_DISABLE=1`
2. Verify that inference completes successfully
3. Verify that no C++ compilation errors occur
4. Verify compatibility with existing RISC-V configurations

## Test Result

**Before the fix:**
- Inference fails with `openai.APIError: EngineCore encountered an issue`
- Users must manually set `TORCH_COMPILE_DISABLE=1` to work around the issue

**After the fix:**
- Inference completes successfully without manual environment variable setting
- No APIError encountered
- No C++ compilation triggered during runtime
- Compatible with existing RISC-V configurations