### PR TITLE
[bugfix] Fix test using nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e

### DIFF
--- a/tests/compile/test_async_tp.py
+++ b/tests/compile/test_async_tp.py
@@ -329,13 +329,7 @@ def async_tp_pass_on_test_model(
         ),
     )
     vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
-
-    # this is a fake model name to construct the model config
-    # in the vllm_config, it's not really used.
-    model_name = "nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e"
-    vllm_config.model_config = ModelConfig(
-        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
-    )
+    vllm_config.model_config = ModelConfig(dtype=dtype, seed=42)
 
     async_tp_pass = AsyncTPPass(vllm_config)
     backend = TestBackend(async_tp_pass)

--- a/tests/compile/test_fusion_all_reduce.py
+++ b/tests/compile/test_fusion_all_reduce.py
@@ -226,13 +226,7 @@ def all_reduce_fusion_pass_on_test_model(
         enable_fi_allreduce_fusion=True, enable_noop=True
     )
     vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
-
-    # this is a fake model name to construct the model config
-    # in the vllm_config, it's not really used.
-    model_name = "nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e"
-    vllm_config.model_config = ModelConfig(
-        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
-    )
+    vllm_config.model_config = ModelConfig(dtype=dtype, seed=42)
 
     all_reduce_fusion_pass = AllReduceFusionPass(vllm_config)
     noop_pass = NoOpEliminationPass(vllm_config)

--- a/tests/compile/test_sequence_parallelism.py
+++ b/tests/compile/test_sequence_parallelism.py
@@ -278,10 +278,7 @@ def sequence_parallelism_pass_on_test_model(
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.
-    model_name = "nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e"
-    vllm_config.model_config = ModelConfig(
-        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
-    )
+    vllm_config.model_config = ModelConfig(dtype=dtype, seed=42)
 
     noop_pass = NoOpEliminationPass(vllm_config)
     sequence_parallelism_pass = SequenceParallelismPass(vllm_config)


### PR DESCRIPTION
## Purpose

Fixes the following test failure when I run on main with regards to the model `nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e`. I'm not sure if the ModelConfig specific to this model is really necessary so I just removed it, and the tests seem to be fine?

<img width="1226" height="361" alt="image" src="https://github.com/user-attachments/assets/80fc74b7-7edd-4d46-aefb-f2735c9f29cf" />

## Test Plan
`pytest -sv tests/compile/test_sequence_parallelism.py` passes now

cc @ProExpertProg @zou3519 

