### PR TITLE
[Bug] Temporally Disable `VLLM_ALLREDUCE_USE_SYMM_MEM` by Default

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -197,7 +197,7 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_MXFP4_BF16: bool = False
     VLLM_ROCM_FP8_MFMA_PAGE_ATTN: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS: bool = False
-    VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
+    VLLM_ALLREDUCE_USE_SYMM_MEM: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
@@ -1338,7 +1338,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Whether to use pytorch symmetric memory for allreduce
     "VLLM_ALLREDUCE_USE_SYMM_MEM": lambda: bool(
-        int(os.getenv("VLLM_ALLREDUCE_USE_SYMM_MEM", "1"))
+        int(os.getenv("VLLM_ALLREDUCE_USE_SYMM_MEM", "0"))
     ),
     # Allows vllm to find tuned config under customized folder
     "VLLM_TUNED_CONFIG_FOLDER": lambda: os.getenv("VLLM_TUNED_CONFIG_FOLDER", None),


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/26922

vllm serve nvidia/DeepSeek-R1-FP4 -tp 4  --enable-expert-parallel --port 9256

will trigger error:

```
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/parallel_state.py", line 363, in __init__
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     self.device_communicator = device_comm_cls(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]                                ^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/device_communicators/cuda_communicator.py", line 70, in __init__
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     self.symm_mem_comm = SymmMemCommunicator(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]                          ^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/device_communicators/symm_mem.py", line 94, in __init__
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     handle = torch_symm_mem.rendezvous(self.buffer, self.group.group_name)
ERROR 10-15 09:00:49 [multiproc_executor.py:628]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/.venv/lib/python3.12/site-packages/torch/distributed/_symmetric_memory/__init__.py", line 1711, in rendezvous
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     return _SymmetricMemory.rendezvous(tensor, group_name)
ERROR 10-15 09:00:49 [multiproc_executor.py:628]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628] RuntimeError: CUDA driver error: system not yet initialized
ERROR 10-15 09:00:49 [multiproc_executor.py:628] WorkerProc failed to start.
ERROR 10-15 09:00:49 [multiproc_executor.py:628] Traceback (most recent call last):
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/v1/executor/multiproc_executor.py", line 602, in worker_main
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     worker = WorkerProc(*args, **kwargs)
ERROR 10-15 09:00:49 [multiproc_executor.py:628]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/v1/executor/multiproc_executor.py", line 449, in __init__
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     self.worker.init_device()
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/v1/worker/worker_base.py", line 332, in init_device
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     self.worker.init_device()  # type: ignore
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_worker.py", line 180, in init_device
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     init_worker_distributed_environment(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_worker.py", line 773, in init_worker_distributed_environment
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     ensure_model_parallel_initialized(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/parallel_state.py", line 1349, in ensure_model_parallel_initialized
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     initialize_model_parallel(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/parallel_state.py", line 1269, in initialize_model_parallel
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     _TP = init_model_parallel_group(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]           ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/parallel_state.py", line 1027, in init_model_parallel_group
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     return GroupCoordinator(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]            ^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/parallel_state.py", line 363, in __init__
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     self.device_communicator = device_comm_cls(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]                                ^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/device_communicators/cuda_communicator.py", line 70, in __init__
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     self.symm_mem_comm = SymmMemCommunicator(
ERROR 10-15 09:00:49 [multiproc_executor.py:628]                          ^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/vllm-source/vllm/distributed/device_communicators/symm_mem.py", line 94, in __init__
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     handle = torch_symm_mem.rendezvous(self.buffer, self.group.group_name)
ERROR 10-15 09:00:49 [multiproc_executor.py:628]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628]   File "/home/wentao/.venv/lib/python3.12/site-packages/torch/distributed/_symmetric_memory/__init__.py", line 1711, in rendezvous
ERROR 10-15 09:00:49 [multiproc_executor.py:628]     return _SymmetricMemory.rendezvous(tensor, group_name)
ERROR 10-15 09:00:49 [multiproc_executor.py:628]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-15 09:00:49 [multiproc_executor.py:628] RuntimeError: CUDA driver error: system not yet initialized
```

Let's disable it now to fix issue in the main, and we can have following up PR to find the root cause and fix throughly

CC @ilmarkov @mgoin 

## Test

Now FP4 could run normally

```bash
vllm serve nvidia/DeepSeek-R1-FP4 -tp 4  --enable-expert-parallel --port 9256

vllm bench serve --model nvidia/DeepSeek-R1-FP4  --dataset-name random --host 127.0.0.1 --port 9256 --random-input-len 256 --random-output-len 256 --request-rate inf --num-prompts 1024

100%|█████████████████████████████████████████████████████████████| 1024/1024 [00:31<00:00, 32.47it/s]
tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     1024      
Benchmark duration (s):                  31.53     
Total input tokens:                      261120    
Total generated tokens:                  244971    
Request throughput (req/s):              32.47     
Output token throughput (tok/s):         7768.38   
Peak output token throughput (tok/s):    11615.00  
Peak concurrent requests:                1024.00   
Total Token throughput (tok/s):          16048.87  
---------------Time to First Token----------------
Mean TTFT (ms):                          4900.58   
Median TTFT (ms):                        4804.21   
P99 TTFT (ms):                           9213.38   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          106.23    
Median TPOT (ms):                        102.24    
P99 TPOT (ms):                           256.29    
---------------Inter-token Latency----------------
Mean ITL (ms):                           101.19    
Median ITL (ms):                         85.05     
P99 ITL (ms):                            265.07    
==================================================
```