### PR TITLE
Support block size of 256 used by Intel HPU

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -19,7 +19,7 @@ else:
 
 logger = init_logger(__name__)
 
-BlockSize = Literal[1, 8, 16, 32, 64, 128]
+BlockSize = Literal[1, 8, 16, 32, 64, 128, 256]
 CacheDType = Literal["auto", "bfloat16", "fp8", "fp8_e4m3", "fp8_e5m2", "fp8_inc"]
 MambaDType = Literal["auto", "float32"]
 PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor"]


### PR DESCRIPTION
This PR adds block size of 256 to the list which is used by Intel HPU fp8 models
