### PR TITLE
[Performance][B200] Fix deepgemm prologue

### DIFF
--- a/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
@@ -232,6 +232,7 @@ class BatchedDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
         """
         super().__init__(quant_config)
         assert self.block_shape == get_mk_alignment_for_contiguous_layout()
+        assert self.quant_config.use_fp8_w8a8
         self.max_num_tokens = max_num_tokens
         self.num_dispatchers = num_dispatchers
 
@@ -249,6 +250,12 @@ class BatchedDeepGemmExperts(mk.FusedMoEPermuteExpertsUnpermute):
 
     def supports_expert_map(self) -> bool:
         return False
+
+    def supports_packed_ue8m0_act_scales(self) -> bool:
+        """
+        DeepGemm supports packed ue8m0 activation scales format in devices == sm100
+        """
+        return current_platform.is_device_capability(100)
 
     def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         # Let PrepareAndFinalize::finalize() decide the impl.

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -100,7 +100,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         # We don't have enough information to determine if we should dispatch
         # activation scales in a packed ue8m0 format during object construction
         # time. This setting is handled by post_init_setup.
-        self.use_ue8m0 = False
+        self.use_ue8m0_dispatch = False
 
     def post_init_setup(self, fused_experts: mk.FusedMoEPermuteExpertsUnpermute):
         if not fused_experts.supports_packed_ue8m0_act_scales():
@@ -111,7 +111,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             logger.debug_once(
                 "Update DeepEPLLPrepareFinalize to do packed ue8m0 scales dispatch."
             )
-            self.use_ue8m0 = True
+            self.use_ue8m0_dispatch = True
         else:
             logger.warning_once(
                 "DeepEPLLPrepareAndFinalize is setup to dispatch raw/unquantized "
@@ -233,8 +233,8 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             num_experts,
             use_fp8=self.use_fp8_dispatch,
             # round_scale needs to be set to dispatch in ue8m0
-            round_scale=self.use_ue8m0,
-            use_ue8m0=self.use_ue8m0,
+            round_scale=self.use_ue8m0_dispatch,
+            use_ue8m0=self.use_ue8m0_dispatch,
             async_finish=False,
             return_recv_hook=True,
         )

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -6,6 +6,7 @@ import deep_ep
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate,
@@ -19,6 +20,8 @@ from vllm.v1.worker.ubatching import (
     dbo_enabled,
     dbo_maybe_run_recv_hook,
 )
+
+logger = init_logger(__name__)
 
 # DeepEP kernels quantize dispatch inputs in 128 element chunks.
 DEEPEP_QUANT_BLOCK_SIZE = 128
@@ -93,6 +96,28 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         # combine function.
         self.handles: list[tuple | None] = [None, None]
         self.num_dispatchers_ = num_dispatchers
+
+        # We don't have enough information to determine if we should dispatch
+        # activation scales in a packed ue8m0 format during object construction
+        # time. This setting is handled by setup_packed_ue8m0_scales_dispatch.
+        self.use_ue8m0 = False
+
+    def supports_packed_ue8m0_scales_dispatch(self) -> bool:
+        return True
+
+    def setup_packed_ue8m0_scales_dispatch(self) -> None:
+        if self.use_fp8_dispatch:
+            logger.debug_once(
+                "Update DeepEPLLPrepareFinalize to do packed ue8m0 scales dispatch"
+            )
+            self.use_ue8m0 = True
+        else:
+            logger.warning_once(
+                "Ignoring request to dispatch activation scales in a packed "
+                "ue8m0 format as DeepEPLLPrepareAndFinalize is setup to"
+                "dispatch raw/unquantized activations.",
+                scope="local",
+            )
 
     def num_dispatchers(self) -> int:
         return self.num_dispatchers_
@@ -206,6 +231,9 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             self.max_tokens_per_rank,
             num_experts,
             use_fp8=self.use_fp8_dispatch,
+            # round_scale needs to be set to dispatch in ue8m0
+            round_scale=self.use_ue8m0,
+            use_ue8m0=self.use_ue8m0,
             async_finish=False,
             return_recv_hook=True,
         )

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -347,6 +347,20 @@ class FusedMoEPrepareAndFinalize(ABC):
         """
         raise NotImplementedError
 
+    def supports_packed_ue8m0_scales_dispatch(self) -> bool:
+        """
+        Return true if the implementation can dispatch activation scales in
+        packed ue8m0 format.
+        """
+        return False
+
+    def setup_packed_ue8m0_scales_dispatch(self) -> None:
+        """
+        Setup internal state of the implementation to dispatch activation scales
+        in packed ue8m0 format.
+        """
+        raise NotImplementedError
+
 
 # TODO: add supported activations method (return string)
 class FusedMoEPermuteExpertsUnpermute(ABC):
@@ -502,6 +516,13 @@ class FusedMoEPermuteExpertsUnpermute(ABC):
         A flag indicating whether or not this class supports expert maps
         """
         raise NotImplementedError
+
+    def supports_packed_ue8m0_act_scales(self) -> bool:
+        """
+        A flag indicating whether or not this class can process packed ue8m0
+        activation scales.
+        """
+        return False
 
     def workspace_dtype(self, act_dtype: torch.dtype) -> torch.dtype:
         """
@@ -698,6 +719,8 @@ class FusedMoEModularKernel(torch.nn.Module):
         self.prepare_finalize = prepare_finalize
         self.fused_experts = fused_experts
         self.shared_experts = shared_experts
+
+        self._post_init_setup()
         assert (
             prepare_finalize.activation_format == fused_experts.activation_formats[0]
         ), (
@@ -706,6 +729,17 @@ class FusedMoEModularKernel(torch.nn.Module):
             f"{fused_experts.__class__.__name__}."
             f"{fused_experts.activation_formats[0]}"
         )
+
+    def _post_init_setup(self):
+        """
+        Resolve any leftover setup dependencies between self.prepare_finalize
+        and self.fused_experts here.
+        """
+        if (
+            self.fused_experts.supports_packed_ue8m0_act_scales()
+            and self.prepare_finalize.supports_packed_ue8m0_scales_dispatch()
+        ):
+            self.prepare_finalize.setup_packed_ue8m0_scales_dispatch()
 
     def supports_expert_map(self) -> bool:
         """

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -149,6 +149,15 @@ class FusedMoEPrepareAndFinalize(ABC):
     described above.
     """
 
+    def post_init_setup(self, fused_experts: "FusedMoEPermuteExpertsUnpermute"):
+        """
+        Initialize FusedMoEPrepareAndFinalize settings that depend on
+        FusedMoEPermuteExpertsUnpermute experts object.
+        The FusedMoEPrepareAndFinalize implementations that have such
+        dependencies may choose to override this function.
+        """
+        return
+
     @abstractmethod
     def prepare(
         self,
@@ -344,20 +353,6 @@ class FusedMoEPrepareAndFinalize(ABC):
         """
         Indicates whether or not the output of finalize is reduced across all
         ranks.
-        """
-        raise NotImplementedError
-
-    def supports_packed_ue8m0_scales_dispatch(self) -> bool:
-        """
-        Return true if the implementation can dispatch activation scales in
-        packed ue8m0 format.
-        """
-        return False
-
-    def setup_packed_ue8m0_scales_dispatch(self) -> None:
-        """
-        Setup internal state of the implementation to dispatch activation scales
-        in packed ue8m0 format.
         """
         raise NotImplementedError
 
@@ -735,11 +730,7 @@ class FusedMoEModularKernel(torch.nn.Module):
         Resolve any leftover setup dependencies between self.prepare_finalize
         and self.fused_experts here.
         """
-        if (
-            self.fused_experts.supports_packed_ue8m0_act_scales()
-            and self.prepare_finalize.supports_packed_ue8m0_scales_dispatch()
-        ):
-            self.prepare_finalize.setup_packed_ue8m0_scales_dispatch()
+        self.prepare_finalize.post_init_setup(self.fused_experts)
 
     def supports_expert_map(self) -> bool:
         """

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -973,6 +973,7 @@ def deepgemm_post_process_fp8_weight_block(
 
     return wq, dg_ws
 
+
 def _maybe_pad_fp8_weight(weight: torch.Tensor) -> torch.Tensor:
     """Pad the weight tensor. This is an optimization on ROCm platform, which
     can benefit from tensors located far enough from one another in memory"""
@@ -1194,7 +1195,6 @@ def maybe_post_process_fp8_weight_block(layer: torch.nn.Module):
         )
         layer.weight = torch.nn.Parameter(dg_weight, requires_grad=False)
         layer.weight_scale = torch.nn.Parameter(dg_weight_scale, requires_grad=False)
-
 
 
 def expert_weight_is_col_major(x: torch.Tensor) -> bool:

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -34,6 +34,7 @@ from vllm.utils.deep_gemm import (
     is_deep_gemm_e8m0_used,
     is_deep_gemm_supported,
     should_use_deepgemm_for_fp8_linear,
+    transform_sf_into_required_layout,
 )
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -929,6 +930,49 @@ def requant_weight_ue8m0_inplace(
         s_old.copy_(s_requant)
 
 
+def deepgemm_post_process_fp8_weight_block(
+    wq: torch.Tensor, ws: torch.Tensor, quant_block_shape: tuple[int], use_e8m0: bool
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert wq.dtype == torch.float8_e4m3fn, (
+        "Expected quantized tensor dtype "
+        f"to be torch.float8_e4m3fn, got {wq.dtype} instead."
+    )
+    assert ws.dtype == torch.float32, (
+        f"Expected tensor scales dtype to be torch.float32, got {ws.dtype} instead"
+    )
+
+    if use_e8m0:
+        requant_weight_ue8m0_inplace(wq, ws, block_size=quant_block_shape)
+
+    original_ndim = wq.ndim
+    if wq.ndim == 2:
+        assert ws.ndim == 2
+        wq = wq.unsqueeze(0)
+        ws = ws.unsqueeze(0)
+
+    # From https://github.com/deepseek-ai/DeepGEMM/blob/c9f8b34dcdacc20aa746b786f983492c51072870/csrc/utils/layout.hpp#L46
+    recipe = (1, 128, 128)
+
+    # Ref : https://github.com/deepseek-ai/DeepGEMM/blob/c9f8b34dcdacc20aa746b786f983492c51072870/csrc/apis/gemm.hpp
+    # DeepGemm uses the `transform_sf_into_required_layout` function to
+    # represent scales in the correct format.
+    dg_ws = transform_sf_into_required_layout(
+        sf=ws,
+        mn=wq.size(1),
+        k=wq.size(2),
+        recipe=recipe,
+        num_groups=wq.size(0),
+        # is the scale factors for A in (Refers to the argument A in A @ B).
+        # Weights are B.
+        is_sfa=False,
+    )
+
+    if original_ndim == 2:
+        wq = wq.squeeze(0)
+        dg_ws = dg_ws.squeeze(0)
+
+    return wq, dg_ws
+
 def _maybe_pad_fp8_weight(weight: torch.Tensor) -> torch.Tensor:
     """Pad the weight tensor. This is an optimization on ROCm platform, which
     can benefit from tensors located far enough from one another in memory"""
@@ -1141,11 +1185,16 @@ def maybe_post_process_fp8_weight_block(layer: torch.nn.Module):
     should_use_deepgemm = should_use_deepgemm_for_fp8_linear(
         layer.orig_dtype, layer.weight
     )
-    if is_deep_gemm_e8m0_used() and should_use_deepgemm:
-        block_sz = tuple(layer.weight_block_size)
-        requant_weight_ue8m0_inplace(
-            layer.weight.data, layer.weight_scale.data, block_sz
+    if should_use_deepgemm:
+        dg_weight, dg_weight_scale = deepgemm_post_process_fp8_weight_block(
+            wq=layer.weight.data,
+            ws=layer.weight_scale.data,
+            quant_block_shape=tuple(layer.weight_block_size),
+            use_e8m0=is_deep_gemm_e8m0_used(),
         )
+        layer.weight = torch.nn.Parameter(dg_weight, requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(dg_weight_scale, requires_grad=False)
+
 
 
 def expert_weight_is_col_major(x: torch.Tensor) -> bool:

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -49,10 +49,6 @@ def is_deep_gemm_e8m0_used() -> bool:
         logger.info_once("DeepGEMM E8M0 disabled: _fp8_gemm_nt_impl not found")
         return False
 
-    if envs.VLLM_USE_FLASHINFER_MOE_FP8:
-        logger.info_once("DeepGEMM E8M0 disabled: FlashInfer MOE is enabled.")
-        return False
-
     if envs.VLLM_USE_DEEP_GEMM_E8M0:
         logger.info_once("DeepGEMM E8M0 enabled on current platform.")
         return True
@@ -77,6 +73,7 @@ _fp8_paged_mqa_logits_impl: Callable[..., Any] | None = None
 _get_paged_mqa_logits_metadata_impl: Callable[..., Any] | None = None
 _get_mn_major_tma_aligned_tensor_impl: Callable[..., Any] | None = None
 _get_mk_alignment_for_contiguous_layout_impl: Callable[..., Any] | None = None
+_transform_sf_into_required_layout_impl: Callable[..., Any] | None = None
 
 
 def _lazy_init() -> None:
@@ -86,6 +83,7 @@ def _lazy_init() -> None:
     global _get_paged_mqa_logits_metadata_impl
     global _get_mn_major_tma_aligned_tensor_impl
     global _get_mk_alignment_for_contiguous_layout_impl
+    global _transform_sf_into_required_layout_impl
     # fast path
     if (
         _fp8_gemm_nt_impl is not None
@@ -95,6 +93,7 @@ def _lazy_init() -> None:
         or _fp8_paged_mqa_logits_impl is not None
         or _get_paged_mqa_logits_metadata_impl is not None
         or _get_mk_alignment_for_contiguous_layout_impl is not None
+        or _transform_sf_into_required_layout_impl is not None
     ):
         return
 
@@ -123,6 +122,9 @@ def _lazy_init() -> None:
     )
     _get_mk_alignment_for_contiguous_layout_impl = getattr(
         _dg, "get_mk_alignment_for_contiguous_layout", None
+    )
+    _transform_sf_into_required_layout_impl = getattr(
+        _dg, "transform_sf_into_required_layout", None
     )
 
 
@@ -175,6 +177,15 @@ def fp8_m_grouped_gemm_nt_masked(*args, **kwargs):
     if _grouped_masked_impl is None:
         return _missing(*args, **kwargs)
     return _grouped_masked_impl(
+        *args, disable_ue8m0_cast=not is_deep_gemm_e8m0_used(), **kwargs
+    )
+
+
+def transform_sf_into_required_layout(*args, **kwargs):
+    _lazy_init()
+    if _transform_sf_into_required_layout_impl is None:
+        return _missing(*args, **kwargs)
+    return _transform_sf_into_required_layout_impl(
         *args, disable_ue8m0_cast=not is_deep_gemm_e8m0_used(), **kwargs
     )
 


### PR DESCRIPTION
## Purpose
DeepGEMM requires the activation and weights scales to be in a specific format. When the scales are not provided in the desired format, DeepGEMM transforms the scales itself. This is usually very slow. 

On H100, DeepGEMM needs the scales to be ColumnMajor and in float32. 
On B200, DeepGEMM needs the scales to be ColumnMajor but in a packed E8M0 format. 

Note that we handle the H100 case already on `main`. This PR adds partial support for the B200 case. Concretely, 
 - Import `transform_sf_into_required_layout` from DeepGEMM to perform weight scales transformation. This function handles both SM90 and SM100 internally and can be used commonly. 
 - The DeepEP low latency dispatch supports dispatching the activation scales in packed E8M0 format. This PR enables that. 
 
 `main`:
<img width="2284" height="225" alt="main" src="https://github.com/user-attachments/assets/4881c819-6ee7-4144-8bd1-38238154d10f" />

 `PR`:
<img width="2284" height="225" alt="PR" src="https://github.com/user-attachments/assets/f44ac20a-10d5-45ba-b81a-01d4e1153562" />

## Benchmark

full benchmark numbers - [link](https://docs.google.com/spreadsheets/d/1mpKTZg8v-HTjiBzWTk1dj4jUmibsMYbE8pfEaSMoWPA/edit?usp=sharing) 

server command : `VLLM_ALL2ALL_BACKEND=${A2A} VLLM_USE_DEEP_GEMM=1 canhazgpu run -g2 --  vllm serve Qwen/Qwen3-30B-A3B-FP8 --trust-remote-code --tensor-parallel-size 1 --data-parallel-size 2 --enable-expert-parallel --no-enable-prefix-caching  --port 9010 `

Decode bench command : `vllm bench serve --model Qwen/Qwen3-30B-A3B-FP8 --dataset-name random --num-prompts 128 --random-input-len 1 --random-output-len 1024 --request-rate 128 --ignore-eos --port 9010`

Prefill bench command : ` vllm bench serve --model Qwen/Qwen3-30B-A3B-FP8 --dataset-name random --num-prompts 256 --random-input-len 8192 --random-output-len 1 --request-rate 256 --ignore-eos --port 9010 --backend vllm`

### B200 + deepep_low_latency + decode 
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
  | main | PR
-- | -- | --
Peak output token throughput (tok/s) | 9600 | 12028

### B200 + deepep_high_throughput + prefill 
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
  | main | PR
-- | -- | --
Total Token throughput (tok/s) | 89736.95 | 91310.99

### H100 + deepep_low_latency + decode 
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
  | main | PR
-- | -- | --
Peak output token throughput (tok/s) | 8408 | 8422

### H100 + deepep_high_throughput + prefill
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
  | main | PR
-- | -- | --
Total Token throughput (tok/s) | 73950.14 | 74095.51

## Test Plan

Server command : 
`vllm serve Qwen/Qwen3-30B-A3B-FP8 --trust-remote-code --tensor-parallel-size ${tp_size} --data-parallel-size ${dp_size} --enable-expert-parallel --no-enable-prefix-caching --port 9010`

Server config combinations (`VLLM_ALL2ALL_BACKEND`, `VLLM_USE_DEEP_GEMM`, `dp_size`, `tp_size`) , 
 1. (deepep_low_latency, 1, 2, 1)
 2. (deepep_high_throughput, 1, 2, 1)
 3. (deepep_low_latency, 0, 2, 1) // This PR touches fp8 weight loading when Deepgemm is enabled, this config tests regression
 4. (deepep_high_throughput, 0, 2, 1)
 5. (n/a, 1, 1, 2)
 6. (n/a, 0, 1, 2)
 
lm_eval command : 
```
lm_eval --model local-completions --tasks gsm8k --model_args model=Qwen/Qwen3-30B-A3B-FP8,base_url=http://localhost:9010/v1/completions,num_concurrent=30,max_retries=3 --limit 100
```

## Test Result
lm_eval produces desired results on the PR, on both H100 and B200. 
example of a desired result, 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.87|±  |0.0338|
|     |       |strict-match    |     5|exact_match|↑  | 0.92|±  |0.0273|
```
