### PR TITLE
[Kernel] Re-enable mrope triton kernel for CUDA/ROCM platform by default

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -538,6 +538,13 @@ class VllmConfig:
                 self.compilation_config.cudagraph_mode.has_full_cudagraphs()
             )
 
+            # enable mrope custom op with triton kernel when model uses mrope
+            if (
+                self.model_config.uses_mrope
+                and "-mrope" not in self.compilation_config.custom_ops
+            ):
+                self.compilation_config.custom_ops.append("+mrope")
+
         if self.parallel_config.enable_dbo:
             a2a_backend = self.parallel_config.all2all_backend
             assert a2a_backend in ["deepep_low_latency", "deepep_high_throughput"], (

--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -5,8 +5,7 @@
 import numpy as np
 import torch
 
-from vllm.config import get_cached_compilation_config
-from vllm.platforms import current_platform
+from vllm.model_executor.custom_op import CustomOp
 from vllm.triton_utils import tl, triton
 
 from .base import RotaryEmbedding
@@ -201,6 +200,7 @@ def apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.T
     return x_t
 
 
+@CustomOp.register(name="mrope")
 class MRotaryEmbedding(RotaryEmbedding):
     """Rotary Embedding with Multimodal Sections."""
 
@@ -250,15 +250,6 @@ class MRotaryEmbedding(RotaryEmbedding):
         self.mrope_interleaved = mrope_interleaved
         if self.mrope_section:
             assert sum(self.mrope_section) == rotary_dim // 2
-
-    @classmethod
-    def enabled(cls) -> bool:
-        enabled = super().enabled()
-        compilation_config = get_cached_compilation_config()
-        custom_ops = compilation_config.custom_ops
-        disabled = hasattr(cls, "name") and f"-{cls.name}" in custom_ops
-        use_triton = current_platform.is_cuda_alike()
-        return (use_triton or enabled) and not disabled
 
     def _compute_inv_freq(self, base: float) -> torch.Tensor:
         if self.scaling_factor is None:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Discussion: https://vllm-dev.slack.com/archives/C07QCGVDNUF/p1760976569264999
- #24444 also disabled mrope triton kernel on CUDA/ROCM by default, this PR re-enable it for CUDA/ROCM platform by default without affecting OOT platform.

cc @tjtanaa @ProExpertProg

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

