### PR TITLE
Enhance benchmark_moe.py: vLLM Version Compatibility Fixes

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,25 @@
+# Enhance benchmark_moe.py: vLLM Version Compatibility Fixes
+
+## Description
+
+This PR introduces compatibility fixes to `benchmarks/kernels/benchmark_moe.py` to support multiple vLLM versions and prevent runtime import/parameter errors. The following issues are addressed:
+
+1. ImportError: cannot import name '_get_config_dtype_str'
+
+    - Added a multi-level import fallback that searches possible module locations and class methods for `_get_config_dtype_str` and provides a fallback implementation when unavailable.
+
+2. TypeError: FusedMoEQuantConfig.make() parameter incompatibility
+
+    - Implemented `make_quant_config_compatible()` which tries multiple parameter combinations (including `quant_dtype`, `dtype`, with/without `block_quant_shape`) to create `FusedMoEQuantConfig` across versions.
+
+3. TypeError: fused_experts() parameter incompatibility
+
+    - Implemented `fused_experts_compatible()` which inspects `fused_experts` signature and only passes supported parameters (`quant_config`, `allow_deep_gemm`, etc.).
+
+## Notes
+
+- No change to the benchmark algorithm logic.
+- All output messages are in English and suitable for production logs.
+- These fixes aim to support vLLM 0.6.0+ through 0.10.0+ releases.
+
+Please review and let me know if you'd like additional cleanups or unit tests included.

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import argparse
+import inspect
 import json
 import os
 import time
@@ -9,7 +10,6 @@ from contextlib import nullcontext
 from datetime import datetime
 from itertools import product
 from typing import Any, TypedDict
-import inspect
 
 import ray
 import torch
@@ -568,54 +568,58 @@ def _get_config_dtype_str_compatible(
     use_fp8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
-    **kwargs
+    **kwargs,
 ) -> str | None:
     """Multi-level import fallback for _get_config_dtype_str function."""
     try:
         from vllm.model_executor.layers.fused_moe.config import (
-            _get_config_dtype_str as _original_func
+            _get_config_dtype_str as _original_func,
         )
+
         return _original_func(
             dtype,
             use_fp8_w8a8=use_fp8_w8a8,
             use_int8_w8a16=use_int8_w8a16,
             use_int4_w4a16=use_int4_w4a16,
-            **kwargs
+            **kwargs,
         )
     except ImportError:
         try:
             from vllm.model_executor.layers.fused_moe import (
-                _get_config_dtype_str as _original_func
+                _get_config_dtype_str as _original_func,
             )
+
             return _original_func(
                 dtype,
                 use_fp8_w8a8=use_fp8_w8a8,
                 use_int8_w8a16=use_int8_w8a16,
                 use_int4_w4a16=use_int4_w4a16,
-                **kwargs
+                **kwargs,
             )
         except ImportError:
             try:
                 from vllm.model_executor.layers.fused_moe.layer import (
-                    _get_config_dtype_str as _original_func
+                    _get_config_dtype_str as _original_func,
                 )
+
                 return _original_func(
                     dtype,
                     use_fp8_w8a8=use_fp8_w8a8,
                     use_int8_w8a16=use_int8_w8a16,
                     use_int4_w4a16=use_int4_w4a16,
-                    **kwargs
+                    **kwargs,
                 )
             except ImportError:
                 try:
                     from vllm.model_executor.layers.fused_moe import FusedMoE
-                    if hasattr(FusedMoE, '_get_config_dtype_str'):
-                        return getattr(FusedMoE, '_get_config_dtype_str')(
+
+                    if hasattr(FusedMoE, "_get_config_dtype_str"):
+                        return FusedMoE._get_config_dtype_str(
                             dtype,
                             use_fp8_w8a8=use_fp8_w8a8,
                             use_int8_w8a16=use_int8_w8a16,
                             use_int4_w4a16=use_int4_w4a16,
-                            **kwargs
+                            **kwargs,
                         )
                 except ImportError:
                     pass
@@ -632,35 +636,35 @@ def _get_config_dtype_str_compatible(
                     return "float32"
                 return None
 
+
 def make_quant_config_compatible(
     quant_dtype, w1_scale, w2_scale, a1_scale, a2_scale, block_quant_shape
 ):
     """Compatible wrapper for FusedMoEQuantConfig.make() across vLLM versions."""
-    from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
     if quant_dtype is None:
         return None
     param_combinations = [
         {
-            'quant_dtype': quant_dtype,
-            'w1_scale': w1_scale,
-            'w2_scale': w2_scale,
-            'a1_scale': a1_scale,
-            'a2_scale': a2_scale,
-            'block_quant_shape': block_quant_shape,
+            "quant_dtype": quant_dtype,
+            "w1_scale": w1_scale,
+            "w2_scale": w2_scale,
+            "a1_scale": a1_scale,
+            "a2_scale": a2_scale,
+            "block_quant_shape": block_quant_shape,
         },
         {
-            'quant_dtype': quant_dtype,
-            'w1_scale': w1_scale,
-            'w2_scale': w2_scale,
-            'a1_scale': a1_scale,
-            'a2_scale': a2_scale,
+            "quant_dtype": quant_dtype,
+            "w1_scale": w1_scale,
+            "w2_scale": w2_scale,
+            "a1_scale": a1_scale,
+            "a2_scale": a2_scale,
         },
         {
-            'dtype': quant_dtype,
-            'w1_scale': w1_scale,
-            'w2_scale': w2_scale,
-            'a1_scale': a1_scale,
-            'a2_scale': a2_scale,
+            "dtype": quant_dtype,
+            "w1_scale": w1_scale,
+            "w2_scale": w2_scale,
+            "a1_scale": a1_scale,
+            "a2_scale": a2_scale,
         },
     ]
     for params in param_combinations:
@@ -672,6 +676,7 @@ def make_quant_config_compatible(
     raise TypeError(
         "Unable to create FusedMoEQuantConfig with any known parameter combination."
     )
+
 
 def fused_experts_compatible(
     x,
@@ -685,13 +690,15 @@ def fused_experts_compatible(
 ):
     """Compatible wrapper for fused_experts function."""
     from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
+
     sig = inspect.signature(fused_experts)
-    kwargs = {'inplace': inplace}
-    if 'quant_config' in sig.parameters:
-        kwargs['quant_config'] = quant_config
-    if 'allow_deep_gemm' in sig.parameters:
-        kwargs['allow_deep_gemm'] = allow_deep_gemm
+    kwargs = {"inplace": inplace}
+    if "quant_config" in sig.parameters:
+        kwargs["quant_config"] = quant_config
+    if "allow_deep_gemm" in sig.parameters:
+        kwargs["allow_deep_gemm"] = allow_deep_gemm
     return fused_experts(x, w1, w2, topk_weights, topk_ids, **kwargs)
+
 
 def main(args: argparse.Namespace):
     print(args)

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -9,6 +9,7 @@ from contextlib import nullcontext
 from datetime import datetime
 from itertools import product
 from typing import Any, TypedDict
+import inspect
 
 import ray
 import torch
@@ -16,7 +17,6 @@ from ray.experimental.tqdm_ray import tqdm
 
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
-    _get_config_dtype_str,
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import *
 from vllm.platforms import current_platform
@@ -145,20 +145,15 @@ def benchmark_config(
         else:
             quant_dtype = None
 
-        quant_config = FusedMoEQuantConfig.make(
-            quant_dtype=quant_dtype,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            a1_scale=a1_scale,
-            a2_scale=a2_scale,
-            block_shape=block_quant_shape,
+        quant_config = make_quant_config_compatible(
+            quant_dtype, w1_scale, w2_scale, a1_scale, a2_scale, block_quant_shape
         )
 
         with override_config(config):
             topk_weights, topk_ids, token_expert_indices = fused_topk(
                 x, input_gating, topk, renormalize=not use_deep_gemm
             )
-            return fused_experts(
+            return fused_experts_compatible(
                 x,
                 w1,
                 w2,
@@ -411,7 +406,7 @@ class BenchmarkWorker:
         use_deep_gemm: bool = False,
     ) -> tuple[dict[str, int], float]:
         current_platform.seed_everything(self.seed)
-        dtype_str = _get_config_dtype_str(
+        dtype_str = _get_config_dtype_str_compatible(
             dtype, use_int8_w8a16=use_int8_w8a16, use_fp8_w8a8=use_fp8_w8a8
         )
         # NOTE(woosuk): The current naming convention uses w2.shape[2], which
@@ -544,7 +539,7 @@ def save_configs(
     block_quant_shape: list[int],
     save_dir: str,
 ) -> None:
-    dtype_str = _get_config_dtype_str(
+    dtype_str = _get_config_dtype_str_compatible(
         dtype, use_int8_w8a16=use_int8_w8a16, use_fp8_w8a8=use_fp8_w8a8
     )
 
@@ -567,6 +562,136 @@ def get_weight_block_size_safety(config, default_value=None):
         return quantization_config.get("weight_block_size", default_value)
     return default_value
 
+
+def _get_config_dtype_str_compatible(
+    dtype: torch.dtype,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    **kwargs
+) -> str | None:
+    """Multi-level import fallback for _get_config_dtype_str function."""
+    try:
+        from vllm.model_executor.layers.fused_moe.config import (
+            _get_config_dtype_str as _original_func
+        )
+        return _original_func(
+            dtype,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            **kwargs
+        )
+    except ImportError:
+        try:
+            from vllm.model_executor.layers.fused_moe import (
+                _get_config_dtype_str as _original_func
+            )
+            return _original_func(
+                dtype,
+                use_fp8_w8a8=use_fp8_w8a8,
+                use_int8_w8a16=use_int8_w8a16,
+                use_int4_w4a16=use_int4_w4a16,
+                **kwargs
+            )
+        except ImportError:
+            try:
+                from vllm.model_executor.layers.fused_moe.layer import (
+                    _get_config_dtype_str as _original_func
+                )
+                return _original_func(
+                    dtype,
+                    use_fp8_w8a8=use_fp8_w8a8,
+                    use_int8_w8a16=use_int8_w8a16,
+                    use_int4_w4a16=use_int4_w4a16,
+                    **kwargs
+                )
+            except ImportError:
+                try:
+                    from vllm.model_executor.layers.fused_moe import FusedMoE
+                    if hasattr(FusedMoE, '_get_config_dtype_str'):
+                        return getattr(FusedMoE, '_get_config_dtype_str')(
+                            dtype,
+                            use_fp8_w8a8=use_fp8_w8a8,
+                            use_int8_w8a16=use_int8_w8a16,
+                            use_int4_w4a16=use_int4_w4a16,
+                            **kwargs
+                        )
+                except ImportError:
+                    pass
+                # Fallback implementation that mimics the original function's logic
+                if use_fp8_w8a8:
+                    return "fp8_w8a8"
+                elif use_int8_w8a16:
+                    return "int8_w8a16"
+                elif use_int4_w4a16:
+                    return "int4_w4a16"
+                elif dtype == torch.float:
+                    # avoiding cases where kernel fails when float32 MoE
+                    # use fp16/bfloat16 configs
+                    return "float32"
+                return None
+
+def make_quant_config_compatible(
+    quant_dtype, w1_scale, w2_scale, a1_scale, a2_scale, block_quant_shape
+):
+    """Compatible wrapper for FusedMoEQuantConfig.make() across vLLM versions."""
+    from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+    if quant_dtype is None:
+        return None
+    param_combinations = [
+        {
+            'quant_dtype': quant_dtype,
+            'w1_scale': w1_scale,
+            'w2_scale': w2_scale,
+            'a1_scale': a1_scale,
+            'a2_scale': a2_scale,
+            'block_quant_shape': block_quant_shape,
+        },
+        {
+            'quant_dtype': quant_dtype,
+            'w1_scale': w1_scale,
+            'w2_scale': w2_scale,
+            'a1_scale': a1_scale,
+            'a2_scale': a2_scale,
+        },
+        {
+            'dtype': quant_dtype,
+            'w1_scale': w1_scale,
+            'w2_scale': w2_scale,
+            'a1_scale': a1_scale,
+            'a2_scale': a2_scale,
+        },
+    ]
+    for params in param_combinations:
+        filtered_params = {k: v for k, v in params.items() if v is not None}
+        try:
+            return FusedMoEQuantConfig.make(**filtered_params)
+        except TypeError:
+            continue
+    raise TypeError(
+        "Unable to create FusedMoEQuantConfig with any known parameter combination."
+    )
+
+def fused_experts_compatible(
+    x,
+    w1,
+    w2,
+    topk_weights,
+    topk_ids,
+    inplace=True,
+    quant_config=None,
+    allow_deep_gemm=False,
+):
+    """Compatible wrapper for fused_experts function."""
+    from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
+    sig = inspect.signature(fused_experts)
+    kwargs = {'inplace': inplace}
+    if 'quant_config' in sig.parameters:
+        kwargs['quant_config'] = quant_config
+    if 'allow_deep_gemm' in sig.parameters:
+        kwargs['allow_deep_gemm'] = allow_deep_gemm
+    return fused_experts(x, w1, w2, topk_weights, topk_ids, **kwargs)
 
 def main(args: argparse.Namespace):
     print(args)
@@ -664,8 +789,8 @@ def main(args: argparse.Namespace):
 
     if current_platform.is_rocm() and "HIP_VISIBLE_DEVICES" in os.environ:
         # Ray will set ROCR_VISIBLE_DEVICES for device visibility
-        logger.warning(
-            "Ray uses ROCR_VISIBLE_DEVICES to control device accessibility."
+        print(
+            "Ray uses ROCR_VISIBLE_DEVICES to control device accessibility. "
             "Replacing HIP_VISIBLE_DEVICES with ROCR_VISIBLE_DEVICES."
         )
         val = os.environ["HIP_VISIBLE_DEVICES"]


### PR DESCRIPTION
Title: Enhance benchmark_moe.py: vLLM Version Compatibility Fixes

Description:
This PR introduces compatibility fixes to `benchmarks/kernels/benchmark_moe.py` to support multiple vLLM versions and prevent runtime import/parameter errors. These errors occurred while I was optimizing Qwen3- Coder-30B-A3B-Instruct-FP8:

1. ImportError: cannot import name '_get_config_dtype_str'
   - Added a multi-level import fallback that searches possible module locations and class methods for `_get_config_dtype_str` and provides a fallback implementation when unavailable.

2. TypeError: FusedMoEQuantConfig.make() parameter incompatibility
   - Implemented `make_quant_config_compatible()` which tries multiple parameter combinations (including `quant_dtype`, `dtype`, with/without `block_quant_shape`) to create `FusedMoEQuantConfig` across versions.

3. TypeError: fused_experts() parameter incompatibility
   - Implemented `fused_experts_compatible()` which inspects `fused_experts` signature and only passes supported parameters (`quant_config`, `allow_deep_gemm`, etc.).

Signed-off-by: massif-01 <massif0601@gmail.com>

