### PR TITLE
[Misc] Avoid "PyTorch non-writable tensors" warning in RayPPCommunicator

### DIFF
--- a/vllm/distributed/device_communicators/ray_communicator.py
+++ b/vllm/distributed/device_communicators/ray_communicator.py
@@ -99,7 +99,7 @@ class RayPPCommunicator(Communicator):
 
         # Ray actor IDs are 32-character hex strings (128 bits)
         ACTOR_ID_LEN = 32
-        actor_id_bytes = actor_id_str.encode("utf-8")
+        actor_id_bytes = bytearray(actor_id_str.encode("utf-8"))
         assert len(actor_id_bytes) == ACTOR_ID_LEN, (
             f"Unexpected actor ID length: {len(actor_id_bytes)}"
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

PyTorch warns when a non-writable buffer is used to create a tensor:
```
vllm/distributed/device_communicators/ray_communicator.py:107: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program.
```

Although the current code is safe because the tensor is not written to, this PR avoids the warning so logging won't be confusing to users.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

