### PR TITLE
[BUG] Fix hybrid kvcache kernel page size issue

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -333,7 +333,31 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size
         FlashInferBackend.validate_head_size(self.head_dim)
-        self.page_size = self.kv_cache_spec.block_size
+
+        # IMPORTANT: page_size must match the actual kernel block size,
+        # not the KV manager block size!
+        # When using hybrid blocks (kv_manager_block_size != kernel_block_size),
+        # the KV cache is allocated with kernel_block_size, so we must use that
+        # for page_size when calling FlashInfer.
+        kv_manager_block_size = self.kv_cache_spec.block_size
+        kernel_block_size = self.kv_cache_spec.find_compatible_kernel_block_sizes(
+            FlashInferBackend, return_all=False
+        )[0]
+
+        self.page_size = kernel_block_size
+
+        if kernel_block_size != kv_manager_block_size:
+            logger.info_once(
+                "FlashInfer: Using kernel_block_size=%d (page_size) != "
+                "kv_manager_block_size=%d. Hybrid blocks mode.",
+                kernel_block_size,
+                kv_manager_block_size,
+            )
+        else:
+            logger.info_once(
+                "FlashInfer: Using page_size=%d (matches kv_manager_block_size)",
+                self.page_size,
+            )
 
         self.cache_dtype = self.cache_config.cache_dtype
         if self.cache_dtype.startswith("fp8"):

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -332,28 +332,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         # IMPORTANT: page_size must match the actual kernel block size,
         # not the KV manager block size!
-        # When using hybrid blocks (kv_manager_block_size != kernel_block_size),
+        # When using hybrid blocks(self.kv_cache_spec.block_size != kernel_block_size),
         # the KV cache is allocated with kernel_block_size, so we must use that
         # for page_size when calling FlashInfer.
-        kv_manager_block_size = self.kv_cache_spec.block_size
         kernel_block_size = self.kv_cache_spec.find_compatible_kernel_block_sizes(
             FlashInferBackend, return_all=False
         )[0]
-
         self.page_size = kernel_block_size
-
-        if kernel_block_size != kv_manager_block_size:
-            logger.info_once(
-                "FlashInfer: Using kernel_block_size=%d (page_size) != "
-                "kv_manager_block_size=%d. Hybrid blocks mode.",
-                kernel_block_size,
-                kv_manager_block_size,
-            )
-        else:
-            logger.info_once(
-                "FlashInfer: Using page_size=%d (matches kv_manager_block_size)",
-                self.page_size,
-            )
 
         # Calculate buffer sizes using the actual kernel block size (page_size)
         # to ensure buffers are correctly sized in hybrid mode

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -76,7 +76,7 @@ class AttentionSpec(KVCacheSpec):
         )
 
     def find_compatible_kernel_block_sizes(
-        self, backend_cls: type[AttentionBackend], return_all: bool = False
+        self, backend_cls: "type[AttentionBackend]", return_all: bool = False
     ) -> list[int]:
         """Find compatible kernel block sizes for this spec and backend.
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3925,7 +3925,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         class AttentionGroupKey(NamedTuple):
             attn_backend: type[AttentionBackend]
-            kv_cache_spec: KVCacheSpec
+            kv_cache_spec: AttentionSpec
 
         def get_attn_backends_for_group(
             kv_cache_group_spec: KVCacheGroupSpec,
@@ -3953,6 +3953,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 layer_kv_cache_spec = kv_cache_group_spec.kv_cache_spec
                 if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                     layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
+                assert isinstance(layer_kv_cache_spec, AttentionSpec), (
+                    f"Expected AttentionSpec for attention layer {layer_name}, "
+                    f"but got {type(layer_kv_cache_spec)}"
+                )
                 key = (full_cls_name, layer_kv_cache_spec)
                 attn_backends[key] = AttentionGroupKey(
                     attn_backend, layer_kv_cache_spec

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3925,7 +3925,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         class AttentionGroupKey(NamedTuple):
             attn_backend: type[AttentionBackend]
-            kv_cache_spec: AttentionSpec
+            kv_cache_spec: KVCacheSpec
 
         def get_attn_backends_for_group(
             kv_cache_group_spec: KVCacheGroupSpec,
@@ -3953,10 +3953,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 layer_kv_cache_spec = kv_cache_group_spec.kv_cache_spec
                 if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                     layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
-                assert isinstance(layer_kv_cache_spec, AttentionSpec), (
-                    f"Expected AttentionSpec for attention layer {layer_name}, "
-                    f"but got {type(layer_kv_cache_spec)}"
-                )
                 key = (full_cls_name, layer_kv_cache_spec)
                 attn_backends[key] = AttentionGroupKey(
                     attn_backend, layer_kv_cache_spec
@@ -4171,6 +4167,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         for attn_group in attn_groups:
             kv_cache_spec = attn_group.kv_cache_spec
+            assert isinstance(kv_cache_spec, AttentionSpec), (
+                f"Expected AttentionSpec for attention group {attn_group.layer_names}, "
+                f"but got {type(kv_cache_spec)}"
+            )
             compatible_sizes = kv_cache_spec.find_compatible_kernel_block_sizes(
                 attn_group.backend, return_all=True
             )

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -15,7 +15,7 @@ from vllm.multimodal.registry import MultiModalRegistry
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
 from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
-from vllm.v1.kv_cache_interface import KVCacheGroupSpec, AttentionSpec
+from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
 
 if TYPE_CHECKING:
     from vllm.attention.layer import Attention
@@ -139,13 +139,13 @@ class AttentionGroup:
     # won't have to worry about conflicting with the other ubatches.
     metadata_builders: list[AttentionMetadataBuilder]
     layer_names: list[str]
-    kv_cache_spec: AttentionSpec
+    kv_cache_spec: KVCacheSpec
 
     @staticmethod
     def create_with_metadata_builders(
         backend: type[AttentionBackend],
         layer_names: list[str],
-        kv_cache_spec: AttentionSpec,
+        kv_cache_spec: KVCacheSpec,
         vllm_config: VllmConfig,
         device: torch.device,
         num_metadata_builders: int = 1,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -15,7 +15,7 @@ from vllm.multimodal.registry import MultiModalRegistry
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
 from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
-from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
+from vllm.v1.kv_cache_interface import KVCacheGroupSpec, AttentionSpec
 
 if TYPE_CHECKING:
     from vllm.attention.layer import Attention
@@ -139,13 +139,13 @@ class AttentionGroup:
     # won't have to worry about conflicting with the other ubatches.
     metadata_builders: list[AttentionMetadataBuilder]
     layer_names: list[str]
-    kv_cache_spec: KVCacheSpec
+    kv_cache_spec: AttentionSpec
 
     @staticmethod
     def create_with_metadata_builders(
         backend: type[AttentionBackend],
         layer_names: list[str],
-        kv_cache_spec: KVCacheSpec,
+        kv_cache_spec: AttentionSpec,
         vllm_config: VllmConfig,
         device: torch.device,
         num_metadata_builders: int = 1,


### PR DESCRIPTION
## Purpose
The following 
```
VLLM_USE_TRTLLM_ATTENTION=0 vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp 4 --enable-expert-parallel --no-enable-prefix-caching --async-scheduling
```
```
lm_eval --model local-completions --model_args model=Qwen/Qwen3-Next-80B-A3B-Instruct,base_url=http://localhost:8000/v1/completions -t gsm8k --num_fewshot 5 --batch_size 250
```
Produced 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.0197|±  |0.0038|
|     |       |strict-match    |     5|exact_match|↑  |0.0000|±  |0.0000|
```

The issue was with intermix of `kv_manager_block_size` and `kernel_block_size` we passed `kv_manager_block_size` instead of `kernel_block_size` that cause garbage loads in attn kernel. 

## Test Result
After fix 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8514|±  |0.0098|
|     |       |strict-match    |     5|exact_match|↑  |0.8089|±  |0.0108|
```


