### PR TITLE
[Doc] Fix macOS installation dependency resolution issue

### DIFF
--- a/docs/getting_started/installation/cpu.apple.inc.md
+++ b/docs/getting_started/installation/cpu.apple.inc.md
@@ -28,9 +28,12 @@ After installation of XCode and the Command Line Tools, which include Apple Clan
 ```bash
 git clone https://github.com/vllm-project/vllm.git
 cd vllm
-uv pip install -r requirements/cpu.txt
+uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match
 uv pip install -e .
 ```
+
+!!! tip
+    The `--index-strategy unsafe-best-match` flag is needed to resolve dependencies across multiple package indexes (PyTorch CPU index and PyPI). Without this flag, you may encounter `typing-extensions` version conflicts.
 
 !!! note
     On macOS the `VLLM_TARGET_DEVICE` is automatically set to `cpu`, which is currently the only supported device.

--- a/docs/getting_started/installation/cpu.apple.inc.md
+++ b/docs/getting_started/installation/cpu.apple.inc.md
@@ -34,6 +34,8 @@ uv pip install -e .
 
 !!! tip
     The `--index-strategy unsafe-best-match` flag is needed to resolve dependencies across multiple package indexes (PyTorch CPU index and PyPI). Without this flag, you may encounter `typing-extensions` version conflicts.
+    
+    The term "unsafe" refers to the package resolution strategy, not security. By default, `uv` only searches the first index where a package is found to prevent dependency confusion attacks. This flag allows `uv` to search all configured indexes to find the best compatible versions. Since both PyTorch and PyPI are trusted package sources, using this strategy is safe and appropriate for vLLM installation.
 
 !!! note
     On macOS the `VLLM_TARGET_DEVICE` is automatically set to `cpu`, which is currently the only supported device.


### PR DESCRIPTION
## Purpose

Fixes dependency resolution error that prevents macOS users from installing vLLM following the current documentation.

**Problem:** When running `uv pip install -r requirements/cpu.txt` on macOS, users encounter a `typing-extensions` version conflict. This occurs because `uv` by default only searches the first package index (PyTorch CPU index) and doesn't find compatible versions across multiple indexes (PyTorch CPU + PyPI).

**Solution:** Add `--index-strategy unsafe-best-match` flag to the installation command, which instructs `uv` to search all configured package indexes to find compatible dependency versions.

## Test Plan

1. Fresh macOS environment (Apple M3 Max, macOS Darwin 25.0.0)
2. Follow the updated installation instructions in `docs/getting_started/installation/cpu/apple.inc.md`
3. Verify successful installation without dependency conflicts
4. Run basic vLLM tests to confirm functionality

## Test Result

✅ **Before fix:** Installation failed with `typing-extensions` dependency resolution error  
✅ **After fix:** Installation completed successfully  
✅ **Verification:** Successfully ran vLLM tests:
```bash
# Import test
python -c "import vllm; print(vllm.__version__)"
# Output: 0.1.dev10378+g5c7fe2549

# Model initialization test
python -c "from vllm import LLM; llm = LLM('facebook/opt-125m', max_model_len=512, enforce_eager=True)"
# Output: Successfully initialized

# Unit tests
pytest tests/test_logger.py -v
# Output: 20/20 tests passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
