### PR TITLE
Don't allow `typos` to fix by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
   rev: v1.38.1
   hooks:
   - id: typos
+    args: [--force-exclude]
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v21.1.2
   hooks:


### PR DESCRIPTION
We do this because `typos` changes are silent and therefore dangerous.

See https://github.com/crate-ci/typos/issues/1399 for the report of this issue.