### PR TITLE
[gpt-oss] Update triton_kernels mxfp4 backend to be compatible with triton_kernels upstream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ ba = "ba"
 [tool.typos.type.py.extend-words]
 ba = "ba"
 nd = "nd"
+indx = "indx"
 
 [tool.typos.type.cpp]
 extend-glob = ["*.cu"]

--- a/tests/kernels/moe/test_gpt_oss_triton_kernels.py
+++ b/tests/kernels/moe/test_gpt_oss_triton_kernels.py
@@ -22,16 +22,10 @@ from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.testing import assert_close
 
-from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
-from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
-    BatchedPrepareAndFinalize,
-)
-from vllm.model_executor.layers.fused_moe.fused_moe import fused_topk
+from vllm.model_executor.layers.fused_moe.config import mxfp4_w4a16_moe_quant_config
 from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
-    BatchedOAITritonExperts,
     triton_kernel_moe_forward,
 )
-from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEModularKernel
 from vllm.model_executor.layers.utils import shuffle_weight
 from vllm.utils import round_up
 
@@ -299,11 +293,11 @@ def test_equiv(num_token, a_dtype, w_dtype, tp):
         pc2,
     ) = init_compute_data(M, K, N, E, a_dtype, w_dtype, num_warps=8)
 
-    quant_config = FusedMoEQuantConfig.make(
+    quant_config = mxfp4_w4a16_moe_quant_config(
         w1_bias=w1_bias_tri,
         w2_bias=w2_bias_tri,
-        w1_precision=pc1,
-        w2_precision=pc2,
+        w1_scale=pc1,
+        w2_scale=pc2,
     )
 
     out_triton_monolithic = triton_kernel_moe_forward(
@@ -327,115 +321,6 @@ def test_equiv(num_token, a_dtype, w_dtype, tp):
         topk=topk,
     )
     assert_close(ref=out_ref, tri=out_triton_monolithic, maxtol=0.025, rmstol=0.005)
-
-
-def batched_moe(
-    a: torch.Tensor,
-    w1,
-    w2,
-    gating_output: torch.Tensor,
-    topk: int,
-    renormalize: bool,
-    w1_bias: torch.Tensor,
-    w2_bias: torch.Tensor,
-    w1_precision: PrecisionConfig,
-    w2_precision: PrecisionConfig,
-) -> torch.Tensor:
-    max_num_tokens = round_up(a.shape[0], 64)
-
-    quant_config = FusedMoEQuantConfig.make(
-        w1_precision=w1_precision,
-        w2_precision=w2_precision,
-        w1_bias=w1_bias,
-        w2_bias=w2_bias,
-    )
-
-    fused_experts = FusedMoEModularKernel(
-        BatchedPrepareAndFinalize(
-            max_num_tokens,
-            num_dispatchers=1,
-            num_local_experts=w1.shape[0],
-            rank=0,
-        ),
-        BatchedOAITritonExperts(
-            max_num_tokens=max_num_tokens,
-            num_dispatchers=1,
-            quant_config=quant_config,
-        ),
-    )
-
-    topk_weight, topk_ids, _ = fused_topk(a, gating_output, topk, renormalize)
-
-    return fused_experts(
-        a,
-        w1,
-        w2,
-        topk_weight,
-        topk_ids,
-    )
-
-
-@pytest.mark.parametrize(
-    ", ".join(f.name for f in fields(Case)),
-    [
-        tuple(getattr(case, f.name) for f in fields(Case))
-        for case in [
-            # Case(a_dtype="bf16", w_dtype="bf16"),
-            # Case(a_dtype="fp8_e4m3", w_dtype="fp8_e5m2"),
-            Case(a_dtype="bf16", w_dtype="mx4")
-        ]
-    ],
-)
-@pytest.mark.parametrize("num_token", [64])
-@pytest.mark.parametrize("ep", [1, 2, 4, 8])
-def test_triton_kernel_batched_moe(num_token, a_dtype, w_dtype, ep):
-    M = num_token
-    E = ModelConfig.num_experts // ep
-    K = ModelConfig.hidden_size
-    N = ModelConfig.intermediate_size
-    topk = ModelConfig.experts_per_token
-
-    (
-        x,
-        w1,
-        w1_bias,
-        w2,
-        w2_bias,
-        exp_data,
-        x_tri,
-        w1_tri,
-        w2_tri,
-        exp_data_tri,
-        w1_bias_tri,
-        w2_bias_tri,
-        pc1,
-        pc2,
-    ) = init_compute_data(M, K, N, E, a_dtype, w_dtype, num_warps=4)
-
-    out_tri = batched_moe(
-        a=x_tri,
-        w1=w1_tri,
-        w2=w2_tri,
-        gating_output=exp_data_tri,
-        topk=topk,
-        renormalize=True,
-        w1_bias=w1_bias_tri,
-        w2_bias=w2_bias_tri,
-        w1_precision=pc1,
-        w2_precision=pc2,
-    )
-    out_tri = out_tri[..., :K]
-
-    out_ref = oai_moe_forward(
-        hidden_states=x,
-        w1=w1,
-        w1_bias=w1_bias,
-        w2=w2,
-        w2_bias=w2_bias,
-        gating_output=exp_data,
-        topk=topk,
-    )
-    assert_close(ref=out_ref, tri=out_tri, maxtol=0.025, rmstol=0.005)
 
 
 def test_unit_shuffle():

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -87,7 +87,7 @@ def legacy_routing_from_bitmatrix(
     bitmatrix, expt_scal, expt_indx, n_expts_tot, n_expts_act
 ):
     sparse_logits = SparseMatrix(
-        index=expt_indx,
+        indx=expt_indx,
         vals=expt_scal,
         mask=bitmatrix,
     )
@@ -117,13 +117,13 @@ def legacy_routing(logits, n_expts_act, sm_first=False, expt_indx=None, n_rows=N
         logits,
         n_expts_act,
         apply_softmax=not sm_first,
-        y_index=expt_indx,
+        y_indx=expt_indx,
         n_rows=n_rows,
     )
     return legacy_routing_from_bitmatrix(
         sparse_logits.mask,
         sparse_logits.vals,
-        sparse_logits.index,
+        sparse_logits.indx,
         logits.shape[-1],
         n_expts_act,
     )

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -262,7 +262,6 @@ def make_routing_data(
         dtype=BIT,
         shape=bitmatrix_shape,
         shape_max=bitmatrix_shape_max,
-        scratchpad=None,
     )
 
     # matmul_ogs expects invalid topk_weights to be -1s

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -32,6 +32,7 @@ if has_triton_kernels():
             BIT,
             Bitmatrix,
             SparseMatrix,
+            Tensor,
             make_ragged_tensor_metadata,
         )
         from triton_kernels.topk import topk as triton_topk
@@ -83,7 +84,13 @@ def pack_bitmatrix(
         tl.store(bitmatrix_ptrs, y, mask=offsets_m[:, None] < n_rows)
 
 
-def routing_from_bitmatrix(bitmatrix, expt_scal, expt_indx, n_expts_tot, n_expts_act):
+def routing_from_bitmatrix(
+    bitmatrix: "Bitmatrix",
+    expt_scal: torch.Tensor,
+    expt_indx: torch.Tensor,
+    n_expts_tot: int,
+    n_expts_act: int,
+):
     sparse_logits = SparseMatrix(
         indx=expt_indx,
         vals=expt_scal,
@@ -108,7 +115,13 @@ def routing_from_bitmatrix(bitmatrix, expt_scal, expt_indx, n_expts_tot, n_expts
     return routing_data, gather_idx, scatter_idx
 
 
-def routing(logits, n_expts_act, sm_first=False, expt_indx=None, n_rows=None):
+def routing(
+    logits: "Tensor" | torch.Tensor,
+    n_expts_act: int,
+    sm_first: bool = False,
+    expt_indx: torch.Tensor | None = None,
+    n_rows: torch.Tensor | None = None,
+):
     if sm_first:
         logits = torch.softmax(logits, dim=-1)
     sparse_logits = triton_topk(

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -116,7 +116,7 @@ def routing_from_bitmatrix(
 
 
 def routing(
-    logits: "Tensor" | torch.Tensor,
+    logits: "torch.Tensor | Tensor",
     n_expts_act: int,
     sm_first: bool = False,
     expt_indx: torch.Tensor | None = None,


### PR DESCRIPTION
Recently, triton_kernels introduced routing function [refactoring](https://github.com/triton-lang/triton/pull/8375). We need to incorporate it into vllm. 

Partial address #26582

Accuracy bench
openai/gpt-oss-120b, TP=2, GPQA:
| Reasoning effort | Score |
|:--------|:-----:|
| Low | 65.84  | 
| Medium  | 72.2  | 