### PR TITLE
[Bugfix] fixed inconsistent finish_reason handling between V0 and V1 engines

### DIFF
--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -42,13 +42,6 @@ def remove_all(lst: list, items_to_remove: set) -> list:
 def check_stop(
     request: Request, max_model_len: int, pooler_output: torch.Tensor | None = None
 ) -> bool:
-    if (
-        request.num_tokens >= max_model_len
-        or request.num_output_tokens >= request.max_tokens
-    ):
-        request.status = RequestStatus.FINISHED_LENGTH_CAPPED
-        return True
-
     if request.pooling_params:
         if pooler_output is not None:
             request.status = RequestStatus.FINISHED_STOPPED
@@ -69,5 +62,11 @@ def check_stop(
     if last_token_id in (sampling_params.stop_token_ids or ()):
         request.status = RequestStatus.FINISHED_STOPPED
         request.stop_reason = last_token_id
+        return True
+    if (
+        request.num_tokens >= max_model_len
+        or request.num_output_tokens >= request.max_tokens
+    ):
+        request.status = RequestStatus.FINISHED_LENGTH_CAPPED
         return True
     return False


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm/issues/27390

The direct cause of the inconsistent finish_reason is that during generation stop determination, the V0 Engine first checks for EOS, while the V1 Engine first checks the generation length.

V0:
https://github.com/vllm-project/vllm/blob/01efc7ef781391e744ed08c3292817a773d654e6/vllm/engine/output_processor/stop_checker.py#L31-L92


I think V0's logic is correct: check EOS first, then check length.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

