### PR TITLE
[Bugfix] Avoid too small block m/n for FlexAttention kernel option

### DIFF
--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -896,6 +896,8 @@ def get_kernel_options(
         return kernel_options
     else:
         preferred_block = 32 if query.dtype == torch.float32 else 64
+        block_lower_bound = 16
+
         block_m_candidate = ensure_divisible(preferred_block, block_m)
         block_n_candidate = ensure_divisible(preferred_block, block_n)
 
@@ -910,8 +912,8 @@ def get_kernel_options(
                     max(1, block_n_candidate // 2), block_n
                 )
 
-        block_m_candidate = max(block_m_candidate, block_m)
-        block_n_candidate = max(block_n_candidate, block_n)
+        block_m_candidate = max(block_m_candidate, block_lower_bound)
+        block_n_candidate = max(block_n_candidate, block_lower_bound)
 
         kernel_options["BLOCK_M"] = block_m_candidate
         kernel_options["BLOCK_N"] = block_n_candidate

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -910,6 +910,9 @@ def get_kernel_options(
                     max(1, block_n_candidate // 2), block_n
                 )
 
+        block_m_candidate = max(block_m_candidate, block_m)
+        block_n_candidate = max(block_n_candidate, block_n)
+
         kernel_options["BLOCK_M"] = block_m_candidate
         kernel_options["BLOCK_N"] = block_n_candidate
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix #27724
- Current `get_kernel_options` can cause too small BLOCK_M/BLOCK_N (BLOCK_M=8), which broke some encoder-only models. 

## Test Plan
```
pytest -s -v tests/models/language/pooling_mteb_test/test_jina.py -k test_embed_models_mteb[model_info0]
```

## Test Result
Failed test should pass now.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

