### PR TITLE
[BugFix][LoRA] use lora_int_id instead of id field of lora_request

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -259,7 +259,9 @@ class BlockPool:
                         num_cached_blocks * block_size : num_full_blocks * block_size
                     ],
                     block_size=block_size,
-                    lora_id=request.lora_request.id if request.lora_request else None,
+                    lora_id=request.lora_request.lora_int_id
+                    if request.lora_request
+                    else None,
                     medium=MEDIUM_GPU,
                 )
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
use `lora_int_id` instead of `id` field of lora_request

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

