### PR TITLE
[BUG] Allow runai_streamer_sharded in config check

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -746,10 +746,13 @@ class VllmConfig:
                     "Overriding `load_format` to 'runai_streamer'"
                 )
                 self.load_config.load_format = "runai_streamer"
-            elif self.load_config.load_format != "runai_streamer":
+            elif self.load_config.load_format not in (
+                "runai_streamer",
+                "runai_streamer_sharded",
+            ):
                 raise ValueError(
                     f"To load a model from S3, 'load_format' "
-                    f"must be 'runai_streamer', "
+                    f"must be 'runai_streamer' or 'runai_streamer_sharded', "
                     f"but got '{self.load_config.load_format}'. "
                     f"Model: {self.model_config.model}"
                 )


### PR DESCRIPTION
## Purpose
runai_streamer_sharded cannot be used due to VllmConfig checks. 
## Test Plan
check if run runai_streamer_sharded can be run
## Test Result
Can run 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

