### PR TITLE
[BUGFIX] Adjust kv block sizes

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -16,8 +16,7 @@ from vllm.platforms.rocm import RocmPlatform
 @pytest.fixture(autouse=True)
 def clear_cache():
     """Clear lru cache to ensure each test case runs without caching."""
-    _cached_get_attn_backend.cache_clear()
-
+    pass
 
 # Define MLA and non-MLA backends separately
 DEVICE_MLA_BACKENDS = {

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from vllm.attention.selector import _cached_get_attn_backend, get_attn_backend
+from vllm.attention.selector import get_attn_backend
 from vllm.platforms import current_platform
 from vllm.platforms.cpu import CpuPlatform
 from vllm.platforms.cuda import CudaPlatform
@@ -17,6 +17,7 @@ from vllm.platforms.rocm import RocmPlatform
 def clear_cache():
     """Clear lru cache to ensure each test case runs without caching."""
     pass
+
 
 # Define MLA and non-MLA backends separately
 DEVICE_MLA_BACKENDS = {

--- a/tests/kernels/attention/test_rocm_attention_selector.py
+++ b/tests/kernels/attention/test_rocm_attention_selector.py
@@ -4,7 +4,7 @@
 import pytest
 import torch
 
-from vllm.attention.selector import _cached_get_attn_backend, get_attn_backend
+from vllm.attention.selector import get_attn_backend
 from vllm.platforms.rocm import RocmPlatform
 
 
@@ -12,6 +12,7 @@ from vllm.platforms.rocm import RocmPlatform
 def clear_cache():
     """Clear lru cache to ensure each test case runs without caching."""
     pass
+
 
 @pytest.mark.skip(reason="Skipped for now. Should be revisited.")
 def test_selector(monkeypatch: pytest.MonkeyPatch):

--- a/tests/kernels/attention/test_rocm_attention_selector.py
+++ b/tests/kernels/attention/test_rocm_attention_selector.py
@@ -11,8 +11,7 @@ from vllm.platforms.rocm import RocmPlatform
 @pytest.fixture(autouse=True)
 def clear_cache():
     """Clear lru cache to ensure each test case runs without caching."""
-    _cached_get_attn_backend.cache_clear()
-
+    pass
 
 @pytest.mark.skip(reason="Skipped for now. Should be revisited.")
 def test_selector(monkeypatch: pytest.MonkeyPatch):

--- a/tests/v1/tpu/test_mha_attn.py
+++ b/tests/v1/tpu/test_mha_attn.py
@@ -13,7 +13,6 @@ import torch_xla.core
 import torch_xla.core.xla_model
 
 from vllm.attention.layer import MultiHeadAttention
-from vllm.attention.selector import _cached_get_attn_backend
 from vllm.platforms import current_platform
 
 
@@ -21,6 +20,7 @@ from vllm.platforms import current_platform
 def clear_cache():
     """Clear lru cache to ensure each test case runs without caching."""
     pass
+
 
 def ref_attention(
     query: torch.Tensor,

--- a/tests/v1/tpu/test_mha_attn.py
+++ b/tests/v1/tpu/test_mha_attn.py
@@ -20,8 +20,7 @@ from vllm.platforms import current_platform
 @pytest.fixture(autouse=True)
 def clear_cache():
     """Clear lru cache to ensure each test case runs without caching."""
-    _cached_get_attn_backend.cache_clear()
-
+    pass
 
 def ref_attention(
     query: torch.Tensor,

--- a/vllm/attention/selector.py
+++ b/vllm/attention/selector.py
@@ -58,7 +58,6 @@ def get_attn_backend(
     )
 
 
-@cache
 def _cached_get_attn_backend(
     backend,
     head_size: int,

--- a/vllm/attention/utils/fa_utils.py
+++ b/vllm/attention/utils/fa_utils.py
@@ -11,6 +11,12 @@ if current_platform.is_cuda():
 
     reshape_and_cache_flash = ops.reshape_and_cache_flash
     from vllm.vllm_flash_attn import flash_attn_varlen_func, get_scheduler_metadata
+    from vllm.vllm_flash_attn.flash_attn_interface import (
+        FA2_AVAILABLE,
+        FA2_UNAVAILABLE_REASON,
+        FA3_AVAILABLE,
+        FA3_UNAVAILABLE_REASON,
+    )
 elif current_platform.is_xpu():
     from vllm._ipex_ops import ipex_ops as ops
 
@@ -27,6 +33,56 @@ elif current_platform.is_rocm():
         ) from e
 
 
+# Functions copied from vllm/vllm_flash_attn/flash_attn_interface.py
+# Modified to use current_platform.get_device_capability() instead of
+# torch.cuda.get_device_capability(device) because current_platform.get_device_capability()
+# does not initialize CUDA.
+def _is_fa2_supported(device=None) -> Tuple[bool, Optional[str]]:
+    if not FA2_AVAILABLE:
+        return False, f"FA2 is unavaible due to: {FA2_UNAVAILABLE_REASON}"
+    device_capability = current_platform.get_device_capability()
+    if device_capability.major < 8:
+        return (
+            False,
+            "FA2 is only supported on devices with compute capability >= 8",
+        )
+    return True, None
+
+
+def _is_fa3_supported(device=None) -> Tuple[bool, Optional[str]]:
+    if not FA3_AVAILABLE:
+        return False, f"FA3 is unavaible due to: {FA3_UNAVAILABLE_REASON}"
+    device_capability = current_platform.get_device_capability()
+    if (
+        device_capability.major < 8
+        or device_capability.major >= 10
+        or device_capability == (8, 6)
+        or device_capability == (8, 9)
+    ):
+        return (
+            False,
+            "FA3 is only supported on devices with compute capability >= 8"
+            " excluding 8.6 and 8.9 and Blackwell archs (>=10)",
+        )
+    return True, None
+
+
+def is_fa_version_supported(fa_version: int, device=None) -> bool:
+    assert fa_version in [2, 3], f"Unsupported FA version: {fa_version}"
+    if fa_version == 2:
+        return _is_fa2_supported(device)[0]
+    elif fa_version == 3:
+        return _is_fa3_supported(device)[0]
+
+
+def fa_version_unsupported_reason(fa_version: int, device=None) -> Optional[str]:
+    assert fa_version in [2, 3], f"Unsupported FA version: {fa_version}"
+    if fa_version == 2:
+        return _is_fa2_supported(device)[1]
+    elif fa_version == 3:
+        return _is_fa3_supported(device)[1]
+
+
 def get_flash_attn_version(requires_alibi: bool = False) -> int | None:
     # import here to avoid circular dependencies
     from vllm.platforms import current_platform
@@ -34,11 +90,6 @@ def get_flash_attn_version(requires_alibi: bool = False) -> int | None:
     if current_platform.is_xpu():
         return 2
     try:
-        from vllm.vllm_flash_attn.flash_attn_interface import (
-            fa_version_unsupported_reason,
-            is_fa_version_supported,
-        )
-
         device_capability = current_platform.get_device_capability()
 
         assert device_capability is not None

--- a/vllm/attention/utils/fa_utils.py
+++ b/vllm/attention/utils/fa_utils.py
@@ -35,9 +35,9 @@ elif current_platform.is_rocm():
 
 # Functions copied from vllm/vllm_flash_attn/flash_attn_interface.py
 # Modified to use current_platform.get_device_capability() instead of
-# torch.cuda.get_device_capability(device) because current_platform.get_device_capability()
-# does not initialize CUDA.
-def _is_fa2_supported(device=None) -> Tuple[bool, Optional[str]]:
+# torch.cuda.get_device_capability(device) because
+# current_platform.get_device_capability() does not initialize CUDA.
+def _is_fa2_supported(device=None) -> tuple[bool, str | None]:
     if not FA2_AVAILABLE:
         return False, f"FA2 is unavaible due to: {FA2_UNAVAILABLE_REASON}"
     device_capability = current_platform.get_device_capability()
@@ -49,7 +49,7 @@ def _is_fa2_supported(device=None) -> Tuple[bool, Optional[str]]:
     return True, None
 
 
-def _is_fa3_supported(device=None) -> Tuple[bool, Optional[str]]:
+def _is_fa3_supported(device=None) -> tuple[bool, str | None]:
     if not FA3_AVAILABLE:
         return False, f"FA3 is unavaible due to: {FA3_UNAVAILABLE_REASON}"
     device_capability = current_platform.get_device_capability()
@@ -73,14 +73,18 @@ def is_fa_version_supported(fa_version: int, device=None) -> bool:
         return _is_fa2_supported(device)[0]
     elif fa_version == 3:
         return _is_fa3_supported(device)[0]
+    else:
+        raise ValueError(f"Unsupported FA version: {fa_version}")
 
 
-def fa_version_unsupported_reason(fa_version: int, device=None) -> Optional[str]:
+def fa_version_unsupported_reason(fa_version: int, device=None) -> str | None:
     assert fa_version in [2, 3], f"Unsupported FA version: {fa_version}"
     if fa_version == 2:
         return _is_fa2_supported(device)[1]
     elif fa_version == 3:
         return _is_fa3_supported(device)[1]
+    else:
+        raise ValueError(f"Unsupported FA version: {fa_version}")
 
 
 def get_flash_attn_version(requires_alibi: bool = False) -> int | None:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1224,6 +1224,10 @@ class VllmConfig:
         if architecture is None:
             return
 
+        from vllm.model_executor.layers.config import AttentionConfig
+
+        AttentionConfig.verify_and_update_config(self)
+
         from vllm.model_executor.models.config import (
             MODELS_CONFIG_MAP,
             HybridAttentionMambaModelConfig,

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -37,7 +37,7 @@ class AttentionConfig(VerifyAndUpdateConfig):
             else 16,
         )
 
-        supported_sizes = backend_cls.get_supported_kernel_block_size()
+        supported_sizes = backend_cls.get_supported_kernel_block_sizes()
         supported_sizes = [
             s.base if isinstance(s, MultipleOf) else s for s in supported_sizes
         ]

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -52,7 +52,7 @@ class AttentionConfig(VerifyAndUpdateConfig):
         else:
             new_block_size = lcm(cache_config.block_size, min_size)
 
-        if new_block_size != cache_config.block_size:
+        if cache_config.block_size is None or new_block_size != cache_config.block_size:
             cache_config.block_size = new_block_size
             logger.info(
                 "Setting attention block size to %d tokens "

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from math import lcm
+from typing import TYPE_CHECKING
+
+from vllm.attention.backends.abstract import MultipleOf
+from vllm.attention.selector import get_attn_backend
+from vllm.logger import init_logger
+from vllm.model_executor.models.config import VerifyAndUpdateConfig
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
+
+
+class AttentionConfig(VerifyAndUpdateConfig):
+    @classmethod
+    def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        """
+        Align cache_config.block_size with attention backend's minimum
+        supported kernel block size.
+
+        Args:
+            vllm_config: vLLM Config
+        """
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        assert cache_config is not None
+
+        backend_cls = get_attn_backend(
+            head_size=model_config.get_head_size(),
+            dtype=model_config.dtype,
+            kv_cache_dtype=cache_config.cache_dtype,
+            block_size=cache_config.block_size
+            if cache_config.block_size is not None
+            else 16,
+        )
+        # For now enable it for FlashInfer only.
+        # Other backend need debugging.
+        # TODO: enable it for all backends.
+        if backend_cls.get_name() != "FLASHINFER":
+            return
+
+        supported_sizes = backend_cls.get_supported_kernel_block_size()
+        supported_sizes = [
+            s.base if isinstance(s, MultipleOf) else s for s in supported_sizes
+        ]
+        min_size = min(supported_sizes)
+        if cache_config.block_size is None:
+            new_block_size = min_size
+        else:
+            new_block_size = lcm(cache_config.block_size, min_size)
+
+        if new_block_size != cache_config.block_size:
+            cache_config.block_size = new_block_size
+            logger.info(
+                "Setting attention block size to %d tokens "
+                "to align with %s attention backend's supported kernel block sizes.",
+                new_block_size,
+                backend_cls.get_name(),
+            )

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -36,11 +36,6 @@ class AttentionConfig(VerifyAndUpdateConfig):
             if cache_config.block_size is not None
             else 16,
         )
-        # For now enable it for FlashInfer only.
-        # Other backend need debugging.
-        # TODO: enable it for all backends.
-        if backend_cls.get_name() != "FLASHINFER":
-            return
 
         supported_sizes = backend_cls.get_supported_kernel_block_size()
         supported_sizes = [

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -359,7 +359,11 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
                 dtype=kv_cache_dtype,
             ).page_size_bytes
         else:
-            kernel_block_alignment_size = 16
+            if cache_config.block_size is not None:
+                kernel_block_alignment_size = cache_config.block_size
+            else:
+                kernel_block_alignment_size = 16
+            
             if (
                 current_platform.is_device_capability(100)
                 and model_config.get_head_size() == 256

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -363,7 +363,7 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
                 kernel_block_alignment_size = cache_config.block_size
             else:
                 kernel_block_alignment_size = 16
-            
+
             if (
                 current_platform.is_device_capability(100)
                 and model_config.get_head_size() == 256

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -286,7 +286,7 @@ class FlashInferBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_size() -> list[int | MultipleOf]:
-        # Note: Not sure for all platforms, but on Blackwell, 
+        # Note: Not sure for all platforms, but on Blackwell,
         # only support a page size of 16, 32, 64
         # TODO: 16 is temporary removed because TRT-LLM kernel has a bug when using 16.
         # See https://github.com/flashinfer-ai/flashinfer/issues/1993

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -285,10 +285,13 @@ class FlashInferBackend(AttentionBackend):
     ]
 
     @staticmethod
-    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        # Note: Not sure for all platforms, but on Blackwell,
-        # only support a page size of 16, 32, 64.
-        return [16, 32, 64]
+    def get_supported_kernel_block_size() -> list[int | MultipleOf]:
+        # Note: Not sure for all platforms, but on Blackwell, 
+        # only support a page size of 16, 32, 64
+        # TODO: 16 is temporary removed because TRT-LLM kernel has a bug when using 16.
+        # See https://github.com/flashinfer-ai/flashinfer/issues/1993
+        # for more details.
+        return [32, 64]
 
     @staticmethod
     def get_name() -> str:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -285,7 +285,7 @@ class FlashInferBackend(AttentionBackend):
     ]
 
     @staticmethod
-    def get_supported_kernel_block_size() -> list[int | MultipleOf]:
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         # Note: Not sure for all platforms, but on Blackwell,
         # only support a page size of 16, 32, 64
         # TODO: 16 is temporary removed because TRT-LLM kernel has a bug when using 16.


### PR DESCRIPTION
## Purpose
1. Adjust kv_manager_block_size according to minimum supported `kernel_block_sizes` by attn backed

2. Temporary remove `16` from `supported_kernel_block_size` for flashinfer due to TRT-LLM Gen attn has a bug for `page_size=16` (https://github.com/flashinfer-ai/flashinfer/issues/1993)

## Details
If `kv_manager_block_size is None` we set the default value `16`. Before I tried to remove `16` due to point 2. above every backend support `kernel_block_size` equal to 16 and everything worked fine. But when no 16 (and less) there is a fail because 
`kv_manager_block_size % kernel_block_size` should be `=0`. I fixed it by adjusting `kv_manager_block_size` with `get_supported_kernel_block_size()`.
