### PR TITLE
[Frontend] [gpt-oss] Tool json call parsing error retry

### DIFF
--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -109,6 +109,28 @@ class ConversationContext(ABC):
         raise NotImplementedError("Should not be called.")
 
 
+def _create_json_parse_error_messages(
+    last_msg: Message, e: json.JSONDecodeError
+) -> list[Message]:
+    """
+    Creates an error message when json parse failed.
+    """
+    error_msg = (
+        f"Error parsing tool arguments as JSON: {str(e)}. "
+        "Please ensure the tool call arguments are valid JSON and try again."
+    )
+    content = TextContent(text=error_msg)
+    author = Author(role=Role.TOOL, name=last_msg.recipient)
+    return [
+        Message(
+            author=author,
+            content=[content],
+            recipient=Role.ASSISTANT,
+            channel=last_msg.channel,
+        )
+    ]
+
+
 class SimpleContext(ConversationContext):
     def __init__(self):
         self.last_output = None
@@ -339,7 +361,10 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         tool_name = last_msg.recipient.split(".")[1]
-        args = json.loads(last_msg.content[0].text)
+        try:
+            args = json.loads(last_msg.content[0].text)
+        except json.JSONDecodeError as e:
+            return _create_json_parse_error_messages(last_msg, e)
         result = await tool_session.call_tool(tool_name, args)
         result_str = result.content[0].text
         content = TextContent(text=result_str)
@@ -420,7 +445,10 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         tool_name = last_msg.recipient.split(".")[1].split(" ")[0]
-        args = json.loads(last_msg.content[0].text)
+        try:
+            args = json.loads(last_msg.content[0].text)
+        except json.JSONDecodeError as e:
+            return _create_json_parse_error_messages(last_msg, e)
         result = await tool_session.call_tool(tool_name, args)
         result_str = result.content[0].text
         content = TextContent(text=result_str)

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -362,7 +362,7 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         tool_name = last_msg.recipient.split(".")[1]
-        if envs.TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY:
+        if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.content[0].text)
             except json.JSONDecodeError as e:
@@ -449,7 +449,7 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         tool_name = last_msg.recipient.split(".")[1].split(" ")[0]
-        if envs.TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY:
+        if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.content[0].text)
             except json.JSONDecodeError as e:

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -340,7 +340,19 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
         if len(message.content) != 1:
             raise ValueError("Invalid number of contents in browser message")
         content = message.content[0]
-        browser_call = json.loads(content.text)
+        try:
+            browser_call = json.loads(content.text)
+        except json.JSONDecodeError:
+            # If the content is not valid JSON, then it was
+            # caught and retried by vLLM, which means
+            json_retry_output_message = (
+                f"Invalid JSON args, caught and retried: {content.text}"
+            )
+            browser_call = {
+                "query": json_retry_output_message,
+                "url": json_retry_output_message,
+                "pattern": json_retry_output_message,
+            }
         # TODO: translate to url properly!
         if recipient == "browser.search":
             action = ActionSearch(

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -342,12 +342,14 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
         content = message.content[0]
         # We do not need to check the TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY
         # env variable since if it is not set, we are certain the json is valid
-        # The use of Actions will also be removed in the future entirely
+        # The use of Actions for web search will be removed entirely in
+        # the future, so this is only necessary temporarily
         try:
             browser_call = json.loads(content.text)
         except json.JSONDecodeError:
             # If the content is not valid JSON, then it was
-            # caught and retried by vLLM, which means
+            # caught and retried by vLLM, which means we
+            # need to make note of that so the user is aware
             json_retry_output_message = (
                 f"Invalid JSON args, caught and retried: {content.text}"
             )

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -340,6 +340,9 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
         if len(message.content) != 1:
             raise ValueError("Invalid number of contents in browser message")
         content = message.content[0]
+        # We do not need to check the TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY
+        # env variable since if it is not set, we are certain the json is valid
+        # The use of Actions will also be removed in the future entirely
         try:
             browser_call = json.loads(content.text)
         except json.JSONDecodeError:

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -340,7 +340,7 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
         if len(message.content) != 1:
             raise ValueError("Invalid number of contents in browser message")
         content = message.content[0]
-        # We do not need to check the TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY
+        # We do not need to check the VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY
         # env variable since if it is not set, we are certain the json is valid
         # The use of Actions for web search will be removed entirely in
         # the future, so this is only necessary temporarily

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -199,6 +199,8 @@ if TYPE_CHECKING:
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS: bool = False
+    GPT_OSS_SYSTEM_TOOL_MCP_LABELS: list[str] = []
+    VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
     VLLM_NVTX_SCOPES_FOR_PROFILING: bool = False
     VLLM_KV_EVENTS_USE_INT_BLOCK_HASHES: bool = True
@@ -208,7 +210,6 @@ if TYPE_CHECKING:
     VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK: bool = False
     VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL: bool = False
     VLLM_DBO_COMM_SMS: int = 20
-    GPT_OSS_SYSTEM_TOOL_MCP_LABELS: list[str] = []
     VLLM_PATTERN_MATCH_DEBUG: str | None = None
     VLLM_DEBUG_DUMP_PATH: str | None = None
     VLLM_ENABLE_INDUCTOR_MAX_AUTOTUNE: bool = True
@@ -218,7 +219,6 @@ if TYPE_CHECKING:
     VLLM_USE_FBGEMM: bool = False
     VLLM_GC_DEBUG: str = ""
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
-    VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY: bool = False
 
 
 def get_default_cache_root():
@@ -1332,6 +1332,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": lambda: bool(
         int(os.getenv("VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS", "0"))
     ),
+    # Valid values are container,code_interpreter,web_search_preview
+    # ex GPT_OSS_SYSTEM_TOOL_MCP_LABELS=container,code_interpreter
+    "GPT_OSS_SYSTEM_TOOL_MCP_LABELS": env_list_with_choices(
+        "GPT_OSS_SYSTEM_TOOL_MCP_LABELS",
+        [],
+        ["container", "code_interpreter", "web_search_preview"],
+    ),
+    # Enable automatic retry when tool call JSON parsing fails
+    # If enabled, returns an error message to the model to retry
+    # If disabled (default), raises an exception and fails the request
+    "VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY": lambda: bool(
+        int(os.getenv("VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY", "0"))
+    ),
     # Add optional custom scopes for profiling, disable to avoid overheads
     "VLLM_CUSTOM_SCOPES_FOR_PROFILING": lambda: bool(
         int(os.getenv("VLLM_CUSTOM_SCOPES_FOR_PROFILING", "0"))
@@ -1373,13 +1386,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # The number of SMs to allocate for communication kernels when running DBO
     # the rest of the SMs on the device will be allocated to compute
     "VLLM_DBO_COMM_SMS": lambda: int(os.getenv("VLLM_DBO_COMM_SMS", "20")),
-    # Valid values are container,code_interpreter,web_search_preview
-    # ex GPT_OSS_SYSTEM_TOOL_MCP_LABELS=container,code_interpreter
-    "GPT_OSS_SYSTEM_TOOL_MCP_LABELS": env_list_with_choices(
-        "GPT_OSS_SYSTEM_TOOL_MCP_LABELS",
-        [],
-        ["container", "code_interpreter", "web_search_preview"],
-    ),
     # Enable max_autotune & coordinate_descent_tuning in inductor_config
     # to compile static shapes passed from compile_sizes in compilation_config
     # If set to 1, enable max_autotune; By default, this is enabled (1)
@@ -1408,12 +1414,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: os.getenv(
         "VLLM_DISABLE_SHARED_EXPERTS_STREAM", False
-    ),
-    # Enable automatic retry when tool call JSON parsing fails
-    # If enabled, returns an error message to the model to retry
-    # If disabled (default), raises an exception and fails the request
-    "VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY": lambda: bool(
-        int(os.getenv("VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY", "0"))
     ),
 }
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1409,8 +1409,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_DISABLE_SHARED_EXPERTS_STREAM", False
     ),
     # Enable automatic retry when tool call JSON parsing fails
-    # If enabled (default), returns an error message to the model to retry
-    # If disabled, raises an exception and fails the request
+    # If enabled, returns an error message to the model to retry
+    # If disabled (default), raises an exception and fails the request
     "TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY": lambda: bool(
         int(os.getenv("TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY", "0"))
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -218,6 +218,7 @@ if TYPE_CHECKING:
     VLLM_USE_FBGEMM: bool = False
     VLLM_GC_DEBUG: str = ""
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
+    VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY: bool = False
 
 
 def get_default_cache_root():
@@ -1411,8 +1412,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable automatic retry when tool call JSON parsing fails
     # If enabled, returns an error message to the model to retry
     # If disabled (default), raises an exception and fails the request
-    "TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY": lambda: bool(
-        int(os.getenv("TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY", "0"))
+    "VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY": lambda: bool(
+        int(os.getenv("VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY", "0"))
     ),
 }
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -199,7 +199,6 @@ if TYPE_CHECKING:
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS: bool = False
-    GPT_OSS_SYSTEM_TOOL_MCP_LABELS: list[str] = []
     VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
     VLLM_NVTX_SCOPES_FOR_PROFILING: bool = False
@@ -210,6 +209,7 @@ if TYPE_CHECKING:
     VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK: bool = False
     VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL: bool = False
     VLLM_DBO_COMM_SMS: int = 20
+    GPT_OSS_SYSTEM_TOOL_MCP_LABELS: list[str] = []
     VLLM_PATTERN_MATCH_DEBUG: str | None = None
     VLLM_DEBUG_DUMP_PATH: str | None = None
     VLLM_ENABLE_INDUCTOR_MAX_AUTOTUNE: bool = True
@@ -1332,13 +1332,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": lambda: bool(
         int(os.getenv("VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS", "0"))
     ),
-    # Valid values are container,code_interpreter,web_search_preview
-    # ex GPT_OSS_SYSTEM_TOOL_MCP_LABELS=container,code_interpreter
-    "GPT_OSS_SYSTEM_TOOL_MCP_LABELS": env_list_with_choices(
-        "GPT_OSS_SYSTEM_TOOL_MCP_LABELS",
-        [],
-        ["container", "code_interpreter", "web_search_preview"],
-    ),
     # Enable automatic retry when tool call JSON parsing fails
     # If enabled, returns an error message to the model to retry
     # If disabled (default), raises an exception and fails the request
@@ -1386,6 +1379,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # The number of SMs to allocate for communication kernels when running DBO
     # the rest of the SMs on the device will be allocated to compute
     "VLLM_DBO_COMM_SMS": lambda: int(os.getenv("VLLM_DBO_COMM_SMS", "20")),
+    # Valid values are container,code_interpreter,web_search_preview
+    # ex GPT_OSS_SYSTEM_TOOL_MCP_LABELS=container,code_interpreter
+    "GPT_OSS_SYSTEM_TOOL_MCP_LABELS": env_list_with_choices(
+        "GPT_OSS_SYSTEM_TOOL_MCP_LABELS",
+        [],
+        ["container", "code_interpreter", "web_search_preview"],
+    ),
     # Enable max_autotune & coordinate_descent_tuning in inductor_config
     # to compile static shapes passed from compile_sizes in compilation_config
     # If set to 1, enable max_autotune; By default, this is enabled (1)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1408,6 +1408,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: os.getenv(
         "VLLM_DISABLE_SHARED_EXPERTS_STREAM", False
     ),
+    # Enable automatic retry when tool call JSON parsing fails
+    # If enabled (default), returns an error message to the model to retry
+    # If disabled, raises an exception and fails the request
+    "TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY": lambda: bool(
+        int(os.getenv("TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY", "1"))
+    ),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1412,7 +1412,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If enabled (default), returns an error message to the model to retry
     # If disabled, raises an exception and fails the request
     "TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY": lambda: bool(
-        int(os.getenv("TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY", "1"))
+        int(os.getenv("TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY", "0"))
     ),
 }
 


### PR DESCRIPTION
## Purpose

Add robust error handling for JSON parsing failures in tool call arguments. When models generate invalid JSON for tool calls, this change allows vLLM to return an error message to the model prompting it to retry with valid JSON, instead of crashing the request.

This behavior is controlled by a new environment variable `TOOL_CALL_JSON_PARSING_AUTOMATIC_RETRY` (enabled by default).
 
Taking over from Jialin on #27275 

## Test Plan
n/a
## Test Result
n/a