### PR TITLE
llama4_vision_rope: add HIP override to accept (q, k) and avoid (positions, q, k) mismatch

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/llama4_vision_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/llama4_vision_rope.py
@@ -78,3 +78,10 @@ class Llama4VisionRotaryEmbedding(RotaryEmbedding):
         key: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         return self.forward_native(query, key)
+
+    def forward_hip(  # type: ignore[override]
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        return self.forward_native(query, key)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

On ROCm/HIP, the base RoPE [path](https://github.com/vllm-project/vllm/blob/d3cc8427c0a930937389d0ce6ec99405e7117929/vllm/model_executor/layers/rotary_embedding/base.py#L151) expects `(positions, query, key)` and, in the fallback [branch](https://github.com/vllm-project/vllm/blob/d3cc8427c0a930937389d0ce6ec99405e7117929/vllm/model_executor/layers/rotary_embedding/base.py#L171), calls `forward_cuda(positions, query, key)`. The Llama4‑Vision RoPE [implements](https://github.com/vllm-project/vllm/blob/4821ac1b4d36c5780ec9769c40fcacc0f8c41a7d/vllm/model_executor/layers/rotary_embedding/llama4_vision_rope.py#L75) `forward_cuda(query, key)` (2 args), so HIP can pass the wrong arg order or arg count.

This PR overrides `forward_hip(query, key)` in `Llama4VisionRotaryEmbedding` and delegate to the existing native implementation. This keeps the current [call site](https://github.com/vllm-project/vllm/blob/577d498212022f95dc3a59746b1da1c6ed23eaba/vllm/model_executor/models/mllama4.py#L310) `self.rotary_emb(q, k)` working, avoids creating `positions`, and prevents the base class from calling the 3‑arg CUDA path.


## Test Plan

run with rocm

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

