### PR TITLE
[Compressed Tensors] Remove parameter conversion for sparse24

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -89,7 +89,7 @@ def all_close_1d(x: torch.Tensor) -> bool:
 
 def convert_to_channelwise(
     weight_scale: torch.Tensor, logical_widths: list[int]
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     # Create channelwise buffer
     weight_scale_channel = torch.empty(
         (sum(logical_widths), 1), dtype=torch.float32, device=weight_scale.device


### PR DESCRIPTION
As of https://github.com/vllm-project/vllm/pull/23036, model weights no longer have to be converted from vllm base parameters to regular parameters.