### PR TITLE
[TPU] move torch_xla out of tpu.txt

### DIFF
--- a/docker/Dockerfile.tpu
+++ b/docker/Dockerfile.tpu
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
     python3 -m pip install \
         -r requirements/tpu.txt \
-    pip install torch_xla[tpu, pallas]==2.8.0
+    python3 -m install torch_xla[tpu, pallas]==2.8.0
 
 RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install -e .
 

--- a/docker/Dockerfile.tpu
+++ b/docker/Dockerfile.tpu
@@ -26,7 +26,8 @@ ENV VLLM_TARGET_DEVICE="tpu"
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
     python3 -m pip install \
-        -r requirements/tpu.txt
+        -r requirements/tpu.txt \
+    pip install torch_xla[tpu, pallas]==2.8.0
 
 RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install -e .
 

--- a/docs/getting_started/installation/google_tpu.md
+++ b/docs/getting_started/installation/google_tpu.md
@@ -140,6 +140,7 @@ Install build dependencies:
 
 ```bash
 pip install -r requirements/tpu.txt
+pip install torch_xla[tpu, pallas]==2.8.0
 sudo apt-get install --no-install-recommends --yes libopenblas-base libopenmpi-dev libomp-dev
 ```
 

--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -12,6 +12,3 @@ ray[data]
 setuptools==78.1.0
 nixl==0.3.0
 tpu_info==0.4.0
-
-# Install torch_xla
-torch_xla[tpu, pallas]==2.8.0


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Move the legacy torch_xla requirement out of tpu.txt to avoid conflicts with the new tpu-inference backend.
