### PR TITLE
[NIXL][XPU] update name of nixl wheel

### DIFF
--- a/tools/install_nixl_from_source_ubuntu.py
+++ b/tools/install_nixl_from_source_ubuntu.py
@@ -37,7 +37,7 @@ def is_pip_package_installed(package_name):
 def find_nixl_wheel_in_cache(cache_dir):
     """Finds a nixl wheel file in the specified cache directory."""
     # The repaired wheel will have a 'manylinux' tag, but this glob still works.
-    search_pattern = os.path.join(cache_dir, "nixl-*.whl")
+    search_pattern = os.path.join(cache_dir, "nixl*.whl")
     wheels = glob.glob(search_pattern)
     if wheels:
         # Sort to get the most recent/highest version if multiple exist


### PR DESCRIPTION
The recent update of NIXL's whl filename (`nixl_cu12-0.6.1-cp312-cp312-linux_x86_64.whl`) caused `find_nixl_wheel_in_cache` to fail.