### PR TITLE
[Misc] Feature flag to hide verbose prompt logging to debug level

### DIFF
--- a/vllm/entrypoints/logger.py
+++ b/vllm/entrypoints/logger.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 
 import torch
 
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
@@ -34,18 +35,35 @@ class RequestLogger:
             if prompt_token_ids is not None:
                 prompt_token_ids = prompt_token_ids[:max_log_len]
 
-        logger.info(
-            "Received request %s: prompt: %r, "
-            "params: %s, prompt_token_ids: %s, "
-            "prompt_embeds shape: %s, "
-            "lora_request: %s.",
-            request_id,
-            prompt,
-            params,
-            prompt_token_ids,
-            prompt_embeds.shape if prompt_embeds is not None else None,
-            lora_request,
-        )
+        if envs.VLLM_DEBUG_LOG_API_SERVER_REQUEST_PROMPT:
+            # Split logging: basic info at INFO level, prompt details at DEBUG level
+            logger.info(
+                "Received request %s: params: %s, lora_request: %s.",
+                request_id,
+                params,
+                lora_request,
+            )
+            logger.debug(
+                "Request %s prompt details: prompt: %r, prompt_token_ids: %s, prompt_embeds shape: %s",
+                request_id,
+                prompt,
+                prompt_token_ids,
+                prompt_embeds.shape if prompt_embeds is not None else None,
+            )
+        else:
+            # Original logging behavior
+            logger.info(
+                "Received request %s: prompt: %r, "
+                "params: %s, prompt_token_ids: %s, "
+                "prompt_embeds shape: %s, "
+                "lora_request: %s.",
+                request_id,
+                prompt,
+                params,
+                prompt_token_ids,
+                prompt_embeds.shape if prompt_embeds is not None else None,
+                lora_request,
+            )
 
     def log_outputs(
         self,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     CUDA_VISIBLE_DEVICES: str | None = None
     VLLM_ENGINE_ITERATION_TIMEOUT_S: int = 60
     VLLM_API_KEY: str | None = None
+    VLLM_DEBUG_LOG_API_SERVER_REQUEST_PROMPT: bool = False
     S3_ACCESS_KEY_ID: str | None = None
     S3_SECRET_ACCESS_KEY: str | None = None
     S3_ENDPOINT_URL: str | None = None
@@ -526,6 +527,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to log responses from API Server for debugging
     "VLLM_DEBUG_LOG_API_SERVER_RESPONSE": lambda: os.environ.get(
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE", "False"
+    ).lower()
+    == "true",
+    # Whether to enable debug logging for API server request prompts
+    # When enabled, splits request logging: basic info at INFO level,
+    # prompt details (prompt, prompt_token_ids, prompt_embeds) at DEBUG level
+    "VLLM_DEBUG_LOG_API_SERVER_REQUEST_PROMPT": lambda: os.environ.get(
+        "VLLM_DEBUG_LOG_API_SERVER_REQUEST_PROMPT", "False"
     ).lower()
     == "true",
     # S3 access information, used for tensorizer to load model from S3


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Introduces a feature flag `VLLM_DEBUG_LOG_API_SERVER_REQUEST_PROMPT` to control the verbosity of API server request logging. When enabled, detailed prompt information (prompt, prompt_token_ids, prompt_embeds) is logged at `DEBUG` level instead of `INFO` level, reducing noise in standard `INFO` logs.

## Test Plan

1.  Start the vLLM API server without `VLLM_DEBUG_LOG_API_SERVER_REQUEST_PROMPT` set (or set to `False`).
2.  Send a request to the API server.
3.  Observe the logs: the full prompt details should be visible at `INFO` level.
4.  Start the vLLM API server with `VLLM_DEBUG_LOG_API_SERVER_REQUEST_PROMPT=True` and `VLLM_LOG_LEVEL=debug`.
5.  Send a request to the API server.
6.  Observe the logs: the basic request info should be at `INFO` level, and the detailed prompt information should only appear at `DEBUG` level.

## Test Result

*   Without the flag (or `False`): `INFO` logs contain full prompt details.
*   With the flag (`True`): `INFO` logs contain only basic request info; full prompt details are moved to `DEBUG` logs. This behavior was verified locally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

