### PR TITLE
[Misc][DP] Guard mxfp4 implementation selection

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -813,8 +813,12 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 return TrtLlmGenExperts(self.moe, self.moe_quant_config, **kwargs)
             elif self.mxfp4_backend == Mxfp4Backend.MARLIN:
                 return MarlinExperts(self.moe_quant_config)
-            else:
+            elif self.mxfp4_backend == Mxfp4Backend.TRITON:
                 return OAITritonExperts(self.moe_quant_config)
+            else:
+                raise NotImplementedError(
+                    "Incompatible Mxfp4 backend for EP batched experts format"
+                )
 
     def _route_and_experts(
         self,

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -794,7 +794,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 )
             else:
                 raise NotImplementedError(
-                    "Incompatible Mxfp4 backend for EP batched experts format"
+                    f"Incompatible Mxfp4 backend ({self.mxfp4_backend}) for "
+                    "EP batched experts format"
                 )
         else:
             assert self.moe_quant_config is not None
@@ -817,7 +818,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 return OAITritonExperts(self.moe_quant_config)
             else:
                 raise NotImplementedError(
-                    "Incompatible Mxfp4 backend for EP batched experts format"
+                    f"Incompatible Mxfp4 backend ({self.mxfp4_backend}) for EP"
                 )
 
     def _route_and_experts(


### PR DESCRIPTION
## Purpose
Guard MxFP4 implementation selection in the case of DP

Machine : H100
command : `VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1  VLLM_ALL2ALL_BACKEND="deepep_high_throughput"  vllm serve openai/gpt-oss-20b  --data-parallel-size 2 --enable-expert-parallel --no-enable-prefix-caching --port 9010`

Error on `main`:
```
EngineCore_DP0 pid=1017522)     assert quant_config.use_mxfp4_w4a16, "Supports only mxfp4_w4a16"
(EngineCore_DP0 pid=1017522) AssertionError: Supports only mxfp4_w4a16
```
Here, despite explicitly selecting `SM90_FI_MXFP4_BF16` backend via VLLM_USE_FLASHINFER_MOE_MXFP4_BF16, we choose the OAITritonExperts (`TRITON` backend) for DP and we fail somewhere deep in the codebase.

Error on `PR`:
```
ERROR 10-24 17:09:17 [core.py:779] NotImplementedError: Incompatible Mxfp4 backend for EP batched experts format
```
Much more straightforward error.

## Test Plan
```
VLLM_ALL2ALL_BACKEND="deepep_high_throughput"  vllm serve openai/gpt-oss-20b  --data-parallel-size 2 --enable-expert-parallel --no-enable-prefix-caching
```
and 
```
VLLM_MXFP4_USE_MARLIN=1 VLLM_ALL2ALL_BACKEND="deepep_high_throughput"  vllm serve openai/gpt-oss-20b  --data-parallel-size 2 --enable-expert-parallel --no-enable-prefix-caching
```

## Test Result
The commands work as expected. on H100, The first defaults to using Triton backend and the second uses the Marlin backend. 
