### PR TITLE
Make the cv2 dependency optional

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -30,7 +30,6 @@ from io import BytesIO
 from tempfile import NamedTemporaryFile
 from typing import Any, cast
 
-import cv2
 import numpy as np
 from PIL import Image
 from transformers import PreTrainedTokenizerBase
@@ -850,6 +849,8 @@ class RandomMultiModalDataset(RandomDataset):
         Creates a video with random pixel values, encodes it to MP4 format,
         and returns the content as bytes.
         """
+        import cv2
+
         random_pixels = self._rng.integers(
             0,
             256,


### PR DESCRIPTION

## Purpose

The latest code will requires the `cv2` dependency (no matter command you run, because it's imported by default), and it's completely not necessary (it's only used in benchmark). This PR move cv2 inside the function it's called, to prevent cv2 to be imported by default.

The motivation to remove cv2 is that, it's hard to maintain opencv package consistency if you run vllm along with other related packages.

## Test Plan
None

## Test Result
None

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

