### PR TITLE
Prefer FlashAttention MLA as default over FlashMLA

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -55,15 +55,15 @@ def _get_backend_priorities(
             return [
                 AttentionBackendEnum.CUTLASS_MLA,
                 AttentionBackendEnum.FLASHINFER_MLA,
-                AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.FLASH_ATTN_MLA,
+                AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.TRITON_MLA,
                 AttentionBackendEnum.FLASHMLA_SPARSE,
             ]
         else:
             return [
-                AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.FLASH_ATTN_MLA,
+                AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.FLASHINFER_MLA,
                 AttentionBackendEnum.TRITON_MLA,
                 AttentionBackendEnum.FLASHMLA_SPARSE,


### PR DESCRIPTION
## Purpose
Based on benchmarking in #26835, FlashAttention MLA is faster than FlashMLA across head counts, batch sizes, and query lengths on Hopper. This PR sets it as the preferred backend.

Based on #24794, merge that first

Note: Results shown below apply the fix of #27368, FlashMLA performance is worse prior to the bugfix

## Test Plan

## Test Result
```
Model Parameter Sweep Results:

num_q_heads = 16
              Attention Benchmark Results               
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ Batch      ┃    famla ┃   famla ┃     fmla ┃    fmla ┃
┃ Spec       ┃ Time (s) ┃ vs Best ┃ Time (s) ┃ vs Best ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ 128q128s1k │ 0.001261 │  100.0% │ 0.001912 │  151.7% │
│ 128q16s1k  │ 0.000186 │  100.0% │ 0.000245 │  132.2% │
│ 128q1s1k   │ 0.000071 │  100.0% │ 0.000084 │  118.3% │
│ 128q256s1k │ 0.002368 │  100.0% │ 0.003813 │  161.0% │
│ 128q2s1k   │ 0.000073 │  100.0% │ 0.000085 │  115.9% │
│ 128q32s1k  │ 0.000351 │  100.0% │ 0.000470 │  133.6% │
│ 128q4s1k   │ 0.000075 │  100.0% │ 0.000088 │  116.8% │
│ 128q64s1k  │ 0.000675 │  100.0% │ 0.000924 │  136.9% │
│ 128q8s1k   │ 0.000106 │  100.0% │ 0.000132 │  125.2% │
│ 16q128s1k  │ 0.000175 │  100.0% │ 0.000245 │  140.2% │
│ 16q16s1k   │ 0.000053 │  100.0% │ 0.000093 │  175.1% │
│ 16q1s1k    │ 0.000030 │  100.0% │ 0.000046 │  151.3% │
│ 16q256s1k  │ 0.000319 │  100.0% │ 0.000478 │  150.0% │
│ 16q2s1k    │ 0.000031 │  100.0% │ 0.000047 │  153.8% │
│ 16q32s1k   │ 0.000053 │  100.0% │ 0.000066 │  123.6% │
│ 16q4s1k    │ 0.000031 │  100.0% │ 0.000053 │  170.0% │
│ 16q64s1k   │ 0.000096 │  100.0% │ 0.000125 │  130.0% │
│ 16q8s1k    │ 0.000040 │  100.0% │ 0.000056 │  141.9% │
│ 1q128s1k   │ 0.000037 │  100.0% │ 0.000057 │  154.4% │
│ 1q16s1k    │ 0.000031 │  100.0% │ 0.000050 │  158.4% │
│ 1q1s1k     │ 0.000031 │  100.0% │ 0.000042 │  135.2% │
│ 1q256s1k   │ 0.000049 │  100.0% │ 0.000065 │  133.2% │
│ 1q2s1k     │ 0.000030 │  100.0% │ 0.000043 │  146.6% │
│ 1q32s1k    │ 0.000032 │  100.0% │ 0.000048 │  151.9% │
│ 1q4s1k     │ 0.000031 │  100.0% │ 0.000046 │  148.5% │
│ 1q512s1k   │ 0.000047 │  100.0% │ 0.000064 │  136.7% │
│ 1q64s1k    │ 0.000032 │  100.0% │ 0.000053 │  164.7% │
│ 1q8s1k     │ 0.000033 │  100.0% │ 0.000048 │  147.3% │
│ 2q128s1k   │ 0.000050 │  100.0% │ 0.000088 │  177.3% │
│ 2q16s1k    │ 0.000031 │  100.0% │ 0.000047 │  152.2% │
│ 2q1s1k     │ 0.000030 │  100.0% │ 0.000046 │  151.2% │
│ 2q256s1k   │ 0.000049 │  100.0% │ 0.000065 │  131.7% │
│ 2q2s1k     │ 0.000030 │  100.0% │ 0.000047 │  156.6% │
│ 2q32s1k    │ 0.000031 │  100.0% │ 0.000053 │  170.1% │
│ 2q4s1k     │ 0.000030 │  100.0% │ 0.000049 │  163.8% │
│ 2q512s1k   │ 0.000083 │  100.0% │ 0.000125 │  150.4% │
│ 2q64s1k    │ 0.000037 │  100.0% │ 0.000057 │  153.1% │
│ 2q8s1k     │ 0.000030 │  100.0% │ 0.000050 │  164.2% │
│ 32q128s1k  │ 0.000337 │  100.0% │ 0.000480 │  142.5% │
│ 32q16s1k   │ 0.000055 │  100.0% │ 0.000066 │  120.1% │
│ 32q1s1k    │ 0.000032 │  100.0% │ 0.000051 │  162.2% │
│ 32q256s1k  │ 0.000616 │  100.0% │ 0.000954 │  155.0% │
│ 32q2s1k    │ 0.000034 │  100.0% │ 0.000055 │  162.1% │
│ 32q32s1k   │ 0.000097 │  100.0% │ 0.000127 │  130.4% │
│ 32q4s1k    │ 0.000042 │  100.0% │ 0.000060 │  143.8% │
│ 32q64s1k   │ 0.000181 │  100.0% │ 0.000240 │  133.2% │
│ 32q8s1k    │ 0.000055 │  100.0% │ 0.000094 │  170.9% │
│ 4q128s1k   │ 0.000049 │  100.0% │ 0.000065 │  131.1% │
│ 4q16s1k    │ 0.000031 │  100.0% │ 0.000052 │  168.1% │
│ 4q1s1k     │ 0.000030 │  100.0% │ 0.000045 │  153.3% │
│ 4q256s1k   │ 0.000092 │  100.0% │ 0.000126 │  136.5% │
│ 4q2s1k     │ 0.000030 │  100.0% │ 0.000047 │  158.5% │
│ 4q32s1k    │ 0.000037 │  100.0% │ 0.000055 │  148.1% │
│ 4q4s1k     │ 0.000030 │  100.0% │ 0.000049 │  161.8% │
│ 4q512s1k   │ 0.000146 │  100.0% │ 0.000247 │  169.2% │
│ 4q64s1k    │ 0.000052 │  100.0% │ 0.000091 │  177.0% │
│ 4q8s1k     │ 0.000031 │  100.0% │ 0.000047 │  154.8% │
│ 64q128s1k  │ 0.000655 │  100.0% │ 0.000956 │  146.0% │
│ 64q16s1k   │ 0.000099 │  100.0% │ 0.000127 │  129.4% │
│ 64q1s1k    │ 0.000047 │  100.0% │ 0.000087 │  183.4% │
│ 64q256s1k  │ 0.001197 │  100.0% │ 0.001906 │  159.2% │
│ 64q2s1k    │ 0.000053 │  100.0% │ 0.000090 │  170.9% │
│ 64q32s1k   │ 0.000182 │  100.0% │ 0.000244 │  134.2% │
│ 64q4s1k    │ 0.000063 │  100.0% │ 0.000100 │  158.1% │
│ 64q64s1k   │ 0.000349 │  100.0% │ 0.000470 │  134.8% │
│ 64q8s1k    │ 0.000058 │  100.0% │ 0.000070 │  120.4% │
│ 8q128s1k   │ 0.000094 │  100.0% │ 0.000127 │  134.3% │
│ 8q16s1k    │ 0.000039 │  100.0% │ 0.000054 │  140.3% │
│ 8q1s1k     │ 0.000030 │  100.0% │ 0.000043 │  142.6% │
│ 8q256s1k   │ 0.000169 │  100.0% │ 0.000245 │  145.1% │
│ 8q2s1k     │ 0.000030 │  100.0% │ 0.000045 │  147.9% │
│ 8q32s1k    │ 0.000052 │  100.0% │ 0.000092 │  178.2% │
│ 8q4s1k     │ 0.000031 │  100.0% │ 0.000047 │  153.6% │
│ 8q512s1k   │ 0.000261 │  100.0% │ 0.000474 │  181.5% │
│ 8q64s1k    │ 0.000051 │  100.0% │ 0.000065 │  126.9% │
│ 8q8s1k     │ 0.000031 │  100.0% │ 0.000051 │  165.2% │
└────────────┴──────────┴─────────┴──────────┴─────────┘

num_q_heads = 32
              Attention Benchmark Results               
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ Batch      ┃    famla ┃   famla ┃     fmla ┃    fmla ┃
┃ Spec       ┃ Time (s) ┃ vs Best ┃ Time (s) ┃ vs Best ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ 128q128s1k │ 0.002494 │  100.0% │ 0.003787 │  151.8% │
│ 128q16s1k  │ 0.000351 │  100.0% │ 0.000478 │  136.0% │
│ 128q1s1k   │ 0.000075 │  100.0% │ 0.000085 │  113.2% │
│ 128q256s1k │ 0.004156 │  100.0% │ 0.007579 │  182.4% │
│ 128q2s1k   │ 0.000080 │  100.0% │ 0.000087 │  108.3% │
│ 128q32s1k  │ 0.000686 │  100.0% │ 0.000942 │  137.2% │
│ 128q4s1k   │ 0.000106 │  100.0% │ 0.000132 │  124.1% │
│ 128q64s1k  │ 0.001294 │  100.0% │ 0.001901 │  146.9% │
│ 128q8s1k   │ 0.000186 │  100.0% │ 0.000248 │  133.8% │
│ 16q128s1k  │ 0.000334 │  100.0% │ 0.000481 │  144.1% │
│ 16q16s1k   │ 0.000053 │  100.0% │ 0.000066 │  124.6% │
│ 16q1s1k    │ 0.000031 │  100.0% │ 0.000047 │  153.3% │
│ 16q256s1k  │ 0.000552 │  100.0% │ 0.000950 │  172.2% │
│ 16q2s1k    │ 0.000031 │  100.0% │ 0.000052 │  170.2% │
│ 16q32s1k   │ 0.000099 │  100.0% │ 0.000127 │  128.9% │
│ 16q4s1k    │ 0.000039 │  100.0% │ 0.000056 │  145.2% │
│ 16q64s1k   │ 0.000182 │  100.0% │ 0.000245 │  134.6% │
│ 16q8s1k    │ 0.000053 │  100.0% │ 0.000092 │  172.7% │
│ 1q128s1k   │ 0.000051 │  100.0% │ 0.000066 │  128.8% │
│ 1q16s1k    │ 0.000031 │  100.0% │ 0.000048 │  152.4% │
│ 1q1s1k     │ 0.000031 │  100.0% │ 0.000043 │  138.2% │
│ 1q256s1k   │ 0.000048 │  100.0% │ 0.000065 │  135.0% │
│ 1q2s1k     │ 0.000031 │  100.0% │ 0.000046 │  147.6% │
│ 1q32s1k    │ 0.000032 │  100.0% │ 0.000053 │  162.5% │
│ 1q4s1k     │ 0.000032 │  100.0% │ 0.000048 │  148.9% │
│ 1q512s1k   │ 0.000079 │  100.0% │ 0.000120 │  152.8% │
│ 1q64s1k    │ 0.000037 │  100.0% │ 0.000057 │  152.0% │
│ 1q8s1k     │ 0.000031 │  100.0% │ 0.000048 │  152.3% │
│ 2q128s1k   │ 0.000051 │  100.0% │ 0.000065 │  128.7% │
│ 2q16s1k    │ 0.000031 │  100.0% │ 0.000053 │  170.4% │
│ 2q1s1k     │ 0.000034 │  100.0% │ 0.000046 │  137.8% │
│ 2q256s1k   │ 0.000086 │  100.0% │ 0.000126 │  147.9% │
│ 2q2s1k     │ 0.000030 │  100.0% │ 0.000049 │  161.3% │
│ 2q32s1k    │ 0.000037 │  100.0% │ 0.000057 │  154.0% │
│ 2q4s1k     │ 0.000030 │  100.0% │ 0.000050 │  164.0% │
│ 2q512s1k   │ 0.000144 │  100.0% │ 0.000233 │  161.5% │
│ 2q64s1k    │ 0.000051 │  100.0% │ 0.000089 │  173.5% │
│ 2q8s1k     │ 0.000031 │  100.0% │ 0.000046 │  150.3% │
│ 32q128s1k  │ 0.000652 │  100.0% │ 0.000958 │  146.8% │
│ 32q16s1k   │ 0.000098 │  100.0% │ 0.000127 │  128.9% │
│ 32q1s1k    │ 0.000035 │  100.0% │ 0.000055 │  159.9% │
│ 32q256s1k  │ 0.001065 │  100.0% │ 0.001909 │  179.3% │
│ 32q2s1k    │ 0.000042 │  100.0% │ 0.000059 │  139.4% │
│ 32q32s1k   │ 0.000183 │  100.0% │ 0.000246 │  134.8% │
│ 32q4s1k    │ 0.000054 │  100.0% │ 0.000094 │  173.8% │
│ 32q64s1k   │ 0.000348 │  100.0% │ 0.000477 │  136.9% │
│ 32q8s1k    │ 0.000055 │  100.0% │ 0.000066 │  120.2% │
│ 4q128s1k   │ 0.000095 │  100.0% │ 0.000126 │  132.9% │
│ 4q16s1k    │ 0.000038 │  100.0% │ 0.000056 │  149.1% │
│ 4q1s1k     │ 0.000030 │  100.0% │ 0.000047 │  156.4% │
│ 4q256s1k   │ 0.000156 │  100.0% │ 0.000248 │  159.3% │
│ 4q2s1k     │ 0.000030 │  100.0% │ 0.000049 │  162.6% │
│ 4q32s1k    │ 0.000052 │  100.0% │ 0.000091 │  176.5% │
│ 4q4s1k     │ 0.000031 │  100.0% │ 0.000046 │  149.5% │
│ 4q512s1k   │ 0.000260 │  100.0% │ 0.000458 │  176.4% │
│ 4q64s1k    │ 0.000052 │  100.0% │ 0.000065 │  126.5% │
│ 4q8s1k     │ 0.000031 │  100.0% │ 0.000052 │  168.6% │
│ 64q128s1k  │ 0.001257 │  100.0% │ 0.001910 │  152.0% │
│ 64q16s1k   │ 0.000183 │  100.0% │ 0.000249 │  135.8% │
│ 64q1s1k    │ 0.000052 │  100.0% │ 0.000089 │  170.2% │
│ 64q256s1k  │ 0.002093 │  100.0% │ 0.003779 │  180.5% │
│ 64q2s1k    │ 0.000065 │  100.0% │ 0.000097 │  150.9% │
│ 64q32s1k   │ 0.000351 │  100.0% │ 0.000478 │  136.0% │
│ 64q4s1k    │ 0.000058 │  100.0% │ 0.000070 │  121.6% │
│ 64q64s1k   │ 0.000678 │  100.0% │ 0.000937 │  138.3% │
│ 64q8s1k    │ 0.000099 │  100.0% │ 0.000127 │  128.2% │
│ 8q128s1k   │ 0.000177 │  100.0% │ 0.000250 │  141.3% │
│ 8q16s1k    │ 0.000052 │  100.0% │ 0.000092 │  176.3% │
│ 8q1s1k     │ 0.000030 │  100.0% │ 0.000044 │  147.6% │
│ 8q256s1k   │ 0.000288 │  100.0% │ 0.000486 │  168.5% │
│ 8q2s1k     │ 0.000031 │  100.0% │ 0.000047 │  150.8% │
│ 8q32s1k    │ 0.000067 │  101.0% │ 0.000066 │  100.0% │
│ 8q4s1k     │ 0.000031 │  100.0% │ 0.000051 │  165.8% │
│ 8q512s1k   │ 0.000491 │  100.0% │ 0.000900 │  183.2% │
│ 8q64s1k    │ 0.000098 │  100.0% │ 0.000126 │  129.5% │
│ 8q8s1k     │ 0.000039 │  100.0% │ 0.000054 │  140.6% │
└────────────┴──────────┴─────────┴──────────┴─────────┘

num_q_heads = 64
              Attention Benchmark Results               
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ Batch      ┃    famla ┃   famla ┃     fmla ┃    fmla ┃
┃ Spec       ┃ Time (s) ┃ vs Best ┃ Time (s) ┃ vs Best ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ 128q128s1k │ 0.004345 │  100.0% │ 0.007506 │  172.7% │
│ 128q16s1k  │ 0.000686 │  100.0% │ 0.000950 │  138.4% │
│ 128q1s1k   │ 0.000082 │  100.0% │ 0.000087 │  105.3% │
│ 128q256s1k │ 0.008165 │  100.0% │ 0.014819 │  181.5% │
│ 128q2s1k   │ 0.000114 │  100.0% │ 0.000131 │  114.6% │
│ 128q32s1k  │ 0.001306 │  100.0% │ 0.001896 │  145.1% │
│ 128q4s1k   │ 0.000187 │  100.0% │ 0.000248 │  132.5% │
│ 128q64s1k  │ 0.002533 │  100.0% │ 0.003774 │  149.0% │
│ 128q8s1k   │ 0.000352 │  100.0% │ 0.000483 │  137.2% │
│ 16q128s1k  │ 0.000585 │  100.0% │ 0.000961 │  164.2% │
│ 16q16s1k   │ 0.000100 │  100.0% │ 0.000129 │  129.1% │
│ 16q1s1k    │ 0.000031 │  100.0% │ 0.000052 │  167.6% │
│ 16q256s1k  │ 0.001061 │  100.0% │ 0.001848 │  174.2% │
│ 16q2s1k    │ 0.000040 │  100.0% │ 0.000056 │  141.0% │
│ 16q32s1k   │ 0.000185 │  100.0% │ 0.000247 │  133.9% │
│ 16q4s1k    │ 0.000053 │  100.0% │ 0.000092 │  172.7% │
│ 16q64s1k   │ 0.000350 │  100.0% │ 0.000483 │  137.8% │
│ 16q8s1k    │ 0.000053 │  100.0% │ 0.000066 │  124.3% │
│ 1q128s1k   │ 0.000049 │  100.0% │ 0.000066 │  134.5% │
│ 1q16s1k    │ 0.000032 │  100.0% │ 0.000052 │  162.2% │
│ 1q1s1k     │ 0.000032 │  100.0% │ 0.000045 │  141.6% │
│ 1q256s1k   │ 0.000083 │  100.0% │ 0.000126 │  151.1% │
│ 1q2s1k     │ 0.000031 │  100.0% │ 0.000048 │  153.2% │
│ 1q32s1k    │ 0.000037 │  100.0% │ 0.000057 │  153.3% │
│ 1q4s1k     │ 0.000032 │  100.0% │ 0.000048 │  150.2% │
│ 1q512s1k   │ 0.000143 │  100.0% │ 0.000236 │  165.2% │
│ 1q64s1k    │ 0.000052 │  100.0% │ 0.000065 │  126.7% │
│ 1q8s1k     │ 0.000032 │  100.0% │ 0.000046 │  141.5% │
│ 2q128s1k   │ 0.000088 │  100.0% │ 0.000128 │  145.0% │
│ 2q16s1k    │ 0.000037 │  100.0% │ 0.000057 │  154.5% │
│ 2q1s1k     │ 0.000030 │  100.0% │ 0.000048 │  161.9% │
│ 2q256s1k   │ 0.000157 │  100.0% │ 0.000244 │  155.2% │
│ 2q2s1k     │ 0.000030 │  100.0% │ 0.000050 │  165.0% │
│ 2q32s1k    │ 0.000051 │  100.0% │ 0.000091 │  177.4% │
│ 2q4s1k     │ 0.000031 │  100.0% │ 0.000046 │  151.1% │
│ 2q512s1k   │ 0.000262 │  100.0% │ 0.000452 │  172.6% │
│ 2q64s1k    │ 0.000052 │  100.0% │ 0.000065 │  125.7% │
│ 2q8s1k     │ 0.000031 │  100.0% │ 0.000052 │  167.6% │
│ 32q128s1k  │ 0.001120 │  100.0% │ 0.001892 │  169.0% │
│ 32q16s1k   │ 0.000185 │  100.0% │ 0.000246 │  133.1% │
│ 32q1s1k    │ 0.000042 │  100.0% │ 0.000059 │  139.5% │
│ 32q256s1k  │ 0.002086 │  100.0% │ 0.003681 │  176.4% │
│ 32q2s1k    │ 0.000056 │  100.0% │ 0.000092 │  165.0% │
│ 32q32s1k   │ 0.000351 │  100.0% │ 0.000486 │  138.7% │
│ 32q4s1k    │ 0.000054 │  100.0% │ 0.000066 │  121.9% │
│ 32q64s1k   │ 0.000675 │  100.0% │ 0.000957 │  141.7% │
│ 32q8s1k    │ 0.000099 │  100.0% │ 0.000128 │  129.0% │
│ 4q128s1k   │ 0.000163 │  100.0% │ 0.000250 │  153.4% │
│ 4q16s1k    │ 0.000052 │  100.0% │ 0.000093 │  178.5% │
│ 4q1s1k     │ 0.000030 │  100.0% │ 0.000048 │  160.3% │
│ 4q256s1k   │ 0.000288 │  100.0% │ 0.000475 │  164.7% │
│ 4q2s1k     │ 0.000031 │  100.0% │ 0.000046 │  150.0% │
│ 4q32s1k    │ 0.000052 │  100.0% │ 0.000065 │  126.1% │
│ 4q4s1k     │ 0.000031 │  100.0% │ 0.000051 │  161.9% │
│ 4q512s1k   │ 0.000491 │  100.0% │ 0.000890 │  181.1% │
│ 4q64s1k    │ 0.000099 │  100.0% │ 0.000129 │  129.6% │
│ 4q8s1k     │ 0.000038 │  100.0% │ 0.000056 │  148.5% │
│ 64q128s1k  │ 0.002193 │  100.0% │ 0.003764 │  171.7% │
│ 64q16s1k   │ 0.000354 │  100.0% │ 0.000486 │  137.1% │
│ 64q1s1k    │ 0.000063 │  100.0% │ 0.000097 │  155.4% │
│ 64q256s1k  │ 0.004130 │  100.0% │ 0.007392 │  179.0% │
│ 64q2s1k    │ 0.000061 │  100.0% │ 0.000069 │  114.0% │
│ 64q32s1k   │ 0.000685 │  100.0% │ 0.000947 │  138.3% │
│ 64q4s1k    │ 0.000099 │  100.0% │ 0.000128 │  128.3% │
│ 64q64s1k   │ 0.001290 │  100.0% │ 0.001912 │  148.3% │
│ 64q8s1k    │ 0.000184 │  100.0% │ 0.000249 │  135.1% │
│ 8q128s1k   │ 0.000304 │  100.0% │ 0.000492 │  161.9% │
│ 8q16s1k    │ 0.000052 │  100.0% │ 0.000066 │  126.6% │
│ 8q1s1k     │ 0.000031 │  100.0% │ 0.000046 │  150.7% │
│ 8q256s1k   │ 0.000551 │  100.0% │ 0.000930 │  168.9% │
│ 8q2s1k     │ 0.000031 │  100.0% │ 0.000051 │  165.5% │
│ 8q32s1k    │ 0.000099 │  100.0% │ 0.000129 │  130.0% │
│ 8q4s1k     │ 0.000037 │  100.0% │ 0.000054 │  145.5% │
│ 8q512s1k   │ 0.000949 │  100.0% │ 0.001751 │  184.6% │
│ 8q64s1k    │ 0.000185 │  100.0% │ 0.000246 │  133.5% │
│ 8q8s1k     │ 0.000052 │  100.0% │ 0.000092 │  176.5% │
└────────────┴──────────┴─────────┴──────────┴─────────┘

num_q_heads = 128
              Attention Benchmark Results               
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ Batch      ┃    famla ┃   famla ┃     fmla ┃    fmla ┃
┃ Spec       ┃ Time (s) ┃ vs Best ┃ Time (s) ┃ vs Best ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ 128q128s1k │ 0.008551 │  100.0% │ 0.015035 │  175.8% │
│ 128q16s1k  │ 0.001307 │  100.0% │ 0.001907 │  145.9% │
│ 128q1s1k   │ 0.000113 │  100.0% │ 0.000129 │  114.7% │
│ 128q256s1k │ 0.016206 │  100.0% │ 0.029083 │  179.5% │
│ 128q2s1k   │ 0.000203 │  100.0% │ 0.000248 │  122.2% │
│ 128q32s1k  │ 0.002556 │  100.0% │ 0.003769 │  147.5% │
│ 128q4s1k   │ 0.000355 │  100.0% │ 0.000482 │  135.9% │
│ 128q64s1k  │ 0.004442 │  100.0% │ 0.007509 │  169.0% │
│ 128q8s1k   │ 0.000686 │  100.0% │ 0.000946 │  138.0% │
│ 16q128s1k  │ 0.001122 │  100.0% │ 0.001904 │  169.8% │
│ 16q16s1k   │ 0.000188 │  100.0% │ 0.000249 │  132.6% │
│ 16q1s1k    │ 0.000036 │  100.0% │ 0.000055 │  153.9% │
│ 16q256s1k  │ 0.002079 │  100.0% │ 0.003655 │  175.8% │
│ 16q2s1k    │ 0.000053 │  100.0% │ 0.000092 │  174.0% │
│ 16q32s1k   │ 0.000356 │  100.0% │ 0.000488 │  137.0% │
│ 16q4s1k    │ 0.000053 │  100.0% │ 0.000066 │  123.6% │
│ 16q64s1k   │ 0.000604 │  100.0% │ 0.000960 │  158.8% │
│ 16q8s1k    │ 0.000099 │  100.0% │ 0.000128 │  129.2% │
│ 1q128s1k   │ 0.000088 │  100.0% │ 0.000131 │  148.2% │
│ 1q16s1k    │ 0.000037 │  100.0% │ 0.000057 │  152.9% │
│ 1q1s1k     │ 0.000031 │  100.0% │ 0.000046 │  150.8% │
│ 1q256s1k   │ 0.000160 │  100.0% │ 0.000252 │  157.5% │
│ 1q2s1k     │ 0.000032 │  100.0% │ 0.000048 │  151.0% │
│ 1q32s1k    │ 0.000052 │  100.0% │ 0.000066 │  127.5% │
│ 1q4s1k     │ 0.000033 │  100.0% │ 0.000046 │  140.8% │
│ 1q512s1k   │ 0.000267 │  100.0% │ 0.000465 │  173.8% │
│ 1q64s1k    │ 0.000049 │  100.0% │ 0.000066 │  134.1% │
│ 1q8s1k     │ 0.000033 │  100.0% │ 0.000050 │  151.1% │
│ 2q128s1k   │ 0.000166 │  100.0% │ 0.000255 │  153.6% │
│ 2q16s1k    │ 0.000051 │  100.0% │ 0.000091 │  177.3% │
│ 2q1s1k     │ 0.000030 │  100.0% │ 0.000049 │  165.3% │
│ 2q256s1k   │ 0.000294 │  100.0% │ 0.000487 │  165.4% │
│ 2q2s1k     │ 0.000030 │  100.0% │ 0.000046 │  152.2% │
│ 2q32s1k    │ 0.000052 │  100.0% │ 0.000067 │  128.7% │
│ 2q4s1k     │ 0.000031 │  100.0% │ 0.000052 │  166.8% │
│ 2q512s1k   │ 0.000497 │  100.0% │ 0.000893 │  179.8% │
│ 2q64s1k    │ 0.000089 │  100.0% │ 0.000128 │  143.9% │
│ 2q8s1k     │ 0.000037 │  100.0% │ 0.000056 │  150.3% │
│ 32q128s1k  │ 0.002194 │  100.0% │ 0.003770 │  171.9% │
│ 32q16s1k   │ 0.000358 │  100.0% │ 0.000487 │  136.0% │
│ 32q1s1k    │ 0.000050 │  100.0% │ 0.000092 │  182.8% │
│ 32q256s1k  │ 0.004116 │  100.0% │ 0.007261 │  176.4% │
│ 32q2s1k    │ 0.000056 │  100.0% │ 0.000065 │  114.7% │
│ 32q32s1k   │ 0.000680 │  100.0% │ 0.000966 │  142.1% │
│ 32q4s1k    │ 0.000097 │  100.0% │ 0.000126 │  130.9% │
│ 32q64s1k   │ 0.001144 │  100.0% │ 0.001916 │  167.5% │
│ 32q8s1k    │ 0.000186 │  100.0% │ 0.000249 │  133.4% │
│ 4q128s1k   │ 0.000310 │  100.0% │ 0.000493 │  158.9% │
│ 4q16s1k    │ 0.000052 │  100.0% │ 0.000066 │  127.8% │
│ 4q1s1k     │ 0.000031 │  100.0% │ 0.000045 │  149.0% │
│ 4q256s1k   │ 0.000556 │  100.0% │ 0.000958 │  172.2% │
│ 4q2s1k     │ 0.000031 │  100.0% │ 0.000051 │  163.4% │
│ 4q32s1k    │ 0.000099 │  100.0% │ 0.000128 │  129.6% │
│ 4q4s1k     │ 0.000036 │  100.0% │ 0.000054 │  149.6% │
│ 4q512s1k   │ 0.000950 │  100.0% │ 0.001756 │  184.9% │
│ 4q64s1k    │ 0.000171 │  100.0% │ 0.000251 │  146.9% │
│ 4q8s1k     │ 0.000052 │  100.0% │ 0.000093 │  178.2% │
│ 64q128s1k  │ 0.004298 │  100.0% │ 0.007497 │  174.4% │
│ 64q16s1k   │ 0.000689 │  100.0% │ 0.000959 │  139.2% │
│ 64q1s1k    │ 0.000059 │  100.0% │ 0.000069 │  116.6% │
│ 64q256s1k  │ 0.008185 │  100.0% │ 0.014529 │  177.5% │
│ 64q2s1k    │ 0.000103 │  100.0% │ 0.000124 │  120.6% │
│ 64q32s1k   │ 0.001301 │  100.0% │ 0.001910 │  146.8% │
│ 64q4s1k    │ 0.000185 │  100.0% │ 0.000248 │  134.2% │
│ 64q64s1k   │ 0.002246 │  100.0% │ 0.003775 │  168.1% │
│ 64q8s1k    │ 0.000355 │  100.0% │ 0.000485 │  136.8% │
│ 8q128s1k   │ 0.000588 │  100.0% │ 0.000973 │  165.4% │
│ 8q16s1k    │ 0.000100 │  100.0% │ 0.000129 │  128.7% │
│ 8q1s1k     │ 0.000031 │  100.0% │ 0.000050 │  163.0% │
│ 8q256s1k   │ 0.001060 │  100.0% │ 0.001879 │  177.2% │
│ 8q2s1k     │ 0.000038 │  100.0% │ 0.000054 │  142.2% │
│ 8q32s1k    │ 0.000187 │  100.0% │ 0.000251 │  133.9% │
│ 8q4s1k     │ 0.000050 │  100.0% │ 0.000092 │  183.2% │
│ 8q512s1k   │ 0.001862 │  100.0% │ 0.003422 │  183.8% │
│ 8q64s1k    │ 0.000319 │  100.0% │ 0.000488 │  153.1% │
│ 8q8s1k     │ 0.000052 │  100.0% │ 0.000066 │  126.7% │
└────────────┴──────────┴─────────┴──────────┴─────────┘

num_q_heads = 256
              Attention Benchmark Results               
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ Batch      ┃    famla ┃   famla ┃     fmla ┃    fmla ┃
┃ Spec       ┃ Time (s) ┃ vs Best ┃ Time (s) ┃ vs Best ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ 128q128s1k │ 0.017040 │  100.0% │ 0.029658 │  174.0% │
│ 128q16s1k  │ 0.002558 │  100.0% │ 0.003774 │  147.6% │
│ 128q1s1k   │ 0.000198 │  100.0% │ 0.000242 │  122.2% │
│ 128q256s1k │ 0.032271 │  100.0% │ 0.057412 │  177.9% │
│ 128q2s1k   │ 0.000391 │  100.0% │ 0.000483 │  123.5% │
│ 128q32s1k  │ 0.004430 │  100.0% │ 0.007510 │  169.6% │
│ 128q4s1k   │ 0.000690 │  100.0% │ 0.000947 │  137.2% │
│ 128q64s1k  │ 0.008824 │  100.0% │ 0.014886 │  168.7% │
│ 128q8s1k   │ 0.001306 │  100.0% │ 0.001902 │  145.6% │
│ 16q128s1k  │ 0.002194 │  100.0% │ 0.003728 │  169.9% │
│ 16q16s1k   │ 0.000362 │  100.0% │ 0.000491 │  135.6% │
│ 16q1s1k    │ 0.000047 │  100.0% │ 0.000089 │  190.9% │
│ 16q256s1k  │ 0.004116 │  100.0% │ 0.007171 │  174.2% │
│ 16q2s1k    │ 0.000054 │  100.0% │ 0.000066 │  122.7% │
│ 16q32s1k   │ 0.000608 │  100.0% │ 0.000967 │  159.2% │
│ 16q4s1k    │ 0.000099 │  100.0% │ 0.000128 │  128.3% │
│ 16q64s1k   │ 0.001153 │  100.0% │ 0.001883 │  163.3% │
│ 16q8s1k    │ 0.000188 │  100.0% │ 0.000251 │  133.5% │
│ 1q128s1k   │ 0.000170 │  100.0% │ 0.000260 │  152.9% │
│ 1q16s1k    │ 0.000052 │  100.0% │ 0.000066 │  127.4% │
│ 1q1s1k     │ 0.000032 │  100.0% │ 0.000046 │  143.6% │
│ 1q256s1k   │ 0.000299 │  100.0% │ 0.000490 │  163.8% │
│ 1q2s1k     │ 0.000032 │  100.0% │ 0.000046 │  142.3% │
│ 1q32s1k    │ 0.000049 │  100.0% │ 0.000066 │  134.4% │
│ 1q4s1k     │ 0.000032 │  100.0% │ 0.000051 │  157.7% │
│ 1q512s1k   │ 0.000510 │  100.0% │ 0.000905 │  177.4% │
│ 1q64s1k    │ 0.000090 │  100.0% │ 0.000130 │  144.2% │
│ 1q8s1k     │ 0.000037 │  100.0% │ 0.000057 │  151.4% │
│ 2q128s1k   │ 0.000313 │  100.0% │ 0.000498 │  159.2% │
│ 2q16s1k    │ 0.000052 │  100.0% │ 0.000067 │  128.6% │
│ 2q1s1k     │ 0.000030 │  100.0% │ 0.000045 │  148.7% │
│ 2q256s1k   │ 0.000562 │  100.0% │ 0.000934 │  166.2% │
│ 2q2s1k     │ 0.000031 │  100.0% │ 0.000052 │  168.0% │
│ 2q32s1k    │ 0.000089 │  100.0% │ 0.000131 │  147.3% │
│ 2q4s1k     │ 0.000036 │  100.0% │ 0.000056 │  155.0% │
│ 2q512s1k   │ 0.000957 │  100.0% │ 0.001722 │  179.8% │
│ 2q64s1k    │ 0.000171 │  100.0% │ 0.000253 │  148.3% │
│ 2q8s1k     │ 0.000051 │  100.0% │ 0.000089 │  173.7% │
│ 32q128s1k  │ 0.004335 │  100.0% │ 0.007442 │  171.7% │
│ 32q16s1k   │ 0.000686 │  100.0% │ 0.000967 │  141.0% │
│ 32q1s1k    │ 0.000055 │  100.0% │ 0.000065 │  117.9% │
│ 32q256s1k  │ 0.008182 │  100.0% │ 0.014302 │  174.8% │
│ 32q2s1k    │ 0.000101 │  100.0% │ 0.000125 │  124.2% │
│ 32q32s1k   │ 0.001150 │  100.0% │ 0.001911 │  166.3% │
│ 32q4s1k    │ 0.000186 │  100.0% │ 0.000246 │  132.7% │
│ 32q64s1k   │ 0.002247 │  100.0% │ 0.003726 │  165.8% │
│ 32q8s1k    │ 0.000359 │  100.0% │ 0.000490 │  136.6% │
│ 4q128s1k   │ 0.000591 │  100.0% │ 0.000961 │  162.7% │
│ 4q16s1k    │ 0.000099 │  100.0% │ 0.000130 │  130.8% │
│ 4q1s1k     │ 0.000031 │  100.0% │ 0.000050 │  163.1% │
│ 4q256s1k   │ 0.001068 │  100.0% │ 0.001855 │  173.7% │
│ 4q2s1k     │ 0.000037 │  100.0% │ 0.000054 │  145.8% │
│ 4q32s1k    │ 0.000171 │  100.0% │ 0.000251 │  147.0% │
│ 4q4s1k     │ 0.000050 │  100.0% │ 0.000090 │  180.6% │
│ 4q512s1k   │ 0.001863 │  100.0% │ 0.003406 │  182.9% │
│ 4q64s1k    │ 0.000325 │  100.0% │ 0.000492 │  151.2% │
│ 4q8s1k     │ 0.000052 │  100.0% │ 0.000066 │  127.9% │
│ 64q128s1k  │ 0.008611 │  100.0% │ 0.014794 │  171.8% │
│ 64q16s1k   │ 0.001301 │  100.0% │ 0.001911 │  146.9% │
│ 64q1s1k    │ 0.000101 │  100.0% │ 0.000124 │  123.5% │
│ 64q256s1k  │ 0.016176 │  100.0% │ 0.028746 │  177.7% │
│ 64q2s1k    │ 0.000192 │  100.0% │ 0.000247 │  128.6% │
│ 64q32s1k   │ 0.002251 │  100.0% │ 0.003769 │  167.4% │
│ 64q4s1k    │ 0.000358 │  100.0% │ 0.000487 │  136.3% │
│ 64q64s1k   │ 0.004441 │  100.0% │ 0.007430 │  167.3% │
│ 64q8s1k    │ 0.000690 │  100.0% │ 0.000960 │  139.2% │
│ 8q128s1k   │ 0.001117 │  100.0% │ 0.001883 │  168.5% │
│ 8q16s1k    │ 0.000189 │  100.0% │ 0.000251 │  133.0% │
│ 8q1s1k     │ 0.000034 │  100.0% │ 0.000053 │  156.2% │
│ 8q256s1k   │ 0.002083 │  100.0% │ 0.003610 │  173.3% │
│ 8q2s1k     │ 0.000052 │  100.0% │ 0.000092 │  178.8% │
│ 8q32s1k    │ 0.000324 │  100.0% │ 0.000490 │  151.4% │
│ 8q4s1k     │ 0.000051 │  100.0% │ 0.000066 │  130.1% │
│ 8q512s1k   │ 0.003753 │  100.0% │ 0.006626 │  176.5% │
│ 8q64s1k    │ 0.000606 │  100.0% │ 0.000950 │  156.6% │
│ 8q8s1k     │ 0.000100 │  100.0% │ 0.000128 │  128.7% │
└────────────┴──────────┴─────────┴──────────┴─────────┘
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
