### PR TITLE
[Perf] Exploit out-of-band buffers in shm_broadcast

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -233,7 +233,7 @@ class MessageQueue:
         n_reader,  # number of all readers
         n_local_reader,  # number of local readers through shared memory
         local_reader_ranks: list[int] | None = None,
-        max_chunk_bytes: int = 1024 * 1024 * 32,
+        max_chunk_bytes: int = 1024 * 1024 * 24,  # 24MiB
         max_chunks: int = 10,
         connect_ip: str | None = None,
     ):

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -519,6 +519,7 @@ class MessageQueue:
         def oob_callback(buf: PickleBuffer) -> bool:
             raw_buf = buf.raw()
             if len(raw_buf) < 1024 * 1024:
+                # In-line buffers smaller than 1MiB.
                 return True
             oob_buffers.append(raw_buf)
             nonlocal total_bytes

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from multiprocessing import shared_memory
 from pickle import PickleBuffer
 from threading import Event
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import torch
@@ -33,6 +33,9 @@ from vllm.utils import (
     get_open_zmq_ipc_path,
     is_valid_ipv6_address,
 )
+
+if TYPE_CHECKING:
+    from _typeshed import SizedBuffer
 
 VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
 
@@ -513,7 +516,7 @@ class MessageQueue:
     def enqueue(self, obj, timeout: float | None = None):
         """Write to message queue with optional timeout (in seconds)"""
         assert self._is_writer, "Only writers can enqueue"
-        oob_buffers = []
+        all_buffers: list[SizedBuffer] = [b""]
         total_bytes = 6  # 2 bytes for oob buffer count, 4 for main buffer size
 
         def oob_callback(buf: PickleBuffer) -> bool:
@@ -521,31 +524,25 @@ class MessageQueue:
             if len(raw_buf) < 1024 * 1024:
                 # In-line buffers smaller than 1MiB.
                 return True
-            oob_buffers.append(raw_buf)
+            all_buffers.append(raw_buf)
             nonlocal total_bytes
             total_bytes += len(raw_buf) + 4
             return False
 
-        serialized_obj = pickle.dumps(
+        all_buffers[0] = pickle.dumps(
             obj, protocol=pickle.HIGHEST_PROTOCOL, buffer_callback=oob_callback
         )
         if self.n_local_reader > 0:
-            main_buf_len = len(serialized_obj)
-            total_bytes += main_buf_len
-            if total_bytes >= self.buffer.max_chunk_bytes:
+            if total_bytes + len(all_buffers[0]) >= self.buffer.max_chunk_bytes:
                 with self.acquire_write(timeout) as buf:
                     buf[0] = 1  # overflow
-                self.local_socket.send_multipart(
-                    (serialized_obj, *oob_buffers), copy=False
-                )
+                self.local_socket.send_multipart(all_buffers, copy=False)
             else:
                 with self.acquire_write(timeout) as buf:
                     buf[0] = 0  # not overflow
-                    buf[1:3] = to_bytes_big(len(oob_buffers), 2)  # oob buffer count
-                    buf[3:7] = to_bytes_big(main_buf_len, 4)  # size of main buffer
-                    offset = 7 + main_buf_len
-                    buf[7:offset] = serialized_obj
-                    for buffer in oob_buffers:
+                    offset = 3
+                    buf[1:offset] = to_bytes_big(len(all_buffers), 2)  # oob buf count
+                    for buffer in all_buffers:
                         buf_len = len(buffer)
                         # prepend each buffer with 4 bytes containing its size.
                         buf_offset = offset + 4
@@ -553,9 +550,7 @@ class MessageQueue:
                         buf[buf_offset : (offset := buf_offset + buf_len)] = buffer
 
         if self.n_remote_reader > 0:
-            self.remote_socket.send_multipart(
-                (serialized_obj, *oob_buffers), copy=False
-            )
+            self.remote_socket.send_multipart(all_buffers, copy=False)
 
     def dequeue(
         self,
@@ -568,17 +563,15 @@ class MessageQueue:
             with self.acquire_read(timeout, cancel, indefinite) as buf:
                 overflow = buf[0] == 1
                 if not overflow:
-                    buf_count = from_bytes_big(buf[1:3])
-                    main_buf_len = from_bytes_big(buf[3:7])
-                    offset = 7 + main_buf_len
-                    main_buf = buf[7:offset]
-                    oob_buffers = []
+                    offset = 3
+                    buf_count = from_bytes_big(buf[1:offset])
+                    all_buffers = []
                     for i in range(buf_count):
                         buf_offset = offset + 4
                         buf_len = from_bytes_big(buf[offset:buf_offset])
                         offset = buf_offset + buf_len
-                        oob_buffers.append(buf[buf_offset:offset])
-                    obj = pickle.loads(main_buf, buffers=oob_buffers)
+                        all_buffers.append(buf[buf_offset:offset])
+                    obj = pickle.loads(all_buffers[0], buffers=all_buffers[1:])
             if overflow:
                 obj = MessageQueue.recv(self.local_socket, timeout)
         elif self._is_remote_reader:


### PR DESCRIPTION
Avoid serialization + copy overhead when pickled payload contains large buffers by exploiting https://peps.python.org/pep-0574.

This is beneficial for example when broadcasting bitmask arrays with the multiproc executor.

Benchmark using structured outputs + multiproc executor:
```
canhazgpu run --gpus 1 -- vllm serve Qwen/Qwen3-1.7B --uvicorn-log-level=error  --no-enable-prefix-caching --distributed-executed-backend mp

python3 benchmarks/benchmark_serving_structured_output.py --backend vllm --model Qwen/Qwen3-1.7B --structured-output-ratio 0.8 --request-rate 120 --max-concurrency 800 --num-prompts 5000 --json-schema-path ./test3.json  --output-len 128
```

Before:
```
============ Serving Benchmark Result ============
Successful requests:                     5000      
Maximum request concurrency:             800       
Request rate configured (RPS):           120.00    
Benchmark duration (s):                  83.96     
Total input tokens:                      2405000   
Total generated tokens:                  639936    
Request throughput (req/s):              59.55     
Output token throughput (tok/s):         7621.48   
Total Token throughput (tok/s):          36264.42  
---------------Time to First Token----------------
Mean TTFT (ms):                          327.90    
Median TTFT (ms):                        296.12    
P99 TTFT (ms):                           674.63    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          96.30     
Median TPOT (ms):                        102.40    
P99 TPOT (ms):                           106.44    
---------------Inter-token Latency----------------
Mean ITL (ms):                           96.54     
Median ITL (ms):                         92.78     
P99 ITL (ms):                            251.71    
==================================================
correct_rate(%) 99.6 
```

After:
```
============ Serving Benchmark Result ============
Successful requests:                     5000      
Maximum request concurrency:             800       
Request rate configured (RPS):           120.00    
Benchmark duration (s):                  71.28     
Total input tokens:                      2405000   
Total generated tokens:                  639937    
Request throughput (req/s):              70.15     
Output token throughput (tok/s):         8977.91   
Total Token throughput (tok/s):          42718.52  
---------------Time to First Token----------------
Mean TTFT (ms):                          251.35    
Median TTFT (ms):                        236.60    
P99 TTFT (ms):                           586.14    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          80.32     
Median TPOT (ms):                        86.29     
P99 TPOT (ms):                           90.48     
---------------Inter-token Latency----------------
Mean ITL (ms):                           80.32     
Median ITL (ms):                         78.74     
P99 ITL (ms):                            198.15    
==================================================
correct_rate(%) 99.58 
```