### PR TITLE
[WIP][CI/Build] Fix AMD structured outputs tests OOM

### DIFF
--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -601,6 +601,9 @@ Make the response as short as possible.
                     f"Invalid function call format: {generated_text!r}\nError: {str(e)}"
                 )
 
+    if current_platform.is_rocm():
+        cleanup_dist_env_and_memory()
+
 
 @pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
@@ -681,6 +684,9 @@ def test_structured_output_with_reasoning_matrices(
     output_json = json.loads(content)
     jsonschema.validate(instance=output_json, schema=reasoning_schema)
 
+    if current_platform.is_rocm():
+        cleanup_dist_env_and_memory()
+
 
 @pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize("model_name, tokenizer_mode", PARAMS_MODELS_TOKENIZER_MODE)
@@ -727,6 +733,9 @@ def test_structured_output_auto_mode(
         # Parse to verify it is valid JSON
         parsed_json = json.loads(generated_text)
         assert isinstance(parsed_json, dict)
+
+    if current_platform.is_rocm():
+        cleanup_dist_env_and_memory()
 
 
 @pytest.mark.skip_global_cleanup
@@ -786,6 +795,9 @@ def test_guidance_no_additional_properties():
     assert "a4" not in generated
     assert "a5" not in generated
     assert "a6" not in generated
+
+    if current_platform.is_rocm():
+        cleanup_dist_env_and_memory()
 
 
 @pytest.mark.parametrize("backend", ["guidance", "xgrammar", "outlines"])

--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -602,6 +602,8 @@ Make the response as short as possible.
                 )
 
     if current_platform.is_rocm():
+        del llm
+        torch.cuda.empty_cache()
         cleanup_dist_env_and_memory()
 
 
@@ -685,6 +687,8 @@ def test_structured_output_with_reasoning_matrices(
     jsonschema.validate(instance=output_json, schema=reasoning_schema)
 
     if current_platform.is_rocm():
+        del llm
+        torch.cuda.empty_cache()
         cleanup_dist_env_and_memory()
 
 
@@ -735,6 +739,8 @@ def test_structured_output_auto_mode(
         assert isinstance(parsed_json, dict)
 
     if current_platform.is_rocm():
+        del llm
+        torch.cuda.empty_cache()
         cleanup_dist_env_and_memory()
 
 
@@ -797,6 +803,8 @@ def test_guidance_no_additional_properties():
     assert "a6" not in generated
 
     if current_platform.is_rocm():
+        del llm
+        torch.cuda.empty_cache()
         cleanup_dist_env_and_memory()
 
 
@@ -848,11 +856,10 @@ def test_structured_output_batched_with_non_structured_outputs_requests(
 
     assert outputs is not None
 
-    # Free memory as soon as possible as failed assertions
-    # will short circuit and not free up memory
-    del llm
-    torch.cuda.empty_cache()
-    cleanup_dist_env_and_memory()
+    if current_platform.is_rocm():
+        del llm
+        torch.cuda.empty_cache()
+        cleanup_dist_env_and_memory()
 
     for index, output in enumerate(outputs):
         assert output is not None


### PR DESCRIPTION
## Purpose
More details in https://github.com/vllm-project/vllm/issues/27844.

Structured outputs tests were added in  https://github.com/vllm-project/vllm/pull/12388 with `@pytest.mark.skip_global_cleanup` to speed up testing time, however this is causing tests OOMs on AMD CI specifically. ([example](https://buildkite.com/vllm/amd-ci/builds/736#019a3390-9acd-43ae-9496-9deeed1db4d8)) 
```

2025-10-30 05:48:54 UTC | (EngineCore_DP0 pid=3997) ERROR 10-30 05:48:54 [core.py:779]     self.driver_worker.init_device()
-- | --
  | 2025-10-30 05:48:54 UTC | (EngineCore_DP0 pid=3997) ERROR 10-30 05:48:54 [core.py:779]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/worker_base.py", line 308, in init_device
  | 2025-10-30 05:48:54 UTC | (EngineCore_DP0 pid=3997) ERROR 10-30 05:48:54 [core.py:779]     self.worker.init_device()  # type: ignore
  | 2025-10-30 05:48:54 UTC | (EngineCore_DP0 pid=3997) ERROR 10-30 05:48:54 [core.py:779]     ^^^^^^^^^^^^^^^^^^^^^^^^^
  | 2025-10-30 05:48:54 UTC | (EngineCore_DP0 pid=3997) ERROR 10-30 05:48:54 [core.py:779]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 207, in init_device
  | 2025-10-30 05:48:54 UTC | (EngineCore_DP0 pid=3997) ERROR 10-30 05:48:54 [core.py:779]     raise ValueError(
  | 2025-10-30 05:48:54 UTC | (EngineCore_DP0 pid=3997) ERROR 10-30 05:48:54 [core.py:779] ValueError: Free memory on device (24.92/255.98 GiB) on startup is less than desired GPU memory utilization (0.9, 230.39 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.
```

As for a short term mitigation, we will call `cleanup_dist_env_and_memory` if these tests are running on AMD.

## Test Plan
```
 pytest -v -s tests/v1/entrypoints/llm/test_struct_output_generate.py
...
================================================================== warnings summary ==================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-xgrammar-auto-None]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-guidance-auto-None]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-lm-format-enforcer-auto-None]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-outlines-auto-speculative_config6]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-guidance-auto-speculative_config7]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output_auto_mode[mistralai/Ministral-8B-Instruct-2410-auto]
  /data/users/zhewenli/gitrepos/vllm-fork/vllm/transformers_utils/tokenizer.py:287: FutureWarning: It is strongly recommended to run mistral models with `--tokenizer-mode "mistral"` to ensure correct encoding and decoding.
    return get_tokenizer(

tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output_with_structural_tag[xgrammar]
  /data/users/zhewenli/gitrepos/vllm-fork/tests/v1/entrypoints/llm/test_struct_output_generate.py:902: DeprecationWarning: guided_decoding is deprecated. This will be removed in v0.12.0 or v1.0.0, which ever is soonest. Please use structured_outputs instead.
    },

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 20 passed, 9 warnings in 1123.22s (0:18:43) =====================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
---
TODO
CI still OOM
CI: https://buildkite.com/vllm/amd-ci/builds/774