### PR TITLE
[CI/Build][Bugfix]Fix Quantized Models Test on AMD

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -908,7 +908,7 @@ steps:
 
 - label: Quantized Models Test # 45 min
   timeout_in_minutes: 60
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:

--- a/tests/models/quantization/test_bitsandbytes.py
+++ b/tests/models/quantization/test_bitsandbytes.py
@@ -9,9 +9,15 @@ import pytest
 from transformers import BitsAndBytesConfig
 
 from tests.quantization.utils import is_quant_method_supported
+from vllm.platforms import current_platform
 
 from ...utils import compare_two_settings, multi_gpu_test
 from ..utils import check_embeddings_close, check_logprobs_close
+
+pytestmark = pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="bitsandbytes quantization not supported on ROCm (CUDA-only kernels)",
+)
 
 models_4bit_to_test = [
     ("facebook/opt-125m", "quantize opt model inflight"),

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -413,7 +413,7 @@ class RocmPlatform(Platform):
                 "Using AWQ quantization with ROCm, but VLLM_USE_TRITON_AWQ"
                 " is not set, enabling VLLM_USE_TRITON_AWQ."
             )
-        envs.VLLM_USE_TRITON_AWQ = True
+        os.environ["VLLM_USE_TRITON_AWQ"] = "1"
 
     @classmethod
     def get_punica_wrapper(cls) -> str:


### PR DESCRIPTION
## Purpose
This PR fixes Quantized Models Test on AMD, including:
- Skip `test_bitsandbytes`, since it's not supported on AMD: https://github.com/vllm-project/vllm/blob/main/vllm/platforms/rocm.py#L192 - ` ValidationError: bitsandbytes quantization is currently not supported in rocm`
- Fix AWQ tests: AWQ IS supported on ROCm via Triton, but environment variable propagation is broken [here](https://github.com/vllm-project/vllm/blob/main/vllm/platforms/rocm.py#L416) - we need to set env var with `os.environ` otherwise it will be overwritten by [this](https://github.com/vllm-project/vllm/blob/main/vllm/envs.py#L810) logic. 


## Test Plan
```
pytest -v -s  models/quantization.
...
, rank=4, decoded_token='The'), 319: Logprob(logprob=-2.709829092025757, rank=5, decoded_token='A')}
  gguf: '- Artificial intelligence is a branch of computer science that deals with the simulation of human intelligence processes by machines.\n- Human intelligence, on the other'   {3012: Logprob(logprob=-2.2488694190979004, rank=1, decoded_token='Art'), 12968: Logprob(logprob=-2.4598069190979004, rank=2, decoded_token='Human'), 1724: Logprob(logprob=-2.4754319190979004, rank=3, decoded_token='What'), 450: Logprob(logprob=-2.6004319190979004, rank=4, decoded_token='The'), 319: Logprob(logprob=-2.7879319190979004, rank=5, decoded_token='A')}
    check_logprobs_close(

tests/models/quantization/test_gguf.py::test_models[1-5-32-half-model4]
  /data/users/zhewenli/gitrepos/vllm-fork/tests/models/quantization/test_gguf.py:135: UserWarning: Test4:
  Matched tokens:       [29899, 450, 19964, 12561, 29879, 310, 263, 3186, 988, 372, 508, 367, 3889, 322, 9796, 29889, 13, 29899, 739, 12561, 29879, 310, 263, 3186, 988, 372, 508, 367]
  original:     '- The robot dreams of a world where it can be free and happy.\n- It dreams of a world where it can be loved and cherished'     {18012: Logprob(logprob=-1.4169052839279175, rank=1, decoded_token='loved'), 3889: Logprob(logprob=-1.4481552839279175, rank=2, decoded_token='free'), 263: Logprob(logprob=-2.221592903137207, rank=3, decoded_token='a'), 763: Logprob(logprob=-3.284092903137207, rank=4, decoded_token='like'), 5186: Logprob(logprob=-3.518467903137207, rank=5, decoded_token='equal')}
  gguf: '- The robot dreams of a world where it can be free and happy.\n- It dreams of a world where it can be free and happy.' {3889: Logprob(logprob=-1.3377509117126465, rank=1, decoded_token='free'), 18012: Logprob(logprob=-1.4549384117126465, rank=2, decoded_token='loved'), 263: Logprob(logprob=-2.2361884117126465, rank=3, decoded_token='a'), 763: Logprob(logprob=-3.3143134117126465, rank=4, decoded_token='like'), 5186: Logprob(logprob=-3.6893134117126465, rank=5, decoded_token='equal')}
    check_logprobs_close(

tests/models/quantization/test_gguf.py::test_models[1-5-32-half-model4]
  /data/users/zhewenli/gitrepos/vllm-fork/tests/models/quantization/test_gguf.py:135: UserWarning: Test6:
  Matched tokens:       [29899, 450, 2598, 29874, 29420, 338, 263, 21760, 310, 263, 6114]
  original:     '- The Mona Lisa is a portrait of a woman named Lisa Gherardelli, who was a lady from the Italian city of Florence. The painting is' {4257: Logprob(logprob=-1.2375096082687378, rank=1, decoded_token='named'), 29892: Logprob(logprob=-1.2609471082687378, rank=2, decoded_token=','), 491: Logprob(logprob=-2.5968847274780273, rank=3, decoded_token='by'), 2998: Logprob(logprob=-2.6593847274780273, rank=4, decoded_token='known'), 29889: Logprob(logprob=-3.1906347274780273, rank=5, decoded_token='.')}
  gguf: '- The Mona Lisa is a portrait of a woman, known as Lisa Gherardelli, who was the wife of the Florentine merchant Francesco del'        {29892: Logprob(logprob=-1.1993026733398438, rank=1, decoded_token=','), 4257: Logprob(logprob=-1.4102401733398438, rank=2, decoded_token='named'), 2998: Logprob(logprob=-2.5039901733398438, rank=3, decoded_token='known'), 491: Logprob(logprob=-2.5899276733398438, rank=4, decoded_token='by'), 29889: Logprob(logprob=-3.1524276733398438, rank=5, decoded_token='.')}
    check_logprobs_close(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 9 passed, 30 skipped, 47 warnings in 916.55s (0:15:16) ===============================================
```

CI
https://buildkite.com/vllm/amd-ci/builds/680
<img width="1038" height="528" alt="Screenshot 2025-10-28 at 9 32 49 PM" src="https://github.com/user-attachments/assets/ec4b8a1c-df27-4094-ae98-6dbd6c0f2c07" />
