### PR TITLE
[Fix] Avoid UserWarning when creating tensors from base64 embeddings

### DIFF
--- a/examples/online_serving/pooling/embedding_embed_dtype_client.py
+++ b/examples/online_serving/pooling/embedding_embed_dtype_client.py
@@ -47,7 +47,7 @@ def main(args):
         for data in response.json()["data"]:
             embedding.append(
                 torch.frombuffer(
-                    base64.b64decode(data["embedding"]), dtype=torch_dtype
+                    bytearray(base64.b64decode(data["embedding"])), dtype=torch_dtype
                 ).to(torch.float32)
             )
         embedding = torch.cat(embedding)

--- a/tests/entrypoints/pooling/openai/test_embedding.py
+++ b/tests/entrypoints/pooling/openai/test_embedding.py
@@ -275,7 +275,9 @@ async def test_base64_embed_dtype(
         base64_data = []
         for data in responses_base64.json()["data"]:
             base64_data.append(
-                torch.frombuffer(base64.b64decode(data["embedding"]), dtype=torch_dtype)
+                torch.frombuffer(
+                    bytearray(base64.b64decode(data["embedding"])), dtype=torch_dtype
+                )
                 .to(torch.float32)
                 .tolist()
             )

--- a/tests/entrypoints/pooling/openai/test_pooling.py
+++ b/tests/entrypoints/pooling/openai/test_pooling.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import base64
+import io
 
 import numpy as np
 import pytest
@@ -281,13 +282,19 @@ async def test_base64_embed_dtype(server: RemoteOpenAIServer, model_name: str):
 
         base64_data = []
         for data in responses_base64.json()["data"]:
-            base64_data.append(
-                torch.frombuffer(
-                    bytearray(base64.b64decode(data["data"])), dtype=torch_dtype
-                )
-                .to(torch.float32)
-                .tolist()
-            )
+            # Decode base64 into a writable BytesIO buffer for zero-copy tensor creation
+            bio_in = io.BytesIO(data["data"].encode("ascii"))
+            bio_out = io.BytesIO()
+            base64.decode(bio_in, bio_out)
+
+            # Get writable memoryview and create tensor with zero-copy semantics
+            mv = bio_out.getbuffer()
+            tensor = torch.frombuffer(mv, dtype=torch_dtype)
+
+            # Keep buffer alive to ensure memory validity
+            tensor._buffer_owner = bio_out
+
+            base64_data.append(tensor.to(torch.float32).tolist())
 
         check_embeddings_close(
             embeddings_0_lst=float_data,

--- a/tests/entrypoints/pooling/openai/test_pooling.py
+++ b/tests/entrypoints/pooling/openai/test_pooling.py
@@ -282,7 +282,9 @@ async def test_base64_embed_dtype(server: RemoteOpenAIServer, model_name: str):
         base64_data = []
         for data in responses_base64.json()["data"]:
             base64_data.append(
-                torch.frombuffer(base64.b64decode(data["data"]), dtype=torch_dtype)
+                torch.frombuffer(
+                    bytearray(base64.b64decode(data["data"])), dtype=torch_dtype
+                )
                 .to(torch.float32)
                 .tolist()
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Quick fix to #26781. This resolves the warning by converting the read-only decoded embedding data into a writable bytearray, which is compatible with PyTorch's tensor creation requirements.

FIX #26781

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

