### PR TITLE
[cpu][fix] Fix onednn_mm crash on consecutive matmuls with same M,K,N and different dtype

### DIFF
--- a/csrc/cpu/dnnl_helper.h
+++ b/csrc/cpu/dnnl_helper.h
@@ -199,6 +199,7 @@ class MatMulPrimitiveHandler : public DNNLMatMulPrimitiveHandler {
   struct ClassMatmulCacheKey {
     dnnl_dim_t b_n_size;
     dnnl_dim_t b_k_size;
+    dnnl::memory::data_type b_type;
 
     friend bool operator==(const ClassMatmulCacheKey& l,
                            const ClassMatmulCacheKey& r);


### PR DESCRIPTION
[cpu][fix] Fix onednn_mm crash on consecutive matmuls with same M,K,N and different dtype

Makes weight dtype part of the cache key for `ClassMatmulCacheKey` to avoid having 2 onednn_mm(s) with same src/weight dimensions and different dtypes mapped to the same dnnl::matmul primitive

Fixes: #27465

<!-- markdownlint-disable -->

## Purpose
Fixes: #27465

## Test Plan
Reproducer in #27465

## Test Result
Reproducer in #27465 passes

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

