### PR TITLE
[KV offload] Enable CPU KV offload on CUDA alike Platforms

### DIFF
--- a/tests/v1/kv_offload/test_cpu_offloading.py
+++ b/tests/v1/kv_offload/test_cpu_offloading.py
@@ -12,7 +12,6 @@ from tqdm import tqdm
 from vllm import LLM, SamplingParams, TokensPrompt
 from vllm.config import KVEventsConfig, KVTransferConfig
 from vllm.distributed.kv_events import BlockStored, KVEventBatch
-from vllm.platforms import current_platform
 
 CPU_BLOCK_SIZES = [16, 48]
 
@@ -64,9 +63,6 @@ class MockSubscriber:
         self.sub.close()
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="CPU offloading only supported on CUDA"
-)
 @pytest.mark.parametrize("cpu_block_size", CPU_BLOCK_SIZES)
 def test_cpu_offloading(cpu_block_size: int) -> None:
     """

--- a/vllm/v1/kv_offload/cpu.py
+++ b/vllm/v1/kv_offload/cpu.py
@@ -51,9 +51,9 @@ class CPUOffloadingSpec(OffloadingSpec):
         self, kv_caches: dict[str, torch.Tensor]
     ) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], OffloadingHandler]]:
         if not self._handler:
-            if not current_platform.is_cuda():
+            if not current_platform.is_cuda_alike():
                 raise Exception(
-                    "CPU Offloading is currently only supported on CUDA GPUs"
+                    "CPU Offloading is currently only supported on CUDA-alike GPUs"
                 )
 
             layer_names = list(kv_caches.keys())


### PR DESCRIPTION
## Purpose
See discussion in https://github.com/vllm-project/vllm/pull/27690, we skipped CPU KV offloading test because CPU offloading is currently only supported on CUDA GPUs in vllm/v1/kv_offload/cpu.py:
```
if not current_platform.is_cuda():
    raise Exception(
        "CPU Offloading is currently only supported on CUDA GPUs"
    ) 
```

The reason behind this we haven't tested and verified on other platforms(eg. ROCM), this PR enables CPU KV offloading on CUDA-alike platforms since we have verified it's workin on AMD. 

## Test Plan
https://gist.github.com/zhewenl/9fe5c497d7f5ff5e0d4d907db3850533
```
 pytest -v -s v1/kv_offload/test_cpu_offloading.py
...
================================================================== warnings summary ==================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 2 passed, 2 warnings in 140.35s (0:02:20) ======================================================
```
