### PR TITLE
[BugFix] Reordering extend logic fix

### DIFF
--- a/tests/v1/attention/test_batch_reordering.py
+++ b/tests/v1/attention/test_batch_reordering.py
@@ -53,7 +53,7 @@ REORDER_TEST_CASES = {
         expected_modified=True,
     ),
     "already_ordered": ReorderTestCase(
-        requests=[(1, 10), (1, 20), (100, 100), (200, 200)],
+        requests=[(1, 10), (1, 20), (100, 100), (200, 0)],
         expected_order=[0, 1, 2, 3],
         expected_modified=False,
     ),
@@ -74,13 +74,28 @@ REORDER_TEST_CASES = {
         expected_modified=True,
     ),
     "decode_extend_prefill": ReorderTestCase(
-        requests=[(100, 100), (10, 50), (1, 10)],
+        requests=[(100, 0), (10, 50), (1, 10)],
         expected_order=[2, 1, 0],
         expected_modified=True,
     ),
     "extend_prefill_only": ReorderTestCase(
-        requests=[(100, 100), (10, 50), (200, 200), (20, 75)],
+        requests=[(100, 0), (10, 50), (200, 0), (20, 75)],
         expected_order=[3, 1, 2, 0],  # Only swap 0↔3, keep 1 and 2 in place
+        expected_modified=True,
+    ),
+    "complicated_mixed_interleaved": ReorderTestCase(
+        requests=[
+            (1, 20),
+            (1, 50),
+            (374, 0),
+            (300, 20),
+            (1, 20),
+            (256, 0),
+            (1, 5),
+            (27, 0),
+            (1, 4),
+        ],
+        expected_order=[0, 1, 6, 8, 4, 3, 2, 7, 5],
         expected_modified=True,
     ),
 }
@@ -100,6 +115,9 @@ def test_reorder_batch_to_split_decodes_and_prefills(test_case: ReorderTestCase)
     modified = reorder_batch_to_split_decodes_and_prefills(
         input_batch, scheduler_output, decode_threshold=test_case.decode_threshold
     )
+
+    print(f"input_batch.req_ids: {input_batch.req_ids}")
+    print(f"test_case.expected_order: {test_case.expected_order}")
 
     expected_req_ids = [f"r{i}" for i in test_case.expected_order]
 

--- a/tests/v1/attention/test_batch_reordering.py
+++ b/tests/v1/attention/test_batch_reordering.py
@@ -116,9 +116,6 @@ def test_reorder_batch_to_split_decodes_and_prefills(test_case: ReorderTestCase)
         input_batch, scheduler_output, decode_threshold=test_case.decode_threshold
     )
 
-    print(f"input_batch.req_ids: {input_batch.req_ids}")
-    print(f"test_case.expected_order: {test_case.expected_order}")
-
     expected_req_ids = [f"r{i}" for i in test_case.expected_order]
 
     assert modified == test_case.expected_modified, (


### PR DESCRIPTION
Fix incorrect definition of extends in https://github.com/vllm-project/vllm/pull/27367, more extensive unit tests, fix reordering bug when multiple swaps are involved + light refactor.

Credit to @ganyi1996ppo for finding the issue