### PR TITLE
[Core][Perf] Replace isinstance(CrossAttentionManager) with a class member variable

### DIFF
--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
 from vllm.v1.core.single_type_kv_cache_manager import (
-    CrossAttentionManager,
     FullAttentionManager,
     get_manager_for_kv_cache_spec,
 )
@@ -72,7 +71,7 @@ class KVCacheCoordinator(ABC):
         """
         num_blocks_to_allocate = 0
         for i, manager in enumerate(self.single_type_managers):
-            if isinstance(manager, CrossAttentionManager):
+            if manager.is_cross_attention_manager:
                 # For cross-attention, we issue a single static allocation
                 # of blocks based on the number of encoder input tokens.
                 num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
@@ -119,7 +118,7 @@ class KVCacheCoordinator(ABC):
             manager.allocate_new_blocks(
                 request_id,
                 num_encoder_tokens
-                if isinstance(manager, CrossAttentionManager)
+                if manager.is_cross_attention_manager
                 else num_tokens,
             )
             for manager in self.single_type_managers

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -26,6 +26,8 @@ class SingleTypeKVCacheManager(ABC):
     logic of one specific type of attention layer.
     """
 
+    is_cross_attention_manager: bool = False
+
     def __init__(
         self,
         kv_cache_spec: KVCacheSpec,
@@ -636,6 +638,8 @@ class MambaManager(SingleTypeKVCacheManager):
 
 class CrossAttentionManager(SingleTypeKVCacheManager):
     """Manager for cross-attention KV cache in encoder-decoder models."""
+
+    is_cross_attention_manager: bool = True
 
     def save_new_computed_blocks(
         self, request_id: str, new_computed_blocks: Sequence[KVCacheBlock]


### PR DESCRIPTION
## Purpose
kv_cache_manager.allocate_slots is on critical path even with async scheduling is turned on. And we used isinstance() in multiple places, but isinstance is not very cheap, which involved subclass iterations and dict lookup for cached results.
<img width="919" height="110" alt="Screenshot 2025-10-29 at 11 44 29 PM" src="https://github.com/user-attachments/assets/3e70990d-ca6d-41cc-923f-46fde0804d87" />

## Test Plan & Test Result
For large batch size (500+), with the current change, it could be reduced from 12ms to ~10ms.

**Before**
<img width="1127" height="117" alt="Screenshot 2025-10-29 at 11 48 10 PM" src="https://github.com/user-attachments/assets/4237e10a-e2ee-4011-9cbc-b2fd4992a4be" />
**After**
<img width="705" height="115" alt="Screenshot 2025-10-29 at 11 47 59 PM" src="https://github.com/user-attachments/assets/1806f54f-4058-4105-b8d1-c5a165f8725f" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

