### PR TITLE
Fix issue #27486 double bos token

### DIFF
--- a/tests/entrypoints/llm/test_chat.py
+++ b/tests/entrypoints/llm/test_chat.py
@@ -120,12 +120,14 @@ def test_llm_generate_with_chat_template_no_double_bos(text_llm):
     """
     Test for issue #27486: When using apply_chat_template manually
     and then calling generate(), should not duplicate BOS token.
-    """
-    from transformers import AutoTokenizer
 
+    Note: This test reuses the text_llm fixture's tokenizer to avoid
+    GPU resource conflicts when running the full test suite.
+    """
     from vllm import SamplingParams
 
-    tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B-Instruct")
+    # Reuse the tokenizer from the existing LLM instance
+    tokenizer = text_llm.get_tokenizer()
 
     messages = [{"role": "user", "content": "Hello, how are you?"}]
 

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -230,8 +230,9 @@ class InputPreprocessor:
             return True
 
         # If prompt starts with BOS token text, don't add special tokens
-        # This handles cases like Llama's "<|begin_of_text|>"
-        if prompt.startswith(bos_token):
+        # This handles cases like Llama's "<|begin_of_text|>" and "<s>"
+        # Use lstrip() to handle prompts with leading whitespace
+        if prompt.lstrip().startswith(bos_token):
             logger.debug(
                 "Detected BOS token at the start of prompt. "
                 "Setting add_special_tokens=False to avoid duplication."
@@ -239,11 +240,13 @@ class InputPreprocessor:
             return False
 
         # Check for common chat template markers that indicate special tokens
-        # are already present (e.g., "<|start_header_id|>", "<|im_start|>")
+        # are already present (e.g., "<|start_header_id|>", "<|im_start|>").
+        # Note: "<s>" is intentionally not included here as it is too generic
+        # and can cause false positives (e.g., in "<script>" tags). The check
+        # above handles "<s>" when it's a BOS token via startswith().
         chat_markers = [
             "<|start_header_id|>",  # Llama 3.x
             "<|im_start|>",  # ChatML format
-            "<s>",  # Common BOS in older models
         ]
 
         for marker in chat_markers:


### PR DESCRIPTION
 
## Purpose
Fix issue #27486: Prevent duplicate BOS tokens when users manually apply chat templates before calling `generate()`.

## Problem

When users manually apply chat templates using `tokenizer.apply_chat_template()` and then call `llm.generate()` with the templated string, vLLM was incorrectly adding an additional BOS token during tokenization. This resulted in duplicate BOS tokens at the start of the prompt:

```python
# User code
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B-Instruct")
prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
outputs = llm.generate([prompt])

# Expected: [128000, 128006, ...]  (1 BOS token)
# Actual:   [128000, 128000, 128006, ...]  (2 BOS tokens - WRONG!)
```

This happened because:
1. `apply_chat_template()` generates text containing BOS token markers (e.g., `<|begin_of_text|>`)
2. When vLLM tokenizes this string, it adds special tokens by default
3. The tokenizer adds another BOS token, resulting in duplication

## Solution

Added intelligent detection in `InputPreprocessor._tokenize_prompt()` to check if a prompt already contains special tokens before adding them:

### Changes:
1. **New method `_should_add_special_tokens()`** (`vllm/inputs/preprocess.py`)
   - Detects BOS token text at the start of prompts (e.g., `<|begin_of_text|>`)
   - Detects common chat template markers in the first 100 characters:
     - `<|start_header_id|>` (Llama 3.x)
     - `<|im_start|>` (ChatML format)
     - `<s>` (older models)
   - Returns `False` if special tokens are detected, `True` otherwise

2. **Modified `_tokenize_prompt()`** (`vllm/inputs/preprocess.py`)
   - Calls `_should_add_special_tokens()` before tokenizing
   - Sets `add_special_tokens=False` when chat template markers are detected
   - Preserves backward compatibility - only affects prompts with detected markers

3. **New test case** (`tests/entrypoints/llm/test_chat.py`)
   - `test_llm_generate_with_chat_template_no_double_bos()`
   - Verifies that manually applying chat templates doesn't cause duplicate BOS
   - Compares vLLM output with expected transformers tokenization


## Test Plan
ytest tests/entrypoints/llm/test_chat.py::test_llm_generate_with_chat_template_no_double_bos -v -s pass
 
--- 
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

