### PR TITLE
[CI/Build] improve editable mode setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,12 @@ class cmake_build_ext(build_ext):
     # Perform cmake configuration for a single extension.
     #
     def configure(self, ext: CMakeExtension) -> None:
+        if self.editable_mode:
+            build_dir = Path.cwd() / "build"
+            build_dir.mkdir(exist_ok=True)
+            self.build_temp = build_dir.as_posix()
+            print(f"WARNING: editable mode, set {self.build_temp=} ")
+
         # If we've already configured using the CMakeLists.txt for
         # this extension, exit early.
         if ext.cmake_lists_dir in cmake_build_ext.did_config:


### PR DESCRIPTION

Improves incremental compilation speed by avoiding writing build files to temporary directories in editable mode installs, avoiding copies.


## Benchmarks

Testing out this build with

```bash
export UV_TORCH_BACKEND=cpu VLLM_TARGET_DEVICE=cpu
uv pip install --no-deps --no-build-isolation --editable .
```

### Without ccache/sccache

- fresh build: `0:47.60`
- cached build (existing `./build` dir with `cmake` artifacts): `0:05.05` (~10x speedup)

### With ccache/sccache

- fresh build, `sccache` cache miss: `0:47.39`
- fresh cpu build, no `./build` dir, sccache cache hit: `0:06.60`
- cached cpu build (existing `./build`), sccache cache hit: `0:04.98`
