### PR TITLE
[FusedMoE] Remove cuda hard-code in dual stream execution

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1088,7 +1088,7 @@ class FusedMoE(CustomOp):
         # debug purposes.
         # TODO: Remove this after more extensive testings with TP/DP
         # and other execution modes
-        if envs.VLLM_DISABLE_SHARED_EXPERTS_STREAM:
+        if envs.VLLM_DISABLE_SHARED_EXPERTS_STREAM or current_platform.is_tpu():
             logger.info_once("Disabling MoE shared_experts stream")
             self.shared_experts_stream = None
         else:


### PR DESCRIPTION
## Purpose
Remove cuda hard-code in dual stream execution of FusedMoE

## Test Plan
Test through the exsiting tests

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
