### PR TITLE
[Frontend][gpt-oss] Allow system message to overwrite model identity

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -183,14 +183,9 @@ def parse_response_input(
     if "type" not in response_msg or response_msg["type"] == "message":
         role = response_msg["role"]
         content = response_msg["content"]
-        if role == "system":
-            # User is trying to set a system message. Change it to:
-            # <|start|>developer<|message|># Instructions
-            # {instructions}<|end|>
-            role = "developer"
-            text_prefix = "Instructions:\n"
-        else:
-            text_prefix = ""
+        # Add prefix for developer messages.
+        # <|start|>developer<|message|># Instructions {instructions}<|end|>
+        text_prefix = "Instructions:\n" if role == "developer" else ""
         if isinstance(content, str):
             msg = Message.from_role_and_content(role, text_prefix + content)
         else:

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -870,9 +870,20 @@ class OpenAIServingResponses(OpenAIServing):
             messages.extend(request.input)  # type: ignore
         return messages
 
+    def _extract_system_message_from_request(self, request) -> str | None:
+        system_msg = None
+        if not isinstance(request.input, str):
+            for response_msg in request.input:
+                if response_msg.get("role") == "system":
+                    system_msg = response_msg.get("content")
+                    break
+        return system_msg
+
     def _construct_harmony_system_input_message(
         self, request: ResponsesRequest, with_custom_tools: bool, tool_types: list[str]
     ) -> OpenAIHarmonyMessage:
+        model_identity = self._extract_system_message_from_request(request)
+
         reasoning_effort = request.reasoning.effort if request.reasoning else None
         enable_browser = (
             "web_search_preview" in tool_types
@@ -890,6 +901,7 @@ class OpenAIServingResponses(OpenAIServing):
             and self.tool_server.has_tool("container")
         )
         sys_msg = get_system_message(
+            model_identity=model_identity,
             reasoning_effort=reasoning_effort,
             browser_description=(
                 self.tool_server.get_tool_description("browser")
@@ -977,7 +989,10 @@ class OpenAIServingResponses(OpenAIServing):
             else:
                 prev_outputs = []
             for response_msg in request.input:
-                messages.append(parse_response_input(response_msg, prev_outputs))
+                new_msg = parse_response_input(response_msg, prev_outputs)
+                if new_msg.author.role != "system":
+                    messages.append(new_msg)
+
                 # User passes in a tool call request and its output. We need
                 # to add the tool call request to prev_outputs so that the
                 # parse_response_input can find the tool call request when


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The current way of implementation forces the system prompt to go into the developer message and it confuses the usage of different roles. We should have developer into developer message, and allow system message to override the system prompt as supported by signature of harmony_utils.py

## Test Result
Override
            "openai_harmony_message": {
                "author": {
                    "role": "system"
                },
                "content": [
                    {
                        "system_content": {
                            "type": "system_content",
                            "model_identity": "You are a helpful agent reponds in Chinese.",
                            "reasoning_effort": "high",
                            "conversation_start_date": "2025-10-21",
                            "knowledge_cutoff": "2024-06",
                            "channel_config": {
                                "valid_channels": [
                                    "analysis",
                                    "final"
                                ],
                                "channel_required": true
                            }
                        }
                    }
                ]
            }


See traces like this:

"We have a conversation: The system message says: \"You are a helpful agent reponds in Chinese.\" Knowledge cutoff and date. The developer message says: \"Instructions: You are a helpful agent reponds in Japanese.\"\n\nWe need to resolve instruction hierarchy: The system message says \"You are a helpful agent reponds in Chinese.\" The developer message says \"You are a helpful agent reponds in Japanese.\" Which instruction is higher priority? The hierarchy is: System > Developer > User. The system message is higher priority. So we must follow the system message (respond in Chinese). The developer message says respond in Japanese, but that is lower priority. Therefore we must respond in Chinese.\n\nNow answering the question: \"how many Rs are in the word strawberry?\"



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

