### PR TITLE
[Bugfix] Fix Marlin incompatibility on ROCM 

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -190,6 +190,10 @@ def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
 
 
 def check_moe_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
+    # Marlin is not available on ROCm
+    if current_platform.is_rocm():
+        return False
+        
     hidden_size = layer.hidden_size
     intermediate_size_per_partition = layer.intermediate_size_per_partition
     # apply_router_weight_on_input is not supported for moe marlin

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -75,6 +75,9 @@ def _check_marlin_supported(
     has_zp: bool,
     device_capability: int | None = None,
 ) -> tuple[bool, str | None]:
+    if current_platform.is_rocm():
+        return False, "Marlin quantization is not supported on ROCm platform."
+
     if device_capability is None:
         capability_tuple = current_platform.get_device_capability()
         device_capability = (
@@ -174,6 +177,9 @@ def check_marlin_supports_shape(
 
 
 def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
+    # Marlin is not available on ROCm
+    if current_platform.is_rocm():
+        return False
     output_size_per_partition = (
         getattr(layer, "output_size_per_partition", None) or layer.output_size
     )

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -193,7 +193,7 @@ def check_moe_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
     # Marlin is not available on ROCm
     if current_platform.is_rocm():
         return False
-        
+
     hidden_size = layer.hidden_size
     intermediate_size_per_partition = layer.intermediate_size_per_partition
     # apply_router_weight_on_input is not supported for moe marlin


### PR DESCRIPTION
## Purpose
Marlin is a CUDA-only kernel and it's not available on ROCM, and we will have failure when using Qwen1.5-MoE-W4A16-CT-tp1 on AMD:
```
(EngineCore_DP0 pid=5253) INFO 09-24 05:01:38 [compressed_tensors_moe.py:130] Using CompressedTensorsWNA16MarlinMoEMethod
--
  | (EngineCore_DP0 pid=5253) INFO 09-24 05:01:43 [weight_utils.py:392] Using model weights format ['*.safetensors']
  | Loading safetensors checkpoint shards:   0% Completed \| 0/2 [00:00<?, ?it/s]
  | Loading safetensors checkpoint shards:  50% Completed \| 1/2 [00:01<00:01,  1.29s/it]
  | Loading safetensors checkpoint shards: 100% Completed \| 2/2 [00:02<00:00,  1.12s/it]
  | Loading safetensors checkpoint shards: 100% Completed \| 2/2 [00:02<00:00,  1.15s/it]
  | (EngineCore_DP0 pid=5253)
  | (EngineCore_DP0 pid=5253) INFO 09-24 05:01:46 [default_loader.py:267] Loading weights took 2.40 seconds
  | (EngineCore_DP0 pid=5253) Process EngineCore_DP0:
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708] EngineCore failed to start.
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708] Traceback (most recent call last):
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 699, in run_engine_core
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     engine_core = EngineCoreProc(*args, **kwargs)
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 498, in __init__
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     super().__init__(vllm_config, executor_class, log_stats,
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 83, in __init__
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     self.model_executor = executor_class(vllm_config)
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/executor/executor_base.py", line 54, in __init__
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     self._init_executor()
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/executor/uniproc_executor.py", line 55, in _init_executor
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     self.collective_rpc("load_model")
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/executor/uniproc_executor.py", line 83, in collective_rpc
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     return [run_method(self.driver_worker, method, args, kwargs)]
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/utils/__init__.py", line 3049, in run_method
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     return func(*args, **kwargs)
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]            ^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 221, in load_model
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     self.model_runner.load_model(eep_scale_up=eep_scale_up)
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 2572, in load_model
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     self.model = model_loader.load_model(
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]                  ^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/model_loader/base_loader.py", line 51, in load_model
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     process_weights_after_loading(model, model_config, target_device)
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/model_loader/utils.py", line 112, in process_weights_after_loading
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     quant_method.process_weights_after_loading(module)
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py", line 1433, in process_weights_after_loading
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     marlin_w13_qweight = ops.gptq_marlin_moe_repack(
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/_custom_ops.py", line 975, in gptq_marlin_moe_repack
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     output[e] = torch.ops._C.gptq_marlin_repack(b_q_weight[e], perm[e],
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1353, in __getattr__
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708]     raise AttributeError(
  | (EngineCore_DP0 pid=5253) ERROR 09-24 05:01:46 [core.py:708] AttributeError: '_OpNamespace' '_C' object has no attribute 'gptq_marlin_repack'


```
## Test Plan
1. H100 
```
CUDA_VISIBLE_DEVICES=4 HF_HUB_DISABLE_XET=1 with-proxy pytest -s -v test_lm_eval_correctness.py \
    --config-list-file=configs/models-small.txt \
    --tp-size=1
```
2. AMD CI([before](https://buildkite.com/vllm/ci/builds/35119#0199ea4c-05fd-4da8-9812-6dec9c6bfce0))
```

=========================== short test summary info ============================
--
  | FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness_param[Qwen2.5-VL-3B-Instruct-FP8-dynamic-tp1]
  | FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness_param[Qwen1.5-MoE-W4A16-CT-tp1]
  | FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness_param[DeepSeek-V2-Lite-Instruct-FP8-tp1]
  | ============= 3 failed, 3 passed, 2 warnings in 552.01s (0:09:12) ==============

```


## Test Result
H100:
```
============================================================ warnings summary =============================================================
.buildkite/lm-eval-harness/test_lm_eval_correctness.py::test_lm_eval_correctness_param[config_filename0]
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

.buildkite/lm-eval-harness/test_lm_eval_correctness.py::test_lm_eval_correctness_param[config_filename0]
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

.buildkite/lm-eval-harness/test_lm_eval_correctness.py::test_lm_eval_correctness_param[config_filename0]
  /usr/lib64/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=3992856) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================ 6 passed, 3 warnings in 336.33s (0:05:36) ================================================
```

AMD CI([build](https://buildkite.com/vllm/amd-ci/builds/278)):
```
GSM8K Results for nm-testing/Qwen1.5-MoE-A2.7B-Chat-quantized.w4a16:
--
  | Accuracy: 0.447
  | Expected: 0.450
  | Questions: 1319
  | Invalid rate: 0.002
  | Latency: 108.1s
  | QPS: 12.2
  | ✅ GSM8K test passed for nm-testing/Qwen1.5-MoE-A2.7B-Chat-quantized.w4a16
...

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--
=========================== short test summary info ============================
  | FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness_param[Qwen2.5-VL-3B-Instruct-FP8-dynamic-tp1]
  | FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness_param[DeepSeek-V2-Lite-Instruct-FP8-tp1]
  | ============= 2 failed, 4 passed, 2 warnings in 706.05s (0:11:46) ==============


```


