### PR TITLE
[Bugfix] Fix non-contiguous tensor error in `rocm_unquantized_gemm_impl`

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -286,7 +286,7 @@ steps:
 
 - label: Engine Test # 25min
   timeout_in_minutes: 40
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   #grade: Blocking
   source_file_dependencies:
@@ -371,7 +371,7 @@ steps:
 
 - label: Examples Test # 30min
   timeout_in_minutes: 45
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   working_dir: "/vllm-workspace/examples"
@@ -390,7 +390,8 @@ steps:
     - python3 offline_inference/vision_language_pooling.py --seed 0
     - python3 offline_inference/vision_language_multi_image.py --seed 0
     - python3 others/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 others/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
-    - python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
+    # encoder-decoder is not supported on AMD yet
+    # - python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
     - python3 offline_inference/basic/classify.py
     - python3 offline_inference/basic/embed.py
     - python3 offline_inference/basic/score.py

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -390,11 +390,11 @@ steps:
     - python3 offline_inference/vision_language_pooling.py --seed 0
     - python3 offline_inference/vision_language_multi_image.py --seed 0
     - python3 others/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 others/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
-    # encoder-decoder is not supported on AMD yet
+    # encoder-decoder and encoder-only models are not supported on AMD yet - TritonAttentionImpl only supports DECODER attention
     # - python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
+    # - python3 offline_inference/basic/embed.py
+    # - python3 offline_inference/basic/score.py
     - python3 offline_inference/basic/classify.py
-    - python3 offline_inference/basic/embed.py
-    - python3 offline_inference/basic/score.py
     - python3 offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
     # https://github.com/vllm-project/vllm/pull/26682 uses slightly more memory in PyTorch 2.9+ causing this test to OOM in 1xL4 GPU
     - python3 offline_inference/spec_decode.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
@@ -636,9 +636,11 @@ steps:
   source_file_dependencies:
   - csrc/
   - vllm/entrypoints/openai/
-  - vllm/model_executor/models/whisper.py
+  # encoder-decoder (whisper) is not supported on AMD yet - TritonAttentionImpl doesn't support encoder attention
+  # - vllm/model_executor/models/whisper.py
   commands: # LMEval+Transcription WER check
-  - pytest -s entrypoints/openai/correctness/
+  # encoder-decoder (whisper) tests disabled for AMD
+  - pytest -s entrypoints/openai/correctness/test_lmeval.py
 
 - label: OpenAI-Compatible Tool Use # 23 min
   timeout_in_minutes: 35
@@ -857,7 +859,8 @@ steps:
     - pip install git+https://github.com/TIGER-AI-Lab/Mantis.git
     - pip freeze | grep -E 'torch'
     - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/processing
-    - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model  # Otherwise, mp_method="spawn" doesn't work
+    # encoder-decoder (whisper) is not supported on AMD yet - TritonAttentionImpl doesn't support encoder attention
+    # - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model
 
 - label: Multi-Modal Accuracy Eval (Small Models) # 50min
   mirror_hardwares: [amdexperimental]
@@ -1146,7 +1149,8 @@ steps:
   - pytest models/test_transformers.py -v -s -m 'distributed(num_gpus=2)'
   - pytest models/language -v -s -m 'distributed(num_gpus=2)'
   - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py
-  - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+  # encoder-decoder (whisper) is not supported on AMD yet - TritonAttentionImpl doesn't support encoder attention
+  # - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
 
 - label: Plugin Tests (2 GPUs) # 40min
   timeout_in_minutes: 60

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -371,7 +371,7 @@ steps:
 
 - label: Examples Test # 30min
   timeout_in_minutes: 45
-  mirror_hardwares: [amdexperimental, amdproduction]
+  mirror_hardwares: [amdexperimental]
   agent_pool: mi325_1
   # grade: Blocking
   working_dir: "/vllm-workspace/examples"
@@ -390,11 +390,10 @@ steps:
     - python3 offline_inference/vision_language_pooling.py --seed 0
     - python3 offline_inference/vision_language_multi_image.py --seed 0
     - python3 others/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 others/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
-    # encoder-decoder and encoder-only models are not supported on AMD yet - TritonAttentionImpl only supports DECODER attention
-    # - python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
-    # - python3 offline_inference/basic/embed.py
-    # - python3 offline_inference/basic/score.py
+    - python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
     - python3 offline_inference/basic/classify.py
+    - python3 offline_inference/basic/embed.py
+    - python3 offline_inference/basic/score.py
     - python3 offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
     # https://github.com/vllm-project/vllm/pull/26682 uses slightly more memory in PyTorch 2.9+ causing this test to OOM in 1xL4 GPU
     - python3 offline_inference/spec_decode.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
@@ -636,11 +635,9 @@ steps:
   source_file_dependencies:
   - csrc/
   - vllm/entrypoints/openai/
-  # encoder-decoder (whisper) is not supported on AMD yet - TritonAttentionImpl doesn't support encoder attention
-  # - vllm/model_executor/models/whisper.py
+  - vllm/model_executor/models/whisper.py
   commands: # LMEval+Transcription WER check
-  # encoder-decoder (whisper) tests disabled for AMD
-  - pytest -s entrypoints/openai/correctness/test_lmeval.py
+  - pytest -s entrypoints/openai/correctness/
 
 - label: OpenAI-Compatible Tool Use # 23 min
   timeout_in_minutes: 35
@@ -859,8 +856,7 @@ steps:
     - pip install git+https://github.com/TIGER-AI-Lab/Mantis.git
     - pip freeze | grep -E 'torch'
     - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/processing
-    # encoder-decoder (whisper) is not supported on AMD yet - TritonAttentionImpl doesn't support encoder attention
-    # - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model
+    - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model  # Otherwise, mp_method="spawn" doesn't work
 
 - label: Multi-Modal Accuracy Eval (Small Models) # 50min
   mirror_hardwares: [amdexperimental]
@@ -1149,8 +1145,7 @@ steps:
   - pytest models/test_transformers.py -v -s -m 'distributed(num_gpus=2)'
   - pytest models/language -v -s -m 'distributed(num_gpus=2)'
   - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py
-  # encoder-decoder (whisper) is not supported on AMD yet - TritonAttentionImpl doesn't support encoder attention
-  # - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+  - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
 
 - label: Plugin Tests (2 GPUs) # 40min
   timeout_in_minutes: 60

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -119,17 +119,17 @@ def rocm_unquantized_gemm_impl(
     if use_skinny is not True:
         return torch.nn.functional.linear(x, weight, bias)
 
-    x_view = x.view(-1, x.size(-1))
+    x_view = x.reshape(-1, x.size(-1))
     n = x_view.shape[0]
     m = weight.shape[0]
     cu_count = current_platform.get_cu_count()
 
     if m > 8 and 0 < n <= 4:
         out = ops.wvSplitK(weight, x_view, cu_count, bias)
-        return out.view(*x.shape[:-1], weight.shape[0])
+        return out.reshape(*x.shape[:-1], weight.shape[0])
     elif m % 4 == 0 and n == 1 and k <= 8192 and bias is None:
         out = ops.LLMM1(weight, x_view, 4)
-        return out.view(*x.shape[:-1], weight.shape[0])
+        return out.reshape(*x.shape[:-1], weight.shape[0])
     return torch.nn.functional.linear(x, weight, bias)
 
 


### PR DESCRIPTION
## Purpose
Fixes `RuntimeError: view size is not compatible with input tensor's size and stride`
  in `rocm_unquantized_gemm_impl` when running multimodal models (LLaVA) on AMD/ROCm platform. 
Example CI failure: [link](https://buildkite.com/vllm/amd-ci/builds/629#019a2740-5bfb-4ffd-97c0-8637f82a26d7).
```

2025-09-23 21:43:33 PDT | (EngineCore_DP0 pid=347) ERROR 09-24 04:43:33 [core.py:708]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/utils.py", line 108, in rocm_unquantized_gemm_impl
-- | --
  | 2025-09-23 21:43:33 PDT | (EngineCore_DP0 pid=347) ERROR 09-24 04:43:33 [core.py:708]     x_view = x.view(-1, x.size(-1))
  | 2025-09-23 21:43:33 PDT | (EngineCore_DP0 pid=347) ERROR 09-24 04:43:33 [core.py:708]              ^^^^^^^^^^^^^^^^^^^^^^
  | 2025-09-23 21:43:33 PDT | (EngineCore_DP0 pid=347) ERROR 09-24 04:43:33 [core.py:708] RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```


  **Root Cause:**
  - During multimodal model profiling, tensors passed to `rocm_unquantized_gemm_impl` can be non-contiguous
  - `.view()` requires contiguous memory layout and fails with non-contiguous tensors
  - This occurs specifically in multimodal projector(like LLaVA's) during the profile run
  
## Test Plan

```
pytest -v -s tests/engine/test_short_mm_context.py::test_context_length_too_short
INFO 10-27 13:09:44 [__init__.py:225] Automatically detected platform rocm.
=============================================================== test session starts ================================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0 -- /home/zhewenli/uv_env/vllm-fork/bin/python3
cachedir: .pytest_cache
rootdir: /data/users/zhewenli/gitrepos/vllm-fork
configfile: pyproject.toml
plugins: anyio-4.11.0, asyncio-1.2.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                
...
PASSED

================================================================= warnings summary =================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 1 passed, 2 warnings in 42.37s ==========================================================
```

```
python3 offline_inference/vision_language.py --seed 0
INFO 10-27 13:21:27 [__init__.py:225] Automatically detected platform rocm.
INFO 10-27 13:21:44 [utils.py:243] non-default args: {'seed': 0, 'max_model_len': 4096, 'limit_mm_per_prompt': {'image': 1, 'video': 0, 'audio': 0}, 'model': 'llava-hf/llava-1.5-7b-hf'}
INFO 10-27 13:21:45 [model.py:663] Resolved architecture: LlavaForConditionalGeneration
INFO 10-27 13:21:45 [model.py:1751] Using max model len 4096
INFO 10-27 13:21:46 [scheduler.py:219] Chunked prefill is enabled with max_num_batched_tokens=16384.
WARNING 10-27 13:21:48 [__init__.py:866] We must use the `spawn` multiprocessing start method. Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. See https://docs.vllm.ai/en/latest/usage/troubleshooting.html#python-multiprocessing for more information. Reasons: CUDA is initialized
...
Processed prompts: 100%|█████████████████████████████████████| 4/4 [00:01<00:00,  3.37it/s, est. speed input: 2008.18 toks/s, output: 215.64 toks/s]
--------------------------------------------------
 The image features a tall tower with a spire, surrounded by a beautiful flowering tree. The tree is filled with pink flowers, creating a vibrant and lively atmosphere. The tower stands tall in the background, with the tree's branches extending towards it. The combination of the tower and the flow
--------------------------------------------------
 The image features a tall tower with a spire, surrounded by a beautiful cherry blossom tree. The tree is filled with pink flowers, creating a picturesque scene. The tower stands tall in the background, with the blossoming tree in the foreground. The combination of the tower and the v
--------------------------------------------------
 The image features a tall tower with a spire, surrounded by a beautiful cherry blossom tree. The tree is filled with pink flowers, creating a picturesque scene. The tower stands tall in the background, with the blossoming tree in the foreground. The combination of the tower and the tree
--------------------------------------------------
 The image features a tall tower with a spire, surrounded by a beautiful cherry blossom tree. The tree is filled with pink flowers, creating a picturesque scene. The tower stands tall in the background, with the blossoming tree in the foreground. The combination of the tower and the tree
--------------------------------------------------
[rank0]:[W1027 13:22:58.239203194 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

CI: https://buildkite.com/vllm/amd-ci/builds/632