### PR TITLE
[Build] Enable Marlin and MoE kernels for SM_89 (RTX 4090) and improv…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,11 +326,24 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     SRCS "${VLLM_EXT_SRC}"
     CUDA_ARCHS "${CUDA_ARCHS}")
 
-  # Only build Marlin kernels if we are building for at least some compatible archs.
-  # Keep building Marlin for 9.0 as there are some group sizes and shapes that
-  # are not supported by Machete yet.
-  # 9.0 for latest bf16 atomicAdd PTX
-  cuda_archs_loose_intersection(MARLIN_ARCHS "8.0;8.7;9.0+PTX" "${CUDA_ARCHS}")
+  # ------------------------------------------------------------------------------
+  # Configure Marlin kernel build targets
+  #
+  # Marlin provides optimized FP16/BF16/AWQ GEMM kernels for various CUDA archs.
+  # We enable builds for architectures that are both supported by CUDA and
+  # compatible with the target GPU(s).
+  #
+  # Notes:
+  # - 8.0 / 8.7 : Ampere (A100, L40)
+  # - 8.9       : Ada (RTX 4090, L40S)
+  # - 9.0+PTX   : Hopper (H100) and future architectures (for bf16 atomicAdd)
+  # ------------------------------------------------------------------------------
+
+  cuda_archs_loose_intersection(
+    MARLIN_ARCHS
+    "8.0;8.7;8.9;9.0+PTX"
+    "${CUDA_ARCHS}"
+  )
   if (MARLIN_ARCHS)
 
     #
@@ -912,8 +925,18 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     CUDA_ARCHS "${CUDA_ARCHS}")
 
   list(APPEND VLLM_MOE_EXT_SRC "${VLLM_MOE_WNA16_SRC}")
-  # 9.0 for latest bf16 atomicAdd PTX
-  cuda_archs_loose_intersection(MARLIN_MOE_ARCHS "8.0;8.7;9.0+PTX" "${CUDA_ARCHS}")
+  # ------------------------------------------------------------------------------
+  # Configure Marlin-MoE kernel build targets
+  #
+  # MoE variant requires similar architectural support as base Marlin.
+  # Keep 9.0+PTX enabled for the latest bf16 atomicAdd PTX instructions.
+  # ------------------------------------------------------------------------------
+
+  cuda_archs_loose_intersection(
+    MARLIN_MOE_ARCHS
+    "8.0;8.7;8.9;9.0+PTX"
+    "${CUDA_ARCHS}"
+  )
   if (MARLIN_MOE_ARCHS)
 
     #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,9 +334,9 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # compatible with the target GPU(s).
   #
   # Notes:
-  # - 8.0 / 8.7 : Ampere (A100, L40)
-  # - 8.9       : Ada (RTX 4090, L40S)
-  # - 9.0+PTX   : Hopper (H100) and future architectures (for bf16 atomicAdd)
+  # - 8.0 / 8.7 : Ampere (e.g., A100, A30, A40)
+  # - 8.9       : Ada (e.g., RTX 4090, L40, L40S)
+  # - 9.0+PTX   : Hopper and future architectures (for bf16 atomicAdd)
   # ------------------------------------------------------------------------------
 
   cuda_archs_loose_intersection(


### PR DESCRIPTION
### Summary
Add SM_89 (RTX 4090 / L40S) support for Marlin and MoE kernels in CMake.
### Changes
- Updated `CMakeLists.txt` to include `8.9` in CUDA architectures.
- Improved comments and structure for readability.
- Verified build success with CUDA 12.8 and driver 570.86.10.
### Test Plan
- Successfully compiled vLLM on RTX 4090.
- Confirmed Marlin and MoE kernels built for archs: 8.9.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

