### PR TITLE
Transform HF interleaved weights to halves in vllm

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -324,6 +324,7 @@ class FusedMoE(CustomOp):
         expert_mapping: list[tuple[str, str, int, str]] | None = None,
         n_shared_experts: int | None = None,
         routing_method_type: int | None = None,
+        is_weights_interleaved: bool = False,
     ):
         super().__init__()
 
@@ -362,6 +363,8 @@ class FusedMoE(CustomOp):
             tp_size if tp_size is not None else get_tensor_model_parallel_world_size()
         )
         dp_size_ = dp_size if dp_size is not None else get_dp_group().world_size
+
+        self.is_weights_interleaved = is_weights_interleaved
 
         self.is_sequence_parallel = is_sequence_parallel
         self.sp_size = tp_size_ if is_sequence_parallel else 1

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -173,6 +173,7 @@ class MLPBlock(torch.nn.Module):
             has_bias=True,
             activation="swigluoai",
             is_sequence_parallel=self.is_sequence_parallel,
+            is_weights_interleaved=True,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Purpose
- HF provides the gate + up weights interleaved as [g0, u0, g1, u1]
- vllm expects the gate + up tensors to be in halves [g0, g1, u0, u1]
- Add a funtion to do the transformation for gate + up weights and bias

## Test Plan
Tested with gpt-oss

## Test Result
Gives the correct results on CPU
