### PR TITLE
[Fix][Spec Decode] Fix llama4 draft loading with different quantization

### DIFF
--- a/vllm/model_executor/models/llama4_eagle.py
+++ b/vllm/model_executor/models/llama4_eagle.py
@@ -60,6 +60,10 @@ class LlamaModel(nn.Module):
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
+        # Temporarily modify vllm_config.quant_config for draft model layers
+        original_quant_config = vllm_config.quant_config
+        vllm_config.quant_config = quant_config
+
         self.layers = nn.ModuleList(
             [
                 Llama4DecoderLayer(
@@ -70,6 +74,8 @@ class LlamaModel(nn.Module):
                 for i in range(self.config.num_hidden_layers)
             ]
         )
+        # Restore original quant_config
+        vllm_config.quant_config = original_quant_config
         self.fc = torch.nn.Linear(
             self.config.hidden_size * 2, self.config.hidden_size, bias=False
         )

--- a/vllm/model_executor/models/llama4_eagle.py
+++ b/vllm/model_executor/models/llama4_eagle.py
@@ -63,19 +63,20 @@ class LlamaModel(nn.Module):
         # Temporarily modify vllm_config.quant_config for draft model layers
         original_quant_config = vllm_config.quant_config
         vllm_config.quant_config = quant_config
-
-        self.layers = nn.ModuleList(
-            [
-                Llama4DecoderLayer(
-                    vllm_config=vllm_config,
-                    prefix=maybe_prefix(prefix, f"layers.{i + start_layer_id}"),
-                    config=self.config,
-                )
-                for i in range(self.config.num_hidden_layers)
-            ]
-        )
-        # Restore original quant_config
-        vllm_config.quant_config = original_quant_config
+        try:
+            self.layers = nn.ModuleList(
+                [
+                    Llama4DecoderLayer(
+                        vllm_config=vllm_config,
+                        prefix=maybe_prefix(prefix, f"layers.{i + start_layer_id}"),
+                        config=self.config,
+                    )
+                    for i in range(self.config.num_hidden_layers)
+                ]
+            )
+        finally:
+            # Restore original quant_config
+            vllm_config.quant_config = original_quant_config
         self.fc = torch.nn.Linear(
             self.config.hidden_size * 2, self.config.hidden_size, bias=False
         )


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Purpose

This PR takes care of the case where draft model and target model may use different quantization configs.

`replace` doesn't work with pydantic dataclass
`deepcopy` fails with new error "TypeError: BasevLLMParameter.new() takes 2 positional arguments but 3 were given"

## Test Plan

Tested with loading a llama4 scout model with an eagle draft model with different quantization.

## Test Result

Before:
```
layers.0.self_attn.qkv_proj.weight_scale is not loaded!
```

After:
model successful loads, and gsm8k eval result is expected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

