### PR TITLE
[Bugfix][LoRA][FusedMoE] Select MxFP4 Backend based on LoRA Enablement

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -825,6 +825,8 @@ class FusedMoEConfig:
 
     is_act_and_mul: bool = True
 
+    is_lora_enabled: bool = False
+
     def __post_init__(self):
         if self.dp_size > 1:
             logger.debug_once(

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -73,8 +73,25 @@ class Mxfp4Backend(Enum):
     TRITON = 6
 
 
-def get_mxfp4_backend():
+def get_mxfp4_backend_with_lora() -> Mxfp4Backend:
+    """
+    Not all MXFP4 backends support LoRA. Select backends that are known to
+    have LoRA support.
+    """
+    if not current_platform.is_cuda():
+        return Mxfp4Backend.NONE
+
+    # TODO (varun): Check B200
+    logger.info_once("[get_mxfp4_backend_with_lora] Using Marlin backend")
+    return Mxfp4Backend.MARLIN
+
+
+def get_mxfp4_backend(with_lora_support: bool) -> Mxfp4Backend:
     # Backend Selection
+
+    if with_lora_support:
+        return get_mxfp4_backend_with_lora()
+
     if current_platform.is_cuda():
         if (
             current_platform.is_device_capability(90)
@@ -183,13 +200,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         super().__init__(moe)
         self.topk_indices_dtype = None
         self.moe = moe
-        self.mxfp4_backend = get_mxfp4_backend()
+        self.mxfp4_backend = get_mxfp4_backend(moe.is_lora_enabled)
         self.max_capture_size = (
             get_current_vllm_config().compilation_config.max_cudagraph_capture_size
         )
 
         assert self.mxfp4_backend != Mxfp4Backend.NONE, (
-            "No MXFP4 MoE backend (FlashInfer/Marlin/Triton) available."
+            f"get_mxfp4_backend(with_lora_support={moe.is_lora_enabled}) found"
+            "no compatible MXFP4 MoE backend (FlashInfer/Marlin/Triton)."
             "Please check your environment and try again."
         )
         self._cache_permute_indices: dict[torch.Size, torch.Tensor] = {}

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -81,7 +81,6 @@ def get_mxfp4_backend_with_lora() -> Mxfp4Backend:
     if not current_platform.is_cuda():
         return Mxfp4Backend.NONE
 
-    # TODO (varun): Check B200
     logger.info_once("[get_mxfp4_backend_with_lora] Using Marlin backend")
     return Mxfp4Backend.MARLIN
 


### PR DESCRIPTION
## Purpose

With https://github.com/vllm-project/vllm/pull/27370 , `has_triton_kernels()` will be True and on H100 we will select the `MxFP4Backend.TRITON` by default. 

On `main`, running `pytest -s tests/lora/test_gptoss.py` will fail as we select the `TRITON` backend by default and the only backend that supports LoRA is `MARLIN`. However I verified that `VLLM_MXFP4_USE_MARLIN=1 pytest -s tests/lora/test_gptoss.py` runs successfully. 

This PR introduces a `get_mxfp4_backend_with_lora()` function that selects a backend from the set of backends that support LoRA. At the moment, it is just MARLIN for mxfp4. With this PR `pytest -s tests/lora/test_gptoss.py` runs successfully. 

## Test Plan
`pytest -s tests/lora/test_gptoss.py`

## Test Result
Test passes.

Note:
Note that `pytest -s tests/lora/test_gptoss.py` is flaky on `main` and when it fails, it fails with the following error,
```
E           AssertionError: assert False
E            +  where False = <built-in method startswith of str object at 0x557de5f1cfc0>('I am an AI language model developed by OpenAI. I am here to help you with any questions or tasks you may have.')
E            +    where <built-in method startswith of str object at 0x557de5f1cfc0> = 'I am an AI language model developed by OpenAI. I am designed to assist with a variety of tasks, such as answering que...formation, and generating text. I am not a real person, but I am here to help you in any way I can. <｜end▁of▁sentence｜'.startswith
```
