### PR TITLE
[ResponseAPI] Further polish message serialization and unit tests

### DIFF
--- a/tests/entrypoints/openai/test_protocol.py
+++ b/tests/entrypoints/openai/test_protocol.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from openai_harmony import (
+    Message,
+)
+
+from vllm.entrypoints.openai.protocol import serialize_message, serialize_messages
+
+
+def test_serialize_message() -> None:
+    dict_value = {"a": 1, "b": "2"}
+    assert serialize_message(dict_value) == dict_value
+
+    msg_value = {
+        "role": "assistant",
+        "name": None,
+        "content": [{"type": "text", "text": "Test 1"}],
+        "channel": "analysis",
+    }
+    msg = Message.from_dict(msg_value)
+    assert serialize_message(msg) == msg_value
+
+
+def test_serialize_messages() -> None:
+    assert serialize_messages(None) is None
+    assert serialize_messages([]) is None
+
+    dict_value = {"a": 3, "b": "4"}
+    msg_value = {
+        "role": "assistant",
+        "name": None,
+        "content": [{"type": "text", "text": "Test 2"}],
+        "channel": "analysis",
+    }
+    msg = Message.from_dict(msg_value)
+    assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]

--- a/tests/entrypoints/openai/test_response_api_with_harmony.py
+++ b/tests/entrypoints/openai/test_response_api_with_harmony.py
@@ -12,8 +12,6 @@ from openai_harmony import (
     Message,
 )
 
-from vllm.entrypoints.openai.protocol import serialize_message, serialize_messages
-
 from ...utils import RemoteOpenAIServer
 
 MODEL_NAME = "openai/gpt-oss-20b"
@@ -760,32 +758,3 @@ async def test_output_messages_enabled(client: OpenAI, model_name: str, server):
     assert response.status == "completed"
     assert len(response.input_messages) > 0
     assert len(response.output_messages) > 0
-
-
-def test_serialize_message() -> None:
-    dict_value = {"a": 1, "b": "2"}
-    assert serialize_message(dict_value) == dict_value
-
-    msg_value = {
-        "role": "assistant",
-        "name": None,
-        "content": [{"type": "text", "text": "Test 1"}],
-        "channel": "analysis",
-    }
-    msg = Message.from_dict(msg_value)
-    assert serialize_message(msg) == msg_value
-
-
-def test_serialize_messages() -> None:
-    assert serialize_messages(None) is None
-    assert serialize_messages([]) is None
-
-    dict_value = {"a": 3, "b": "4"}
-    msg_value = {
-        "role": "assistant",
-        "name": None,
-        "content": [{"type": "text", "text": "Test 2"}],
-        "channel": "analysis",
-    }
-    msg = Message.from_dict(msg_value)
-    assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -2071,7 +2071,7 @@ def serialize_message(msg):
     """
     if isinstance(msg, dict):
         return msg
-    elif hasattr(msg, "__dict__"):
+    elif hasattr(msg, "to_dict"):
         return msg.to_dict()
     else:
         # fallback to pyandic dump


### PR DESCRIPTION
## Purpose
Address leftover comments in https://github.com/vllm-project/vllm/pull/26620
- hasattr checks
- unit test location

## Test Plan & Test Result

With the change, unit tests are still finished successfully
```
> pytest tests/entrypoints/openai/test_protocol.py 
> pytest tests/entrypoints/openai/test_response_api_with_harmony.py -k test_streaming
```
<img width="1233" height="348" alt="Screenshot 2025-10-13 at 12 17 09 PM" src="https://github.com/user-attachments/assets/ff1df7a4-2434-4f76-a16b-3fce790c54e5" />
<img width="1084" height="246" alt="Screenshot 2025-10-13 at 12 16 55 PM" src="https://github.com/user-attachments/assets/8e18ce49-66f3-48f9-a3f7-6d220ffce6ed" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

