### PR TITLE
Update the flashinfer version to fix the incorrect method call "isdigit" on a number type

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -371,7 +371,7 @@ RUN --mount=type=bind,from=build,src=/workspace/dist,target=/vllm-workspace/dist
 # Install FlashInfer from source
 ARG FLASHINFER_GIT_REPO="https://github.com/flashinfer-ai/flashinfer.git"
 # Keep this in sync with "flashinfer" extra in setup.py
-ARG FLASHINFER_GIT_REF="v0.3.1"
+ARG FLASHINFER_GIT_REF="v0.4.0"
 # Flag to control whether to compile FlashInfer AOT kernels
 # Set to "true" to enable AOT compilation:
 # docker build --build-arg FLASHINFER_AOT_COMPILE=true ...

--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -246,7 +246,7 @@ RUN pip install setuptools==75.6.0 packaging==23.2 ninja==1.11.1.3 build==1.2.2.
 
 
 # build flashinfer for torch nightly from source around 10 mins
-# release version: v0.3.1
+# release version: v0.4.0
 # todo(elainewy): cache flashinfer build result for faster build
 ENV CCACHE_DIR=/root/.cache/ccache
 RUN --mount=type=cache,target=/root/.cache/ccache \
@@ -254,7 +254,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
     echo "git clone flashinfer..." \
     && git clone --recursive https://github.com/flashinfer-ai/flashinfer.git \
     && cd flashinfer \
-    && git checkout v0.3.1 \
+    && git checkout v0.4.0 \
     && git submodule update --init --recursive \
     && echo "finish git clone flashinfer..." \
     && rm -rf build \

--- a/setup.py
+++ b/setup.py
@@ -666,7 +666,7 @@ setup(
                   "mistral_common[audio]"],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility
         # FlashInfer should be updated together with the Dockerfile
-        "flashinfer": ["flashinfer-python==0.3.1"],
+        "flashinfer": ["flashinfer-python==0.4.0"],
         # Optional deps for AMD FP4 quantization support
         "petit-kernel": ["petit-kernel"],
     },


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm/issues/27729

NVIDIA T4 Compute Capability: 7.5 (i.e., Major 7, Minor 5). When using Flashinfer v0.3.1, it will trigger an AttributeError: 'int' object has no attribute 'isdigit'.
Assignment of `self.TARGET_CUDA_ARCHS` (minor is of numeric type):
```
self.TARGET_CUDA_ARCHS.add((int(major), minor))
```
Error triggered by `minor.isdigit()` in `check_cuda_arch()`:
```
for major, minor in current_compilation_context.TARGET_CUDA_ARCHS:
    if major >= 8:
        eligible = True
    elif major == 7 and minor.isdigit():
        if int(minor) >= 5:
            eligible = True
```

#### Solution
Update the flashinfer version to fix https://github.com/flashinfer-ai/flashinfer/pull/1699 in NVIDIA T4.

## Test Plan
Not needed

## Test Result
Not needed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

