### PR TITLE
Fix: Improve layer skipping and FusedMoE handling in AWQMarlin

### DIFF
--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -178,9 +178,9 @@ class AWQMarlinConfig(QuantizationConfig):
             isinstance(layer, ParallelLMHead) and self.lm_head_quantized
         ):
             if is_layer_skipped(
-                prefix, 
-                self.modules_to_not_convert, 
-                self.packed_modules_mapping, 
+                prefix,
+                self.modules_to_not_convert,
+                self.packed_modules_mapping,
                 skip_with_substr=True
             ):
                 return UnquantizedLinearMethod()

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -178,7 +178,9 @@ class AWQMarlinConfig(QuantizationConfig):
             isinstance(layer, ParallelLMHead) and self.lm_head_quantized
         ):
             if is_layer_skipped(
-                prefix, self.modules_to_not_convert, self.packed_modules_mapping, skip_with_substr=True
+                prefix, self.modules_to_not_convert, 
+                self.packed_modules_mapping, 
+                skip_with_substr=True
             ):
                 return UnquantizedLinearMethod()
             # Check if the layer is supported by AWQMarlin.
@@ -194,8 +196,11 @@ class AWQMarlinConfig(QuantizationConfig):
         elif isinstance(layer, FusedMoE):
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 
-            if is_layer_skipped(prefix, getattr(self, "modules_to_not_convert", []),
-                                skip_with_substr=True):
+            if is_layer_skipped(
+                    prefix, 
+                    getattr(self, "modules_to_not_convert", []),
+                    skip_with_substr=True
+                ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if not check_moe_marlin_supports_layer(layer, self.group_size):
                 logger.warning_once(

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -178,7 +178,8 @@ class AWQMarlinConfig(QuantizationConfig):
             isinstance(layer, ParallelLMHead) and self.lm_head_quantized
         ):
             if is_layer_skipped(
-                prefix, self.modules_to_not_convert, 
+                prefix, 
+                self.modules_to_not_convert, 
                 self.packed_modules_mapping, 
                 skip_with_substr=True
             ):
@@ -197,10 +198,10 @@ class AWQMarlinConfig(QuantizationConfig):
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 
             if is_layer_skipped(
-                    prefix, 
-                    getattr(self, "modules_to_not_convert", []),
-                    skip_with_substr=True
-                ):
+                prefix,
+                getattr(self, "modules_to_not_convert", []),
+                skip_with_substr=True
+            ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if not check_moe_marlin_supports_layer(layer, self.group_size):
                 logger.warning_once(

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -178,7 +178,7 @@ class AWQMarlinConfig(QuantizationConfig):
             isinstance(layer, ParallelLMHead) and self.lm_head_quantized
         ):
             if is_layer_skipped(
-                prefix, self.modules_to_not_convert, self.packed_modules_mapping
+                prefix, self.modules_to_not_convert, self.packed_modules_mapping, skip_with_substr=True
             ):
                 return UnquantizedLinearMethod()
             # Check if the layer is supported by AWQMarlin.
@@ -194,7 +194,8 @@ class AWQMarlinConfig(QuantizationConfig):
         elif isinstance(layer, FusedMoE):
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 
-            if is_layer_skipped(prefix, getattr(self, "modules_to_not_convert", [])):
+            if is_layer_skipped(prefix, getattr(self, "modules_to_not_convert", []),
+                                skip_with_substr=True):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if not check_moe_marlin_supports_layer(layer, self.group_size):
                 logger.warning_once(


### PR DESCRIPTION
 - Updated is_layer_skipped with skip_with_substr=True for better layer skipping.
 - Fixed FusedMoE handling on line 197 for compatibility with deepseek3.2 AWQ layers.

## Purpose
Fix layer skipping logic and improve handling of FusedMoE layers for compatibility with deepseek3.2 AWQ layers in awq_marlin.py. #27401 
## Test Plan
Test loading the deepseek3.2 AWQ on 8 H800 80G and success

## Test Result
Successfully loaded AWQ layers without skipping issues.

No errors or crashes when processing FusedMoE layers in the modified function.
before
```
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]     self.model_runner.load_model(eep_scale_up=eep_scale_up)                      
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]   File                                                                           
"/mnt/cache/zhaohui_share/codes/deepseek-v3.2/py32/lib/python3.12/site-                                                                          
  packa                                                                                                                                          
  ges/vllm/v1/worker/gpu_model_runner.py", line 2890, in load_model                                                                              
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]     self.model = model_loader.load_model(                                        
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]                  ^^^^^^^^^^^^^^^^^^^^^^^^                                        
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]   File                                                                           
"/mnt/cache/zhaohui_share/codes/deepseek-v3.2/py32/lib/python3.12/site-                                                                          
  packa                                                                                                                                          
  ges/vllm/model_executor/model_loader/base_loader.py", line 55, in load_model                                                                   
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]     self.load_weights(model, model_config)                                       
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]   File                                                                           
"/mnt/cache/zhaohui_share/codes/deepseek-v3.2/py32/lib/python3.12/site-                                                                          
  packa                                                                                                                                          
  ges/vllm/model_executor/model_loader/default_loader.py", line 300, in load_weights                                                             
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]     loaded_weights = model.load_weights(                                         
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]                      ^^^^^^^^^^^^^^^^^^^                                         
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]   File                                                                           
"/mnt/cache/zhaohui_share/codes/deepseek-v3.2/py32/lib/python3.12/site-                                                                          
  packa                                                                                                                                          
  ges/vllm/model_executor/models/deepseek_v2.py", line 1489, in load_weights                                                                     
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]     param = params_dict[name]                                                    
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784]             ~~~~~~~~~~~^^^^^^                                                    
  (EngineCore_DP5 pid=63903) ERROR 10-23 14:26:57 [core.py:784] KeyError: 'model.layers.0.mlp.down_proj.weight'    

```
after
```
(APIServer pid=114901) INFO:     Started server process [114901]                                                                   
(APIServer pid=114901) INFO:     Waiting for application startup.                                                                  
(APIServer pid=114901) INFO:     Application startup complete.                                                                     
(APIServer pid=114901) INFO 10-23 17:12:14 [chat_utils.py:546] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=114901) INFO 10-23 17:12:24 [loggers.py:199] Engine 000: Avg prompt throughput: 2.0 tokens/s, Avg generation throughput: 39.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.7%, Prefix cache hit rate: 0.0%
(APIServer pid=114901) INFO:     10.119.28.59:60420 - "POST /v1/chat/completions HTTP/1.1" 200 OK                                                                                                                                                                      
```                                                                                                                                                   
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

