### PR TITLE
[CI/Build] Fix AMD import failures in CI

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -12,7 +12,7 @@ ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
 RUN apt-get update -q -y && apt-get install -q -y \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
     apt-transport-https ca-certificates wget curl
-# Remove sccache    
+# Remove sccache
 RUN python3 -m pip install --upgrade pip
 RUN apt-get purge -y sccache; python3 -m pip uninstall -y sccache; rm -f "$(which sccache)"
 ARG COMMON_WORKDIR

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -29,4 +29,6 @@ matplotlib==3.10.3
 # Multi-Modal Models Test (Extended) 3
 blobfile==3.0.0
 
+schemathesis==3.39.15 # Required for openai schema test.
 
+mteb[bm25s]>=1.38.11, <2 # required for mteb test


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When checking the current AMD CI([example](https://buildkite.com/vllm/ci/builds/32227#019979e1-da69-485c-9ba5-64d7d4e8b0fc)), Entrypoints Integration Test (API Server) on AMD is failing due to lack of imports in [rocm-test.txt](https://github.com/vllm-project/vllm/blob/main/requirements/rocm-test.txt) vs what we have in [test.in](https://github.com/vllm-project/vllm/blob/main/requirements/test.in#L42).

```

==================================== ERRORS ====================================
  | _______ ERROR collecting tests/entrypoints/openai/test_openai_schema.py ________
  | ImportError while importing test module '/vllm-workspace/tests/entrypoints/openai/test_openai_schema.py'.
  | Hint: make sure your test modules/packages have valid Python names.
  | Traceback:
  | /usr/lib/python3.12/importlib/__init__.py:90: in import_module
  | return _bootstrap._gcd_import(name[level:], package, level)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | entrypoints/openai/test_openai_schema.py:7: in <module>
  | import schemathesis
  | E   ModuleNotFoundError: No module named 'schemathesis'


```
```
models/language/pooling_mteb_test/test_baai.py:11: in <module>
--
  | from .mteb_utils import mteb_test_embed_models, mteb_test_rerank_models
  | models/language/pooling_mteb_test/mteb_utils.py:8: in <module>
  | import mteb
  | E   ModuleNotFoundError: No module named 'mteb'
```

## Test Plan
CI
## Test Result
import errors are gone, still need to fix tests...([build](https://buildkite.com/vllm/ci/builds/35129#0199ea73-d05e-4082-89c8-06f4b23013c0))
AMD MI300: Language Models Test (MTEB)
```
FAILED models/language/pooling_mteb_test/test_st_projector.py::test_embed_models_mteb[model_info0]
--
  | FAILED models/language/pooling_mteb_test/test_st_projector.py::test_embed_models_mteb[model_info1]
  | ===== 26 failed, 5 passed, 84 skipped, 38815 warnings in 692.55s (0:11:32) =====
  | sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
  | Error response from daemon: No such container: rocm_0e37ffc2ff33ee00eda068a991c89704dad20089_ksbPpNOeyN
  | 🚨 Error: The command exited with status 1
```
Entrypoints Integration Test (API Server)
```
ERROR entrypoints/openai/test_translation_validation.py::test_long_audio_request[openai/whisper-small]
--
  | = 8 failed, 238 passed, 8 skipped, 48 warnings, 51 errors, 27 subtests passed in 2341.46s (0:39:01) =
  | sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
  | Error response from daemon: No such container: rocm_0e37ffc2ff33ee00eda068a991c89704dad20089_Dsl20w9FZ
```
