### PR TITLE
[Quantization] Support pre-load  online quantization for  compressed-tensors W8A8 channel-wise schema

### DIFF
--- a/docs/features/quantization/fp8.md
+++ b/docs/features/quantization/fp8.md
@@ -140,7 +140,7 @@ print(result[0].outputs[0].text)
 
 ### Online Channelwise Quantization
 
-For improved accuracy with online quantization, vLLM supports **channelwise quantization** using the `compressed-tensors` quantization method. This approach quantizes weights on a per-channel basis during model loading, providing better accuracy than per-tensor quantization while still requiring no calibration data.
+vLLM supports **channelwise quantization** using the `compressed-tensors` quantization method. This approach quantizes weights on a per-channel basis during model loading, providing better accuracy than per-tensor quantization while still requiring no calibration data.
 
 To enable channelwise online quantization, use both the `--quantization` and `--quantization-schema` flags:
 
@@ -169,7 +169,6 @@ This mode provides:
 - **Per-channel weight quantization**: Each output channel of weight matrices gets its own scale factor, preserving more information than per-tensor scaling
 - **Dynamic per-token activation quantization**: Activations are quantized dynamically per token for maximum accuracy
 - **No calibration required**: Quantization happens automatically during model loading based on the weight statistics
-- **Better accuracy**: Channelwise quantization typically provides better accuracy than per-tensor quantization, especially for models with varying weight distributions across channels
 
 !!! note
     Channelwise quantization is currently supported for FP8 (W8A8) with the `compressed-tensors` quantization method. It uses static per-channel quantization for weights and dynamic per-token quantization for activations.

--- a/docs/features/quantization/fp8.md
+++ b/docs/features/quantization/fp8.md
@@ -138,5 +138,41 @@ result = llm.generate("Hello, my name is")
 print(result[0].outputs[0].text)
 ```
 
+### Online Channelwise Quantization
+
+For improved accuracy with online quantization, vLLM supports **channelwise quantization** using the `compressed-tensors` quantization method. This approach quantizes weights on a per-channel basis during model loading, providing better accuracy than per-tensor quantization while still requiring no calibration data.
+
+To enable channelwise online quantization, use both the `--quantization` and `--quantization-schema` flags:
+
+```bash
+vllm serve meta-llama/Llama-3-8B-Instruct \
+  --quantization compressed-tensors \
+  --quantization-schema fp8_channelwise
+```
+
+Or in Python:
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    "meta-llama/Llama-3-8B-Instruct",
+    quantization="compressed-tensors",
+    quantization_schema="fp8_channelwise"
+)
+result = llm.generate("Hello, my name is")
+print(result[0].outputs[0].text)
+```
+
+This mode provides:
+
+- **Per-channel weight quantization**: Each output channel of weight matrices gets its own scale factor, preserving more information than per-tensor scaling
+- **Dynamic per-token activation quantization**: Activations are quantized dynamically per token for maximum accuracy
+- **No calibration required**: Quantization happens automatically during model loading based on the weight statistics
+- **Better accuracy**: Channelwise quantization typically provides better accuracy than per-tensor quantization, especially for models with varying weight distributions across channels
+
+!!! note
+    Channelwise quantization is currently supported for FP8 (W8A8) with the `compressed-tensors` quantization method. It uses static per-channel quantization for weights and dynamic per-token quantization for activations.
+
 !!! warning
     Currently, we load the model at original precision before quantizing down to 8-bits, so you need enough memory to load the whole model.

--- a/tests/quantization/test_fp8_channelwise.py
+++ b/tests/quantization/test_fp8_channelwise.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for FP8 channelwise quantization utilities.
+
+Run `pytest tests/quantization/test_fp8_channelwise.py`.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    fp8_channelwise_quantize,
+)
+from vllm.platforms import current_platform
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="FP8 channelwise quantization requires CUDA",
+)
+class TestFp8ChannelwiseQuantize:
+    """Test suite for fp8_channelwise_quantize function."""
+
+    def test_basic_quantization(self):
+        """Test basic quantization with standard input."""
+        x = torch.randn(4, 8, dtype=torch.float32, device="cuda")
+        quantized, scale = fp8_channelwise_quantize(x)
+
+        # Check output types and shapes
+        assert quantized.dtype == current_platform.fp8_dtype()
+        assert scale.dtype == torch.float32
+        assert quantized.shape == x.shape
+        assert scale.shape == (4, 1)  # Per-channel scale
+
+    def test_different_dtypes(self):
+        """Test quantization with different float input dtypes."""
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            x = torch.randn(4, 8, dtype=dtype, device="cuda")
+            quantized, scale = fp8_channelwise_quantize(x)
+
+            assert quantized.dtype == current_platform.fp8_dtype()
+            assert scale.dtype == dtype
+
+    def test_custom_channel_dim(self):
+        """Test quantization with custom channel dimension."""
+        x = torch.randn(4, 8, 16, dtype=torch.float32, device="cuda")
+        quantized, scale = fp8_channelwise_quantize(x, channel_dim=1)
+
+        assert quantized.shape == x.shape
+        assert scale.shape == (4, 1, 16)
+
+    def test_dequantization_accuracy(self):
+        """Test that quantization-dequantization has reasonable accuracy."""
+        x = torch.randn(4, 8, dtype=torch.float32, device="cuda")
+        quantized, scale = fp8_channelwise_quantize(x.clone())
+
+        # Dequantize
+        dequantized = quantized.to(torch.float32) * scale
+
+        # Check relative error
+        relative_error = torch.abs(x - dequantized) / (torch.abs(x) + 1e-6)
+        assert torch.mean(relative_error) < 0.1  # 10% average error
+
+    def test_per_channel_independence(self):
+        """Test that channels are quantized independently."""
+        x = torch.randn(4, 8, dtype=torch.float32, device="cuda")
+
+        # Make channels have very different scales
+        x[0] = x[0] * 100.0
+        x[1] = x[1] * 0.01
+
+        quantized, scale = fp8_channelwise_quantize(x)
+
+        # Scales should be different across channels
+        assert scale[0] > scale[1]  # First channel should have larger scale
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="FP8 channelwise quantization requires CUDA",
+)
+class TestFp8ChannelwiseQuantizeValidation:
+    """Test suite for input validation of fp8_channelwise_quantize."""
+
+    def test_empty_tensor_raises(self):
+        """Test that empty tensor raises assertion error."""
+        x = torch.tensor([], dtype=torch.float32, device="cuda")
+        with pytest.raises(AssertionError, match="Input tensor must not be empty"):
+            fp8_channelwise_quantize(x)
+
+    def test_scalar_tensor_raises(self):
+        """Test that scalar tensor raises assertion error."""
+        x = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+        with pytest.raises(
+            AssertionError, match="Input tensor must have at least 1 dimension"
+        ):
+            fp8_channelwise_quantize(x)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -20,9 +20,6 @@ from vllm.config.pooler import PoolerConfig
 from vllm.config.scheduler import RunnerType
 from vllm.config.utils import assert_hashable, config, getattr_iter
 from vllm.logger import init_logger
-from vllm.model_executor.layers.batch_invariant import (
-    vllm_is_batch_invariant,
-)
 from vllm.model_executor.layers.quantization import get_default_quantization_hf_config
 from vllm.platforms import current_platform
 from vllm.transformers_utils.config import (
@@ -464,10 +461,6 @@ class ModelConfig:
         if isinstance(self.hf_config_path, str):
             self.hf_config_path = maybe_model_redirect(self.hf_config_path)
 
-        quant_config_override = get_default_quantization_hf_config(
-            self.quantization, self.quantization_schema
-        )
-
         if callable(self.hf_overrides):
             hf_overrides_kw = {}
             hf_overrides_fn = self.hf_overrides
@@ -477,8 +470,12 @@ class ModelConfig:
             # We'll determine how to apply dict overrides after loading the config
             hf_overrides_kw = {}
             dict_overrides = {}
-            if quant_config_override:
-                dict_overrides["quantization_config"] = quant_config_override
+            if self.quantization_schema:
+                quant_config_override = get_default_quantization_hf_config(
+                    self.quantization, self.quantization_schema
+                )
+                if quant_config_override:
+                    dict_overrides["quantization_config"] = quant_config_override
             for key, value in self.hf_overrides.items():
                 if isinstance(value, dict):
                     if dict_overrides.get(key):

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -442,6 +442,7 @@ class EngineArgs:
     hf_overrides: HfOverrides = get_field(ModelConfig, "hf_overrides")
     tokenizer_revision: str | None = ModelConfig.tokenizer_revision
     quantization: QuantizationMethods | None = ModelConfig.quantization
+    quantization_schema: str | None = ModelConfig.quantization_schema
     enforce_eager: bool = ModelConfig.enforce_eager
     disable_custom_all_reduce: bool = ParallelConfig.disable_custom_all_reduce
     limit_mm_per_prompt: dict[str, int | dict[str, int]] = get_field(
@@ -620,6 +621,9 @@ class EngineArgs:
         )
         model_group.add_argument("--max-model-len", **model_kwargs["max_model_len"])
         model_group.add_argument("--quantization", "-q", **model_kwargs["quantization"])
+        model_group.add_argument(
+            "--quantization-schema", **model_kwargs["quantization_schema"]
+        )
         model_group.add_argument("--enforce-eager", **model_kwargs["enforce_eager"])
         model_group.add_argument("--max-logprobs", **model_kwargs["max_logprobs"])
         model_group.add_argument("--logprobs-mode", **model_kwargs["logprobs_mode"])
@@ -1192,6 +1196,7 @@ class EngineArgs:
             tokenizer_revision=self.tokenizer_revision,
             max_model_len=self.max_model_len,
             quantization=self.quantization,
+            quantization_schema=self.quantization_schema,
             enforce_eager=self.enforce_eager,
             max_logprobs=self.max_logprobs,
             logprobs_mode=self.logprobs_mode,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -931,6 +931,22 @@ class FusedMoE(CustomOp):
         expert_id: int,
         return_success: bool = False,
     ) -> bool | None:
+        results = self.quant_method.process_weights_before_loading(
+            self, param, loaded_weight
+        )
+        scale = results.get("scale", None)
+        loaded_weight = results.get("quantized", loaded_weight)
+        if scale is not None and hasattr(param, "scale"):
+            # load scale
+            scale_param = self.get_parameter(param.scale)
+            scale_param.weight_loader(
+                scale_param,
+                scale,
+                weight_name + "_scale",
+                shard_id,
+                expert_id,
+                return_success,
+            )
         if self.quant_config and self.quant_config.get_name() == "mxfp4":
             # (FIXME) for gpt-oss all experts are combined
             if "bias" in weight_name:

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -3,7 +3,10 @@
 
 from typing import Any, Literal, get_args
 
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+logger = init_logger(__name__)
 
 QuantizationMethods = Literal[
     "awq",
@@ -36,6 +39,8 @@ QuantizationMethods = Literal[
     "mxfp4",
     "petit_nvfp4",
 ]
+
+
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))
 
 # The customized quantization methods which will be added to this dict.
@@ -191,6 +196,12 @@ def get_default_quantization_hf_config(
             "quant_method": "compressed-tensors",
             "quantization_status": "compressed",
         }
+    logger.warning_once(
+        "No default quantization hf config found for quantization %s and "
+        "quantization_schema %s",
+        quantization,
+        quantization_schema,
+    )
     return {}
 
 

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Literal, get_args
+from typing import Any, Literal, get_args
 
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
@@ -156,6 +156,42 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     method_to_config.update(_CUSTOMIZED_METHOD_TO_QUANT_CONFIG)
 
     return method_to_config[quantization]
+
+
+def get_default_quantization_hf_config(
+    quantization: str, quantization_schema: str | None
+) -> dict[str, Any]:
+    if (
+        quantization == "compressed-tensors"
+        and quantization_schema == "fp8_channelwise"
+    ):
+        return {
+            "config_groups": {
+                "group_0": {
+                    "input_activations": {
+                        "dynamic": True,
+                        "num_bits": 8,
+                        "observer_kwargs": {},
+                        "strategy": "token",
+                        "type": "float",
+                    },
+                    "targets": ["Linear"],
+                    "weights": {
+                        "dynamic": False,
+                        "num_bits": 8,
+                        "observer": "minmax",
+                        "observer_kwargs": {},
+                        "strategy": "channel",
+                        "symmetric": True,
+                        "type": "float",
+                    },
+                }
+            },
+            "format": "float-quantized",
+            "quant_method": "compressed-tensors",
+            "quantization_status": "compressed",
+        }
+    return {}
 
 
 __all__ = [

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch import nn
 
+from vllm.model_executor.parameter import BasevLLMParameter
+
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization import QuantizationMethods
     from vllm.model_executor.models.utils import WeightsMapper
@@ -47,6 +49,18 @@ class QuantizeMethodBase(ABC):
         This can be used for example, to transpose weights for computation.
         """
         return
+
+    def process_weights_before_loading(
+        self,
+        layer: nn.Module,
+        param: torch.nn.Parameter | BasevLLMParameter,
+        weight: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Process the weight before loading.
+
+        This can be used for pre-load quantization to save memory usage.
+        """
+        return {}
 
 
 def method_has_implemented_embedding(method_class: type[QuantizeMethodBase]) -> bool:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -61,6 +61,7 @@ from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     cutlass_fp4_supported,
 )
+from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
@@ -822,6 +823,14 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.scheme.process_weights_after_loading(layer)
+
+    def process_weights_before_loading(
+        self,
+        layer: torch.nn.Module,
+        param: torch.nn.Parameter | BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        return layer.scheme.process_weights_before_loading(layer, param, loaded_weight)
 
     def create_weights(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -42,6 +42,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compress
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
     find_matched_target,
+    fp8_channelwise_quantize,
 )
 from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
@@ -593,6 +594,42 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         )
         self.disable_expert_map = False
 
+    def process_weights_before_loading(
+        self,
+        layer: torch.nn.Module,
+        param: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        current_platform_fp8_dtype = current_platform.fp8_dtype()
+        if self.weight_quant.strategy == QuantizationStrategy.CHANNEL:
+            if (
+                param.data.dtype == current_platform_fp8_dtype
+                and loaded_weight.dtype != current_platform_fp8_dtype
+            ):
+                logger.debug("Quantizing %s to fp8", layer.layer_name)
+                quantized, scale = fp8_channelwise_quantize(
+                    loaded_weight.to(param.data.device)
+                )
+                logger.debug("Quantizing %s to fp8 done", layer.layer_name)
+                return {
+                    "quantized": quantized,
+                    "scale": scale,
+                }
+            else:
+                return {}
+        else:
+            if (
+                param.data.dtype == current_platform_fp8_dtype
+                and loaded_weight.dtype != current_platform_fp8_dtype
+            ):
+                logger.warning(
+                    "Not supporting online quantization for strategy "
+                    " %s, this will lead to downcasting "
+                    "of your weight which could impact accuracy.",
+                    self.weight_quant.strategy,
+                )
+            return {}
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -702,6 +739,8 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             )
             set_weight_attrs(w13_weight_scale, extra_weight_attrs)
             set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+            set_weight_attrs(w13_weight, {"scale": "w13_weight_scale"})
+            set_weight_attrs(w2_weight, {"scale": "w2_weight_scale"})
 
         elif self.weight_quant.strategy == QuantizationStrategy.BLOCK:
             w13_weight_scale = torch.nn.Parameter(

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -446,6 +446,11 @@ class Llama4Model(LlamaModel):
         # [num_experts, hidden_in, hidden_out], so we must transpose the last
         # two dimensions to match the expected layout of the parameters.
         if fused and loaded_weight.ndim == 3:
+            if self.vllm_config.model_config.quantization_schema:
+                # For online quantization, load the weight to device
+                # before transpose to avoid expensive contiguous operators
+                param_device = list(params_dict.values())[0].device
+                loaded_weight = loaded_weight.to(param_device)
             loaded_weight = loaded_weight.transpose(-1, -2)
 
             # If the gate_proj and up_proj weights are fused into a single


### PR DESCRIPTION
## Purpose

Support pre-load online quantization for  compressed-tensors W8A8 channel-wise schema on bf16 ckpt.

-  **Memory Optimization**: This differentiates from the other online quantization approach that is post loading through `process_weights_after_loading`, we add quantization of weights through `process_weights_before_loading` when the hardware GPU can not hold the original dtype weights and cpu offloading is too slow. This approach quantize each weight while loading. This enables online dynamic quantization for **Llama4 Maverick Raw BF16 on H100**, which is not doable before.
- **Extendible**: The PR implements compressed-tensor fp8 channelwise (same as FP_dynamic in offline quantization), while the approach is extendible to other quantization method if the method implements process_weights_before_loading.
- **MOE and Linear Support**: This support both MOE and linear layers.
- **llama4 specific optimization**: Llama4 has a transposed/chunked fused weights when calling weight loader, this PR also has an improvement on llama4 model loading that copy to device before transpose/chunk happenning to avoid expensive contiguous (the model loading reduced from 40 minutes to 2 mintues)

```
 --quantization compressed-tensors \
--quantization-schema fp8_channelwise \
--hf-overrides '{"quantization_config":{"ignore":["re:.*self_attn","re:.*lm_head","re:.*router","re:.*vision_model","re:.*multi_modal_projector","re:.*feed_forward.gate_up_proj","re:.*feed_forward.down_proj", "re:.*shared_expert"]}}'
```

## Test Plan

### Online Serving
```
vllm serve /data/local/models/oss/Llama-4-Maverick-17B-128E-Instruct -tp 8 --quantization compressed-tensors --quantization-schema fp8_channelwise --hf-overrides '{"quantization_config":{"ignore":["re:.*self_attn","re:.*lm_head","re:.*router","re:.*vision_model","re:.*multi_modal_projector","re:.*feed_forward.gate_up_proj","re:.*feed_forward.down_proj", "re:.*shared_expert"]}}' --max_num_seqs 32 --max-model-len 32768
```

### UT/CI Tests

```
pytest tests/quantization/test_fp8_channelwise.py
pytest tests/quantization/tes
t_compressed_tensors.py -k "test_compressed_tensors_fp8_online_quantization_channelwise"
```

Added both llama3 and Qwen to guard linear and MOE models.

## Test Result

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.940|±  |0.0168|
|     |       |strict-match    |     5|exact_match|↑  |0.945|±  |0.0162|
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

