### PR TITLE
[Bugfix] grafana.json: rename vllm:gpu_cache_usage_perc to vllm:kv_cache_usage_perc

### DIFF
--- a/examples/online_serving/prometheus_grafana/grafana.json
+++ b/examples/online_serving/prometheus_grafana/grafana.json
@@ -852,9 +852,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "vllm:gpu_cache_usage_perc{model_name=\"$model_name\"}",
+          "expr": "vllm:kv_cache_usage_perc{model_name=\"$model_name\"}",
           "instant": false,
-          "legendFormat": "GPU Cache Usage",
+          "legendFormat": "KV Cache Usage",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
## Purpose

Update `grafana.json` to rename the deprecated metric "vllm:gpu_cache_usage_perc" to "vllm:kv_cache_usage_perc". This change is required for Cache Utilization to display values on a Grafana dashboard as of vLLM 0.11.0.

For reference, the GPU cache usage metric was renamed and deprecated here: [vllm/v1/metrics/loggers.py#L415-L438](https://github.com/vllm-project/vllm/blob/main/vllm/v1/metrics/loggers.py#L415-L438)

## Test Plan

1. Install and run vLLM version 0.11.0
2. Configure Prometheus and Grafana as instructed here: https://docs.vllm.ai/en/latest/examples/online_serving/prometheus_grafana.html
3. In Grafana edit JSON model by renaming "vllm:gpu_cache_usage_perc" to "vllm:kv_cache_usage_perc" and "GPU Cache Usage" to "KV Cache Usage"

## Test Result

Success. Cache Utilization now displays values on the Grafana dashboard.
