### PR TITLE
[torch.compile] Passing only necessary compilation config to inductor pass config

### DIFF
--- a/tests/compile/test_async_tp.py
+++ b/tests/compile/test_async_tp.py
@@ -341,6 +341,15 @@ def async_tp_pass_on_test_model(
     async_tp_pass = AsyncTPPass(vllm_config)
     backend = TestBackend(async_tp_pass)
 
+    assert (
+        async_tp_pass.compilation_config.splitting_ops
+        == vllm_config.compilation_config.splitting_ops
+    )
+    assert (
+        async_tp_pass.compilation_config.use_inductor_graph_partition
+        == vllm_config.compilation_config.use_inductor_graph_partition
+    )
+
     model = test_model_cls(hidden_size, dtype)  # Pass dtype to model constructor
 
     hidden_states = torch.randn(

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import copy
+
 import pytest
 
 from vllm.compilation.counter import compilation_counter
+from vllm.compilation.fix_functionalization import FixFunctionalizationPass
 from vllm.config import CompilationConfig, CUDAGraphMode, VllmConfig
 from vllm.config.compilation import CompilationMode
 from vllm.utils import _is_torch_equal_or_newer, is_torch_equal_or_newer
@@ -23,6 +26,20 @@ def test_use_cudagraphs_dynamic():
     # engine decides when to capture based on runtime settings instead of a
     # blanket default.
     assert vllm_config.compilation_config.use_cudagraph
+
+
+def test_copy_pass():
+    vllm_config = VllmConfig()
+    inductor_pass = FixFunctionalizationPass(vllm_config)
+    copied_inductor_pass = copy.deepcopy(inductor_pass)
+    assert (
+        copied_inductor_pass.compilation_config.use_inductor_graph_partition
+        == vllm_config.compilation_config.use_inductor_graph_partition
+    )
+    assert (
+        copied_inductor_pass.compilation_config.splitting_ops
+        == vllm_config.compilation_config.splitting_ops
+    )
 
 
 def test_custom_op():

--- a/tests/compile/test_sequence_parallelism.py
+++ b/tests/compile/test_sequence_parallelism.py
@@ -285,6 +285,14 @@ def sequence_parallelism_pass_on_test_model(
 
     noop_pass = NoOpEliminationPass(vllm_config)
     sequence_parallelism_pass = SequenceParallelismPass(vllm_config)
+    assert (
+        sequence_parallelism_pass.compilation_config.splitting_ops
+        == vllm_config.compilation_config.splitting_ops
+    )
+    assert (
+        sequence_parallelism_pass.compilation_config.use_inductor_graph_partition
+        == vllm_config.compilation_config.use_inductor_graph_partition
+    )
     func_pass = FixFunctionalizationPass(vllm_config)
     cleanup_pass = PostCleanupPass(vllm_config)
 

--- a/vllm/compilation/vllm_inductor_pass.py
+++ b/vllm/compilation/vllm_inductor_pass.py
@@ -23,7 +23,6 @@ logger = init_logger(__name__)
 class InductorCompilationConfig:
     splitting_ops: list[str] | None = None
     use_inductor_graph_partition: bool = False
-    compile_sizes: list[int | str] | None = None
 
 
 class VllmInductorPass(InductorPass):
@@ -39,9 +38,8 @@ class VllmInductorPass(InductorPass):
         # Get only the necessary CompilationConfig for the inductor pass, since
         # full `CompilationConfig` contains pointer to model which is unsafe.
         self.compilation_config = InductorCompilationConfig(
-            splitting_ops=config.splitting_ops,
-            use_inductor_graph_partition=config.use_inductor_graph_partition,
-            compile_sizes=config.compile_sizes,
+            splitting_ops=config.compilation_config.splitting_ops,
+            use_inductor_graph_partition=config.compilation_config.use_inductor_graph_partition,
         )
         self.pass_config = config.compilation_config.pass_config
         self.model_dtype = config.model_config.dtype if config.model_config else None

--- a/vllm/compilation/vllm_inductor_pass.py
+++ b/vllm/compilation/vllm_inductor_pass.py
@@ -11,7 +11,7 @@ import torch
 from torch._dynamo.utils import lazy_format_graph_code
 from torch._inductor.pattern_matcher import PatternMatcherPass, PatternPrettyPrinter
 
-from vllm.config import CompilationConfig, VllmConfig
+from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
 from .inductor_pass import InductorPass
@@ -20,23 +20,10 @@ logger = init_logger(__name__)
 
 
 @dataclass
-class SimplifiedCompilationConfig:
+class InductorCompilationConfig:
     splitting_ops: list[str] | None = None
     use_inductor_graph_partition: bool = False
     compile_sizes: list[int | str] | None = None
-
-
-def copy_necessary_config_for_pass(
-    config: CompilationConfig,
-) -> SimplifiedCompilationConfig:
-    """Get only the necessary CompilationConfig for the inductor pass, since
-    full `CompilationConfig` contains pointer to model which is unsafe.
-    """
-    return SimplifiedCompilationConfig(
-        splitting_ops=config.splitting_ops,
-        use_inductor_graph_partition=config.use_inductor_graph_partition,
-        compile_sizes=config.compile_sizes,
-    )
 
 
 class VllmInductorPass(InductorPass):
@@ -49,8 +36,12 @@ class VllmInductorPass(InductorPass):
     """Keep track of pass index for debug dump ordering."""
 
     def __init__(self, config: VllmConfig):
-        self.compilation_config = copy_necessary_config_for_pass(
-            config.compilation_config
+        # Get only the necessary CompilationConfig for the inductor pass, since
+        # full `CompilationConfig` contains pointer to model which is unsafe.
+        self.compilation_config = InductorCompilationConfig(
+            splitting_ops=config.splitting_ops,
+            use_inductor_graph_partition=config.use_inductor_graph_partition,
+            compile_sizes=config.compile_sizes,
         )
         self.pass_config = config.compilation_config.pass_config
         self.model_dtype = config.model_config.dtype if config.model_config else None


### PR DESCRIPTION
Summary: we should not pass the weakref to compilation_config, which  include static_forward_context that will holds the pointers to the model layers (e.g. moe, attention), which is dangerous, as this will be passed as config to torch.compile

Differential Revision: D84790018

```
pytest -v test_sequence_parallelism.py 
pytest -vvv test_async_tp.py
 pytest -vvv test_config.py -k "test_copy_pass"
```
