### PR TITLE
[Misc] Add TPU usage report when using tpu_inference.

### DIFF
--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -176,6 +176,32 @@ class UsageMessage:
         self._report_usage_once(model_architecture, usage_context, extra_kvs)
         self._report_continuous_usage()
 
+    def _report_tpu_inference_usage(self) -> bool:
+        try:
+            from tpu_inference import tpu_info, utils
+
+            self.gpu_count = tpu_info.get_num_chips()
+            self.gpu_type = tpu_info.get_tpu_type()
+            self.gpu_memory_per_device = utils.get_device_hbm_limit()
+            self.cuda_runtime = "tpu_inference"
+            return True
+        except Exception:
+            return False
+
+    def _report_torch_xla_usage(self) -> bool:
+        try:
+            import torch_xla
+
+            self.gpu_count = torch_xla.runtime.world_size()
+            self.gpu_type = torch_xla.tpu.get_tpu_type()
+            self.gpu_memory_per_device = torch_xla.core.xla_model.get_memory_info()[
+                "bytes_limit"
+            ]
+            self.cuda_runtime = "torch_xla"
+            return True
+        except Exception:
+            return False
+
     def _report_usage_once(
         self,
         model_architecture: str,
@@ -193,15 +219,9 @@ class UsageMessage:
         if current_platform.is_cuda():
             self.cuda_runtime = torch.version.cuda
         if current_platform.is_tpu():
-            try:
-                import torch_xla
-
-                self.gpu_count = torch_xla.runtime.world_size()
-                self.gpu_type = torch_xla.tpu.get_tpu_type()
-                self.gpu_memory_per_device = torch_xla.core.xla_model.get_memory_info()[
-                    "bytes_limit"
-                ]
-            except Exception:
+            if (not self._report_tpu_inference_usage()) and (
+                not self._report_torch_xla_usage()
+            ):
                 logger.exception("Failed to collect TPU information")
         self.provider = _detect_cloud_provider()
         self.architecture = platform.machine()

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -218,7 +218,7 @@ class UsageMessage:
             )
         if current_platform.is_cuda():
             self.cuda_runtime = torch.version.cuda
-        if current_platform.is_tpu():
+        if current_platform.is_tpu():  # noqa: SIM102
             if (not self._report_tpu_inference_usage()) and (
                 not self._report_torch_xla_usage()
             ):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Report usage for users who are using tpu_inference, aka vllm-tpu 2.0

The associated PR in the tpu_inference repo is: https://github.com/vllm-project/tpu-inference/pull/925

## Test Plan

Tested manually.

## Test Result

Create the usage_stats file: $HOME/.config/vllm/usage_stats.json and start vllm server, a report such as this was generated:

```
{"uuid": "dd2ebebc-fa7c-4b5c-88f9-c6136bad1a2e", "provider": "GCP", "num_cpu": 180, "cpu_type": "AMD EPYC 9B14", "cpu_family_model_stepping": "25,17,1", "total_memory": 1521841610752, "architecture": "x86_64", "platform": "Linux-6.8.0-1015-gcp-x86_64-with-glibc2.35", "cuda_runtime": "tpu_inference", "gpu_count": 8, "gpu_type": "v6e-8", "gpu_memory_per_device": 34359738368, "env_var_json": "{\"VLLM_USE_MODELSCOPE\": false, \"VLLM_USE_TRITON_FLASH_ATTN\": true, \"VLLM_ATTENTION_BACKEND\": null, \"VLLM_USE_FLASHINFER_SAMPLER\": null, \"VLLM_PP_LAYER_PARTITION\": null, \"VLLM_USE_TRITON_AWQ\": false, \"VLLM_USE_V1\": true, \"VLLM_ENABLE_V1_MULTIPROCESSING\": true}", "model_architecture": "Qwen2_5_VLForConditionalGeneration", "vllm_version": "0.11.0rc2.dev369+gc6187f55f.d20251010", "context": "ENGINE_CONTEXT", "log_time": 1761231915326027008, "source": "production", "dtype": "<class 'jax.numpy.bfloat16'>", "block_size": 128, "gpu_memory_utilization": 0.9, "kv_cache_memory_bytes": null, "quantization": null, "kv_cache_dtype": "auto", "enable_lora": false, "enable_prefix_caching": false, "enforce_eager": false, "disable_custom_all_reduce": true, "tensor_parallel_size": 1, "data_parallel_size": 1, "pipeline_parallel_size": 1, "enable_expert_parallel": false, "all2all_backend": "allgather_reducescatter", "kv_connector": null}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

