### PR TITLE
[BUGFIX][NIXL] quick fix for 'assert self.connector_worker is not None' in get_kv_connector_stats

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -241,7 +241,8 @@ class NixlConnector(KVConnectorBase_V1):
         return self.connector_worker.get_block_ids_with_load_errors()
 
     def get_kv_connector_stats(self) -> KVConnectorStats | None:
-        assert self.connector_worker is not None
+        if self.connector_worker is None:
+            return None
         return self.connector_worker.get_kv_connector_stats()
 
     @classmethod


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Propose a quick fix which occurs after #26046 
```
vllm/tests/v1/kv_connector/nixl_integratio/run_accuracy_test.sh
```

```
File "/workspace/vllm/vllm/v1/engine/core.py", line 328, in step
engine_core_outputs = self.scheduler.update_from_output(
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/workspace/vllm/vllm/v1/core/sched/scheduler.py", line 926, in update_from_output
stats = self.connector.get_kv_connector_stats()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/workspace/vllm/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 244, in get_kv_connector_stats
assert self.connector_worker is not None
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

