### PR TITLE
[XPU] Update latest IPEX 2.8 release

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-xpu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-xpu-test.sh
@@ -20,7 +20,10 @@ trap remove_docker_container EXIT
 
 # Run the image and test offline inference/tensor parallel
 docker run \
-    --device /dev/dri \
+    --device /dev/dri:/dev/dri \
+    --net=host \
+    --ipc=host \
+    --privileged \
     -v /dev/dri/by-path:/dev/dri/by-path \
     --entrypoint="" \
     -e "HF_TOKEN=${HF_TOKEN}" \
@@ -42,7 +45,7 @@ docker run \
     pytest -v -s v1/sample --ignore=v1/sample/test_logprobs.py --ignore=v1/sample/test_logprobs_e2e.py
     pytest -v -s v1/worker --ignore=v1/worker/test_gpu_model_runner.py
     pytest -v -s v1/structured_output
-    pytest -v -s v1/spec_decode --ignore=v1/spec_decode/test_max_len.py --ignore=v1/spec_decode/test_tree_attention.py
+    pytest -v -s v1/spec_decode --ignore=v1/spec_decode/test_max_len.py --ignore=v1/spec_decode/test_tree_attention.py --ignore=v1/spec_decode/test_speculators_eagle3.py
     pytest -v -s v1/kv_connector/unit --ignore=v1/kv_connector/unit/test_multi_connector.py --ignore=v1/kv_connector/unit/test_nixl_connector.py --ignore=v1/kv_connector/unit/test_shared_storage_connector.py
     pytest -v -s v1/test_serial_utils.py
 '

--- a/docs/getting_started/installation/gpu.xpu.inc.md
+++ b/docs/getting_started/installation/gpu.xpu.inc.md
@@ -56,8 +56,10 @@ docker build -f docker/Dockerfile.xpu -t vllm-xpu-env --shm-size=4g .
 docker run -it \
              --rm \
              --network=host \
-             --device /dev/dri \
+             --device /dev/dri:/dev/dri \
              -v /dev/dri/by-path:/dev/dri/by-path \
+             --ipc=host \
+             --privileged \
              vllm-xpu-env
 ```
 

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -15,4 +15,4 @@ torchaudio
 torchvision
 --extra-index-url=https://download.pytorch.org/whl/xpu
 
-intel-extension-for-pytorch @ https://intel-extension-for-pytorch.s3.us-east-1.amazonaws.com/ipex_dev/xpu/intel_extension_for_pytorch-2.8.10.post0%2Bxpu-cp312-cp312-linux_x86_64.whl
+intel-extension-for-pytorch @ https://intel-extension-for-pytorch.s3.us-east-1.amazonaws.com/ipex_dev/xpu/intel_extension_for_pytorch-2.8.10.post1%2Bxpu-cp312-cp312-linux_x86_64.whl

--- a/vllm/_ipex_ops.py
+++ b/vllm/_ipex_ops.py
@@ -148,28 +148,6 @@ class ipex_ops:
         )
 
     @staticmethod
-    def batched_rotary_embedding(
-        positions: torch.Tensor,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        head_size: int,
-        cos_sin_cache: torch.Tensor,
-        is_neox: bool,
-        rot_dim: int,
-        cos_sin_cache_offsets: torch.Tensor,
-    ) -> None:
-        ipex.llm.functional.rotary_embedding_batched(
-            positions,
-            query,
-            key,
-            head_size,
-            cos_sin_cache,
-            is_neox,
-            rot_dim,
-            cos_sin_cache_offsets,
-        )
-
-    @staticmethod
     def rms_norm(
         input: torch.Tensor, weight: torch.Tensor, epsilon: float
     ) -> torch.Tensor:

--- a/vllm/_ipex_ops.py
+++ b/vllm/_ipex_ops.py
@@ -296,16 +296,6 @@ class ipex_ops:
         num_splits=0,
         s_aux: torch.Tensor | None = None,
     ):
-        if cu_seqlens_k is None:
-            # cu_seqlens_k is not used in ipex kernel.
-            cu_seqlens_k = torch.cumsum(seqused_k, dim=0)
-            cu_seqlens_k = torch.cat(
-                [
-                    torch.tensor([0], device=seqused_k.device, dtype=torch.int32),
-                    cu_seqlens_k,
-                ]
-            ).to(torch.int32)
-
         real_window_size: tuple[int, int]
         if window_size is None:
             real_window_size = (-1, -1)
@@ -318,7 +308,7 @@ class ipex_ops:
             k,
             v,
             cu_seqlens_q,
-            cu_seqlens_k,
+            seqused_k,
             max_seqlen_q,
             max_seqlen_k,
             softmax_scale,

--- a/vllm/_ipex_ops.py
+++ b/vllm/_ipex_ops.py
@@ -174,7 +174,7 @@ class ipex_ops:
         input: torch.Tensor, weight: torch.Tensor, epsilon: float
     ) -> torch.Tensor:
         out = torch.empty_like(input)
-        torch.ops.torch_ipex.rms_norm_vllm(out, input, weight, epsilon)
+        torch.ops.torch_ipex.rms_norm_vllm(out, input.contiguous(), weight, epsilon)
         return out
 
     @staticmethod


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR update latest ipex release (2.8.10.post1) with some fix:
1. attention kernel interface fix, no longer need cu_seqlen_k, use seq_used_k which is aligned with cuda kernel.
2. add new rms_norm/ fused_add_rms_norm kernel with better accuracy
3. kernel performance improvement. 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

