### PR TITLE
[Bugfix] Fix broken MTP weight loading for FP8 KV Scales

### DIFF
--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -16,7 +16,10 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
@@ -276,6 +279,10 @@ class DeepSeekMTP(nn.Module, SupportsPP):
                 else:
                     # Skip loading extra bias for GPTQ models.
                     if name.endswith(".bias") and name not in params_dict:
+                        continue
+
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
                         continue
 
                     # According to DeepSeek-V3 Technical Report, MTP modules


### PR DESCRIPTION
## Purpose

`maybe_remap_kv_scale_name` is a part of the DS weight loading logic, but it missing from MTP. This causes a crash when loading, for example, `nvidia/DeepSeek-R1-0528-FP4` with MTP which uses this feature by default.

## Test Plan

LM Eval GSM8k of `nvidia/DeepSeek-R1-0528-FP4` on 4xB200:


## Test Result

```
local-completions (base_url=http://0.0.0.0:8049/v1/completions,model=nvidia/DeepSeek-R1-0528-FP4,tokenized_requests=False,tokenizer_backend=None,num_concurrent=128,timeout=120,max_retries=5), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9530|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9484|±  |0.0061|
```
