### PR TITLE
[Core] Allow vLLM to stream n tokens at a time

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -15,6 +15,7 @@ from vllm.inputs import PromptType
 from vllm.outputs import RequestOutput
 from vllm.platforms import current_platform
 from vllm.sampling_params import RequestOutputKind
+from vllm.streaming_params import StreamingParams
 from vllm.utils.torch_utils import set_default_torch_num_threads
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.metrics.loggers import (
@@ -57,6 +58,7 @@ async def generate(
     output_kind: RequestOutputKind,
     max_tokens: int,
     n: int = 1,
+    streaming_params: StreamingParams | None = None,
     prompt_logprobs: int | None = None,
     cancel_after: int | None = None,
 ) -> tuple[int, str]:
@@ -73,8 +75,11 @@ async def generate(
         n=n,
         prompt_logprobs=prompt_logprobs,
     )
+    if streaming_params is None:
+        streaming_params = StreamingParams(stream_n=3)
     async for out in engine.generate(
-        request_id=request_id, prompt=prompt, sampling_params=sampling_params
+        request_id=request_id, prompt=prompt, sampling_params=sampling_params,
+                                     streaming_params=streaming_params
     ):
         num_tokens = sum(len(output.token_ids) for output in out.outputs)
         if output_kind == RequestOutputKind.DELTA:
@@ -312,9 +317,10 @@ async def test_finished_flag(
         )
         outputs = [
             out
-            async for out in engine.generate(
-                request_id="request-33", prompt=prompt, sampling_params=sampling_params
-            )
+            async for out in engine.generate(request_id="request-33",
+                                             prompt=prompt,
+                                             sampling_params=sampling_params,
+                                             streaming_params=None)
         ]
 
         # Assert only the last output has the finished flag set
@@ -342,6 +348,7 @@ async def test_mid_stream_cancellation(
 
         request_ids = [f"request-{i}" for i in range(NUM_REQUESTS)]
 
+        streaming_params = StreamingParams(stream_n=3)
         # Create concurrent requests that will be cancelled mid-stream
         tasks = []
         for request_id in request_ids:
@@ -353,6 +360,7 @@ async def test_mid_stream_cancellation(
                         prompt,
                         RequestOutputKind.DELTA,
                         NUM_TOKENS,
+                        streaming_params=streaming_params,
                         cancel_after=NUM_EXPECTED_TOKENS,
                     )
                 )
@@ -360,13 +368,15 @@ async def test_mid_stream_cancellation(
 
         # Wait for all tasks to complete
         results = await asyncio.gather(*tasks)
+        MIN_EXP_TOKENS = NUM_EXPECTED_TOKENS
+        MAX_EXP_TOKENS = NUM_EXPECTED_TOKENS + streaming_params.stream_n
 
         # Verify all tasks were cancelled at the expected point
         for num_generated_tokens, request_id in results:
-            assert num_generated_tokens == NUM_EXPECTED_TOKENS, (
+            assert MIN_EXP_TOKENS <= num_generated_tokens <= MAX_EXP_TOKENS, (
                 f"{request_id} generated {num_generated_tokens} tokens but "
-                f"expected to cancel after {NUM_EXPECTED_TOKENS}"
-            )
+                f"expected to cancel after {MIN_EXP_TOKENS} and "
+                f"before {MAX_EXP_TOKENS}")
 
         # Make sure no requests are left hanging
         assert not engine.output_processor.has_unfinished_requests()
@@ -374,14 +384,53 @@ async def test_mid_stream_cancellation(
         # Confirm we can reuse the request id after the cancellations.
         request_id = request_ids[0]
         task = asyncio.create_task(
-            generate(
-                engine, request_id, prompt, RequestOutputKind.DELTA, NUM_EXPECTED_TOKENS
-            )
-        )
+            generate(engine,
+                     request_id,
+                     prompt,
+                     RequestOutputKind.DELTA,
+                     NUM_EXPECTED_TOKENS,
+                     streaming_params=streaming_params))
         num_generated_tokens, request_id = await task
-        assert num_generated_tokens == NUM_EXPECTED_TOKENS
+        assert MIN_EXP_TOKENS <= num_generated_tokens <= MAX_EXP_TOKENS, (
+            f"{request_id} generated {num_generated_tokens} tokens but "
+            f"expected to cancel after {MIN_EXP_TOKENS} and "
+            f"before {MAX_EXP_TOKENS}")
         assert not engine.output_processor.has_unfinished_requests()
 
+@pytest.mark.parametrize("n", [1, 3])
+@pytest.mark.parametrize("engine_args,prompt",
+                         [(TEXT_ENGINE_ARGS, TEXT_PROMPT),
+                          (VISION_ENGINE_ARGS, VISION_PROMPT)])
+@pytest.mark.asyncio
+async def test_streaming_params(monkeypatch: pytest.MonkeyPatch, n: int,
+                                engine_args: AsyncEngineArgs,
+                                prompt: PromptType):
+
+    with monkeypatch.context() as m, ExitStack() as after:
+        m.setenv("VLLM_USE_V1", "1")
+
+        engine = AsyncLLM.from_engine_args(engine_args)
+        after.callback(engine.shutdown)
+
+        sampling_params = SamplingParams(max_tokens=100,
+                                         output_kind=RequestOutputKind.DELTA,
+                                         temperature=1.0,
+                                         seed=33,
+                                         n=n)
+        streaming_params = StreamingParams(stream_n=3)
+        outputs = [
+            out
+            async for out in engine.generate(request_id="request-33",
+                                             prompt=prompt,
+                                             sampling_params=sampling_params,
+                                             streaming_params=streaming_params)
+        ]
+
+        # Assert that all but the last output have at least stream_n tokens
+        assert all(
+            sum(len(o.token_ids)
+                for o in out.outputs) >= streaming_params.stream_n
+            for out in outputs[:-1])
 
 class MockLoggingStatLogger(LoggingStatLogger):
     def __init__(self, vllm_config: VllmConfig, engine_index: int = 0):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -88,6 +88,7 @@ from vllm.sampling_params import (
     SamplingParams,
     StructuredOutputsParams,
 )
+from vllm.streaming_params import StreamingParams
 from vllm.utils import random_uuid
 from vllm.utils.import_utils import resolve_obj_by_qualname
 
@@ -233,6 +234,7 @@ AnyResponseFormat: TypeAlias = (
 class StreamOptions(OpenAIBaseModel):
     include_usage: bool | None = True
     continuous_usage_stats: bool | None = False
+    stream_n: Optional[int] = 1
 
 
 class FunctionDefinition(OpenAIBaseModel):
@@ -1411,6 +1413,13 @@ class CompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
         )
+    
+    def to_streaming_params(self, ) -> StreamingParams:
+        stream_n = None
+        if self.stream_options is not None and \
+            self.stream_options.stream_n is not None:
+            stream_n = self.stream_options.stream_n
+        return StreamingParams(stream_n=stream_n)
 
     @model_validator(mode="before")
     @classmethod
@@ -2720,6 +2729,12 @@ class TranscriptionRequest(OpenAIBaseModel):
             else RequestOutputKind.FINAL_ONLY,
             extra_args=self.vllm_xargs,
         )
+    
+    def to_streaming_params(
+        self,
+    ) -> StreamingParams:  # stream_options not defined in transcription request
+        return None
+
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -234,7 +234,7 @@ AnyResponseFormat: TypeAlias = (
 class StreamOptions(OpenAIBaseModel):
     include_usage: bool | None = True
     continuous_usage_stats: bool | None = False
-    stream_n: Optional[int] = 1
+    stream_n: int | None = 1
 
 
 class FunctionDefinition(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -920,6 +920,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
         )
+    
+    def to_streaming_params(self, ) -> StreamingParams:
+        stream_n = None
+        if self.stream_options is not None and \
+            self.stream_options.stream_n is not None:
+            stream_n = self.stream_options.stream_n
+        return StreamingParams(stream_n=stream_n)
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -2733,7 +2733,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     def to_streaming_params(
         self,
     ) -> StreamingParams:  # stream_options not defined in transcription request
-        return None
+        return StreamingParams()
 
 
     @model_validator(mode="before")

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -920,11 +920,12 @@ class ChatCompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
         )
-    
-    def to_streaming_params(self, ) -> StreamingParams:
+
+    def to_streaming_params(
+        self,
+    ) -> StreamingParams:
         stream_n = None
-        if self.stream_options is not None and \
-            self.stream_options.stream_n is not None:
+        if self.stream_options is not None and self.stream_options.stream_n is not None:
             stream_n = self.stream_options.stream_n
         return StreamingParams(stream_n=stream_n)
 
@@ -1420,11 +1421,12 @@ class CompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
         )
-    
-    def to_streaming_params(self, ) -> StreamingParams:
+
+    def to_streaming_params(
+        self,
+    ) -> StreamingParams:
         stream_n = None
-        if self.stream_options is not None and \
-            self.stream_options.stream_n is not None:
+        if self.stream_options is not None and self.stream_options.stream_n is not None:
             stream_n = self.stream_options.stream_n
         return StreamingParams(stream_n=stream_n)
 
@@ -2736,12 +2738,11 @@ class TranscriptionRequest(OpenAIBaseModel):
             else RequestOutputKind.FINAL_ONLY,
             extra_args=self.vllm_xargs,
         )
-    
+
     def to_streaming_params(
         self,
     ) -> StreamingParams:  # stream_options not defined in transcription request
         return StreamingParams()
-
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm/streaming_params.py
+++ b/vllm/streaming_params.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Streaming parameters for token streaming during text generation."""
-from typing import Optional, Annotated
+from typing import Annotated
 
 import msgspec
 

--- a/vllm/streaming_params.py
+++ b/vllm/streaming_params.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Streaming parameters for token streaming during text generation."""
+from typing import Optional, Annotated
+
+import msgspec
+
+
+class StreamValidationError(ValueError):
+    pass
+
+
+class StreamDefaults:
+    STREAM_N_DEFAULT = 1
+
+
+class StreamLimits:
+    STREAM_N_MIN = 1
+    STREAM_N_MAX = 1024
+
+
+class StreamingParams(
+        msgspec.Struct,
+        omit_defaults=True,  # type: ignore[call-arg]
+        dict=True):  # type: ignore[call-arg]
+    """Streaming parameters for token streaming during text generation.
+
+    Args:
+        stream_n: Number of tokens to stream at a time. Must be an integer >= 1.
+            Defaults to 1.
+    """
+
+    stream_n: Annotated[int, msgspec.Meta(
+        ge=StreamLimits.STREAM_N_MIN)] = (StreamDefaults.STREAM_N_DEFAULT)
+
+    def __post_init__(self) -> None:
+        if self.stream_n is None:
+            self.stream_n = StreamDefaults.STREAM_N_DEFAULT
+        if not isinstance(self.stream_n, int):
+            raise StreamValidationError(
+                f"stream_n must be an integer, got {type(self.stream_n)}.")
+        if not (StreamLimits.STREAM_N_MIN <= self.stream_n <=
+                StreamLimits.STREAM_N_MAX):
+            raise StreamValidationError(
+                f"stream_n must be between {StreamLimits.STREAM_N_MIN} and "
+                f"{StreamLimits.STREAM_N_MAX}, got {self.stream_n}.")
+
+    def __repr__(self) -> str:
+        return f"StreamingParams(stream_n={self.stream_n})"

--- a/vllm/streaming_params.py
+++ b/vllm/streaming_params.py
@@ -27,7 +27,7 @@ class StreamingParams(
 ):  # type: ignore[call-arg]
     """Streaming parameters for token streaming during text generation.
 
-    Args:
+    Attributes:
         stream_n (int): Number of tokens to stream at a time. Must be an integer >= 1.
             Defaults to 1.
     """

--- a/vllm/streaming_params.py
+++ b/vllm/streaming_params.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Streaming parameters for token streaming during text generation."""
+
 from typing import Annotated
 
 import msgspec
@@ -20,30 +21,35 @@ class StreamLimits:
 
 
 class StreamingParams(
-        msgspec.Struct,
-        omit_defaults=True,  # type: ignore[call-arg]
-        dict=True):  # type: ignore[call-arg]
+    msgspec.Struct,
+    omit_defaults=True,  # type: ignore[call-arg]
+    dict=True,
+):  # type: ignore[call-arg]
     """Streaming parameters for token streaming during text generation.
 
     Args:
-        stream_n: Number of tokens to stream at a time. Must be an integer >= 1.
+        stream_n (int): Number of tokens to stream at a time. Must be an integer >= 1.
             Defaults to 1.
     """
 
-    stream_n: Annotated[int, msgspec.Meta(
-        ge=StreamLimits.STREAM_N_MIN)] = (StreamDefaults.STREAM_N_DEFAULT)
+    stream_n: Annotated[int, msgspec.Meta(ge=StreamLimits.STREAM_N_MIN)] = (
+        StreamDefaults.STREAM_N_DEFAULT
+    )
 
     def __post_init__(self) -> None:
         if self.stream_n is None:
             self.stream_n = StreamDefaults.STREAM_N_DEFAULT
         if not isinstance(self.stream_n, int):
             raise StreamValidationError(
-                f"stream_n must be an integer, got {type(self.stream_n)}.")
-        if not (StreamLimits.STREAM_N_MIN <= self.stream_n <=
-                StreamLimits.STREAM_N_MAX):
+                f"stream_n must be an integer, got {type(self.stream_n)}."
+            )
+        if not (
+            StreamLimits.STREAM_N_MIN <= self.stream_n <= StreamLimits.STREAM_N_MAX
+        ):
             raise StreamValidationError(
                 f"stream_n must be between {StreamLimits.STREAM_N_MIN} and "
-                f"{StreamLimits.STREAM_N_MAX}, got {self.stream_n}.")
+                f"{StreamLimits.STREAM_N_MAX}, got {self.stream_n}."
+            )
 
     def __repr__(self) -> str:
         return f"StreamingParams(stream_n={self.stream_n})"

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -294,8 +294,9 @@ class AsyncLLM(EngineClient):
         is_pooling = isinstance(params, PoolingParams)
 
         # Create a new output collector for the request.
-        queue = RequestOutputCollector(output_kind=params.output_kind,
-                                       streaming_params=streaming_params)
+        queue = RequestOutputCollector(
+            output_kind=params.output_kind, streaming_params=streaming_params
+        )
 
         # Convert Input --> Request.
         if isinstance(prompt, EngineCoreRequest):

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -24,6 +24,7 @@ from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.plugins.io_processors import get_io_processor
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
+from vllm.streaming_params import StreamingParams
 from vllm.tasks import SupportedTask
 from vllm.tracing import init_tracer
 from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
@@ -276,6 +277,7 @@ class AsyncLLM(EngineClient):
         request_id: str,
         prompt: EngineCoreRequest | PromptType,
         params: SamplingParams | PoolingParams,
+        streaming_params: Optional[StreamingParams] = None,
         arrival_time: float | None = None,
         lora_request: LoRARequest | None = None,
         tokenization_kwargs: dict[str, Any] | None = None,
@@ -292,7 +294,8 @@ class AsyncLLM(EngineClient):
         is_pooling = isinstance(params, PoolingParams)
 
         # Create a new output collector for the request.
-        queue = RequestOutputCollector(output_kind=params.output_kind)
+        queue = RequestOutputCollector(output_kind=params.output_kind,
+                                       streaming_params=streaming_params)
 
         # Convert Input --> Request.
         if isinstance(prompt, EngineCoreRequest):
@@ -365,6 +368,7 @@ class AsyncLLM(EngineClient):
         sampling_params: SamplingParams,
         request_id: str,
         *,
+        streaming_params: StreamingParams | None = None,
         prompt_text: str | None = None,
         lora_request: LoRARequest | None = None,
         tokenization_kwargs: dict[str, Any] | None = None,
@@ -417,6 +421,7 @@ class AsyncLLM(EngineClient):
                 request_id,
                 prompt,
                 sampling_params,
+                streaming_params=streaming_params,
                 lora_request=lora_request,
                 tokenization_kwargs=tokenization_kwargs,
                 trace_headers=trace_headers,

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -277,7 +277,7 @@ class AsyncLLM(EngineClient):
         request_id: str,
         prompt: EngineCoreRequest | PromptType,
         params: SamplingParams | PoolingParams,
-        streaming_params: Optional[StreamingParams] = None,
+        streaming_params: StreamingParams | None = None,
         arrival_time: float | None = None,
         lora_request: LoRARequest | None = None,
         tokenization_kwargs: dict[str, Any] | None = None,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -15,6 +15,7 @@ from vllm.outputs import (
     RequestOutput,
 )
 from vllm.sampling_params import RequestOutputKind
+from vllm.streaming_params import StreamingParams
 from vllm.tracing import SpanAttributes, SpanKind, Tracer, extract_trace_context
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import length_from_prompt_token_ids_or_embeds
@@ -34,25 +35,41 @@ class RequestOutputCollector:
     producer gets ahead of the consumer.
     """
 
-    def __init__(self, output_kind: RequestOutputKind):
+    def __init__(self,
+                 output_kind: RequestOutputKind,
+                 streaming_params: Optional[StreamingParams] = None):
         self.aggregate = output_kind == RequestOutputKind.DELTA
         self.output: RequestOutput | PoolingRequestOutput | Exception | None = None
         self.ready = asyncio.Event()
+        self.streaming_params = streaming_params
 
     def put(self, output: RequestOutput | PoolingRequestOutput | Exception) -> None:
         """Non-blocking put operation."""
-        if self.output is None or isinstance(output, Exception):
+        if isinstance(output, Exception):
             self.output = output
             self.ready.set()
-        elif isinstance(self.output, (RequestOutput, PoolingRequestOutput)):
-            # This ensures that request outputs with different request indexes
-            # (if n > 1) do not override each other.
-            self.output.add(output, aggregate=self.aggregate)
+        else:
+            if self.output is None:
+                self.output = output
+            elif isinstance(self.output,
+                            (RequestOutput, PoolingRequestOutput)):
+                # This ensures that request outputs with different request
+                # indexes(if n > 1) do not override each other.
+                self.output.add(output, aggregate=self.aggregate)
+
+            if isinstance(
+                    self.output, (RequestOutput, PoolingRequestOutput)) and (
+                        self.output.finished or self.streaming_params is None
+                        or sum(len(o.token_ids) for o in self.output.outputs)
+                        >= self.streaming_params.stream_n):
+                self.ready.set()
 
     async def get(self) -> RequestOutput | PoolingRequestOutput:
         """Get operation blocks on put event."""
         while (output := self.output) is None:
+            self.ready.clear()
             await self.ready.wait()
+
         self.output = None
         self.ready.clear()
         if isinstance(output, Exception):

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -35,9 +35,11 @@ class RequestOutputCollector:
     producer gets ahead of the consumer.
     """
 
-    def __init__(self,
-                 output_kind: RequestOutputKind,
-                 streaming_params: StreamingParams | None = None):
+    def __init__(
+        self,
+        output_kind: RequestOutputKind,
+        streaming_params: StreamingParams | None = None,
+    ):
         self.aggregate = output_kind == RequestOutputKind.DELTA
         self.output: RequestOutput | PoolingRequestOutput | Exception | None = None
         self.ready = asyncio.Event()
@@ -51,17 +53,17 @@ class RequestOutputCollector:
         else:
             if self.output is None:
                 self.output = output
-            elif isinstance(self.output,
-                            (RequestOutput, PoolingRequestOutput)):
+            elif isinstance(self.output, (RequestOutput, PoolingRequestOutput)):
                 # This ensures that request outputs with different request
                 # indexes(if n > 1) do not override each other.
                 self.output.add(output, aggregate=self.aggregate)
 
-            if isinstance(
-                    self.output, (RequestOutput, PoolingRequestOutput)) and (
-                        self.output.finished or self.streaming_params is None
-                        or sum(len(o.token_ids) for o in self.output.outputs)
-                        >= self.streaming_params.stream_n):
+            if isinstance(self.output, (RequestOutput, PoolingRequestOutput)) and (
+                self.output.finished
+                or self.streaming_params is None
+                or sum(len(o.token_ids) for o in self.output.outputs)
+                >= self.streaming_params.stream_n
+            ):
                 self.ready.set()
 
     async def get(self) -> RequestOutput | PoolingRequestOutput:

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -37,7 +37,7 @@ class RequestOutputCollector:
 
     def __init__(self,
                  output_kind: RequestOutputKind,
-                 streaming_params: Optional[StreamingParams] = None):
+                 streaming_params: StreamingParams | None = None):
         self.aggregate = output_kind == RequestOutputKind.DELTA
         self.output: RequestOutput | PoolingRequestOutput | Exception | None = None
         self.ready = asyncio.Event()


### PR DESCRIPTION
This PR introduces support for streaming n tokens at a time in vLLM, which can help alleviate potential network bandwidth issues.

It adds a new StreamingParams class to store the stream_n parameter and other future parameters related to token streaming behavior.

This is an exact copy of [PR #19240](https://github.com/vllm-project/vllm/pull/19240), recreated here because I no longer have access to my previous GitHub account.