### PR TITLE
feat(benchmarks): support HF model names in multi-turn benchmark

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -1429,8 +1429,6 @@ async def main() -> None:
     random.seed(args.seed)
     np.random.seed(args.seed)
 
-    if not os.path.exists(args.model):
-        raise OSError(f"Path does not exist: {args.model}")
     logger.info("Loading tokenizer")
     tokenizer = AutoTokenizer.from_pretrained(args.model)
 


### PR DESCRIPTION
## Summary

This PR enables `benchmark_serving_multi_turn.py` to accept HuggingFace model names directly (e.g., `meta-llama/Llama-2-7b-hf`), in addition to local file paths.

## Problem

Previously, the script would fail when given a HuggingFace model name:

```bash
python benchmark_serving_multi_turn.py --model meta-llama/Llama-2-7b-hf ...
# Error: OSError: Path does not exist: meta-llama/Llama-2-7b-hf
```

## Solution

Remove the path validation check and let `AutoTokenizer.from_pretrained()` handle both local paths and HuggingFace model names. This is safe because AutoTokenizer already provides clear, informative error messages for invalid inputs.

## Changes

```diff
- if not os.path.exists(args.model):
-     raise OSError(f"Path does not exist: {args.model}")
  logger.info("Loading tokenizer")
  tokenizer = AutoTokenizer.from_pretrained(args.model)
```

## AutoTokenizer Error Messages

Testing shows that AutoTokenizer provides excellent error messages for all invalid inputs:

**Non-existent absolute path:**
```
Error: HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/nonexistent/model/path'
```

**Non-existent relative path:**
```
Error: HFValidationError: Repo id must use alphanumeric chars, '-', '_' or '.': './nonexistent_model'
```

**Non-existent simple name:**
```
Error: OSError: nonexistent_model is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
```

**Invalid HuggingFace model name:**
```
Error: OSError: invalid/model-name-12345 is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
```

These error messages clearly distinguish between local paths and HuggingFace model names, making additional validation unnecessary.

## Testing

This change can be tested with:

```bash
# With HuggingFace model name (now works)
python benchmarks/multi_turn/benchmark_serving_multi_turn.py \
  --model meta-llama/Llama-2-7b-hf \
  --input-file input.json \
  --url http://localhost:8000

# With local path (still works as before)
python benchmarks/multi_turn/benchmark_serving_multi_turn.py \
  --model /path/to/local/model \
  --input-file input.json \
  --url http://localhost:8000
```
