### PR TITLE
[Bugfix][CI] Fix `Distributed Tests (4 GPUs)` async_sched+ray test

### DIFF
--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -78,6 +78,9 @@ async def generate(
 async def test_load(
     output_kind: RequestOutputKind, data_parallel_backend: str, async_scheduling: bool
 ):
+    if async_scheduling and data_parallel_backend == "ray":
+        # TODO(NickLucche) Re-enable when async scheduling is supported
+        pytest.skip("Async scheduling is not supported with ray")
     stats_loggers = {}
 
     @dataclass


### PR DESCRIPTION
Fix issue currently on CI:

```
[2025-10-20T13:11:22Z] E           ValueError: Currently, async scheduling only supports `mp` or `uni` distributed executor backend, but you choose `ray`.
[2025-10-20T13:11:22Z]
[2025-10-20T13:11:22Z] /usr/local/lib/python3.12/dist-packages/vllm/engine/arg_utils.py:1513: ValueError
[2025-10-20T13:11:22Z] =============================== warnings summary ===============================
[2025-10-20T13:11:22Z] <frozen importlib._bootstrap>:488
[2025-10-20T13:11:22Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
[2025-10-20T13:11:22Z]
[2025-10-20T13:11:22Z] <frozen importlib._bootstrap>:488
[2025-10-20T13:11:22Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
[2025-10-20T13:11:22Z]
[2025-10-20T13:11:22Z] ../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
[2025-10-20T13:11:22Z]   /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
[2025-10-20T13:11:22Z]     ref_error: type[Exception] = jsonschema.RefResolutionError,
[2025-10-20T13:11:22Z]
[2025-10-20T13:11:22Z] tests/v1/distributed/test_async_llm_dp.py::test_load[True-mp-RequestOutputKind.DELTA]
[2025-10-20T13:11:22Z] tests/v1/distributed/test_async_llm_dp.py::test_load[True-mp-RequestOutputKind.DELTA]
[2025-10-20T13:11:22Z] tests/v1/distributed/test_async_llm_dp.py::test_load[True-mp-RequestOutputKind.DELTA]
[2025-10-20T13:11:22Z] tests/v1/distributed/test_async_llm_dp.py::test_load[True-mp-RequestOutputKind.FINAL_ONLY]
[2025-10-20T13:11:22Z] tests/v1/distributed/test_async_llm_dp.py::test_load[True-mp-RequestOutputKind.FINAL_ONLY]
[2025-10-20T13:11:22Z] tests/v1/distributed/test_async_llm_dp.py::test_load[True-mp-RequestOutputKind.FINAL_ONLY]
[2025-10-20T13:11:22Z]   /usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=9294) is multi-threaded, use of fork() may lead to deadlocks in the child.
[2025-10-20T13:11:22Z]     self.pid = os.fork()
[2025-10-20T13:11:22Z]
[2025-10-20T13:11:22Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
[2025-10-20T13:11:22Z] =========================== short test summary info ============================
[2025-10-20T13:11:22Z] FAILED v1/distributed/test_async_llm_dp.py::test_load[True-ray-RequestOutputKind.DELTA] - ValueError: Currently, async scheduling only supports `mp` or `uni` distributed executor backend, but you choose `ray`.
[2025-10-20T13:11:22Z] !!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
```
