### PR TITLE
[Docs] Add a start tag to build.inc.md

### DIFF
--- a/docs/getting_started/installation/cpu/arm.inc.md
+++ b/docs/getting_started/installation/cpu/arm.inc.md
@@ -23,7 +23,7 @@ ARM CPU backend currently supports Float32, FP16 and BFloat16 datatypes.
 # --8<-- [end:pre-built-wheels]
 # --8<-- [start:build-wheel-from-source]
 
---8<-- "docs/getting_started/installation/cpu/build.inc.md"
+--8<-- "docs/getting_started/installation/cpu/build.inc.md:extra-information"
 
 Testing has been conducted on AWS Graviton3 instances for compatibility.
 

--- a/docs/getting_started/installation/cpu/build.inc.md
+++ b/docs/getting_started/installation/cpu/build.inc.md
@@ -1,3 +1,5 @@
+# --8<-- [start:extra-information]
+
 First, install the recommended compiler. We recommend using `gcc/g++ >= 12.3.0` as the default compiler to avoid potential problems. For example, on Ubuntu 22.4, you can run:
 
 ```bash
@@ -38,8 +40,5 @@ If you want to develop vLLM, install it in editable mode instead.
 ```bash
 VLLM_TARGET_DEVICE=cpu python setup.py develop
 ```
-
-!!! note
-    If you are building vLLM from source and not using the pre-built images, remember to set `LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4:$LD_PRELOAD"` on x86 machines before running vLLM.
 
 # --8<-- [end:extra-information]


### PR DESCRIPTION
- Add a `start` tag to `build.inc.md`, to form a pair with the bottom tag `# --8<-- [end:extra-information]` 
- Update the referenced URL in `arm.inc.md`. Only this file referenced it.
- Remove a note by following the gemini tips https://github.com/vllm-project/vllm/pull/26747#discussion_r2427694034

cc @hmellor @DarkLight1337 PTAL