### PR TITLE
[Bugfix] Fix ReplicatedLinearWithLoRA 

### DIFF
--- a/vllm/lora/layers/replicated_linear.py
+++ b/vllm/lora/layers/replicated_linear.py
@@ -56,3 +56,15 @@ class ReplicatedLinearWithLoRA(BaseLinearLayerWithLoRA):
         model_config: PretrainedConfig | None,
     ) -> bool:
         return type(source_layer) is ReplicatedLinear
+
+    def slice_lora_a(
+        self, lora_a: torch.Tensor | list[torch.Tensor | None]
+    ) -> torch.Tensor | list[torch.Tensor | None]:
+        """Slice lora a if splitting for tensor parallelism."""
+        return lora_a
+
+    def slice_lora_b(
+        self, lora_b: torch.Tensor | list[torch.Tensor | None]
+    ) -> torch.Tensor | list[torch.Tensor | None]:
+        """Slice lora b if splitting with tensor parallelism."""
+        return lora_b


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When setting tp>1 and initializing `ReplicatedLinearWithLoRA `(e.g., gate linear in MoE model), the following error will be raised:

```text
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700]   File "/root/Code/vllm_dev/vllm/vllm/lora/models.py", line 434, in activate_adapter
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700]     module.set_lora(
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700]   File "/root/Code/vllm_dev/vllm/vllm/lora/layers/base_linear.py", line 114, in set_lora
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700]     self.lora_a_stacked[0][index, 0, : lora_a.shape[0], : lora_a.shape[1]].copy_(
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700]                                        ^^^^^^^^^^^^
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700] AttributeError: 'NoneType' object has no attribute 'shape'
(EngineCore_DP0 pid=180361) (Worker_TP0 pid=180367) ERROR 10-17 02:06:25 [multiproc_executor.py:700]
```
The root cause is that `ReplicatedLinearWithLoRA` doesn't implement ` slice_lora_a` and `slice_lora_b`,this PR fixes this bug

FIX https://github.com/vllm-project/vllm/issues/26991
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

