### PR TITLE
[Bugfix] Respect ignore list for NVFP4/BF16 mixed MoE checkpoints

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -158,6 +158,10 @@ class CompressedTensorsConfig(QuantizationConfig):
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
         if isinstance(layer, FusedMoE):
+            if should_ignore_layer(
+                prefix, ignore=self.ignore, fused_mapping=self.packed_modules_mapping
+            ):
+                return None
             return CompressedTensorsMoEMethod.get_moe_method(self, layer)
         return None
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -70,6 +70,8 @@ def should_ignore_layer(
             layer_name=layer_name, targets=ignore
         )
         if not should_ignore_layer:
+            # Handle configs that list only child params so the containing
+            # module inherits their ignore state.
             prefix = f"{layer_name}."
             should_ignore_layer = any(
                 target.startswith(prefix) and not target.startswith("re:")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -69,6 +69,12 @@ def should_ignore_layer(
         should_ignore_layer = check_equal_or_regex_match(
             layer_name=layer_name, targets=ignore
         )
+        if not should_ignore_layer:
+            prefix = f"{layer_name}."
+            should_ignore_layer = any(
+                target.startswith(prefix) and not target.startswith("re:")
+                for target in ignore
+            )
 
     assert should_ignore_layer is not None
     return should_ignore_layer


### PR DESCRIPTION
## Purpose
Fix #27607

The entire model shares the same quantization configuration, so vLLM attempts to load all layers as NVFP4.
None of the methods in the call stack check whether a layer is in the ignore list.

The call stack:
`Qwen3MoeSparseMoeBlock.__init__ => FusedMoE.__init__ => CompressedTensorsConfig.get_quant_method => CompressedTensorsMoEMethod.get_moe_method`

To fix this, I added a `should_ignore_layer` check inside `CompressedTensorsConfig.get_quant_method`:
```python
if isinstance(layer, FusedMoE):
    if should_ignore_layer(
        prefix, ignore=self.ignore, fused_mapping=self.packed_modules_mapping
    ):
        return None
    return CompressedTensorsMoEMethod.get_moe_method(self, layer)
```
Additionally, I modified `should_ignore_layer` to check its child parameters,
since the `prefix` corresponds to the parent layer (`experts`).

## Test Plan
Execute the following to serve the NVFP4/BF16 mixed model. It shouldn't product any error (Blackwell GPU is required):
```
VLLM_USE_FLASHINFER_MOE_FP4=1 vllm serve Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED --max_model_len 40960 --host 0.0.0.0 --port 8000
```
The model: https://huggingface.co/Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED

<details>
<summary> The script used to create the mixed model: </summary>

```python
from datasets import load_dataset
from transformers import AutoModelForCausalLM, AutoTokenizer

from llmcompressor import oneshot
from llmcompressor.modifiers.quantization import QuantizationModifier
from llmcompressor.utils import dispatch_for_generation

MODEL_ID = "Qwen/Qwen3-30B-A3B-Instruct-2507"

# Load model.
model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)


DATASET_ID = "neuralmagic/calibration"
NUM_CALIBRATION_SAMPLES = 256
MAX_SEQUENCE_LENGTH = 8192

ds = load_dataset(DATASET_ID, name="LLM", split=f"train[:{NUM_CALIBRATION_SAMPLES}]")
ds = ds.shuffle(seed=42)

def preprocess_function(example):
    messgages = []
    for message in example["messages"]:
        messgages.append(
            {
                "role": message["role"],
                "content": [{"type": "text", "text": message["content"]}],
            }
        )

    return tokenizer.apply_chat_template(
        messgages,
        padding=False,
        truncation=True,
        max_length=MAX_SEQUENCE_LENGTH,
        tokenize=True,
        add_special_tokens=False,
        return_dict=True,
        add_generation_prompt=False,
    )


ds = ds.map(preprocess_function, batched=False, remove_columns=ds.column_names)

recipe = QuantizationModifier(
    targets="Linear", scheme="NVFP4", ignore=["lm_head", "re:.*mlp.gate$", "re:.*self_attn.*", "re:.*layers\\.47\\..*"]
)

# Apply quantization.
oneshot(
    model=model,
    dataset=ds,
    recipe=recipe,
    max_seq_length=MAX_SEQUENCE_LENGTH,
    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
    calibrate_moe_context=True,
)

# Save to disk in compressed-tensors format.
SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-NVFP4"
model.save_pretrained(SAVE_DIR, save_compressed=True)

tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
tokenizer.save_pretrained(SAVE_DIR)

```

</details>

## Test Result
No error, and the model generates coherent output.
<details>
<summary> vllm serve log </summary>

```
(APIServer pid=158061) INFO 10-27 21:28:45 [api_server.py:1870] vLLM API server version 0.1.dev10765+gf4e815407
(APIServer pid=158061) INFO 10-27 21:28:45 [utils.py:253] non-default args: {'model_tag': 'Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED', 'host': '0.0.0.0', 'model': 'Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED', 'max_model_len': 40960}
(APIServer pid=158061) INFO 10-27 21:28:50 [model.py:667] Resolved architecture: Qwen3MoeForCausalLM
(APIServer pid=158061) INFO 10-27 21:28:50 [model.py:1778] Using max model len 40960
(APIServer pid=158061) INFO 10-27 21:28:51 [scheduler.py:211] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=158314) INFO 10-27 21:28:55 [core.py:93] Initializing a V1 LLM engine (v0.1.dev10765+gf4e815407) with config: model='Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED', speculative_config=None, tokenizer='Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=40960, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=compressed-tensors, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED, enable_prefix_caching=True, chunked_prefill_enabled=True, pooler_config=None, compilation_config={'level': None, 'mode': 3, 'debug_dump_path': None, 'cache_dir': '', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention', 'vllm::sparse_attn_indexer'], 'use_inductor': None, 'compile_sizes': [], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'use_cudagraph': True, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'full_cuda_graph': True, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {}, 'max_cudagraph_capture_size': 512, 'local_cache_dir': None}
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=158314) INFO 10-27 21:28:55 [parallel_state.py:1325] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=158314) INFO 10-27 21:28:56 [gpu_model_runner.py:2849] Starting to load model Benasd/Qwen3-30B-A3B-Instruct-2507-NVFP4-BF16-MIXED...
(EngineCore_DP0 pid=158314) INFO 10-27 21:28:56 [cuda.py:405] Using Flash Attention backend on V1 engine.
(EngineCore_DP0 pid=158314) INFO 10-27 21:28:56 [nvfp4_moe_support.py:38] Using FlashInfer kernels for CompressedTensorsW4A4MoeMethod.
Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  40% Completed | 2/5 [00:00<00:01,  2.12it/s]
Loading safetensors checkpoint shards:  60% Completed | 3/5 [00:01<00:01,  1.50it/s]
Loading safetensors checkpoint shards:  80% Completed | 4/5 [00:02<00:00,  1.36it/s]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:03<00:00,  1.36it/s]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:03<00:00,  1.44it/s]
(EngineCore_DP0 pid=158314) 
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:01 [default_loader.py:314] Loading weights took 3.51 seconds
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:01 [gpu_model_runner.py:2914] Model loading took 18.9305 GiB and 4.909722 seconds
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:05 [backends.py:618] Using cache directory: /root/.cache/vllm/torch_compile_cache/25f9bc99e4/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:05 [backends.py:634] Dynamo bytecode transform time: 3.52 s
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:05 [backends.py:248] Cache the graph for dynamic shape for later use
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:08 [backends.py:279] Compiling a graph for dynamic shape takes 2.69 s
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:09 [monitor.py:34] torch.compile takes 6.21 s in total
(EngineCore_DP0 pid=158314) WARNING 10-27 21:29:09 [fused_moe.py:884] Using default MoE config. Performance might be sub-optimal! Config file not found at ['/workspaces/vllm_test/vllm/vllm/model_executor/layers/fused_moe/configs/E=128,N=768,device_name=NVIDIA_GeForce_RTX_5090.json']
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:10 [gpu_worker.py:319] Available KV cache memory: 7.80 GiB
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:10 [kv_cache_utils.py:1229] GPU KV cache size: 85,232 tokens
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:10 [kv_cache_utils.py:1234] Maximum concurrency for 40,960 tokens per request: 2.08x
(EngineCore_DP0 pid=158314) 2025-10-27 21:29:10,848 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
(EngineCore_DP0 pid=158314) 2025-10-27 21:29:11,326 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|████████████████████| 51/51 [00:01<00:00, 31.34it/s]
Capturing CUDA graphs (decode, FULL): 100%|███████████████████████████████████████| 35/35 [00:01<00:00, 33.91it/s]
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:14 [gpu_model_runner.py:3842] Graph capturing finished in 3 secs, took 0.24 GiB
(EngineCore_DP0 pid=158314) INFO 10-27 21:29:14 [core.py:237] init engine (profile, create kv cache, warmup model) took 12.96 seconds
(APIServer pid=158061) INFO 10-27 21:29:16 [api_server.py:1648] Supported tasks: ['generate']
(APIServer pid=158061) WARNING 10-27 21:29:16 [model.py:1608] Default sampling parameters have been overridden by the model's Hugging Face generation config recommended from the model creator. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=158061) INFO 10-27 21:29:16 [serving_responses.py:148] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=158061) INFO 10-27 21:29:16 [serving_chat.py:130] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=158061) INFO 10-27 21:29:17 [serving_completion.py:68] Using default completion sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=158061) INFO 10-27 21:29:17 [api_server.py:1939] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:38] Available routes are:
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=158061) INFO 10-27 21:29:17 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=158061) INFO:     Started server process [158061]
(APIServer pid=158061) INFO:     Waiting for application startup.
(APIServer pid=158061) INFO:     Application startup complete.
```
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

