### PR TITLE
[Bugfix] [ROCm] Enable DCP through Triton MLA on ROCm

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -546,7 +546,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
 
         self.num_heads = self.model_config.get_num_attention_heads(parallel_config)
         self.mla_dims = get_mla_dims(self.model_config)
-        self.aot_schedule = current_platform.is_cuda()
+        self.aot_schedule = current_platform.is_cuda_alike()
         try:
             self.dcp_world_size = get_dcp_group().world_size
             self.dcp_rank = get_dcp_group().rank_in_group


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Enable DCP on ROCm through Triton MLA backend.

`self.aot_schedule` is renamed to  `self.align_chunk_ctx_to_page_size` to fit recent semantics.

## Test Plan

Evaluate the lm_eval score of DeepSeek-R1 with DCP enabled

Triton MLA TP only
```
#!/bin/bash
rm -rf /root/.cache/vllm

MODEL=deepseek-ai/DeepSeek-R1

vllm serve $MODEL \
--tensor-parallel-size 8 \
--max-num-batched-tokens 32768 \
--disable-log-requests \
--trust-remote-code \
-dcp 8 \
--port 6789
```

When DCP is disabled and TP only

```
#!/bin/bash
rm -rf /root/.cache/vllm

MODEL=deepseek-ai/DeepSeek-R1

vllm serve $MODEL \
--tensor-parallel-size 8 \
--max-num-batched-tokens 32768 \
--disable-log-requests \
--trust-remote-code \
--block-size 16 \
--port 6789
```

Triton MLA TP only
Use ck flash attention in prefill
```
MODEL=deepseek-ai/DeepSeek-R1

VLLM_USE_V1=1
VLLM_USE_TRITON_FLASH_ATTN=0 \
VLLM_ATTENTION_BACKEND="TRITON_MLA" \
VLLM_ROCM_USE_AITER=0 \
vllm serve $MODEL \
--tensor-parallel-size 8 \
--max-num-batched-tokens 32768 \
--disable-log-requests \
--trust-remote-code \
--block-size 16 \
--port 6789
```

```

Triton MLA Enable DCP
Use ck flash attention in prefill
```
MODEL=deepseek-ai/DeepSeek-R1

VLLM_USE_V1=1
VLLM_USE_TRITON_FLASH_ATTN=0 \
VLLM_ATTENTION_BACKEND="TRITON_MLA" \
VLLM_ROCM_USE_AITER=0 \
vllm serve $MODEL \
--tensor-parallel-size 8 \
--max-num-batched-tokens 32768 \
--disable-log-requests \
--trust-remote-code \
--block-size 16 \
-dcp 8 \
--port 6789
```

When AITER MLA is enabled with TP only

```
#!/bin/bash
rm -rf /root/.cache/vllm

MODEL=deepseek-ai/DeepSeek-R1

VLLM_ATTENTION_BACKEND="ROCM_AITER_MLA" \
vllm serve $MODEL \
--tensor-parallel-size 8 \
--max-num-batched-tokens 32768 \
--disable-log-requests \
--trust-remote-code \
--block-size 1 \
--port 6789
```

## Test Result

lm eval score on GSM8k

Triton MLA TP8 DCP8
```
[2025-10-15 12:32:09] INFO evaluation_tracker.py:280: Output path not provided, skipping saving results aggregated
local-completions (model=deepseek-ai/DeepSeek-R1,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9484|±  |0.0061|
|     |       |strict-match    |     5|exact_match|↑  |0.9469|±  |0.0062|
```

Triton MLA TP8 only (without DCP)
```
local-completions (model=deepseek-ai/DeepSeek-R1,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.956|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.956|±  |0.0056|
```

Triton MLA TP only
```
[2025-10-15 15:04:22] INFO evaluation_tracker.py:280: Output path not provided, skipping saving results aggregated
local-completions (model=deepseek-ai/DeepSeek-R1,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9530|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|
```

Triton MLA Enable DCP
```
[2025-10-15 15:20:56] INFO evaluation_tracker.py:280: Output path not provided, skipping saving results aggregated
local-completions (model=deepseek-ai/DeepSeek-R1,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9568|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9545|±  |0.0057|
```

AITER MLA TP8 only

```
[2025-10-15 13:49:08] INFO evaluation_tracker.py:280: Output path not provided, skipping saving results aggregated
local-completions (model=deepseek-ai/DeepSeek-R1,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9492|±  |0.0060|
|     |       |strict-match    |     5|exact_match|↑  |0.9484|±  |0.0061|
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

