### PR TITLE
[Chore] remove structural tags logging lines

### DIFF
--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -103,7 +103,6 @@ class XgrammarBackend(StructuredOutputBackend):
                 ]
                 ctx = self.compiler.compile_structural_tag(tags, s_tag["triggers"])
             else:
-                logger.info("Compiling structural tag grammar_spec: %s", grammar_spec)
                 ctx = self.compiler.compile_structural_tag(grammar_spec)
         else:
             logger.error(


### PR DESCRIPTION
This PR removes an excessive lines in logging of the xgrammar backend.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
