### PR TITLE
[cmake]  fix ROCm hip/clr build on platforms without GPUs attached

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ set(VLLM_TARGET_DEVICE "cuda" CACHE STRING "Target device backend for vLLM")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Target device: ${VLLM_TARGET_DEVICE}")
 
+if(DEFINED ENV{PYTORCH_ROCM_ARCH})
+    set(PYTORCH_ROCM_ARCH_VAL $ENV{PYTORCH_ROCM_ARCH})
+    set(GPU_TARGETS "${PYTORCH_ROCM_ARCH_VAL}")
+endif()
+
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
 
 # Suppress potential warnings about unused manually-specified variables


### PR DESCRIPTION
I'm not 100% sure this is the right place to implement this fix, but this works so I thought I would use it as a starting point for discussion.

The problem is that if you build vLLM for ROCm following [these instructions](https://docs.vllm.ai/en/stable/getting_started/installation/gpu.html) when cmake processes hip/clr it drops into [this conditional](https://github.com/ROCm/clr/blob/58b81d67903bde27abf92ed269c744b0cd723d23/hipamd/hip-config-amd.cmake.in#L78) because the build doesnt define `GPU_TARGETS`. This is fine when building on platforms that have AMD GPUs attached because cmake runs `amdgpu-arch` which resolves the targets just fine. However, if building in an environment without attached GPUs, it fails to resolve targets and then when pytorch tries to build kernels for the targets specified in PYTORCH_ROCM_ARCH things explode because hip is built for a different arch then the kernels youre trying to compile and the build fails.

So at some point somewhere the cmake build should propagate `PYTORCH_ROCM_ARCH` to `GPU_TARGETS`. I just put the block next to some other GPU architecture stuff in the main cmake file. But possible this should be in pytorch or something. Let me know what you think.


<!-- markdownlint-disable -->

## Purpose

Fix ROCm build on platforms without GPUs attached (building linux images for worker nodes in chroot)

## Test Plan

AMD build instructions [here](https://docs.vllm.ai/en/stable/getting_started/installation/gpu.html) succeed when run in context where AMD GPYs

## Test Result

Build passes with fix, fails without fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x ] The test plan, such as providing test command.
- [ x] The test results, such as pasting the results comparison before and after, or e2e results
- [ N/A] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [N/A ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

