### PR TITLE
[Bug] Fix DBO IMA issue for DeepEPHT

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
@@ -16,6 +16,7 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
     dbo_enabled,
+    dbo_get_previous_event,
     dbo_switch_to_comm,
     dbo_switch_to_compute,
     dbo_switch_to_compute_sync,
@@ -110,6 +111,10 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         # for the other ubatch before the dispatch kernel starts.
         dbo_yield_and_switch_from_compute_to_comm()
 
+        # capture a DeepEP event and pass it as previous_event so
+        # DeepEP honors the dependency internally.
+        previous_event = dbo_get_previous_event(self.buffer.capture)
+
         (
             num_tokens_per_rank,
             num_tokens_per_rdma_rank,
@@ -119,7 +124,7 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         ) = self.buffer.get_dispatch_layout(
             topk_idx=rank_topk_ids,
             num_experts=num_experts,
-            previous_event=None,
+            previous_event=previous_event,
             async_finish=False,
             allocate_on_comm_stream=False,
         )
@@ -148,7 +153,7 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             # to this value.
             expert_alignment=1,
             config=self._get_dispatch_config(),
-            previous_event=None,
+            previous_event=previous_event,
             async_finish=self.async_prepare and not dbo_enabled(),
             allocate_on_comm_stream=False,
         )
@@ -339,13 +344,14 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         assert fused_expert_output.dtype == torch.bfloat16, (
             f"Expected fused_expert_output bfloat16, got {fused_expert_output.dtype}"
         )
+        previous_event = dbo_get_previous_event(self.buffer.capture)
         combined_x, _, event = self.buffer.combine(
             # HT combine only supports BF16
             x=fused_expert_output,
             handle=handle,
             topk_weights=None,
             config=self._get_combine_config(),
-            previous_event=None,
+            previous_event=previous_event,
             async_finish=do_async and not dbo_enabled(),
             allocate_on_comm_stream=False,
         )

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -185,6 +185,15 @@ def dbo_register_recv_hook(recv_hook):
         next_ctx.recv_hook = recv_hook
 
 
+def dbo_get_previous_event(func, *args, **kwargs):
+    if len(_THREAD_ID_TO_CONTEXT) > 0:
+        ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
+        ctx = _CURRENT_CONTEXTS[ctx_idx]
+        # execute callable on the ubatch compute stream to record/wait events there
+        with torch.cuda.stream(ctx.compute_stream):
+            return func(*args, **kwargs)
+
+
 def make_ubatch_contexts(
     num_micro_batches: int,
     compute_stream: torch.cuda.Stream,


### PR DESCRIPTION
## Purpose

`VLLM_ALL2ALL_BACKEND=deepep_high_throughput vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 --trust-remote-code --tensor-parallel-size 1 --data-parallel-size 4 --no-enable-prefix-caching --enable-expert-parallel  --enable-dbo --enforce-eager`

will trigger

```bash
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/ep_kernels_workspace/DeepEP/deep_ep/buffer.py", line 393, in dispatch
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     return forward_call(*args, **kwargs)
    self.runtime.intranode_dispatch(x, x_scales, topk_idx, topk_weights,
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m RuntimeError: DeepEP error: CPU recv timeout
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1184, in forward
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     return self._finalize(
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m            ^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1070, in _finalize
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     finalize_ret = self.prepare_finalize.finalize_async(
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py", line 385, in finalize_async
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     receiver = self._finalize(
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m                ^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py", line 338, in _finalize
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     dbo_yield_and_switch_from_compute_to_comm()
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/v1/worker/ubatching.py", line 160, in wrapper
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     func(ctx, *args, **kwargs)
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/v1/worker/ubatching.py", line 134, in yield_and_switch_from_compute_to_comm
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     self._wait_compute_done()
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/v1/worker/ubatching.py", line 84, in _wait_compute_done
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     self.comm_stream.wait_event(self.gpu_compute_done_event)
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/.venv/lib/python3.12/site-packages/torch/cuda/streams.py", line 57, in wait_event
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     event.wait(self)
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/.venv/lib/python3.12/site-packages/torch/cuda/streams.py", line 203, in wait
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     super().wait(stream)
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m torch.AcceleratorError: CUDA error: an illegal memory access was encountered

...

^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_model_runner.py", line 3464, in _dummy_run
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     outputs = self.model(
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m               ^^^^^^^^^^^
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_ubatch_wrapper.py", line 466, in __call__
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     return self._run_ubatches(ubatch_metadata, self.model)
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_ubatch_wrapper.py", line 283, in _run_ubatches
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m     result = torch.cat(sorted_results, dim=0)
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(EngineCore_DP0 pid=2344883)^[[0;0m RuntimeError: torch.cat(): expected a non-empty list of Tensors
```

This is because we didn't care the internal comm stream of deepEP, this PR fixes that

## Test

`VLLM_ALL2ALL_BACKEND=deepep_high_throughput vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 --trust-remote-code --tensor-parallel-size 1 --data-parallel-size 4 --no-enable-prefix-caching --enable-expert-parallel  --enable-dbo --enforce-eager`

```bash
(APIServer pid=2481637) INFO 10-28 09:06:51 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=2481637) INFO 10-28 09:06:51 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=2481637) INFO 10-28 09:06:51 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=2481637) INFO 10-28 09:06:51 [launcher.py:46] Route: /start_profile, Methods: POST
(APIServer pid=2481637) INFO 10-28 09:06:51 [launcher.py:46] Route: /stop_profile, Methods: POST
(APIServer pid=2481637) INFO 10-28 09:06:51 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=2481637) INFO:     Started server process [2481637]
(APIServer pid=2481637) INFO:     Waiting for application startup.
(APIServer pid=2481637) INFO:     Application startup complete.
```