### PR TITLE
[Bugfix][Frontend] validate arg priority in frontend LLM class before add request

### DIFF
--- a/tests/entrypoints/llm/test_generate.py
+++ b/tests/entrypoints/llm/test_generate.py
@@ -86,6 +86,10 @@ def test_multiple_priority(llm: LLM):
             PROMPTS, sampling_params=None, priority=[0] * (len(PROMPTS) - 1)
         )
 
+    # Exception raised, if the priority list is empty
+    with pytest.raises(ValueError):
+        outputs = llm.generate(PROMPTS, sampling_params=None, priority=[])
+
 
 def test_max_model_len():
     max_model_len = 20

--- a/tests/entrypoints/llm/test_generate.py
+++ b/tests/entrypoints/llm/test_generate.py
@@ -71,6 +71,22 @@ def test_multiple_sampling_params(llm: LLM):
     assert len(PROMPTS) == len(outputs)
 
 
+def test_multiple_priority(llm: LLM):
+    # Generate works when priority is None
+    outputs = llm.generate(PROMPTS, sampling_params=None, priority=None)
+    assert len(PROMPTS) == len(outputs)
+
+    # Generate works when length of priority is same as the len(PROMPTS)
+    outputs = llm.generate(PROMPTS, sampling_params=None, priority=[0] * len(PROMPTS))
+    assert len(PROMPTS) == len(outputs)
+
+    # Exception raised, if the length of priority does not match the length of prompts
+    with pytest.raises(ValueError):
+        outputs = llm.generate(
+            PROMPTS, sampling_params=None, priority=[0] * (len(PROMPTS) - 1)
+        )
+
+
 def test_max_model_len():
     max_model_len = 20
     llm = LLM(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1565,7 +1565,11 @@ class LLM:
                 "The lengths of prompts and lora_request must be the same."
             )
         if priority is not None and len(priority) != num_requests:
-            raise ValueError("The lengths of prompts and priority must be the same.")
+            raise ValueError(
+                "The lengths of prompts "
+                f"({num_requests}) and priority ({len(priority)}) "
+                "must be the same."
+            )
 
         for sp in params if isinstance(params, Sequence) else (params,):
             if isinstance(sp, SamplingParams):

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1564,6 +1564,8 @@ class LLM:
             raise ValueError(
                 "The lengths of prompts and lora_request must be the same."
             )
+        if priority is not None and len(priority) != num_requests:
+            raise ValueError("The lengths of prompts and priority must be the same.")
 
         for sp in params if isinstance(params, Sequence) else (params,):
             if isinstance(sp, SamplingParams):


### PR DESCRIPTION
## Purpose

FIX #27595

Now:
```
    outputs = llm.generate(promtps, priority=[0, 0, 0])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/inference_playground/vllm/vllm/entrypoints/llm.py", line 432, in generate
    self._validate_and_add_requests(
  File "/home/ec2-user/inference_playground/vllm/vllm/entrypoints/llm.py", line 1591, in _validate_and_add_requests
    priority=priority[i] if priority else 0,
             ~~~~~~~~^^^
IndexError: list index out of range
```

After fix:
```
    outputs = llm.generate(promtps, priority=[0, 0, 0])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/inference_playground/vllm/vllm/entrypoints/llm.py", line 432, in generate
    self._validate_and_add_requests(
  File "/home/ec2-user/inference_playground/vllm/vllm/entrypoints/llm.py", line 1568, in _validate_and_add_requests
    raise ValueError("The lengths of prompts and priority must be the same.")
ValueError: The lengths of prompts and priority must be the same.
```

## Test Plan
pytest -s -v tests/entrypoints/llm/test_generate.py

## Test Result

### Unit Test
Pass

### Full CI Test: 
- [6b286b7](https://github.com/vllm-project/vllm/pull/27596/commits/6b286b7d1563ae16fb250cb0a378d3f9f01d9911): An unrelated test failed `test_chat_utils.py::test_resolve_content_format_fallbacks[deepseek-ai/deepseek-vl2-tiny-string` which is fixed by https://github.com/vllm-project/vllm/pull/27610
- [0073e9e](https://github.com/vllm-project/vllm/pull/27596/commits/0073e9ea1f198d6ea2e8c89eb1d7d09e00397486) Consumed test fix, but [ubuntu was down](https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQFMY_6s8e7AbWcGbatrjSU_aoghGrAcVK7slWXgWMkizA==)
-  [2f09f35](https://github.com/vllm-project/vllm/pull/27596/commits/2f09f359df1e2c7fc17c5173aee3714c921ac38c) ubuntu seems to be recovered from outage, merge again to trigger CI, and got hit by [second outage of the day](https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQGJS5KMnhX91YjyF6wnpAuaoNnb5eGi8Db5M09jNPORug==)
- [fb2a80b](https://github.com/vllm-project/vllm/pull/27596/commits/fb2a80b03ee971fabc5ceee387a82987c7a03d06) ubuntu say its resolved, and failed again.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x ] The test plan, such as providing test command.
- [x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

