### PR TITLE
[Bugfix][plugin] fla crash on plugin

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -17,6 +17,7 @@ from typing import Any, Literal
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import triton
 
 logger = logging.getLogger(__name__)
@@ -137,8 +138,8 @@ def _check_platform() -> Literal["nvidia", "amd", "intel", "musa"]:
 # For AMD GPUs, the triton backend is 'hip', while for Nvidia GPUs, the triton backend is 'cuda'.
 # However, the torch backend is 'cuda' for both Nvidia and AMD GPUs.
 # Therefore, we need to check the triton backend to determine the actual GPU vendor.
-device = get_available_device() if get_available_device() != "hip" else "cuda"
-device_torch_lib = getattr(torch, device)
+device = "cuda" if current_platform.is_cuda_alike() else get_available_device()
+device_torch_lib = getattr(torch, device, None)
 device_platform = _check_platform()
 
 is_amd = device_platform == "amd"


### PR DESCRIPTION

## Purpose
There's some problem while supporting fla on plugin. 
While importing the `fla/ops/utils`, it crashed on [here](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fla/ops/utils.py#L141).

Since in plugin the `device` might got their own value (here in vllm-metax is `maca`) and `device_torch_lib` still need to be their own. (here in vllm-metax is `torch.cuda`)

So I use is_cuda_alike  and set default value to None on `getattr` to make some compatibilities for handling the corner cases. The semantics should be consistent with the original code.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

