### PR TITLE
[Models][QwenVL] Remove unnecessary `.contiguous()` calls

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -396,7 +396,7 @@ class Qwen2_5_VisionAttention(nn.Module):
         q, k, v = self.split_qkv(x)
         batch_size = q.shape[1]
 
-        q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous() for x in (q, k, v))
+        q, k, v = (rearrange(x, "s b ... -> b s ...") for x in (q, k, v))
         if rotary_pos_emb is not None:
             # [2 * b, s, heads, head_dim]
             qk_concat = torch.cat([q, k], dim=0)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -423,7 +423,7 @@ class Qwen2VisionAttention(nn.Module):
         q, k, v = self.split_qkv(x)
         batch_size = q.shape[1]
 
-        q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous() for x in (q, k, v))
+        q, k, v = (rearrange(x, "s b ... -> b s ...") for x in (q, k, v))
         if rotary_pos_emb is not None:
             # [2 * b, s, heads, head_dim]
             qk_concat = torch.cat([q, k], dim=0)


### PR DESCRIPTION
## Purpose

This PR removes calls to `.contiguous()` in the `QwenVisionAttention` module. Tested with both xformers and flash attention backend.

## Test Plan

```
vllm bench serve Qwen/Qwen2.5-VL-3B-Instruct

vllm bench serve --backend openai-chat --model Qwen/Qwen2.5-VL-3B-Instruct --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/VisionArena-Chat --hf-split train --num-prompts 1000
```

## Test Result

### Before

<img width="662" height="263" alt="Screenshot 2025-10-17 at 16 05 07" src="https://github.com/user-attachments/assets/252533eb-50f4-409f-891f-a3a628390089" />
<img width="704" height="87" alt="Screenshot 2025-10-17 at 16 06 26" src="https://github.com/user-attachments/assets/1e79b2ff-d308-41ae-a232-ff9a1eebe4d6" />

```
============ Serving Benchmark Result ============
Successful requests:                     998
Failed requests:                         2
Benchmark duration (s):                  100.72
Total input tokens:                      94309
Total generated tokens:                  105944
Request throughput (req/s):              9.91
Output token throughput (tok/s):         1051.90
Peak output token throughput (tok/s):    5104.00
Peak concurrent requests:                998.00
Total Token throughput (tok/s):          1988.28
---------------Time to First Token----------------
Mean TTFT (ms):                          44047.03
Median TTFT (ms):                        43652.87
P99 TTFT (ms):                           95956.25
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          199.36
Median TPOT (ms):                        217.51
P99 TPOT (ms):                           252.47
---------------Inter-token Latency----------------
Mean ITL (ms):                           199.33
Median ITL (ms):                         220.68
P99 ITL (ms):                            437.93
==================================================
```

### After

```
============ Serving Benchmark Result ============
Successful requests:                     998
Failed requests:                         2
Benchmark duration (s):                  100.23
Total input tokens:                      94290
Total generated tokens:                  106295
Request throughput (req/s):              9.96
Output token throughput (tok/s):         1060.55
Peak output token throughput (tok/s):    4899.00
Peak concurrent requests:                998.00
Total Token throughput (tok/s):          2001.33
---------------Time to First Token----------------
Mean TTFT (ms):                          43825.06
Median TTFT (ms):                        42747.21
P99 TTFT (ms):                           95296.01
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          197.58
Median TPOT (ms):                        213.70
P99 TPOT (ms):                           252.91
---------------Inter-token Latency----------------
Mean ITL (ms):                           197.16
Median ITL (ms):                         218.65
P99 ITL (ms):                            462.42
==================================================
```
