### PR TITLE
[Model][Bugfix] fix ernie45 moe 300B SharedFusedMoE output tuple

### DIFF
--- a/vllm/model_executor/models/ernie45_moe.py
+++ b/vllm/model_executor/models/ernie45_moe.py
@@ -215,6 +215,8 @@ class Ernie4_5_MoeMoE(nn.Module):
 
         if self.has_shared_experts:
             final_hidden_states = final_hidden_states[0] + final_hidden_states[1]
+        else:
+            final_hidden_states = final_hidden_states[1]
 
         if self.tp_size > 1:
             final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(


### PR DESCRIPTION
## Purpose

fix the following issue
``` text
ERROR 10-22 10:37:51 [multiproc_executor.py:695]   File "/root/paddlejob/wangyafeng/myGithub/vllm/vllm/model_executor/models/ernie45_moe.py", line 222, in forward
(Worker_TP5 pid=203750) (Worker_TP1 pid=203740) (Worker_TP6 pid=203751) ERROR 10-22 10:37:51 [multiproc_executor.py:695] Declaration: vllm::all_reduce(Tensor tensor, str group_name) -> Tensor
ERROR 10-22 10:37:51 [multiproc_executor.py:695]   File "/root/paddlejob/wangyafeng/myGithub/vllm/vllm/v1/worker/gpu_worker.py", line 280, in determine_available_memory
(Worker_TP7 pid=203752) ERROR 10-22 10:37:51 [multiproc_executor.py:695]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 10-22 10:37:51 [multiproc_executor.py:695]     final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(
(Worker_TP5 pid=203750) (Worker_TP1 pid=203740) (Worker_TP6 pid=203751) ERROR 10-22 10:37:51 [multiproc_executor.py:695] Cast error details: Unable to cast (None, tensor([[ 1.7700e-02, -1.8539e-03,  2.2650e-05,  ...,  1.3885e-03,
```

ERNIE-4.5-300B-A47B-PT non shared expert model, but the output of `SharedFuseMoE` is still tuple

Add an else branch to handle this situation
```python
if self.has_shared_experts:
    final_hidden_states = final_hidden_states[0] + final_hidden_states[1]
else:
    final_hidden_states = final_hidden_states[1]
```

## Test Plan
```bash
vllm serve baidu/ERNIE-4.5-300B-A47B-PT --tensor-parallel-size 8 --quantization fp8 --enforce-eager
```