### PR TITLE
[Bug] Fix deepep low latency use nvlink by default

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -205,7 +205,7 @@ if TYPE_CHECKING:
     VLLM_OBJECT_STORAGE_SHM_BUFFER_NAME: str = "VLLM_OBJECT_STORAGE_SHM_BUFFER"
     VLLM_DEEPEP_BUFFER_SIZE_MB: int = 1024
     VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE: bool = False
-    VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK: bool = False
+    VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK: bool = True
     VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL: bool = False
     VLLM_DBO_COMM_SMS: int = 20
     GPT_OSS_SYSTEM_TOOL_MCP_LABELS: list[str] = []
@@ -1362,7 +1362,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Allow DeepEP to use nvlink for internode_ll kernel, turn this on for
     # better latency on GB200 like system
     "VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK": lambda: bool(
-        int(os.getenv("VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK", "0"))
+        int(os.getenv("VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK", "1"))
     ),
     # Allow DeepEP to use MNNVL (multi-node nvlink) for internode_ll kernel,
     # turn this for better latency on GB200 like system


### PR DESCRIPTION
## Purpose

Fixes the issue https://github.com/vllm-project/vllm/issues/27676 introduced by https://github.com/vllm-project/vllm/pull/27328

The default behavior of deepep low latency is using `VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK` to True instead of False (introduced by that PR). This PR fixes that

https://github.com/deepseek-ai/DeepEP/blob/2be0d4f8e9b555510139307bb3b0947834f34c37/deep_ep/buffer.py#L38

 
## Test

`vllm serve deepseek-ai/DeepSeek-V2-lite -dp 2 --enable_expert_parallel`

```bash
(APIServer pid=2739475) INFO 10-28 12:24:23 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=2739475) INFO 10-28 12:24:23 [launcher.py:46] Route: /start_profile, Methods: POST
(APIServer pid=2739475) INFO 10-28 12:24:23 [launcher.py:46] Route: /stop_profile, Methods: POST
(APIServer pid=2739475) INFO 10-28 12:24:23 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=2739475) INFO:     Started server process [2739475]
(APIServer pid=2739475) INFO:     Waiting for application startup.
(APIServer pid=2739475) INFO:     Application startup complete.
```
