### PR TITLE
[Chore] Remove duplicate `has_` functions in vllm.utils

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -5,7 +5,6 @@ import contextlib
 import datetime
 import enum
 import getpass
-import importlib.util
 import inspect
 import json
 import multiprocessing
@@ -1046,46 +1045,6 @@ def check_use_alibi(model_config: ModelConfig) -> bool:
             )
         )
     )
-
-
-@cache
-def _has_module(module_name: str) -> bool:
-    """Return True if *module_name* can be found in the current environment.
-
-    The result is cached so that subsequent queries for the same module incur
-    no additional overhead.
-    """
-    return importlib.util.find_spec(module_name) is not None
-
-
-def has_pplx() -> bool:
-    """Whether the optional `pplx_kernels` package is available."""
-
-    return _has_module("pplx_kernels")
-
-
-def has_deep_ep() -> bool:
-    """Whether the optional `deep_ep` package is available."""
-
-    return _has_module("deep_ep")
-
-
-def has_deep_gemm() -> bool:
-    """Whether the optional `deep_gemm` package is available."""
-
-    return _has_module("deep_gemm")
-
-
-def has_triton_kernels() -> bool:
-    """Whether the optional `triton_kernels` package is available."""
-
-    return _has_module("triton_kernels")
-
-
-def has_tilelang() -> bool:
-    """Whether the optional `tilelang` package is available."""
-
-    return _has_module("tilelang")
 
 
 def length_from_prompt_token_ids_or_embeds(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Part of #26900 

#27201 seems to have accidentally the`has_` functions again. This is just to remove the duplicate functions.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

