### PR TITLE
[Test] Make `test_failure` more stable for batch invariance

### DIFF
--- a/tests/v1/generation/test_batch_invariance.py
+++ b/tests/v1/generation/test_batch_invariance.py
@@ -59,12 +59,15 @@ def _random_prompt(min_words: int = 1024, max_words: int = 1024 * 2) -> str:
     # Pick a random template
     base_prompt = random.choice(prompt_templates)
 
-    # Add some padding to vary the length if needed
-    if min_words > 50:
+    if max_words < min_words:
+        max_words = min_words
+    target_words = random.randint(min_words, max_words)
+
+    if target_words > 50:
         # For longer prompts, repeat context
         padding_text = (
             " This is an interesting topic that deserves more explanation. "
-            * (min_words // 50)
+            * (target_words // 50)
         )
         base_prompt = base_prompt + padding_text
 

--- a/tests/v1/generation/test_batch_invariance.py
+++ b/tests/v1/generation/test_batch_invariance.py
@@ -523,19 +523,16 @@ def test_logprobs_WITHOUT_batch_invariance_should_FAIL(backend):
         long_min = int(os.getenv("VLLM_MIN_PROMPT", "768"))
         long_max = int(os.getenv("VLLM_MAX_PROMPT", "2048"))
         prompts: list[str] = []
-        for i in range(32):
-            if i % 4 == 0:
-                # very long
-                prompts.append(_random_prompt(max(long_min, 1536), max(long_max, 3072)))
-            elif i % 4 == 1:
-                # long
-                prompts.append(_random_prompt(max(1024, long_min), max(2048, long_max)))
-            elif i % 4 == 2:
-                # mid
-                prompts.append(_random_prompt(256, 512))
-            else:
-                # short
-                prompts.append(_random_prompt(10, 20))
+        options = [
+            (max(long_min, 1536), max(long_max, 3072)),  # very long
+            (max(1024, long_min), max(2048, long_max)),  # long
+            (256, 512),  # mid
+            (10, 20),  # short
+        ]
+
+        for _ in range(32):
+            lo, hi = random.choice(options)
+            prompts.append(_random_prompt(lo, hi))
 
         sp = SamplingParams(
             temperature=0.6,


### PR DESCRIPTION
## Purpose

Some of the models may fail in `test_failure`

This PR make it more stable for the test by making the prompt more different.

## Test

Tested on H100, with `export VLLM_USE_DEEP_GEMM=0`

Origin

```bash
VLLM_TEST_MODEL=Qwen/Qwen3-30B-A3B-FP8 pytest test_batch_invariance.py

FAILED test_batch_invariance.py::test_logprobs_WITHOUT_batch_invariance_should_FAIL[FLASH_ATTN] - Failed: ✗ UNEXPECTED: All 32 prompts matched between BS=1 and BS=N even with batch invariance DISABLED. This suggests batch inv...
```

Now

```bash
VLLM_TEST_MODEL=Qwen/Qwen3-30B-A3B-FP8 pytest test_batch_invariance.py

============================================ 7 passed, 12 warnings in 365.61s (0:06:05) ============================================
```

And this doesn't affect original test

```bash
(wentao) wentao@H100-GPU17:~/vllm-source/tests/v1/generation$ pytest
======================================================= test session starts ========================================================
platform linux -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/wentao/vllm-source
configfile: pyproject.toml
plugins: anyio-4.10.0
collected 96 items                                                                                                                 

test_batch_invariance.py .......                                                                                             [  7%]
test_rms_norm_batch_invariant.py .........................................................................................   [100%]

=========================================== 96 passed, 12 warnings in 167.21s (0:02:47) ============================================
```