### PR TITLE
[compile] Disable dynamo guards check for AOT compilation.

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -302,6 +302,7 @@ def _support_torch_compile(
                     start_monitoring_torch_compile(self.vllm_config)
                     loaded_fn = torch.compiler.load_compiled_function(f)
                 _verify_source_unchanged(loaded_fn.source_info(), self.vllm_config)
+                loaded_fn.disable_guard_check()
                 self.aot_compiled_fn = loaded_fn
             except Exception as e:
                 if os.path.exists(aot_compilation_path):


### PR DESCRIPTION
Summary:

Fixing issue https://github.com/vllm-project/vllm/issues/27286

In AOT compilation, we turn on dynamo guards check by default. While they can be useful in general sense, in VLLM they mostly generate noise and cause compilation failure when there shouldn't be compile or recompiles. For example, I saw some CI failures over when we are changing the number of threads.

We should turn off dynamo guards check. AOT compilation provides a function called `disable_guards_check()` which can be used to resolve this.

Test Plan:

(with torch 2.10.dev)
pytest tests/basic_correctness/test_basic_correctness.py

Reviewers:

Subscribers:

Tasks:

Tags:


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

