### PR TITLE
[compile] Turn standalone_compile back on

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -131,7 +131,7 @@ if TYPE_CHECKING:
     VLLM_DP_RANK: int = 0
     VLLM_DP_RANK_LOCAL: int = -1
     VLLM_DP_SIZE: int = 1
-    VLLM_USE_STANDALONE_COMPILE: bool = False
+    VLLM_USE_STANDALONE_COMPILE: bool = True
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_MOE_DP_CHUNK_SIZE: int = 256
@@ -494,10 +494,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.environ.get("VLLM_FLASH_ATTN_VERSION", None)
     ),
     # Feature flag to enable/disable Inductor standalone compile.
-    # In torch <= 2.7 we ignore this flag; in torch >= 2.8 this is
-    # disabled by default.
+    # In torch <= 2.7 we ignore this flag; in torch >= 2.9 this is
+    # enabled by default.
     "VLLM_USE_STANDALONE_COMPILE": lambda: os.environ.get(
-        "VLLM_USE_STANDALONE_COMPILE", "0"
+        "VLLM_USE_STANDALONE_COMPILE", "1"
     )
     == "1",
     # Debug pattern matching inside custom passes.


### PR DESCRIPTION
We turned it off due to it having a bad interaction with gemma3n. This has now been fixed in PyTorch 2.9.

Closes #24547

Test Plan:
- `vllm serve google/gemma-3n-E2B-it -tp 1`
- the two qwen test cases in https://github.com/vllm-project/vllm/issues/24547#issuecomment-3322335609 (with deepgemm and with triton)
