### PR TITLE
[Config] Remove Unused Environment Variable `VLLM_DISABLE_PAD_FOR_CUDAGRAPH`

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -197,7 +197,6 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS: bool = False
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
-    VLLM_DISABLE_PAD_FOR_CUDAGRAPH: bool = False
     VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
     VLLM_NVTX_SCOPES_FOR_PROFILING: bool = False
@@ -1302,12 +1301,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, allows GC to run during capture.
     "VLLM_ENABLE_CUDAGRAPH_GC": lambda: bool(
         int(os.getenv("VLLM_ENABLE_CUDAGRAPH_GC", "0"))
-    ),
-    # Disable padding to CUDA graph capture batch sizes.
-    # TODO(wentao): https://github.com/vllm-project/vllm/issues/23378
-    # After the issue is fixed, we can remove this flag.
-    "VLLM_DISABLE_PAD_FOR_CUDAGRAPH": lambda: bool(
-        int(os.getenv("VLLM_DISABLE_PAD_FOR_CUDAGRAPH", "0"))
     ),
     # Used to force set up loopback IP
     "VLLM_LOOPBACK_IP": lambda: os.getenv("VLLM_LOOPBACK_IP", ""),

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2066,7 +2066,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def _get_num_input_tokens(self, num_scheduled_tokens: int) -> int:
         if (
             self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
-            and not envs.VLLM_DISABLE_PAD_FOR_CUDAGRAPH
             and hasattr(self, "cudagraph_batch_sizes")
             and self.cudagraph_batch_sizes
             and num_scheduled_tokens <= self.cudagraph_batch_sizes[-1]


### PR DESCRIPTION
## Purpose

For https://github.com/vllm-project/vllm/issues/23378

The hang issue has been fixed by lucas, now we can safely remove the env var now.

## Test

```bash
vllm serve --model="deepseek-ai/DeepSeek-R1" --max-num-seqs 1024 --trust-remote-code --data-parallel-size 8 --enable-expert-parallel --gpu-memory-utilization 0.75 --port 9256 --disable-log-requests --no-enable-prefix-caching -O '{"full_cuda_graph": true}' --cuda-graph-sizes 16 32 48 64 96 128 160 192 256 512 1024 --max-model-len 8192
vllm bench serve --model deepseek-ai/DeepSeek-R1  --base-url http://0.0.0.0:9256 --dataset-name random  --random-input-len 16 --random-output-len 200  --request-rate inf     --num-prompts 2048
```

we get 

```bash
100%|███████████████████████████████████| 2048/2048 [00:13<00:00, 147.03it/s]
tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     2048      
Benchmark duration (s):                  13.93     
Total input tokens:                      30720     
Total generated tokens:                  312242    
Request throughput (req/s):              147.03    
Output token throughput (tok/s):         22416.31  
Peak output token throughput (tok/s):    33379.00  
Peak concurrent requests:                2048.00   
Total Token throughput (tok/s):          24621.75  
---------------Time to First Token----------------
Mean TTFT (ms):                          2067.13   
Median TTFT (ms):                        1924.46   
P99 TTFT (ms):                           2432.37   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          62.23     
Median TPOT (ms):                        59.66     
P99 TPOT (ms):                           85.83     
---------------Inter-token Latency----------------
Mean ITL (ms):                           59.73     
Median ITL (ms):                         55.84     
P99 ITL (ms):                            126.04    
==================================================
```