### PR TITLE
fix(engine): Add death_pipe monitoring to EngineCoreProc for graceful shutdown

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -253,7 +253,8 @@ def wait_for_completion_or_failure(
 
         actor_run_refs = []
         if isinstance(engine_manager, CoreEngineProcManager):
-            for proc in engine_manager.processes:
+            for proc_handle in engine_manager.proc_handles:
+                proc = proc_handle.proc
                 sentinel_to_proc[proc.sentinel] = proc
         elif isinstance(engine_manager, CoreEngineActorManager):
             actor_run_refs = engine_manager.get_run_refs()


### PR DESCRIPTION

## Purpose

This PR addresses an issue where `EngineCoreProc` processes, launched directly by `CoreEngineProcManager` (typically in headless mode, single-server non-Ray deployments, or offline inference), could become orphaned if the parent vLLM process terminated unexpectedly (e.g., via `SIGTERM`, crash). The parent's exit did not automatically propagate to the child engine process, potentially leading to resource leaks.

This commit implements the `death_pipe` mechanism, mirroring the existing implementation used for `WorkerProc` within the `MultiprocExecutor`, to ensure `EngineCoreProc` detects parent termination and shuts down gracefully.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

