### PR TITLE
[Core][Env Cache] Enable environment variable cache for Worker as well

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -52,9 +52,18 @@ def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
         environment_variables
     )
 
+    # No-op, if we call envs cache enable again
+    enable_envs_cache()
+    assert envs.__getattr__.cache_info().hits == start_hits + 2 + len(
+        environment_variables
+    )
+
     # Reset envs.__getattr__ back to none-cached version to
     # avoid affecting other tests
     envs.__getattr__ = envs.__getattr__.__wrapped__
+    # Ensured the wrapped function is not cached
+    # (i.e. we only wrapped functools.cache it once)
+    assert not hasattr(envs.__getattr__, "cache_info")
 
 
 class TestEnvWithChoices:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1469,8 +1469,12 @@ def enable_envs_cache() -> None:
     runtime overhead. This also means that environment variables should NOT
     be updated after the service is initialized.
     """
-    # Tag __getattr__ with functools.cache
     global __getattr__
+    # Check if __getattr__ is already cached
+    if hasattr(__getattr__, "cache_info"):
+        return
+
+    # Tag __getattr__ with functools.cache
     __getattr__ = functools.cache(__getattr__)
 
     # Cache all environment variables

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -24,6 +24,7 @@ from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
 )
+from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
@@ -224,6 +225,10 @@ class Worker(WorkerBase):
         if self.rank == 0:
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
+
+        # Enable environment variable cache (e.g. assume no more
+        # environment variable overrides after this point)
+        enable_envs_cache()
 
     # FIXME(youkaichao & ywang96): Use TorchDispatchMode instead of memory pool
     # to hijack tensor allocation.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -226,16 +226,16 @@ class Worker(WorkerBase):
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
 
-        # Enable environment variable cache (e.g. assume no more
-        # environment variable overrides after this point)
-        enable_envs_cache()
-
     # FIXME(youkaichao & ywang96): Use TorchDispatchMode instead of memory pool
     # to hijack tensor allocation.
     def load_model(self) -> None:
         eep_scale_up = os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") == "1"
         with self._maybe_get_memory_pool_context(tag="weights"):
             self.model_runner.load_model(eep_scale_up=eep_scale_up)
+
+        # Enable environment variable cache (e.g. assume no more
+        # environment variable overrides after this point)
+        enable_envs_cache()
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)


### PR DESCRIPTION
## Purpose
Enable environment variable caching in Worker at the end of model_load.

This should be helpful for use cases who use ray of torchrun to spawn processes.

We also avoid duplicated functools.cache wrappings and enhanced unit tests in this PR.

**Context**
We firstly introduced and enabled environment variable caching in https://github.com/vllm-project/vllm/pull/26146 in EngineCore and Executor, this PR is a followup PR suggested by @youkaichao (https://github.com/vllm-project/vllm/pull/26146#pullrequestreview-3371329881)

## Test Plan / Test Result
CI

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

