### PR TITLE
[Docs] fix clangd log to marker

### DIFF
--- a/tests/standalone_tests/python_only_compile.sh
+++ b/tests/standalone_tests/python_only_compile.sh
@@ -23,7 +23,7 @@ VLLM_TEST_USE_PRECOMPILED_NIGHTLY_WHEEL=1 VLLM_USE_PRECOMPILED=1 pip3 install -v
 # Run the script
 python3 -c 'import vllm'
 
-# Check if the changed log file was created
+# Check if the marker file was created
 if [ ! -f /tmp/changed.file ]; then
     echo "changed.file was not created, python only compilation failed"
     exit 1

--- a/tests/standalone_tests/python_only_compile.sh
+++ b/tests/standalone_tests/python_only_compile.sh
@@ -23,7 +23,7 @@ VLLM_TEST_USE_PRECOMPILED_NIGHTLY_WHEEL=1 VLLM_USE_PRECOMPILED=1 pip3 install -v
 # Run the script
 python3 -c 'import vllm'
 
-# Check if the clangd log file was created
+# Check if the changed log file was created
 if [ ! -f /tmp/changed.file ]; then
     echo "changed.file was not created, python only compilation failed"
     exit 1


### PR DESCRIPTION

## Purpose
Fix a typo in the Python-only compilation test script tests/standalone_tests/python_only_compile.sh.Corrected comment from # Check if the clangd log file was created to # Check if the marker file was created.

## Test Plan
Ran the Python-only compilation test script to ensure it still executes without errors:
```
bash tests/standalone_tests/python_only_compile.sh
```
Verified that /tmp/changed.file is created as expected.

## Test Result
Script runs successfully.
Marker file /tmp/changed.file is created.
No functional changes, only comment typo fixed.

---
