### PR TITLE
[perf] Optimize Qwen2-VL Startup Performance with LRU Cache

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -27,7 +27,7 @@
 
 import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from functools import partial
+from functools import lru_cache, partial
 from typing import Annotated, Any, Literal, TypeAlias
 
 import torch
@@ -1034,6 +1034,7 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
         )
         return num_video_tokens
 
+    @lru_cache(maxsize=128)  # noqa: B019
     def get_image_size_with_most_features(self) -> ImageSize:
         max_image_size, _ = self._get_vision_info(
             image_width=9999999,


### PR DESCRIPTION
## Summary

Add `@lru_cache` to `get_image_size_with_most_features()` to eliminate redundant `smart_resize()` calls during profiling, improving startup performance for Qwen2-VL family models.

## Problem

During profiling/startup, `get_image_size_with_most_features()` is called twice:
1. Once for calculating max image tokens
2. Once for calculating max video tokens

Each call triggers expensive `smart_resize()` computation , causing slow startup as noted in `vllm/multimodal/processing.py:1178-1181`.

## Solution

Add `@lru_cache(maxsize=128)  # noqa: B019` decorator to cache the result:

```python
@lru_cache(maxsize=128)  # noqa: B019
def get_image_size_with_most_features(self) -> ImageSize:
    max_image_size, _ = self._get_vision_info(...)
    return max_image_size
```

The second call hits cache instead of recomputing, eliminating duplicate work.

## Performance Impact

- **Cache efficiency**: 50% reduction in `smart_resize()` calls
- **Code change**: Only 1 line added

## Affected Models

- Qwen2VLForConditionalGeneration
- Qwen2_5_VLForConditionalGeneration
- Qwen3VLForConditionalGeneration
- Tarsier2ForConditionalGeneration

## Testing

- Syntax check: ✅ Pass
- Pre-commit hooks: ✅ Expected to pass (follows existing pattern)
- Manual verification: Confirmed cache decorator placement

## Files Changed

- `vllm/model_executor/models/qwen2_vl.py`: +1 line