### PR TITLE
[WideEP][P/D] Add usage stats for DP+EP and KV Connector

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -370,8 +370,8 @@ def report_usage_stats(
             # Distributed parallelism settings
             "tensor_parallel_size": parallel_config.tensor_parallel_size,
             "data_parallel_size": parallel_config.data_parallel_size,
-            "enable_expert_parallel": parallel_config.enable_expert_parallel,
             "pipeline_parallel_size": parallel_config.pipeline_parallel_size,
+            "enable_expert_parallel": parallel_config.enable_expert_parallel,
             # All2All backend for MoE expert parallel
             "all2all_backend": parallel_config.all2all_backend,
             # KV connector used

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -345,13 +345,17 @@ def report_usage_stats(
 
     parallel_config = vllm_config.parallel_config
 
+    # Prepare KV connector string if applicable
+    kv_connector = None
+    if vllm_config.kv_transfer_config is not None:
+        kv_connector = vllm_config.kv_transfer_config.kv_connector
+
     usage_message.report_usage(
         get_architecture_class_name(vllm_config.model_config),
         usage_context,
         extra_kvs={
             # Common configuration
             "dtype": str(vllm_config.model_config.dtype),
-            "tensor_parallel_size": parallel_config.tensor_parallel_size,
             "block_size": vllm_config.cache_config.block_size,
             "gpu_memory_utilization": vllm_config.cache_config.gpu_memory_utilization,
             "kv_cache_memory_bytes": vllm_config.cache_config.kv_cache_memory_bytes,
@@ -363,6 +367,15 @@ def report_usage_stats(
             "enable_prefix_caching": vllm_config.cache_config.enable_prefix_caching,
             "enforce_eager": vllm_config.model_config.enforce_eager,
             "disable_custom_all_reduce": parallel_config.disable_custom_all_reduce,
+            # Distributed parallelism settings
+            "tensor_parallel_size": parallel_config.tensor_parallel_size,
+            "data_parallel_size": parallel_config.data_parallel_size,
+            "enable_expert_parallel": parallel_config.enable_expert_parallel,
+            "pipeline_parallel_size": parallel_config.pipeline_parallel_size,
+            # All2All backend for MoE expert parallel
+            "all2all_backend": parallel_config.all2all_backend,
+            # KV connector used
+            "kv_connector": kv_connector,
         },
     )
 


### PR DESCRIPTION
## Purpose

Add usage stats for disaggregated serving + more distributed serving parameters. Lets us see how vLLM is parallelized, what All2All implementation is being used, and what KV connectors are in use.

Example output from running:
```
vllm serve Qwen/Qwen3-30B-A3B-FP8 --port 8192 -dp 4 --enable-expert-parallel \
        --kv-transfer-config.kv_connector OffloadingConnector \
        --kv-transfer-config.kv_role kv_both \
        --kv-transfer-config.kv_connector_extra_config.num_cpu_blocks 12 \
        --enforce-eager
```

```
{
  "uuid": "88749d0c-1fea-4505-b47a-e1cdbf23d889",
  "provider": "UNKNOWN",
  "num_cpu": 384,
  "cpu_type": "AMD EPYC 9654 96-Core Processor",
  "cpu_family_model_stepping": "25,17,1",
  "total_memory": 1622917644288,
  "architecture": "x86_64",
  "platform": "Linux-5.15.0-113-generic-x86_64-with-glibc2.35",
  "cuda_runtime": "12.8",
  "gpu_count": 1,
  "gpu_type": "NVIDIA H100 80GB HBM3",
  "gpu_memory_per_device": 85029158912,
  "env_var_json": "{\"VLLM_USE_MODELSCOPE\": false, \"VLLM_USE_TRITON_FLASH_ATTN\": true, \"VLLM_ATTENTION_BACKEND\": null, \"VLLM_USE_FLASHINFER_SAMPLER\": null, \"VLLM_PP_LAYER_PARTITION\": null, \"VLLM_USE_TRITON_AWQ\": false, \"VLLM_USE_V1\": true, \"VLLM_ENABLE_V1_MULTIPROCESSING\": true}",
  "model_architecture": "Qwen3MoeForCausalLM",
  "vllm_version": "0.11.1rc1.dev456+g314285d4f",
  "context": "ENGINE_CONTEXT",
  "log_time": 1760468089404900000,
  "source": "production",
  "dtype": "torch.bfloat16",
  "block_size": 16,
  "gpu_memory_utilization": 0.9,
  "kv_cache_memory_bytes": null,
  "quantization": "fp8",
  "kv_cache_dtype": "auto",
  "enable_lora": false,
  "enable_prefix_caching": true,
  "enforce_eager": true,
  "disable_custom_all_reduce": false,
  "tensor_parallel_size": 1,
  "data_parallel_size": 4,
  "pipeline_parallel_size": 1,
  "enable_expert_parallel": true,
  "all2all_backend": "allgather_reducescatter",
  "kv_connector": "OffloadingConnector"
}
```
