### PR TITLE
[Kimi-Linear] Correct prefixes and add compatibility to AWQ quants

### DIFF
--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -155,6 +155,7 @@ class KimiMoE(nn.Module):
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,
+                prefix=f"{prefix}.shared_experts",
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -340,7 +341,7 @@ class KimiDecoderLayer(nn.Module):
             self.block_sparse_moe = KimiMoE(
                 config=config,
                 quant_config=quant_config,
-                prefix=f"{prefix}.mlp",
+                prefix=f"{prefix}.block_sparse_moe",
             )
             self.mlp = self.block_sparse_moe
         else:


### PR DESCRIPTION
## Purpose
This PR purpose is to add prefix to shared_experts params and correct block_sparse_moe prefix from "mlp" to "block_sparse_moe", which ultimately allows vllm to initiate layer names correctly as e.g., `layers.1.block_sparse_moe.shared_experts.down_proj` instead of `layers.1.mlp.down_proj` (layer 1 does not have mlp.down_proj).

Not initiating names correctly as its state_dict leads to e.g.,:
`KeyError: layers.1.block_sparse_moe.shared_experts.down_proj`
as the it can not match the block_sparse_moe.shared_experts modules to AWQ quantization config.

The error occurs with this [AWQ model](https://huggingface.co/cyankiwi/Kimi-Linear-48B-A3B-Instruct-AWQ-4bit) quant.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
