### PR TITLE
[Hardware][POWERPC] Disable oneDNN path in vllm/model_executor/layers/utils.py for Powerpc

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -8,7 +8,7 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm import envs
-from vllm.platforms import current_platform
+from vllm.platforms import current_platform, CpuArchEnum
 from vllm.utils.torch_utils import direct_register_custom_op
 
 
@@ -178,7 +178,8 @@ def dispatch_cpu_unquantized_gemm(
         )
         if remove_weight:
             layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)
-    elif ops._supports_onednn:
+    elif (ops._supports_onednn and 
+         current_platform.get_cpu_architecture() != CpuArchEnum.POWERPC):
         origin_weight = layer.weight
         if remove_weight:
             layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -8,7 +8,7 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm import envs
-from vllm.platforms import current_platform, CpuArchEnum
+from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
 
@@ -178,8 +178,10 @@ def dispatch_cpu_unquantized_gemm(
         )
         if remove_weight:
             layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)
-    elif (ops._supports_onednn and 
-         current_platform.get_cpu_architecture() != CpuArchEnum.POWERPC):
+    elif (
+        ops._supports_onednn
+        and current_platform.get_cpu_architecture() != CpuArchEnum.POWERPC
+    ):
         origin_weight = layer.weight
         if remove_weight:
             layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)


### PR DESCRIPTION
PR: #27183 removes the architecture check and the oneDNN paths fails for POWERPC. This PR introduces the architecture check in order to avoid the oneDNN path.

cc: @bigPYJ1151 