### PR TITLE
[Bugfix][CI] Fix config resolving logic with remote models

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -622,9 +622,10 @@ def get_config(
     # Architecture mapping for models without explicit architectures field
     if not config.architectures:
         if config.model_type not in MODEL_MAPPING_NAMES:
-            raise ValueError(f"Cannot find architecture name for {config.model_type}")
-        model_type = MODEL_MAPPING_NAMES[config.model_type]
-        config.update({"architectures": [model_type]})
+            config.update({"architectures": ["AutoModel"]})
+        else:
+            model_type = MODEL_MAPPING_NAMES[config.model_type]
+            config.update({"architectures": [model_type]})
 
     # ModelOpt 0.31.0 and after saves the quantization config in the model
     # config file.

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -622,7 +622,11 @@ def get_config(
     # Architecture mapping for models without explicit architectures field
     if not config.architectures:
         if config.model_type not in MODEL_MAPPING_NAMES:
-            config.update({"architectures": ["AutoModel"]})
+            logger.warning(
+                "Model config does not have a top-level 'architectures' field: "
+                "expecting `hf_overrides={'architectures': ['...']}` to be passed "
+                "in engine args."
+            )
         else:
             model_type = MODEL_MAPPING_NAMES[config.model_type]
             config.update({"architectures": [model_type]})


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#27566 introduced a regression where remote models (e.g, `deepseek-ai/deepseek-vl2`) without architectures will be not deploy-able even with `--hf_overrides '{"architectures": ["DeepseekVLV2ForCausalLM"]}'` on vLLM because of a strict model type check.  This PR relaxes this check and adds a warning when this happens.

This also fixes the failed `entrypoints/test_chat_utils.py::test_resolve_content_format_fallbacks[deepseek-ai/deepseek-vl2-tiny-string]` CI test on main.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

