### PR TITLE
Prevent overwriting drafters lm-head and embed_tokens

### DIFF
--- a/vllm/model_executor/models/deepseek_eagle.py
+++ b/vllm/model_executor/models/deepseek_eagle.py
@@ -25,7 +25,7 @@ from vllm.model_executor.models.deepseek_v2 import (
     DeepseekV3ForCausalLM,
 )
 
-from .utils import AutoWeightsLoader, maybe_prefix
+from .utils import AutoWeightsLoader, maybe_prefix, process_eagle_weight
 
 
 @support_torch_compile
@@ -243,6 +243,7 @@ class EagleDeepseekV3ForCausalLM(DeepseekV3ForCausalLM):
             name, loaded_weight = inputs
             if "lm_head" not in name:
                 name = "model." + name
+            process_eagle_weight(self, name)
             return name, loaded_weight
 
         loader = AutoWeightsLoader(

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1214,7 +1214,7 @@ class DeepseekV2MixtureOfExperts(MixtureOfExperts):
 
 
 class DeepseekV2ForCausalLM(
-    nn.Module, SupportsPP, MixtureOfExperts, SupportsLoRA, SupportsEagle
+    nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle
 ):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -87,7 +87,7 @@ from vllm.v1.attention.backends.mla.indexer import (
 )
 from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
-from .interfaces import MixtureOfExperts, SupportsLoRA, SupportsPP
+from .interfaces import MixtureOfExperts, SupportsEagle, SupportsLoRA, SupportsPP
 from .utils import (
     PPMissingLayer,
     is_pp_missing_parameter,
@@ -1172,7 +1172,9 @@ class DeepseekV2Model(nn.Module):
         return hidden_states
 
 
-class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoRA):
+class DeepseekV2ForCausalLM(
+    nn.Module, SupportsPP, MixtureOfExperts, SupportsLoRA, SupportsEagle
+):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
     }

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -922,6 +922,16 @@ class SupportsEagle3(Protocol):
         MRO of your model class.
     """
 
+    has_own_lm_head: ClassVar[bool] = False
+    """
+    A flag that indicates this model has trained its own lm_head.
+    """
+
+    has_own_embed_tokens: ClassVar[bool] = False
+    """
+    A flag that indicates this model has trained its own input embeddings.
+    """
+
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         """
         Set which layers should output auxiliary

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -908,13 +908,43 @@ def supports_transcription(
 
 
 @runtime_checkable
-class SupportsEagle3(Protocol):
-    """The interface required for models that support
-    EAGLE3 speculative decoding."""
+class SupportsEagleBase(Protocol):
+    """Base interface for models that support EAGLE-based speculative decoding."""
 
-    supports_eagle3: ClassVar[Literal[True]] = True
+    has_own_lm_head: bool = False
     """
-    A flag that indicates this model supports EAGLE3 
+    A flag that indicates this model has trained its own lm_head.
+    """
+
+    has_own_embed_tokens: bool = False
+    """
+    A flag that indicates this model has trained its own input embeddings.
+    """
+
+
+@overload
+def supports_any_eagle(model: type[object]) -> TypeIs[type[SupportsEagleBase]]: ...
+
+
+@overload
+def supports_any_eagle(model: object) -> TypeIs[SupportsEagleBase]: ...
+
+
+def supports_any_eagle(
+    model: type[object] | object,
+) -> TypeIs[type[SupportsEagleBase]] | TypeIs[SupportsEagleBase]:
+    """Check if model supports any EAGLE variant (1, 2, or 3)."""
+    return supports_eagle(model) or supports_eagle3(model)
+
+
+@runtime_checkable
+class SupportsEagle(SupportsEagleBase, Protocol):
+    """The interface required for models that support
+    EAGLE-1 and EAGLE-2 speculative decoding."""
+
+    supports_eagle: ClassVar[Literal[True]] = True
+    """
+    A flag that indicates this model supports EAGLE-1 and EAGLE-2 
     speculative decoding.
 
     Note:
@@ -922,20 +952,40 @@ class SupportsEagle3(Protocol):
         MRO of your model class.
     """
 
-    has_own_lm_head: ClassVar[bool] = False
-    """
-    A flag that indicates this model has trained its own lm_head.
-    """
 
-    has_own_embed_tokens: ClassVar[bool] = False
+@overload
+def supports_eagle(model: type[object]) -> TypeIs[type[SupportsEagle]]: ...
+
+
+@overload
+def supports_eagle(model: object) -> TypeIs[SupportsEagle]: ...
+
+
+def supports_eagle(
+    model: type[object] | object,
+) -> TypeIs[type[SupportsEagle]] | TypeIs[SupportsEagle]:
+    return isinstance(model, SupportsEagle)
+
+
+@runtime_checkable
+class SupportsEagle3(SupportsEagleBase, Protocol):
+    """The interface required for models that support
+    EAGLE-3 speculative decoding."""
+
+    supports_eagle3: ClassVar[Literal[True]] = True
     """
-    A flag that indicates this model has trained its own input embeddings.
+    A flag that indicates this model supports EAGLE-3 
+    speculative decoding.
+
+    Note:
+        There is no need to redefine this flag if this class is in the
+        MRO of your model class.
     """
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         """
         Set which layers should output auxiliary
-        hidden states for EAGLE3.
+        hidden states for EAGLE-3.
 
         Args:
             layers: Tuple of layer indices that should output auxiliary
@@ -946,7 +996,7 @@ class SupportsEagle3(Protocol):
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
         """
         Get the layer indices that should output auxiliary hidden states
-        for EAGLE3.
+        for EAGLE-3.
 
         Returns:
             Tuple of layer indices for auxiliary hidden state outputs.

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -58,7 +58,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsEagle3, SupportsLoRA, SupportsPP
+from .interfaces import SupportsEagle, SupportsEagle3, SupportsLoRA, SupportsPP
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -507,7 +507,9 @@ class LlamaModel(nn.Module):
         return loaded_params
 
 
-class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
+class LlamaForCausalLM(
+    nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, SupportsEagle3
+):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],

--- a/vllm/model_executor/models/llama4_eagle.py
+++ b/vllm/model_executor/models/llama4_eagle.py
@@ -35,7 +35,7 @@ from vllm.model_executor.models.llama4 import Llama4DecoderLayer, Llama4ForCausa
 from vllm.model_executor.models.utils import extract_layer_index
 
 from .interfaces import SupportsMultiModal
-from .utils import AutoWeightsLoader, maybe_prefix
+from .utils import AutoWeightsLoader, maybe_prefix, process_eagle_weight
 
 logger = init_logger(__name__)
 
@@ -209,6 +209,7 @@ class EagleLlama4ForCausalLM(Llama4ForCausalLM):
             name, weight = self.permute_qk_weight_for_rotary(name, loaded_weight)
             if "lm_head" not in name:
                 name = "model." + name
+            process_eagle_weight(self, name)
             return name, weight
 
         loader = AutoWeightsLoader(

--- a/vllm/model_executor/models/llama_eagle.py
+++ b/vllm/model_executor/models/llama_eagle.py
@@ -17,7 +17,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmb
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.llama import LlamaDecoderLayer, LlamaForCausalLM
 
-from .utils import AutoWeightsLoader, maybe_prefix
+from .utils import AutoWeightsLoader, maybe_prefix, process_eagle_weight
 
 logger = init_logger(__name__)
 
@@ -179,6 +179,7 @@ class EagleLlamaForCausalLM(LlamaForCausalLM):
             name, loaded_weight = inputs
             if "lm_head" not in name:
                 name = "model." + name
+            process_eagle_weight(self, name)
             return name, loaded_weight
 
         loader = AutoWeightsLoader(

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -148,6 +148,7 @@ class LlamaModel(nn.Module):
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
+        self.has_own_embed_tokens = False
 
         self.layers = nn.ModuleList(
             [
@@ -263,6 +264,8 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
             requires_grad=False,
         )
+        # To prevent overriding lm_head with target model's lm_head
+        self.has_own_lm_head = False
 
     def get_input_embeddings(
         self,
@@ -327,6 +330,12 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             if "embed_tokens" in name:
                 includes_embed_tokens = True
             model_weights[name] = loaded_weight
+
+            # To prevent overriding with target model's layers
+            if "lm_head" in name:
+                self.has_own_lm_head = True
+            if "embed_tokens" in name:
+                self.model.has_own_embed_tokens = True
 
         skip_substrs = []
         if not includes_draft_id_mapping:

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -148,7 +148,6 @@ class LlamaModel(nn.Module):
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
-        self.has_own_embed_tokens = False
 
         self.layers = nn.ModuleList(
             [
@@ -264,8 +263,6 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
             requires_grad=False,
         )
-        # To prevent overriding lm_head with target model's lm_head
-        self.has_own_lm_head = False
 
     def get_input_embeddings(
         self,
@@ -335,7 +332,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             if "lm_head" in name:
                 self.has_own_lm_head = True
             if "embed_tokens" in name:
-                self.model.has_own_embed_tokens = True
+                self.has_own_embed_tokens = True
 
         skip_substrs = []
         if not includes_draft_id_mapping:

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -24,7 +24,7 @@ from vllm.model_executor.models.llama import LlamaDecoderLayer, LlamaForCausalLM
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import NestedTensors
 
-from .utils import AutoWeightsLoader, maybe_prefix
+from .utils import AutoWeightsLoader, maybe_prefix, process_eagle_weight
 
 logger = init_logger(__name__)
 
@@ -327,12 +327,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             if "embed_tokens" in name:
                 includes_embed_tokens = True
             model_weights[name] = loaded_weight
-
-            # To prevent overriding with target model's layers
-            if "lm_head" in name:
-                self.has_own_lm_head = True
-            if "embed_tokens" in name:
-                self.has_own_embed_tokens = True
+            process_eagle_weight(self, name)
 
         skip_substrs = []
         if not includes_draft_id_mapping:

--- a/vllm/model_executor/models/minicpm_eagle.py
+++ b/vllm/model_executor/models/minicpm_eagle.py
@@ -44,7 +44,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import SupportsEagle, SupportsLoRA, SupportsPP
 from .minicpm import MiniCPMAttention as EagleMiniCPMAttention
 from .minicpm import MiniCPMMLP as EagleMiniCPMMLP
 from .minicpm import MiniCPMMoE as EagleMiniCPMMoE
@@ -53,6 +53,7 @@ from .utils import (
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     maybe_prefix,
+    process_eagle_weight,
 )
 
 
@@ -296,7 +297,7 @@ class EagleMiniCPMModel(nn.Module):
         return loaded_params
 
 
-class EagleMiniCPMForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class EagleMiniCPMForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -393,8 +394,13 @@ class EagleMiniCPMForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        def transform(inputs):
+            name, loaded_weight = inputs
+            process_eagle_weight(self, name)
+            return name, loaded_weight
+
         loader = AutoWeightsLoader(
             self,
             skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
         )
-        return loader.load_weights(weights)
+        return loader.load_weights(map(transform, weights))

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -20,6 +20,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.interfaces import supports_any_eagle
 from vllm.multimodal import NestedTensors
 from vllm.sequence import IntermediateTensors
 from vllm.utils.math_utils import cdiv
@@ -828,3 +829,27 @@ direct_register_custom_op(
     fake_impl=sequence_parallel_chunk_impl_fake,
     tags=(torch.Tag.needs_fixed_stride_order,),
 )
+
+
+def process_eagle_weight(
+    model: nn.Module,
+    name: str,
+) -> None:
+    """
+    Update EAGLE model flags based on loaded weight name.
+
+    This should be called during weight loading to detect if a model
+    has its own lm_head or embed_tokens weight.
+
+    Args:
+        model: The model instance (must support EAGLE)
+        name: The name of the weight to process
+    """
+    if not supports_any_eagle(model):
+        return
+
+    # To prevent overriding with target model's layers
+    if "lm_head" in name:
+        model.has_own_lm_head = True
+    if "embed_tokens" in name:
+        model.has_own_embed_tokens = True

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -998,20 +998,17 @@ class EagleProposer:
                     "Target model does not have 'embed_tokens' or 'embedding' attribute"
                 )
 
-            # Check if shapes match and we found the embedding
-            eagle_shape = self.model.model.embed_tokens.weight.shape
-            target_shape = target_embed_tokens.weight.shape
-            if eagle_shape == target_shape:
+            if not self.model.model.has_own_embed_tokens:
                 logger.info(
-                    "Assuming the EAGLE head shares the same vocab embedding"
-                    " with the target model."
+                    "Draft model embed_tokens are uninitialized. "
+                    "Sharing vocab embedding with the target model."
                 )
                 del self.model.model.embed_tokens
                 self.model.model.embed_tokens = target_embed_tokens
             else:
                 logger.info(
-                    "The EAGLE head's vocab embedding will be loaded separately"
-                    " from the target model."
+                    "Draft model embed_tokens are already initialized. "
+                    "Keeping separate vocab embedding from the target model."
                 )
         else:
             logger.info(
@@ -1028,21 +1025,20 @@ class EagleProposer:
                 self.model.lm_head = target_language_model.lm_head
         else:
             if (
-                hasattr(self.model, "lm_head")
-                and hasattr(target_language_model, "lm_head")
-                and self.model.lm_head.weight.shape
-                == target_language_model.lm_head.weight.shape
+                hasattr(target_language_model, "lm_head")
+                and hasattr(self.model, "lm_head")
+                and not self.model.has_own_lm_head
             ):
                 logger.info(
-                    "Assuming the EAGLE head shares the same lm_head"
-                    " with the target model."
+                    "Draft model lm_head is uninitialized. "
+                    "Sharing lm_head with the target model."
                 )
                 del self.model.lm_head
                 self.model.lm_head = target_language_model.lm_head
             else:
                 logger.info(
-                    "The EAGLE head's lm_head will be loaded separately"
-                    " from the target model."
+                    "Draft model lm_head is already initialized. "
+                    "Keeping separate lm_head from the target model."
                 )
 
     @torch.inference_mode()

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1000,15 +1000,15 @@ class EagleProposer:
 
             if not self.model.has_own_embed_tokens:
                 logger.info(
-                    "Draft model embed_tokens are uninitialized. "
-                    "Sharing vocab embedding with the target model."
+                    "Draft model embed_tokens are not initialized from the checkpoint weights. "
+                    "Assuming draft model should share the embedding weights with the target model to save memory."
                 )
                 del self.model.model.embed_tokens
                 self.model.model.embed_tokens = target_embed_tokens
             else:
                 logger.info(
-                    "Draft model embed_tokens are already initialized. "
-                    "Keeping separate vocab embedding from the target model."
+                    "Draft model embed_tokens are initialized from the checkpoint weights. "
+                    "Keeping separate embedding weights from the target model."
                 )
         else:
             logger.info(
@@ -1030,15 +1030,15 @@ class EagleProposer:
                 and not self.model.has_own_lm_head
             ):
                 logger.info(
-                    "Draft model lm_head is uninitialized. "
-                    "Sharing lm_head with the target model."
+                    "Draft model lm_head is not initialized from the checkpoint weights. "
+                    "Assuming draft model should share the lm_head weights with the target model to save memory."
                 )
                 del self.model.lm_head
                 self.model.lm_head = target_language_model.lm_head
             else:
                 logger.info(
-                    "Draft model lm_head is already initialized. "
-                    "Keeping separate lm_head from the target model."
+                    "Draft model lm_head is initialized from the checkpoint weights. "
+                    "Keeping separate lm_head weights from the target model."
                 )
 
     @torch.inference_mode()

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -998,7 +998,7 @@ class EagleProposer:
                     "Target model does not have 'embed_tokens' or 'embedding' attribute"
                 )
 
-            if not self.model.model.has_own_embed_tokens:
+            if not self.model.has_own_embed_tokens:
                 logger.info(
                     "Draft model embed_tokens are uninitialized. "
                     "Sharing vocab embedding with the target model."


### PR DESCRIPTION
Some EAGLE3 drafters might have their own lm_head and/or embed_tokens layers. Existing codebase ignores this and always overrides them with target model's layers.


#### Test-case 1: for a model which needs copying of lm_head and embed_tokens from verifier model, the behavior should not change

Eval command to verify:

```bash
CUDA_VISIBLE_DEVICES=0,1 python examples/offline_inference/spec_decode.py \
  --method "eagle3" \
  --tp 2 \
  --model-dir "openai/gpt-oss-120b" \
  --eagle-dir "nvidia/gpt-oss-120b-Eagle3" \
  --dataset_name "hf" \
  --dataset_path "philschmid/mt-bench" \
  --num-spec-tokens 3
```

Before this PR:
```bash
--------------------------------------------------
total_num_output_tokens: 241888
num_drafts: 105426
num_draft_tokens: 316278
num_accepted_tokens: 136330
mean acceptance length: 2.29
--------------------------------------------------
acceptance at token 0: 0.65
acceptance at token 1: 0.40
acceptance at token 2: 0.24
```

After this PR:
```
--------------------------------------------------
total_num_output_tokens: 241168
num_drafts: 105678
num_draft_tokens: 317034
num_accepted_tokens: 135362
mean acceptance length: 2.28
--------------------------------------------------
acceptance at token 0: 0.65
acceptance at token 1: 0.39
acceptance at token 2: 0.24
```


#### Test-case 2: for a model with has its own lm_head and embed_tokens, and therefore does not require copying from target's layers, acceptance rates look significantly better

Before this PR:
```bash
--------------------------------------------------
total_num_output_tokens: 247973
num_drafts: 187566
num_draft_tokens: 562698
num_accepted_tokens: 59726
mean acceptance length: 1.32
--------------------------------------------------
acceptance at token 0: 0.23
acceptance at token 1: 0.07
acceptance at token 2: 0.02
```

After this PR:
```bash
--------------------------------------------------
total_num_output_tokens: 247974
num_drafts: 99354
num_draft_tokens: 298062
num_accepted_tokens: 148677
mean acceptance length: 2.50
--------------------------------------------------
acceptance at token 0: 0.70
acceptance at token 1: 0.48
acceptance at token 2: 0.31
```

Note: idea for lm_head check inspired by https://github.com/vllm-project/vllm/pull/27688
