### PR TITLE
fix: ModernBERT layer_norm_eps attribute error  Use config.norm_eps i…

### DIFF
--- a/.buildkite/lm-eval-harness/configs/Meta-Llama-3-8B-QQQ.yaml
+++ b/.buildkite/lm-eval-harness/configs/Meta-Llama-3-8B-QQQ.yaml
@@ -1,0 +1,12 @@
+# For vllm script, with -t option (tensor parallel size).
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m HandH1998/QQQ-Llama-3-8b-g128 -b 32 -l 1000 -f 5 -t 1
+model_name: "HandH1998/QQQ-Llama-3-8b-g128"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.419
+  - name: "exact_match,flexible-extract"
+    value: 0.416
+limit: 1000
+num_fewshot: 5

--- a/.buildkite/lm-eval-harness/configs/Meta-Llama-4-Maverick-17B-128E-Instruct-FP8-MM.yaml
+++ b/.buildkite/lm-eval-harness/configs/Meta-Llama-4-Maverick-17B-128E-Instruct-FP8-MM.yaml
@@ -1,0 +1,11 @@
+# For hf script, without -t option (tensor parallel size).
+# bash .buildkite/lm-eval-harness/run-lm-eval-chartqa-vllm-vlm-baseline.sh -m meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 -b 32 -l 100 -t 8
+model_name: "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
+backend: "vllm-vlm"
+tasks:
+- name: "chartqa"
+  metrics:
+  - name: "relaxed_accuracy,none"
+    value: 0.90
+limit: 100
+num_fewshot: 0

--- a/.buildkite/lm-eval-harness/configs/Meta-Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/.buildkite/lm-eval-harness/configs/Meta-Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -1,0 +1,11 @@
+# For hf script, without -t option (tensor parallel size).
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 -b 32 -l 250 -t 8 -f 5
+model_name: "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
+backend: "vllm-vlm"
+tasks:
+- name: "mmlu_pro"
+  metrics:
+  - name: "exact_match,custom-extract"
+    value: 0.80
+limit: 250 # will run on 250 * 14 subjects = 3500 samples
+num_fewshot: 5

--- a/.buildkite/lm-eval-harness/configs/Qwen2.5-VL-3B-Instruct-FP8-dynamic.yaml
+++ b/.buildkite/lm-eval-harness/configs/Qwen2.5-VL-3B-Instruct-FP8-dynamic.yaml
@@ -1,4 +1,5 @@
-# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m RedHatAI/Qwen2.5-VL-3B-Instruct-FP8-Dynamic -b auto -l 1319 -f 5 -t 1
+# For vllm script, with -t option (tensor parallel size)
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m RedHatAI/Qwen2.5-VL-3B-Instruct-FP8-Dynamic -l 1319 -t 1
 model_name: "RedHatAI/Qwen2.5-VL-3B-Instruct-FP8-Dynamic"
 tasks:
 - name: "gsm8k"

--- a/.buildkite/lm-eval-harness/configs/Qwen2.5-VL-7B-Instruct.yaml
+++ b/.buildkite/lm-eval-harness/configs/Qwen2.5-VL-7B-Instruct.yaml
@@ -1,0 +1,12 @@
+# For vllm script, with -t option (tensor parallel size).
+# bash .buildkite/lm-eval-harness/run-lm-eval-chartqa-vllm-vlm-baseline.sh -m Qwen/Qwen2.5-VL-7B-Instruct -l 2500 -t 1
+
+model_name: "Qwen/Qwen2.5-VL-7B-Instruct"
+backend: "vllm-vlm"
+tasks:
+- name: "chartqa"
+  metrics:
+  - name: "relaxed_accuracy,none"
+    value: 0.855
+limit: 2500
+num_fewshot: 0

--- a/.buildkite/lm-eval-harness/configs/models-large-h100.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large-h100.txt
@@ -1,0 +1,1 @@
+Meta-Llama-4-Maverick-17B-128E-Instruct-FP8.yaml

--- a/.buildkite/lm-eval-harness/configs/models-mm-large-h100.txt
+++ b/.buildkite/lm-eval-harness/configs/models-mm-large-h100.txt
@@ -1,0 +1,1 @@
+Meta-Llama-4-Maverick-17B-128E-Instruct-FP8-MM.yaml

--- a/.buildkite/lm-eval-harness/configs/models-mm-small.txt
+++ b/.buildkite/lm-eval-harness/configs/models-mm-small.txt
@@ -1,0 +1,1 @@
+Qwen2.5-VL-7B-Instruct.yaml

--- a/.buildkite/lm-eval-harness/run-lm-eval-chartqa-vllm-vlm-baseline.sh
+++ b/.buildkite/lm-eval-harness/run-lm-eval-chartqa-vllm-vlm-baseline.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# We can use this script to compute baseline accuracy on chartqa for vllm.
+#
+# Make sure you have lm-eval-harness installed:
+#   pip install lm-eval==0.4.9
+
+usage() {
+    echo``
+    echo "Runs lm eval harness on ChartQA using multimodal vllm."
+    echo "This pathway is intended to be used to create baselines for "
+    echo "our correctness tests in vllm's CI."
+    echo
+    echo "usage: ${0} <options>"
+    echo
+    echo "  -m    - huggingface stub or local directory of the model"
+    echo "  -l    - limit number of samples to run"
+    echo "  -t    - tensor parallel size to run at"
+    echo
+}
+
+while getopts "m:l:t:" OPT; do
+  case ${OPT} in
+    m ) 
+        MODEL="$OPTARG"
+        ;;
+    l ) 
+        LIMIT="$OPTARG"
+        ;;
+    t ) 
+        TP_SIZE="$OPTARG"
+        ;;
+    \? ) 
+        usage
+        exit 1
+        ;;
+  esac
+done
+
+lm_eval --model vllm-vlm \
+  --model_args "pretrained=$MODEL,tensor_parallel_size=$TP_SIZE" \
+  --tasks chartqa \
+  --batch_size auto \
+  --apply_chat_template \
+  --limit $LIMIT

--- a/.buildkite/lm-eval-harness/run-lm-eval-mmlupro-vllm-baseline.sh
+++ b/.buildkite/lm-eval-harness/run-lm-eval-mmlupro-vllm-baseline.sh
@@ -1,46 +1,50 @@
 #!/bin/bash
-# We can use this script to compute baseline accuracy on GSM for transformers.
+# We can use this script to compute baseline accuracy on MMLUPRO for vllm.
+# We use this for fp8, which HF does not support.
 #
 # Make sure you have lm-eval-harness installed:
 #   pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d#egg=lm-eval[api]
 
 usage() {
     echo``
-    echo "Runs lm eval harness on GSM8k using huggingface transformers."
+    echo "Runs lm eval harness on MMLU Pro using huggingface transformers."
     echo "This pathway is intended to be used to create baselines for "
     echo "our automated nm-test-accuracy workflow"
     echo
     echo "usage: ${0} <options>"
     echo
     echo "  -m    - huggingface stub or local directory of the model"
-    echo "  -b    - batch size to run the evaluation at"
     echo "  -l    - limit number of samples to run"
     echo "  -f    - number of fewshot samples to use"
+    echo "  -t    - tensor parallel size to run at"
     echo
 }
 
-while getopts "m:b:l:f:" OPT; do
+while getopts "m:b:l:f:t:" OPT; do
   case ${OPT} in
-    m ) 
+    m )
         MODEL="$OPTARG"
         ;;
-    b ) 
+    b )
         BATCH_SIZE="$OPTARG"
         ;;
-    l ) 
+    l )
         LIMIT="$OPTARG"
         ;;
-    f ) 
+    f )
         FEWSHOT="$OPTARG"
         ;;
-    \? ) 
+    t )
+        TP_SIZE="$OPTARG"
+        ;;
+    \? )
         usage
         exit 1
         ;;
   esac
 done
 
-lm_eval --model hf \
-  --model_args "pretrained=$MODEL,parallelize=True" \
-  --tasks gsm8k --num_fewshot "$FEWSHOT" --limit "$LIMIT" \
-  --batch_size "$BATCH_SIZE"
+lm_eval --model vllm \
+  --model_args "pretrained=$MODEL,tensor_parallel_size=$TP_SIZE,add_bos_token=true,trust_remote_code=true,max_model_len=4096" \
+  --tasks mmlu_pro --num_fewshot "$FEWSHOT" --limit "$LIMIT" \
+  --batch_size auto

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -734,6 +734,16 @@ steps:
     - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/processing
     - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model  # Otherwise, mp_method="spawn" doesn't work
 
+- label: Multi-Modal Accuracy Eval (Small Models) # 50min
+  timeout_in_minutes: 70
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  source_file_dependencies:
+  - vllm/multimodal/
+  - vllm/inputs/
+  - vllm/v1/core/
+  commands:
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-mm-small.txt --tp-size=1
+
 - label: Multi-Modal Models Test (Extended) 1
   mirror_hardwares: [amdexperimental]
   optional: true

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -39,11 +39,11 @@ class ModernBertEmbeddings(nn.Module):
         self.tok_embeddings = VocabParallelEmbedding(
             config.vocab_size, config.hidden_size
         )
-        cands = (
+        eps_candidates = (
             getattr(config, "norm_eps", None),
             getattr(config, "layer_norm_eps", None),
         )
-        eps = next((v for v in cands if v is not None), 1e-5)
+        eps = next((v for v in eps_candidates if v is not None), 1e-5)
         self.norm = nn.LayerNorm(config.hidden_size, eps=eps, bias=config.norm_bias)
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -39,11 +39,12 @@ class ModernBertEmbeddings(nn.Module):
         self.tok_embeddings = VocabParallelEmbedding(
             config.vocab_size, config.hidden_size
         )
-        cands = (getattr(config, "norm_eps", None), getattr(config, "layer_norm_eps", None))
-        eps = next((v for v in cands if v is not None), 1e-5)
-        self.norm = nn.LayerNorm(
-            config.hidden_size, eps=eps, bias=config.norm_bias
+        cands = (
+            getattr(config, "norm_eps", None),
+            getattr(config, "layer_norm_eps", None),
         )
+        eps = next((v for v in cands if v is not None), 1e-5)
+        self.norm = nn.LayerNorm(config.hidden_size, eps=eps, bias=config.norm_bias)
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.tok_embeddings(input_ids)

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -39,8 +39,10 @@ class ModernBertEmbeddings(nn.Module):
         self.tok_embeddings = VocabParallelEmbedding(
             config.vocab_size, config.hidden_size
         )
+        cands = (getattr(config, "norm_eps", None), getattr(config, "layer_norm_eps", None))
+        eps = next((v for v in cands if v is not None), 1e-5)
         self.norm = nn.LayerNorm(
-            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+            config.hidden_size, eps=eps, bias=config.norm_bias
         )
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -40,7 +40,7 @@ class ModernBertEmbeddings(nn.Module):
             config.vocab_size, config.hidden_size
         )
         self.norm = nn.LayerNorm(
-            config.hidden_size, eps=config.layer_norm_eps, bias=config.norm_bias
+            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
         )
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Fix ModernBERT model initialization failure due to missing `layer_norm_eps` attribute in configuration.

Resolves #26894

ModernBERT configuration uses `norm_eps` instead of `layer_norm_eps`, but vLLM's ModernBERT implementation expected the latter. This caused `AttributeError` when loading any ModernBERT model for sequence classification.

Fixes: AttributeError: 'ModernBertConfig' object has no attribute 'layer_norm_eps'

## Test Plan

Test with any ModernBERT sequence classification model:

```sh
vllm serve raft-security-lab/modernbert-text-cls-vllm-error \
    --task classify \
    --dtype float16 \
    --max-model-len 512
 ```
Test Result
Before:
❌ ModernBERT models failed to load with AttributeError: 'ModernBertConfig' object has no attribute 'layer_norm_eps'
After:
✅ ModernBERT models load successfully
✅ Classification inference works as expected
<details> <summary> Essential Elements of an Effective PR Description Checklist </summary>
 The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
 The test plan, such as providing test command.
 The test results, such as pasting the results comparison before and after, or e2e results
 (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.
 (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details> ```