### PR TITLE
[CI/Build] Fix AMD CI: test_cpu_gpu.py

### DIFF
--- a/tests/v1/kv_offload/test_cpu_gpu.py
+++ b/tests/v1/kv_offload/test_cpu_gpu.py
@@ -8,10 +8,39 @@ import torch
 
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
-from vllm.v1.attention.backends.flashinfer import FlashInferBackend
-from vllm.v1.attention.backends.mla.flashattn_mla import FlashAttnMLABackend
 from vllm.v1.kv_offload.mediums import CPULoadStoreSpec, GPULoadStoreSpec
 from vllm.v1.kv_offload.worker.cpu_gpu import CpuGpuOffloadingHandler
+
+BACKENDS_TO_TEST = [FlashAttentionBackend]
+
+try:
+    from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+
+    BACKENDS_TO_TEST.append(FlashInferBackend)
+except ImportError:
+    pass
+
+try:
+    from vllm.v1.attention.backends.mla.flashattn_mla import FlashAttnMLABackend
+
+    BACKENDS_TO_TEST.append(FlashAttnMLABackend)
+except ImportError:
+    pass
+
+if current_platform.is_rocm():
+    try:
+        from vllm.v1.attention.backends.rocm_attn import RocmAttentionBackend
+
+        BACKENDS_TO_TEST.append(RocmAttentionBackend)
+    except ImportError:
+        pass
+
+try:
+    from vllm.v1.attention.backends.triton_attn import TritonAttentionBackend
+
+    BACKENDS_TO_TEST.append(TritonAttentionBackend)
+except ImportError:
+    pass
 
 NUM_GPU_BLOCKS = [64]
 NUM_CPU_BLOCKS = [256]
@@ -26,6 +55,10 @@ CUDA_DEVICES = ["cuda:0"]
 NUM_MAPPINGS = [3]
 
 
+@pytest.mark.skipif(
+    len(BACKENDS_TO_TEST) < 2,
+    reason="Need at least 2 backends to test heterogeneous KV cache layouts",
+)
 @pytest.mark.parametrize("gpu_to_cpu", [True, False])
 @pytest.mark.parametrize("num_mappings", NUM_MAPPINGS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
@@ -55,8 +88,7 @@ def test_transfer(
 ) -> None:
     current_platform.seed_everything(seed)
 
-    # create per-layer GPU KV caches
-    attn_backends_list = [FlashAttentionBackend, FlashInferBackend, FlashAttnMLABackend]
+    attn_backends_list = BACKENDS_TO_TEST
 
     gpu_caches = {}
     attn_backends = {}


### PR DESCRIPTION
## Purpose
`test_cpu_gpu.py` is added in https://github.com/vllm-project/vllm/pull/21448, while it add different attention backends to test, some backends might not be compatible with platforms - like FlashInferBackend is not supported in ROCM at the current moment.

This PR refactors the test to conditional import backends, like what we did in [test_attention_backends.py](https://github.com/vllm-project/vllm/blob/7e0941055fdf89bae93045683dd80542177f3241/tests/v1/attention/test_attention_backends.py#L29).

## Test Plan
```
pytest -v -s v1/kv_offload/test_cpu_gpu.py
INFO 10-22 21:15:25 [__init__.py:225] Automatically detected platform rocm.
================================================================= test session starts =================================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0 -- /home/zhewenli/uv_env/vllm-fork/bin/python3
cachedir: .pytest_cache
rootdir: /data/users/zhewenli/gitrepos/vllm-fork
configfile: pyproject.toml
plugins: anyio-4.11.0, asyncio-1.2.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... WARNING 10-22 21:15:43 [interface.py:512] Current platform cuda does not have '__test__' attribute.
WARNING 10-22 21:15:43 [interface.py:512] Current platform cuda does not have '__bases__' attribute.
WARNING 10-22 21:15:43 [interface.py:512] Current platform cuda does not have '__test__' attribute.
collected 4 items                                                                                                                                     

v1/kv_offload/test_cpu_gpu.py::test_transfer[cuda:0-0-dtype0-4-256-64-1-16-8-64-3-True] INFO 10-22 21:15:43 [cpu_gpu.py:78] Allocating 4 CPU tensors...
PASSED
v1/kv_offload/test_cpu_gpu.py::test_transfer[cuda:0-0-dtype0-4-256-64-1-16-8-64-3-False] INFO 10-22 21:15:44 [cpu_gpu.py:78] Allocating 4 CPU tensors...
PASSED
v1/kv_offload/test_cpu_gpu.py::test_transfer[cuda:0-0-dtype0-4-256-64-3-16-8-64-3-True] INFO 10-22 21:15:44 [cpu_gpu.py:78] Allocating 4 CPU tensors...
PASSED
v1/kv_offload/test_cpu_gpu.py::test_transfer[cuda:0-0-dtype0-4-256-64-3-16-8-64-3-False] INFO 10-22 21:15:45 [cpu_gpu.py:78] Allocating 4 CPU tensors...
PASSED

================================================================== warnings summary ===================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================ 4 passed, 2 warnings in 2.86s ============================================================
```


