### PR TITLE
[Model] Siglip2 Model Support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -774,7 +774,7 @@ The following table lists those that are tested in vLLM.
 | `CLIPModel` | CLIP | T / I | `openai/clip-vit-base-patch32`, `openai/clip-vit-large-patch14`, etc. | | |
 | `LlavaNextForConditionalGeneration`<sup>C</sup> | LLaVA-NeXT-based | T / I | `royokong/e5-v` | | ✅︎ |
 | `Phi3VForCausalLM`<sup>C</sup> | Phi-3-Vision-based | T + I | `TIGER-Lab/VLM2Vec-Full` | | ✅︎ |
-| `SiglipModel` | SigLIP | T / I | `google/siglip-base-patch16-224` | | |
+| `SiglipModel` | SigLIP | T / I | `google/siglip-base-patch16-224`,`google/siglip2-base-patch16-224`  | | |
 | `*ForConditionalGeneration`<sup>C</sup>, `*ForCausalLM`<sup>C</sup>, etc. | Generative models | \* | N/A | \* | \* |
 
 <sup>C</sup> Automatically converted into an embedding model via `--convert embed`. ([details](./pooling_models.md#model-conversion))  

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -774,7 +774,7 @@ The following table lists those that are tested in vLLM.
 | `CLIPModel` | CLIP | T / I | `openai/clip-vit-base-patch32`, `openai/clip-vit-large-patch14`, etc. | | |
 | `LlavaNextForConditionalGeneration`<sup>C</sup> | LLaVA-NeXT-based | T / I | `royokong/e5-v` | | ✅︎ |
 | `Phi3VForCausalLM`<sup>C</sup> | Phi-3-Vision-based | T + I | `TIGER-Lab/VLM2Vec-Full` | | ✅︎ |
-| `SiglipModel` | SigLIP | T / I | `google/siglip-base-patch16-224`,`google/siglip2-base-patch16-224`  | | |
+| `SiglipModel` | SigLIP / SigLIP2 | T / I | `google/siglip-base-patch16-224`,`google/siglip2-base-patch16-224`  | | |
 | `*ForConditionalGeneration`<sup>C</sup>, `*ForCausalLM`<sup>C</sup>, etc. | Generative models | \* | N/A | \* | \* |
 
 <sup>C</sup> Automatically converted into an embedding model via `--convert embed`. ([details](./pooling_models.md#model-conversion))  

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -774,7 +774,7 @@ The following table lists those that are tested in vLLM.
 | `CLIPModel` | CLIP | T / I | `openai/clip-vit-base-patch32`, `openai/clip-vit-large-patch14`, etc. | | |
 | `LlavaNextForConditionalGeneration`<sup>C</sup> | LLaVA-NeXT-based | T / I | `royokong/e5-v` | | ✅︎ |
 | `Phi3VForCausalLM`<sup>C</sup> | Phi-3-Vision-based | T + I | `TIGER-Lab/VLM2Vec-Full` | | ✅︎ |
-| `SiglipModel` | SigLIP / SigLIP2 | T / I | `google/siglip-base-patch16-224`,`google/siglip2-base-patch16-224`  | | |
+| `SiglipModel` | SigLIP, SigLIP2 | T / I | `google/siglip-base-patch16-224`, `google/siglip2-base-patch16-224` | | |
 | `*ForConditionalGeneration`<sup>C</sup>, `*ForCausalLM`<sup>C</sup>, etc. | Generative models | \* | N/A | \* | \* |
 
 <sup>C</sup> Automatically converted into an embedding model via `--convert embed`. ([details](./pooling_models.md#model-conversion))  

--- a/tests/models/multimodal/pooling/test_siglip.py
+++ b/tests/models/multimodal/pooling/test_siglip.py
@@ -19,7 +19,7 @@ HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts(
     }
 )
 
-MODELS = ["google/siglip-base-patch16-224"]
+MODELS = ["google/siglip-base-patch16-224", "google/siglip2-base-patch16-224"]
 
 
 def _run_test(

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -174,9 +174,11 @@ class SiglipMultiModalProcessor(BaseMultiModalProcessor[SiglipProcessingInfo]):
     @cached_property
     def image_token_id(self) -> int:
         tokenizer = self.info.get_tokenizer()
-        dummy_token_id = 6
-
-        assert dummy_token_id not in tokenizer.all_special_ids
+        dummy_token_id = next(
+            token_id
+            for token_id in range(tokenizer.vocab_size)
+            if token_id not in tokenizer.all_special_ids
+        )
 
         return dummy_token_id
 

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -174,7 +174,7 @@ class SiglipMultiModalProcessor(BaseMultiModalProcessor[SiglipProcessingInfo]):
     @cached_property
     def image_token_id(self) -> int:
         tokenizer = self.info.get_tokenizer()
-        dummy_token_id = 0
+        dummy_token_id = 6
 
         assert dummy_token_id not in tokenizer.all_special_ids
 

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -622,7 +622,7 @@ def get_config(
     # Architecture mapping for models without explicit architectures field
     if not config.architectures:
         if config.model_type not in MODEL_MAPPING_NAMES:
-            raise ValueError(f"Model type {config.model_type} not supported")
+            raise ValueError(f"Cannot find architecture name for {config.model_type}")
         model_type = MODEL_MAPPING_NAMES[config.model_type]
         config.update({"architectures": [model_type]})
 

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -26,7 +26,10 @@ from huggingface_hub.utils import (
 )
 from transformers import GenerationConfig, PretrainedConfig
 from transformers.models.auto.image_processing_auto import get_image_processor_config
-from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+from transformers.models.auto.modeling_auto import (
+    MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
+    MODEL_MAPPING_NAMES,
+)
 from transformers.models.auto.tokenization_auto import get_tokenizer_config
 from transformers.utils import CONFIG_NAME as HF_CONFIG_NAME
 
@@ -614,6 +617,13 @@ def get_config(
         if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
         model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
+        config.update({"architectures": [model_type]})
+
+    # Architecture mapping for models without explicit architectures field
+    if config.architectures is None:
+        if config.model_type not in MODEL_MAPPING_NAMES:
+            raise ValueError(f"Model type {config.model_type} not supported")
+        model_type = MODEL_MAPPING_NAMES[config.model_type]
         config.update({"architectures": [model_type]})
 
     # ModelOpt 0.31.0 and after saves the quantization config in the model

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -620,7 +620,7 @@ def get_config(
         config.update({"architectures": [model_type]})
 
     # Architecture mapping for models without explicit architectures field
-    if config.architectures is None:
+    if not config.architectures:
         if config.model_type not in MODEL_MAPPING_NAMES:
             raise ValueError(f"Model type {config.model_type} not supported")
         model_type = MODEL_MAPPING_NAMES[config.model_type]


### PR DESCRIPTION
## Purpose
Extend SigLIP model support to SigLIP2, building upon the existing SigLIP embedding architecture.
 - Added handling for model configs missing the architectures field by automatically get the architecture through MODEL_MAPPING_NAMES
 - Dynamically select dummy_token_id by finding the first non-special token ID, replacing the previous hardcoded value. This ensures compatibility with both SigLIP and SigLIP2 tokenizers across different versions
-  Maintains the existing SigLIP embedding architecture: for text inputs, only token_embedding is applied in get_input_embeddings; for image inputs, complete vision encoding is applied in get_input_embeddings
This PR extends multimodal embedding capabilities to support SigLIP2 models, which are widely used for vision-language tasks.
To resolve #13663 and resolve #25581 - This PR builds upon SigLIP embedding support #27324 to add SigLIP2 support.
## Test Plan
 - Added google/siglip2-base-patch16-224 tests in tests/models/multimodal/pooling/test_siglip.py
 - Updated model registry to include SigLIP2 embedding support
 - Updated supported_models.md documentation with SigLIP2 model examples
 - Verified with local test runs
## Test Result
 - All SigLIP2-specific tests pass
 - Model registry correctly recognizes SigLIP2 embedding models
 - Both text and image embedding generation work as expected
 - Config processing logic correctly handles models without architectures field
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

