### PR TITLE
[Feature] Add process_weights_after_loading to AttentionImpl

### DIFF
--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -207,6 +207,9 @@ class AttentionImpl(ABC, Generic[T]):
         """
         return False
 
+    def process_weights_after_loading(self, act_dtype: torch.dtype):
+        pass
+
 
 class MLAAttentionImpl(AttentionImpl[T], Generic[T]):
     @abstractmethod

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -407,14 +407,6 @@ class Attention(nn.Module, AttentionLayerBase):
         if hasattr(self.impl, "process_weights_after_loading"):
             self.impl.process_weights_after_loading(act_dtype)
 
-        # FlashInfer requires attention sinks to be float32
-        if self.backend == _Backend.FLASHINFER and hasattr(self.impl, "sinks"):
-            from vllm.v1.attention.backends.flashinfer import FlashInferImpl
-
-            assert isinstance(self.impl, FlashInferImpl)
-            if self.impl.sinks is not None and self.impl.sinks.dtype != torch.float32:
-                self.impl.sinks = self.impl.sinks.to(torch.float32)
-
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -404,8 +404,7 @@ class Attention(nn.Module, AttentionLayerBase):
         return s
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
-        if hasattr(self.impl, "process_weights_after_loading"):
-            self.impl.process_weights_after_loading(act_dtype)
+        self.impl.process_weights_after_loading(act_dtype)
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -833,6 +833,11 @@ class FlashInferImpl(AttentionImpl):
 
         return self.support_trtllm_attn
 
+    # FlashInfer requires attention sinks to be float32
+    def process_weights_after_loading(self, act_dtype: torch.dtype):
+        if self.sinks is not None and self.sinks.dtype != torch.float32:
+            self.sinks = self.sinks.to(torch.float32)
+
     def forward(
         self,
         layer: torch.nn.Module,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

FIX: https://github.com/vllm-project/vllm/issues/26817

## Test Plan

```
$ VLLM_ATTENTION_BACKEND=FLASHINFER python3-m vllm.entrypoints.cli.main serve Qwen/Qwen3-0.6B
```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

