### PR TITLE
Notice for deprecation of AutoAWQ

### DIFF
--- a/docs/features/quantization/auto_awq.md
+++ b/docs/features/quantization/auto_awq.md
@@ -1,7 +1,9 @@
 # AutoAWQ
 
-Notice:
-AutoAWQ has been deprecated but has been adopted by the vLLM project into [llm-compressor](https://github.com/vllm-project/llm-compressor), you can find more information about [AWQ in llm-compressor](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq) or go to [AutoAWQ](https://github.com/casper-hansen/AutoAWQ) to see details about the deprecation.
+!!! warning "AutoAWQ is Deprecated"
+    The `AutoAWQ` library is deprecated. This functionality is now maintained by the vLLM project in [`llm-compressor`](https://github.com/vllm-project/llm-compressor).
+
+    For the recommended quantization workflow, please see the [AWQ examples in `llm-compressor`](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq). For more details on the deprecation, refer to the original [AutoAWQ repository](https://github.com/casper-hansen/AutoAWQ).
 
 To create a new 4-bit quantized model, you can leverage [AutoAWQ](https://github.com/casper-hansen/AutoAWQ).
 Quantization reduces the model's precision from BF16/FP16 to INT4 which effectively reduces the total model memory footprint.

--- a/docs/features/quantization/auto_awq.md
+++ b/docs/features/quantization/auto_awq.md
@@ -1,6 +1,6 @@
 # AutoAWQ
 
-> [!WARNING]
+> ⚠️ **Warning:**
     The `AutoAWQ` library is deprecated. This functionality has been adopted by the vLLM project in [`llm-compressor`](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq).
     For the recommended quantization workflow, please see the AWQ examples in [`llm-compressor`](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq). For more details on the deprecation, refer to the original [AutoAWQ repository](https://github.com/casper-hansen/AutoAWQ).
 

--- a/docs/features/quantization/auto_awq.md
+++ b/docs/features/quantization/auto_awq.md
@@ -1,5 +1,8 @@
 # AutoAWQ
 
+Notice:
+AutoAWQ has been deprecated but has been adopted by the vLLM project into [llm-compressor](https://github.com/vllm-project/llm-compressor), you can find more information about [AWQ in llm-compressor](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq) or go to [AutoAWQ](https://github.com/casper-hansen/AutoAWQ) to see details about the deprecation.
+
 To create a new 4-bit quantized model, you can leverage [AutoAWQ](https://github.com/casper-hansen/AutoAWQ).
 Quantization reduces the model's precision from BF16/FP16 to INT4 which effectively reduces the total model memory footprint.
 The main benefits are lower latency and memory usage.

--- a/docs/features/quantization/auto_awq.md
+++ b/docs/features/quantization/auto_awq.md
@@ -1,9 +1,8 @@
 # AutoAWQ
 
-!!! warning "AutoAWQ is Deprecated"
-    The `AutoAWQ` library is deprecated. This functionality is now maintained by the vLLM project in [`llm-compressor`](https://github.com/vllm-project/llm-compressor).
-
-    For the recommended quantization workflow, please see the [AWQ examples in `llm-compressor`](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq). For more details on the deprecation, refer to the original [AutoAWQ repository](https://github.com/casper-hansen/AutoAWQ).
+> [!WARNING]
+    The `AutoAWQ` library is deprecated. This functionality has been adopted by the vLLM project in [`llm-compressor`](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq).
+    For the recommended quantization workflow, please see the AWQ examples in [`llm-compressor`](https://github.com/vllm-project/llm-compressor/tree/main/examples/awq). For more details on the deprecation, refer to the original [AutoAWQ repository](https://github.com/casper-hansen/AutoAWQ).
 
 To create a new 4-bit quantized model, you can leverage [AutoAWQ](https://github.com/casper-hansen/AutoAWQ).
 Quantization reduces the model's precision from BF16/FP16 to INT4 which effectively reduces the total model memory footprint.


### PR DESCRIPTION
## Purpose

Having a deprecated tool front and center in the quantization section of the vllm docs may be contributing to the number of users we see struggling to get AWQ working in vllm (https://discuss.vllm.ai/t/a-bit-of-frustration-with-quantization/1720). Directing them to maintained frameworks first has the potential to reduce this.

## Test Plan

documentation preview

## Test Result

(building)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
