### PR TITLE
[Bug] Batch invariant: Fix flash attn MLA `RuntimeError: scheduler_metadata must have shape (metadata_size)`

### DIFF
--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
+import functools
 import os
 from collections import namedtuple
 from collections.abc import Callable
@@ -846,6 +847,7 @@ def get_batch_invariant_attention_block_size() -> AttentionBlockSize:
     return AttentionBlockSize(block_m=16, block_n=16)
 
 
+@functools.cache
 def vllm_is_batch_invariant():
     env_key = "VLLM_BATCH_INVARIANT"
     is_overridden = False

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -163,6 +163,9 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
             # we only set num_splits when using cuda graphs.
             max_num_splits = self.max_num_splits
 
+        if vllm_is_batch_invariant():
+            max_num_splits = 1
+
         scheduler_metadata = self._schedule_decode(
             num_reqs=seq_lens_cpu.numel(),
             cu_query_lens=query_start_loc_device,
@@ -187,9 +190,6 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
             # output buffer.
             self.scheduler_metadata[n:] = 0
             scheduler_metadata = self.scheduler_metadata[:n]
-
-        if vllm_is_batch_invariant():
-            max_num_splits = 1
 
         metadata = FlashAttnMLADecodeMetadata(
             block_table=block_table_tensor,


### PR DESCRIPTION
## Purpose

```bash
export VLLM_BATCH_INVARIANT=1
vllm serve deepseek-ai/DeepSeek-V3 -tp 8  --enable-expert-parallel --port 9256
vllm bench serve --model deepseek-ai/DeepSeek-V3  --dataset-name random --host 127.0.0.1 --port 9256 --random-input-len 4 --random-output-len 64 --request-rate inf --num-prompts 256
```

will trigger error:

```bash
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]     return self._op(*args, **kwargs)
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]            ^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]   File "/home/yewentao256/vllm-source/vllm/attention/layer.py", line 1055, in unified_mla_attention_with_output
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]     self.impl.forward(
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]   File "/home/yewentao256/vllm-source/vllm/v1/attention/backends/mla/common.py", line 2024, in forward
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]     attn_out, lse = self._forward_decode(
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]                     ^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]   File "/home/yewentao256/vllm-source/vllm/v1/attention/backends/mla/flashattn_mla.py", line 289, in _forward_decode
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]     attn_out = flash_attn_varlen_func(
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]                ^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]   File "/home/yewentao256/vllm-source/vllm/vllm_flash_attn/flash_attn_interface.py", line 261, in flash_attn_varlen_func
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]     out, softmax_lse, _, _ = torch.ops._vllm_fa3_C.fwd(
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]   File "/home/yewentao256/.venv/lib64/python3.12/site-packages/torch/_ops.py", line 1255, in __call__
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]     return self._op(*args, **kwargs)
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703]            ^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(Worker_TP4_EP4 pid=4005888)^[[0;0m ERROR 10-31 00:28:52 [multiproc_executor.py:703] RuntimeError: scheduler_metadata must have shape (metadata_size)
```

This is caused from we set `split_k` after `_schedule_decode`, this PR fixes the issue

## Test

```bash
export VLLM_BATCH_INVARIANT=1
vllm serve deepseek-ai/DeepSeek-V3 -tp 8  --enable-expert-parallel --port 9256
vllm bench serve --model deepseek-ai/DeepSeek-V3  --dataset-name random --host 127.0.0.1 --port 9256 --random-input-len 4 --random-output-len 64 --request-rate inf --num-prompts 256
```

The command works now without error

```bash
^[[1;36m(APIServer pid=4012508)^[[0;0m INFO:     127.0.0.1:39292 - "POST /v1/completions HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=4012508)^[[0;0m INFO:     127.0.0.1:39296 - "POST /v1/completions HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=4012508)^[[0;0m INFO:     127.0.0.1:39310 - "POST /v1/completions HTTP/1.1" 200 OK
...
```