### PR TITLE
[benchmark] Support generalized SSE protocol

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -29,22 +29,26 @@ class StreamedResponseHandler:
     def add_chunk(self, chunk_bytes: bytes) -> list[str]:
         """Add a chunk of bytes to the buffer and return any complete
         messages."""
+        messages = []
+        if not chunk_bytes:
+            return messages
+
         chunk_str = chunk_bytes.decode("utf-8")
         self.buffer += chunk_str
-
-        messages = []
 
         # Split by double newlines (SSE message separator)
         while "\n\n" in self.buffer:
             message, self.buffer = self.buffer.split("\n\n", 1)
             message = message.strip()
-            if message:
-                messages.append(message)
+            # Filter out non-data channel in SSE, e.g. event:<xxx>
+            for line in message.splitlines():
+                if line.startswith("data:"):
+                    messages.append(line)
 
         # if self.buffer is not empty, check if it is a complete message
         # by removing data: prefix and check if it is a valid JSON
-        if self.buffer.startswith("data: "):
-            message_content = self.buffer.removeprefix("data: ").strip()
+        if self.buffer.startswith("data:"):
+            message_content = self.buffer.removeprefix("data:").strip()
             if message_content == "[DONE]":
                 messages.append(self.buffer.strip())
                 self.buffer = ""
@@ -190,10 +194,6 @@ async def async_request_openai_completions(
                 handler = StreamedResponseHandler()
 
                 async for chunk_bytes in response.content.iter_any():
-                    chunk_bytes = chunk_bytes.strip()
-                    if not chunk_bytes:
-                        continue
-
                     messages = handler.add_chunk(chunk_bytes)
                     for message in messages:
                         # NOTE: SSE comments (often used as pings) start with
@@ -202,7 +202,8 @@ async def async_request_openai_completions(
                         if message.startswith(":"):
                             continue
 
-                        chunk = message.removeprefix("data: ")
+                        # NOTE: SSE packet may come with data:<payload> or data:<space><payload>
+                        chunk = message.removeprefix("data:").strip()
 
                         if chunk != "[DONE]":
                             data = json.loads(chunk)
@@ -322,10 +323,6 @@ async def async_request_openai_chat_completions(
             if response.status == 200:
                 handler = StreamedResponseHandler()
                 async for chunk_bytes in response.content.iter_any():
-                    chunk_bytes = chunk_bytes.strip()
-                    if not chunk_bytes:
-                        continue
-
                     messages = handler.add_chunk(chunk_bytes)
                     for message in messages:
                         # NOTE: SSE comments (often used as pings) start with
@@ -334,14 +331,16 @@ async def async_request_openai_chat_completions(
                         if message.startswith(":"):
                             continue
 
-                        chunk = message.removeprefix("data: ")
+                        # NOTE: SSE packet may come with data:<payload> or data:<space><payload>
+                        chunk = message.removeprefix("data:").strip()
 
                         if chunk != "[DONE]":
                             timestamp = time.perf_counter()
                             data = json.loads(chunk)
 
                             if choices := data.get("choices"):
-                                content = choices[0]["delta"].get("content")
+                                # Count the CoT token as an output token
+                                content = choices[0]["delta"].get("content") or choices[0]["delta"].get("reasoning_content")
                                 # First token
                                 if ttft == 0.0:
                                     ttft = timestamp - st
@@ -436,13 +435,9 @@ async def async_request_openai_audio(
                     handler = StreamedResponseHandler()
 
                     async for chunk_bytes in response.content.iter_any():
-                        chunk_bytes = chunk_bytes.strip()
-                        if not chunk_bytes:
-                            continue
-
                         messages = handler.add_chunk(chunk_bytes)
                         for message in messages:
-                            chunk = message.decode("utf-8").removeprefix("data: ")
+                            chunk = message.removeprefix("data:").strip()
                             if chunk != "[DONE]":
                                 timestamp = time.perf_counter()
                                 data = json.loads(chunk)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR https://github.com/vllm-project/vllm/pull/24373 proposed to handle SSE protocol in order to support long context benchmarking.

However it lacks several SSE handling

1. SSE support `data:`, `event:`, `id:`, `retry:` channel in one message, we should iterate over the lines to get all the channel.
2. SSE use `\n\n` to separate messages, we should not call `chunk_bytes.strip` since it removes all trailing `\n\n`, leading to parsing error
3. Some SSE server (in my case, golang server) send `data:` instead of `data: ` (extra space), this PR supports both format, like openai client do.

Another minor changes:
1. Support counting CoT tokens as output tokens.

## Test Plan
vllm serve Qwen/Qwen2.5-0.5B-Instruct
`vllm bench serve --backend openai-chat --endpoint "/v1/chat/completions" --base_url "http://localhost:8888" --model_name "Qwen/Qwen2.5-0.5B-Instruct"

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

