### PR TITLE
[Bugfix] Fix HF format InternVL large variants video processing

### DIFF
--- a/vllm/model_executor/models/interns1.py
+++ b/vllm/model_executor/models/interns1.py
@@ -184,6 +184,8 @@ class InternS1ProcessingInfo(BaseProcessingInfo):
         hf_processor.video_processor = cached_video_processor_from_config(
             self.ctx.model_config, processor_cls=InternVLVideoProcessor, **kwargs
         )
+        if hf_processor.video_processor.size != hf_processor.image_processor.size:
+            hf_processor.video_processor.size = hf_processor.image_processor.size
         return hf_processor
 
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:

--- a/vllm/model_executor/models/interns1.py
+++ b/vllm/model_executor/models/interns1.py
@@ -182,10 +182,11 @@ class InternS1ProcessingInfo(BaseProcessingInfo):
     def get_hf_processor(self, **kwargs: object) -> InternVLProcessor:
         hf_processor = self.ctx.get_hf_processor(InternVLProcessor, **kwargs)
         hf_processor.video_processor = cached_video_processor_from_config(
-            self.ctx.model_config, processor_cls=InternVLVideoProcessor, **kwargs
+            self.ctx.model_config,
+            processor_cls=InternVLVideoProcessor,
+            size=hf_processor.image_processor.size,
+            **kwargs,
         )
-        if hf_processor.video_processor.size != hf_processor.image_processor.size:
-            hf_processor.video_processor.size = hf_processor.image_processor.size
         return hf_processor
 
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix #27250
- For some issues from Transformers side, HF format InternVL's video processor doesn't respect `size` in `preprocessor_config.json`, this PR adds a workaround to fix it.

## Test Plan
```
vllm serve OpenGVLab/InternVL3_5-14B-HF
```

## Test Result
Model should work now.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

