### PR TITLE
[Build] Revert triton_kernels requirements

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -13,5 +13,3 @@ torchvision==0.24.0 # Required for phi3v processor. See https://github.com/pytor
 xformers==0.0.33+5d4b92a5.d20251026; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.4.1
-# Triton Kernels are needed for mxfp4 fused moe. (Should be updated alongside torch)
-triton_kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels


### PR DESCRIPTION
## Purpose
Revert part of https://github.com/vllm-project/vllm/pull/27370 

Adding this triton_kernels as dependency seems to break wheel installation. 

```
(new) coder@4xl40s devspaces (main) $ uv pip install vllm --extra-index-url https://wheels.vllm.ai/nightly
Using Python 3.12.11 environment at: new
  × Failed to resolve dependencies for `vllm` (v0.11.1rc4.dev17+g361a7463d.cu129)
  ╰─▶ Package `triton-kernels` was included as a URL dependency. URL dependencies must be expressed as direct requirements or constraints.
      Consider adding `triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels` to your
      dependencies or constraints file.
```

Solve : https://github.com/vllm-project/vllm/issues/27573

## Test Plan

## Test Result
