### PR TITLE
[Bugfix][Core] Fix xgrammar import failure on unsupported platforms

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -29,7 +29,16 @@ from vllm.v1.structured_output.backend_lm_format_enforcer import (
 from vllm.v1.structured_output.backend_outlines import (
     validate_structured_output_request_outlines,
 )
-from vllm.v1.structured_output.backend_xgrammar import validate_xgrammar_grammar
+from vllm.v1.structured_output.utils import is_xgrammar_supported
+
+if is_xgrammar_supported():
+    from vllm.v1.structured_output.backend_xgrammar import validate_xgrammar_grammar
+else:
+    def validate_xgrammar_grammar(params):
+        raise ValueError(
+            "xgrammar is not supported on this platform. "
+            "Please use a different backend."
+        )
 
 logger = init_logger(__name__)
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -14,7 +14,17 @@ from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
 )
-from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+from vllm.v1.structured_output.utils import is_xgrammar_supported
+
+if is_xgrammar_supported():
+    from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+else:
+    class XgrammarBackend:
+        def __init__(self, *args, **kwargs):
+            raise ValueError(
+                "xgrammar is not supported on this platform. "
+                "Cannot initialize XgrammarBackend."
+            )
 
 if TYPE_CHECKING:
     import numpy as np

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -13,6 +13,7 @@ from diskcache import Cache
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.import_utils import LazyLoader
 
 if TYPE_CHECKING:
@@ -182,7 +183,7 @@ def get_outlines_cache():
 
 
 re_llama_byte_token = re.compile(r"^<0x[0-9A-F]{2}>$")
-re_replacement_seq = re.compile(r"^.{0,6}�+.{0,6}$")
+re_replacement_seq = re.compile(r"^.{0,6}\ufffd+.{0,6}$")
 
 
 def _reduced_vocabulary(
@@ -458,3 +459,8 @@ def choice_as_grammar(choice: list[str]) -> str:
     escaped_choices = (escape_ebnf_string(c) for c in choice)
     grammar = "root ::= " + " | ".join(f'"{c}"' for c in escaped_choices)
     return grammar
+
+
+def is_xgrammar_supported() -> bool:
+    arch = current_platform.get_cpu_architecture()
+    return arch in (CpuArchEnum.X86, CpuArchEnum.ARM)


### PR DESCRIPTION
## Purpose
Fix ModuleNotFoundError when importing xgrammar on unsupported platforms (RISC-V, PowerPC, s390x, etc.).
Current Issues:
- xgrammar has platform restrictions in requirements/common.txt (x86_64, aarch64, arm64 only)
- Code unconditionally imports XgrammarBackend, causing failures on unsupported platforms
 RISC-V users cannot use vLLM even with alternative backends available
Solution:
- Add is_xgrammar_supported() platform detection helper in vllm/v1/structured_output/utils.py
- Conditionally import xgrammar-related modules in __init__.py and processor.py based on platform
- Update "auto" backend selection to skip xgrammar on unsupported platforms
- Provide clear error messages when xgrammar is explicitly requested on unsupported platforms
## Test Plan
## Test Result
Before Fix RISC-V Platform
ModuleNotFoundError: No module named 'xgrammar'  
  File "/AI/hebo/vllm/vllm/v1/structured_output/backend_xgrammar.py", line 131  
After Fix RISC-V Platform
$ python -c "from vllm import LLM, SamplingParams"$
No errors - successfully imports core modules