### PR TITLE
[Platform] Cleanup useless function

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -463,6 +463,12 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def check_if_supports_dtype(cls, dtype: torch.dtype):
+        logger.warning_once(
+            "check_if_supports_dtype is deprecated and will be removed in"
+            "v0.12.0 or v1.0.1. It's replaced by "
+            "`vllm.utils.platform_utils.check_if_supports_dtype` for cuda like "
+            "devices."
+        )
         if dtype == torch.bfloat16:  # noqa: SIM102
             if not cls.has_device_capability(80):
                 capability = cls.get_device_capability()

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -571,6 +571,9 @@ class Platform:
     def check_if_supports_dtype(cls, dtype: torch.dtype):
         """
         Check if the dtype is supported by the current platform.
+
+        This method is deprecated and will be removed in v0.12.0 or v1.0.1.
+        Do not use it in the plugin project.
         """
         raise NotImplementedError
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -437,27 +437,6 @@ class RocmPlatform(Platform):
         return cuda_device_count_stateless()
 
     @classmethod
-    def check_if_supports_dtype(cls, dtype: torch.dtype):
-        if dtype == torch.bfloat16:  # noqa: SIM102
-            if not cls.has_device_capability(80):
-                capability = cls.get_device_capability()
-                gpu_name = cls.get_device_name()
-
-                if capability is None:
-                    compute_str = "does not have a compute capability"
-                else:
-                    version_str = capability.as_version_str()
-                    compute_str = f"has compute capability {version_str}"
-
-                raise ValueError(
-                    "Bfloat16 is only supported on GPUs "
-                    "with compute capability of at least 8.0. "
-                    f"Your {gpu_name} GPU {compute_str}. "
-                    "You can use float16 instead by explicitly setting the "
-                    "`dtype` flag in CLI, for example: --dtype=half."
-                )
-
-    @classmethod
     def support_hybrid_kv_cache(cls) -> bool:
         return True
 

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -228,18 +228,6 @@ class XPUPlatform(Platform):
         return torch.xpu.device_count()
 
     @classmethod
-    def check_if_supports_dtype(cls, dtype: torch.dtype):
-        if dtype == torch.bfloat16:  # noqa: SIM102
-            device_name = cls.get_device_name().lower()
-            # client gpu a770
-            if device_name.count("a770") > 0:
-                raise ValueError(
-                    "Intel Arc A770 have bfloat16 accuracy known issue. "
-                    "You can use float16 instead by explicitly setting the "
-                    "`dtype` flag in CLI, for example: --dtype=half."
-                )
-
-    @classmethod
     def opaque_attention_op(cls) -> bool:
         return True
 

--- a/vllm/utils/platform_utils.py
+++ b/vllm/utils/platform_utils.py
@@ -57,3 +57,26 @@ def is_uva_available() -> bool:
     # UVA requires pinned memory.
     # TODO: Add more requirements for UVA if needed.
     return is_pin_memory_available()
+
+
+def check_if_supports_dtype(dtype: torch.dtype):
+    from vllm.platforms import current_platform
+
+    if dtype == torch.bfloat16:  # noqa: SIM102
+        if not current_platform.has_device_capability(80):
+            capability = current_platform.get_device_capability()
+            gpu_name = current_platform.get_device_name()
+
+            if capability is None:
+                compute_str = "does not have a compute capability"
+            else:
+                version_str = capability.as_version_str()
+                compute_str = f"has compute capability {version_str}"
+
+            raise ValueError(
+                "Bfloat16 is only supported on GPUs "
+                "with compute capability of at least 8.0. "
+                f"Your {gpu_name} GPU {compute_str}. "
+                "You can use float16 instead by explicitly setting the "
+                "`dtype` flag in CLI, for example: --dtype=half."
+            )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -41,6 +41,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
+from vllm.utils.platform_utils import check_if_supports_dtype
 from vllm.v1.core.sched.output import GrammarOutput
 from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
@@ -208,9 +209,7 @@ class Worker(WorkerBase):
 
             self.device = torch.device(f"cuda:{self.local_rank}")
             current_platform.set_device(self.device)
-
-            current_platform.check_if_supports_dtype(self.model_config.dtype)
-
+            check_if_supports_dtype(self.model_config.dtype)
             # Initialize the distributed environment BEFORE taking
             # memory snapshot
             # This ensures NCCL buffers are allocated before we measure


### PR DESCRIPTION
## Purpose
The purpose of Platform interface is to  provide functions between vLLM framework and hardware implement. Hardware implement it and vLLM call it. But `check_if_supports_dtype` broke the principle. This function is only called in hardware worker. So it should be in the worker only. 

This PR remove this useless interface.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

