### PR TITLE
[CI Failure] fix test_default_mm_loras

### DIFF
--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -30,7 +30,8 @@ VLLM_RUNNER_BASE_KWARGS = {
     "enable_lora": "True",
     "max_num_seqs": 2,
     "max_lora_rank": 320,
-    "max_model_len": 12800,
+    # Keep these LoRA tests on short-RoPE for determinism post-LongRoPE change.
+    "max_model_len": 4096,
     "gpu_memory_utilization": 0.8,
     "limit_mm_per_prompt": {"audio": 1},
     "enforce_eager": True,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

LoRA Tests are failing in nightly (https://buildkite.com/vllm/ci/builds/36869/steps/canvas?sid=019a3346-cea1-4bac-ba60-8e4eabb0c2b0, https://buildkite.com/vllm/ci/builds/36869/steps/canvas?sid=019a3346-cea1-4129-9d36-72bb43d662f6, https://buildkite.com/vllm/ci/builds/36869/steps/canvas?sid=019a3346-cea2-4b6b-a02b-b280e7d52b3b) due to recent change from [PR](https://github.com/vllm-project/vllm/pull/27431) - In LongRoPE, decide short vs long based on `max_model_len`, models with LongRoPE now pick the short‑ or long‑scaling path at init time based on `max_model_len`. Our LoRA default‑MM tests were using `max_model_len=12800`, which pushed Phi‑4‑MM into the long‑RoPE path and introduced tiny but deterministic output shifts, , causing brittle exact‑suffix assertions to fail in nightly.

This PR changes `max_model_len` from 12800 to 4096 to stay on short‑RoPE.

## Test Plan

CI

## Test Result

https://buildkite.com/vllm/ci/builds/36882/steps/canvas?sid=019a33cd-1ae3-4f0d-a8d5-a939c35eb6e2

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

