### PR TITLE
[Bugfix] mamba-block-size is set for vision language model

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -5,7 +5,7 @@ import hashlib
 from dataclasses import field
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import Field, SkipValidation, field_validator, model_validator
+from pydantic import Field, SkipValidation, field_validator
 from pydantic.dataclasses import dataclass
 
 from vllm.config.utils import config
@@ -185,11 +185,3 @@ class CacheConfig:
             raise ValueError("Too large swap space. " + msg)
         elif cpu_memory_usage > 0.4 * total_cpu_memory:
             logger.warning("Possibly too large swap space. %s", msg)
-
-    @model_validator(mode="after")
-    def validate_mamba_block_size(self) -> "CacheConfig":
-        if self.mamba_block_size is not None and not self.enable_prefix_caching:
-            raise ValueError(
-                "--mamba-block-size can only be set with --enable-prefix-caching"
-            )
-        return self

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import torch
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 from pydantic.dataclasses import dataclass
 
 import vllm.envs as envs
@@ -942,6 +942,18 @@ class VllmConfig:
             f"pooler_config={self.model_config.pooler_config!r}, "
             f"compilation_config={self.compilation_config!r}"
         )
+
+    @model_validator(mode="after")
+    def validate_mamba_block_size(self) -> "VllmConfig":
+        mamba_block_size_is_set = (
+            self.cache_config.mamba_block_size is not None
+            and self.cache_config.mamba_block_size != self.model_config.max_model_len
+        )
+        if mamba_block_size_is_set and not self.cache_config.enable_prefix_caching:
+            raise ValueError(
+                "--mamba-block-size can only be set with --enable-prefix-caching"
+            )
+        return self
 
 
 _current_vllm_config: VllmConfig | None = None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -945,6 +945,8 @@ class VllmConfig:
 
     @model_validator(mode="after")
     def validate_mamba_block_size(self) -> "VllmConfig":
+        if self.model_config is None:
+            return self
         mamba_block_size_is_set = (
             self.cache_config.mamba_block_size is not None
             and self.cache_config.mamba_block_size != self.model_config.max_model_len


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
```
vllm serve nvidia/Nemotron-Nano-12B-v2-VL-BF16 --trust-remote-code
```
get this error
```
(EngineCore_DP0 pid=861647)   Value error, --mamba-block-size can only be set with --enable-prefix-caching [type=value_error, input_value=CacheConfig(block_size=67...cache_memory_bytes=None), input_type=CacheConfig]
```

## Test Plan
try this model
## Test Result
can run now
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

