### PR TITLE
[Misc] Refactor Attention kv transfer methods into decorator

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -886,7 +886,7 @@ def get_attention_context(
     Returns:
         A tuple containing:
         - attn_metadata: Attention metadata for this specific layer, or None if
-           no metadata available
+            no metadata available
         - attn_layer: The attention layer instance (Attention or MLAAttention)
         - kv_cache: The KV cache tensor for current virtual engine
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -955,6 +955,7 @@ direct_register_custom_op(
 )
 
 
+@maybe_transfer_kv_layer
 def unified_mla_attention(
     q: torch.Tensor,
     kv_c_normed: torch.Tensor,

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -15,14 +15,10 @@ from vllm.attention.backends.abstract import AttentionBackend, MLAAttentionImpl
 from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.attention.selector import get_attn_backend
 from vllm.attention.utils.kv_sharing_utils import validate_kv_sharing_target
+from vllm.attention.utils.kv_transfer_utils import maybe_transfer_kv_layer
 from vllm.config import CacheConfig, get_current_vllm_config
 from vllm.config.multimodal import MultiModalConfig
 from vllm.config.vllm import VllmConfig
-from vllm.distributed.kv_transfer import (
-    get_kv_transfer_group,
-    has_kv_transfer_group,
-    is_v1_kv_transfer_group,
-)
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -842,41 +838,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         )
 
 
-def wait_for_kv_layer_from_connector(layer_name: str):
-    if not has_kv_transfer_group() or not is_v1_kv_transfer_group():
-        return
-
-    connector = get_kv_transfer_group()
-    if not connector.has_connector_metadata():
-        return
-
-    forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.attn_metadata
-    if attn_metadata is None:
-        return
-    assert isinstance(attn_metadata, dict)
-    connector.wait_for_layer_load(layer_name)
-
-
-def maybe_save_kv_layer_to_connector(
-    layer_name: str,
-    kv_cache_layer: list[torch.Tensor],
-):
-    if not has_kv_transfer_group() or not is_v1_kv_transfer_group():
-        return
-
-    connector = get_kv_transfer_group()
-    if not connector.has_connector_metadata():
-        return
-
-    forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.attn_metadata
-    if attn_metadata is None:
-        return
-    assert isinstance(attn_metadata, dict)
-    connector.save_kv_layer(layer_name, kv_cache_layer, attn_metadata[layer_name])
-
-
 def maybe_calc_kv_scales(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -911,14 +872,13 @@ direct_register_custom_op(
 )
 
 
+@maybe_transfer_kv_layer
 def unified_attention(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     layer_name: str,
 ) -> torch.Tensor:
-    wait_for_kv_layer_from_connector(layer_name)
-
     forward_context: ForwardContext = get_forward_context()
     attn_metadata = forward_context.attn_metadata
     if isinstance(attn_metadata, dict):
@@ -927,7 +887,6 @@ def unified_attention(
     kv_cache = self.kv_cache[forward_context.virtual_engine]
     output = self.impl.forward(self, query, key, value, kv_cache, attn_metadata)
 
-    maybe_save_kv_layer_to_connector(layer_name, kv_cache)
     return output
 
 
@@ -947,6 +906,7 @@ direct_register_custom_op(
 )
 
 
+@maybe_transfer_kv_layer
 def unified_attention_with_output(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -956,7 +916,6 @@ def unified_attention_with_output(
     output_scale: torch.Tensor | None = None,
     output_block_scale: torch.Tensor | None = None,
 ) -> None:
-    wait_for_kv_layer_from_connector(layer_name)
     forward_context: ForwardContext = get_forward_context()
     attn_metadata = forward_context.attn_metadata
     if isinstance(attn_metadata, dict):
@@ -974,8 +933,6 @@ def unified_attention_with_output(
         output_scale=output_scale,
         output_block_scale=output_block_scale,
     )
-
-    maybe_save_kv_layer_to_connector(layer_name, kv_cache)
 
 
 def unified_attention_with_output_fake(
@@ -1004,8 +961,6 @@ def unified_mla_attention(
     k_pe: torch.Tensor,
     layer_name: str,
 ) -> torch.Tensor:
-    wait_for_kv_layer_from_connector(layer_name)
-
     forward_context: ForwardContext = get_forward_context()
     attn_metadata = forward_context.attn_metadata
     if isinstance(attn_metadata, dict):
@@ -1014,7 +969,6 @@ def unified_mla_attention(
     kv_cache = self.kv_cache[forward_context.virtual_engine]
     output = self.impl.forward(self, q, kv_c_normed, k_pe, kv_cache, attn_metadata)
 
-    maybe_save_kv_layer_to_connector(layer_name, kv_cache)
     return output
 
 
@@ -1036,6 +990,7 @@ direct_register_custom_op(
 )
 
 
+@maybe_transfer_kv_layer
 def unified_mla_attention_with_output(
     q: torch.Tensor,
     kv_c_normed: torch.Tensor,
@@ -1045,7 +1000,6 @@ def unified_mla_attention_with_output(
     output_scale: torch.Tensor | None = None,
     output_block_scale: torch.Tensor | None = None,
 ) -> None:
-    wait_for_kv_layer_from_connector(layer_name)
     forward_context: ForwardContext = get_forward_context()
     attn_metadata = forward_context.attn_metadata
     if isinstance(attn_metadata, dict):
@@ -1063,8 +1017,6 @@ def unified_mla_attention_with_output(
         output_scale=output_scale,
         output_block_scale=output_block_scale,
     )
-
-    maybe_save_kv_layer_to_connector(layer_name, kv_cache)
 
 
 def unified_mla_attention_with_output_fake(

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -886,7 +886,7 @@ def get_attention_context(
     Returns:
         A tuple containing:
         - attn_metadata: Attention metadata for this specific layer, or None if
-          no metadata available
+           no metadata available
         - attn_layer: The attention layer instance (Attention or MLAAttention)
         - kv_cache: The KV cache tensor for current virtual engine
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -208,6 +208,36 @@ def _init_kv_cache_quant(
         layer.quant_method.create_weights(layer)
 
 
+def get_attention_context(
+    layer_name: str,
+) -> tuple[dict | object | None, "Attention | MLAAttention", torch.Tensor]:
+    """Extract attention context for a given layer.
+
+    This helper function extracts the attention metadata, attention layer
+    instance, and KV cache tensor for a specific layer.
+
+    Args:
+        layer_name: The name/identifier of the attention layer.
+
+    Returns:
+        A tuple containing:
+        - attn_metadata: Attention metadata for this specific layer, or None if
+          no metadata available
+        - attn_layer: The attention layer instance (Attention or MLAAttention)
+        - kv_cache: The KV cache tensor for current virtual engine
+
+        Note: attn_metadata may be None, but attn_layer and kv_cache are always
+        extracted from the forward context.
+    """
+    forward_context: ForwardContext = get_forward_context()
+    attn_metadata = forward_context.attn_metadata
+    if isinstance(attn_metadata, dict):
+        attn_metadata = attn_metadata[layer_name]
+    attn_layer: Attention | MLAAttention = forward_context.no_compile_layers[layer_name]
+    kv_cache = attn_layer.kv_cache[forward_context.virtual_engine]
+    return attn_metadata, attn_layer, kv_cache
+
+
 class Attention(nn.Module, AttentionLayerBase):
     """Attention layer.
 
@@ -879,12 +909,7 @@ def unified_attention(
     value: torch.Tensor,
     layer_name: str,
 ) -> torch.Tensor:
-    forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.attn_metadata
-    if isinstance(attn_metadata, dict):
-        attn_metadata = attn_metadata[layer_name]
-    self = forward_context.no_compile_layers[layer_name]
-    kv_cache = self.kv_cache[forward_context.virtual_engine]
+    attn_metadata, self, kv_cache = get_attention_context(layer_name)
     output = self.impl.forward(self, query, key, value, kv_cache, attn_metadata)
 
     return output
@@ -916,12 +941,7 @@ def unified_attention_with_output(
     output_scale: torch.Tensor | None = None,
     output_block_scale: torch.Tensor | None = None,
 ) -> None:
-    forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.attn_metadata
-    if isinstance(attn_metadata, dict):
-        attn_metadata = attn_metadata[layer_name]
-    self = forward_context.no_compile_layers[layer_name]
-    kv_cache = self.kv_cache[forward_context.virtual_engine]
+    attn_metadata, self, kv_cache = get_attention_context(layer_name)
     self.impl.forward(
         self,
         query,
@@ -962,12 +982,7 @@ def unified_mla_attention(
     k_pe: torch.Tensor,
     layer_name: str,
 ) -> torch.Tensor:
-    forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.attn_metadata
-    if isinstance(attn_metadata, dict):
-        attn_metadata = attn_metadata[layer_name]
-    self: MLAAttention = forward_context.no_compile_layers[layer_name]
-    kv_cache = self.kv_cache[forward_context.virtual_engine]
+    attn_metadata, self, kv_cache = get_attention_context(layer_name)
     output = self.impl.forward(self, q, kv_c_normed, k_pe, kv_cache, attn_metadata)
 
     return output
@@ -1001,12 +1016,7 @@ def unified_mla_attention_with_output(
     output_scale: torch.Tensor | None = None,
     output_block_scale: torch.Tensor | None = None,
 ) -> None:
-    forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.attn_metadata
-    if isinstance(attn_metadata, dict):
-        attn_metadata = attn_metadata[layer_name]
-    self: MLAAttention = forward_context.no_compile_layers[layer_name]
-    kv_cache = self.kv_cache[forward_context.virtual_engine]
+    attn_metadata, self, kv_cache = get_attention_context(layer_name)
     self.impl.forward(
         self,
         q,

--- a/vllm/attention/utils/kv_transfer_utils.py
+++ b/vllm/attention/utils/kv_transfer_utils.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
+from functools import wraps
+from typing import TYPE_CHECKING
+
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+    is_v1_kv_transfer_group,
+)
+from vllm.forward_context import ForwardContext, get_forward_context
+
+if TYPE_CHECKING:
+    from vllm.attention import Attention
+    from vllm.attention.layer import MLAAttention
+
+
+def maybe_transfer_kv_layer(func: Callable) -> Callable:
+    """Decorator that handles KV layer transfer prior and after execution of
+    an attention layer, if enabled. Otherwise, the wrapper is a no-op.
+
+    On entry: waits for the KV layer from the connector.
+    On exit: saves the KV layer to the connector.
+
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not has_kv_transfer_group() or not is_v1_kv_transfer_group():
+            return func(*args, **kwargs)
+
+        layer_name: str = kwargs["layer_name"]
+        forward_context: ForwardContext = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            return func(*args, **kwargs)
+        assert isinstance(attn_metadata, dict)
+        # Wait for KV layer on entry
+        connector = get_kv_transfer_group()
+        connector.wait_for_layer_load(layer_name)
+
+        # Execute the function
+        result = func(*args, **kwargs)
+
+        # Save KV cache layer on exit
+        attn_layer: Attention | MLAAttention = forward_context.no_compile_layers[
+            layer_name
+        ]
+        kv_cache = attn_layer.kv_cache[forward_context.virtual_engine]
+        connector.save_kv_layer(layer_name, kv_cache, attn_metadata[layer_name])
+
+        return result
+
+    return wrapper

--- a/vllm/attention/utils/kv_transfer_utils.py
+++ b/vllm/attention/utils/kv_transfer_utils.py
@@ -22,7 +22,6 @@ def maybe_transfer_kv_layer(func: Callable) -> Callable:
 
     On entry: waits for the KV layer from the connector.
     On exit: saves the KV layer to the connector.
-
     """
 
     @wraps(func)

--- a/vllm/attention/utils/kv_transfer_utils.py
+++ b/vllm/attention/utils/kv_transfer_utils.py
@@ -42,11 +42,11 @@ def maybe_transfer_kv_layer(func: Callable) -> Callable:
 
         # Extract attention context (layer-specific metadata, layer, and kv_cache)
         attn_metadata, attn_layer, kv_cache = get_attention_context(layer_name)
-        if attn_metadata is None:
+        connector = get_kv_transfer_group()
+        if attn_metadata is None or not connector.has_connector_metadata():
             return func(*args, **kwargs)
 
         # Wait for KV layer on entry
-        connector = get_kv_transfer_group()
         connector.wait_for_layer_load(layer_name)
 
         # Execute the function

--- a/vllm/attention/utils/kv_transfer_utils.py
+++ b/vllm/attention/utils/kv_transfer_utils.py
@@ -3,16 +3,12 @@
 import inspect
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING
 
 from vllm.distributed.kv_transfer import (
     get_kv_transfer_group,
     has_kv_transfer_group,
     is_v1_kv_transfer_group,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 def maybe_transfer_kv_layer(func: Callable) -> Callable:


### PR DESCRIPTION
Small quality of life improvement by removing some of the kv transfer-specifc code in `layer.py` and refactoring that into a decorator. I believe the on entry-on exit pattern (wait_read-wait_write) here is very suitable for that.
The result is simply that there's less non-attention related code in the file. Behavior should be unchanged.

Also, I found that after grouping some common boilerplate code for both `maybe_save_kv_layer_to_connector` and `wait_for_kv_layer_from_connector`, I think there's too little left to justify a separate function for both, hence I ended-up inlining both connector method calls. 

cc @ApostaC who wrote the initial connector code