### PR TITLE
[Bugfix] Limit the default value of `max_model_len` when it is not specified by users

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2116,25 +2116,7 @@ def _get_and_verify_max_len(
     # the model config as a default value.
     if max_model_len is None:
         max_model_len = int(derived_max_model_len)
-        if current_platform.is_tpu():
-            logger.warning(
-                "--max-model-len is not specified, "
-                "it's currently using model's default length %d, "
-                "which might be too large."
-                "Please input with --max-model-len based on your "
-                "request input length and output length, to avoid "
-                "unnecessary degradation.",
-                max_model_len,
-            )
-        elif current_platform.device_name == "npu" and max_model_len > 65536:
-            logger.warning(
-                "max_model_len is not specified and the default value"
-                "derived from the model config is %d, which is too large"
-                "and will make the engine stuck in initializing distributed"
-                "communication. Set max_model_len to 65536.",
-                max_model_len,
-            )
-            max_model_len = 65536
+        max_model_len = current_platform.check_max_model_len(max_model_len)
     # If the user specified a max length, make sure it is smaller than the
     # derived length from the HF model config.
     elif max_model_len > derived_max_model_len:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2129,9 +2129,10 @@ def _get_and_verify_max_len(
         elif current_platform.device_name == "npu" and max_model_len > 65536:
             logger.warning(
                 "max_model_len is not specified and the default value"
-                "derived from the model config is {max_model_len}, which is"
-                "too large and will make the engine stuck in initializing"
-                "distributed communication. Set max_model_len to 65536."
+                "derived from the model config is %s, which is too large"
+                "and will make the engine stuck in initializing distributed"
+                "communication. Set max_model_len to 65536.",
+                max_model_len,
             )
             max_model_len = 65536
     # If the user specified a max length, make sure it is smaller than the

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2119,7 +2119,7 @@ def _get_and_verify_max_len(
         if current_platform.is_tpu():
             logger.warning(
                 "--max-model-len is not specified, "
-                "it's currently using model's default length %s, "
+                "it's currently using model's default length %d, "
                 "which might be too large."
                 "Please input with --max-model-len based on your "
                 "request input length and output length, to avoid "
@@ -2129,7 +2129,7 @@ def _get_and_verify_max_len(
         elif current_platform.device_name == "npu" and max_model_len > 65536:
             logger.warning(
                 "max_model_len is not specified and the default value"
-                "derived from the model config is %s, which is too large"
+                "derived from the model config is %d, which is too large"
                 "and will make the engine stuck in initializing distributed"
                 "communication. Set max_model_len to 65536.",
                 max_model_len,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -608,6 +608,13 @@ class Platform:
         """
         return None
 
+    @classmethod
+    def check_max_model_len(cls, max_model_len: int) -> int:
+        """
+        Check max_model_len for the current platform.
+        """
+        return max_model_len
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -251,6 +251,22 @@ class TpuPlatform(Platform):
     def use_sync_weight_loader(cls) -> bool:
         return True
 
+    @classmethod
+    def check_max_model_len(cls, max_model_len: int) -> int:
+        """
+        Check max_model_len for the current platform.
+        """
+        logger.warning(
+            "--max-model-len is not specified, "
+            "it's currently using model's default length %d, "
+            "which might be too large."
+            "Please input with --max-model-len based on your "
+            "request input length and output length, to avoid "
+            "unnecessary degradation.",
+            max_model_len,
+        )
+        return max_model_len
+
 
 try:
     from tpu_inference.platforms import TpuPlatform as TpuInferencePlatform


### PR DESCRIPTION
## Purpose

When we launch vllm without specifying `--max-model-len`, it will use the default value derived from the model config, e.g., `max_position_embeddings`.

```bash
vllm serve /root/.cache/modelscope/hub/models/Qwen/Qwen3-VL-30B-A3B-Instruct \
--tensor-parallel-size 4 \
--enable-expert-parallel \
--enforce-eager
```

With regard to `Qwen3-VL-30B-A3B`, its default `max_model_len` is `262144`, which is too large and will make the engine stuck in initializing distributed communication.

```bash
...
Using max model len 262144
...
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 0 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 1 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 1, EP rank 1
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 3 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 3, EP rank 3
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 2 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 2, EP rank 2
# Get stuck in here
```

Thus, we need to set a limited default value when `--max-model-len` is not specified. After testing, I find that the engine will get stuck when `max_model_len` > **65536** on Ascend A2 devices. Thus, we set it to **65536** when the default value is too large.

> Note: this change is safe since it only affect the usage on Ascend NPU devices.

https://github.com/vllm-project/vllm-ascend/issues/3508

## Test Plan

```bash
vllm serve /root/.cache/modelscope/hub/models/Qwen/Qwen3-VL-30B-A3B-Instruct \
--tensor-parallel-size 4 \
--enable-expert-parallel \
--enforce-eager
```

## Test Result

The engine launched successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

