### PR TITLE
[AMD] Use Decoupled Kernel Block Size to Support AITER MLA block_size=1

### DIFF
--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -119,14 +119,12 @@ class AttentionBackend(ABC):
             return True
 
         for supported_size in cls.supported_kernel_block_sizes:
-            is_multiple_of = (
-                isinstance(supported_size, MultipleOf)
-                and block_size % supported_size.base == 0
-            )
-            is_int_equal = (
-                isinstance(supported_size, int) and block_size == supported_size
-            )
-            if is_multiple_of or is_int_equal:
+            if isinstance(supported_size, MultipleOf):
+                supported_size = supported_size.base
+            # With hybrid_blocks feature, the framework-level block size
+            # only needs to be a multiple of the kernel's requirement,
+            # even if the kernel requires a fixed block_size.
+            if block_size % supported_size == 0:
                 return True
         return False
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -201,23 +201,18 @@ class CudaPlatformBase(Platform):
 
             from vllm.attention.ops.flashmla import is_flashmla_dense_supported
 
-            def round_up_block_size(size):
-                cache_config.block_size = (
-                    (cache_config.block_size + size - 1) // size * size
-                )
-
             if (
                 use_flashmla
                 and is_flashmla_dense_supported()[0]
                 and cache_config.block_size % 64 != 0
             ):
-                round_up_block_size(64)
-                logger.info("Forcing kv cache block size to 64*N for FlashMLA backend.")
+                cache_config.block_size = 64
+                logger.info("Forcing kv cache block size to 64 for FlashMLA backend.")
 
             if use_cutlass_mla and cache_config.block_size % 128 != 0:
-                round_up_block_size(128)
+                cache_config.block_size = 128
                 logger.info(
-                    "Forcing kv cache block size to 128*N for CUTLASS_MLA backend."
+                    "Forcing kv cache block size to 128 for CUTLASS_MLA backend."
                 )
 
             if (
@@ -225,16 +220,16 @@ class CudaPlatformBase(Platform):
                 and cache_config.block_size != 32
                 and cache_config.block_size % 64 != 0
             ):
-                round_up_block_size(64)
+                cache_config.block_size = 64
                 logger.info(
-                    "Forcing kv cache block size to 64*N for FlashInferMLA backend."
+                    "Forcing kv cache block size to 64 for FlashInferMLA backend."
                 )
 
             # TODO(Chen): remove this hacky code
-            if use_sparse and cache_config.block_size % 64 != 0:
-                round_up_block_size(64)
+            if use_sparse and cache_config.block_size != 64:
+                cache_config.block_size = 64
                 logger.info(
-                    "Forcing kv cache block size to 64*N for FlashMLASparse backend."
+                    "Forcing kv cache block size to 64 for FlashMLASparse backend."
                 )
         # lazy import to avoid circular import
         from vllm.config import CUDAGraphMode
@@ -364,7 +359,7 @@ class CudaPlatformBase(Platform):
                     head_size,
                     dtype,
                     kv_cache_dtype,
-                    block_size,
+                    None,
                     use_mla,
                     has_sink,
                     use_sparse,
@@ -388,7 +383,7 @@ class CudaPlatformBase(Platform):
             head_size,
             dtype,
             kv_cache_dtype,
-            block_size,
+            None,
             use_mla,
             has_sink,
             use_sparse,


### PR DESCRIPTION
PR #24486 implemented this mechanism but did not fully utilize it. 
The block_size restriction during startup (when using operators such as FlashMla and AiterMLA) has now been lifted.

Compared to #27224, this PR avoids remapping before each operator execution, instead making use of the functionality provided by the framework (by #24486), and also provides support for scenarios other than AMD aiter.
