### PR TITLE
[V1][Spec Decode] Fix greedy temperature detection after sampler refactor

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -15,7 +15,7 @@ from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 logger = init_logger(__name__)
 
 PLACEHOLDER_TOKEN_ID: tl.constexpr = -1
-GREEDY_TEMPERATURE: tl.constexpr = -1
+GREEDY_TEMPERATURE: tl.constexpr = 0
 # Maximum number of speculative draft tokens allowed per request in a single
 # step. This value is chosen to be large enough to handle typical use cases.
 MAX_SPEC_LEN = 128

--- a/vllm/v1/sample/tpu/metadata.py
+++ b/vllm/v1/sample/tpu/metadata.py
@@ -30,6 +30,7 @@ class TPUSupportedSamplingMetadata:
     top_p: torch.Tensor = None
 
     all_greedy: bool = True
+    all_random: bool = False
 
     # Whether logprobs are to be gathered in this batch of request. To balance
     # out compile time and runtime, a fixed `max_number_logprobs` value is used
@@ -110,6 +111,7 @@ class TPUSupportedSamplingMetadata:
                 xla_device
             ),
             all_greedy=input_batch.all_greedy,
+            all_random=input_batch.all_random,
             # TODO enable more and avoid returning None values
             top_p=input_batch.top_p_cpu_tensor[:padded_num_reqs].to(xla_device),
             top_k=input_batch.top_k_cpu_tensor[:padded_num_reqs].to(xla_device),

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -37,6 +37,7 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.sampler import _SAMPLING_EPS
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
@@ -1140,8 +1141,13 @@ def compute_probs_and_sample_next_token(
         next_token_ids = logits.argmax(dim=-1)
         return next_token_ids, probs
 
-    is_greedy = sampling_metadata.temperature == -1
-    temperature = torch.where(is_greedy, 1.0, sampling_metadata.temperature)
+    # Use epsilon comparison to detect greedy sampling (temperature ~ 0.0)
+    # consistent with sampler.py's _SAMPLING_EPS threshold
+    temperature = sampling_metadata.temperature
+    # Avoid division by zero if there are greedy requests.
+    if not sampling_metadata.all_random:
+        is_greedy = temperature < _SAMPLING_EPS
+        temperature = torch.where(is_greedy, 1.0, temperature)
     logits.div_(temperature.view(-1, 1))
     probs = logits.softmax(dim=-1, dtype=torch.float32)
 

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1141,6 +1141,8 @@ def compute_probs_and_sample_next_token(
         next_token_ids = logits.argmax(dim=-1)
         return next_token_ids, probs
 
+    assert sampling_metadata.temperature is not None
+
     # Use epsilon comparison to detect greedy sampling (temperature ~ 0.0)
     # consistent with sampler.py's _SAMPLING_EPS threshold
     temperature = sampling_metadata.temperature

--- a/vllm/v1/worker/tpu_input_batch.py
+++ b/vllm/v1/worker/tpu_input_batch.py
@@ -215,8 +215,8 @@ class InputBatch:
         sampling_params = request.sampling_params
         assert sampling_params is not None, "pooling requests not supported yet"
         if sampling_params.sampling_type == SamplingType.GREEDY:
-            # Avoid later division by zero.
-            self.temperature_cpu[req_index] = -1.0
+            # Should avoid division by zero later when apply_temperature.
+            self.temperature_cpu[req_index] = 0.0
             self.greedy_reqs.add(req_id)
         else:
             self.temperature_cpu[req_index] = sampling_params.temperature


### PR DESCRIPTION
## Description

Fixes division by zero and negative acceptance values in speculative decoding caused by incomplete temperature migration in commit a676e668e.

## Issue

Commit a676e668e changed greedy sampling temperature from `-1.0` to `0.0` in `gpu_input_batch.py`, but several components still checking for `temperature == -1` were not updated, causing:
- Division by zero in rejection sampler  
- NaN/Inf logits
- Empty `generated_token_ids`
- Negative acceptance values (`len([]) - 1 = -1`)
- Prometheus metrics crash: "ValueError: Gauge metric cannot decrease"

## Root Cause

Multiple components were not updated after the temperature refactor:
1. **TPU input batch** (`tpu_input_batch.py`): Still using `-1.0` sentinel value
2. **Eagle** (`eagle.py`): Hardcoded `temperature == -1` check in unused function
3. **Rejection sampler** (`rejection_sampler.py`): `GREEDY_TEMPERATURE` constant set to `-1`

The rejection sampler's `expand_batch_to_tokens()` function replaces `GREEDY_TEMPERATURE` (-1) with 1.0 before division, but when actual temperature is 0.0, the replacement doesn't happen, causing division by zero.

## Impact

Affects ALL models using speculative decoding with rejection sampling:
- Eagle/Eagle3
- deepseek_mtp  
- ernie_mtp
- qwen3_next_mtp
- longcat_flash_mtp

## Solution

Complete the temperature migration consistently across all components:

1. **tpu_input_batch.py** (line 219): Change `temperature = -1.0` → `0.0` for consistency with GPU
2. **eagle.py** (lines 40, 1144-1151):
   - Import `_SAMPLING_EPS` from `sampler.py`
   - Use epsilon comparison: `temperature < _SAMPLING_EPS` instead of `== -1`
   - Add `if not all_random:` check before protection (consistent with `sampler.py`)
3. **rejection_sampler.py** (line 18): Change `GREEDY_TEMPERATURE` constant from `-1` → `0`

## Testing

- Verified Eagle speculation works correctly with temperature 0.0
- No longer produces negative acceptance errors
- Prometheus metrics no longer crash

## Related

- Original temperature refactor: #24734 (commit a676e668e)