### PR TITLE
add a warmup mode in CUDAGraphMode

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -4,6 +4,7 @@ import copy
 from contextlib import nullcontext
 
 import pytest
+from pydantic import ValidationError
 
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.fix_functionalization import FixFunctionalizationPass
@@ -306,3 +307,21 @@ def test_cudagraph_sizes_post_init(
     assert (
         vllm_config.compilation_config.max_cudagraph_capture_size == expected_max_size
     )
+
+
+def test_cudagraph_compilation_modes():
+    with pytest.raises(ValidationError):
+        _ = CompilationConfig(
+            cudagraph_mode=CUDAGraphMode.WARMUP,
+        )
+
+    for mode in [
+        CUDAGraphMode.NONE,
+        CUDAGraphMode.FULL,
+        CUDAGraphMode.PIECEWISE,
+        CUDAGraphMode.FULL_DECODE_ONLY,
+        CUDAGraphMode.FULL_AND_PIECEWISE,
+    ]:
+        _ = CompilationConfig(
+            cudagraph_mode=mode,
+        )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3432,7 +3432,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # we allow forcing NONE when the dispatcher disagrees to support
                 # warm ups for cudagraph capture
                 assert (
-                    cudagraph_runtime_mode == CUDAGraphMode.NONE
+                    cudagraph_runtime_mode in (CUDAGraphMode.NONE, CUDAGraphMode.WARMUP)
                     or cudagraph_runtime_mode == _cg_mode
                 ), (
                     f"Cudagraph runtime mode mismatch at dummy_run. "
@@ -3895,7 +3895,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
                 self._dummy_run(
                     num_tokens,
-                    cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                    cudagraph_runtime_mode=CUDAGraphMode.WARMUP,
                     force_attention=force_attention,
                     uniform_decode=uniform_decode,
                     allow_microbatching=allow_microbatching,


### PR DESCRIPTION
Summary: during cuda graph capturing warm-up time, we need to call the underlying model in eager mode but switch on code paths for cuda graphs, previoulsy there was no good way to distinguish real eager mode run vs. warmup runs.

Test Plan: CI

Differential Revision: D85613194


