### PR TITLE
[Bugfix] Fix race condition when KV transfer times out before request finishes

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2012,11 +2012,7 @@ def test_kv_connector_finished_sending_race_condition():
         kv_connector_output=kv_connector_output,
     )
 
-    # This should NOT crash with AssertionError
-    # Before the fix, this would fail at _free_blocks with:
-    # AssertionError at line 1228: assert request.is_finished()
-    #
-    # After the fix, it should handle the race condition gracefully
+    # This should handle the race condition gracefully
     # by logging a warning and skipping block freeing.
     _ = scheduler.update_from_output(scheduler_output2, model_runner_output2)
 


### PR DESCRIPTION
This fixes a race condition where the KV transfer times out before the request is marked finished and adds a unit test.

Here's a log from the failure:
```
(EngineCore_DP3 pid=654) DEBUG 10-15 12:29:26 [distributed/.../v1/nixl_connector.py:322] NIXLConnector update_state_after_alloc: num_external_tokens=0, kv_transfer_params={'do_remote_decode': True, 'do_remote_prefill': False, 'remote_block_ids': None, 'remote_engine_id': None, 'remote_host': None, 'remote_port': None}
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710] EngineCore encountered a fatal error.
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710] Traceback (most recent call last):
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]   File "/app/vllm/vllm/v1/engine/core.py", line 701, in run_engine_core
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]     engine_core.run_busy_loop()
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]   File "/app/vllm/vllm/v1/engine/core.py", line 1045, in run_busy_loop
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]     executed = self._process_engine_step()
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]   File "/app/vllm/vllm/v1/engine/core.py", line 754, in _process_engine_step
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]     outputs, model_executed = self.step_fn()
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]                               ^^^^^^^^^^^^^^
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]   File "/app/vllm/vllm/v1/engine/core.py", line 349, in step_with_batch_queue
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]     engine_core_outputs = self.scheduler.update_from_output(
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]   File "/app/vllm/vllm/v1/core/sched/scheduler.py", line 990, in update_from_output
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]     self._update_from_kv_xfer_finished(
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]   File "/app/vllm/vllm/v1/core/sched/scheduler.py", line 1296, in _update_from_kv_xfer_finished
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]     self._free_blocks(self.requests[req_id])
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]   File "/app/vllm/vllm/v1/core/sched/scheduler.py", line 1163, in _free_blocks
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]     assert request.is_finished()
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP7 pid=658) ERROR 10-15 12:29:26 [v1/engine/core.py:710] AssertionError
```