### PR TITLE
[Bugfix][ROCm][DeepSeek] Fix for forward_hip in rope for DeepSeek

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/base.py
+++ b/vllm/model_executor/layers/rotary_embedding/base.py
@@ -165,11 +165,8 @@ class RotaryEmbedding(CustomOp):
                 self.rotary_dim,
                 self.is_neox_style,
             )
-        else:
-            # ops.rotary_embedding() is an in-place operation
-            # that updates the query and key tensors.
-            self.forward_cuda(positions, query, key)
-        return query, key
+            return query, key
+        return self.forward_cuda(positions, query, key)
 
     def forward_xpu(
         self,


### PR DESCRIPTION
Starting with #25135 Rope's forward_hip falls back to forward_cuda while assuming that the function modifies the values in place, which is not the case for DeepSeek's deepseek_scaling_rope implementation.
Instead of relying on an in-place modification we should return the values from the forward function implementation.