### PR TITLE
[BugFix]: --enable-lora with model granite-4.0-micro crash

### DIFF
--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -605,6 +605,9 @@ class GraniteMoeHybridForCausalLM(
             "k_proj",
             "v_proj",
         ],
+        "conv1d": ["conv1d"],
+        "in_proj": ["in_proj"],
+        "input_linear": ["input_linear"],
     }
     embedding_modules = {
         "embed_tokens": "input_embeddings",


### PR DESCRIPTION
## Purpose

Fix: #27620

note: must set `--enforce-eager` otherwise vllm will crash when use vscode debug mode

## Test Plan

## Test Result

start up log:
```
INFO 10-29 09:17:34 [__init__.py:224] Automatically detected platform cuda.
(APIServer pid=6796) INFO 10-29 09:17:44 [api_server.py:1882] vLLM API server version 0.11.0rc2.dev330+ge3938e2e9.d20251009
(APIServer pid=6796) INFO 10-29 09:17:44 [utils.py:239] non-default args: {'model': '/home/jovyan/granite-4-micro', 'enforce_eager': True, 'served_model_name': ['granite-4-micro'], 'enable_lora': True}
(APIServer pid=6796) INFO 10-29 09:17:44 [model.py:653] Resolved architecture: GraniteMoeHybridForCausalLM
(APIServer pid=6796) `torch_dtype` is deprecated! Use `dtype` instead!
(APIServer pid=6796) INFO 10-29 09:17:44 [model.py:1714] Using max model len 131072
(APIServer pid=6796) INFO 10-29 09:17:45 [scheduler.py:225] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=6796) WARNING 10-29 09:17:45 [lora.py:92] `lora_extra_vocab_size` is deprecated and will be removed in v0.12.0. Additional vocabulary support for LoRA adapters is being phased out.
(APIServer pid=6796) INFO 10-29 09:17:45 [config.py:313] Disabling cascade attention since it is not supported for hybrid models.
(APIServer pid=6796) INFO 10-29 09:17:49 [config.py:403] Setting attention block size to 1312 tokens to ensure that attention page size is >= mamba page size.
(APIServer pid=6796) INFO 10-29 09:17:49 [config.py:427] Padding mamba page size by 1.20% to ensure that mamba page size and attention page size are exactly equal.
(APIServer pid=6796) INFO 10-29 09:17:49 [vllm.py:373] Cudagraph is disabled under eager mode
/home/jovyan/conda-envs/vllm-base/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
INFO 10-29 09:18:05 [__init__.py:224] Automatically detected platform cuda.
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:10 [core.py:719] Waiting for init message from front-end.
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:10 [core.py:94] Initializing a V1 LLM engine (v0.11.0rc2.dev330+ge3938e2e9.d20251009) with config: model='/home/jovyan/granite-4-micro', speculative_config=None, tokenizer='/home/jovyan/granite-4-micro', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=131072, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=granite-4-micro, enable_prefix_caching=False, chunked_prefill_enabled=True, pooler_config=None, compilation_config={'level': 0, 'debug_dump_path': None, 'cache_dir': '', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': None, 'use_inductor': None, 'compile_sizes': [], 'inductor_compile_config': {'enable_auto_functionalized_v2': False}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'use_cudagraph': False, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'full_cuda_graph': False, 'use_inductor_graph_partition': False, 'pass_config': {}, 'max_capture_size': 0, 'local_cache_dir': None}
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:16 [parallel_state.py:1231] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=7050) WARNING 10-29 09:18:17 [topk_topp_sampler.py:70] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:17 [gpu_model_runner.py:2823] Starting to load model /home/jovyan/granite-4-micro...
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:17 [gpu_model_runner.py:2853] Loading model from scratch...
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:17 [cuda.py:392] Using Flash Attention backend on V1 engine.
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  2.38it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  1.27it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  1.36it/s]
(EngineCore_DP0 pid=7050) 
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:19 [default_loader.py:314] Loading weights took 1.67 seconds
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:19 [punica_selector.py:20] Using PunicaWrapperGPU.
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:20 [gpu_model_runner.py:2885] Model loading took 6.4400 GiB and 2.010429 seconds
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:28 [gpu_worker.py:314] Available KV cache memory: 28.54 GiB
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:29 [kv_cache_utils.py:1272] GPU KV cache size: 373,920 tokens
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:29 [kv_cache_utils.py:1277] Maximum concurrency for 131,072 tokens per request: 2.85x
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:29 [core.py:235] init engine (profile, create kv cache, warmup model) took 8.98 seconds
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:29 [vllm.py:373] Cudagraph is disabled under eager mode
(APIServer pid=6796) INFO 10-29 09:18:29 [loggers.py:148] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 285
(EngineCore_DP0 pid=7050) INFO 10-29 09:18:30 [gc_utils.py:40] GC Debug Config. enabled:False,top_objects:-1
(APIServer pid=6796) INFO 10-29 09:18:30 [api_server.py:1629] Supported_tasks: ['generate']
(APIServer pid=6796) INFO 10-29 09:18:30 [api_server.py:1952] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:38] Available routes are:
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /docs, Methods: HEAD, GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=6796) INFO 10-29 09:18:30 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=6796) INFO:     Started server process [6796]
(APIServer pid=6796) INFO:     Waiting for application startup.
(APIServer pid=6796) INFO:     Application startup complete.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

