### PR TITLE
[Bugfix] vLLM should check Inductor config for compile cache enablement status

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -33,6 +33,7 @@ from .compiler_interface import (
     EagerAdaptor,
     InductorAdaptor,
     InductorStandaloneAdaptor,
+    is_compile_cache_enabled,
 )
 from .counter import compilation_counter
 from .inductor_pass import InductorPass
@@ -240,7 +241,7 @@ class CompilerManager:
         assert compiled_graph is not None, "Failed to compile the graph"
 
         # store the artifact in the cache
-        if not envs.VLLM_DISABLE_COMPILE_CACHE and handle is not None:
+        if is_compile_cache_enabled(additional_inductor_config) and handle is not None:
             self.cache[(runtime_shape, graph_index, self.compiler.name)] = handle
             compilation_counter.num_cache_entries_updated += 1
             self.is_cache_updated = True
@@ -612,7 +613,9 @@ class VllmBackend:
         os.makedirs(local_cache_dir, exist_ok=True)
         self.compilation_config.local_cache_dir = local_cache_dir
 
-        disable_cache = envs.VLLM_DISABLE_COMPILE_CACHE
+        disable_cache = not is_compile_cache_enabled(
+            self.compilation_config.inductor_compile_config
+        )
 
         if disable_cache:
             logger.info_once("vLLM's torch.compile cache is disabled.", scope="local")


### PR DESCRIPTION
Summary:
vLLM should not assume compile cache is enabled just because VLLM_DISABLE_COMPILE_CACHE=0. Users may use TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 to disable compile cache at PyTorch level, effectively making it impossible for vLLM compile cache to function. 

This PR adds necessary checks to ensure vLLM considers Torch Inductor compile cache enablement status.


Signed off by: Yanan Cao <gmagogsfm@gmail.com>