### PR TITLE
[Kernel] Support attention sinks in vLLM

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -37,8 +37,8 @@ if(VLLM_FLASH_ATTN_SRC_DIR)
 else()
   FetchContent_Declare(
           vllm-flash-attn
-          GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG a893712401d70362fbb299cd9c4b3476e8e9ed54
+          GIT_REPOSITORY https://github.com/dudugong-gitch/flash-attention.git
+          GIT_TAG 0ff951ce9faa60570f41c00717d216a146d9ada8
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -493,9 +493,6 @@ class FlashAttentionImpl(AttentionImpl):
 
         self.sinks = sinks
         if self.sinks is not None:
-            assert self.vllm_flash_attn_version == 3, (
-                "Sinks are only supported in FlashAttention 3"
-            )
             assert self.sinks.shape[0] == num_heads, (
                 "Sinks must have the same number of heads as the number of "
                 "heads in the layer"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Support attention sinks for flash attention2. Add GPT-OSS 20b accuracy numbers so that the vLLM CI can safely pick up this branch.
## Test Plan
use the following test code testing hellaswag and mmlu, getting socres 42.20%,72.8% respectively:
#################################################
"""
Quick accuracy smoke test for GPT-OSS.
Supports MMLU & HellaSwag; auto-download dataset or use local dir.
VLLM_FLASH_ATTN_VERSION=2 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 '/workspace/test_accuacy.py' --model /workspace/model/gptoss20b/ --datasets mmlu
VLLM_FLASH_ATTN_VERSION=2 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 '/workspace/test_accuacy.py' --model /workspace/model/gptoss20b/ --datasets hellaswag
"""
import argparse
import json
import os
import re
from pathlib import Path

import torch
import datasets
from vllm import LLM, SamplingParams

TASK2CHOICES = {"mmlu": 4, "hellaswag": 4}

def local_vllm_generate(model_path, prompts):
    llm = LLM(model=model_path, tensor_parallel_size=torch.cuda.device_count())
    params = SamplingParams(temperature=0, max_tokens=16, stop=["\n"])
    outputs = llm.generate(prompts, params, use_tqdm=False)
    return [out.outputs[0].text.strip() for out in outputs]

def extract_choice(text):
    m = re.search(r'\b([A-D])\b', text.upper())
    return m.group(1) if m else None

def load_dataset_local(task, data_root, limit):
    if task == "mmlu":
        files = list(Path(data_root).joinpath("mmlu").glob("*.csv"))
        if not files:
            raise FileNotFoundError(f"no csv found under {data_root}/mmlu")
        ds = datasets.load_dataset("csv", data_files={"test": files})["test"]
    else:  # hellaswag
        val_file = Path(data_root).joinpath("hellaswag_val.jsonl")
        if not val_file.exists():
            raise FileNotFoundError(f"{val_file} not found")
        ds = datasets.load_dataset("json", data_files={"validation": str(val_file)})["validation"]
    return ds.select(range(min(limit, len(ds))))

def eval_one(task, model_path, data_root=None, limit=500):
    if data_root:
        dataset = load_dataset_local(task, data_root, limit)
    else:
        if task == "mmlu":
            dataset = datasets.load_dataset("cais/mmlu", "all", split=f"test[:{limit}]")
        else:  # hellaswag
            dataset = datasets.load_dataset("hellaswag", split=f"validation[:{limit}]")

    prompts, labels = [], []
    for row in dataset:
        if task == "mmlu":
            q, choices, lab = row["question"], row["choices"], int(row["answer"])
            prompt = f"{q}\n" + "\n".join([f"{chr(65+i)}. {c}" for i, c in enumerate(choices)]) + "\nAnswer:"
            labels.append(chr(65 + lab))
        else:  # hellaswag
            ctx, endings, lab = row["ctx"], row["endings"], int(row["label"])
            prompt = f"{ctx}\n" + "\n".join([f"{chr(65+i)}. {e}" for i, e in enumerate(endings)]) + "\nAnswer:"
            labels.append(chr(65 + lab))
        prompts.append(prompt)

    preds = local_vllm_generate(model_path, prompts)
    preds = [extract_choice(p) or "A" for p in preds]
    acc = sum(p == l for p, l in zip(preds, labels)) / len(labels)
    return acc

def main():
    ap = argparse.ArgumentParser()
    ap.add_argument("--model", required=True, help="local path to GPT-OSS")
    ap.add_argument("--datasets", nargs="+", default=["mmlu", "hellaswag"],
                    choices=list(TASK2CHOICES.keys()))
    ap.add_argument("--dataset_path", default=None,
                    help="local root folder with mmlu/*.csv & hellaswag_val.jsonl; None=auto download")
    ap.add_argument("--limit", type=int, default=500, help="samples per set")
    args = ap.parse_args()

    results = {}
    for d in args.datasets:
        print(f"\nRunning {d} ...")
        results[d] = eval_one(d, args.model, args.dataset_path, args.limit)
        print(f"{d}: {results[d]:.2%}")

    with open("ci_results.json", "w") as f:
        json.dump(results, f, indent=2)
    print("\nci_results.json saved.")

if __name__ == "__main__":
    main()

#################################################

## Test Result
hellaswag: 42.20%
mmlu: 72.8%
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Support attention sinks for flash attention2".
- [ ] The test plan: VLLM_FLASH_ATTN_VERSION=2 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 '/workspace/test_accuacy.py' --model /workspace/model/gptoss20b/ --datasets mmlu
- [ ] The test results: hellaswag: 42.20%, mmlu: 72.8%
(https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

