### PR TITLE
Fix seed reproducibility issue by adding output.copy_(out)

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -563,6 +563,7 @@ class MambaMixer2(MambaBase, CustomOp):
             hidden_states, _B, _C = split_hidden_states_B_C_fn(hidden_states_B_C)
             hidden_states = self.norm(hidden_states, gate)
             out, _ = self.out_proj(hidden_states)
+            output.copy_(out)
             return out
 
         # NOTE: V0 put prefill before decode, v1 puts decode before prefill


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR fixes the seed reproducibility issue in vLLM MambaMixer2. Despite setting the seed in the script, the results were not consistent across multiple runs. The issue was found to be in the mamba_mixer2.py file, where the missing output.copy_(out) line prevented correct output from being written to the buffer, causing unstable results.

## Test Plan
Added the line output.copy_(out) to the V1 configuration section in mamba_mixer2.py to ensure stable seed reproducibility.

## Test Result
When using script like this:
```python
# init env
current_platform.seed_everything(42)
vllm_mixer.kv_cache = (torch.tensor([]), torch.tensor([]))
from vllm.forward_context import set_forward_context

current_platform.seed_everything(42)
vllm_mixer.kv_cache = (torch.tensor([]), torch.tensor([]))
vllm_out = torch.empty_like(x)
vllm_mixer.eval()
with set_forward_context(attn_metadata=None, vllm_config=vllm_config):
    vllm_mixer(x, vllm_out)

current_platform.seed_everything(42)
vllm_mixer.kv_cache = (torch.tensor([]), torch.tensor([]))
vllm_out2 = torch.empty_like(x)
vllm_mixer.eval()
with set_forward_context(attn_metadata=None, vllm_config=vllm_config):
    vllm_mixer(x, vllm_out2)
assert torch.allclose(vllm_out, vllm_out2), 'vLLM MambaMixer2 outputs are different'
```
output:
```python
vllm_out1:
tensor([[[-0.1016,  1.0547, -1.2422,  ..., -1.8438,  1.0234, -0.4102],
         [ 0.4160,  0.3359, -0.4199,  ...,  0.3828,  0.7383, -1.7188],
         [-0.0303,  0.4746,  0.7812,  ...,  1.3984, -0.2891,  0.2930],
         [ 0.4043,  0.5469,  0.2812,  ...,  0.8242, -0.3145,  2.5625]]],
       device='cuda:0', dtype=torch.bfloat16, grad_fn=<CopyBackwards>)
torch.Size([1, 4, 1920])

vllm_out2:
tensor([[[-0.1016,  1.0547, -1.2422,  ..., -1.8438,  1.0234, -0.4102],
         [ 0.4160,  0.3359, -0.4199,  ...,  0.3828,  0.7383, -1.7188],
         [-0.0303,  0.4746,  0.7812,  ...,  1.3984, -0.2891,  0.2930],
         [ 0.4043,  0.5469,  0.2812,  ...,  0.8242, -0.3145,  2.5625]]],
       device='cuda:0', dtype=torch.bfloat16, grad_fn=<CopyBackwards>)
torch.Size([1, 4, 1920])

vLLM MambaMixer2 outputs are the same
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

