### PR TITLE
fixing mm placeholder replacement issue with gemma3

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -403,7 +403,7 @@ class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
 
         def get_repl_toks(tok: int) -> list[int]:
             if tok == newline_3:
-                return [newline_1, newline_2]
+                return [newline_2, newline_1]
             if tok == newline_4:
                 return [newline_2, newline_2]
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When sending mm inference req with prompt below to gemma3 (gemma3n as well), user didn't add placeholder string <start_of_image> themself.

`{'role': 'system', 'content': [{'type': 'text', 'text': 'you are a helpful artist'}]}, {'role': 'user', 'content': [{'type': 'text', 'text': 'Describe the images in detail.'}
`
after parse_chat_messages, the prompt becomes:

`{'role': 'system', 'content': 'you are a helpful artist'}, {'role': 'user', 'content': '<start_of_image>\nDescribe the images in detail.'}`
 **note the single \n with token id 107 is inserted**

with vllm tries to replace mm placeholder tokens 
[108, 255999, 262144 ... 262144, 256000, 108] with 255999, this is determined by logic [here](https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/gemma3/processing_gemma3.py#L71C106-L71C111 ) 

then the token becomes [...262144, 262144, 256000, 108, 107...], according the logic [here](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/gemma3_mm.py#L376), token 108, 107 will be merged into 109

while in [_find_mm_placeholders](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/gemma3_mm.py#L406) 109(\n\n\n) was replaced as 107(\n), 108(\n\n), so this will cause mm placeholder couldn't be found.

There might be better way to fix this, feel free to suggest, I can apply to gemma3n as well if looks good.

## Test Plan
Runs locally, before this change, the above inference failed to find mm placeholder, after this change, request can go through

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] fixing mm placeholder replacement issue with gemma3
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

