### PR TITLE
kv_offload: Change default block size to 256

### DIFF
--- a/vllm/v1/kv_offload/spec.py
+++ b/vllm/v1/kv_offload/spec.py
@@ -31,9 +31,7 @@ class OffloadingSpec(ABC):
         self.extra_config = kv_transfer_config.kv_connector_extra_config
 
         self.gpu_block_size = vllm_config.cache_config.block_size
-        self.offloaded_block_size = int(
-            self.extra_config.get("block_size", self.gpu_block_size)
-        )
+        self.offloaded_block_size = int(self.extra_config.get("block_size", 256))
 
         assert self.offloaded_block_size % self.gpu_block_size == 0
 


### PR DESCRIPTION
This PR changes the default block size for KV offloading to 256. This should improve offloading transfer latency.

For example, on llama:

Offload single block throughput (16 tokens)	1.16 GB/s
Offload single block throughput (64 tokens)	2.09 GB/s
Offload single block throughput (256 tokens)	2.5 GB/s