### PR TITLE
Fix EventPublisherFactory logic for disabled KV cache events

### DIFF
--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -263,3 +263,52 @@ def test_data_parallel_rank_tagging(publisher_config):
         pub_1.shutdown()
         sub_0.close()
         sub_1.close()
+
+
+def test_event_publisher_factory():
+    """Test event publisher factory creation behavior under different configurations"""
+    from vllm.config.kv_events import KVEventsConfig
+    from vllm.distributed.kv_events import ZmqEventPublisher
+
+    # test config is None
+    publisher = EventPublisherFactory.create(None, DP_RANK)
+    assert isinstance(publisher, NullEventPublisher)
+    publisher.shutdown()
+
+    # test disable kv cache events
+    config = KVEventsConfig(
+        enable_kv_cache_events=False,
+        publisher="zmq",  # Even if zmq is specified, should return NullEventPublisher
+        endpoint="tcp://localhost:5557",
+    )
+    publisher = EventPublisherFactory.create(config, DP_RANK)
+    assert isinstance(publisher, NullEventPublisher)
+    publisher.shutdown()
+
+    # test zmq publisher
+    config = KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="zmq",
+        endpoint="inproc://test-factory-true",
+    )
+    publisher = EventPublisherFactory.create(config, DP_RANK)
+    assert isinstance(publisher, ZmqEventPublisher)
+    publisher.shutdown()
+
+    # test unknown publisher
+    with pytest.raises(ValueError, match="Input should be 'null' or 'zmq'"):
+        KVEventsConfig(
+            enable_kv_cache_events=True,
+            publisher="unknown_publisher",
+            endpoint="tcp://localhost:5557",
+        )
+
+    # test publisher not specified
+    config = KVEventsConfig(
+        enable_kv_cache_events=True,
+        # publisher not specified, should default to "zmq"
+        endpoint="tcp://localhost:5557",
+    )
+    publisher = EventPublisherFactory.create(config, DP_RANK)
+    assert isinstance(publisher, ZmqEventPublisher)
+    publisher.shutdown()

--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -296,7 +296,7 @@ def test_event_publisher_factory():
     publisher.shutdown()
 
     # test unknown publisher
-    with pytest.raises(ValueError, match="Input should be 'null' or 'zmq'"):
+    with pytest.raises(ValueError, match="Input should be"):
         KVEventsConfig(
             enable_kv_cache_events=True,
             publisher="unknown_publisher",

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -353,7 +353,11 @@ class EventPublisherFactory:
         cls, config: KVEventsConfig | None, data_parallel_rank: int = 0
     ) -> EventPublisher:
         """Create publisher from a config mapping."""
-        if config is None or config.publisher == "null":
+        if (
+            config is None
+            or not config.enable_kv_cache_events
+            or config.publisher == "null"
+        ):
             return NullEventPublisher()
 
         config_dict = asdict(config)


### PR DESCRIPTION
## Purpose
Fixed a logic flaw in the `EventPublisherFactory.create()` method to ensure it properly returns `NullEventPublisher` when `enable_kv_cache_events=False`.

#### Changes
- Fixed conditional logic in `EventPublisherFactory.create()` method

## Test Plan
- New test cases verify correct behavior across various configuration combinations
- Ensures backward compatibility
- All existing tests continue to pass

## Test Result
Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>