### PR TITLE
[CI/Build] Skip cpu offloading test on AMD

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -329,7 +329,7 @@ steps:
 
 - label: V1 Test others # 42min
   timeout_in_minutes: 60
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -329,7 +329,7 @@ steps:
 
 - label: V1 Test others # 42min
   timeout_in_minutes: 60
-  mirror_hardwares: [amdexperimental, amdproduction]
+  mirror_hardwares: [amdexperimental]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:

--- a/tests/v1/kv_offload/test_cpu_offloading.py
+++ b/tests/v1/kv_offload/test_cpu_offloading.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 from vllm import LLM, SamplingParams, TokensPrompt
 from vllm.config import KVEventsConfig, KVTransferConfig
 from vllm.distributed.kv_events import BlockStored, KVEventBatch
+from vllm.platforms import current_platform
 
 CPU_BLOCK_SIZES = [16, 48]
 
@@ -63,6 +64,9 @@ class MockSubscriber:
         self.sub.close()
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="CPU offloading only supported on CUDA"
+)
 @pytest.mark.parametrize("cpu_block_size", CPU_BLOCK_SIZES)
 def test_cpu_offloading(cpu_block_size: int) -> None:
     """


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Details in https://github.com/vllm-project/vllm/issues/27687.

`test_cpu_offloading` is failing on AMD CI with the exception:
```
2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847) ERROR 10-28 04:28:16 [core.py:779]     for src_cls, dst_cls, handler in self.spec.get_handlers(kv_caches):
-- | --
  | 2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847) ERROR 10-28 04:28:16 [core.py:779]                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | 2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847) ERROR 10-28 04:28:16 [core.py:779]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/kv_offload/cpu.py", line 55, in get_handlers
  | 2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847) ERROR 10-28 04:28:16 [core.py:779]     raise Exception(
  | 2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847) ERROR 10-28 04:28:16 [core.py:779] Exception: CPU Offloading is currently only supported on CUDA GPUs
  | 2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847) Traceback (most recent call last):
  | 2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
  | 2025-10-27 21:28:16 PDT | (EngineCore_DP0 pid=2847)     self.run()
```

This is because CPU offloading is currently only supported on CUDA GPUs in `vllm/v1/kv_offload/cpu.py`:
```python
if not current_platform.is_cuda():
    raise Exception(
        "CPU Offloading is currently only supported on CUDA GPUs"
    )
```

## Test Plan
```
pytest -v -s v1/kv_offload/test_cpu_offloading.py
================================================================ test session starts =================================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0 -- /home/zhewenli/uv_env/vllm-fork/bin/python3
cachedir: .pytest_cache
rootdir: /data/users/zhewenli/gitrepos/vllm-fork
configfile: pyproject.toml
plugins: asyncio-1.2.0, anyio-4.11.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... WARNING 10-28 13:44:43 [interface.py:508] Current platform cuda does not have '__test__' attribute.
WARNING 10-28 13:44:43 [interface.py:508] Current platform cuda does not have '__bases__' attribute.
WARNING 10-28 13:44:43 [interface.py:508] Current platform cuda does not have '__test__' attribute.
collected 2 items                                                                                                                                    

v1/kv_offload/test_cpu_offloading.py::test_cpu_offloading[16] SKIPPED (CPU offloading only supported on CUDA)
v1/kv_offload/test_cpu_offloading.py::test_cpu_offloading[48] SKIPPED (CPU offloading only supported on CUDA)

================================================================== warnings summary ==================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 2 skipped, 2 warnings in 0.02s ===========================================================
```

CI: https://buildkite.com/vllm/amd-ci/builds/669
