### PR TITLE
[ROCm] Fix DeepSeek R1/V3 incorrect output in eager mode.

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/base.py
+++ b/vllm/model_executor/layers/rotary_embedding/base.py
@@ -168,7 +168,8 @@ class RotaryEmbedding(CustomOp):
         else:
             # ops.rotary_embedding() is an in-place operation
             # that updates the query and key tensors.
-            self.forward_cuda(positions, query, key)
+            # FIXME: self.forward_cuda is not a in-place operation in eager mode.
+            return self.forward_cuda(positions, query, key)
         return query, key
 
     def forward_xpu(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
DeepSeek R1/V3 models produce incorrect output when running in eager mode, while graph mode works correctly.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

