### PR TITLE
[torch.compile] fix simple inductor graph partition test

### DIFF
--- a/tests/compile/piecewise/test_simple.py
+++ b/tests/compile/piecewise/test_simple.py
@@ -142,8 +142,7 @@ def test_simple_piecewise_compile(use_inductor):
 
 
 @torch.inference_mode()
-@pytest.mark.parametrize("splitting_ops", [["silly::attention"], []])
-def test_simple_inductor_graph_partition(splitting_ops, monkeypatch):
+def test_simple_inductor_graph_partition(monkeypatch):
     if not is_torch_equal_or_newer("2.9.0.dev"):
         pytest.skip("inductor graph partition is only available in PyTorch 2.9+")
 
@@ -153,7 +152,7 @@ def test_simple_inductor_graph_partition(splitting_ops, monkeypatch):
 
     _run_simple_model(
         # Inductor graph partition automatically resets splitting_ops to an empty list
-        splitting_ops=splitting_ops,
+        splitting_ops=["silly::attention"],
         use_inductor_graph_partition=True,
         use_inductor=True,
         # Since not splitting at fx graph level

--- a/tests/compile/piecewise/test_simple.py
+++ b/tests/compile/piecewise/test_simple.py
@@ -151,7 +151,6 @@ def test_simple_inductor_graph_partition(monkeypatch):
     monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
 
     _run_simple_model(
-        # Inductor graph partition automatically resets splitting_ops to an empty list
         splitting_ops=["silly::attention"],
         use_inductor_graph_partition=True,
         use_inductor=True,


### PR DESCRIPTION
This PR fixes a inductor graph partition [test](https://buildkite.com/vllm/ci/builds/35198/steps/canvas?jid=0199ec4f-a64c-4f7b-90c5-c789647eb341).

The error happened since silly attention is NOT partitioned. Why? Because #25845 lets inductor partition respect splitting_ops and the test `splitting_ops=[]` says don't partition on any ops.