### PR TITLE
[Bugfix] Disable FlexAttention direct block mask building for encoder-only models

### DIFF
--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -658,7 +658,10 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
             total_cache_tokens=total_cache_tokens,
             decode_offset=offset_tensor,
             num_blocks_per_seq=num_blocks_per_seq,
-            direct_build=self.direct_build,
+            # FIXME(Isotr0py): direct build has issue to build bidirectional
+            # attention block mask for encoder-only models, disable it temporarily.
+            # see: https://github.com/vllm-project/vllm/pull/27329#issuecomment-3431484053
+            direct_build=(self.direct_build and common_attn_metadata.causal),
             q_block_size=self.q_block_size,
             kv_block_size=self.kv_block_size,
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- The FP32 Mteb tests are failing after pytorch2.9 update, because `_build_block_mask_direct` return incorrect block mask shape. (https://buildkite.com/vllm/ci/builds/35829/steps/canvas?sid=019a0a13-ef28-4260-87f8-b6f4d685791a)
```
(EngineCore_DP0 pid=41725)   Developer debug context: raised exception ValueError([ConstantVariable(str: "block_mask was created for block_mask.shape=(1, 1, 7, 16) but got q_len=7 and kv_len=7. As the block mask was created for a larger length than you're using it for, you can either 1. create a new block mask with the correct length, or 2. 'adjust' the existing block mask to the correct length by calling block_mask._adjust(q_len, kv_len). This essentially 'crops' the block mask to the upper left corner, which does not work for all mask_mods!")])
```
- Let's disable it to unblock #27329 first, then fix the issue in a follow-up PR.

## Test Plan
```
pytest -s -v tests/models/language/pooling_mteb_test/test_st_projector.py -k test_embed_models_mteb[model_info1]
```

## Test Result
Test can still pass with `create_block_mask` code path

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

