### PR TITLE
[Bugfix][Hybrid] Index misalignment in mamba_mixer2

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -733,8 +733,10 @@ class MambaMixer2(MambaBase, CustomOp):
                     ]
 
                     # Number of blocks that need to be written
-                    n_blocks_to_fill = (
-                        block_idx_last_scheduled_token - block_idx_first_scheduled_token
+                    n_blocks_to_fill = (  # noqa: E501
+                        block_idx_last_scheduled_token
+                        - block_idx_first_scheduled_token
+                        + 1
                     )
 
                     # Skip sequences that don't have any blocks to fill
@@ -742,9 +744,10 @@ class MambaMixer2(MambaBase, CustomOp):
                         continue
 
                     # Look up the state indices
-                    cache_blocks_to_fill = state_indices_tensor_p[
+                    cache_blocks_to_fill = state_indices_tensor_p[  # noqa: E501
                         seq_idx,
-                        block_idx_first_scheduled_token:block_idx_last_scheduled_token,
+                        block_idx_first_scheduled_token : block_idx_last_scheduled_token
+                        + 1,
                     ]
 
                     # First chunk index for this sequence
@@ -754,7 +757,7 @@ class MambaMixer2(MambaBase, CustomOp):
                         first_chunk = 1 + last_chunk_indices_p[seq_idx - 1]
 
                     # First chunk that is aligned on the mamba block boundary
-                    first_aligned_chunk = first_chunk + chunk_stride - 1
+                    first_aligned_chunk = first_chunk
 
                     # Calculate the number of computed tokens that were not
                     # already cached


### PR DESCRIPTION
## Purpose
While working on #27813  , I found the index misalignment in `cache_blocks_to_fill` in the prefix caching enablement in mamba_mixer2.py. I didn't go into ssm state further, so the `first_aligned_chunk` line update could be a stopgap.

@heheda12345 

## Test Plan
```
from vllm import LLM, SamplingParams
from vllm.distributed import cleanup_dist_env_and_memory
import time
MODEL = "ibm-granite/granite-4.0-tiny-preview"
PROMPT_MULTIPLE = 310
sampling_params = SamplingParams(temperature=0.0)
prefix = ( # examples/offline_inference/prefix_caching.py
    "You are an expert school principal, skilled in effectively managing "
    "faculty and staff. Draft 10-15 questions for a potential first grade "
    "Head Teacher for my K-12, all-girls', independent school that emphasizes "
    "community, joyful discovery, and life-long learning. The candidate is "
    "coming in for a first-round panel interview for a 8th grade Math "
    "teaching role. They have 5 years of previous teaching experience "
    "as an assistant teacher at a co-ed, public school with experience "
    "in middle school math teaching. ")
prefix2 = ("Based on these information, fulfill "
            "the following paragraph: ")
prompt = PROMPT_MULTIPLE * prefix + prefix2 + "Hello, my name is"
print('Prompt length:', len(prompt))
for APC in [False, True]:
    engine = LLM(model=MODEL, enable_prefix_caching=APC, 
        gpu_memory_utilization=0.8, max_model_len=40000, disable_log_stats=False)  
    for i in range(3):
        if i == 0:
            print('Warm-up')
        if i == 1:
            print('Measuring')
            start_time = time.time()
        outputs = engine.generate(prompt, sampling_params)
        print('APC:', APC, i, f"Generated text: {outputs[0].outputs[0].text!r}")
        for m in engine.llm_engine.get_metrics():
            if 'vllm:prefix_cache_hits' in m.name:
                print(m.name, m.value)
    print('APC:', APC, "loop took --- %s seconds ---" % (time.time() - start_time))
    del engine
    cleanup_dist_env_and_memory()
```
## Test Result
- before
```
Cache block to fill:  tensor([593, 594, 595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607],  # the last index not captured
Cache block to fill:  tensor([609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623], device='cuda:0', dtype=torch.int32)
```
- after
```
Cache block to fill:  tensor([593, 594, 595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608],
Cache block to fill:  tensor([609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624], device='cuda:0', dtype=torch.int32)
```