### PR TITLE
[Bugfix][Attention][DCP] Set reorder_batch_threshold back to 1 when using FlashMLA and enable DCP

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -558,6 +558,19 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             self.dcp_world_size = 1
             self.dcp_rank = 0
 
+        if (
+            self.dcp_world_size > 1
+            and self.__class__.reorder_batch_threshold > 1
+            and self.__class__.__name__ != "FlashAttnMLAMetadataBuilder"
+        ):
+            logger.warning_once(
+                "DCP is enabled but not FlashAttnMLA is used. "
+                "Set query_len_support back to SINGLE_ONLY "
+                "and reorder_batch_threshold back to 1."
+            )
+            self.__class__.query_len_support = QueryLenSupport.SINGLE_ONLY
+            self.__class__.reorder_batch_threshold = 1
+
         # Don't try to access the runner on AMD
         if self.aot_schedule:
             self.page_size = self.kv_cache_spec.block_size


### PR DESCRIPTION
## Purpose
For FlashMLA backend, https://github.com/vllm-project/vllm/pull/26541 set the default value of `reorder_batch_threshold` to 512.
https://github.com/vllm-project/vllm/blob/00417f4e44378bc5c5c5c6698b4d8a86017198d3/vllm/v1/attention/backends/mla/flashmla.py#L71-L76

However, DCP support `reorder_batch_threshold` > 1 only when FlashAttnMLA backend is used (https://github.com/vllm-project/vllm/pull/25049). Therefore, the following assertion error occurs when using the FlashMLA backend.
https://github.com/vllm-project/vllm/blob/00417f4e44378bc5c5c5c6698b4d8a86017198d3/vllm/v1/worker/gpu_model_runner.py#L586-L596

This PR temporarily fixes the issue by setting `reorder_batch_threshold back` to 1. 

Looking forward to DCP supporting `reorder_batch_threshold` > 1  with FlashMLA in the future :).

## Test Plan
```shell
export VLLM_ATTENTION_BACKEND="FLASHMLA"
vllm serve /deepseek-ai/DeepSeek-R1/ --gpu-memory-utilization 0.9 --tensor-parallel-size 8 --decode-context-parallel-size 8

curl http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "/ossfs/workspace/DeepSeek-R1/", "messages": [{"role": "user", "content": "who is there"}], "temperature": 0.0, "max_tokens": 100}'
```

## Test Result
### main
```shell
...
ERROR 10-16 20:49:34 [multiproc_executor.py:700]  assert self.reorder_batch_threshold == 1, (
ERROR 10-16 20:49:34 [multiproc_executor.py:700] AssertionError: DCP not support reorder_batch_threshold > 1 now.
...
INFO:     127.0.0.1:46314 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```

### this PR
```shell
INFO:     127.0.0.1:47140 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

cc @minosfuture @MatthewBonanni @youkaichao @LucasWilkinson 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

