### PR TITLE
[BugFix] Don’t compute reorder threshold when there are no attention groups

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4149,6 +4149,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             group.get_metadata_builder().reorder_batch_threshold
             for group in self._attn_group_iterator()
         ]
+        # If there are no attention groups (attention-free model) or no backend
+        # reports a threshold, leave reordering disabled.
+        if len(reorder_batch_thresholds) == 0:
+            self.reorder_batch_threshold = None
+            return
         self.reorder_batch_threshold = reduce(min_none_high, reorder_batch_thresholds)
 
     def _find_compatible_block_sizes(


### PR DESCRIPTION

## Purpose

This PR fixes a startup crash in the v1 runtime for attention‑free models (e.g., Terratorch) introduced after #27809. The engine unconditionally computed the batch reorder threshold even when no attention backends were created, leading to:
```
TypeError: reduce() of empty iterable with no initial value
```
from the nightly run (https://buildkite.com/vllm/ci/builds/37041/steps/canvas?sid=019a386d-1b25-4c07-9a9b-085c1e07ea05, https://buildkite.com/vllm/ci/builds/37041/steps/canvas?sid=019a386d-1b26-4f42-b55f-f0125da20368)

This PR (1) skip the calculation when there are no attention groups, and (2) make calculate_reorder_batch_threshold() defensive by resolving an empty list to None.

## Test Plan

CI

## Test Result

Basic Models Tests (Extra Initialization) 1 + Basic Models Tests (Extra Initialization) 2
https://buildkite.com/vllm/ci/builds/37052/steps/canvas?sid=019a3901-5ee6-45ba-bace-2ccb858b53a1
Basic Models Tests (Initialization)
https://buildkite.com/vllm/ci/builds/37052/steps/canvas?sid=019a3901-5ee5-48b7-ac1d-0cf8db1b054d

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

