### PR TITLE
[Hardware][AWS Neuron] allow device_name/device_type to support neuron in plugin

### DIFF
--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -68,7 +68,7 @@ class DeviceConfig:
                 self.device_type = self.device.type
 
         # Some device types require processing inputs on CPU
-        if self.device_type in ["tpu"]:
+        if self.device_type in ["tpu", "neuron"]:
             self.device = None
         else:
             # Set device with device type

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -350,7 +350,12 @@ class GroupCoordinator:
         elif current_platform.is_xpu():
             self.device = torch.device(f"xpu:{local_rank}")
         elif current_platform.is_out_of_tree():
-            self.device = torch.device(f"{current_platform.device_name}:{local_rank}")
+            if current_platform.device_name in ["neuron"]:
+                self.device = torch.device("cpu")
+            else:
+                self.device = torch.device(
+                    f"{current_platform.device_name}:{local_rank}"
+                )
         else:
             self.device = torch.device("cpu")
 


### PR DESCRIPTION
The PR allows [vLLM Neuron plugin](https://github.com/vllm-project/vllm-neuron/tree/main) to specify `device_name` and `device_type` as `neuron`, instead of the current value as `cpu` ([code link](https://github.com/vllm-project/vllm-neuron/blob/97bb42983f99aebfc1bd3a5bb28c7af9814527c2/vllm_neuron/platform.py#L27-L28)).

This PR does not impact other platforms. Tests have been conducted to make sure Neuron plugin works.


