### PR TITLE
[cpu][feat] Enable SWA and hybrid local-global models for CPU backend

### DIFF
--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -7,6 +7,10 @@ import pytest
 import torch
 
 from tests.kernels.allclose_default import get_default_atol, get_default_rtol
+from tests.kernels.attention.utils import (
+    ref_multi_query_kv_attention,
+    ref_single_query_cached_kv_attention,
+)
 from tests.kernels.utils import opcheck
 from vllm import _custom_ops as ops
 from vllm.attention.layer import Attention, MultiHeadAttention
@@ -42,76 +46,6 @@ USE_ALIBI = [False, True]
 KV_CACHE_DTYPE = ["auto", "fp8"]
 SEEDS = [0]
 CUDA_DEVICES = [f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)]
-
-
-def ref_masked_attention(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
-    scale: float,
-    attn_mask: torch.Tensor | None = None,
-) -> torch.Tensor:
-    attn_weights = scale * torch.einsum("qhd,khd->hqk", query, key).float()
-    if attn_mask is not None:
-        attn_weights = attn_weights + attn_mask.float()
-    attn_weights = torch.softmax(attn_weights, dim=-1).to(value.dtype)
-    out = torch.einsum("hqk,khd->qhd", attn_weights, value)
-    return out
-
-
-def ref_single_query_cached_kv_attention(
-    output: torch.Tensor,
-    query: torch.Tensor,
-    num_queries_per_kv: int,
-    key_cache: torch.Tensor,
-    value_cache: torch.Tensor,
-    block_tables: torch.Tensor,
-    seq_lens: torch.Tensor,
-    scale: float,
-    alibi_slopes: torch.Tensor | None,
-) -> None:
-    num_query_heads = query.shape[1]
-    num_kv_heads = value_cache.shape[1]
-    head_size = value_cache.shape[2]
-    block_size = value_cache.shape[3]
-    num_seqs = query.shape[0]
-
-    block_tables_lst = block_tables.cpu().tolist()
-    seq_lens_lst = seq_lens.cpu().tolist()
-    for i in range(num_seqs):
-        q = query[i].unsqueeze(0)
-        block_table = block_tables_lst[i]
-        seq_len = int(seq_lens_lst[i])
-
-        keys_lst: list[torch.Tensor] = []
-        values_lst: list[torch.Tensor] = []
-        for j in range(seq_len):
-            block_number = int(block_table[j // block_size])
-            block_offset = j % block_size
-
-            k = key_cache[block_number, :, :, block_offset, :]
-            k = k.reshape(num_kv_heads, head_size)
-            keys_lst.append(k)
-
-            v = value_cache[block_number, :, :, block_offset]
-            values_lst.append(v)
-        keys = torch.stack(keys_lst, dim=0)
-        values = torch.stack(values_lst, dim=0)
-        if num_queries_per_kv > 1:
-            # Handle MQA and GQA
-            keys = torch.repeat_interleave(keys, num_queries_per_kv, dim=1)
-            values = torch.repeat_interleave(values, num_queries_per_kv, dim=1)
-
-        alibi_bias = None
-        if alibi_slopes is not None:
-            # Create the ALiBi bias used in the paged attention kernel.
-            position_ids = torch.arange(seq_len).int()
-            alibi_bias = (position_ids - seq_len + 1).float()
-            alibi_bias = alibi_slopes.view(-1, 1, 1) * alibi_bias.view(1, 1, -1)
-
-        out = ref_masked_attention(q, keys, values, scale, alibi_bias)
-        out = out.view(num_query_heads, head_size)
-        output[i].copy_(out, non_blocking=True)
 
 
 @pytest.mark.parametrize(
@@ -406,46 +340,6 @@ def test_paged_attention(
     if kv_cache_dtype == "fp8":
         atol, rtol = 1e-2, 1e-5
     torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol)
-
-
-def ref_multi_query_kv_attention(
-    cu_seq_lens: list[int],
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
-    scale: float,
-    alibi_bias: list[torch.Tensor] | None,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    num_seqs = len(cu_seq_lens) - 1
-    ref_outputs: list[torch.Tensor] = []
-    if alibi_bias:
-        assert len(alibi_bias) == num_seqs
-    for i in range(num_seqs):
-        start_idx = cu_seq_lens[i]
-        end_idx = cu_seq_lens[i + 1]
-        seq_len = end_idx - start_idx
-
-        # Create attention mask. ALiBi already includes a tril causal mask.
-        if alibi_bias:
-            attn_mask = alibi_bias[i]
-        else:
-            attn_mask = torch.triu(
-                torch.ones(seq_len, seq_len, dtype=dtype), diagonal=1
-            )
-            attn_mask = attn_mask * torch.finfo(dtype).min
-            attn_mask = attn_mask.to(dtype=dtype)
-
-        ref_output = ref_masked_attention(
-            query[start_idx:end_idx],
-            key[start_idx:end_idx],
-            value[start_idx:end_idx],
-            scale,
-            attn_mask=attn_mask,
-        )
-        ref_outputs.append(ref_output)
-
-    return torch.cat(ref_outputs, dim=0)
 
 
 @pytest.mark.parametrize("num_seqs", NUM_PREFILL_SEQS)

--- a/tests/kernels/attention/test_cpu_decode_attention.py
+++ b/tests/kernels/attention/test_cpu_decode_attention.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import random
+
+import pytest
+import torch
+
+from tests.kernels.allclose_default import get_default_atol, get_default_rtol
+from tests.kernels.attention.utils import ref_single_query_cached_kv_attention
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.cpu_attn import _PagedAttention
+
+NUM_BLOCKS = 4321  # Arbitrary values for testing
+BLOCK_SIZE = 16
+
+
+# TODO: Make this token-granular once paged_attn API/impls support it
+def get_block_granular_sliding_window_mask(
+    kv_len: int, window: int | None, block_size: int, dtype
+) -> torch.Tensor | None:
+    # [1,1,1,kv_len] additive mask,
+    # masks out the first N full blocks outside the window
+    if not window or window >= kv_len:
+        return None
+    num_blocks_to_skip = (kv_len - window) // block_size
+    num_tokens_to_skip = num_blocks_to_skip * block_size
+    keep = min(kv_len, kv_len - num_tokens_to_skip)
+    m = torch.zeros((1, 1, kv_len), dtype=dtype)
+    m[..., : kv_len - keep] = float("-inf")
+    return m
+
+
+@pytest.mark.parametrize(
+    "sliding_window", [0, None, BLOCK_SIZE - 1, BLOCK_SIZE, BLOCK_SIZE + 1, 128]
+)
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[42], [19, 21, 127, 129], [1234, BLOCK_SIZE - 1, BLOCK_SIZE + 1, BLOCK_SIZE]],
+)
+@pytest.mark.parametrize("num_heads", [(8, 8), (64, 8)])
+@pytest.mark.parametrize("head_size", [32])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("seed", [42])
+def test_paged_attention(
+    kv_cache_factory,
+    sliding_window: int,
+    seq_lens: list[int],
+    num_heads: tuple[int, int],
+    head_size: int,
+    dtype: torch.dtype,
+    seed: int,
+) -> None:
+    device = "cpu"
+    current_platform.seed_everything(seed)
+    torch.set_default_device(device)
+    scale = float(1.0 / (head_size**0.5))
+    num_query_heads, num_kv_heads = num_heads
+    num_seqs = len(seq_lens)
+    query = torch.empty(num_seqs, num_query_heads, head_size, dtype=dtype)
+    query.uniform_(-scale, scale)
+
+    assert num_query_heads % num_kv_heads == 0
+    num_queries_per_kv = num_query_heads // num_kv_heads
+    alibi_slopes = None
+
+    max_seq_len = max(seq_lens)
+    # Create the block tables.
+    max_num_blocks_per_seq = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    block_tables_lst: list[list[int]] = []
+    for _ in range(num_seqs):
+        block_table = [
+            random.randint(0, NUM_BLOCKS - 1) for _ in range(max_num_blocks_per_seq)
+        ]
+        block_tables_lst.append(block_table)
+
+    block_tables = torch.tensor(block_tables_lst, dtype=torch.int)
+
+    kv_cache_dtype = "bfloat16" if dtype == torch.bfloat16 else "float"
+    # Create the KV caches.
+    key_caches, value_caches = kv_cache_factory(
+        NUM_BLOCKS,
+        BLOCK_SIZE,
+        1,
+        num_kv_heads,
+        head_size,
+        kv_cache_dtype,
+        dtype,
+        seed,
+        device,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+
+    # Using default kv_scale
+    k_scale = v_scale = torch.tensor(1.0, dtype=torch.float32, device=device)
+
+    # Call the paged attention kernel.
+    output = torch.empty_like(query)
+    _PagedAttention.forward_decode(
+        output,
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        torch.tensor(seq_lens, dtype=torch.int),
+        max_seq_len,
+        sliding_window,
+        kv_cache_dtype,
+        num_kv_heads,
+        scale,
+        None,  # alibi_slopes
+        k_scale,
+        v_scale,
+    )
+    # Run the reference implementation.
+    ref_output = torch.empty_like(query)
+    attn_masks = [
+        get_block_granular_sliding_window_mask(
+            seq_len, sliding_window, BLOCK_SIZE, torch.float32
+        )
+        for seq_len in seq_lens
+    ]
+    ref_single_query_cached_kv_attention(
+        ref_output,
+        query,
+        num_queries_per_kv,
+        key_cache,
+        value_cache,
+        block_tables,
+        torch.tensor(seq_lens, dtype=torch.int),
+        scale,
+        alibi_slopes,
+        attn_masks,
+    )
+
+    atol = get_default_atol(output)
+    rtol = get_default_rtol(output)
+
+    torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol)

--- a/tests/kernels/attention/utils.py
+++ b/tests/kernels/attention/utils.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+
+def ref_masked_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+    attn_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    attn_weights = scale * torch.einsum("qhd,khd->hqk", query, key).float()
+    if attn_mask is not None:
+        attn_weights = attn_weights + attn_mask.float()
+    attn_weights = torch.softmax(attn_weights, dim=-1).to(value.dtype)
+    out = torch.einsum("hqk,khd->qhd", attn_weights, value)
+    return out
+
+
+def ref_single_query_cached_kv_attention(
+    output: torch.Tensor,
+    query: torch.Tensor,
+    num_queries_per_kv: int,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+    alibi_slopes: torch.Tensor | None,
+    attn_masks: list[torch.Tensor | None] | None = None,
+) -> None:
+    num_query_heads = query.shape[1]
+    num_kv_heads = value_cache.shape[1]
+    head_size = value_cache.shape[2]
+    block_size = value_cache.shape[3]
+    num_seqs = query.shape[0]
+
+    assert attn_masks is None or len(attn_masks) == num_seqs
+
+    block_tables_lst = block_tables.cpu().tolist()
+    seq_lens_lst = seq_lens.cpu().tolist()
+    for i in range(num_seqs):
+        q = query[i].unsqueeze(0)
+        block_table = block_tables_lst[i]
+        seq_len = int(seq_lens_lst[i])
+
+        keys_lst: list[torch.Tensor] = []
+        values_lst: list[torch.Tensor] = []
+        for j in range(seq_len):
+            block_number = int(block_table[j // block_size])
+            block_offset = j % block_size
+
+            k = key_cache[block_number, :, :, block_offset, :]
+            k = k.reshape(num_kv_heads, head_size)
+            keys_lst.append(k)
+
+            v = value_cache[block_number, :, :, block_offset]
+            values_lst.append(v)
+        keys = torch.stack(keys_lst, dim=0)
+        values = torch.stack(values_lst, dim=0)
+        if num_queries_per_kv > 1:
+            # Handle MQA and GQA
+            keys = torch.repeat_interleave(keys, num_queries_per_kv, dim=1)
+            values = torch.repeat_interleave(values, num_queries_per_kv, dim=1)
+
+        alibi_bias = None
+        seq_attn_mask = None
+        if alibi_slopes is not None:
+            # Create the ALiBi bias used in the paged attention kernel.
+            position_ids = torch.arange(seq_len).int()
+            alibi_bias = (position_ids - seq_len + 1).float()
+            alibi_bias = alibi_slopes.view(-1, 1, 1) * alibi_bias.view(1, 1, -1)
+            seq_attn_mask = alibi_bias
+
+        if attn_masks is not None:
+            if seq_attn_mask is not None:
+                if attn_masks[i] is not None:
+                    seq_attn_mask += attn_masks[i]  # add mask to alibi bias
+            else:
+                seq_attn_mask = attn_masks[i]
+
+        out = ref_masked_attention(q, keys, values, scale, seq_attn_mask)
+        out = out.view(num_query_heads, head_size)
+        output[i].copy_(out, non_blocking=True)
+
+
+def ref_multi_query_kv_attention(
+    cu_seq_lens: list[int],
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+    alibi_bias: list[torch.Tensor] | None,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    num_seqs = len(cu_seq_lens) - 1
+    ref_outputs: list[torch.Tensor] = []
+    if alibi_bias:
+        assert len(alibi_bias) == num_seqs
+    for i in range(num_seqs):
+        start_idx = cu_seq_lens[i]
+        end_idx = cu_seq_lens[i + 1]
+        seq_len = end_idx - start_idx
+
+        # Create attention mask. ALiBi already includes a tril causal mask.
+        if alibi_bias:
+            attn_mask = alibi_bias[i]
+        else:
+            attn_mask = torch.triu(
+                torch.ones(seq_len, seq_len, dtype=dtype), diagonal=1
+            )
+            attn_mask = attn_mask * torch.finfo(dtype).min
+            attn_mask = attn_mask.to(dtype=dtype)
+
+        ref_output = ref_masked_attention(
+            query[start_idx:end_idx],
+            key[start_idx:end_idx],
+            value[start_idx:end_idx],
+            scale,
+            attn_mask=attn_mask,
+        )
+        ref_outputs.append(ref_output)
+
+    return torch.cat(ref_outputs, dim=0)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1778,7 +1778,12 @@ class EngineArgs:
                 _raise_or_fallback(feature_name=name, recommend_to_remove=False)
                 return False
 
-        if current_platform.is_cpu() and model_config.get_sliding_window() is not None:
+        # SWA not supported by ipex in CPU attention backend
+        if (
+            current_platform.is_cpu()
+            and current_platform.get_cpu_architecture() == CpuArchEnum.X86
+            and model_config.get_sliding_window() is not None
+        ):
             _raise_or_fallback(
                 feature_name="sliding window (CPU backend)", recommend_to_remove=False
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

- Enables Sliding Window Attention (SWA) for the CPU backend.
- Enables models with hybrid local-global attention (i.e., those with multiple KV cache groups) for the CPU backend.
- Fixes a bug in `TorchSDPAMetadataBuilderV1` where `query_start_loc_cpu` was updated in-place despite being shared between multiple KV cache groups.
- Adds a unit test for the decode phase in the CPU attention backend.
- Adds reference implementations used to test paged attention to a common utils module and reuses it for the decode attention CPU test.

SWA is enabled by truncating full blocks/pages that are outside the window (similar to https://github.com/vllm-project/vllm/pull/23010). Hence, the implementation is block-granular and may attend to at most (block_size - 1) extra tokens (but no degradation in generation quality for the tests I ran). 
This is the best we can do with the current paged-attention API/implementation, which does not support SWA natively See: https://github.com/vllm-project/vllm/pull/4768 for context and the attempt to enable native SWA support in paged_attn.

## Test Plan
- Added a unit test for CPU backend decode attention (with multiple window values)
- Ran end to end tests with `google/gemma-2-2b-it` (alternates between full attention and SWA with window=4096). The tests include prompts (e.g. asking the model to explain code) with lengths `>` and `<` `window size`  (e.g. `4740`, `6618`, `6047`, `25`, `26`) and generations of up to `1024` tokens.
## Test Result
- Unit test for CPU backed decode attention passes for all configurations
- Eye-balled the end-to-end generations of the `google/gemma-2-2b-it` with `vllm` and made sure that all generations are meaningful and close enough to what one gets with `transformers` 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

