### PR TITLE
[Test] Adjust abort sleep time to reduce AsyncLLM test flake

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -249,7 +249,7 @@ async def test_multi_abort(output_kind: RequestOutputKind):
             )
 
         # Let requests start
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1.0)
 
         # Use multi-abort to abort multiple requests at once
         abort_request_ids = [request_ids[i] for i in REQUEST_IDS_TO_ABORT]


### PR DESCRIPTION
It is tricky to test this from the outside in a deterministic way that doesn't rely on timing.

Example occurrence: https://buildkite.com/vllm/ci/builds/36825#019a3209-d6cb-4ae2-94a2-4aab39752d23