### PR TITLE
[Models] Remove unneeded re-computation of `inv_freq` in cached RotaryEmbedding

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -664,19 +664,6 @@ class Glm4vVisionRotaryEmbedding(nn.Module):
         if seqlen > self._seq_len_cached:
             seqlen *= 2
             self._seq_len_cached = seqlen
-            self.inv_freq = 1.0 / (
-                self.theta
-                ** (
-                    torch.arange(
-                        0,
-                        self.dim,
-                        2,
-                        dtype=torch.float,
-                        device=self.inv_freq.device,
-                    )
-                    / self.dim
-                )
-            )
             seq = torch.arange(
                 seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
             )

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -609,15 +609,6 @@ class Qwen2_5_VisionRotaryEmbedding(nn.Module):
         if seqlen > self._seq_len_cached:
             seqlen *= 2
             self._seq_len_cached = seqlen
-            self.inv_freq = 1.0 / (
-                self.theta
-                ** (
-                    torch.arange(
-                        0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device
-                    )
-                    / self.dim
-                )
-            )
             seq = torch.arange(
                 seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
             )

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -634,15 +634,6 @@ class Qwen2VisionRotaryEmbedding(nn.Module):
         if seqlen > self._seq_len_cached:
             seqlen *= 2
             self._seq_len_cached = seqlen
-            self.inv_freq = 1.0 / (
-                self.theta
-                ** (
-                    torch.arange(
-                        0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device
-                    )
-                    / self.dim
-                )
-            )
             seq = torch.arange(
                 seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
             )


### PR DESCRIPTION
## Purpose

`self.inv_freq` is already initialised as a buffer and doesn't change with different sequence lengths so as far as I can tell we can just remove the re-computation unless I'm missing something.
https://github.com/vllm-project/vllm/blob/6c9fdbf7258146a9e335c50aab12969cd95e9227/vllm/model_executor/models/qwen2_5_vl.py#L601-L604

## Test Plan

CI

## Test Result
