### PR TITLE
fix incorrect type annotation in KimiMLP

### DIFF
--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -22,7 +22,6 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
-    QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -61,7 +60,7 @@ class KimiMLP(nn.Module):
         hidden_size: int,
         intermediate_size: int,
         hidden_act: str,
-        quant_config: QKVParallelLinear | None = None,
+        quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
         prefix: str = "",
     ) -> None:


### PR DESCRIPTION
Description:
## Summary
Fixed incorrect type annotation for `quant_config` parameter in `KimiMLP.__init__()`.

## Changes
- Changed `quant_config` type from `QKVParallelLinear | None` to `QuantizationConfig | None`
- Removed unused `QKVParallelLinear` import

## Impact
Type-only change, no runtime behavior affected.