### PR TITLE
[BugFix] Fix lazy imports involving outlines_core

### DIFF
--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright 2025-present the Outlines developers
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import ast
 import importlib
 import json

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import hashlib
 import importlib.metadata
 import os


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix outlines_core lazy imports broken by #26633

Annotations are executed at import time by default. To reproduce the issue, run the following

```bash
uv pip uninstall outlines_core
python -c "from vllm.v1.engine.llm_engine import LLMEngine"
```

Error stack trace
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/engine/llm_engine.py", line 31, in <module>
    from vllm.v1.engine.core_client import EngineCoreClient
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/engine/core_client.py", line 42, in <module>
    from vllm.v1.engine.core import EngineCore, EngineCoreProc
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/engine/core.py", line 39, in <module>
    from vllm.v1.core.kv_cache_utils import (
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/core/kv_cache_utils.py", line 27, in <module>
    from vllm.v1.request import Request
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/request.py", line 22, in <module>
    from vllm.v1.structured_output.request import StructuredOutputRequest
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/structured_output/__init__.py", line 17, in <module>
    from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/structured_output/backend_xgrammar.py", line 20, in <module>
    from vllm.v1.structured_output.utils import (
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/structured_output/utils.py", line 120, in <module>
    class OutlinesVocabulary:
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/v1/structured_output/utils.py", line 126, in OutlinesVocabulary
    def __init__(self, vocabulary: oc.Vocabulary) -> None:
                                   ^^^^^^^^^^^^^
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/utils/import_utils.py", line 320, in __getattr__
    self._module = self._load()
                   ^^^^^^^^^^^^
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/utils/import_utils.py", line 310, in _load
    raise err from None
  File "/data/users/quinnzhu/gitrepos/vllm/vllm/utils/import_utils.py", line 304, in _load
    module = importlib.import_module(self.__name__)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'outlines_core'
```


## Test Plan
```bash
uv pip uninstall outlines_core
python -c "from vllm.v1.engine.llm_engine import LLMEngine"
```

## Test Result
Passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

