### PR TITLE
Fix a robust parsing issue in KimiK2ToolParser that causes IndexError

### DIFF
--- a/tests/tool_use/test_kimi_k2_tool_parser.py
+++ b/tests/tool_use/test_kimi_k2_tool_parser.py
@@ -37,11 +37,11 @@ def assert_tool_calls(
         assert actual_tool_call.type == "function"
         assert actual_tool_call.function == expected_tool_call.function
 
-        # assert tool call id format
-        assert actual_tool_call.id.startswith("functions.")
+        # assert tool call id format: should contain function name and numeric index
+        # Format can be either "functions.func_name:0" or "func_name:0"
         assert actual_tool_call.id.split(":")[-1].isdigit()
         assert (
-            actual_tool_call.id.split(".")[1].split(":")[0]
+            actual_tool_call.id.split(":")[0].split(".")[-1]
             == expected_tool_call.function.name
         )
 

--- a/vllm/entrypoints/openai/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/kimi_k2_tool_parser.py
@@ -96,8 +96,8 @@ class KimiK2ToolParser(ToolParser):
                 tool_calls = []
                 for match in function_call_tuples:
                     function_id, function_args = match
-                    # function_id: functions.get_weather:0
-                    function_name = function_id.split(".")[1].split(":")[0]
+                    # function_id: functions.get_weather:0 or get_weather:0
+                    function_name = function_id.split(":")[0].split(".")[-1]
                     tool_calls.append(
                         ToolCall(
                             id=function_id,
@@ -254,7 +254,7 @@ class KimiK2ToolParser(ToolParser):
                 )
                 if current_tool_call_matches:
                     tool_id, tool_args = current_tool_call_matches.groups()
-                    tool_name = tool_id.split(".")[1].split(":")[0]
+                    tool_name = tool_id.split(":")[0].split(".")[-1]
                     current_tool_call["id"] = tool_id
                     current_tool_call["name"] = tool_name
                     current_tool_call["arguments"] = tool_args
@@ -264,7 +264,7 @@ class KimiK2ToolParser(ToolParser):
                     )
                     if current_tool_call_name_matches:
                         (tool_id_str,) = current_tool_call_name_matches.groups()
-                        tool_name = tool_id_str.split(".")[1].split(":")[0]
+                        tool_name = tool_id_str.split(":")[0].split(".")[-1]
                         current_tool_call["id"] = tool_id_str
                         current_tool_call["name"] = tool_name
                         current_tool_call["arguments"] = ""


### PR DESCRIPTION
… when function_id format doesn't match the hardcoded assumption. Signed-off-by: wangln19 <wanglinian@stu.pku.edu.cn>

<!-- markdownlint-disable -->
## Purpose

Fix a robust parsing issue in KimiK2ToolParser that causes IndexError when function_id format doesn't match the hardcoded assumption.

**Problem:**
The current implementation assumes function_id is always in the format `functions.xxx:0`, using fragile parsing logic: `split('.')[1].split(':')[0]`. This causes an `IndexError` crash when the function_id is in the format `xxx:0` (without the `functions.` prefix).

**Solution:**
Replace the fragile parsing logic with a more robust approach: `split(':')[0].split('.')[-1]`. This works correctly for both formats:
- `functions.get_weather:0` → `get_weather` ✅
- `get_weather:0` → `get_weather` ✅
- `a.b.c.func:1` → `func` ✅

This change follows the principle of eliminating special cases - the code now handles all format variations uniformly without conditional branches.

**Changes:**
- Fixed 3 occurrences in `kimi_k2_tool_parser.py` (line 98, 247, 257)
- Updated test assertions in `test_kimi_k2_tool_parser.py` to remove overly strict format requirements and use the same robust parsing logic

## Test Plan

Run existing test suite for KimiK2ToolParser:
```bash
pytest tests/tool_use/test_kimi_k2_tool_parser.py -v
```

## Test Result

All existing tests pass with the new parsing logic. The updated parser now gracefully handles both function_id formats:
- Original format: `functions.function_name:index`
- Simplified format: `function_name:index`

The test suite validates:
- Basic tool call extraction
- Multi-tool call scenarios
- Streaming functionality
- Invalid JSON handling
- Invalid function call format handling

---

**Checklist:**
- [x] The purpose of the PR - Fix IndexError crash in KimiK2ToolParser when function_id lacks namespace prefix
- [x] The test plan - Run existing pytest suite
- [x] The test results - All tests pass with more robust parsing logic
- [ ] Documentation update - Not needed (internal parser logic improvement)
- [ ] Release notes - Bug fix, no user-facing API changes
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

