### PR TITLE
[CI/Build]Add eval config for Qwen3-235B-A22B-Instruct-2507-FP8

### DIFF
--- a/.buildkite/lm-eval-harness/configs/Qwen3-235B-A22B-Instruct-2507-FP8.yaml
+++ b/.buildkite/lm-eval-harness/configs/Qwen3-235B-A22B-Instruct-2507-FP8.yaml
@@ -1,0 +1,14 @@
+model_name: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
+tasks:
+  - name: "mmlu_pro"
+    metrics:
+      - name: "exact_match,custom-extract"
+        value: 0.82
+limit: 250 # will run on 250 * 14 subjects = 3500 samples
+num_fewshot: 5
+enforce_eager: false # we use false to speed up the eval process
+kv_cache_dtype: fp8 # we use fp8 to speed up the eval process
+max_model_len: 40960
+apply_chat_template: true
+fewshot_as_multiturn: true
+gen_kwargs: "temperature=0,top_p=1,top_k=0,max_gen_toks=5632,until=<|ENDANSWER|>"

--- a/.buildkite/lm-eval-harness/configs/models-large-h100.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large-h100.txt
@@ -1,1 +1,0 @@
-Meta-Llama-4-Maverick-17B-128E-Instruct-FP8.yaml

--- a/.buildkite/lm-eval-harness/configs/models-large-hopper.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large-hopper.txt
@@ -1,0 +1,1 @@
+Qwen3-235B-A22B-Instruct-2507-FP8.yaml

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -401,7 +401,7 @@ steps:
       --ignore=lora/test_deepseekv2_tp.py \
       --ignore=lora/test_gptoss.py \
       --ignore=lora/test_qwen3moe_tp.py
-      
+
   parallelism: 4
 
 - label: PyTorch Compilation Unit Tests # 15min
@@ -1124,7 +1124,7 @@ steps:
   - tests/weight_loading
   commands:
     - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-large.txt
-  
+
 - label: NixlConnector PD accuracy tests (Distributed) # 30min
   timeout_in_minutes: 30
   working_dir: "/vllm-workspace/tests"
@@ -1165,6 +1165,19 @@ steps:
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large.txt --tp-size=4
+
+##### H100 test #####
+- label: LM Eval Large Models (H100) # optional
+  gpu: h100
+  optional: true
+  num_gpus: 4
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  source_file_dependencies:
+  - csrc/
+  - vllm/model_executor/layers/quantization
+  commands:
+    - export VLLM_USE_DEEP_GEMM=0  # We found Triton is faster than DeepGEMM for H100
+    - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-hopper.txt --tp-size=4
 
 ##### H200 test #####
 - label: Distributed Tests (H200) # optional


### PR DESCRIPTION
## Purpose

* This PR adds eval config for [Qwen3-235B-A22B-Instruct-2507-FP8](https://huggingface.co/Qwen/Qwen3-235B-A22B-Thinking-2507-FP8)
* We rename `.buildkite/lm-eval-harness/configs/models-large-h100.txt` to use `.buildkite/lm-eval-harness/configs/models-large-hopper.txt` per suggestion.
* Add a new test/label `label: LM Eval Large Models (H100) # optional` to run `configs/models-large-hopper.txt`

## Test Plan
```
pytest -s -v .buildkite/lm-eval-harness/test_lm_eval_correctness.py \
   --config-list-file .buildkite/lm-eval-harness/configs/models-large-hopper.txt \
   --tp-size 4
```

## Test Result
**WIP**

### VLLM_USE_DEEP_GEMM=1
`1 passed, 104 warnings in 3062.67s (0:51:02)`
https://buildkite.com/vllm/ci/builds/36443/steps/canvas?sid=019a272c-b17c-4404-96e9-0e83356d6bb8

### VLLM_USE_DEEP_GEMM=1 
`1 passed, 104 warnings in 3041.13s (0:50:41)`
https://buildkite.com/vllm/ci/builds/36457/steps/canvas?sid=019a27b5-4ec8-4166-8bba-091034e14805

### VLLM_USE_DEEP_GEMM=0
`1 passed, 104 warnings in 1900.52s (0:31:40)`
https://buildkite.com/vllm/ci/builds/36470/steps/canvas?sid=019a2826-8d7a-4453-925b-472e24acf179

### VLLM_USE_DEEP_GEMM=0 + kv_cache_dtype=fp8
`1 passed, 104 warnings in 1445.30s (0:24:05)`
https://buildkite.com/vllm/ci/builds/36607/steps/canvas?sid=019a2b72-d030-4a51-aefa-ff0838ffc8fb

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

