### PR TITLE
[ROCM] Enable CompressedTensorsWNA16

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -142,7 +142,7 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
             # group_size=None means channelwise
             group_size = weight_quant.group_size or -1
             # Prefer to use the MarlinMoE kernel when it is supported.
-            if not check_moe_marlin_supports_layer(layer, group_size):
+            if not check_moe_marlin_supports_layer(layer, group_size) or current_platform.is_rocm():
                 if (
                     weight_quant.strategy == QuantizationStrategy.GROUP
                     and weight_quant.actorder

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -142,7 +142,10 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
             # group_size=None means channelwise
             group_size = weight_quant.group_size or -1
             # Prefer to use the MarlinMoE kernel when it is supported.
-            if not check_moe_marlin_supports_layer(layer, group_size) or current_platform.is_rocm():
+            if (
+                not check_moe_marlin_supports_layer(layer, group_size)
+                or current_platform.is_rocm()
+            ):
                 if (
                     weight_quant.strategy == QuantizationStrategy.GROUP
                     and weight_quant.actorder


### PR DESCRIPTION
I'm currently using ROCM with RDNA3. I've been trying to use compressed-tensors for a while, and I thought it was only supported on CUDA.

This change simply avoids entering: CompressedTensorsWNA16MarlinMoEMethod for CUDA when using ROCM and allows inference of a model like the following:

[jart25/Qwen3-VL-30B-A3B-Instruct-AWQ-8bit
](https://huggingface.co/jart25/Qwen3-VL-30B-A3B-Instruct-AWQ-8bit)
using: CompressedTensorsWNA16MoEMethod and ExllamaLinearKernel

Note that it must be run with:

export VLLM_USE_TRITON_AWQ=1