### PR TITLE
[ROCm][Tools] Add environment variable tuning package for optimized defaults

### DIFF
--- a/tools/vllm-rocm-autotuner-configs/README.md
+++ b/tools/vllm-rocm-autotuner-configs/README.md
@@ -1,0 +1,198 @@
+# vLLM ROCm Auto-Tuner Configurations
+
+Optimized environment variable settings for vLLM on ROCm-enabled GPUs.
+
+## Installation
+
+```bash
+# In the repo root directory
+pip install -e .                   # Base install
+pip install -e ".[gpu-detect]"     # With GPU detection
+pip install -e ".[dev]"            # With dev tools
+```
+
+## Quick Start
+
+```bash
+# Auto-detect and apply optimal settings
+vllm serve /data/models/your-model/
+
+# Use specific recipe
+vllm serve /data/models/your-model/ --rocm-tuner-recipe optimal
+
+# With HuggingFace model ID (no duplicate model specification needed)
+vllm serve --model amd/Llama-3.3-70B-Instruct-FP8-KV --rocm-tuner-is-hf
+
+# Explicit config file
+vllm serve --model /data/models/your-model/ --rocm-tuner-config /path/to/rocm_config_gfx950.json
+
+# Disable tuner
+vllm serve --model your-model --rocm-tuner-disable
+```
+
+## Supported GPUs
+
+| Architecture | GPU Series     | Status |
+|--------------|----------------|--------|
+| gfx942       | MI300X, MI300A | ✅ Supported |
+| gfx950       | MI350X, MI355X | ✅ Supported |
+
+## How It Works
+
+Models are matched by **signature** - a unique identifier from their config.json:
+
+```log
+GptOssForCausalLM_36L_2880H_64A
+└─ Architecture   │   │      └─ Attention heads
+                  │   └─ Hidden size  
+                  └─ Layers
+```
+
+If no exact match is found, the tuner gracefully exits without affecting vLLM operation.
+
+## Platform Safety
+
+- **NVIDIA GPUs**: Tuner disabled automatically, no changes made
+- **No AMD GPU detected**: Tuner exits gracefully with clear message
+- **Unsupported AMD GPU**: Tuner exits gracefully, lists supported architectures
+- **Missing config**: Tuner exits gracefully, vLLM uses defaults
+- **Model not in config**: Tuner exits gracefully, vLLM uses defaults
+
+## Adding New Models
+
+### For Local Models
+
+```bash
+# Generate signature
+python tools/generate_signature.py /data/models/your-model/
+
+# Output shows:
+# Signature: GptOssForCausalLM_36L_2880H_64A
+# Add to config: ...
+```
+
+Manually add to `configs/rocm_config_gfx950.json`:
+
+```json
+{
+  "model_configs": {
+    "openai/gpt-oss-120b": {
+      "signature": "GptOssForCausalLM_36L_2880H_64A",
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Optimized for throughput",
+          "env_vars": {
+            "VLLM_ROCM_USE_AITER": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "gpu-memory-utilization": 0.92
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### For HuggingFace Models
+
+```bash
+# Auto-fetch configs and add signatures
+pip install huggingface-hub  # Required
+
+# Dry run first
+python tools/add_signatures.py --dry-run
+
+# Add signatures to all configs
+python tools/add_signatures.py
+
+# Add to specific config
+python tools/add_signatures.py --config configs/rocm_config_gfx950.json
+```
+
+This automatically fetches config.json from HuggingFace and generates signatures for all models in your config files that have HuggingFace IDs (format: `org/model-name`).
+
+## vLLM Integration
+
+The tuner integrates automatically when vLLM starts:
+
+1. Detects your GPU architecture
+2. Loads the appropriate config file from package
+3. Reads your model's config.json
+4. Matches by signature or model ID
+5. Applies environment variables
+6. Provides CLI argument defaults (user args take precedence)
+
+## CLI Arguments
+
+All CLI arguments can be found under `vllm/vllm/entrypoints/cli/autotune.py`, and are:
+
+```bash
+--rocm-tuner-config PATH        # Explicit config file path (overrides auto-detection)
+--rocm-tuner-recipe NAME        # Recipe name to use (default: rank 1 "optimal")
+--rocm-tuner-is-hf              # Model is HuggingFace ID (uses --model arg for matching)
+--rocm-tuner-use-defaults       # Apply default_config settings from config file
+--rocm-tuner-model-id           # Explicit model ID for config matching (overrides signature detection)
+--rocm-tuner-disable            # Disable tuner completely (skip all optimizations)
+```
+
+### Using `--rocm-tuner-is-hf`
+
+When your model argument is already a HuggingFace model ID, use this flag to avoid duplication:
+
+```bash
+# Before (redundant):
+vllm serve --model amd/Llama-3.3-70B-Instruct-FP8-KV --rocm-tuner-model-id amd/Llama-3.3-70B-Instruct-FP8-KV
+
+# After (clean):
+vllm serve --model amd/Llama-3.3-70B-Instruct-FP8-KV --rocm-tuner-is-hf
+```
+
+## Config File Discovery
+
+Configs are searched in this order:
+
+1. **Package configs** (recommended) - Bundled with installation
+2. **Explicit path** via `--rocm-tuner-config`
+
+Previous versions searched additional locations (`./`, `~/.config/`, `/etc/`), but these have been removed for simplicity. Use `--rocm-tuner-config` for custom configs.
+
+## Troubleshooting
+
+```bash
+# Check GPU architecture
+vllm-rocm-detect
+
+# Check GPU architecture (JSON output)
+vllm-rocm-detect --json
+
+# Check available configs
+python -c "import vllm_rocm_autotuner_configs; \
+print(vllm_rocm_autotuner_configs.list_available_configs())"
+
+# Generate signature for your model
+python tools/generate_signature.py /path/to/model
+
+# Verify signature in config
+grep -A2 "signature" src/vllm_rocm_autotuner_configs/configs/rocm_config_gfx950.json
+```
+
+### Development tools
+
+In `tools/` (not installed with package):
+
+- **`generate_signature.py`** - Generate signature for a model
+
+  ```bash
+  python tools/generate_signature.py /path/to/model
+  ```
+
+- **`add_signatures.py`** - Batch add signatures for HF models
+
+  ```bash
+  python tools/add_signatures.py --dry-run  # Preview
+  python tools/add_signatures.py            # Apply
+  ```

--- a/tools/vllm-rocm-autotuner-configs/pyproject.toml
+++ b/tools/vllm-rocm-autotuner-configs/pyproject.toml
@@ -7,7 +7,7 @@ name = "vllm-rocm-autotuner-configs"
 version = "0.2.1"
 description = "ROCm tuned environment variable configurations for vLLM on AMD GPUs"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = []
 
 [project.scripts]

--- a/tools/vllm-rocm-autotuner-configs/pyproject.toml
+++ b/tools/vllm-rocm-autotuner-configs/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=79.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vllm-rocm-autotuner-configs"
+version = "0.2.1"
+description = "ROCm tuned environment variable configurations for vLLM on AMD GPUs"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[project.scripts]
+vllm-rocm-detect = "vllm_rocm_autotuner_configs.utils:main"
+
+[project.optional-dependencies]
+gpu-detect = [
+    "amdsmi>=6.4.4",
+]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-cov>=6.0.0",
+    "amdsmi>=6.4.4",
+    "huggingface-hub>=0.35.3",
+    "ruff>=0.8.0",
+    "mypy>=1.13.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+vllm_rocm_autotuner_configs = ["configs/*.json", "py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "requires_vllm: marks tests that require vLLM installed",
+    "requires_gpu: marks tests that require actual GPU",
+]
+addopts = [
+    "--verbose",
+    "--strict-markers",
+    "-ra",
+    "--tb=short",
+    "-m", "not slow and not e2e and not requires_gpu",
+]
+log_cli = true
+log_cli_level = "INFO"

--- a/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/__init__.py
+++ b/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/__init__.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""vLLM ROCm Auto-Tuner Configurations.
+
+Provides optimized environment variable settings for vLLM on ROCm-enabled GPUs.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+class GPUDetectionError(Exception):
+    """Raised when GPU detection fails."""
+
+    pass
+
+
+try:
+    from .utils import GPUDetectionError as _GPUDetectionError
+    from .utils import (check_amdsmi_available, get_amd_gpu_info,
+                        get_amd_gpu_info_safe)
+
+    # Use the imported version if available
+    GPUDetectionError = _GPUDetectionError  # type: ignore[misc]
+    _HAS_UTILS = True
+except ImportError:
+    _HAS_UTILS = False
+
+    def get_amd_gpu_info() -> tuple[str, int]:  # type: ignore[misc]
+        """Stub function when utils not available."""
+        raise GPUDetectionError("amdsmi not available")
+
+    def get_amd_gpu_info_safe() -> tuple[str | None, int]:
+        """Stub function when utils not available."""
+        return None, 0
+
+    def check_amdsmi_available() -> bool:
+        """Stub function when utils not available."""
+        return False
+
+
+__version__ = "0.2.1"
+
+_logger = logging.getLogger(__name__)
+_CONFIG_DIR = Path(__file__).parent / "configs"
+
+# Supported architectures
+SUPPORTED_ARCHITECTURES = frozenset(["gfx942", "gfx950"])
+
+# Architecture mappings for older GPUs
+ARCHITECTURE_MAPPINGS: dict[str, str] = {
+    # "gfx90a": "gfx942",  # MI200 series maps to MI300X config
+}
+
+
+class ConfigNotFoundError(Exception):
+    """Raised when a configuration file cannot be found."""
+
+
+class UnsupportedArchitectureError(Exception):
+    """Raised when GPU architecture is not supported."""
+
+
+def get_config_path(
+    arch: str | None = None,
+    config_file: str | Path | None = None,
+) -> Path:
+    """Get path to config file for given architecture.
+
+    Simplified to only search:
+    1. Explicit config_file if provided
+    2. Package bundled configs
+
+    Args:
+        arch: GPU architecture (e.g., 'gfx942'). If None, attempts
+            auto-detection.
+        config_file: Explicit path to config file. Takes precedence over arch.
+
+    Returns:
+        Path to config file.
+
+    Raises:
+        ConfigNotFoundError: If no suitable config file is found.
+        UnsupportedArchitectureError: If architecture is detected but not
+            supported.
+
+    Examples:
+        >>> # Auto-detect and get config
+        >>> path = get_config_path()
+        >>>
+        >>> # Specific architecture
+        >>> path = get_config_path(arch='gfx942')
+        >>>
+        >>> # Explicit config file
+        >>> path = get_config_path(config_file='/path/to/config.json')
+    """
+    # 1. Explicit config file takes precedence
+    if config_file is not None:
+        config_path = Path(config_file)
+        if not config_path.exists():
+            raise ConfigNotFoundError(f"Config file not found: {config_path}")
+        _logger.info(f"Using explicit config: {config_path}")  # noqa: G004
+        return config_path
+
+    # 2. Try auto-detection if no arch specified
+    if arch is None:
+        if _HAS_UTILS and check_amdsmi_available():
+            try:
+                detected_arch, gpu_count = get_amd_gpu_info()
+                if gpu_count == 0:
+                    raise ConfigNotFoundError(
+                        "No AMD GPUs detected. ROCm tuner requires AMD GPUs.")
+                if detected_arch and detected_arch != "unknown":
+                    arch = detected_arch
+                    _logger.info(
+                        f"Auto-detected GPU architecture: {arch}"  # noqa: G004
+                    )
+            except GPUDetectionError as e:
+                raise ConfigNotFoundError(f"GPU detection failed: {e}") from e
+        else:
+            raise ConfigNotFoundError(
+                "Cannot auto-detect GPU architecture. "
+                "Install with: pip install "
+                "vllm-rocm-autotuner-configs[gpu-detect]")
+
+    if arch is None:
+        raise ConfigNotFoundError(
+            "No architecture specified and auto-detection failed")
+
+    # 3. Apply architecture mappings for older GPUs
+    original_arch = arch
+    if arch in ARCHITECTURE_MAPPINGS:
+        mapped_arch = ARCHITECTURE_MAPPINGS[arch]
+        _logger.info(f"Mapping {arch} -> {mapped_arch}")  # noqa: G004
+        arch = mapped_arch
+
+    # 4. Check if architecture is supported
+    if arch not in SUPPORTED_ARCHITECTURES:
+        raise UnsupportedArchitectureError(
+            f"GPU architecture '{original_arch}' is not supported. "
+            f"Supported: {', '.join(sorted(SUPPORTED_ARCHITECTURES))}")
+
+    # 5. Look for config in package
+    config_file_path = _CONFIG_DIR / f"rocm_config_{arch}.json"
+    if not config_file_path.exists():
+        raise ConfigNotFoundError(
+            f"Config file for architecture '{arch}' not found in package")
+
+    _logger.info(
+        f"Using package config: {config_file_path.name}")  # noqa: G004
+    return config_file_path
+
+
+def list_available_configs() -> list[str]:
+    """List all available GPU architectures with configs.
+
+    Returns:
+        Sorted list of architecture names.
+
+    Examples:
+        >>> configs = list_available_configs()
+        >>> print(f"Available configs: {', '.join(configs)}")
+        Available configs: gfx942, gfx950
+    """
+    if not _CONFIG_DIR.exists():
+        return []
+
+    configs = []
+    for config_file in _CONFIG_DIR.glob("rocm_config_*.json"):
+        arch = config_file.stem.replace("rocm_config_", "")
+        configs.append(arch)
+
+    return sorted(configs)
+
+
+__all__ = [
+    "__version__",
+    "get_config_path",
+    "list_available_configs",
+    "ConfigNotFoundError",
+    "UnsupportedArchitectureError",
+    "SUPPORTED_ARCHITECTURES",
+    "ARCHITECTURE_MAPPINGS",
+    "get_amd_gpu_info",
+    "get_amd_gpu_info_safe",
+    "check_amdsmi_available",
+    "GPUDetectionError",
+]

--- a/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/__init__.py
+++ b/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/__init__.py
@@ -19,8 +19,7 @@ class GPUDetectionError(Exception):
 
 try:
     from .utils import GPUDetectionError as _GPUDetectionError
-    from .utils import (check_amdsmi_available, get_amd_gpu_info,
-                        get_amd_gpu_info_safe)
+    from .utils import check_amdsmi_available, get_amd_gpu_info, get_amd_gpu_info_safe
 
     # Use the imported version if available
     GPUDetectionError = _GPUDetectionError  # type: ignore[misc]
@@ -91,10 +90,10 @@ def get_config_path(
         >>> path = get_config_path()
         >>>
         >>> # Specific architecture
-        >>> path = get_config_path(arch='gfx942')
+        >>> path = get_config_path(arch="gfx942")
         >>>
         >>> # Explicit config file
-        >>> path = get_config_path(config_file='/path/to/config.json')
+        >>> path = get_config_path(config_file="/path/to/config.json")
     """
     # 1. Explicit config file takes precedence
     if config_file is not None:
@@ -111,7 +110,8 @@ def get_config_path(
                 detected_arch, gpu_count = get_amd_gpu_info()
                 if gpu_count == 0:
                     raise ConfigNotFoundError(
-                        "No AMD GPUs detected. ROCm tuner requires AMD GPUs.")
+                        "No AMD GPUs detected. ROCm tuner requires AMD GPUs."
+                    )
                 if detected_arch and detected_arch != "unknown":
                     arch = detected_arch
                     _logger.info(
@@ -123,11 +123,11 @@ def get_config_path(
             raise ConfigNotFoundError(
                 "Cannot auto-detect GPU architecture. "
                 "Install with: pip install "
-                "vllm-rocm-autotuner-configs[gpu-detect]")
+                "vllm-rocm-autotuner-configs[gpu-detect]"
+            )
 
     if arch is None:
-        raise ConfigNotFoundError(
-            "No architecture specified and auto-detection failed")
+        raise ConfigNotFoundError("No architecture specified and auto-detection failed")
 
     # 3. Apply architecture mappings for older GPUs
     original_arch = arch
@@ -140,16 +140,17 @@ def get_config_path(
     if arch not in SUPPORTED_ARCHITECTURES:
         raise UnsupportedArchitectureError(
             f"GPU architecture '{original_arch}' is not supported. "
-            f"Supported: {', '.join(sorted(SUPPORTED_ARCHITECTURES))}")
+            f"Supported: {', '.join(sorted(SUPPORTED_ARCHITECTURES))}"
+        )
 
     # 5. Look for config in package
     config_file_path = _CONFIG_DIR / f"rocm_config_{arch}.json"
     if not config_file_path.exists():
         raise ConfigNotFoundError(
-            f"Config file for architecture '{arch}' not found in package")
+            f"Config file for architecture '{arch}' not found in package"
+        )
 
-    _logger.info(
-        f"Using package config: {config_file_path.name}")  # noqa: G004
+    _logger.info(f"Using package config: {config_file_path.name}")  # noqa: G004
     return config_file_path
 
 

--- a/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/configs/rocm_config_gfx942.json
+++ b/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/configs/rocm_config_gfx942.json
@@ -1,0 +1,333 @@
+{
+  "default_config": {
+    "env_vars": {
+      "VLLM_DISABLE_COMPILE_CACHE": "1",
+      "VLLM_LOGGING_LEVEL": "INFO"
+    },
+    "cli_args": {
+      "dataset-name": "random",
+      "input-len": 1024,
+      "output-len": 1024,
+      "num-prompts": 32,
+      "swap-space": 16,
+      "async-scheduling": true,
+      "no-enable-prefix-caching": true,
+      "load-format": "dummy",
+      "tensor-parallel-size": 8
+    }
+  },
+  "model_configs": {
+    "deepseek-ai/DeepSeek-R1-0528": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "Alternative with unified attention",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With MOE padding disabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_MOE_PADDING": "0",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        }
+      ],
+      "signature": "DeepseekV3ForCausalLM_61L_7168H_128A"
+    },
+    "amd/Llama-3.1-405B-Instruct-FP8-KV": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_MOE": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With INT4 quantization",
+          "env_vars": {
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION": "INT4",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_LINEAR": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_MOE": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "0",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With custom paged attention",
+          "env_vars": {
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_CUSTOM_PAGED_ATTN": "1",
+            "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION": "INT4",
+            "VLLM_ROCM_USE_AITER_PAGED_ATTN": "0"
+          },
+          "cli_args": {
+            "block-size": 32,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        }
+      ],
+      "signature": "LlamaForCausalLM_126L_16384H_128A"
+    },
+    "amd/Llama-3.3-70B-Instruct-FP8-KV": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With AITER enabled and scratch reclaim",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "0"
+          },
+          "cli_args": {
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With AITER and RMSNORM",
+          "env_vars": {
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_MOE": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        }
+      ],
+      "signature": "LlamaForCausalLM_80L_8192H_64A"
+    },
+    "Qwen/Qwen3-235B-A22B-FP8": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "HIP_VISIBLE_DEVICES": "0,1,2,3",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 32,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With AITER enabled",
+          "env_vars": {
+            "HIP_VISIBLE_DEVICES": "0,1,2,3",
+            "VLLM_ROCM_USE_AITER": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "gpu-memory-utilization": 0.95,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With selective AITER components",
+          "env_vars": {
+            "HIP_VISIBLE_DEVICES": "0,1,2,3",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_MHA": "1",
+            "VLLM_ROCM_USE_AITER_MOE": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "0"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "gpu-memory-utilization": 0.95,
+            "kv-cache-dtype": "fp8",
+            "no-enable-prefix-caching": true
+          }
+        }
+      ],
+      "signature": "Qwen3MoeForCausalLM_94L_4096H_64A"
+    }
+  }
+}

--- a/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/configs/rocm_config_gfx950.json
+++ b/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/configs/rocm_config_gfx950.json
@@ -1,0 +1,545 @@
+{
+  "default_config": {
+    "env_vars": {
+      "VLLM_DISABLE_COMPILE_CACHE": "1",
+      "VLLM_LOGGING_LEVEL": "INFO"
+    },
+    "cli_args": {
+      "dataset-name": "random",
+      "input-len": 1024,
+      "output-len": 1024,
+      "num-prompts": 32,
+      "swap-space": 16,
+      "async-scheduling": true,
+      "no-enable-prefix-caching": true,
+      "load-format": "dummy",
+      "tensor-parallel-size": 8
+    }
+  },
+  "model_configs": {
+    "amd/DeepSeek-R1-0528-MXFP4-Preview": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {},
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"]
+            },
+            "gpu-memory-utilization": 0.95,
+            "kv-cache-dtype": "fp8"
+          }
+        }
+      ],
+      "signature": "DeepseekV3ForCausalLM_61L_7168H_128A"
+    },
+    "deepseek-ai/DeepSeek-R1-0528": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With unified attention and CK tile linear disabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_CK_TILE_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With MOE preshuffle scales disabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "ROCM_TRITON_MOE_PRESHUFFLE_SCALES": "0",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        },
+        {
+          "name": "alternative_3",
+          "rank": 4,
+          "description": "With fused add RMSNORM pad disabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD": "0"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        },
+        {
+          "name": "alternative_4",
+          "rank": 5,
+          "description": "With triton linear enabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_CK_TILE_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_LINEAR": "1",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 1,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95
+          }
+        }
+      ],
+      "signature": "DeepseekV3ForCausalLM_61L_7168H_128A"
+    },
+    "amd/Llama-3.1-405B-Instruct-MXFP4-Preview": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "AMDGCN_USE_BUFFER_OPS": "1",
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION": "INT4",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_TRITON_FP4_GEMM_USE_ASM": "1",
+            "VLLM_USE_AITER_TRITON_ROPE": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 32,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With INT8 quantization instead of INT4",
+          "env_vars": {
+            "AMDGCN_USE_BUFFER_OPS": "1",
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION": "INT8",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_TRITON_FP4_GEMM_USE_ASM": "1",
+            "VLLM_USE_AITER_TRITON_ROPE": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 32,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "Without quick reduce quantization",
+          "env_vars": {
+            "AMDGCN_USE_BUFFER_OPS": "1",
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_TRITON_FP4_GEMM_USE_ASM": "1",
+            "VLLM_USE_AITER_TRITON_ROPE": "1",
+            "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 32,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        }
+      ],
+      "signature": "LlamaForCausalLM_126L_16384H_128A"
+    },
+    "amd/Llama-3.3-70B-Instruct-FP8-KV": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "AMDGCN_USE_BUFFER_OPS": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_USE_AITER_TRITON_ROPE": "1"
+          },
+          "cli_args": {
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With scratch reclaim and RMSNORM disabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "TRITON_HIP_PRESHUFFLE_SCALES": "1",
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "0"
+          },
+          "cli_args": {
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With custom paged attention",
+          "env_vars": {
+            "TRITON_HIP_USE_ASYNC_COPY": "1",
+            "TRITON_HIP_USE_BLOCK_PINGPONG": "1",
+            "VLLM_ROCM_CUSTOM_PAGED_ATTN": "1",
+            "VLLM_ROCM_USE_AITER_PAGED_ATTN": "0"
+          },
+          "cli_args": {
+            "block-size": 32,
+            "gpu-memory-utilization": 0.92,
+            "kv-cache-dtype": "fp8"
+          }
+        }
+      ],
+      "signature": "LlamaForCausalLM_80L_8192H_64A"
+    },
+    "Qwen/Qwen3-235B-A22B-FP8": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "HIP_VISIBLE_DEVICES": "0,1,2,3",
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "ROCM_TRITON_MOE_PRESHUFFLE_SCALES": "0",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_FP8_BMM": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_FUSED_MUL_ADD": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_SILU_MUL_FP8_QUANT": "0",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With unified attention and simpler AITER config",
+          "env_vars": {
+            "HIP_VISIBLE_DEVICES": "0,1,2,3",
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95,
+            "kv-cache-dtype": "fp8"
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With AITER linear disabled",
+          "env_vars": {
+            "HIP_VISIBLE_DEVICES": "0,1,2,3",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.95,
+            "kv-cache-dtype": "fp8"
+          }
+        }
+      ],
+      "signature": "Qwen3MoeForCausalLM_94L_4096H_64A"
+    },
+    "openai/gpt-oss-120b": {
+      "recipes": [
+        {
+          "name": "optimal",
+          "rank": 1,
+          "description": "Best performance configuration",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_LINEAR": "1",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "compile_sizes": [1, 2, 4, 8, 16, 24, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+              "cudagraph_capture_sizes": [8192, 4096, 2048, 1024, 1008, 992, 976, 960, 944, 928, 912, 896, 880, 864, 848, 832, 816, 800, 784, 768, 752, 736, 720, 704, 688, 672, 656, 640, 624, 608, 592, 576, 560, 544, 528, 512, 496, 480, 464, 448, 432, 416, 400, 384, 368, 352, 336, 320, 304, 288, 272, 256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176, 168, 160, 152, 144, 136, 128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 4, 2, 1],
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92
+          }
+        },
+        {
+          "name": "alternative_1",
+          "rank": 2,
+          "description": "With fused RMSNORM FP8 quant disabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT": "0",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "compile_sizes": [1, 2, 4, 8, 16, 24, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+              "cudagraph_capture_sizes": [8192, 4096, 2048, 1024, 1008, 992, 976, 960, 944, 928, 912, 896, 880, 864, 848, 832, 816, 800, 784, 768, 752, 736, 720, 704, 688, 672, 656, 640, 624, 608, 592, 576, 560, 544, 528, 512, 496, 480, 464, 448, 432, 416, 400, 384, 368, 352, 336, 320, 304, 288, 272, 256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176, 168, 160, 152, 144, 136, 128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 4, 2, 1],
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92
+          }
+        },
+        {
+          "name": "alternative_2",
+          "rank": 3,
+          "description": "With selective AITER components disabled",
+          "env_vars": {
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_LINEAR": "0",
+            "VLLM_ROCM_USE_AITER_MHA": "0",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "0",
+            "VLLM_USE_AITER_UNIFIED_ATTENTION": "1"
+          },
+          "cli_args": {
+            "block-size": 64,
+            "compilation-config": {
+              "compile_sizes": [1, 2, 4, 8, 16, 24, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+              "cudagraph_capture_sizes": [8192, 4096, 2048, 1024, 1008, 992, 976, 960, 944, 928, 912, 896, 880, 864, 848, 832, 816, 800, 784, 768, 752, 736, 720, 704, 688, 672, 656, 640, 624, 608, 592, 576, 560, 544, 528, 512, 496, 480, 464, 448, 432, 416, 400, 384, 368, 352, 336, 320, 304, 288, 272, 256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176, 168, 160, 152, 144, 136, 128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 4, 2, 1],
+              "pass_config": {
+                "enable_attn_fusion": true,
+                "enable_noop": true,
+                "enable_fusion": true
+              },
+              "cudagraph_mode": "FULL",
+              "custom_ops": ["+silu_and_mul", "+quant_fp8"],
+              "splitting_ops": []
+            },
+            "gpu-memory-utilization": 0.92
+          }
+        }
+      ],
+      "signature": "GptOssForCausalLM_36L_2880H_64A"
+    }
+  }
+}

--- a/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/utils.py
+++ b/tools/vllm-rocm-autotuner-configs/src/vllm_rocm_autotuner_configs/utils.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Utility functions for GPU detection and configuration management."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import sys
+from functools import lru_cache
+
+_logger = logging.getLogger("vllm_rocm_autotuner_configs")
+
+try:
+    from amdsmi import (AmdSmiException, amdsmi_get_gpu_asic_info,
+                        amdsmi_get_processor_handles, amdsmi_init,
+                        amdsmi_shut_down)
+
+    _HAS_AMDSMI = True
+except (ImportError, KeyError, OSError) as e:
+    _HAS_AMDSMI = False
+    _logger.debug(
+        f"amdsmi not available ({type(e).__name__}). "  # noqa: G004
+        "GPU auto-detection unavailable. "
+        "Install with: pip install vllm-rocm-autotuner-configs[gpu-detect]")
+
+
+class GPUDetectionError(Exception):
+    """Raised when GPU detection fails."""
+
+    pass
+
+
+@lru_cache(maxsize=1)
+def get_amd_gpu_info() -> tuple[str, int]:
+    """
+    Gets GPU architecture and count for AMD GPUs.
+
+    Returns:
+        Tuple of (architecture_name, num_gpus)
+        - architecture_name: GPU architecture string (e.g., 'gfx942', 'gfx90a')
+        - num_gpus: Number of detected GPUs
+
+    Examples:
+        >>> arch, count = get_amd_gpu_info()
+        >>> print(f"Found {count} GPU(s) with architecture {arch}")
+        Found 8 GPU(s) with architecture gfx942
+
+    Raises:
+        GPUDetectionError: If detection fails or amdsmi is not available
+    """
+    if not _HAS_AMDSMI:
+        raise GPUDetectionError(
+            "amdsmi library not available. "
+            "Install with: pip install vllm-rocm-autotuner-configs[gpu-detect]"
+        )
+
+    try:
+        amdsmi_init()
+        devices = amdsmi_get_processor_handles()
+
+        if not devices:
+            _logger.warning("No AMD GPUs detected")
+            return "unknown", 0
+
+        all_info = []
+        for dev in devices:
+            try:
+                info = amdsmi_get_gpu_asic_info(dev)
+                all_info.append(info)
+            except AmdSmiException as e:
+                _logger.warning(
+                    f"Failed to get info for device {dev}: {e}")  # noqa: G004
+                continue
+
+        if not all_info:
+            raise GPUDetectionError("Failed to get info for any GPU")
+
+        num_gpus = len(all_info)
+        unique_device_ids = {info.get("device_id") for info in all_info}
+        if len(unique_device_ids) == 1:
+            gfx_version = all_info[0].get("target_graphics_version", "unknown")
+            arch = _normalize_arch_name(gfx_version)
+            _logger.debug("Detected %s GPU(s) with architecture %s", num_gpus,
+                          arch)
+            return arch, num_gpus
+        else:
+            _logger.warning(
+                f"Detected mixed GPU architectures: {unique_device_ids}. "  # noqa: G004
+                "Using 'mixed' as architecture name.")
+            return "mixed", num_gpus
+
+    except AmdSmiException as e:
+        raise GPUDetectionError(f"AMDSMI error: {e}") from e
+    finally:
+        with contextlib.suppress(AmdSmiException, NameError):
+            amdsmi_shut_down()
+
+
+def _normalize_arch_name(gfx_version: str) -> str:
+    """
+    Normalize GPU architecture name to standard format.
+
+    Args:
+        gfx_version: Raw GPU architecture string from amdsmi
+
+    Returns:
+        Normalized architecture name (e.g., 'gfx942')
+
+    Examples:
+        >>> _normalize_arch_name('gfx942:sramecc+:xnack-')
+        'gfx942'
+        >>> _normalize_arch_name('gfx90a')
+        'gfx90a'
+    """
+    if not gfx_version or gfx_version == "unknown":
+        return "unknown"
+
+    base_arch = gfx_version.split(
+        ":")[0] if ":" in gfx_version else gfx_version
+    base_arch = base_arch.strip().lower()
+
+    return base_arch
+
+
+def get_amd_gpu_info_safe() -> tuple[str | None, int]:
+    """
+    Safe version of get_amd_gpu_info that never raises exceptions.
+
+    Returns:
+        Tuple of (architecture_name, num_gpus)
+        - architecture_name: GPU architecture string or None if detection failed
+        - num_gpus: Number of detected GPUs, 0 if detection failed
+
+    Examples:
+        >>> arch, count = get_amd_gpu_info_safe()
+        >>> if arch:
+        ...     print(f"Detected {arch}")
+        ... else:
+        ...     print("GPU detection failed")
+    """
+    try:
+        return get_amd_gpu_info()
+    except GPUDetectionError as e:
+        _logger.debug(f"GPU detection failed: {e}")  # noqa: G004
+        return None, 0
+    except Exception as e:
+        _logger.warning(
+            f"Unexpected error during GPU detection: {e}")  # noqa: G004
+        return None, 0
+
+
+def check_amdsmi_available() -> bool:
+    """
+    Check if amdsmi library is available.
+
+    Returns:
+        True if amdsmi is available, False otherwise
+
+    Examples:
+        >>> if check_amdsmi_available():
+        ...     arch, count = get_amd_gpu_info()
+        ... else:
+        ...     print("Install amdsmi for GPU auto-detection")
+    """
+    return _HAS_AMDSMI
+
+
+def clear_gpu_info_cache() -> None:
+    """
+    Clear the cached GPU information.
+
+    Useful if GPUs are added/removed during runtime or for testing.
+
+    Examples:
+        >>> get_amd_gpu_info()  # Cached result
+        >>> # ... GPU configuration changes ...
+        >>> clear_gpu_info_cache()
+        >>> get_amd_gpu_info()  # Fresh detection
+    """
+    get_amd_gpu_info.cache_clear()
+
+
+def main() -> int:
+    """
+    Command-line interface for GPU detection.
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Detect AMD GPU architecture and count")
+    parser.add_argument("-v",
+                        "--verbose",
+                        action="store_true",
+                        help="Enable verbose output")
+    parser.add_argument("--json",
+                        action="store_true",
+                        help="Output in JSON format")
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG,
+                            format="%(levelname)s: %(message)s")
+    else:
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if not check_amdsmi_available():
+        print(
+            "Error: amdsmi library not found.\n"
+            "Install with: pip install vllm-rocm-autotuner-configs[gpu-detect]",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        arch, num_gpus = get_amd_gpu_info()
+
+        if args.json:
+            import json
+
+            result = {
+                "architecture": arch,
+                "num_gpus": num_gpus,
+                "amdsmi_available": True,
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Number of AMD GPUs: {num_gpus}")
+            if num_gpus > 0:
+                print(f"GPU Architecture: {arch}")
+            else:
+                print("No AMD GPUs detected")
+
+        return 0
+
+    except GPUDetectionError as e:
+        if args.json:
+            import json
+
+            result = {
+                "error": str(e),
+                "architecture": None,
+                "num_gpus": 0,
+                "amdsmi_available": True,
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/vllm-rocm-autotuner-configs/tests/conftest.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/conftest.py
@@ -12,8 +12,9 @@ import pytest
 @pytest.fixture
 def configs_dir():
     """Get the configs directory."""
-    return (Path(__file__).parent.parent / "src" /
-            "vllm_rocm_autotuner_configs" / "configs")
+    return (
+        Path(__file__).parent.parent / "src" / "vllm_rocm_autotuner_configs" / "configs"
+    )
 
 
 @pytest.fixture
@@ -47,27 +48,20 @@ def sample_config(tmp_path):
     """Create a sample config file for testing."""
     config = {
         "default_config": {
-            "env_vars": {
-                "TEST_VAR": "test"
-            },
-            "cli_args": {
-                "test-arg": 123
-            },
+            "env_vars": {"TEST_VAR": "test"},
+            "cli_args": {"test-arg": 123},
         },
         "model_configs": {
             "test/model": {
-                "signature":
-                "GptOssForCausalLM_36L_2880H_64A",
-                "recipes": [{
-                    "name": "optimal",
-                    "rank": 1,
-                    "env_vars": {
-                        "VLLM_TEST": "1"
-                    },
-                    "cli_args": {
-                        "block-size": 64
-                    },
-                }],
+                "signature": "GptOssForCausalLM_36L_2880H_64A",
+                "recipes": [
+                    {
+                        "name": "optimal",
+                        "rank": 1,
+                        "env_vars": {"VLLM_TEST": "1"},
+                        "cli_args": {"block-size": 64},
+                    }
+                ],
             }
         },
     }

--- a/tools/vllm-rocm-autotuner-configs/tests/conftest.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/conftest.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared fixtures for tests."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def configs_dir():
+    """Get the configs directory."""
+    return (Path(__file__).parent.parent / "src" /
+            "vllm_rocm_autotuner_configs" / "configs")
+
+
+@pytest.fixture
+def clean_env():
+    """Clean and restore environment."""
+    original = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(original)
+
+
+@pytest.fixture
+def mock_model_dir(tmp_path):
+    """Create a mock model directory."""
+    model_dir = tmp_path / "test_model"
+    model_dir.mkdir()
+
+    config = {
+        "architectures": ["GptOssForCausalLM"],
+        "num_hidden_layers": 36,
+        "hidden_size": 2880,
+        "num_attention_heads": 64,
+    }
+
+    (model_dir / "config.json").write_text(json.dumps(config, indent=2))
+    return model_dir
+
+
+@pytest.fixture
+def sample_config(tmp_path):
+    """Create a sample config file for testing."""
+    config = {
+        "default_config": {
+            "env_vars": {
+                "TEST_VAR": "test"
+            },
+            "cli_args": {
+                "test-arg": 123
+            },
+        },
+        "model_configs": {
+            "test/model": {
+                "signature":
+                "GptOssForCausalLM_36L_2880H_64A",
+                "recipes": [{
+                    "name": "optimal",
+                    "rank": 1,
+                    "env_vars": {
+                        "VLLM_TEST": "1"
+                    },
+                    "cli_args": {
+                        "block-size": 64
+                    },
+                }],
+            }
+        },
+    }
+
+    config_file = tmp_path / "test_config.json"
+    config_file.write_text(json.dumps(config, indent=2))
+    return config_file

--- a/tools/vllm-rocm-autotuner-configs/tests/test_configs.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/test_configs.py
@@ -24,8 +24,11 @@ class TestConfigStructure:
     @pytest.mark.parametrize(
         "config_name,config_data",
         load_all_configs(
-            Path(__file__).parent.parent / "src" /
-            "vllm_rocm_autotuner_configs" / "configs"),
+            Path(__file__).parent.parent
+            / "src"
+            / "vllm_rocm_autotuner_configs"
+            / "configs"
+        ),
     )
     def test_valid_json(self, config_name, config_data):
         """Test that configs are valid JSON."""
@@ -35,8 +38,11 @@ class TestConfigStructure:
     @pytest.mark.parametrize(
         "config_name,config_data",
         load_all_configs(
-            Path(__file__).parent.parent / "src" /
-            "vllm_rocm_autotuner_configs" / "configs"),
+            Path(__file__).parent.parent
+            / "src"
+            / "vllm_rocm_autotuner_configs"
+            / "configs"
+        ),
     )
     def test_model_configs_structure(self, config_name, config_data):
         """Test model_configs section structure."""
@@ -61,8 +67,11 @@ class TestConfigStructure:
     @pytest.mark.parametrize(
         "config_name,config_data",
         load_all_configs(
-            Path(__file__).parent.parent / "src" /
-            "vllm_rocm_autotuner_configs" / "configs"),
+            Path(__file__).parent.parent
+            / "src"
+            / "vllm_rocm_autotuner_configs"
+            / "configs"
+        ),
     )
     def test_signature_format(self, config_name, config_data):
         """Test signature format is correct."""
@@ -87,8 +96,11 @@ class TestConfigStructure:
     @pytest.mark.parametrize(
         "config_name,config_data",
         load_all_configs(
-            Path(__file__).parent.parent / "src" /
-            "vllm_rocm_autotuner_configs" / "configs"),
+            Path(__file__).parent.parent
+            / "src"
+            / "vllm_rocm_autotuner_configs"
+            / "configs"
+        ),
     )
     def test_recipes_ranked(self, config_name, config_data):
         """Test that recipes are properly ranked."""
@@ -98,16 +110,18 @@ class TestConfigStructure:
             if len(recipes) > 1:
                 ranks = [r["rank"] for r in recipes]
                 # Ranks should be unique
-                assert len(ranks) == len(
-                    set(ranks)), f"{model_id}: duplicate ranks"
+                assert len(ranks) == len(set(ranks)), f"{model_id}: duplicate ranks"
                 # Should have rank 1
                 assert 1 in ranks, f"{model_id}: missing rank 1 recipe"
 
     @pytest.mark.parametrize(
         "config_name,config_data",
         load_all_configs(
-            Path(__file__).parent.parent / "src" /
-            "vllm_rocm_autotuner_configs" / "configs"),
+            Path(__file__).parent.parent
+            / "src"
+            / "vllm_rocm_autotuner_configs"
+            / "configs"
+        ),
     )
     def test_env_vars_valid(self, config_name, config_data):
         """Test that env vars are valid."""
@@ -119,19 +133,22 @@ class TestConfigStructure:
                     # Keys should be uppercase
                     assert key.isupper() or key.startswith("VLLM_"), (
                         f"{model_id}/{recipe['name']}: "
-                        f"env var {key} should be uppercase")
+                        f"env var {key} should be uppercase"
+                    )
 
                     # Values should be strings or convertible
-                    assert isinstance(
-                        value,
-                        (str, int, float)), (f"{model_id}/{recipe['name']}: "
-                                             f"env var {key} has invalid type")
+                    assert isinstance(value, (str, int, float)), (
+                        f"{model_id}/{recipe['name']}: env var {key} has invalid type"
+                    )
 
     @pytest.mark.parametrize(
         "config_name,config_data",
         load_all_configs(
-            Path(__file__).parent.parent / "src" /
-            "vllm_rocm_autotuner_configs" / "configs"),
+            Path(__file__).parent.parent
+            / "src"
+            / "vllm_rocm_autotuner_configs"
+            / "configs"
+        ),
     )
     def test_cli_args_valid(self, config_name, config_data):
         """Test that CLI args are valid."""
@@ -142,11 +159,10 @@ class TestConfigStructure:
                 for key, value in cli_args.items():
                     # Keys should use hyphens, not underscores
                     assert "_" not in key or key.startswith("_"), (
-                        f"{model_id}/{recipe['name']}: "
-                        f"CLI arg {key} should use hyphens")
+                        f"{model_id}/{recipe['name']}: CLI arg {key} should use hyphens"
+                    )
 
                     # Values should be valid types
-                    assert isinstance(
-                        value, (str, int, float, bool,
-                                dict)), (f"{model_id}/{recipe['name']}: "
-                                         f"CLI arg {key} has invalid type")
+                    assert isinstance(value, (str, int, float, bool, dict)), (
+                        f"{model_id}/{recipe['name']}: CLI arg {key} has invalid type"
+                    )

--- a/tools/vllm-rocm-autotuner-configs/tests/test_configs.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/test_configs.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Validate all config files."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def load_all_configs(configs_dir):
+    """Load all config files."""
+    configs = []
+    for config_file in configs_dir.glob("rocm_config_*.json"):
+        with open(config_file) as f:
+            data = json.load(f)
+            configs.append((config_file.name, data))
+    return configs
+
+
+class TestConfigStructure:
+    """Test config file structure."""
+
+    @pytest.mark.parametrize(
+        "config_name,config_data",
+        load_all_configs(
+            Path(__file__).parent.parent / "src" /
+            "vllm_rocm_autotuner_configs" / "configs"),
+    )
+    def test_valid_json(self, config_name, config_data):
+        """Test that configs are valid JSON."""
+        assert isinstance(config_data, dict)
+        assert "model_configs" in config_data
+
+    @pytest.mark.parametrize(
+        "config_name,config_data",
+        load_all_configs(
+            Path(__file__).parent.parent / "src" /
+            "vllm_rocm_autotuner_configs" / "configs"),
+    )
+    def test_model_configs_structure(self, config_name, config_data):
+        """Test model_configs section structure."""
+        model_configs = config_data["model_configs"]
+
+        for model_id, model_data in model_configs.items():
+            # Must have recipes
+            if "recipes" in model_data:
+                recipes = model_data["recipes"]
+                assert isinstance(recipes, list)
+                assert len(recipes) > 0
+
+                for recipe in recipes:
+                    # Required fields
+                    assert "name" in recipe
+                    assert "rank" in recipe
+                    assert isinstance(recipe["rank"], int)
+
+                    # Must have at least one config type
+                    assert "env_vars" in recipe or "cli_args" in recipe
+
+    @pytest.mark.parametrize(
+        "config_name,config_data",
+        load_all_configs(
+            Path(__file__).parent.parent / "src" /
+            "vllm_rocm_autotuner_configs" / "configs"),
+    )
+    def test_signature_format(self, config_name, config_data):
+        """Test signature format is correct."""
+        for model_id, model_data in config_data["model_configs"].items():
+            if "signature" in model_data:
+                sig = model_data["signature"]
+                parts = sig.split("_")
+
+                assert len(parts) == 4, f"Signature must have 4 parts: {sig}"
+                assert parts[1].endswith("L"), f"Part 2 must end with L: {sig}"
+                assert parts[2].endswith("H"), f"Part 3 must end with H: {sig}"
+                assert parts[3].endswith("A"), f"Part 4 must end with A: {sig}"
+
+                # Extract numbers
+                try:
+                    int(parts[1][:-1])
+                    int(parts[2][:-1])
+                    int(parts[3][:-1])
+                except ValueError:
+                    pytest.fail(f"Invalid signature numbers: {sig}")
+
+    @pytest.mark.parametrize(
+        "config_name,config_data",
+        load_all_configs(
+            Path(__file__).parent.parent / "src" /
+            "vllm_rocm_autotuner_configs" / "configs"),
+    )
+    def test_recipes_ranked(self, config_name, config_data):
+        """Test that recipes are properly ranked."""
+        for model_id, model_data in config_data["model_configs"].items():
+            recipes = model_data.get("recipes", [])
+
+            if len(recipes) > 1:
+                ranks = [r["rank"] for r in recipes]
+                # Ranks should be unique
+                assert len(ranks) == len(
+                    set(ranks)), f"{model_id}: duplicate ranks"
+                # Should have rank 1
+                assert 1 in ranks, f"{model_id}: missing rank 1 recipe"
+
+    @pytest.mark.parametrize(
+        "config_name,config_data",
+        load_all_configs(
+            Path(__file__).parent.parent / "src" /
+            "vllm_rocm_autotuner_configs" / "configs"),
+    )
+    def test_env_vars_valid(self, config_name, config_data):
+        """Test that env vars are valid."""
+        for model_id, model_data in config_data["model_configs"].items():
+            for recipe in model_data.get("recipes", []):
+                env_vars = recipe.get("env_vars", {})
+
+                for key, value in env_vars.items():
+                    # Keys should be uppercase
+                    assert key.isupper() or key.startswith("VLLM_"), (
+                        f"{model_id}/{recipe['name']}: "
+                        f"env var {key} should be uppercase")
+
+                    # Values should be strings or convertible
+                    assert isinstance(
+                        value,
+                        (str, int, float)), (f"{model_id}/{recipe['name']}: "
+                                             f"env var {key} has invalid type")
+
+    @pytest.mark.parametrize(
+        "config_name,config_data",
+        load_all_configs(
+            Path(__file__).parent.parent / "src" /
+            "vllm_rocm_autotuner_configs" / "configs"),
+    )
+    def test_cli_args_valid(self, config_name, config_data):
+        """Test that CLI args are valid."""
+        for model_id, model_data in config_data["model_configs"].items():
+            for recipe in model_data.get("recipes", []):
+                cli_args = recipe.get("cli_args", {})
+
+                for key, value in cli_args.items():
+                    # Keys should use hyphens, not underscores
+                    assert "_" not in key or key.startswith("_"), (
+                        f"{model_id}/{recipe['name']}: "
+                        f"CLI arg {key} should use hyphens")
+
+                    # Values should be valid types
+                    assert isinstance(
+                        value, (str, int, float, bool,
+                                dict)), (f"{model_id}/{recipe['name']}: "
+                                         f"CLI arg {key} has invalid type")

--- a/tools/vllm-rocm-autotuner-configs/tests/test_scripts.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/test_scripts.py
@@ -13,18 +13,15 @@ class TestGenerateSignature:
     """Test generate_signature.py script."""
 
     def test_script_exists(self):
-        script = Path(
-            __file__).parent.parent / "tools" / "generate_signature.py"
+        script = Path(__file__).parent.parent / "tools" / "generate_signature.py"
         assert script.exists()
 
     def test_generate_signature(self, mock_model_dir):
         """Test signature generation."""
-        script = Path(
-            __file__).parent.parent / "tools" / "generate_signature.py"
+        script = Path(__file__).parent.parent / "tools" / "generate_signature.py"
 
         result = subprocess.run(
-            [sys.executable, str(script),
-             str(mock_model_dir)],
+            [sys.executable, str(script), str(mock_model_dir)],
             capture_output=True,
             text=True,
         )
@@ -35,8 +32,7 @@ class TestGenerateSignature:
 
     def test_missing_model_path(self):
         """Test handling of missing model."""
-        script = Path(
-            __file__).parent.parent / "tools" / "generate_signature.py"
+        script = Path(__file__).parent.parent / "tools" / "generate_signature.py"
 
         result = subprocess.run(
             [sys.executable, str(script), "/nonexistent/path"],

--- a/tools/vllm-rocm-autotuner-configs/tests/test_scripts.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/test_scripts.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test utility tools."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class TestGenerateSignature:
+    """Test generate_signature.py script."""
+
+    def test_script_exists(self):
+        script = Path(
+            __file__).parent.parent / "tools" / "generate_signature.py"
+        assert script.exists()
+
+    def test_generate_signature(self, mock_model_dir):
+        """Test signature generation."""
+        script = Path(
+            __file__).parent.parent / "tools" / "generate_signature.py"
+
+        result = subprocess.run(
+            [sys.executable, str(script),
+             str(mock_model_dir)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert "Signature:" in result.stdout
+        assert "GptOssForCausalLM_36L_2880H_64A" in result.stdout
+
+    def test_missing_model_path(self):
+        """Test handling of missing model."""
+        script = Path(
+            __file__).parent.parent / "tools" / "generate_signature.py"
+
+        result = subprocess.run(
+            [sys.executable, str(script), "/nonexistent/path"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert "Error" in result.stdout or "Error" in result.stderr
+
+
+class TestAddSignatures:
+    """Test add_signatures.py script."""
+
+    def test_script_exists(self):
+        script = Path(__file__).parent.parent / "tools" / "add_signatures.py"
+        assert script.exists()
+
+    @pytest.mark.slow
+    def test_dry_run(self):
+        """Test dry run mode."""
+        script = Path(__file__).parent.parent / "tools" / "add_signatures.py"
+
+        result = subprocess.run(
+            [sys.executable, str(script), "--dry-run"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert "Dry run" in result.stdout or "dry run" in result.stdout.lower()

--- a/tools/vllm-rocm-autotuner-configs/tests/test_utils.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/test_utils.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test GPU detection utilities."""
+
+import pytest
+
+try:
+    from vllm_rocm_autotuner_configs.utils import (_normalize_arch_name,
+                                                   check_amdsmi_available,
+                                                   get_amd_gpu_info,
+                                                   get_amd_gpu_info_safe)
+
+    _UTILS_AVAILABLE = True
+except ImportError:
+    _UTILS_AVAILABLE = False
+
+
+@pytest.mark.skipif(not _UTILS_AVAILABLE, reason="utils module not available")
+class TestArchNormalization:
+    """Test architecture name normalization."""
+
+    def test_simple_arch(self):
+        assert _normalize_arch_name("gfx942") == "gfx942"
+        assert _normalize_arch_name("gfx950") == "gfx950"
+
+    def test_arch_with_features(self):
+        assert _normalize_arch_name("gfx942:sramecc+:xnack-") == "gfx942"
+        assert _normalize_arch_name("gfx950:sramecc+:xnack+") == "gfx950"
+
+    def test_unknown(self):
+        assert _normalize_arch_name("unknown") == "unknown"
+        assert _normalize_arch_name("") == "unknown"
+
+    def test_whitespace(self):
+        assert _normalize_arch_name("  gfx942  ") == "gfx942"
+        assert _normalize_arch_name("GFX942") == "gfx942"
+
+
+@pytest.mark.skipif(not _UTILS_AVAILABLE, reason="utils module not available")
+class TestGPUDetection:
+    """Test GPU detection."""
+
+    def test_check_amdsmi_available(self):
+        result = check_amdsmi_available()
+        assert isinstance(result, bool)
+
+    def test_safe_detection_never_raises(self):
+        arch, count = get_amd_gpu_info_safe()
+        assert isinstance(count, int)
+        assert count >= 0
+        assert arch is None or isinstance(arch, str)
+
+    @pytest.mark.requires_gpu
+    def test_gpu_detection_on_real_hardware(self):
+        """Only runs if amdsmi available and GPU present."""
+        if not check_amdsmi_available():
+            pytest.skip("amdsmi not available")
+
+        try:
+            arch, count = get_amd_gpu_info()
+            assert arch is not None
+            assert count > 0
+            assert arch.startswith("gfx")
+        except Exception:
+            pytest.skip("No AMD GPU available")

--- a/tools/vllm-rocm-autotuner-configs/tests/test_utils.py
+++ b/tools/vllm-rocm-autotuner-configs/tests/test_utils.py
@@ -5,10 +5,12 @@
 import pytest
 
 try:
-    from vllm_rocm_autotuner_configs.utils import (_normalize_arch_name,
-                                                   check_amdsmi_available,
-                                                   get_amd_gpu_info,
-                                                   get_amd_gpu_info_safe)
+    from vllm_rocm_autotuner_configs.utils import (
+        _normalize_arch_name,
+        check_amdsmi_available,
+        get_amd_gpu_info,
+        get_amd_gpu_info_safe,
+    )
 
     _UTILS_AVAILABLE = True
 except ImportError:

--- a/tools/vllm-rocm-autotuner-configs/tools/add_signatures.py
+++ b/tools/vllm-rocm-autotuner-configs/tools/add_signatures.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Add signatures to models in config files by fetching from HuggingFace."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def get_signature(config: dict) -> str:
+    """Generate signature from config."""
+    arch = config.get("architectures", ["Unknown"])[0]
+    layers = config.get("num_hidden_layers", 0)
+    hidden = config.get("hidden_size", 0)
+    heads = config.get("num_attention_heads", 0)
+    return f"{arch}_{layers}L_{hidden}H_{heads}A"
+
+
+def fetch_hf_config(model_id: str) -> Optional[dict]:
+    """Fetch config.json from HuggingFace."""
+    try:
+        import json
+
+        from huggingface_hub import hf_hub_download
+
+        config_path = hf_hub_download(
+            repo_id=model_id,
+            filename="config.json",
+            repo_type="model",
+        )
+
+        with open(config_path) as f:
+            return json.load(f)
+    except ImportError:
+        print("Error: huggingface_hub not installed")
+        print("Install: pip install huggingface-hub")
+        return None
+    except Exception as e:
+        print(f"Error fetching {model_id}: {e}")
+        return None
+
+
+def add_signatures_to_config(config_path: Path, dry_run: bool = False) -> None:
+    """Add signatures to models in a config file."""
+    print(f"\nProcessing {config_path.name}...")
+
+    with open(config_path) as f:
+        data = json.load(f)
+
+    model_configs = data.get("model_configs", {})
+    modified = False
+
+    for model_id, model_data in model_configs.items():
+        if "signature" in model_data:
+            print(f"  {model_id}: already has signature "
+                  f"({model_data['signature']})")
+            continue
+
+        if "/" not in model_id:
+            print(f"  {model_id}: skipping (architecture-only entry)")
+            continue
+
+        if "recipes" not in model_data or not model_data["recipes"]:
+            print(f"  {model_id}: skipping (no recipes)")
+            continue
+
+        print(f"  {model_id}: fetching from HuggingFace...")
+        hf_config = fetch_hf_config(model_id)
+
+        if not hf_config:
+            print(f"  {model_id}: FAILED - could not fetch config")
+            continue
+
+        signature = get_signature(hf_config)
+        print(f"  {model_id}: generated signature: {signature}")
+
+        if not dry_run:
+            model_data["signature"] = signature
+            modified = True
+
+    if modified and not dry_run:
+        with open(config_path, "w") as f:
+            json.dump(data, f, indent=2)
+        print(f"\nUpdated {config_path.name}")
+    elif dry_run:
+        print("\n(Dry run - no changes made)")
+    else:
+        print("\n  No changes needed")
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Add signatures to HuggingFace models in config files")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Specific config file to process (default: all in configs/)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+
+    args = parser.parse_args()
+
+    if args.config:
+        config_files = [args.config]
+    else:
+        configs_dir = (Path(__file__).parent.parent / "src" /
+                       "vllm_rocm_autotuner_configs" / "configs")
+        if not configs_dir.exists():
+            print(f"Error: configs directory not found: {configs_dir}")
+            return 1
+        config_files = list(configs_dir.glob("rocm_config_*.json"))
+
+    for config_file in config_files:
+        if not config_file.exists():
+            print(f"Error: {config_file} not found")
+            continue
+        add_signatures_to_config(config_file, dry_run=args.dry_run)
+
+    print("\nDone")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/vllm-rocm-autotuner-configs/tools/add_signatures.py
+++ b/tools/vllm-rocm-autotuner-configs/tools/add_signatures.py
@@ -5,7 +5,6 @@
 import json
 import sys
 from pathlib import Path
-from typing import Optional
 
 
 def get_signature(config: dict) -> str:
@@ -17,7 +16,7 @@ def get_signature(config: dict) -> str:
     return f"{arch}_{layers}L_{hidden}H_{heads}A"
 
 
-def fetch_hf_config(model_id: str) -> Optional[dict]:
+def fetch_hf_config(model_id: str) -> dict | None:
     """Fetch config.json from HuggingFace."""
     try:
         import json
@@ -53,8 +52,7 @@ def add_signatures_to_config(config_path: Path, dry_run: bool = False) -> None:
 
     for model_id, model_data in model_configs.items():
         if "signature" in model_data:
-            print(f"  {model_id}: already has signature "
-                  f"({model_data['signature']})")
+            print(f"  {model_id}: already has signature ({model_data['signature']})")
             continue
 
         if "/" not in model_id:
@@ -93,7 +91,8 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Add signatures to HuggingFace models in config files")
+        description="Add signatures to HuggingFace models in config files"
+    )
     parser.add_argument(
         "--config",
         type=Path,
@@ -110,8 +109,12 @@ def main():
     if args.config:
         config_files = [args.config]
     else:
-        configs_dir = (Path(__file__).parent.parent / "src" /
-                       "vllm_rocm_autotuner_configs" / "configs")
+        configs_dir = (
+            Path(__file__).parent.parent
+            / "src"
+            / "vllm_rocm_autotuner_configs"
+            / "configs"
+        )
         if not configs_dir.exists():
             print(f"Error: configs directory not found: {configs_dir}")
             return 1

--- a/tools/vllm-rocm-autotuner-configs/tools/generate_signature.py
+++ b/tools/vllm-rocm-autotuner-configs/tools/generate_signature.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Generate signature for a HuggingFace model."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def get_signature_from_local(model_path: Path) -> str:
+    """Get signature from local model directory."""
+    config_file = model_path / "config.json"
+
+    if not config_file.exists():
+        raise FileNotFoundError(f"config.json not found in {model_path}")
+
+    with open(config_file) as f:
+        config = json.load(f)
+
+    arch = config.get("architectures", ["Unknown"])[0]
+    layers = config.get("num_hidden_layers", 0)
+    hidden = config.get("hidden_size", 0)
+    heads = config.get("num_attention_heads", 0)
+
+    return f"{arch}_{layers}L_{hidden}H_{heads}A"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python generate_signature.py <model_path>")
+        print("Example: python generate_signature.py "
+              "openai/gpt-oss-120b")
+        return 1
+
+    model_path = Path(sys.argv[1])
+
+    if not model_path.exists():
+        print(f"Error: path does not exist: {model_path}")
+        return 1
+
+    try:
+        signature = get_signature_from_local(model_path)
+        print(f"\nModel: {model_path.name}")
+        print(f"Signature: {signature}")
+        print("\nAdd to your config file:")
+        print('  "your-org/model-name": {')
+        print(f'    "signature": "{signature}",')
+        print('    "recipes": [...]')
+        print("  }")
+        return 0
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/vllm-rocm-autotuner-configs/tools/generate_signature.py
+++ b/tools/vllm-rocm-autotuner-configs/tools/generate_signature.py
@@ -28,8 +28,7 @@ def get_signature_from_local(model_path: Path) -> str:
 def main():
     if len(sys.argv) != 2:
         print("Usage: python generate_signature.py <model_path>")
-        print("Example: python generate_signature.py "
-              "openai/gpt-oss-120b")
+        print("Example: python generate_signature.py openai/gpt-oss-120b")
         return 1
 
     model_path = Path(sys.argv[1])


### PR DESCRIPTION
## Purpose

Introduces `vllm-rocm-autotuner-configs` - a standalone package that automatically applies optimized environment variables and CLI arguments for vLLM on AMD ROCm GPUs. Addresses [#21138](https://github.com/vllm-project/vllm/issues/21138) by eliminating the need to manually configure multiple ROCm-specific flags.

**Key Features:**
- Auto-detects GPU architecture (gfx942, gfx950) and applies optimal settings
- Matches models by signature (e.g., `LlamaForCausalLM_80L_8192H_64A`) or HuggingFace ID
- Multiple optimization recipes per model with ranking system
- Platform-safe: auto-disables on NVIDIA GPUs, graceful fallback on unsupported configs
- Zero-config by default, extensible via CLI flags

**Usage:**
```bash
# Auto-detect and apply (default)
vllm serve --model /path/to/model

# HuggingFace models
vllm serve --model amd/Llama-3.3-70B-Instruct-FP8-KV --rocm-tuner-is-hf

# Custom recipe or disable
vllm serve --model your-model --rocm-tuner-recipe optimal
vllm serve --model your-model --rocm-tuner-disable
```

## Test Plan

```bash
# Install and run tests
cd tools/vllm-rocm-autotuner-configs
pip install -e ".[dev]"
pytest tests/ -v

# Test GPU detection
vllm-rocm-detect
```

## Documentation

- Comprehensive README with installation, usage, troubleshooting