### PR TITLE
[CI] Fix flaky `test_two_responses_with_same_prev_id` test 

### DIFF
--- a/tests/v1/entrypoints/openai/responses/conftest.py
+++ b/tests/v1/entrypoints/openai/responses/conftest.py
@@ -6,7 +6,7 @@ import pytest_asyncio
 from tests.utils import RemoteOpenAIServer
 
 # Use a small reasoning model to test the responses API.
-MODEL_NAME = "Qwen/Qwen3-0.6B"
+MODEL_NAME = "Qwen/Qwen3-1.7B"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This test occasionally fails with 

```
[2025-10-27T06:07:53Z] FAILED v1/entrypoints/openai/responses/test_stateful.py::test_two_responses_with_same_prev_id - assert 'John' in "\n\nI don't have a name."
[2025-10-27T06:07:53Z]  +  where "\n\nI don't have a name." = ResponseOutputText(annotations=[], text="\n\nI don't have a name.", type='output_text', logprobs=None).text
[2025-10-27T06:07:53Z] ============ 1 failed, 90 passed, 29 warnings in 1625.46s (0:27:05) ============ 
```
