### PR TITLE
[TPU] Fix tpu torch compile error

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -55,9 +55,14 @@ def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
             logger.debug("Using InductorAdaptor")
             return InductorAdaptor()
     else:
-        assert compilation_config.backend == "eager", (
-            "Custom backends not supported with CompilationMode.VLLM_COMPILE"
-        )
+        if current_platform.is_tpu():
+            assert compilation_config.backend == "openxla", (
+                "TPU platform should use openxla as compiler backend."
+            )
+        else:
+            assert compilation_config.backend == "eager", (
+                "Custom backends not supported with CompilationMode.VLLM_COMPILE"
+            )
 
         logger.debug("Using EagerAdaptor")
         return EagerAdaptor()

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -654,7 +654,7 @@ class CompilationConfig:
             return resolve_obj_by_qualname(self.backend)
 
         assert self.mode == CompilationMode.VLLM_COMPILE
-        if self.backend not in ["eager", "inductor"]:
+        if not current_platform.is_tpu() and self.backend not in ["eager", "inductor"]:
             raise ValueError(
                 f"Invalid backend for piecewise compilation: {self.backend}"
             )

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -326,6 +326,7 @@ class VllmConfig:
             if (
                 self.compilation_config.backend == "inductor"
                 and self.compilation_config.mode > CompilationMode.NONE
+                and not current_platform.is_tpu()
             ):
                 self.compilation_config.custom_ops.append("none")
             else:

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -140,8 +140,9 @@ class TpuPlatform(Platform):
             )
             compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
-        if compilation_config.backend == "":
-            compilation_config.backend = "openxla"
+        # Note: the default backend is set to inductor now
+        # we want to overwrite to openxla to execute the ops properly on TPU.
+        compilation_config.backend = "openxla"
 
         assert vllm_config.speculative_config is None, (
             "TPU does not support speculative decoding"


### PR DESCRIPTION
Fix torch compile error on TPU platforms, reopen https://github.com/vllm-project/vllm/pull/26453

This pr includes:

1. Set compilation backend to openxla on TPU platform
2. Make sure TPU is using forward_tpu when dispatching in custom ops
3. Bypass some backend checks which require either eager or inductor for non-tpu platforms.