### PR TITLE
[Misc] Separate prompt logging to debug

### DIFF
--- a/vllm/entrypoints/logger.py
+++ b/vllm/entrypoints/logger.py
@@ -34,16 +34,20 @@ class RequestLogger:
             if prompt_token_ids is not None:
                 prompt_token_ids = prompt_token_ids[:max_log_len]
 
-        logger.info(
-            "Received request %s: prompt: %r, "
-            "params: %s, prompt_token_ids: %s, "
-            "prompt_embeds shape: %s, "
-            "lora_request: %s.",
+        logger.debug(
+            "Request %s details: prompt: %r, "
+            "prompt_token_ids: %s, "
+            "prompt_embeds shape: %s.",
             request_id,
             prompt,
-            params,
             prompt_token_ids,
             prompt_embeds.shape if prompt_embeds is not None else None,
+        )
+
+        logger.info(
+            "Received request %s: params: %s, lora_request: %s.",
+            request_id,
+            params,
             lora_request,
         )
 


### PR DESCRIPTION
## Purpose

Split the `logger.info` call in `vllm/entrypoints/logger.py` to differentiate between verbose prompt-related details and essential request parameters.

This change moves `request_id`, `prompt`, `prompt_token_ids`, and `prompt_embeds` to a new `logger.debug` call. The original `logger.info` now only contains `params` and `lora_request`. This improves log clarity by:
- Reducing log noise at the `INFO` level in production environments.
- Providing detailed prompt information only when debug logging is enabled.

## Test Plan

1.  Run existing unit and integration tests to ensure no regressions.
2.  Enable debug logging and verify that prompt-related information (`request_id`, `prompt`, `prompt_token_ids`, `prompt_embeds`) is correctly logged at the `DEBUG` level.
3.  With default info-level logging, verify that only `params` and `lora_request` are logged by the `logger.info` call.

## Test Result

-   The `logger.info` call in `vllm/entrypoints/logger.py` has been split.
-   Prompt-related fields (`request_id`, `prompt`, `prompt_token_ids`, `prompt_embeds`) are now logged via `logger.debug`.
-   Essential request parameters (`params`, `lora_request`) remain in the `logger.info` call.
-   No functional changes or regressions are expected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

