### PR TITLE
[CI/Build] Fix test_torch_utils in AMD CI

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -50,7 +50,7 @@ steps:
 
 - label: Async Engine, Inputs, Utils, Worker Test # 36min
   timeout_in_minutes: 50
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:


### PR DESCRIPTION
## Purpose
Fix AMD/ROCm test failures in test_torch_utils.py by adding platform-specific stream behavior tests. The original
test_current_stream_multithread test assumed all platforms use the default CUDA stream (address 0x0), but ROCm intentionally creates dedicated streams for performance optimization with RCCL.
```
if not hasattr(_current_stream_tls, "value") or _current_stream_tls.value is None:
        # when this function is called before any stream is set,
        # we return the default stream.
        # On ROCm using the default 0 stream in combination with RCCL
        # is hurting performance. Therefore creating a dedicated stream
        # per process
        if current_platform.is_rocm():
            # torch.cuda.set_stream here is the alias of _pathed_set_stream
            torch.cuda.set_stream(torch.cuda.Stream())
        elif current_platform.is_cpu():
```
So the test is failing on AMD:
```
>           assert main_current_stream == main_default_stream, (
  | "Main thread's current_stream is not the default stream"
  | )
  | E           AssertionError: Main thread's current_stream is not the default stream
  | E           assert <torch.cuda.Stream device=cuda:0 cuda_stream=0x1e282410> == <torch.cuda.Stream device=cuda:0 cuda_stream=0x0>
  |  
  | utils_/test_torch_utils.py:93: AssertionError
  |  

<br class="Apple-interchange-newline">
```
## Test Plan

ROCM:
```
pytest -v -s tests/utils_/test_torch_utils.py
INFO 10-23 17:56:31 [__init__.py:225] Automatically detected platform rocm.
=============================================================== test session starts ================================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0 -- /home/zhewenli/uv_env/vllm-fork/bin/python3
cachedir: .pytest_cache
rootdir: /data/users/zhewenli/gitrepos/vllm-fork
configfile: pyproject.toml
plugins: anyio-4.11.0, asyncio-1.2.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 28 items                                                                                                                                 

tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype0-tgt_dtype0-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype1-tgt_dtype1-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype2-tgt_dtype2-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype3-tgt_dtype3-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype4-tgt_dtype4-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype5-tgt_dtype5-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype6-tgt_dtype6-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype7-tgt_dtype7-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype8-tgt_dtype8-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype9-tgt_dtype9-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype10-tgt_dtype10-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype11-tgt_dtype11-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype12-tgt_dtype12-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype13-tgt_dtype13-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype14-tgt_dtype14-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype15-tgt_dtype15-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype16-tgt_dtype16-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype17-tgt_dtype17-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype18-tgt_dtype18-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype19-tgt_dtype19-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype20-tgt_dtype20-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype21-tgt_dtype21-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype22-tgt_dtype22-False] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes0-expected_result0] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes1-expected_result1] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes2-expected_result2] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes3-expected_result3] PASSED
tests/utils_/test_torch_utils.py::test_current_stream_multithread PASSED

================================================================= warnings summary =================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 28 passed, 2 warnings in 8.33s ==========================================================
```

CUDA:
```
pytest -v -s tests/utils_/test_torch_utils.py
INFO 10-23 17:58:32 [__init__.py:225] Automatically detected platform cuda.
/home/zhewenli/uv_env/vllm/lib64/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================= test session starts ==========================================================
platform linux -- Python 3.12.11, pytest-8.3.5, pluggy-1.5.0 -- /home/zhewenli/uv_env/vllm/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/home/zhewenli/zhewen/vllm/.hypothesis/examples'))
rootdir: /home/zhewenli/zhewen/vllm
configfile: pyproject.toml
plugins: mock-3.14.0, timeout-2.3.1, subtests-0.14.1, anyio-4.6.2.post1, forked-1.6.0, rerunfailures-14.0, hypothesis-6.131.0, shard-0.1.2, asyncio-0.24.0, cov-6.3.0, buildkite-test-collector-0.1.9, schemathesis-3.39.15, hydra-core-1.3.2
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 28 items                                                                                                                     
Running 28 items in this shard: tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype0-tgt_dtype0-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype1-tgt_dtype1-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype2-tgt_dtype2-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype3-tgt_dtype3-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype4-tgt_dtype4-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype5-tgt_dtype5-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype6-tgt_dtype6-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype7-tgt_dtype7-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype8-tgt_dtype8-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype9-tgt_dtype9-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype10-tgt_dtype10-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype11-tgt_dtype11-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype12-tgt_dtype12-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype13-tgt_dtype13-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype14-tgt_dtype14-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype15-tgt_dtype15-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype16-tgt_dtype16-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype17-tgt_dtype17-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype18-tgt_dtype18-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype19-tgt_dtype19-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype20-tgt_dtype20-False], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype21-tgt_dtype21-True], tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype22-tgt_dtype22-False], tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes0-expected_result0], tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes1-expected_result1], tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes2-expected_result2], tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes3-expected_result3], tests/utils_/test_torch_utils.py::test_current_stream_multithread

tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype0-tgt_dtype0-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype1-tgt_dtype1-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype2-tgt_dtype2-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype3-tgt_dtype3-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype4-tgt_dtype4-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype5-tgt_dtype5-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype6-tgt_dtype6-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype7-tgt_dtype7-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype8-tgt_dtype8-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype9-tgt_dtype9-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype10-tgt_dtype10-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype11-tgt_dtype11-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype12-tgt_dtype12-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype13-tgt_dtype13-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype14-tgt_dtype14-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype15-tgt_dtype15-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype16-tgt_dtype16-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype17-tgt_dtype17-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype18-tgt_dtype18-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype19-tgt_dtype19-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype20-tgt_dtype20-False] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype21-tgt_dtype21-True] PASSED
tests/utils_/test_torch_utils.py::test_is_lossless_cast[src_dtype22-tgt_dtype22-False] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes0-expected_result0] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes1-expected_result1] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes2-expected_result2] PASSED
tests/utils_/test_torch_utils.py::test_common_broadcastable_dtype[dtypes3-expected_result3] PASSED
tests/utils_/test_torch_utils.py::test_current_stream_multithread PASSED

=========================================================== warnings summary ===========================================================
../../uv_env/vllm/lib64/python3.12/site-packages/torch/cuda/__init__.py:63
  /home/zhewenli/uv_env/vllm/lib64/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
    import pynvml  # type: ignore[import]

../../uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305
  /home/zhewenli/uv_env/vllm/lib64/python3.12/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 28 passed, 2 warnings in 6.57s ====================================================
```

This PR also enable the test in amd-ci:  ([build](https://buildkite.com/vllm/amd-ci/builds/468#019a0a4e-c6af-4cc2-a13b-e41dc58557ed))
<img width="1713" height="610" alt="Screenshot 2025-10-21 at 10 41 04 PM" src="https://github.com/user-attachments/assets/95efddcb-e1b0-4790-8731-272bf60fadb0" />
