### PR TITLE
[Core][Bookkeeping Optimization] Update against numpy view of is_token_ids tensor

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -108,9 +108,7 @@ class InputBatch:
             pin_memory=False,
         )
         self.token_ids_cpu = self.token_ids_cpu_tensor.numpy()
-        self.is_token_ids = torch.zeros(
-            (max_num_reqs, max_model_len), device="cpu", dtype=bool, pin_memory=False
-        )
+        self.is_token_ids = np.zeros((max_num_reqs, max_model_len), dtype=bool)
         # Store prompt embeddings per request to avoid OOM from large upfront
         # allocation if max_model_len is big.
         # Maps req_index -> tensor of shape (num_prompt_tokens, hidden_size)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -108,7 +108,10 @@ class InputBatch:
             pin_memory=False,
         )
         self.token_ids_cpu = self.token_ids_cpu_tensor.numpy()
-        self.is_token_ids = np.zeros((max_num_reqs, max_model_len), dtype=bool)
+        self.is_token_ids_tensor = torch.zeros(
+            (max_num_reqs, max_model_len), device="cpu", dtype=bool, pin_memory=False
+        )
+        self.is_token_ids = self.is_token_ids_tensor.numpy()
         # Store prompt embeddings per request to avoid OOM from large upfront
         # allocation if max_model_len is big.
         # Maps req_index -> tensor of shape (num_prompt_tokens, hidden_size)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1103,7 +1103,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             out=self.input_ids.cpu[:total_num_scheduled_tokens],
         )
         if self.enable_prompt_embeds:
-            is_token_ids = self.input_batch.is_token_ids.flatten()
+            is_token_ids = self.input_batch.is_token_ids_tensor.flatten()
             torch.index_select(
                 is_token_ids,
                 0,


### PR DESCRIPTION
## Purpose
Bookkeeping logic is on critical path even when async scheduling is turned on. And we found the overhead of bookkeeping is mainly coming from tensor operations.

<img width="1372" height="133" alt="Screenshot 2025-10-27 at 6 22 07 PM" src="https://github.com/user-attachments/assets/c2612546-02c1-4a78-b4f3-650e09f62544" />

And we found that replacing is_token_ids from tensor to numpy array could bring down the bookkeeping overhead by 50%+.

## Test Plan & Test Result

Bookkeeping cost is reduced from 2+ms to 0.8ms (50+%).

**After**
<img width="1301" height="875" alt="Screenshot 2025-10-27 at 6 16 30 PM" src="https://github.com/user-attachments/assets/7d85bb4d-3e6f-4c14-87f7-8b32162c34a9" />

**Before**
<img width="1141" height="404" alt="Screenshot 2025-10-27 at 5 56 27 PM" src="https://github.com/user-attachments/assets/79b37cfc-04f5-401f-a56e-6945bf5bdf01" />


Repo
```
# Server
VLLM_TORCH_PROFILER_DIR=~/vllm_profile vllm serve   facebook/opt-125m   --swap-space 16   --disable-log-requests   --host ::   --dtype float16   --async_scheduling   --port 12341 2>&1 | tee /data/users/$USER/logs/server.$(date +%Y%m%d_%H%M%S)-async.log
# Loadgen
vllm bench serve   --dataset-name random   --model facebook/opt-125m   --served-model-name facebook/opt-125m   --random-input-len 48   --random-output-len 10   --endpoint /v1/completions   --ignore-eos   --host localhost   --port 12341   --num-prompts 200 --profile
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

