### PR TITLE
[bugfix] Fix online serving crash when text type response_format is received

### DIFF
--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -672,6 +672,25 @@ async def test_response_format_json_schema(client: openai.AsyncOpenAI):
 
 
 @pytest.mark.asyncio
+async def test_response_format_text(client: openai.AsyncOpenAI):
+    for _ in range(2):
+        resp = await client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "what is 1+1?",
+                }
+            ],
+            max_completion_tokens=10,
+            response_format={"type": "text"},
+        )
+
+        content = resp.choices[0].message.content
+        assert content is not None
+
+
+@pytest.mark.asyncio
 async def test_extra_fields_allowed(client: openai.AsyncOpenAI):
     resp = await client.chat.completions.create(
         model=MODEL_NAME,

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -5,6 +5,7 @@
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/protocol/openai_api_protocol.py
 import json
 import time
+from dataclasses import replace
 from typing import Annotated, Any, ClassVar, Literal
 
 import torch
@@ -417,18 +418,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         response_format = self.response_format
         if response_format is not None:
-            # If structured outputs wasn't already enabled,
-            # we must enable it for these features to work
-            if self.structured_outputs is None:
-                self.structured_outputs = StructuredOutputsParams()
+            kwargs_changes = dict[str, Any]()
 
             # Set structured output params for response format
             if response_format.type == "json_object":
-                self.structured_outputs.json_object = True
+                kwargs_changes["json_object"] = True
             elif response_format.type == "json_schema":
                 json_schema = response_format.json_schema
                 assert json_schema is not None
-                self.structured_outputs.json = json_schema.json_schema
+                kwargs_changes["json"] = json_schema.json_schema
             elif response_format.type == "structural_tag":
                 structural_tag = response_format
                 assert structural_tag is not None and isinstance(
@@ -439,7 +437,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     ),
                 )
                 s_tag_obj = structural_tag.model_dump(by_alias=True)
-                self.structured_outputs.structural_tag = json.dumps(s_tag_obj)
+                kwargs_changes["structural_tag"] = json.dumps(s_tag_obj)
+
+            # If structured outputs wasn't already enabled,
+            # we must enable it for these features to work
+            if len(kwargs_changes) > 0:
+                self.structured_outputs = (
+                    StructuredOutputsParams(**kwargs_changes)
+                    if self.structured_outputs is None
+                    else replace(self.structured_outputs, **kwargs_changes)
+                )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
         if self.kv_transfer_params:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -418,15 +418,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         response_format = self.response_format
         if response_format is not None:
-            kwargs_changes = dict[str, Any]()
+            structured_outputs_kwargs = dict[str, Any]()
 
             # Set structured output params for response format
             if response_format.type == "json_object":
-                kwargs_changes["json_object"] = True
+                structured_outputs_kwargs["json_object"] = True
             elif response_format.type == "json_schema":
                 json_schema = response_format.json_schema
                 assert json_schema is not None
-                kwargs_changes["json"] = json_schema.json_schema
+                structured_outputs_kwargs["json"] = json_schema.json_schema
             elif response_format.type == "structural_tag":
                 structural_tag = response_format
                 assert structural_tag is not None and isinstance(
@@ -437,15 +437,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     ),
                 )
                 s_tag_obj = structural_tag.model_dump(by_alias=True)
-                kwargs_changes["structural_tag"] = json.dumps(s_tag_obj)
+                structured_outputs_kwargs["structural_tag"] = json.dumps(s_tag_obj)
 
             # If structured outputs wasn't already enabled,
             # we must enable it for these features to work
-            if len(kwargs_changes) > 0:
+            if len(structured_outputs_kwargs) > 0:
                 self.structured_outputs = (
-                    StructuredOutputsParams(**kwargs_changes)
+                    StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else replace(self.structured_outputs, **kwargs_changes)
+                    else replace(self.structured_outputs, **structured_outputs_kwargs)
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -5,6 +5,7 @@
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/protocol/openai_api_protocol.py
 import json
 import time
+from dataclasses import replace
 from typing import Annotated, Any, Literal
 
 import torch
@@ -247,18 +248,15 @@ class CompletionRequest(OpenAIBaseModel):
 
         response_format = self.response_format
         if response_format is not None:
-            # If structured outputs wasn't already enabled,
-            # we must enable it for these features to work
-            if self.structured_outputs is None:
-                self.structured_outputs = StructuredOutputsParams()
+            kwargs_changes = dict[str, Any]()
 
             # Set structured output params for response format
             if response_format.type == "json_object":
-                self.structured_outputs.json_object = True
+                kwargs_changes["json_object"] = True
             elif response_format.type == "json_schema":
                 json_schema = response_format.json_schema
                 assert json_schema is not None
-                self.structured_outputs.json = json_schema.json_schema
+                kwargs_changes["json"] = json_schema.json_schema
             elif response_format.type == "structural_tag":
                 structural_tag = response_format
                 assert structural_tag is not None and isinstance(
@@ -269,7 +267,16 @@ class CompletionRequest(OpenAIBaseModel):
                     ),
                 )
                 s_tag_obj = structural_tag.model_dump(by_alias=True)
-                self.structured_outputs.structural_tag = json.dumps(s_tag_obj)
+                kwargs_changes["structural_tag"] = json.dumps(s_tag_obj)
+
+            # If structured outputs wasn't already enabled,
+            # we must enable it for these features to work
+            if len(kwargs_changes) > 0:
+                self.structured_outputs = (
+                    StructuredOutputsParams(**kwargs_changes)
+                    if self.structured_outputs is None
+                    else replace(self.structured_outputs, **kwargs_changes)
+                )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
         if self.kv_transfer_params:

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -248,15 +248,15 @@ class CompletionRequest(OpenAIBaseModel):
 
         response_format = self.response_format
         if response_format is not None:
-            kwargs_changes = dict[str, Any]()
+            structured_outputs_kwargs = dict[str, Any]()
 
             # Set structured output params for response format
             if response_format.type == "json_object":
-                kwargs_changes["json_object"] = True
+                structured_outputs_kwargs["json_object"] = True
             elif response_format.type == "json_schema":
                 json_schema = response_format.json_schema
                 assert json_schema is not None
-                kwargs_changes["json"] = json_schema.json_schema
+                structured_outputs_kwargs["json"] = json_schema.json_schema
             elif response_format.type == "structural_tag":
                 structural_tag = response_format
                 assert structural_tag is not None and isinstance(
@@ -267,15 +267,15 @@ class CompletionRequest(OpenAIBaseModel):
                     ),
                 )
                 s_tag_obj = structural_tag.model_dump(by_alias=True)
-                kwargs_changes["structural_tag"] = json.dumps(s_tag_obj)
+                structured_outputs_kwargs["structural_tag"] = json.dumps(s_tag_obj)
 
             # If structured outputs wasn't already enabled,
             # we must enable it for these features to work
-            if len(kwargs_changes) > 0:
+            if len(structured_outputs_kwargs) > 0:
                 self.structured_outputs = (
-                    StructuredOutputsParams(**kwargs_changes)
+                    StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else replace(self.structured_outputs, **kwargs_changes)
+                    else replace(self.structured_outputs, **structured_outputs_kwargs)
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -9,7 +9,7 @@ from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from http import HTTPStatus
 from typing import Final
 
@@ -467,16 +467,16 @@ class OpenAIServingResponses(OpenAIServing):
 
                 if self.reasoning_parser is not None:
                     reasoning_parser = self.reasoning_parser(tokenizer)
-                    sampling_params.structured_outputs = (
-                        None
-                        if (struct_out := sampling_params.structured_outputs) is None
-                        or struct_out.all_non_structural_tag_constraints_none()
-                        else StructuredOutputsParams(
+                    if isinstance(
+                        struct_out := sampling_params.structured_outputs,
+                        StructuredOutputsParams,
+                    ):
+                        sampling_params.structured_outputs = replace(
+                            struct_out,
                             structural_tag=reasoning_parser.prepare_structured_tag(
                                 struct_out.structural_tag, self.tool_server
-                            )
+                            ),
                         )
-                    )
                 generator = self._generate_with_builtin_tools(
                     request_id=request.request_id,
                     engine_prompt=engine_prompt,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -467,9 +467,12 @@ class OpenAIServingResponses(OpenAIServing):
 
                 if self.reasoning_parser is not None:
                     reasoning_parser = self.reasoning_parser(tokenizer)
-                    if isinstance(
-                        struct_out := sampling_params.structured_outputs,
-                        StructuredOutputsParams,
+                    if (
+                        isinstance(
+                            struct_out := sampling_params.structured_outputs,
+                            StructuredOutputsParams,
+                        )
+                        and struct_out.all_non_structural_tag_constraints_none()
                     ):
                         sampling_params.structured_outputs = replace(
                             struct_out,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -467,16 +467,16 @@ class OpenAIServingResponses(OpenAIServing):
 
                 if self.reasoning_parser is not None:
                     reasoning_parser = self.reasoning_parser(tokenizer)
-                    if sampling_params.structured_outputs is None:
-                        sampling_params.structured_outputs = StructuredOutputsParams()
-                    struct_out = sampling_params.structured_outputs
-                    if struct_out.all_non_structural_tag_constraints_none():
-                        sampling_params.structured_outputs.structural_tag = (
-                            reasoning_parser.prepare_structured_tag(
-                                sampling_params.structured_outputs.structural_tag,
-                                self.tool_server,
+                    sampling_params.structured_outputs = (
+                        None
+                        if (struct_out := sampling_params.structured_outputs) is None
+                        or struct_out.all_non_structural_tag_constraints_none()
+                        else StructuredOutputsParams(
+                            structural_tag=reasoning_parser.prepare_structured_tag(
+                                struct_out.structural_tag, self.tool_server
                             )
                         )
+                    )
                 generator = self._generate_with_builtin_tools(
                     request_id=request.request_id,
                     engine_prompt=engine_prompt,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -67,6 +67,11 @@ class StructuredOutputsParams:
                 "You can only use one kind of structured outputs constraint "
                 f"but multiple are specified: {self.__dict__}"
             )
+        if count < 1:
+            raise ValueError(
+                "You must use one kind of structured outputs constraint "
+                f"but none are specified: {self.__dict__}"
+            )
 
     def all_constraints_none(self) -> bool:
         """

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -65,11 +65,11 @@ class ToolParser:
         # Set structured output params for tool calling
         if json_schema_from_tool is not None:
             if isinstance(request, ChatCompletionRequest):
-                request.structured_outputs = StructuredOutputsParams()
                 # tool_choice: "Forced Function" or "required" will override
                 # structured output json settings to make tool calling work correctly
-                request.structured_outputs.json = json_schema_from_tool
-                request.response_format = None
+                request.structured_outputs = StructuredOutputsParams(
+                    json=json_schema_from_tool
+                )
             if isinstance(request, ResponsesRequest):
                 request.text = ResponseTextConfig()
                 request.text.format = ResponseFormatTextJSONSchemaConfig(

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -70,6 +70,7 @@ class ToolParser:
                 request.structured_outputs = StructuredOutputsParams(
                     json=json_schema_from_tool
                 )
+                request.response_format = None
             if isinstance(request, ResponsesRequest):
                 request.text = ResponseTextConfig()
                 request.text.format = ResponseFormatTextJSONSchemaConfig(


### PR DESCRIPTION
## Purpose

Fix #26639.

Especially, this PR adds a proper input validation to `StructuredOutpusParams` not to generate unschedulable structured outputs params, and adjust sampling parameter generation logic in `ChatCompletionRequest.to_sampling_parameters()` and `OpenAIServingResponses.create_responses()` to reflect the change and be more robust.

co-authored by @j0shuajun who first reported the issue and minimal reproducible examples on our side.

## Test Plan

Pass a chat completion request with `"response_format": {"type": "text"}`:

```curl
curl -XPOST http://localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"openai/gpt-oss-120b","messages":[{"role":"user","content":"hello"}],"max_tokens":2048,"stream":false,"response_format":{"type":"text"}}'
```

Plus, pass a chat completion request with `"response_format": {"type": "json_object"}` to check for regressions.

```curl
curl -XPOST http://localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"openai/gpt-oss-120b","messages":[{"role":"user","content":"hello"}],"max_tokens":2048,"stream":false,"response_format":{"type":"json_object"}}'
```

## Test Result

Return a valid response in both cases.

```text
# response_format text - respond with normal text
{"id":"chatcmpl-b6a22dfca265460ab316d7ea490d974b","object":"chat.completion","created":1760457543,"model":"openai/gpt-oss-120b","choices":[{"index":0,"messages":{"role":"assistant","content":"Hello! How can I assist you today?","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":"We need to respond: greeting. No instructions."},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":70,"total_tokens":99,"completion_tokens":29,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_tokens_ids":null,"kv_transfer_params":null}

# response_format json_object - respond with JSON object
{"id":"chatcmpl-9643189ba2674cc2b471bd9a63472e
69","object":"chat.completion","created":1760457566,"model":"openai/gpt-oss-120b","choices":[{"index":0,"messages":{"role":"assistant","content":"{\"response\":\"Hello! How can I assist you today?\"}","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":"The user says \"hello\". We just respond politely."},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":70,"total_tokens":104,"completion_tokens":34,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_tokens_ids":null,"kv_transfer_params":null}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

