### PR TITLE
[Bugfix] In LongRoPE, decide short vs long based on max_model_len

### DIFF
--- a/tests/entrypoints/openai/test_default_mm_loras.py
+++ b/tests/entrypoints/openai/test_default_mm_loras.py
@@ -29,7 +29,7 @@ def multimodal_server():  # noqa: F811
         "--dtype",
         "half",
         "--max-model-len",
-        "12800",
+        "4096",
         "--enforce-eager",
         # lora config below
         "--enable-lora",

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2116,7 +2116,9 @@ def _get_and_verify_max_len(
         elif rope_type == "longrope":
             # For LongRoPE, we default to the original max to avoid performance
             # degradation for shorter sequences.
-            derived_max_model_len = rope_scaling["original_max_position_embeddings"]
+            derived_max_model_len = getattr(
+                hf_config, "original_max_position_embeddings", derived_max_model_len
+            )
 
     if encoder_config and "max_seq_length" in encoder_config:
         derived_max_model_len = encoder_config["max_seq_length"]

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2113,6 +2113,10 @@ def _get_and_verify_max_len(
             if rope_type == "yarn":
                 derived_max_model_len = rope_scaling["original_max_position_embeddings"]
             derived_max_model_len *= scaling_factor
+        elif rope_type == "longrope":
+            # For LongRoPE, we default to the original max to avoid performance
+            # degradation for shorter sequences.
+            derived_max_model_len = rope_scaling["original_max_position_embeddings"]
 
     if encoder_config and "max_seq_length" in encoder_config:
         derived_max_model_len = encoder_config["max_seq_length"]

--- a/vllm/model_executor/layers/rotary_embedding/phi3_long_rope_scaled_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/phi3_long_rope_scaled_rope.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import logging
 import math
 
 import torch
 import torch.nn as nn
 
 from vllm.config import get_current_vllm_config
+from vllm.logger import init_logger
 
 from .common import rotate_neox
 
-logger = logging.getLogger(__name__)
+logger = init_logger(__name__)
 
 
 class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
@@ -54,7 +54,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
         max_model_len = get_current_vllm_config().model_config.max_model_len
         self.use_long_rope = max_model_len > original_max_position_embeddings
         if self.use_long_rope:
-            logger.warning(
+            logger.warning_once(
                 "Using LongRoPE scaling factors. This enables longer "
                 "contexts (%d tokens vs original %d tokens) at the cost of "
                 "some performance degradation for shorter sequences. If "


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Per suggestion by @LucasWilkinson, fixes #27414 by choosing short vs long RoPE factors at init time based on `max_model_len`

## Test Plan
### Functionality
```
vllm serve microsoft/Phi-3.5-mini-instruct

guidellm benchmark \
  --target "http://localhost:8080" \
  --rate-type concurrent \
  --rate 16 \
  --data "prompt_tokens=3900,output_tokens=500" \
  --max-requests 100
```

### Accuracy
```
vllm serve microsoft/Phi-3.5-mini-instruct --max-model-len <len>

lm_eval \
  --model local-chat-completions \
  --model_args base_url=http://localhost:8000/v1/chat/completions,
               model=microsoft/Phi-3.5-mini-instruct,
               num_concurrent=32,
               max_retries=3,
               tokenized_requests=False \
  --tasks gsm8k \
  --apply_chat_template
```

## Test Result
### Functionality
No longer produces random tokens after threshold

### Accuracy
with `max-model-len=4096` (new default):
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7559|±  |0.0118|
|     |       |strict-match    |     5|exact_match|↑  |0.5679|±  |0.0136|
```
with `max-model-len=4097` (to trigger long rope)
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6702|±  |0.0129|
|     |       |strict-match    |     5|exact_match|↑  |0.3071|±  |0.0127|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

