### PR TITLE
[Perf] Support stream interval for reducing host overhead

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -145,7 +145,7 @@ class SchedulerConfig:
     stream_interval: int = Field(default=1, ge=1)
     """The interval (or buffer size) for streaming in terms of token length.
     A smaller value (1) makes streaming smoother by sending each token immediately,
-    while a larger value (e.g., 10) reduces host overhead and increases throughput
+    while a larger value (e.g., 10) reduces host overhead and may increase throughput
     by batching multiple tokens before sending."""
 
     def get_scheduler_cls(self) -> type["SchedulerInterface"]:

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -142,6 +142,12 @@ class SchedulerConfig:
     speculative decoding and pipeline parallelism.
     """
 
+    stream_interval: int = Field(default=1, ge=1)
+    """The interval (or buffer size) for streaming in terms of token length.
+    A smaller value (1) makes streaming smoother by sending each token immediately,
+    while a larger value (e.g., 10) reduces host overhead and increases throughput
+    by batching multiple tokens before sending."""
+
     def get_scheduler_cls(self) -> type["SchedulerInterface"]:
         if self.scheduler_cls is None:
             if self.async_scheduling:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -558,6 +558,8 @@ class EngineArgs:
 
     async_scheduling: bool | None = SchedulerConfig.async_scheduling
 
+    stream_interval: int = SchedulerConfig.stream_interval
+
     kv_sharing_fast_prefill: bool = CacheConfig.kv_sharing_fast_prefill
 
     kv_offloading_size: float | None = CacheConfig.kv_offloading_size
@@ -1067,6 +1069,9 @@ class EngineArgs:
         scheduler_group.add_argument(
             "--async-scheduling", **scheduler_kwargs["async_scheduling"]
         )
+        scheduler_group.add_argument(
+            "--stream-interval", **scheduler_kwargs["stream_interval"]
+        )
 
         # Compilation arguments
         compilation_kwargs = get_kwargs(CompilationConfig)
@@ -1562,6 +1567,7 @@ class EngineArgs:
             long_prefill_token_threshold=self.long_prefill_token_threshold,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
+            stream_interval=self.stream_interval,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -120,8 +120,9 @@ class AsyncLLM(EngineClient):
         )
 
         # OutputProcessor (converts EngineCoreOutputs --> RequestOutput).
+        stream_interval = self.vllm_config.scheduler_config.stream_interval
         self.output_processor = OutputProcessor(
-            self.tokenizer, log_stats=self.log_stats
+            self.tokenizer, log_stats=self.log_stats, stream_interval=stream_interval
         )
         endpoint = self.observability_config.otlp_traces_endpoint
         if endpoint is not None:

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -96,8 +96,9 @@ class LLMEngine:
         )
 
         # OutputProcessor (convert EngineCoreOutputs --> RequestOutput).
+        stream_interval = self.vllm_config.scheduler_config.stream_interval
         self.output_processor = OutputProcessor(
-            self.tokenizer, log_stats=self.log_stats
+            self.tokenizer, log_stats=self.log_stats, stream_interval=stream_interval
         )
         endpoint = self.observability_config.otlp_traces_endpoint
         if endpoint is not None:

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 
 import torch
 
-from vllm.logger import init_logger
 from vllm.outputs import (
     CompletionOutput,
     PoolingOutput,
@@ -29,8 +28,6 @@ from vllm.v1.metrics.stats import (
     RequestStateStats,
     SchedulerStats,
 )
-
-logger = init_logger(__name__)
 
 
 class RequestOutputCollector:

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -217,7 +217,7 @@ class RequestState:
 
         if self.stream_interval > 1:
             assert self.detokenizer is not None
-    
+
             # Send output request only when
             # 1. It has finished, or
             # 2. It is the first token, or
@@ -229,7 +229,7 @@ class RequestState:
                 >= self.stream_interval
             ):
                 return None
-    
+
             if self.output_kind == RequestOutputKind.DELTA:
                 # Send tokens from the offset in DELTA mode, otherwise all
                 # tokens are sent.
@@ -244,7 +244,7 @@ class RequestState:
                 request_id, [self._new_pooling_output(pooling_output)], finished
             )
 
-        output = self._new_completion_output(tokens_to_send, finish_reason, stop_reason)
+        output = self._new_completion_output(new_token_ids, finish_reason, stop_reason)
 
         if self.parent_req is None:
             outputs = [output]


### PR DESCRIPTION
## Purpose

Support `--stream-interval <num_of_tokens>`. The flag will buffer a number of tokens for a single request before sending back to client. The buffering can reduce the time needed to send responses back to clients, thereby saving host overhead like network/IO.

cc @benchislett @pavanimajety @nvpohanh 

## Testing with `openai/gpt-oss-20b`:
B200 server cmd:
```
VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1 \
vllm serve openai/gpt-oss-20b \
--kv-cache-dtype fp8 \
--tensor-parallel-size 1 \
--max-num-seqs 1024 \
--max-model-len 10240 \
--max-num-batched-tokens 8192 \
--max-cudagraph-capture-size 2048 \
-O.pass_config.enable_noop=True \
--async-scheduling \
--no-enable-prefix-caching
```

## Accuracy Test
```
OPENAI_API_KEY="test" \
python -m gpt_oss.evals \
--sampler chat_completions \
--model openai/gpt-oss-20b \
--reasoning-effort medium \
--n-threads 512 \
--eval aime25
```
Without `--stream-interval`(by default is set to `1`):
```
[{'eval_name': 'aime25', 'model_name': 'gpt-oss-20b-medium_temp1.0_20251031_095139', 'metric': 0.7083333333333334}]
```
With `--stream-interval 10`:
```
[{'eval_name': 'aime25', 'model_name': 'gpt-oss-20b-medium_temp1.0_20251031_150201', 'metric': 0.7291666666666666}]
```

## Perf Test
```
vllm bench serve \
--model openai/gpt-oss-20b \
--trust-remote-code \
--dataset-name random \
--ignore-eos \
--max-concurrency 1024 \
--num-prompts 5120 \
--random-input-len 1024 \
--random-output-len 1024
```
Without `--stream-interval`(by default is set to `1`):
```
============ Serving Benchmark Result ============
Successful requests:                     5120
Failed requests:                         0
Maximum request concurrency:             1024
Benchmark duration (s):                  153.85
Total input tokens:                      5242880
Total generated tokens:                  5242880
Request throughput (req/s):              33.28
Output token throughput (tok/s):         34078.85
Peak output token throughput (tok/s):    42240.00
Peak concurrent requests:                1554.00
Total Token throughput (tok/s):          68157.70
---------------Time to First Token----------------
Mean TTFT (ms):                          2698.80
Median TTFT (ms):                        2300.56
P99 TTFT (ms):                           6826.32
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.16
Median TPOT (ms):                        27.40
P99 TPOT (ms):                           28.57
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.41
Median ITL (ms):                         25.22
P99 ITL (ms):                            89.70
==================================================
```
With `--stream-interval 10`: **57% e2e perf gain**
```
============ Serving Benchmark Result ============
Successful requests:                     5120
Failed requests:                         0
Maximum request concurrency:             1024
Benchmark duration (s):                  98.17
Total input tokens:                      5242880
Total generated tokens:                  5242880
Request throughput (req/s):              52.15
Output token throughput (tok/s):         53403.94
Peak output token throughput (tok/s):    8216.00
Peak concurrent requests:                1180.00
Total Token throughput (tok/s):          106807.88
---------------Time to First Token----------------
Mean TTFT (ms):                          1002.64
Median TTFT (ms):                        262.37
P99 TTFT (ms):                           6749.87
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.09
Median TPOT (ms):                        18.68
P99 TPOT (ms):                           18.85
---------------Inter-token Latency----------------
Mean ITL (ms):                           179.65
Median ITL (ms):                         137.12
P99 ITL (ms):                            512.61
==================================================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

