### PR TITLE
[bugfix] fix wrong `dcp_local_seq_lens` calc

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -799,7 +799,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             dcp_local_seq_lens[:num_decodes] = seq_lens[
                 :num_decodes
             ] // self.dcp_world_size + (
-                self.dcp_rank <= (seq_lens[:num_decodes] - 1) % self.dcp_world_size
+                self.dcp_rank < seq_lens[:num_decodes] % self.dcp_world_size
             )
 
         assert num_decodes + num_prefills == num_reqs


### PR DESCRIPTION
When the `seq_lens` is exactly divisible by the `dcp_world_size`, it causes the `dcp_local_seq_lens` on all ranks to be incremented by one. Fix this calculation logic.

CC @youzhedian @minosfuture @youkaichao 