### PR TITLE
[Qwen3-Next]Change ColumnParallelLinear to RowParallelLinear

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -288,7 +288,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             prefix=f"{prefix}.in_proj_qkvz",
         )
         # ba_proj doesn't support blockwise fp8 quantization.
-        self.in_proj_ba = ColumnParallelLinear(
+        self.in_proj_ba = RowParallelLinear(
             input_size=self.hidden_size,
             output_size=self.projection_size_ba,
             bias=False,


### PR DESCRIPTION
## Purpose

This PR corrects the tensor parallelism strategy for the `self.in_proj_ba` layer in the Qwen3-Next model implementation. The layer is changed from `ColumnParallelLinear` to `RowParallelLinear`.

The justification for this change is based on the tensor's shape and vLLM's documented best practices for tensor parallelism:
<img width="1550" height="82" alt="image" src="https://github.com/user-attachments/assets/5daacae6-5aac-4a07-b056-67863a688885" />

1.  The `self.in_proj_ba` weight matrix has a shape of `(in_features=2048, out_features=64)`, where the input dimension is significantly larger than the output dimension.
2.  According to the vLLM developer documentation:
      * **`RowParallelLinear`** partitions the weight matrix along the **rows (input dimension)**. This is optimal for matrices where `in_features >> out_features`.
      * **`ColumnParallelLinear`** partitions the weight matrix along the **columns (output dimension)**.
3.  By switching to `RowParallelLinear`, we partition the weight matrix along its larger dimension (2048), which is the correct and more efficient approach for this specific layer. The previous implementation partitioned along the smaller dimension (64).

This change aligns the implementation with the intended parallelism strategy, improving computational efficiency for this layer.

## Test Plan

```
from vllm import LLM, SamplingParams

def main():
    llm = LLM(model="Qwen/Qwen3-Next-80B-A3B-Instruct-FP8", trust_remote_code=True)
    sampling_params = SamplingParams(temperature=0.1, top_p=0.9, max_tokens=500)

    vllm_inputs_text_only = {"prompt": "USER: Please introduce yourself. ASSISTANT:"}
    outputs = llm.generate(vllm_inputs_text_only, sampling_params)
    for output_item in outputs:
        print(f"{output_item.outputs[0].text}\n" + "-" * 20)

if __name__ == '__main__':
    main()
```

## Test Result

<img width="1730" height="344" alt="image" src="https://github.com/user-attachments/assets/af057b68-1902-4ef2-a73e-ef1e869e6269" />