### PR TITLE
[MISC] Move length cap checks to the end for better understanding

### DIFF
--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -63,6 +63,7 @@ def check_stop(
         request.status = RequestStatus.FINISHED_STOPPED
         request.stop_reason = last_token_id
         return True
+
     if (
         request.num_tokens >= max_model_len
         or request.num_output_tokens >= request.max_tokens


### PR DESCRIPTION


<!-- markdownlint-disable -->

## Purpose

When the model completes inference normally and also hits the length limit, the `finish_reason` should be set to `STOP` to indicate a natural completion, rather than a `FINISHED_LENGTH_CAPPED`. This approach is more logical.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

