### PR TITLE
[Feature] Add MetaShufflingMoE as Optional MoE backend to Llama4 models

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -218,6 +218,8 @@ if TYPE_CHECKING:
     VLLM_USE_FBGEMM: bool = False
     VLLM_GC_DEBUG: str = ""
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
+    VLLM_USE_META_SHUFFLING_MOE: bool = False
+    VLLM_META_SHUFFLING_GEMM_BACKEND: Literal["cutlass", "triton"] = "cutlass"
 
 
 def get_default_cache_root():
@@ -1408,6 +1410,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: os.getenv(
         "VLLM_DISABLE_SHARED_EXPERTS_STREAM", False
     ),
+    "VLLM_USE_META_SHUFFLING_MOE": lambda: bool(
+        int(os.getenv("VLLM_USE_META_SHUFFLING_MOE", "0"))
+    ),
+    "VLLM_META_SHUFFLING_GEMM_BACKEND": env_with_choices(
+        "VLLM_META_SHUFFLING_GEMM_BACKEND", "cutlass", ["cutlass", "triton"]
+    ),
 }
 
 # --8<-- [end:env-vars-definition]
@@ -1534,6 +1542,7 @@ def compute_hash() -> str:
         "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE",
         "VLLM_DEEPEP_LOW_LATENCY_ALLOW_NVLINK",
         "VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL",
+        "VLLM_META_SHUFFLING_GEMM_BACKEND",
     ]
     for key in environment_variables_to_hash:
         # if this goes out of sync with environment_variables,

--- a/vllm/model_executor/layers/meta_shuffling_moe/__init__.py
+++ b/vllm/model_executor/layers/meta_shuffling_moe/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from vllm.model_executor.layers.meta_shuffling_moe.meta_shuffling_moe import (
+    MetaShufflingMoE,
+)
+
+__all__ = ["MetaShufflingMoE"]

--- a/vllm/model_executor/layers/meta_shuffling_moe/dispatch_combine.py
+++ b/vllm/model_executor/layers/meta_shuffling_moe/dispatch_combine.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass
+
+import torch
+
+import vllm.envs as envs
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_fbgemm_gpu_gen_ai
+
+if current_platform.is_cuda_alike() and has_fbgemm_gpu_gen_ai():
+    from fbgemm_gpu.experimental.gen_ai.moe import (
+        gather_scale_dense_tokens,
+        scatter_add_dense_tokens,
+    )
+
+
+@dataclass
+class RouteInfo:
+    expert_indices: torch.Tensor
+    token_counts: torch.Tensor
+    token_indices: torch.Tensor
+    num_routed_tokens: torch.Tensor
+    num_recv_tokens: torch.Tensor | None = None
+    recv_sizes_across_ranks: torch.Tensor | None = None
+    recv_sizes_across_ranks_cpu: torch.Tensor | None = None
+    send_sizes_across_ranks: torch.Tensor | None = None
+    send_sizes_across_ranks_cpu: torch.Tensor | None = None
+
+
+# Skeleton code to prepare for enabling EP.
+# In TP only case, dispatch/combine are almost no-ops.
+class MetaShufflingDispatchAndCombine:
+    """
+    Dispatch/Combine using Meta Shuffling kernels.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "instance"):
+            cls.instance = super().__new__(cls)
+            cls.instance._initialized = False
+        return cls.instance
+
+    def __init__(self) -> None:
+        if self._initialized:
+            return
+        self.world_size = 1
+        assert current_platform.is_cuda_alike() and has_fbgemm_gpu_gen_ai()
+        self._initialized: bool = True
+
+    def dispatch(
+        self,
+        tokens: torch.Tensor,  # tokens
+        route_info: RouteInfo,
+        scores: torch.Tensor,  # scores,
+        apply_router_weight_on_input: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if apply_router_weight_on_input:
+            tokens = gather_scale_dense_tokens(
+                tokens,
+                route_info.token_indices.flatten(),
+                route_info.expert_indices.flatten(),
+                scores,
+                valid_token_count=route_info.num_routed_tokens,
+            )
+        assert self.world_size == 1
+        return tokens, route_info.token_counts
+
+    def combine(
+        self,
+        routed_out: torch.Tensor,
+        route_info: RouteInfo,
+        scores: torch.Tensor,
+        shared_out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert self.world_size == 1
+        if envs.VLLM_META_SHUFFLING_GEMM_BACKEND == "cutlass":
+            scatter_add_dense_tokens(
+                out_tokens=shared_out,
+                in_tokens=routed_out,
+                token_indices=route_info.token_indices,
+                valid_token_count=route_info.num_routed_tokens,
+            )
+            return shared_out
+        # Assume in TP only case, we have already produced
+        # fused output from routed and shared by calling
+        # grouped_gemm with shared output when using triton grouped_gemm.
+        else:
+            return routed_out

--- a/vllm/model_executor/layers/meta_shuffling_moe/meta_shuffling_moe.py
+++ b/vllm/model_executor/layers/meta_shuffling_moe/meta_shuffling_moe.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+import vllm.envs as envs
+from vllm.config import get_current_vllm_config
+from vllm.distributed import get_dp_group, get_tensor_model_parallel_world_size
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+)
+from vllm.model_executor.layers.fused_moe.layer import (
+    FusedMoE,
+    UnquantizedFusedMoEMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_fbgemm_gpu_gen_ai
+
+from .dispatch_combine import MetaShufflingDispatchAndCombine, RouteInfo
+from .routed_experts import MetaShufflingMoERoutedExperts
+
+if current_platform.is_cuda_alike() and has_fbgemm_gpu_gen_ai():
+    from fbgemm_gpu.experimental.gen_ai.moe import index_shuffling
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+# We only need the weight loader from unquantized fused moe method.
+class MetaShufflingMoEMethod(UnquantizedFusedMoEMethod):
+    def __init__(
+        self,
+        moe: FusedMoEConfig,
+        quant_config: QuantizationConfig | None = None,
+    ):
+        super().__init__(moe)
+        self.quant_config = quant_config
+
+    # Override to no ops.
+    def init_prepare_finalize(self, layer: torch.nn.Module):
+        assert self.moe is not None
+
+
+class MetaShufflingMoE(FusedMoE):
+    def __init__(
+        self,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        prefix: str,
+        quant_config: QuantizationConfig | None = None,
+        shared_experts: torch.nn.Module | None = None,
+        scoring_func: str = "softmax",
+        apply_router_weight_on_input: bool = False,
+        activation: str = "silu",
+        is_sequence_parallel: bool = False,
+        **kwargs,
+    ):
+        CustomOp.__init__(self)
+
+        logger.info_once("Initialized with MetaShufflingMoE")
+
+        assert current_platform.is_cuda_alike(), (
+            "MetaShufflingMoE only supports CUDA and AMD for now."
+        )
+        assert has_fbgemm_gpu_gen_ai(), (
+            "MetaShufflingMoE requires fbgemm_gpu_gen_ai. \
+            Run pip install fbgemm-gpu-genai"
+        )
+
+        params_dtype = kwargs.get("params_dtype", torch.get_default_dtype())
+        tp_size_ = kwargs.get("tp_size", get_tensor_model_parallel_world_size())
+        dp_size_ = kwargs.get("dp_size", get_dp_group().world_size)
+        assert not is_sequence_parallel, "Sequence parallel is not supported yet."
+        # Parallelism
+        vllm_config = get_current_vllm_config()
+        self.moe_parallel_config: FusedMoEParallelConfig = FusedMoEParallelConfig.make(
+            tp_size_=tp_size_,
+            dp_size_=dp_size_,
+            vllm_parallel_config=vllm_config.parallel_config,
+        )
+        etp_size_ = 1 if self.use_ep else tp_size_
+        assert not self.use_ep, "Ep is not supported yet."
+        self.tp2ep_size = tp_size_ // etp_size_
+        self.dp2ep = self.ep_size // self.tp2ep_size
+        assert self.dp2ep == dp_size_, "Doesn't support dp > dp2ep yet"
+
+        # Determine expert maps
+        assert num_experts % self.ep_size == 0, (
+            "Does not support duplicate experts for now."
+        )
+        self.global_num_experts = num_experts
+        self.local_num_experts = self.global_num_experts
+        self.group_expert_start = 0
+        self.group_expert_end = self.global_num_experts
+        self.experts_mask = torch.arange(
+            self.group_expert_start, self.group_expert_end, device="cuda"
+        ).view(-1, 1, 1)
+        self.local_num_experts, self.expert_map, self.expert_mask = (
+            self.global_num_experts,
+            None,
+            None,
+        )
+
+        # Layer setup
+        # TODO: Most of the weights loading logic is
+        # similar to base fused_moe. We should probably refactor
+        # the code so that common shared logic can be shared.
+        compilation_config = vllm_config.compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError("Duplicate layer name: {}".format(prefix))
+        compilation_config.static_forward_context[prefix] = self
+        self.layer_name = prefix
+
+        assert intermediate_size % self.tp_size == 0
+        self.hidden_size = hidden_size
+        self.intermediate_size_per_partition = intermediate_size // self.tp_size
+        self.scoring_func = scoring_func
+        self.apply_router_weight_on_input = apply_router_weight_on_input
+        assert self.apply_router_weight_on_input, (
+            "Only support apply_router_weight_on_input=True for now."
+        )
+        self.activation = activation
+        self.top_k = top_k
+
+        if vllm_config.model_config is not None:
+            model_dtype = vllm_config.model_config.dtype
+        else:
+            # TODO (bnell): This is a hack to get test_mixtral_moe to work
+            # since model_config is not set in the pytest test.
+            model_dtype = params_dtype
+
+        moe = FusedMoEConfig(
+            num_experts=self.global_num_experts,
+            experts_per_token=top_k,
+            hidden_dim=hidden_size,
+            num_local_experts=self.local_num_experts,
+            moe_parallel_config=self.moe_parallel_config,
+            in_dtype=model_dtype,
+            max_num_tokens=envs.VLLM_MOE_DP_CHUNK_SIZE,
+            has_bias=False,
+        )
+        self.moe_config = moe
+
+        self.is_routed_fp8_rowwise: bool = False
+        assert quant_config is None, "Quantization is not supported yet."
+        self.quant_config = quant_config
+
+        # Note: get_quant_method will look at the layer's local_num_experts
+        # for heuristic purposes, so it must be initialized first.
+        self.quant_method = MetaShufflingMoEMethod(moe, quant_config=quant_config)
+
+        moe_quant_params = {
+            "num_experts": self.local_num_experts,
+            "hidden_size": hidden_size,
+            "intermediate_size_per_partition": self.intermediate_size_per_partition,
+            "params_dtype": params_dtype,
+            "weight_loader": self.weight_loader,
+        }
+        # need full intermediate size pre-sharding for WNA16 act order
+        if self.quant_method.__class__.__name__ in (
+            "GPTQMarlinMoEMethod",
+            "CompressedTensorsWNA16MarlinMoEMethod",
+            "CompressedTensorsWNA16MoEMethod",
+        ):
+            moe_quant_params["intermediate_size_full"] = intermediate_size
+
+        self.quant_method.create_weights(layer=self, **moe_quant_params)
+
+        self._shared_experts = shared_experts
+        self.dispatch_and_combine = MetaShufflingDispatchAndCombine()
+        self.routed_experts = MetaShufflingMoERoutedExperts(
+            quant_config=self.quant_config
+        )
+
+    @property
+    def shared_experts(self) -> torch.nn.Module | None:
+        return self._shared_experts
+
+    def route(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, RouteInfo]:
+        assert self.scoring_func == "sigmoid", (
+            "only support sigmoid scoring function for now "
+        )
+        if self.scoring_func == "sigmoid":
+            scores = torch.sigmoid(router_logits.to(torch.float32))
+        top_k = self.moe_config.experts_per_token
+        if top_k in {1, 2, 4} and self.global_num_experts in {16, 128}:
+            token_counts, expert_indices, token_indices = index_shuffling(
+                scores,  # num_tokens
+                self.group_expert_start,
+                self.group_expert_end,
+                top_k=top_k,
+            )
+            num_routed_tokens = token_counts[-1]
+            token_counts = token_counts[self.group_expert_start : self.group_expert_end]
+        else:
+            # Slow route using torch topk.
+            _, global_selected_indices = torch.topk(scores, top_k, dim=1)
+            expert_indices, token_indices = torch.sort(
+                global_selected_indices.flatten(), dim=0, stable=True
+            )
+            token_indices = token_indices // top_k
+            mask = self.experts_mask == expert_indices
+            token_counts = (mask).sum(dim=2, dtype=torch.int32).flatten()
+            num_routed_tokens = token_counts.sum().view(
+                -1,
+            )
+        return scores, RouteInfo(
+            expert_indices=expert_indices,
+            token_indices=token_indices,
+            token_counts=token_counts,
+            num_routed_tokens=num_routed_tokens,
+        )
+
+    def forward_impl(
+        self, hidden_states: torch.Tensor, router_logits: torch.Tensor
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        scores, route_info = self.route(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
+        shuffled_recv_tokens, recv_token_counts = self.dispatch_and_combine.dispatch(
+            tokens=hidden_states,
+            scores=scores,
+            route_info=route_info,
+            apply_router_weight_on_input=self.apply_router_weight_on_input,
+        )
+        # TODO: add using separate streams for shared experts when there's comms.
+        if self._shared_experts is not None:
+            shared_out = self._shared_experts(hidden_states)
+        else:
+            # This is so that we can call scatter_add_dense_tokens
+            # without shared_experts.
+            shared_out = torch.zeros_like(hidden_states)
+
+        routed_out = self.routed_experts.run(
+            x=shuffled_recv_tokens,
+            token_counts=recv_token_counts,
+            w1=self.w13_weight.data,
+            w2=self.w2_weight.data,
+            activation=self.activation,
+            scores=scores,
+            apply_router_weight_on_input=self.apply_router_weight_on_input,
+            num_valid_tokens=route_info.num_recv_tokens,
+            shared_out=shared_out if not self.use_ep else None,
+            token_indices=route_info.token_indices if not self.use_ep else None,
+        )
+
+        output = self.dispatch_and_combine.combine(
+            routed_out=routed_out,
+            shared_out=shared_out,
+            route_info=route_info,
+            scores=scores,
+        )
+        output = output.view(hidden_states.shape)
+        if shared_out is None:
+            return output
+        else:
+            # create a fake shared_output as moe_forward_shared expect to return a tuple
+            return torch.empty_like(output), output

--- a/vllm/model_executor/layers/meta_shuffling_moe/routed_experts.py
+++ b/vllm/model_executor/layers/meta_shuffling_moe/routed_experts.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+import vllm.envs as envs
+from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_fbgemm_gpu_gen_ai
+
+if current_platform.is_cuda_alike() and has_fbgemm_gpu_gen_ai():
+    from fbgemm_gpu.experimental.gen_ai.moe import grouped_gemm, silu_mul
+
+
+class MetaShufflingMoERoutedExperts:
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "instance"):
+            cls.instance = super().__new__(cls)
+            cls.instance._initialized = False
+        return cls.instance
+
+    def __init__(
+        self,
+        quant_config: FusedMoEQuantConfig | None,
+    ) -> None:
+        if self._initialized:
+            return
+        self.quant_config = quant_config
+        self._initialized: bool = True
+
+    @staticmethod
+    def _apply_activation(
+        activation: str,
+        x0: torch.Tensor,
+        x1: torch.Tensor,
+        valid_count: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if activation == "silu":
+            return silu_mul(x0, x1, valid_token_count=valid_count)
+        else:
+            raise ValueError(f"Unsupported FusedMoe activation: {activation}")
+
+    def run(
+        self,
+        x: torch.Tensor,
+        token_counts: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        activation: str,
+        scores: torch.Tensor,  # scores,
+        apply_router_weight_on_input: bool,
+        num_valid_tokens: torch.Tensor | None = None,
+        shared_out: torch.Tensor | None = None,
+        token_indices: torch.Tensor | None = None,
+    ):
+        if x.shape[0] == 0:
+            return x
+        D = x.shape[-1]
+        assert w1.shape[-1] == x.shape[-1]
+        HD_L = w2.shape[-1]
+        if envs.VLLM_META_SHUFFLING_GEMM_BACKEND == "cutlass":
+            token_counts = token_counts.to(torch.int64)
+            y = torch.ops.fbgemm.bf16bf16bf16_grouped_stacked(x, w1, token_counts)
+        else:
+            y = grouped_gemm(
+                x,
+                w1.view(-1, D),
+                token_counts,
+                use_fast_accum=True,
+                _use_warp_specialization=False,
+            )
+
+        # TODO: Add support for scores multiplication after gemm
+        z = self._apply_activation(
+            activation, y[:, :HD_L], y[:, HD_L:], valid_count=num_valid_tokens
+        )
+
+        if envs.VLLM_META_SHUFFLING_GEMM_BACKEND == "cutlass":
+            out = torch.ops.fbgemm.bf16bf16bf16_grouped_stacked(z, w2, token_counts)
+        else:
+            out = grouped_gemm(
+                z,
+                w2.view(-1, HD_L),
+                token_counts,
+                use_fast_accum=True,
+                _use_warp_specialization=False,
+                _output_tensor=shared_out,
+                _scatter_add_indices=token_indices,
+            )
+
+        return out

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -403,3 +403,8 @@ def has_triton_kernels() -> bool:
 def has_tilelang() -> bool:
     """Whether the optional `tilelang` package is available."""
     return _has_module("tilelang")
+
+
+def has_fbgemm_gpu_gen_ai() -> bool:
+    """Whether the optional `fbgemm-gpu-genai` package is available."""
+    return _has_module("fbgemm_gpu.experimental.gen_ai")


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Add MetaShufflingMoE as an Optional MoE backend for Llama4 models.
This PR adds only the TP support for bf16 models. It has basic skeleton code to prepare for future support of EP and fp8 models.

MetaShufflingMoE shows better TTFT performance at 1k and 2k input len 


--request-rate 4 --random-input-len 1024 --random-output-len 128 --num-prompts 1000
--

Serving Benchmark Result | Fused MoE | MetaShuffling MoE cutlass grouped gemm |   | MetaShuffling MoE triton grouped gemm |  
-- | -- | -- | -- | -- | --
Successful requests | 1000 | 1000 |   | 1000 |  
Failed requests | 0 | 0 |   | 0 |  
Request rate configured (RPS) | 4 | 4 |   | 4 |  
Benchmark duration (s) | 251.21 | 251.1 |   | 251.15 |  
Total input tokens | 1023000 | 1023000 |   | 1023000 |  
Total generated tokens | 115584 | 115798 |   | 115586 |  
Request throughput (req/s) | 3.98 | 3.98 |   | 3.98 |  
Output token throughput (tok/s) | 460.1 | 461.16 |   | 460.22 |  
Peak output token throughput (tok/s) | 988 | 1018 |   | 1048 |  
Peak concurrent requests | 25 | 26 |   | 25 |  
Total Token throughput (tok/s) | 4532.34 | 4535.18 |   | 4533.43 |  
---------------Time to First Token---------------- |   |   |   |   |  
Mean TTFT (ms) | 78.29 | 69.2 | -11.61% | 71.68 | -8.44%
Median TTFT (ms) | 74.84 | 66.12 | -11.65% | 69.01 | -7.79%
P99 TTFT (ms) | 118.97 | 107.02 | -10.04% | 108.11 | -9.13%
-----Time per Output Token (excl. 1st token)------ |   |   |   |   |  
Mean TPOT (ms) | 14.66 | 14.22 | -3.00% | 14.2 | -3.14%
Median TPOT (ms) | 14.63 | 14.21 | -2.87% | 14.26 | -2.53%
P99 TPOT (ms) | 19.6 | 18.61 | -5.05% | 19.07 | -2.70%
---------------Inter-token Latency---------------- |   |   |   |   |  
Mean ITL (ms) | 14.66 | 14.22 | -3.00% | 14.18 | -3.27%
Median ITL (ms) | 11.89 | 11.86 | -0.25% | 11.81 | -0.67%
P99 ITL (ms) | 56.53 | 49.5 | -12.44% | 51.87 | -8.24%


--request-rate 4 --random-input-len 2048 --random-output-len 128 --num-prompts 1000
--


Serving Benchmark Result | Fused MoE | MetaShuffling MoE cutlass grouped gemm |   | MetaShuffling MoE triton grouped gemm |  
-- | -- | -- | -- | -- | --
Successful requests | 1000 | 1000 |   | 1000 |  
Failed requests | 0 | 0 |   | 0 |  
Request rate configured (RPS) | 4 | 4 |   | 4 |  
Benchmark duration (s) | 251.4 | 251.38 |   | 251.32 |  
Total input tokens | 2047000 | 2047000 |   | 2047000 |  
Total generated tokens | 109075 | 108784 | -0.27% | 108163 |  
Request throughput (req/s) | 3.98 | 3.98 | 0.00% | 3.98 |  
Output token throughput (tok/s) | 433.86 | 432.75 | -0.26% | 430.37 |  
Peak output token throughput (tok/s) | 1018 | 1030 | 1.18% | 1079 |  
Peak concurrent requests | 26 | 24 | -7.69% | 22 |  
Total Token throughput (tok/s) | 8576.12 | 8575.88 | 0.00% | 8575.25 |  
---------------Time to First Token---------------- |   |   |   |   |  
Mean TTFT (ms) | 84.43 | 82.5 | -2.29% | 79.47 | -5.87%
Median TTFT (ms) | 78.56 | 76.59 | -2.51% | 74.12 | -5.65%
P99 TTFT (ms) | 149.37 | 143.42 | -3.98% | 144.85 | -3.03%
-----Time per Output Token (excl. 1st token)------ |   |   |   |   |  
Mean TPOT (ms) | 14.64 | 14.69 | 0.34% | 13.95 | -4.71%
Median TPOT (ms) | 14.49 | 14.47 | -0.14% | 13.78 | -4.90%
P99 TPOT (ms) | 21.56 | 20.61 | -4.41% | 19.34 | -10.30%
---------------Inter-token Latency---------------- |   |   |   |   |  
Mean ITL (ms) | 14.52 | 14.61 | 0.62% | 13.88 | -4.41%
Median ITL (ms) | 11.73 | 11.82 | 0.77% | 11.5 | -1.96%
P99 ITL (ms) | 55.74 | 54.77 | -1.74% | 51.98 | -6.75%


## Test Plan
Running lm_eval 

`HF_HUB_DISABLE_XET=1 with-proxy VLLM_USE_MODELSCOPE=False lm_eval --model vllm --model_args "pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,trust_remote_code=True,tensor_parallel_size=8,max_model_len=32768" --tasks gsm8k --num_fewshot 8 --batch_size 128`

Baseline results 

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9219|±  |0.0074|
|     |       |strict-match    |     8|exact_match|↑  |0.9098|±  |0.0079|

```


## Test Result

Cutlass Backend


`HF_HUB_DISABLE_XET=1 with-proxy VLLM_USE_MODELSCOPE=False VLLM_USE_META_SHUFFLING_MOE=1 lm_eval --model vllm --model_args "pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,trust_remote_code=True,tensor_parallel_size=8,max_model_len=32768" --tasks gsm8k --num_fewshot 8 --batch_size 128 `


```
ResourceWarning: Enable tracemalloc to get the object allocation traceback
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9204|±  |0.0075|
|     |       |strict-match    |     8|exact_match|↑  |0.9105|±  |0.0079|
```

Triton Backend 

`HF_HUB_DISABLE_XET=1 with-proxy VLLM_USE_MODELSCOPE=False VLLM_USE_META_SHUFFLING_MOE=1 VLLM_META_SHUFFLING_GEMM_BACKEND=triton lm_eval --model vllm --model_args "pretrained=meta-llama/Llama-4-Scout-17B-16E-Instruct,trust_remote_code=True,tensor_parallel_size=8,max_model_len=32768" --tasks gsm8k --num_fewshot 8 --batch_size 128`


```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9204|±  |0.0075|
|     |       |strict-match    |     8|exact_match|↑  |0.9105|±  |0.0079|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x ] The test plan, such as providing test command.
- [x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

