### PR TITLE
[CI/Build] Use 127.0.0.1 instead of localhost in utils

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -156,7 +156,7 @@ class RemoteOpenAIServer:
             self.host = None
             self.port = None
         else:
-            self.host = str(args.host or "localhost")
+            self.host = str(args.host or "127.0.0.1")
             self.port = int(args.port)
 
         self.show_hidden_metrics = args.show_hidden_metrics_for_version is not None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This ensure we set always set default to ipv4, which was causing issues when running the tests on ipv6 hosts.

## Test Plan
```
HF_HUB_DISABLE_XET=1 wp pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt --tp-size=1
```
## Test Result
```
================================================================================================================= warnings summary ==================================================================================================================
../../../../../../home/yeq/uv_env/vllm/lib64/python3.12/site-packages/torch/cuda/__init__.py:63
  /home/yeq/uv_env/vllm/lib64/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that instal
led pynvml for you.
    import pynvml  # type: ignore[import]

../../../../../../home/yeq/uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305
  /home/yeq/uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch refe
rencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================== 6 passed, 2 warnings in 429.01s (0:07:09) =====================================================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

