### PR TITLE
[Feature] Batch invariant torch.compile

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -20,9 +20,6 @@ from vllm.config.pooler import PoolerConfig
 from vllm.config.scheduler import RunnerType
 from vllm.config.utils import assert_hashable, config, getattr_iter
 from vllm.logger import init_logger
-from vllm.model_executor.layers.batch_invariant import (
-    vllm_is_batch_invariant,
-)
 from vllm.platforms import current_platform
 from vllm.transformers_utils.config import (
     ConfigFormat,
@@ -437,10 +434,6 @@ class ModelConfig:
         skip_mm_profiling: bool | None,
         video_pruning_rate: float | None,
     ) -> None:
-        # Enable batch invariance settings if requested
-        if vllm_is_batch_invariant():
-            self.enforce_eager = True
-
         # Set the default seed to 0 in V1.
         # NOTE(woosuk): In V0, we set the default seed to None because the
         # driver worker shares the same process as the user process, and thus

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -252,6 +252,9 @@ def disable_compile_cache() -> bool:
 
 
 def use_aot_compile() -> bool:
+    from vllm.model_executor.layers.batch_invariant import (
+        vllm_is_batch_invariant,
+    )
     from vllm.utils.torch_utils import is_torch_equal_or_newer
 
     default_value = (
@@ -260,7 +263,10 @@ def use_aot_compile() -> bool:
         else "0"
     )
 
-    return os.environ.get("VLLM_USE_AOT_COMPILE", default_value) == "1"
+    return (
+        not vllm_is_batch_invariant()
+        and os.environ.get("VLLM_USE_AOT_COMPILE", default_value) == "1"
+    )
 
 
 def env_with_choices(

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -11,6 +11,7 @@ import torch
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 logger = init_logger(__name__)
 
@@ -676,6 +677,10 @@ def linear_batch_invariant(input, weight, bias=None):
 _batch_invariant_MODE = False
 _batch_invariant_LIB = None
 _original_torch_bmm = None
+_original_fp16_reduction_precision = None
+_original_bf16_reduction_precision = None
+_original_cublas_workspace_cfg = None
+_original_cublaslt_workspace_size = None
 
 
 def is_batch_invariant_mode_enabled():
@@ -684,6 +689,8 @@ def is_batch_invariant_mode_enabled():
 
 def enable_batch_invariant_mode():
     global _batch_invariant_MODE, _batch_invariant_LIB, _original_torch_bmm
+    global _original_fp16_reduction_precision, _original_bf16_reduction_precision
+    global _original_cublas_workspace_cfg, _original_cublaslt_workspace_size
     if _batch_invariant_MODE:
         return
 
@@ -705,14 +712,75 @@ def enable_batch_invariant_mode():
     _original_torch_bmm = torch.bmm
     torch.bmm = bmm_batch_invariant
 
+    _original_bf16_reduction_precision = (
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+    )
+    _original_fp16_reduction_precision = (
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
+    )
+
+    reduced_precision_val = (
+        (False, False) if is_torch_equal_or_newer("2.10.0.dev") else False
+    )
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
+        reduced_precision_val
+    )
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
+        reduced_precision_val
+    )
+    torch.backends.cuda.preferred_blas_library(backend="cublaslt")
+
+    if not is_torch_equal_or_newer("2.10.0.dev"):
+        _original_cublas_workspace_cfg = os.environ.get("CUBLAS_WORKSPACE_CONFIG", None)
+        _original_cublaslt_workspace_size = os.environ.get(
+            "CUBLASLT_WORKSPACE_SIZE", None
+        )
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+        os.environ["CUBLASLT_WORKSPACE_SIZE"] = "1"
+
 
 def disable_batch_invariant_mode():
     global _batch_invariant_MODE, _batch_invariant_LIB, _original_torch_bmm
+    global _original_fp16_reduction_precision, _original_bf16_reduction_precision
+    global _original_cublas_workspace_cfg, _original_cublaslt_workspace_size
+    if not _batch_invariant_MODE:
+        return
+
     if _batch_invariant_LIB is not None:
         _batch_invariant_LIB._destroy()
     if _original_torch_bmm is not None:
         torch.bmm = _original_torch_bmm
         _original_torch_bmm = None
+
+    if _original_bf16_reduction_precision is not None:
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
+            _original_bf16_reduction_precision
+        )
+        _original_bf16_reduction_precision = None
+    if _original_fp16_reduction_precision is not None:
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
+            _original_fp16_reduction_precision
+        )
+        _original_fp16_reduction_precision = None
+
+    torch.backends.cuda.preferred_blas_library(backend="default")
+
+    if not is_torch_equal_or_newer("2.10.0.dev"):
+        # Set cublas env vars to previous results. If previous results are None,
+        # that means the env vars were not set, so we should remove them.
+        if _original_cublas_workspace_cfg:
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] = _original_cublas_workspace_cfg
+        elif "CUBLAS_WORKSPACE_CONFIG" in os.environ:
+            del os.environ["CUBLAS_WORKSPACE_CONFIG"]
+
+        if _original_cublaslt_workspace_size:
+            os.environ["CUBLASLT_WORKSPACE_SIZE"] = _original_cublaslt_workspace_size
+        elif "CUBLASLT_WORKSPACE_SIZE" in os.environ:
+            del os.environ["CUBLASLT_WORKSPACE_SIZE"]
+
+    _original_cublas_workspace_cfg = None
+    _original_cublaslt_workspace_size = None
+
     _batch_invariant_MODE = False
     _batch_invariant_LIB = None
 
@@ -790,6 +858,9 @@ def override_envs_for_invariance():
     os.environ["NCCL_ALGO"] = "allreduce:tree"
     os.environ["NCCL_NTHREADS"] = "1"
     os.environ["NCCL_SOCKET_NTHREADS"] = "1"
+
+    # torch.compile settings
+    os.environ["VLLM_USE_AOT_COMPILE"] = "0"
 
 
 def init_batch_invariance():

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -363,6 +363,7 @@ class Fp8LinearMethod(LinearMethodBase):
             self.use_marlin = False
 
         self.use_aiter_and_is_supported = check_aiter_fp8_linear_support()
+        self.use_deep_gemm = is_deep_gemm_supported()
 
         self.weight_block_size = self.quant_config.weight_block_size
         self.block_quant = self.weight_block_size is not None
@@ -545,8 +546,10 @@ class Fp8LinearMethod(LinearMethodBase):
         # if batch invariant mode is enabled, prefer DeepGEMM FP8 path
         # we will use BF16 dequant when DeepGEMM is not supported.
         if vllm_is_batch_invariant():
+            # Call is_deep_gemm_supported() ahead of time for torch.compile
+            # dynamo has trouble tracing through
             if self.block_quant and should_use_deepgemm_for_fp8_linear(
-                torch.bfloat16, layer.weight, None
+                torch.bfloat16, layer.weight, self.use_deep_gemm
             ):
                 # use group quant consistent with block size across K
                 assert self.act_q_group_shape is not None


### PR DESCRIPTION
## Purpose
Building off of https://github.com/vllm-project/vllm/pull/27660 to enable batch invariant numerics in vllm, this PR allows batch invariant numerics in conjunction with `torch.compile`. Namely, we just disable cublas level optimizations that cause different numerics based on batch size, for example split-k. This PR is mainly just using work that @ngimel has done in PyTorch for manipulating cuBLAS to be batch invariant.

This change allows deepseek v3 to pass along with all the tests in `test_batch_invariance`

https://pastebin.com/yV5vXTPY is the inductor generated output code of one of the layers of the deepseek model. There are 2 reduction kernels:
1. triton_red_fused__to_copy_add_mean_mul_pow_rsqrt_* - from the RMSNorm. This contains the ReductionHint.INNER hint https://github.com/pytorch/pytorch/blob/release/2.9/torch/_inductor/runtime/triton_heuristics.py#L2685 
3. triton_red_fused_5 - not sure which op this is coming from, but contains ReductionHint.DEFAULT, benchmarking over all possible configs: https://github.com/pytorch/pytorch/blob/release/2.9/torch/_inductor/runtime/triton_heuristics.py#L2693

These kernels are inherently batch invariant, as the thread layout is fixed + masking to deal with bounds at compile time. Empirical results from `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN` where we parameterize:
`@pytest.mark.parametrize("max_model_len", [64, 67, 69, 128, 256, 512, 1024, 1025, 1027, 2011, 2020])`
`@pytest.mark.parametrize("batch_size", [3, 5, 17, 27, 32, 58, 62, 64])`
show that the kernels generated are indeed batch invariant.

In fact, most Inductor reduction kernels are structured like this, showing that Inductor out of box generally leans much more to batch invariance than eager does, in which custom ops needed to be defined in `batch_invariance.py`

## Test Plan
`pytest tests/v1/generation/test_batch_invariance.py`

`VLLM_TEST_MODEL="deepseek-ai/DeepSeek-V3.1" VLLM_TEST_TP_SIZE=8 VLLM_ATTENTION_BACKEND="FLASH_ATTN_MLA" pytest tests/v1/generation/test_batch_invariance.py -k "test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[FLASH_ATTN]"`
## Test Result
Deepseek test:
```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/paulzhan/vllm
configfile: pyproject.toml
plugins: hypothesis-6.142.4, anyio-4.11.0
collected 7 items / 6 deselected / 1 selected

tests/v1/generation/test_batch_invariance.py .                           [100%]

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/v1/generation/test_batch_invariance.py:78
  /home/paulzhan/vllm/tests/v1/generation/test_batch_invariance.py:78: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.timeout(1000)

tests/v1/generation/test_batch_invariance.py:224
  /home/paulzhan/vllm/tests/v1/generation/test_batch_invariance.py:224: PytestUnknownMarkWarning: Unknown pytest.mark.forked - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.forked

tests/v1/generation/test_batch_invariance.py:485
  /home/paulzhan/vllm/tests/v1/generation/test_batch_invariance.py:485: PytestUnknownMarkWarning: Unknown pytest.mark.forked - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.forked

tests/v1/generation/test_batch_invariance.py:712
  /home/paulzhan/vllm/tests/v1/generation/test_batch_invariance.py:712: PytestUnknownMarkWarning: Unknown pytest.mark.forked - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.forked

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 1 passed, 6 deselected, 6 warnings in 173.22s (0:02:53) ============
```

## Performance
`VLLM_BATCH_INVARIANT=1 VLLM_ATTENTION_BACKEND="TRITON_MLA" vllm serve deepseek-ai/DeepSeek-R1 -tp 8  --enable-expert-parallel --port 9256 --gpu_memory_utilization 0.95 --max_model_len 40960`

`vllm bench serve --model deepseek-ai/DeepSeek-R1  --dataset-name random --host 127.0.0.1 --port 9256 --random-input-len 4 --random-output-len 64 --request-rate inf --num-prompts 256`

torch.compile batch invariant performance:
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Benchmark duration (s):                  13.02     
Total input tokens:                      768       
Total generated tokens:                  16275     
Request throughput (req/s):              19.66     
Output token throughput (tok/s):         1249.89   
Peak output token throughput (tok/s):    1536.00   
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          1308.87   
---------------Time to First Token----------------
Mean TTFT (ms):                          621.36    
Median TTFT (ms):                        625.59    
P99 TTFT (ms):                           646.03    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          196.24    
Median TPOT (ms):                        196.24    
P99 TPOT (ms):                           196.75    
---------------Inter-token Latency----------------
Mean ITL (ms):                           196.25    
Median ITL (ms):                         195.88    
P99 ITL (ms):                            204.07    
==================================================
```

Eager
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Benchmark duration (s):                  14.92     
Total input tokens:                      768       
Total generated tokens:                  16338     
Request throughput (req/s):              17.16     
Output token throughput (tok/s):         1095.29   
Peak output token throughput (tok/s):    1280.00   
Peak concurrent requests:                256.00    
Total Token throughput (tok/s):          1146.78   
---------------Time to First Token----------------
Mean TTFT (ms):                          615.97    
Median TTFT (ms):                        617.50    
P99 TTFT (ms):                           638.13    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          226.46    
Median TPOT (ms):                        226.46    
P99 TPOT (ms):                           226.49    
---------------Inter-token Latency----------------
Mean ITL (ms):                           226.47    
Median ITL (ms):                         226.31    
P99 ITL (ms):                            238.29    
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

