### PR TITLE
[Bug] Pass correct ep_rank_start and ep_rank_end

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -618,8 +618,8 @@ class GptOssModel(nn.Module):
             )
         else:
             return self._load_weights_other(
-                ep_rank_end,
                 ep_rank_start,
+                ep_rank_end,
                 heads_per_rank,
                 head_start,
                 weights,


### PR DESCRIPTION
## Purpose
- _load_weights_others expect the parameters as ep_rank_start and ep_rank_end but its passed in the reverse order
- Fix to pass the correct parameters

## Test Plan
Tested with gpt-oss and enabling the expert parallelism

## Test Result
Earlier gpt-oss was failing when expert parallelism was enabled, after the fix it started passing
