### PR TITLE
[Bug] Raise error explicitly if using incompatible backend

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -271,7 +271,7 @@ class CudaPlatformBase(Platform):
                 _Backend.XFORMERS,
             }:
                 raise ValueError(
-                    "Selected attention backend is incompatible with MLA models. "
+                    f"Attention backend {selected_backend} incompatible with MLA. "
                     "Please use one of the MLA backends: FLASHINFER_MLA, CUTLASS_MLA, "
                     "FLASHMLA, FLASH_ATTN_MLA, or TRITON_MLA. Alternatively, set "
                     "VLLM_MLA_DISABLE=1 to disable MLA for this model."

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -261,6 +261,21 @@ class CudaPlatformBase(Platform):
         from vllm.attention.backends.registry import _Backend
 
         if use_mla:
+            # explicitly reject non-MLA backends when MLA is enabled to avoid
+            # silently selecting an incompatible backend (e.g., FLASHINFER).
+            if selected_backend in {
+                _Backend.FLASHINFER,
+                _Backend.FLASH_ATTN,
+                _Backend.TRITON_ATTN,
+                _Backend.TREE_ATTN,
+                _Backend.XFORMERS,
+            }:
+                raise ValueError(
+                    "Selected attention backend is incompatible with MLA models. "
+                    "Please use one of the MLA backends: FLASHINFER_MLA, CUTLASS_MLA, "
+                    "FLASHMLA, FLASH_ATTN_MLA, or TRITON_MLA. Alternatively, set "
+                    "VLLM_MLA_DISABLE=1 to disable MLA for this model."
+                )
             if not use_v1:
                 raise RuntimeError(
                     "MLA attention backends require the V1 engine. "


### PR DESCRIPTION
## Purpose

If the users choose the wrong backend, will meet unexpected error, eg:

```
(EngineCore_DP7 pid=4191233)   File "/home/wentao/vllm-source/vllm/model_executor/models/utils.py", line 642, in make_layers
(EngineCore_DP7 pid=4191233)     maybe_offload_to_cpu(layer_fn(prefix=f"{prefix}.{idx}"))
(EngineCore_DP7 pid=4191233)                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP7 pid=4191233)   File "/home/wentao/vllm-source/vllm/model_executor/models/deepseek_v2.py", line 1128, in <lambda>
(EngineCore_DP7 pid=4191233)     lambda prefix: DeepseekV2DecoderLayer(
(EngineCore_DP7 pid=4191233)                    ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP7 pid=4191233)   File "/home/wentao/vllm-source/vllm/model_executor/models/deepseek_v2.py", line 1005, in __init__
(EngineCore_DP7 pid=4191233)     self.self_attn = attn_cls(
(EngineCore_DP7 pid=4191233)                      ^^^^^^^^^
(EngineCore_DP7 pid=4191233)   File "/home/wentao/vllm-source/vllm/model_executor/models/deepseek_v2.py", line 953, in __init__
(EngineCore_DP7 pid=4191233)     self.mla_attn = MultiHeadLatentAttentionWrapper(
(EngineCore_DP7 pid=4191233)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP7 pid=4191233)   File "/home/wentao/vllm-source/vllm/model_executor/layers/mla.py", line 90, in __init__
(EngineCore_DP7 pid=4191233)     self.mla_attn = MLAAttention(
(EngineCore_DP7 pid=4191233)                     ^^^^^^^^^^^^^
(EngineCore_DP7 pid=4191233)   File "/home/wentao/vllm-source/vllm/attention/layer.py", line 651, in __init__
(EngineCore_DP7 pid=4191233)     self.impl = impl_cls(
(EngineCore_DP7 pid=4191233)                 ^^^^^^^^^
(EngineCore_DP7 pid=4191233) TypeError: FlashInferImpl.__init__() got an unexpected keyword argument 'q_lora_rank'
```

This PR raise error explicitly and let users know how to solve the issue


```
ValueError: Attention backend _Backend.FLASHINFER is incompatible with MLA models. Please use one of the MLA backends: FLASHINFER_MLA, CUTLASS_MLA, FLASHMLA, FLASH_ATTN_MLA, or TRITON_MLA. Alternatively, set VLLM_MLA_DISABLE=1 to disable MLA for this model.
```