### PR TITLE
[Attention][DSA] Abstrat DSA topk-indices-buffer to AttentionBackend

### DIFF
--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -96,6 +96,10 @@ class AttentionBackend(ABC):
     def full_cls_name(cls) -> tuple[str, str]:
         return (cls.__module__, cls.__qualname__)
 
+    @classmethod
+    def enable_dsa_topk_indices_buffer(cls) -> bool:
+        return False
+
 
 class AttentionMetadata:
     pass

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -19,7 +19,11 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
 
-from .deepseek_v2 import DeepseekV2DecoderLayer, get_spec_layer_idx_from_weight_name
+from .deepseek_v2 import (
+    DeepseekV2DecoderLayer,
+    enable_dsa_topk_indices_buffer,
+    get_spec_layer_idx_from_weight_name,
+)
 from .interfaces import SupportsPP
 from .utils import maybe_prefix
 
@@ -57,7 +61,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
 
         self.is_v32 = hasattr(config, "index_topk")
-        if self.is_v32:
+        if self.is_v32 and enable_dsa_topk_indices_buffer():
             topk_tokens = config.index_topk
             topk_indices_buffer = torch.empty(
                 vllm_config.scheduler_config.max_num_batched_tokens,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -75,7 +75,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
-from vllm.utils import cdiv, direct_register_custom_op
+from vllm.utils import cdiv, direct_register_custom_op, resolve_obj_by_qualname
 from vllm.utils.deep_gemm import fp8_mqa_logits, fp8_paged_mqa_logits
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerBackend,
@@ -1168,7 +1168,7 @@ class DeepseekV2Model(nn.Module):
 
         self.vocab_size = config.vocab_size
         self.is_v32 = hasattr(config, "index_topk")
-        if self.is_v32:
+        if self.is_v32 and enable_dsa_topk_indices_buffer():
             topk_tokens = config.index_topk
             topk_indices_buffer = torch.empty(
                 vllm_config.scheduler_config.max_num_batched_tokens,
@@ -1508,3 +1508,19 @@ def get_spec_layer_idx_from_weight_name(
             if weight_name.startswith(f"model.layers.{layer_idx + i}."):
                 return layer_idx + i
     return None
+
+
+def enable_dsa_topk_indices_buffer():
+    return resolve_obj_by_qualname(
+        current_platform.get_attn_backend_cls(
+            selected_backend=None,
+            head_size=None,
+            dtype=None,
+            kv_cache_dtype=None,
+            block_size=None,
+            use_v1=True,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+        )
+    ).enable_dsa_topk_indices_buffer()

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -92,6 +92,10 @@ class FlashMLASparseBackend(AttentionBackend):
     def get_supported_head_sizes(cls) -> list[int]:
         return [576]
 
+    @classmethod
+    def enable_dsa_topk_indices_buffer(cls) -> bool:
+        return True
+
 
 @dataclass
 class FlashMLASparseMetadata:


### PR DESCRIPTION
## Purpose
Abstrat DSA topk-indices-buffer to `AttentionBackend`, seperated from #26656. Some attention backends do not need to create this buffer, such as the attention backend in vLLM-Ascend. This seems to be a logic closely related to the attention backend, and abstracting it into `AttentionBackend` will benefit a wide range of backend implementations
## Test Plan
Test with DeepSeek-V3.2-Exp

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

