### PR TITLE
[Perf][Async Scheduling] Remove CPU->GPU sync in dummy_run

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3495,7 +3495,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.eplb_step(is_dummy=True, is_profile=is_profile)
 
         logit_indices = np.cumsum(num_scheduled_tokens) - 1
-        return hidden_states, hidden_states[logit_indices]
+        logit_indices_device = torch.from_numpy(logit_indices).to(
+            self.device, non_blocking=True
+        )
+        return hidden_states, hidden_states[logit_indices_device]
 
     @torch.inference_mode()
     def _dummy_sampler_run(


### PR DESCRIPTION
In DP case,  by default, copying a tensor from CPU to GPU uses a synchronous copy in dummy run. Switching to an asynchronous copy reduces synchronization operations, which can reduce the impact on async scheduling performance.

<img width="1181" height="270" alt="Clipboard_Screenshot_1761276568" src="https://github.com/user-attachments/assets/12fde5ea-def4-4055-b51c-d90db3b15fd7" />
