### PR TITLE
[Feature] Support multi-stream parallelism for the q, kv norm calculations in the Qwen3 model.

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -27,11 +27,12 @@
 
 from collections.abc import Iterable
 from itertools import islice
-from typing import Any
+from typing import Any, Optional
 
 import torch
 from torch import nn
 from transformers import Qwen2Config
+from vllm.platforms import current_platform
 
 from vllm.attention import Attention, AttentionType
 from vllm.attention.layers.encoder_only_attention import EncoderOnlyAttention
@@ -297,6 +298,7 @@ class Qwen2Model(nn.Module):
         vllm_config: VllmConfig,
         prefix: str = "",
         decoder_layer_type: type[nn.Module] = Qwen2DecoderLayer,
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
 
@@ -341,6 +343,7 @@ class Qwen2Model(nn.Module):
                 cache_config=cache_config,
                 quant_config=quant_config,
                 prefix=prefix,
+                alt_stream=alt_stream,
             ),
             prefix=f"{prefix}.layers",
         )

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -24,11 +24,12 @@
 """Inference-only Qwen3 model compatible with HuggingFace weights."""
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Optional
 
 import torch
 from torch import nn
 from transformers import Qwen3Config
+from vllm.platforms import current_platform
 
 from vllm.attention import Attention, AttentionType
 from vllm.compilation.decorators import support_torch_compile
@@ -68,6 +69,7 @@ class Qwen3Attention(nn.Module):
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
         dual_chunk_attention_config: dict[str, Any] | None = None,
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -135,6 +137,7 @@ class Qwen3Attention(nn.Module):
         )
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.alt_stream = alt_stream
 
     def forward(
         self,
@@ -144,12 +147,26 @@ class Qwen3Attention(nn.Module):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         # Add qk-norm
-        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-        q_by_head = self.q_norm(q_by_head)
-        q = q_by_head.view(q.shape)
-        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-        k_by_head = self.k_norm(k_by_head)
-        k = k_by_head.view(k.shape)
+        device_module = torch.get_device_module()
+        if self.alt_stream is not None:
+            current_stream = device_module.current_stream()
+            self.alt_stream.wait_stream(current_stream)
+            q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+            q_by_head = self.q_norm(q_by_head)
+            q = q_by_head.view(q.shape)
+            with device_module.stream(self.alt_stream):
+                k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+                k_by_head = self.k_norm(k_by_head)
+                k = k_by_head.view(k.shape)
+            current_stream.wait_stream(self.alt_stream)
+        else:
+            q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+            q_by_head = self.q_norm(q_by_head)
+            q = q_by_head.view(q.shape)
+            k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+            k_by_head = self.k_norm(k_by_head)
+            k = k_by_head.view(k.shape)
+
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
@@ -163,6 +180,7 @@ class Qwen3DecoderLayer(nn.Module):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -197,6 +215,7 @@ class Qwen3DecoderLayer(nn.Module):
             prefix=f"{prefix}.self_attn",
             attn_type=attn_type,
             dual_chunk_attention_config=dual_chunk_attention_config,
+            alt_stream=alt_stream,
         )
         self.mlp = Qwen3MLP(
             hidden_size=self.hidden_size,
@@ -250,8 +269,11 @@ ALL_DECODER_LAYER_TYPES = {
 )
 class Qwen3Model(Qwen2Model):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        alt_stream = None
+        if current_platform.is_cuda() or current_platform.is_out_of_tree():
+            alt_stream = torch.get_device_module().Stream()
         super().__init__(
-            vllm_config=vllm_config, prefix=prefix, decoder_layer_type=Qwen3DecoderLayer
+            vllm_config=vllm_config, prefix=prefix, decoder_layer_type=Qwen3DecoderLayer, alt_stream=alt_stream,
         )
 
 

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -26,10 +26,11 @@
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
-from typing import Any
+from typing import Any, Optional
 
 import torch
 from torch import nn
+from vllm.platforms import current_platform
 
 from vllm.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
@@ -224,6 +225,7 @@ class Qwen3MoeAttention(nn.Module):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         dual_chunk_attention_config: dict[str, Any] | None = None,
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -293,6 +295,7 @@ class Qwen3MoeAttention(nn.Module):
 
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.alt_stream = alt_stream
 
     def forward(
         self,
@@ -302,13 +305,26 @@ class Qwen3MoeAttention(nn.Module):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         # Add qk-norm
-        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-        q_by_head = self.q_norm(q_by_head)
-        q = q_by_head.view(q.shape)
+        device_module = torch.get_device_module()
+        if self.alt_stream is not None:
+            current_stream = device_module.current_stream()
+            self.alt_stream.wait_stream(current_stream)
+            q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+            q_by_head = self.q_norm(q_by_head)
+            q = q_by_head.view(q.shape)
+            with device_module.stream(self.alt_stream):
+                k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+                k_by_head = self.k_norm(k_by_head)
+                k = k_by_head.view(k.shape)
+            current_stream.wait_stream(self.alt_stream)
+        else:
+            q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+            q_by_head = self.q_norm(q_by_head)
+            q = q_by_head.view(q.shape)
+            k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+            k_by_head = self.k_norm(k_by_head)
+            k = k_by_head.view(k.shape)
 
-        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-        k_by_head = self.k_norm(k_by_head)
-        k = k_by_head.view(k.shape)
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
@@ -316,7 +332,8 @@ class Qwen3MoeAttention(nn.Module):
 
 
 class Qwen3MoeDecoderLayer(nn.Module):
-    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "",
+                 alt_stream: Optional[torch.cuda.Stream] = None,) -> None:
         super().__init__()
 
         config = vllm_config.model_config.hf_text_config
@@ -344,6 +361,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
             dual_chunk_attention_config=dual_chunk_attention_config,
+            alt_stream=alt_stream,
         )
 
         # `mlp_only_layers` in the config.
@@ -413,9 +431,12 @@ class Qwen3MoeModel(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.embed_tokens",
         )
+        alt_stream = None
+        if current_platform.is_cuda() or current_platform.is_out_of_tree():
+            alt_stream = torch.get_device_module().Stream()
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
-            lambda prefix: Qwen3MoeDecoderLayer(vllm_config=vllm_config, prefix=prefix),
+            lambda prefix: Qwen3MoeDecoderLayer(vllm_config=vllm_config, prefix=prefix, alt_stream=alt_stream),
             prefix=f"{prefix}.layers",
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Support multi-stream parallelism for the q, k, v norm calculations in the Qwen3 model. 

Because the qwen3 model has no dependency in the calculation of q norm and kv norm, it can be processed in parallel. After testing, a single layer can reduce approximately 8-10 microseconds.
## Test Plan
We will provide the test results later. We'll test this in fullgraph, piecewise_graph, and eager mode in GPU, NPU.
## Test Result



