### PR TITLE
[Bugfix][Multi Modal] Fix incorrect Molmo token processing

### DIFF
--- a/vllm/model_executor/models/molmo.py
+++ b/vllm/model_executor/models/molmo.py
@@ -1264,13 +1264,16 @@ class MolmoMultiModalProcessor(BaseMultiModalProcessor[MolmoProcessingInfo]):
     ) -> list[int]:
         processor = self.info.get_hf_processor()
 
-        # Apply the chat template to the tokens
+        # The chat template is already applied to the prompt tokens
+        # Use message_format="none" to avoid applying it again
+        # Prepend an empty space if `always_start_with_space` is True
         tokens = processor.processor.get_tokens_input(  # type: ignore
             self.info.get_tokenizer().decode(prompt_tokens),
-            message_format=processor.message_format,
+            message_format="none",
             always_start_with_space=processor.always_start_with_space,
         )
 
+        # Prepend a BOS token id to the tokens
         processed_data = self.info.ctx.call_hf_processor(
             processor,  # type: ignore
             dict(tokens=tokens),


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When serving a Molmo model online using chat completion, the vLLM code first applies Molmo’s chat template to the input text and tokenizes it. It then calls the custom `_apply_hf_processor_tokens_only` method in `MolmoMultiModalProcessor` for further processing.
However, `_apply_hf_processor_tokens_only` internally calls the `get_tokens_input` of the Molmo's HF processor, which **applies the chat template once again**, resulting in double templating.

This behavior can be verified by running the following code:

```python
from vllm import LLM
from vllm.sampling_params import SamplingParams
from transformers import AutoProcessor

model = LLM(
    model="allenai/Molmo-7B-D-0924",
    tensor_parallel_size=torch.cuda.device_count(),
    trust_remote_code=True,
    dtype='bfloat16',
    gpu_memory_utilization=0.95,
)

processor = AutoProcessor.from_pretrained(
    "allenai/Molmo-7B-D-0924",
    trust_remote_code=True,
    dtype="auto",
    device_map="auto",
)

sampling_params = SamplingParams(max_tokens=448, temperature=0)

image_url = "https://www.visitscotland.com/binaries/content/gallery/visitscotland/cms-images/2022/06/24/clashnessie-bay-car-road"

messages = [
    {
        "role": "user",
        "content": [
            {
                "type": "text",
                "text": "Describe the image."
            },
            {
                "type": "image_url",
                "image_url": {
                    "url": image_url
                }
            },
        ],
    },
]

outputs = model.chat(messages, sampling_params=sampling_params)
prompt = processor.tokenizer.decode(outputs[0].prompt_token_ids, skip_special_tokens=True)
print(prompt)
```

This prints:

```python
 User: User: Describe the image. Assistant: Assistant:
```

The double "User:" and "Assistant:" indicate that the chat template is applied twice.

This PR fixes this double templating issue.

## Changes Made
Make sure that `_apply_hf_processor_tokens_only` uses the `"none"` message format instead of the model's default configuration:

```python
        # The chat template is already applied to the prompt tokens
        # Use message_format="none" to avoid applying it again
        # Prepend an empty space if `always_start_with_space` is True
        tokens = processor.processor.get_tokens_input(  # type: ignore
            self.info.get_tokenizer().decode(prompt_tokens),
            message_format="none",
            always_start_with_space=processor.always_start_with_space,
        )

```

## Test Plan
Run the same code snippet above.

## Test Result

```python
 User: Describe the image. Assistant:
```

The double templating is resolved.
