### PR TITLE
[Bugfix] Add missing 'is_internal_router' attribute to FusedMoEWithLoRA

### DIFF
--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -405,3 +405,7 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
     @property
     def quant_method(self):
         return self.base_layer.quant_method
+
+    @property
+    def is_internal_router(self) -> bool:
+        return self.base_layer.is_internal_router


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
`is_internal_router` was introduced by  https://github.com/vllm-project/vllm/pull/26440
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

