### PR TITLE
[Core] Early return in SlidingWindowManager.remove_skipped_blocks

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1582,6 +1582,8 @@ class LLM:
                     prompt.get("multi_modal_data"), prompt.get("multi_modal_uuids")
                 )
 
+            if i % 100 == 99:
+                self.llm_engine.start_profile()
             self._add_request(
                 prompt,
                 params[i] if isinstance(params, Sequence) else params,
@@ -1590,6 +1592,8 @@ class LLM:
                 else lora_request,
                 priority=priority[i] if priority else 0,
             )
+            if i % 100 == 99:
+                self.llm_engine.stop_profile()
 
     def _validate_mm_data_and_uuids(
         self,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1582,8 +1582,6 @@ class LLM:
                     prompt.get("multi_modal_data"), prompt.get("multi_modal_uuids")
                 )
 
-            if i % 100 == 99:
-                self.llm_engine.start_profile()
             self._add_request(
                 prompt,
                 params[i] if isinstance(params, Sequence) else params,
@@ -1592,8 +1590,6 @@ class LLM:
                 else lora_request,
                 priority=priority[i] if priority else 0,
             )
-            if i % 100 == 99:
-                self.llm_engine.stop_profile()
 
     def _validate_mm_data_and_uuids(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -398,7 +398,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # Early return if tokens are not enough to fill the sliding window
             return
         blocks = self.req_to_blocks[request_id]
-        if not blocks or blocks[last_useful_block - 1] == self._null_block:
+        if blocks[last_useful_block - 1] == self._null_block:
             # Early return if there are no blocks to remove
             return
         removed_blocks: list[KVCacheBlock] = []

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -395,8 +395,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         last_useful_token = num_computed_tokens - self.sliding_window + 1
         last_useful_block = last_useful_token // self.block_size
         if last_useful_block <= 0:
-            # Early return if the last useful block is out of boundary
-            # (i.e. sliding window is not filled yet)
+            # Early return if tokens are not enough to fill the sliding window
             return
         blocks = self.req_to_blocks[request_id]
         if blocks[last_useful_block - 1] == self._null_block:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -398,9 +398,8 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # Early return if tokens are not enough to fill the sliding window
             return
         blocks = self.req_to_blocks[request_id]
-        if blocks[last_useful_block - 1] == self._null_block:
-            # Early return if the last useful block is already
-            # a null block (i.e. no block to remove)
+        if not blocks or blocks[last_useful_block - 1] == self._null_block:
+            # Early return if there are no blocks to remove
             return
         removed_blocks: list[KVCacheBlock] = []
         for i in range(last_useful_block - 1, -1, -1):


### PR DESCRIPTION
## Purpose
When SlidingWindowAttention is enabled, remove_skipped_blocks consumes ~25% of cost under allocate_slots.

In this PR, we leverage the fact that, most remove_skipped_blocks invocations does NOT remove any blocks. By introducing some lightweight checks ahead, we should be able to get rid of multiple function invocations and list comprehesions against empty list.

## Test Plan & Test Result

When early stop happened, the cost reduced from 6.3us to 1.6us now.

**After**
<img width="1085" height="152" alt="Screenshot 2025-10-28 at 11 48 39 AM" src="https://github.com/user-attachments/assets/06ded859-57c3-4dd7-8130-70c446ce638e" />

**Before**
<img width="1042" height="191" alt="Screenshot 2025-10-28 at 11 48 55 AM" src="https://github.com/user-attachments/assets/952779e5-18f2-49e9-ad5c-2171bd746f81" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

