### PR TITLE
Fix typo in ValueError message: use `kv_role` instead of `kv_disagg_role`

### DIFF
--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -94,7 +94,7 @@ class KVTransferConfig:
 
         if self.kv_connector is not None and self.kv_role is None:
             raise ValueError(
-                "Please specify kv_disagg_role when kv_connector "
+                "Please specify kv_role when kv_connector "
                 f"is set, supported roles are {get_args(KVRole)}"
             )
 


### PR DESCRIPTION
## Purpose
Correct field name in ValueError message to match the actual parameter kv_role.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [√] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

