### PR TITLE
[compile] Add fallback path to AOT compile when serialization fails.

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -402,8 +402,17 @@ def _support_torch_compile(
                     output = self.aot_compiled_fn(self, *args, **kwargs)
                     assert aot_compilation_path is not None
                     assert cache_dir is not None
-                    os.makedirs(cache_dir, exist_ok=True)
-                    self.aot_compiled_fn.save_compiled_function(aot_compilation_path)
+                    try:
+                        os.makedirs(cache_dir, exist_ok=True)
+                        self.aot_compiled_fn.save_compiled_function(
+                            aot_compilation_path
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Cannot save aot compilation to path %s, error: %s",
+                            aot_compilation_path,
+                            str(e),
+                        )
                 else:
                     output = self.compiled_callable(*args, **kwargs)
             return output


### PR DESCRIPTION
Summary:
Fixing issue https://github.com/vllm-project/vllm/issues/27348

For dynamo caching, it's possible that the compilation succeeds but the serialization step fails. In this case, the failure of serialization step shouldn't block user from getting compilation results correctly.

Therefore we add a handling of the serialization error and only give warning when model saving fails. When saving fails, VLLM model runner should be able to just fallback to the old path, and in the next process, it will fail to load dynamo cache but still fallback to retracing with dynamo + loading inductor cache, which is the same behavior to AOT compile turned of off.

This is mostly a short term fix and in the long term we should resolve the serialization bugs by eliminating pickling of graph modules.

i.e. Once https://github.com/vllm-project/vllm/pull/25205 is merged, we should be able to resolve the issue at a lower level.

Test Plan:

pytest tests/lora/test_quant_model.py

Reviewers:

Subscribers:

Tasks:

Tags:


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

