### PR TITLE
[Feature] Added Prefix Repetition with Random Lengths dataset

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -3242,7 +3242,8 @@ class PrefixRepetitionRandomLengthsDataset(BenchmarkDataset):
             prompt_len = len(combined_tokens)
             # Keep a buffer of 10 tokens from max_model_len
             output_len = max(1, min(int(np.random.normal(
-                loc=output_len_mean, scale=output_len_std)), max_model_len - input_len - 10))
+                loc=output_len_mean, scale=output_len_std)),
+                max_model_len - input_len - 10))
 
             requests.append(
                 SampleRequest(


### PR DESCRIPTION
## Purpose

Fixes issue: #27129

vLLM’s bench serve currently supports a [PrefixRepetitionRandomDataset](https://github.com/vllm-project/vllm/blob/f50cc221ea7861686fec5ae9e949018c9628f328/vllm/benchmarks/datasets.py#L2945) for generating prompts with fixed-length prefix and suffix lengths. It also has support for a [RandomDataset](https://github.com/vllm-project/vllm/blob/f50cc221ea7861686fec5ae9e949018c9628f328/vllm/benchmarks/datasets.py#L441) which samples input and expected output lengths from a distribution and a fixed prefix length. For my use case benchmarking [llm-d ](https://github.com/llm-d/llm-d)which uses vLLM, I would like to combine the two into a PrefixRandomLengthsDataset, which allows the following:

* sampling input lengths from a distribution, given input length mean and standard deviation
* sampling expected output lengths from a distribution, given output length mean and standard deviation
* sampling prefix hit ratio from a distribution, given prefix hit ratio mean and standard deviation.

## Test Plan

How to run the new dataset with vllm bench serve:

```
vllm bench serve --dataset-name prefix_repetition_with_random_lengths --model <model_of_choice>
```

## Test Result

With the new dataset, you should still be able to see the benchmark metrics printed out.

cc @sriumcp, @toslali-ibm