### PR TITLE
[Model] make the `inv_freq` in `Qwen2_5_VisionRotaryEmbedding` device-agnostic

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -607,9 +607,7 @@ class Qwen2_5_VisionRotaryEmbedding(nn.Module):
         super().__init__()
         self.dim = dim
         self.theta = theta
-        inv_freq = 1.0 / (
-            theta ** (torch.arange(0, dim, 2, dtype=torch.float, device="cpu") / dim)
-        )
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self._seq_len_cached = 0
         self._freqs_cached = None


### PR DESCRIPTION
## Purpose
Currently the `inv_freq` in `Qwen2_5_VisionRotaryEmbedding` is set to 'cpu' explicitly.
https://github.com/vllm-project/vllm/blob/a8d2e326ecb70876aa73dce70dbe2434c64b710a/vllm/model_executor/models/qwen2_5_vl.py#L610-L612
This PR makes it device-agnostic.