### PR TITLE
[Benchmark] Add support for list of tokenized ids for custom dataset

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -1936,15 +1936,24 @@ class CustomDataset(BenchmarkDataset):
                 break
             prompt = item["prompt"]
 
-            # apply template
-            if not skip_chat_template:
-                prompt = tokenizer.apply_chat_template(
-                    [{"role": "user", "content": prompt}],
-                    add_generation_prompt=True,
-                    tokenize=False,
-                )
+            if isinstance(prompt, list):
+                # Prompt is a list of token IDs
+                if not all(isinstance(token_id, int) for token_id in prompt):
+                    raise ValueError(
+                        f"Prompt must be either a string or a list of integers, "
+                        f"got list with non-integer elements at index {i}"
+                    )
+                prompt_len = len(prompt)
+            else:
+                # Prompt is a string, apply template if needed
+                if not skip_chat_template:
+                    prompt = tokenizer.apply_chat_template(
+                        [{"role": "user", "content": prompt}],
+                        add_generation_prompt=True,
+                        tokenize=False,
+                    )
+                prompt_len = len(tokenizer(prompt).input_ids)
 
-            prompt_len = len(tokenizer(prompt).input_ids)
             sampled_requests.append(
                 SampleRequest(
                     prompt=prompt,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
A simple benchmark enhancement to support not only the string in the custom dataset(https://docs.vllm.ai/en/latest/contributing/benchmarks.html#online-benchmark), but also list of token ids.

Before:
```
{"prompt": "What is the capital of India?"}
{"prompt": "What is the capital of Iran?"}
{"prompt": "What is the capital of China?"}
```
After(addition):
```
{"prompt": [1, 2, 3]}
{"prompt": [1, 2, 4]}
{"prompt": [1, 2, 5]}
```

Why?
1. The `/v1/completions` endpoint support list of tokenized ids as input, there's no reason not to support it in the benchmark suite.
2. To replay tokenized traces like https://github.com/kvcache-ai/Mooncake/blob/main/FAST25-release/traces/conversation_trace.jsonl, it's not convenient/accurate to convert them back to prompt in string format.
## Test Plan
Test tokenized jsonl like this with the same command.
```
{"prompt": [1, 2, 3]}
{"prompt": [1, 2, 4]}
{"prompt": [1, 2, 5]}
```
## Test Result
The result remains the same.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

