### PR TITLE
[Misc] Raise error for missing video metadata in `MultiModalDataParser`

### DIFF
--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -506,6 +506,10 @@ class MultiModalDataParser:
         for data_item in data_items:
             video, metadata = self._get_video_with_metadata(data_item)
             if self.video_needs_metadata:
+                assert metadata is not None, (
+                    "Video metadata is required but not found in mm input. "
+                    "Please check your video input in `multi_modal_data`"
+                )
                 new_videos.append((video, metadata))
                 metadata_lst.append(metadata)
             else:

--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -506,10 +506,11 @@ class MultiModalDataParser:
         for data_item in data_items:
             video, metadata = self._get_video_with_metadata(data_item)
             if self.video_needs_metadata:
-                assert metadata is not None, (
-                    "Video metadata is required but not found in mm input. "
-                    "Please check your video input in `multi_modal_data`"
-                )
+                if metadata is None:
+                    raise ValueError(
+                        "Video metadata is required but not found in mm input. "
+                        "Please check your video input in `multi_modal_data`"
+                    )
                 new_videos.append((video, metadata))
                 metadata_lst.append(metadata)
             else:


### PR DESCRIPTION

## Purpose
- Fix #27587
- Some users feel confused about the errors when they send video without metadata when using Qwen3-VL
- This PR raised an error in this case for better message

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

