### PR TITLE
[CI/Build] Skip spec decode tests using Triton backend 

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -304,7 +304,7 @@ steps:
 
 - label: V1 Test e2e + engine # 30min
   timeout_in_minutes: 45
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:
@@ -372,7 +372,7 @@ steps:
 - label: Examples Test # 30min
   timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental, amdproduction]
-  agent_pool: mi325_1
+  agent_pool: mi325_2
   # grade: Blocking
   working_dir: "/vllm-workspace/examples"
   source_file_dependencies:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -312,21 +312,21 @@ steps:
     - tests/v1
   commands:
     # Run v1/e2e tests without AITER, excluding spec_decode tests
-    - pytest -v -s v1/e2e --ignore=v1/e2e/test_spec_decode.py
+    # - pytest -v -s v1/e2e --ignore=v1/e2e/test_spec_decode.py
     - pytest -v -s v1/engine
 
-- label: V1 Test spec_decode with AITER # 15min
-  timeout_in_minutes: 25
-  mirror_hardwares: [amdexperimental, amdproduction]
-  agent_pool: mi325_1
-  # grade: Blocking
-  source_file_dependencies:
-    - vllm/
-    - tests/v1/e2e/test_spec_decode.py
-  commands:
-    # Spec decode tests require AITER FA for ROCm
-    # See: https://github.com/vllm-project/vllm/issues/27619
-    - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/e2e/test_spec_decode.py
+# - label: V1 Test spec_decode with AITER # 15min
+#   timeout_in_minutes: 25
+#   mirror_hardwares: [amdexperimental, amdproduction]
+#   agent_pool: mi325_1
+#   # grade: Blocking
+#   source_file_dependencies:
+#     - vllm/
+#     - tests/v1/e2e/test_spec_decode.py
+#   commands:
+#     # Spec decode tests require AITER FA for ROCm
+#     # See: https://github.com/vllm-project/vllm/issues/27619
+#     - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/e2e/test_spec_decode.py
 
 - label: V1 Test entrypoints # 35min
   timeout_in_minutes: 50

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -302,7 +302,7 @@ steps:
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization
 
-- label: V1 Test e2e + engine # 30min
+- label: V1 Test e2e (excluding spec_decode) + engine # 30min
   timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
@@ -311,10 +311,22 @@ steps:
     - vllm/
     - tests/v1
   commands:
-    # TODO: accuracy does not match, whether setting
-    # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
-    - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/e2e
+    # Run v1/e2e tests without AITER, excluding spec_decode tests
+    - pytest -v -s v1/e2e --ignore=v1/e2e/test_spec_decode.py
     - pytest -v -s v1/engine
+
+- label: V1 Test spec_decode with AITER # 15min
+  timeout_in_minutes: 25
+  mirror_hardwares: [amdexperimental, amdproduction]
+  agent_pool: mi325_1
+  # grade: Blocking
+  source_file_dependencies:
+    - vllm/
+    - tests/v1/e2e/test_spec_decode.py
+  commands:
+    # Spec decode tests require AITER FA for ROCm
+    # See: https://github.com/vllm-project/vllm/issues/27619
+    - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/e2e/test_spec_decode.py
 
 - label: V1 Test entrypoints # 35min
   timeout_in_minutes: 50

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -304,7 +304,7 @@ steps:
 
 - label: V1 Test e2e + engine # 30min
   timeout_in_minutes: 45
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:
@@ -329,7 +329,7 @@ steps:
 
 - label: V1 Test others # 42min
   timeout_in_minutes: 60
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental,amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:
@@ -371,7 +371,7 @@ steps:
 
 - label: Examples Test # 30min
   timeout_in_minutes: 45
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   working_dir: "/vllm-workspace/examples"
@@ -394,9 +394,10 @@ steps:
     - python3 offline_inference/basic/classify.py
     - python3 offline_inference/basic/embed.py
     - python3 offline_inference/basic/score.py
-    - python3 offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
+    # Use AITER FA to test spec decode until triton attention is fixed: https://github.com/vllm-project/vllm/issues/27619
+    - VLLM_ROCM_USE_AITER=1 python3 offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
     # https://github.com/vllm-project/vllm/pull/26682 uses slightly more memory in PyTorch 2.9+ causing this test to OOM in 1xL4 GPU
-    - python3 offline_inference/spec_decode.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
+    - VLLM_ROCM_USE_AITER=1 python3 offline_inference/spec_decode.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
     #- python3 offline_inference/spec_decode.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
 
 - label: Platform Tests (CUDA) # 4min

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -313,7 +313,7 @@ steps:
   commands:
     # TODO: accuracy does not match, whether setting
     # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
-    - pytest -v -s v1/e2e
+    - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/e2e
     - pytest -v -s v1/engine
 
 - label: V1 Test entrypoints # 35min
@@ -372,7 +372,7 @@ steps:
 - label: Examples Test # 30min
   timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental, amdproduction]
-  agent_pool: mi325_2
+  agent_pool: mi325_1
   # grade: Blocking
   working_dir: "/vllm-workspace/examples"
   source_file_dependencies:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -304,7 +304,7 @@ steps:
 
 - label: V1 Test e2e + engine # 30min
   timeout_in_minutes: 45
-  mirror_hardwares: [amdexperimental, amdproduction]
+  mirror_hardwares: [amdexperimental]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:
@@ -329,7 +329,7 @@ steps:
 
 - label: V1 Test others # 42min
   timeout_in_minutes: 60
-  mirror_hardwares: [amdexperimental,amdproduction]
+  mirror_hardwares: [amdexperimental]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:
@@ -390,10 +390,11 @@ steps:
     - python3 offline_inference/vision_language_pooling.py --seed 0
     - python3 offline_inference/vision_language_multi_image.py --seed 0
     - python3 others/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 others/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
-    - python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
     - python3 offline_inference/basic/classify.py
-    - python3 offline_inference/basic/embed.py
-    - python3 offline_inference/basic/score.py
+    # Encoder-decoder and encoder-only models are not supported on AMD yet: https://github.com/vllm-project/vllm/issues/27442
+    # - python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
+    # - python3 offline_inference/basic/embed.py
+    # - python3 offline_inference/basic/score.py
     # Use AITER FA to test spec decode until triton attention is fixed: https://github.com/vllm-project/vllm/issues/27619
     - VLLM_ROCM_USE_AITER=1 python3 offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
     # https://github.com/vllm-project/vllm/pull/26682 uses slightly more memory in PyTorch 2.9+ causing this test to OOM in 1xL4 GPU

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -367,6 +367,11 @@ def test_eagle_correctness(
             "TREE_ATTN is flaky in the test disable for now until it can be "
             "resolved (see https://github.com/vllm-project/vllm/issues/22922)"
         )
+    if attn_backend == "TRITON_ATTN":
+        pytest.skip(
+            "TRITON_ATTN has illegal memory access issue in the test disable for now "
+            "until it can be resolved (see https://github.com/vllm-project/vllm/issues/27619)"
+        )
 
     # Generate test prompts inside the function instead of using fixture
     test_prompts = get_test_prompts(mm_enabled)
@@ -384,12 +389,6 @@ def test_eagle_correctness(
         else:
             m.setenv("VLLM_MLA_DISABLE", "1")
             m.setenv("VLLM_ATTENTION_BACKEND", attn_backend)
-
-        if attn_backend == "TRITON_ATTN" and not current_platform.is_rocm():
-            pytest.skip(
-                "TRITON_ATTN does not support "
-                "multi-token eagle spec decode on current platform"
-            )
 
         if attn_backend == "FLASH_ATTN" and current_platform.is_rocm():
             m.setenv("VLLM_ROCM_USE_AITER", "1")

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -331,7 +331,7 @@ def test_speculators_model_integration(
             True,
             marks=large_gpu_mark(min_gb=80),
         ),  # works on 4x H100
-        (
+        pytest.param(
             (
                 "eagle",
                 "eagle618/deepseek-v3-random",
@@ -340,6 +340,11 @@ def test_speculators_model_integration(
             ),
             False,
             False,
+            marks=pytest.mark.skipif(
+                current_platform.is_rocm(),
+                reason="DeepSeek head_dim=192 not supported by "
+                "AiterFlashAttention on ROCm",
+            ),
         ),
     ],
     ids=[
@@ -444,7 +449,15 @@ def test_eagle_correctness(
     ["model_setup", "mm_enabled"],
     [
         (("mtp", "XiaomiMiMo/MiMo-7B-Base", 1), False),
-        (("mtp", "ZixiQi/DeepSeek-V3-4layers-MTP-FP8", 1), False),
+        pytest.param(
+            ("mtp", "ZixiQi/DeepSeek-V3-4layers-MTP-FP8", 1),
+            False,
+            marks=pytest.mark.skipif(
+                current_platform.is_rocm(),
+                reason="DeepSeek head_dim=192 not supported by "
+                "AiterFlashAttention on ROCm",
+            ),
+        ),
     ],
     ids=["mimo", "deepseek"],
 )

--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -426,10 +426,10 @@ def test_load_model(
 def test_propose(method, attn_backend, num_speculative_tokens, monkeypatch):
     monkeypatch.setenv("VLLM_ATTENTION_BACKEND", attn_backend)
 
-    if attn_backend == "TRITON_ATTN" and not current_platform.is_rocm():
+    if attn_backend == "TRITON_ATTN":
         pytest.skip(
-            "TRITON_ATTN does not support "
-            "multi-token eagle spec decode on current platform"
+            "TRITON_ATTN has illegal memory access issue in the test disable for now "
+            "until it can be  resolved (see https://github.com/vllm-project/vllm/issues/27619)"
         )
 
     if attn_backend == "TREE_ATTN":


### PR DESCRIPTION
## Purpose
More details in https://github.com/vllm-project/vllm/issues/27619. 

EAGLE speculative decoding is failing on AMD GPUs with a `HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION` error. The error occurs immediately when processing prompts starts, after successful CUDA graph capturing. 
It can be reproduced with spec decode + EAGLE + Triton Attention Backend(default for AMD), example:
```
python3 offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
```

## Error Details
```
:0:rocdevice.cpp:3675: Callback: Queue 0x7f4db0300000 aborting with error:
HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION: The agent attempted to access memory beyond the largest legal address. code: 0x29
```

(using a different backend could work: eg. `ROCM_AITER_FA`, `ROCM_AITER_UNIFIED_ATTN`, but `TritonAttentionBackend` is the **default**  attention backend for AMD: [gist:fb8bbb2cbde391905d86908ca4a46c02](https://gist.github.com/zhewenl/fb8bbb2cbde391905d86908ca4a46c02))

## Test Plan
```
 pytest -v -s tests/v1/e2e/test_spec_decode.py::test_eagle_correctness
```
CI: https://buildkite.com/vllm/amd-ci/builds/814


