### PR TITLE
[Bugfix] DeepSeek V3.2 MTP metadata & CUDA graph issues

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -109,6 +109,7 @@ class EagleProposer:
             else []
         )
 
+        self.use_cuda_graph = self.use_cuda_graph and bool(self.cudagraph_batch_sizes)
         # persistent buffers for cuda graph
         self.input_ids = torch.zeros(
             self.max_num_tokens, dtype=torch.int32, device=device
@@ -939,7 +940,7 @@ class EagleProposer:
             self.vllm_config, DeepseekV32IndexerCache
         )
         draft_indexer_layer_names = indexer_layers.keys() - target_indexer_layer_names
-        self.attn_layer_names = list(draft_attn_layer_names)
+        self.attn_layer_names = list(draft_attn_layer_names - draft_indexer_layer_names)
         self.indexer_layer_names = list(draft_indexer_layer_names)
 
         if self.indexer_layer_names:
@@ -1051,9 +1052,7 @@ class EagleProposer:
         use_cudagraphs=True,
     ) -> None:
         # Determine if CUDA graphs should be used for this run.
-        cudagraphs_enabled = (
-            use_cudagraphs and self.use_cuda_graph and bool(self.cudagraph_batch_sizes)
-        )
+        cudagraphs_enabled = use_cudagraphs and self.use_cuda_graph
         if cudagraphs_enabled and num_tokens <= self.cudagraph_batch_sizes[-1]:
             num_tokens = self.vllm_config.pad_for_cudagraph(num_tokens)
 

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1050,16 +1050,22 @@ class EagleProposer:
         num_tokens: int,
         use_cudagraphs=True,
     ) -> None:
-        if use_cudagraphs and num_tokens <= self.cudagraph_batch_sizes[-1]:
+        if (
+            use_cudagraphs
+            and self.use_cuda_graph
+            and num_tokens <= self.cudagraph_batch_sizes[-1]
+        ):
             num_tokens = self.vllm_config.pad_for_cudagraph(num_tokens)
 
         with set_forward_context(
             None,
             self.vllm_config,
             num_tokens=num_tokens,
-            cudagraph_runtime_mode=CUDAGraphMode.PIECEWISE
-            if use_cudagraphs
-            else CUDAGraphMode.NONE,
+            cudagraph_runtime_mode=(
+                CUDAGraphMode.PIECEWISE
+                if (use_cudagraphs and self.use_cuda_graph)
+                else CUDAGraphMode.NONE
+            ),
         ):
             if self.supports_mm_inputs:
                 input_ids = None


### PR DESCRIPTION
## Purpose
(see [Issue #26711](https://github.com/vllm-project/vllm/issues/26711)).  
1. **Fix CUDA Graph Capture Crash in EAGLE**  
   Resolve `IndexError: list index out of range` when accessing `self.cudagraph_batch_sizes[-1]` during CUDA Graph capture 
   - **Root Cause**:  
     - When using PIECEWISE capture, `gpu_model_runner` passes `use_cudagraphs=True`, but MTP heads of draft models (e.g., DeepSeek MTP) lack native CUDA graph support.  
     - EAGLE sets `self.use_cuda_graph = False` and initializes `self.cudagraph_batch_sizes` as an empty list for such models.  
     - PR #25109 ignored `self.use_cuda_graph` in `dummy_run` arguments, leading to out-of-range access of the empty `cudagraph_batch_sizes` list.  
   - **Change**: In `vllm/v1/spec_decode/eagle.py:dummy_run`, gate padding and `cudagraph_runtime_mode` with `(use_cudagraphs and self.use_cuda_graph)` to prevent empty-list indexing and align with runner behavior.

2. **Fix DeepSeek V3.2 MTP Metadata & Sparse MLA Layer Selection**  
   Resolve incorrect layer classification and metadata mapping for DeepSeek V3.2 Sparse MLA.  
   - **Root Cause**:  
     - PR https://github.com/vllm-project/vllm/pull/25103 Separate MLAAttention class from Attention, but the Indexer layers were not excluded from attention layer lists, causing mismatches between MTP metadata and model components.  
     - Sparse MLA architectures require strict separation of attention and indexer layers to ensure proper metadata propagation for expert routing.  
   - **Change**: In `vllm/v1/spec_decode/eagle.py:load_model`, filter indexer layers from attention layer lists using `draft_attn_layer_names - draft_indexer_layer_names`, ensuring accurate metadata selection for DeepSeek MTP heads.

## Test Plan
For the scenarios described in Issue #26711 (DeepSeek V3.2 MTP metadata anomalies and CUDA graph capture crashes in EAGLE mode), run tests with and without the fix applied to verify if the issues recur.

## Test Result
Verification for Issue #26711 has been completed. After the fix: DeepSeek V3.2 MTP metadata mapping works normally, and there are no crashes in CUDA graph capture under EAGLE mode. The original issues have been resolved.

