### PR TITLE
Add FLASHINFER_MLA to test_mla_backends and add B200 CI run

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -322,6 +322,15 @@ steps:
   commands:
     - pytest -v -s v1/attention
 
+- label: V1 Test attention (B200) # 10min
+  timeout_in_minutes: 30
+  gpu: b200
+  source_file_dependencies:
+    - vllm/v1/attention
+    - tests/v1/attention
+  commands:
+    - pytest -v -s v1/attention
+
 - label: V1 Test others (CPU) # 5 mins
   source_file_dependencies:
     - vllm/

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -329,6 +329,7 @@ steps:
     - vllm/v1/attention
     - tests/v1/attention
   commands:
+    - export VLLM_DISABLE_FLASHINFER_PREFILL=1 # TODO: FI prefill is bugged and causes incorrectness, fix this
     - pytest -v -s v1/attention
 
 - label: V1 Test others (CPU) # 5 mins

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -21,6 +21,7 @@ from tests.v1.attention.utils import (
 from vllm import _custom_ops as ops
 from vllm.attention.backends.registry import _Backend
 from vllm.attention.ops.flashmla import is_flashmla_dense_supported
+from vllm.attention.utils.fa_utils import flash_attn_supports_mla
 from vllm.config.vllm import set_current_vllm_config
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
@@ -40,6 +41,10 @@ BACKENDS_TO_TEST = [
 if not torch.cuda.is_available() or torch.cuda.get_device_properties(0).major < 10:
     BACKENDS_TO_TEST.remove(_Backend.CUTLASS_MLA)
     BACKENDS_TO_TEST.remove(_Backend.FLASHINFER_MLA)
+
+# Remove FLASH_ATTN_MLA from the list if not supported
+if not flash_attn_supports_mla():
+    BACKENDS_TO_TEST.remove(_Backend.FLASH_ATTN_MLA)
 
 # Remove FLASHMLA from the list if not supported
 if not is_flashmla_dense_supported()[0]:

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -36,9 +36,10 @@ BACKENDS_TO_TEST = [
     _Backend.TRITON_MLA,
 ]
 
-# Remove CUTLASS_MLA from the list if not using sm100
+# Remove sm100 backends from the list if not using sm100
 if not torch.cuda.is_available() or torch.cuda.get_device_properties(0).major < 10:
     BACKENDS_TO_TEST.remove(_Backend.CUTLASS_MLA)
+    BACKENDS_TO_TEST.remove(_Backend.FLASHINFER_MLA)
 
 # Remove FLASHMLA from the list if not supported
 if not is_flashmla_dense_supported()[0]:

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -254,6 +254,13 @@ class MockAttentionLayer:
         self._q_scale = torch.tensor(1.0, device=device)
         self._k_scale = torch.tensor(1.0, device=device)
         self._v_scale = torch.tensor(1.0, device=device)
+        self._prob_scale = torch.tensor(1.0, device=device)
+        self._q_scale_float = 1.0
+        self._k_scale_float = 1.0
+        self._v_scale_float = 1.0
+
+    def forward(self, *_args, **_kwargs):
+        raise NotImplementedError
 
 
 class MockMLAAttentionLayer(AttentionLayerBase):
@@ -263,11 +270,9 @@ class MockMLAAttentionLayer(AttentionLayerBase):
         self.impl = impl
 
     def get_attn_backend(self):
-        """Not used in tests, but required by AttentionLayerBase."""
         raise NotImplementedError
 
     def get_kv_cache_spec(self, vllm_config):
-        """Not used in tests, but required by AttentionLayerBase."""
         raise NotImplementedError
 
 

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -401,7 +401,7 @@ def test_backend_correctness(dist_init, batch_spec_name: str, model: str):
     batch_spec = BATCH_SPECS[batch_spec_name]
     is_spec_decode_test = batch_spec_name.startswith("spec_decode")
 
-    block_size = 16
+    block_size = 32
     required_blocks = sum(
         (seq_len + block_size - 1) // block_size for seq_len in batch_spec.seq_lens
     )

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -23,6 +23,7 @@ from vllm.attention.backends.registry import _Backend
 from vllm.attention.ops.flashmla import is_flashmla_dense_supported
 from vllm.attention.utils.fa_utils import flash_attn_supports_mla
 from vllm.config.vllm import set_current_vllm_config
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.attention.backends.mla.common import QueryLenSupport
@@ -255,11 +256,19 @@ class MockAttentionLayer:
         self._v_scale = torch.tensor(1.0, device=device)
 
 
-class MockMLAAttentionLayer:
+class MockMLAAttentionLayer(AttentionLayerBase):
     """A mock MLA attention layer for populating static_forward_context."""
 
     def __init__(self, impl):
         self.impl = impl
+
+    def get_attn_backend(self):
+        """Not used in tests, but required by AttentionLayerBase."""
+        raise NotImplementedError
+
+    def get_kv_cache_spec(self, vllm_config):
+        """Not used in tests, but required by AttentionLayerBase."""
+        raise NotImplementedError
 
 
 def run_attention_backend(

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -783,5 +783,13 @@ def test_backend_correctness(dist_init, batch_spec_name: str, model: str):
 
     # Report all failures at once
     if failures:
-        failure_msg = "\n".join(failures)
-        pytest.fail(f"Backend correctness test failed:\n{failure_msg}")
+        # Create a summary for the single-line failure message
+        backend_names = []
+        for f in failures:
+            if "[_Backend." in f:
+                backend_name = f.split("[")[1].split("]")[0]
+                backend_names.append(backend_name)
+
+        summary = f"{len(failures)} backend(s) failed: {', '.join(backend_names)}"
+        detailed_msg = "\n".join(failures)
+        pytest.fail(f"{summary}\n{detailed_msg}")

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -663,7 +663,7 @@ def test_backend_correctness(dist_init, batch_spec_name: str, model: str):
             batch_spec, block_size, device
         )
 
-        # Pad block table to meet CUTLASS MLA requirement:
+        # Pad block table to meet requirement:
         # block_num % (128 / block_size) == 0
         required_divisor = int(128 / block_size)
         current_block_num = common_attn_metadata.block_table_tensor.shape[1]

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -73,7 +73,7 @@ for backend in BACKENDS_TO_TEST:
         )
     else:
         block_size = 16
-    BACKEND_BLOCK_SIZES[backend.name] = block_size
+    BACKEND_BLOCK_SIZES[backend] = block_size
 
 torch.manual_seed(42)
 

--- a/tests/v1/attention/utils.py
+++ b/tests/v1/attention/utils.py
@@ -285,7 +285,6 @@ full_cg_backend_configs = {
         name="CutlassMLA",
         env_vars={
             "VLLM_ATTENTION_BACKEND": "CUTLASS_MLA",
-            "FORCE_NUM_KV_SPLITS": "1",  # TODO: remove this when hang issue is fixed
         },
         comp_config={
             "cudagraph_mode": "FULL_AND_PIECEWISE",

--- a/tests/v1/attention/utils.py
+++ b/tests/v1/attention/utils.py
@@ -291,6 +291,17 @@ full_cg_backend_configs = {
         },
         specific_gpu_arch=(10, 0),
     ),
+    # FlashInfer MLA on Blackwell
+    "FlashInferMLA": BackendConfig(
+        name="FlashInferMLA",
+        env_vars={
+            "VLLM_ATTENTION_BACKEND": "FLASHINFER_MLA",
+        },
+        comp_config={
+            "cudagraph_mode": "FULL_AND_PIECEWISE",
+        },
+        specific_gpu_arch=(10, 0),
+    ),
     # FlashAttention MLA on Hopper
     "FlashAttentionMLA": BackendConfig(
         name="FlashAttentionMLA",

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 import torch
 from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
 
-from vllm.attention.backends.abstract import AttentionLayer, AttentionType
+from vllm.attention.backends.abstract import AttentionLayer, AttentionType, MultipleOf
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.mla.common import (
     MLACommonBackend,
@@ -39,6 +39,10 @@ class FlashInferMLABackend(MLACommonBackend):
     @staticmethod
     def get_builder_cls() -> type["FlashInferMLAMetadataBuilder"]:
         return FlashInferMLAMetadataBuilder
+
+    @classmethod
+    def get_supported_kernel_block_size(cls) -> list[int | MultipleOf]:
+        return [32, 64]
 
 
 g_fi_workspace = torch.zeros(


### PR DESCRIPTION
## Purpose
Adds `FLASHINFER_MLA` to `test_mla_backends.py`. While #26597 added this to CI, it was only run on H100. This PR adds a B200 runner so that this and other SM100 backends get tested as well.
## Test Plan
`pytest tests/v1/attention/test_mla_backends.py`

## Test Result
Passes (as long as FlashInfer prefill is disabled)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

