### PR TITLE
Lazily initialize null_block only when it is needed

### DIFF
--- a/tests/v1/core/test_block_pool.py
+++ b/tests/v1/core/test_block_pool.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for BlockPool lazy null block allocation."""
+
+import pytest
+
+from vllm.v1.core.block_pool import BlockPool
+
+
+class TestBlockPoolLazyNullBlock:
+    """Test lazy null block allocation in BlockPool."""
+
+    def test_null_block_not_allocated_initially(self):
+        """Test that null block is not allocated during BlockPool initialization."""
+        pool = BlockPool(num_gpu_blocks=4, enable_caching=True)
+
+        # Initially, null block should not be allocated
+        assert pool._null_block is None
+        assert pool.get_num_free_blocks() == 4
+
+        # Verify null_block is a property, not an instance attribute
+        assert "null_block" not in pool.__dict__
+        assert isinstance(type(pool).null_block, property)
+
+    def test_null_block_lazy_allocation(self):
+        """Test that null block is allocated only when first accessed."""
+        pool = BlockPool(num_gpu_blocks=4, enable_caching=True)
+
+        # Before accessing null_block
+        assert pool._null_block is None
+        assert pool.get_num_free_blocks() == 4
+
+        # Access null_block - should trigger lazy allocation
+        null_block = pool.null_block
+
+        # After accessing null_block
+        assert pool._null_block is not None
+        assert pool.get_num_free_blocks() == 3  # One block consumed
+        assert null_block.is_null is True
+        assert null_block.block_id == 0
+
+    def test_null_block_reuse(self):
+        """Test that multiple accesses return the same null block instance."""
+        pool = BlockPool(num_gpu_blocks=4, enable_caching=True)
+
+        # First access
+        null_block1 = pool.null_block
+        free_blocks_after_first = pool.get_num_free_blocks()
+
+        # Second access
+        null_block2 = pool.null_block
+        free_blocks_after_second = pool.get_num_free_blocks()
+
+        # Should return same instance without additional allocation
+        assert null_block1 is null_block2
+        assert free_blocks_after_first == free_blocks_after_second == 3
+
+    def test_null_block_allocation_when_no_blocks_available(self):
+        """Test error handling when trying to allocate null block with
+        no free blocks."""
+        pool = BlockPool(num_gpu_blocks=2, enable_caching=True)
+
+        # Consume all available blocks
+        pool.get_new_blocks(2)
+        assert pool.get_num_free_blocks() == 0
+
+        # Trying to access null_block should raise RuntimeError
+        with pytest.raises(RuntimeError, match="Cannot allocate null block"):
+            _ = pool.null_block
+
+    def test_get_usage_with_lazy_null_block(self):
+        """Test that get_usage() correctly accounts for lazy null block allocation."""
+        pool = BlockPool(num_gpu_blocks=4, enable_caching=True)
+
+        # Before null block allocation
+        usage_before = pool.get_usage()
+        assert usage_before == 0.0  # No blocks used, no null block overhead
+
+        # After null block allocation (but no actual workload blocks allocated)
+        _ = pool.null_block
+        usage_after = pool.get_usage()
+        # Null block is overhead, not "usage" - so usage should still be 0
+        assert usage_after == 0.0
+
+        # Now allocate actual workload blocks
+        _ = pool.get_new_blocks(2)
+        usage_with_workload = pool.get_usage()
+        # Formula: 1.0 - (1 / 3) = 2/3 (1 free block out of 3 available)
+        assert usage_with_workload == pytest.approx(2.0 / 3.0)
+
+    def test_reset_prefix_cache_with_lazy_null_block(self):
+        """Test that reset_prefix_cache() works correctly with lazy null block."""
+        pool = BlockPool(num_gpu_blocks=4, enable_caching=True)
+
+        # Before null block allocation - should succeed
+        assert pool.reset_prefix_cache() is True
+
+        # After null block allocation - should still succeed
+        _ = pool.null_block
+        assert pool.reset_prefix_cache() is True
+
+
+class TestManagerLazyNullBlock:
+    """Test lazy null block allocation in KV cache managers."""

--- a/tests/v1/core/test_block_pool.py
+++ b/tests/v1/core/test_block_pool.py
@@ -98,7 +98,3 @@ class TestBlockPoolLazyNullBlock:
         # After null block allocation - should still succeed
         _ = pool.null_block
         assert pool.reset_prefix_cache() is True
-
-
-class TestManagerLazyNullBlock:
-    """Test lazy null block allocation in KV cache managers."""

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -404,7 +404,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         removed_blocks: list[KVCacheBlock] = []
 
         for i in range(last_useful_block - 1, -1, -1):
-            if blocks[i] == self.null_block:
+            if self._null_block is not None and blocks[i] == self._null_block:
                 # If the block is already a null block, the blocks before it
                 # should also have been set to null blocks by the previous calls
                 # to this function.
@@ -557,7 +557,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
         removed_blocks: list[KVCacheBlock] = []
         # we need to keep the last block to get the previous hash key
         for i in range(first_useful_block_idx - 1, -1, -1):
-            if blocks[i] == self.null_block:
+            if self._null_block is not None and blocks[i] == self._null_block:
                 # If the block is already a null block, the blocks before it
                 # should also have been set to null blocks by the previous calls
                 # to this function.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -59,9 +59,7 @@ class SingleTypeKVCacheManager(ABC):
         self.num_cached_block: dict[str, int] = {}
 
         self.kv_cache_group_id = kv_cache_group_id
-        # Store reference to block_pool for lazy null block access
-        self.block_pool = block_pool
-        self._null_block = None  # Lazy initialization
+        self._null_block: KVCacheBlock | None = None
 
     @property
     def null_block(self) -> KVCacheBlock:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -412,18 +412,24 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
 
             removed_blocks.append(blocks[i])
 
-            # Handle an edge case where no free blocks available -
-            # repurpose the first removed block as null_block
+            # Handle an edge case where no free blocks available
+            # but we haven't allocated the null block yet
             if (
                 self._null_block is None
                 and len(removed_blocks) == 1
                 and self.block_pool.get_num_free_blocks() == 0
             ):
-                self.block_pool._null_block = removed_blocks[0]
-                self.block_pool._null_block.is_null = True
-                # Cache it in the manager as well
-                self._null_block = self.block_pool._null_block
-                blocks[i] = self._null_block
+                # It's possible that another manager already allocated a null block
+                # in the shared block pool
+                if self.block_pool._null_block is not None:
+                    self._null_block = self.block_pool._null_block
+                else:
+                    # If not, repurpose the first removed block as the null block
+                    self.block_pool._null_block = removed_blocks[0]
+                    self.block_pool._null_block.is_null = True
+                    # Cache it in the manager as well
+                    self._null_block = self.block_pool._null_block
+                    blocks[i] = self._null_block
             else:
                 # Normal case: call the null_block property to allocate from free queue
                 blocks[i] = self.null_block
@@ -565,18 +571,24 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
 
             removed_blocks.append(blocks[i])
 
-            # Handle an edge case where no free blocks available -
-            # repurpose the first removed block as null_block
+            # Handle an edge case where no free blocks available
+            # but we haven't allocated the null block yet
             if (
                 self._null_block is None
                 and len(removed_blocks) == 1
                 and self.block_pool.get_num_free_blocks() == 0
             ):
-                self.block_pool._null_block = removed_blocks[0]
-                self.block_pool._null_block.is_null = True
-                # Cache it in the manager as well
-                self._null_block = self.block_pool._null_block
-                blocks[i] = self._null_block
+                # It's possible that another manager already allocated a null block
+                # in the shared block pool
+                if self.block_pool._null_block is not None:
+                    self._null_block = self.block_pool._null_block
+                else:
+                    # If not, repurpose the first removed block as the null block
+                    self.block_pool._null_block = removed_blocks[0]
+                    self.block_pool._null_block.is_null = True
+                    # Cache it in the manager as well
+                    self._null_block = self.block_pool._null_block
+                    blocks[i] = self._null_block
             else:
                 # Normal case: call the null_block property to allocate from free queue
                 blocks[i] = self.null_block

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -429,7 +429,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
                     self.block_pool._null_block.is_null = True
                     # Cache it in the manager as well
                     self._null_block = self.block_pool._null_block
-                    blocks[i] = self._null_block
+                blocks[i] = self._null_block
             else:
                 # Normal case: call the null_block property to allocate from free queue
                 blocks[i] = self.null_block
@@ -588,7 +588,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
                     self.block_pool._null_block.is_null = True
                     # Cache it in the manager as well
                     self._null_block = self.block_pool._null_block
-                    blocks[i] = self._null_block
+                blocks[i] = self._null_block
             else:
                 # Normal case: call the null_block property to allocate from free queue
                 blocks[i] = self.null_block


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
After PR https://github.com/vllm-project/vllm/pull/14097 we now always subtract 1 usable block from the block pool and designate it as the `null_block`, even when sliding window attention is not used. This creates an edge case when users specify the minimum required number of blocks for their model & config via `--num-gpu-blocks-override` but then vllm comes and deducts 1 from that (if user specifies 1 block it's effectively 0). 

This PR proposes to lazily-initialize the null_block only when it is called (mainly in `remove_skipped_blocks`). As a result, for kv cache managers like [FullAttentionManager](https://github.com/vllm-project/vllm/blob/a86b4c58e8f72f4903d873d25510f53f7577366f/vllm/v1/core/single_type_kv_cache_manager.py#L260), the `null_block` never materializes and all blocks are available for allocation.

## Test Plan
Added unit tests. 

Also tested the change E2E locally on Neuron device with the following server command and request:

```
python3 -m vllm.entrypoints.openai.api_server \
  --model "TinyLlama/TinyLlama-1.1B-Chat-v1.0" \
  --max-num-seqs 1 \
  --max-model-len 128 \
  --tensor-parallel-size 64 \
  --enable-prefix-caching \
  --block-size 32 \
  --num-gpu-blocks-override 4 \
  --additional-config '{
    "override_neuron_config": {
        "is_prefix_caching": true,
        "is_block_kv_layout": true,
        "pa_num_blocks": 4,
        "pa_block_size": 32,
    }
  }' \
  --port 8000
```

```
curl -s http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
  "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
  "prompt": ["You are an expert software engineer and DevOps specialist. Tell me a story."],
  "min_tokens": 109,
  "max_tokens": 109,
  "temperature": 0
}'
```


## Test Result

Without the change, the vllm scheduler is unable to schedule the request since it only sees 3 blocks available. It will repeatedly send an empty SchedulerOutput to the model runner and the server hangs indefinitely.

After the change, the request goes through successfully. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

