### PR TITLE
ARM64 CUDA 12.9 wheels built and uploaded to index incorrectly

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -8,7 +8,7 @@ steps:
     commands:
       # #NOTE: torch_cuda_arch_list is derived from upstream PyTorch build files here:
       # https://github.com/pytorch/pytorch/blob/main/.ci/aarch64_linux/aarch64_ci_build.sh#L7
-      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.9.1 --build-arg VLLM_MAIN_CUDA_VERSION=12.9 --build-arg torch_cuda_arch_list='8.7 8.9 9.0 10.0+PTX 12.0' --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.9.1 --build-arg torch_cuda_arch_list='8.7 8.9 9.0 10.0+PTX 12.0' --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
       - "mkdir artifacts"
       - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
       - "bash .buildkite/scripts/upload-wheels.sh"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -116,9 +116,6 @@ ENV UV_LINK_MODE=copy
 # as it was causing spam when compiling the CUTLASS kernels
 RUN apt-get install -y gcc-10 g++-10
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 110 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-RUN <<EOF
-gcc --version
-EOF
 
 # Workaround for https://github.com/openai/triton/issues/2507 and
 # https://github.com/pytorch/pytorch/issues/107960 -- hopefully


### PR DESCRIPTION
# Fix: arm wheels tagged incorrectly

Related to: https://vllm-dev.slack.com/archives/C07R5PAL2L9/p1760721161081999

## Issue

The vLLM wheels index contains both `arm64` and `amd64` wheels for CUDA, however the wheel for arm does not contain the `cu<CUDA_VERSION>` identifier, while the `amd64` one is.

## Cause

I believe this is happening because in the `arm` wheel pipeline we pass `VLLM_MAIN_CUDA_VERSION` as `12.9` which it understands to be the same Major and Minor version as `CUDA_VERSION` of `12.9.1` for this pipeline - as a result it omits the `cu129` identifier from the build. This should fix our release pipeline to ensure wheels match the index generated for them and are consistent with the `x86_64` ones.

cc @wseaton @simon-mo @khluu