### PR TITLE
[Qwen3-Next] Add tuned MoE config for Qwen3-Next FP8 on H100 tp2

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=512,N=256,device_name=NVIDIA_H100_80GB_HBM3,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=512,N=256,device_name=NVIDIA_H100_80GB_HBM3,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.4.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}


### PR DESCRIPTION
## Purpose
This PR adds tuned fused MoE config for Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 on 2xH100 (tp2). This was generated by running `python3 benchmarks/kernels/benchmark_moe.py --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 --tp-size 2 --dtype fp8_w8a8 --tune`. 

## Test Plan
Benchmarking on v0.11.0
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
            --port 8000 \
            --host 0.0.0.0 \
            --no-enable-prefix-caching \
            --tensor-parallel-size 2 \
            --gpu-memory-utilization 0.85  # needed to avoid triton ooms

vllm bench serve \
  --backend openai-chat \
  --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
  --endpoint /v1/chat/completions \
  --dataset-name random \
  --ignore-eos \
  --random-input-len 1024 \
  --random-output-len 128 \
  --num-prompts 1000 \
  --max-concurrency 64

vllm bench serve \
  --backend openai-chat \
  --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
  --endpoint /v1/chat/completions \
  --dataset-name random \
  --ignore-eos \
  --random-input-len 128 \
  --random-output-len 1024 \
  --num-prompts 1000 \
  --max-concurrency 64
```

## Test Result

### 1024 in 128 out

| Metric                         | Before   | After    | Improvement |
|--------------------------------|:----------:|:----------:|:-------------:|
| Output token throughput (tok/s) | 2111.26  | 2231.28  | +5.7%        |
| Peak output token throughput (tok/s) | 3487.00   | 3656.00  | +4.8%        |
| Total token throughput (tok/s) | 18956.02  | 20033.66  | +5.7%        |
| Median TPOT (ms)               | 26.20    | 24.54    | –6.3%        |
| P99 TPOT (ms)                  | 28.75   | 26.95   | –6.3%        |
| Median ITL (ms)                | 18.99    | 17.99    | –5.3%        |
| P99 ITL (ms)                | 165.27    | 165.01    | –0%        |


**Before:**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Maximum request concurrency:             64        
Benchmark duration (s):                  60.63     
Total input tokens:                      1021255   
Total generated tokens:                  128000    
Request throughput (req/s):              16.49     
Output token throughput (tok/s):         2111.26   
Peak output token throughput (tok/s):    3487.00   
Peak concurrent requests:                128.00    
Total Token throughput (tok/s):          18956.02  
---------------Time to First Token----------------
Mean TTFT (ms):                          561.54    
Median TTFT (ms):                        493.51    
P99 TTFT (ms):                           1586.04   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.68     
Median TPOT (ms):                        26.20     
P99 TPOT (ms):                           28.75     
---------------Inter-token Latency----------------
Mean ITL (ms):                           25.51     
Median ITL (ms):                         18.99     
P99 ITL (ms):                            165.27    
==================================================
```

**After:**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Maximum request concurrency:             64        
Benchmark duration (s):                  57.37     
Total input tokens:                      1021255   
Total generated tokens:                  128000    
Request throughput (req/s):              17.43     
Output token throughput (tok/s):         2231.28   
Peak output token throughput (tok/s):    3656.00   
Peak concurrent requests:                120.00    
Total Token throughput (tok/s):          20033.66  
---------------Time to First Token----------------
Mean TTFT (ms):                          505.97    
Median TTFT (ms):                        491.39    
P99 TTFT (ms):                           1561.91   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.49     
Median TPOT (ms):                        24.54     
P99 TPOT (ms):                           26.95     
---------------Inter-token Latency----------------
Mean ITL (ms):                           24.30     
Median ITL (ms):                         17.99     
P99 ITL (ms):                            165.01    
==================================================
```

### 128 in 1024 out

| Metric                         | Before   | After    | Improvement |
|--------------------------------|:----------:|:----------:|:-------------:|
| Output token throughput (tok/s) | 2886.49  | 3053.20  | +5.8%        |
| Peak output token throughput (tok/s) | 3520.00   | 3648.00  | +3.6%        |
| Total token throughput (tok/s) | 3246.69  | 3434.20  | +5.8%        |
| Median TPOT (ms)               | 21.54    | 20.18    | –6.3%        |
| P99 TPOT (ms)                  | 21.83   | 21.02   | –3.7%        |
| Median ITL (ms)                | 21.14    | 19.93    | –5.7%        |
| P99 ITL (ms)                | 28.00    | 27.00    | –3.6%        |

**Before:**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Maximum request concurrency:             64        
Benchmark duration (s):                  354.76    
Total input tokens:                      127782    
Total generated tokens:                  1024000   
Request throughput (req/s):              2.82      
Output token throughput (tok/s):         2886.49   
Peak output token throughput (tok/s):    3520.00   
Peak concurrent requests:                128.00    
Total Token throughput (tok/s):          3246.69   
---------------Time to First Token----------------
Mean TTFT (ms):                          363.53    
Median TTFT (ms):                        337.14    
P99 TTFT (ms):                           738.74    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.36     
Median TPOT (ms):                        21.54     
P99 TPOT (ms):                           21.83     
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.40     
Median ITL (ms):                         21.14     
P99 ITL (ms):                            28.00     
==================================================
```

**After:**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Maximum request concurrency:             64        
Benchmark duration (s):                  335.39    
Total input tokens:                      127782    
Total generated tokens:                  1024000   
Request throughput (req/s):              2.98      
Output token throughput (tok/s):         3053.20   
Peak output token throughput (tok/s):    3648.00   
Peak concurrent requests:                126.00    
Total Token throughput (tok/s):          3434.20   
---------------Time to First Token----------------
Mean TTFT (ms):                          427.19    
Median TTFT (ms):                        418.37    
P99 TTFT (ms):                           721.88    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.11     
Median TPOT (ms):                        20.18     
P99 TPOT (ms):                           21.02     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.14     
Median ITL (ms):                         19.93     
P99 ITL (ms):                            27.00     
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

