### PR TITLE
[Bugfix] Allow 64-bit integer values for LoRA IDs to avoid overflow/truncation

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -204,7 +204,7 @@ class InputBatch:
         self.num_accepted_tokens_cpu = self.num_accepted_tokens_cpu_tensor.numpy()
 
         # lora related
-        self.request_lora_mapping = np.zeros((self.max_num_reqs,), dtype=np.int32)
+        self.request_lora_mapping = np.zeros((self.max_num_reqs,), dtype=np.int64)
         self.lora_id_to_request_ids: dict[int, set[str]] = {}
         self.lora_id_to_lora_request: dict[int, LoRARequest] = {}
 

--- a/vllm/v1/worker/tpu_input_batch.py
+++ b/vllm/v1/worker/tpu_input_batch.py
@@ -139,7 +139,7 @@ class InputBatch:
         self.min_tokens: dict[int, tuple[int, set[int]]] = {}
 
         # lora related
-        self.request_lora_mapping = np.zeros((self.max_num_reqs,), dtype=np.int32)
+        self.request_lora_mapping = np.zeros((self.max_num_reqs,), dtype=np.int64)
         self.lora_id_to_request_ids: dict[int, set[str]] = {}
         self.lora_id_to_lora_request: dict[int, LoRARequest] = {}
 


### PR DESCRIPTION
## Purpose
`LoRARequest.lora_int_id` is currently just clamped to > 0, but inside `InputBatch`, the backing store that maps this ID is an `ndarray` of type `np.int32`. However, both in the docs and in the `FilesystemResolver` LoRA resolver, the built-in `hash` function is used to generate this ID.

`hash` returns a `Py_sssize_t` value (64-bits on 64-bit builds of Python), and this gets truncated and interpreted as an `np.int32` when added to `InputBatch.request_lora_mapping`, creating a mismatch. This corrupted value gets propagated through the pipeline until it hits a code path (`vllm.lora.punicia_wrapper.util.convert_mapping`) where the existence of the (correct/untruncated) LoRA ID in this mapping is a precondition, leading to an `IndexError`.

Since `InputBatch` is only initialized once per worker and the size of the mapping is bounded, increasing the data width of the mapping to `np.int64` should have minimal impact on memory usage while being backward-compatible with the usage of `hash` in the codebase and elsewhere.

One could theoretically pass an `int` larger than 64-bits, but this corner case will raise an error on the `numpy`/CPython side as the internal, non-wrapping/truncating conversion to the C `long` POD will fail.

## Test Plan
CI

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

