### PR TITLE
[BugFix] Stopgap - Flashinfer Autotuner + GPT-OSS + DP/TP

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -32,6 +32,7 @@ def flashinfer_autotune_supported(vllm_config: VllmConfig) -> bool:
     """
     return not (
         vllm_config.parallel_config.data_parallel_size > 1
+        and envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
         and (
             envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16
             or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -37,7 +37,9 @@ def flashinfer_autotune_supported(vllm_config: VllmConfig) -> bool:
         envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8
         or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16
         or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS
-    )
+    ) or current_platform.is_device_capability(
+        100
+    )  # on >sm100, default mxfp4 backend is flashinfer
     is_eager = vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
 
     return not (is_tp_or_dp and is_fi_mxfp4_backend and is_eager)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -37,9 +37,9 @@ def flashinfer_autotune_supported(vllm_config: VllmConfig) -> bool:
         envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8
         or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16
         or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS
-    ) or current_platform.is_device_capability(
-        100
-    )  # on >sm100, default mxfp4 backend is flashinfer
+    ) or (
+        current_platform.is_cuda() and current_platform.is_device_capability(100)
+    )  # on >=sm100, default mxfp4 backend is flashinfer
     is_eager = vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
 
     return not (is_tp_or_dp and is_fi_mxfp4_backend and is_eager)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import torch
 
 import vllm.envs as envs
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.warmup.deep_gemm_warmup import deep_gemm_warmup
 from vllm.platforms import current_platform
@@ -30,14 +30,17 @@ def flashinfer_autotune_supported(vllm_config: VllmConfig) -> bool:
     Record known issues with vllm + flashinfer autotune here. Return True if
     and only if flashinfer autotune will run through without issues.
     """
-    return not (
-        vllm_config.parallel_config.data_parallel_size > 1
-        and envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
-        and (
-            envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16
-            or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8
-        )
+    is_tp_or_dp = (vllm_config.parallel_config.data_parallel_size > 1) or (
+        vllm_config.parallel_config.tensor_parallel_size > 1
     )
+    is_fi_mxfp4_backend = (
+        envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8
+        or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16
+        or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS
+    )
+    is_eager = vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+
+    return not (is_tp_or_dp and is_fi_mxfp4_backend and is_eager)
 
 
 def kernel_warmup(worker: "Worker"):


### PR DESCRIPTION
## Purpose
Running the Flashinfer autotuner when,
 - using data-parallel or tensor-parallel, and
 - using a flashinfer mxfp4 backend, and
 - eager-mode

Causes the engine startup to fail with, 
```
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm-test/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP1 pid=3074289)     return forward_call(*args, **kwargs)
(EngineCore_DP1 pid=3074289)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1168, in forward
(EngineCore_DP1 pid=3074289)     fused_out = self._fused_experts(
(EngineCore_DP1 pid=3074289)                 ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1021, in _fused_experts
(EngineCore_DP1 pid=3074289)     self.fused_experts.apply(
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm/model_executor/layers/fused_moe/trtllm_moe.py", line 135, in apply
(EngineCore_DP1 pid=3074289)     trtllm_fp4_block_scale_routed_moe(**kwargs)
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm-test/lib/python3.12/site-packages/flashinfer/fused_moe/core.py", line 1850, in trtllm_fp4_block_scale_routed_moe
(EngineCore_DP1 pid=3074289)     return get_trtllm_moe_sm100_module().trtllm_fp4_block_scale_moe(
(EngineCore_DP1 pid=3074289)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm-test/lib/python3.12/site-packages/flashinfer/fused_moe/core.py", line 1348, in trtllm_fp4_block_scale_moe_op
(EngineCore_DP1 pid=3074289)     _, tactic = tuner.choose_one(
(EngineCore_DP1 pid=3074289)                 ^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm-test/lib/python3.12/site-packages/flashinfer/autotuner.py", line 457, in choose_one
(EngineCore_DP1 pid=3074289)     profiles = self._generate_optimization_profiles(tuning_config, inputs)
(EngineCore_DP1 pid=3074289)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3074289)   File "/home/varun-sundar-rabindranath/code/vllm/vllm-test/lib/python3.12/site-packages/flashinfer/autotuner.py", line 643, in _generate_optimization_profiles
(EngineCore_DP1 pid=3074289)     assert len(opt_shapes) > 0, "Empty tuning buckets are not allowed"
(EngineCore_DP1 pid=3074289)            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3074289) AssertionError: Empty tuning buckets are not allowed
```

This error was initially thought to be related to DP + certain choices for the MXFP4 backend. This PR updates the skip condition.

## Test Plan and Test Result

### B200 DP

VLLM_ALL2ALL_BACKEND="deepep_high_throughput" canhazgpu run -g2 --   vllm serve openai/gpt-oss-20b --data-parallel-size 2 --tensor-parallel-size 1 --enable-expert-parallel   --no-enable-prefix-caching  --port 9010 
- PR Pass
- main Fail

`VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1 canhazgpu run -g2 --   vllm serve openai/gpt-oss-20b --data-parallel-size 2 --tensor-parallel-size 1 --enable-expert-parallel   --no-enable-prefix-caching  --port 9010   --enforce-eager`
- PR Pass
- main Pass

`VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS=1 canhazgpu  run -g2 --   vllm serve openai/gpt-oss-20b --data-parallel-size 2 --tensor-parallel-size 1 --enable-expert-parallel   --no-enable-prefix-caching  --port 9010   --enforce-eager`
- PR Pass
- main fail

`VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1  canhazgpu run -g2 --   vllm serve openai/gpt-oss-20b --data-parallel-size 2 --tensor-parallel-size 1 --enable-expert-parallel   --no-enable-prefix-caching  --port 9010   --enforce-eager`
- PR Pass
- main pass

### B200 TP
`VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1 canhazgpu run -g2 --  vllm serve openai/gpt-oss-20b --data-parallel-size 1 --tensor-parallel-size 2 --no-enable-prefix-caching  --port 9010   --enforce-eager`
- PR Pass
- main fail

`VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS=1 canhazgpu run -g2 -- vllm serve openai/gpt-oss-20b --data-parallel-size 1 --tensor-parallel-size 2 --no-enable-prefix-caching  --port 9010   --enforce-eager`
- PR Pass
- main fail

`VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1 canhazgpu run -g2 -- vllm serve openai/gpt-oss-20b --data-parallel-size 1 --tensor-parallel-size 2 --no-enable-prefix-caching  --port 9010   --enforce-eager`
- PR Pass
- main fail

### H100 DP
`VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1  canhazgpu run -g2 --  vllm serve openai/gpt-oss-20b --data-parallel-size 2 --tensor-parallel-size 1 --enable-expert-parallel   --no-enable-prefix-caching  --port 9010 --enforce-eager`
- PR pass
- main pass

### H100 TP
`VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1  canhazgpu run -g2 --  vllm serve openai/gpt-oss-20b --data-parallel-size 1 --tensor-parallel-size 2   --no-enable-prefix-caching  --port 9010 --enforce-eager`
- PR pass
- main fail
