### PR TITLE
[CI/Build] Fix amd model executor test

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -553,7 +553,7 @@ steps:
 
 - label: Model Executor Test # 23min
   timeout_in_minutes: 35
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:

--- a/tests/model_executor/model_loader/fastsafetensors_loader/test_fastsafetensors_loader.py
+++ b/tests/model_executor/model_loader/fastsafetensors_loader/test_fastsafetensors_loader.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
+
 from vllm import SamplingParams
+from vllm.platforms import current_platform
 
 test_model = "openai-community/gpt2"
 
@@ -15,6 +18,9 @@ prompts = [
 sampling_params = SamplingParams(temperature=0.8, top_p=0.95, seed=0)
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="fastsafetensors requires CUDA/NVIDIA GPUs"
+)
 def test_model_loader_download_files(vllm_runner):
     with vllm_runner(test_model, load_format="fastsafetensors") as llm:
         deserialized_outputs = llm.generate(prompts, sampling_params)

--- a/tests/model_executor/model_loader/fastsafetensors_loader/test_weight_utils.py
+++ b/tests/model_executor/model_loader/fastsafetensors_loader/test_weight_utils.py
@@ -5,6 +5,7 @@ import glob
 import tempfile
 
 import huggingface_hub.constants
+import pytest
 import torch
 
 from vllm.model_executor.model_loader.weight_utils import (
@@ -12,8 +13,12 @@ from vllm.model_executor.model_loader.weight_utils import (
     fastsafetensors_weights_iterator,
     safetensors_weights_iterator,
 )
+from vllm.platforms import current_platform
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="fastsafetensors requires CUDA/NVIDIA GPUs"
+)
 def test_fastsafetensors_model_loader():
     with tempfile.TemporaryDirectory() as tmpdir:
         huggingface_hub.constants.HF_HUB_OFFLINE = False


### PR DESCRIPTION
## Purpose
Fix Model Executor Test running on AMD CI:([example](https://buildkite.com/vllm/ci/builds/36286#019a1ead-5049-40ac-b0df-ccfaab9f34af))
We need to skip [fastsafetensors](https://github.com/foundation-model-stack/fastsafetensors) tests, since it's only supporting CUDA platform.

## Test Plan
CI: https://buildkite.com/vllm/amd-ci/builds/635
<img width="1535" height="459" alt="Screenshot 2025-10-27 at 5 20 07 PM" src="https://github.com/user-attachments/assets/b67702d8-54c2-467a-9e40-b013d2834213" />

```
pytest -v -s model_executor
...
================================================================== warnings summary ==================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

model_executor/model_loader/tensorizer_loader/test_tensorizer.py:281
  /data/users/zhewenli/gitrepos/vllm-fork/tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py:281: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=3)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/home/zhewenli/uv_env/vllm-fork/lib64/python3.12/site-packages/urllib3/response.py:429: KeyboardInterrupt
(to show a full traceback on KeyboardInterrupt use --full-trace)
=============================================== 13 passed, 2 skipped, 3 warnings in 1592.21s (0:26:32) ===============================================
```

