### PR TITLE
[Fix] Skip `record_sleep_state` logic in `PrometheusStatsLogger` if not in dev mode

### DIFF
--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1052,6 +1052,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.gauge_lora_info.labels(**lora_info_labels).set_to_current_time()
 
     def record_sleep_state(self, sleep: int = 0, level: int = 0):
+        if not envs.VLLM_SERVER_DEV_MODE:
+            return
+
         awake = 1
         discard_all = 0
         weights_offloaded = 0


### PR DESCRIPTION

## Purpose

Fixes #27788 


## Test Plan

I added a basic test `test_deep_sleep_async` to test the async llm engine and the sleep path. 

Note that this is pretty redundant with `test_deep_sleep`, since both the LLM class and the AsyncLLM class share most of the logic here. However, in order to catch subtle differences in the codepaths, it's better to just have this duplicated test IMO. 

## Test Result

Test passes with the minor fix in this PR

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

