### PR TITLE
[BugFix] fix: skip check unstreamed tool arg tokens when tool call name is present

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1729,7 +1729,10 @@ class OpenAIServingChat(OpenAIServing):
         """
         Check to see if we should check for unstreamed tool arguments tokens.
         This is only applicable when auto tool parsing is enabled, the delta
-        is a tool call with arguments.
+        is a tool call with arguments. We only enter this branch when arguments
+        are being streamed incrementally (i.e., when name is not present).
+        This branch is skipped if the complete tool call (including name) is present
+        or will be streamed.
         """
 
         return bool(
@@ -1743,6 +1746,9 @@ class OpenAIServingChat(OpenAIServing):
             and delta_message.tool_calls[0]
             and delta_message.tool_calls[0].function
             and delta_message.tool_calls[0].function.arguments is not None
+            # Only enter this branch when name is not already streamed
+            # (i.e., when arguments are being streamed incrementally)
+            and not delta_message.tool_calls[0].function.name
         )
 
     def _make_request_with_harmony(


### PR DESCRIPTION
## Purpose
- In most cases tool calling parsers support incremental stream responses
- However, if the tool call parser doesn't support incremental tool call stream response, it can cause a bug that omits the function name in the OpenAI chat completion API
- Therefore, the `_should_check_for_unstreamed_tool_arg_tokens` function should verify that the current delta doesn't contain a name before entering this branch, since this logic is specifically designed to handle cases where only arguments are being streamed incrementally, not complete tool calls with both name and arguments
- If tool call parser doesn't support incremental stream responses, due to the following part, it will omit function name.
https://github.com/vllm-project/vllm/blob/af826e082045e8bcd3ab2ea3129bcf91da7d58de/vllm/entrypoints/openai/serving_chat.py#L1157-L1166

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

