### PR TITLE
[ROCm][Platform] Add MI308X device id in _ROCM_DEVICE_ID_NAME_MAP

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -72,6 +72,7 @@ _ROCM_DEVICE_ID_NAME_MAP: dict[str, str] = {
     "0x74a0": "AMD_Instinct_MI300A",
     "0x74a1": "AMD_Instinct_MI300X",
     "0x74b5": "AMD_Instinct_MI300X",  # MI300X VF
+    "0x74a2": "AMD_Instinct_MI308X",
     "0x74a5": "AMD_Instinct_MI325X",
     "0x74b9": "AMD_Instinct_MI325X",  # MI325X VF
     "0x74a9": "AMD_Instinct_MI300X_HF",


### PR DESCRIPTION

## Purpose
vLLM rely on `device_name` to properly load triton tuned configurations, e.g. [E=8,N=8192,device_name=AMD_Instinct_MI300X.json](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fused_moe/configs/E%3D8%2CN%3D8192%2Cdevice_name%3DAMD_Instinct_MI300X.json)

`vllm.platfroms.rocm.get_device_name` detects rocm platform information via amd-smi:
https://github.com/vllm-project/vllm/blob/61fbfe52742bb34ce8a04d3fb734582268bdcd10/vllm/platforms/rocm.py#L348-L358
If `asic_info["device_id"]` not found in `_ROCM_DEVICE_ID_NAME_MAP`, it will return `asic_info["market_name"]` instead. 

However, `amd-smi static | grep "MARKET_NAME"` may return different outputs from different docker images on same MI308X machine as follow:
- `AMD Radeon Graphics`
- `AMD Instinct MI308X`
- `AMD Instinct MI308X OAM`

Mismatch of the device name will block vllm to load pre-tuned triton configs and fallback to default config, resulting in sub-optimal performance.

This PR aim to add MI308X device id “0x74a2" in `_ROCM_DEVICE_ID_NAME_MAP` to use unified device name: "AMD_Instinct_MI308X", which ensure that all tune triton configs on MI308X can be loaded and used properly.

## Test Plan
Run following code on server with AMD Instinct MI308X GPU:
`from vllm.platforms import current_platform; device_name = current_platform.get_device_name().replace(" ", "_"); print("device_name: ", device_name)`

## Test Result
`device_name:  AMD_Instinct_MI308X`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

