### PR TITLE
[Performance] Optimize encoder cache memory consumption by storing encoder outputs only

### DIFF
--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -192,7 +192,7 @@ class Request:
 
     def get_num_encoder_tokens(self, input_id: int) -> int:
         assert input_id < len(self.mm_features)
-        num_tokens = self.mm_features[input_id].mm_position.length
+        num_tokens = self.mm_features[input_id].mm_position.num_embeds
         return num_tokens
 
     def record_event(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix #25903

This PR modifies model runners (they operates encoder cache) & multi modal Placeholder (they provide the metadata) to count and cache the original encoder cache instead of the interleaved encoder cache.

In detail, this PR includes following modifications:
1. add post-init behaviour in PlaceholderRange:
   - cache the `num_embeds`
   - remove the leading & tailing False in `is_embed` to enable more concrete scheduling
2. modify the encoder cache behaviour
   - cache the original `encoder_output` (instead of the interleaved one currently)
   - slice the cached `encoder_output` by counting `True` in `PlaceholderRange.is_embed` mask
4. modify `Request.get_num_encoder_tokens` to return actual encoder tokens num (without non embedding tokens) for encoder cache scheduling, coresponding to the modified encoder caching behaviour

## Still in draft part

- modify the profiling behaviour?
- modify other model runners besides gpu_model_runner
- enhance the performance of counting True in `is_embed`

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

