### PR TITLE
[Bugfix] fix empty prompts for async-engine mode in benchmark throughput

### DIFF
--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -221,6 +221,7 @@ async def run_vllm_async(
                     detokenize=not disable_detokenize,
                 )
             )
+            prompts.append(prompt)
             lora_requests.append(request.lora_request)
 
         generators = []


### PR DESCRIPTION
## Purpose
fix prompts are empty when run `vllm bench throughput ` with `--async-engine`

## Test Plan

```
vllm bench throughput --dataset-name random --input-len 2000 --output-len 1000 --model /data/local/models/oss/llama_70b_oss/ --async-engine -tp 4 --max-model-len 16384 --max-num-seq 128 
```

## Test Result

```
Throughput: 2.23 requests/s, 6699.75 total tokens/s, 2234.00 output tokens/s
Total num prompt tokens:  1999000
Total num output tokens:  1000000
