### PR TITLE
[CI] Introduce autorun_on_main feature

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -25,6 +25,7 @@
 #     and $$BUILDKITE_PARALLEL_JOB_COUNT environment variables.
 # working_dir(str): specify the place where the command should execute, default to /vllm-workspace/tests
 # source_file_dependencies(list): the list of prefixes to opt-in the test for, if empty, the test will always run.
+# autorun_on_main (bool): default to false, if true, the test will run automatically when commit is pushed to main branch.
 
 # When adding a test
 # - If the test belongs to an existing group, add it there
@@ -606,6 +607,7 @@ steps:
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization
+  autorun_on_main: true
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt --tp-size=1
 
@@ -939,7 +941,7 @@ steps:
     # this runner has 2 GPUs available even though num_gpus=2 is not set
     - pytest -v -s tests/compile/test_fusion_all_reduce.py
     # Limit to Inductor partition, no custom ops, and allreduce & attn fusion to reduce running time
-    # Wrap with quotes to escape yaml 
+    # Wrap with quotes to escape yaml
     - "pytest -v -s tests/compile/test_fusions_e2e.py::test_tp2_attn_quant_allreduce_rmsnorm -k 'True and Llama-3.1 and -quant_fp8 and -rms_norm'"
 
 - label: Blackwell Fusion E2E Tests # 30 min


### PR DESCRIPTION
## Purpose

Corresponding PR on vllm-project/ci-infra - https://github.com/vllm-project/ci-infra/pull/200

This PR adds `autorun_on_main: true` into test `label: LM Eval Small Models` ~~`label: LM Eval Large Models (H100)`~~. As explained from PR on ci-infra side, we want to maintain limited/heavy tests to guard the trunk health at some degree. 

> The goal of this PR is to add a new feature - if a test/label has autorun_on_main as True AND the PR has been merged into main, then the corresponding test/label will run automatically (so no need to manually click to unblock).

> The hope of the feature is adding some selected tests/labels to run automatically on PR to maintain trunk health. Some alternatives could be (1) merge queue, (2) new symbol other than ready. I am open to alternative, but it could change user experience a bit.

For any tests on broad to autorun_on_main, it will likely increase the CI cost. Please keep this in mind.


## Test Plan

CI

## Test Result

https://buildkite.com/vllm/ci/builds/38581/steps/canvas?sid=019a7696-a611-4e2f-8ce6-d0b873f4f5fa

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

