### PR TITLE
Add nsys iteration range profile and iteration ctxt/gen info

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -102,11 +102,11 @@ class EngineCore:
             self.profiler_start_iters, self.profiler_stop_iters = (
                 self._get_profiler_iteration_index_env_var("VLLM_PROFILE_START_STOP")
             )
-            self.print_profile_step_iteration_info = os.environ.get("VLLM_PROFILE_ITERATION_INFO", "").lower() == "true"
+            self.print_profile_step_iteration_info = os.environ.get("VLLM_PROFILE_ITERATION_INFO", "0") == "1"
             # The dict initially records each request's context token size. After processing, the size will decrease.
             # When this size <= 0, then it means this request is in generation phase. This helps to collect iteration
             # info.
-        self.schedule_requests: dict[str, int] = {}
+            self.schedule_requests: dict[str, int] = {}
 
         self.log_stats = log_stats
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Based on https://github.com/vllm-project/vllm/pull/21814 and updated.



(1) Use VLLM_PROFILE_START_STOP to indicate specfic range. Usage is like export VLLM_PROFILE_START_STOP="800-810".

(2) Print each step iteration context/generation phase requests and tokens number. Enable it by using "VLLM_PROFILE_ITERATION_INFO" environment variable. Like export VLLM_PROFILE_ITERATION_INFO=1.

(3) The nsys profile related code will be gated by a flag self.profile_enabled, which is set to True only when the env variable VLLM_PROFILE_START_STOP is set by the user. 

## Purpose
Most of Nvidia simulation and optimazation tools depends on nsys profile. Currently, to enable nsys profile requires intrusive changes to vllm source code repeatedly on different models, which introduces extra burden to developers. Adding this feature to vllm upstream will greatly benefits all users that has interests in nsys profiling for vllm models.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

