### PR TITLE
[BugFix][Performance] Restore flashinfer autotuning for all scenarios

### DIFF
--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -172,21 +172,9 @@ def test_gptoss_mxfp4mxfp8_moe_flashinfer_trtllm(monkeypatch: pytest.MonkeyPatch
     can_initialize("openai/gpt-oss-20b", hf_overrides=HF_OVERRIDE_TEXT)
 
 
-def test_gptoss_dp2_mxfp4mxfp8_moe_flashinfer_trtllm(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8", "1")
-    monkeypatch.setenv("VLLM_ALL2ALL_BACKEND", "deepep_high_throughput")
+def test_gptoss_eager(monkeypatch: pytest.MonkeyPatch):
     can_initialize(
         "openai/gpt-oss-20b",
-        extra_args=["--data-parallel-size", "2", "--enable-expert-parallel"],
         hf_overrides=HF_OVERRIDE_TEXT,
-    )
-
-
-def test_gptoss_dp2_mxfp4bf16_moe_flashinfer_trtllm(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_MXFP4_BF16", "1")
-    monkeypatch.setenv("VLLM_ALL2ALL_BACKEND", "deepep_high_throughput")
-    can_initialize(
-        "openai/gpt-oss-20b",
-        extra_args=["--data-parallel-size", "2", "--enable-expert-parallel"],
-        hf_overrides=HF_OVERRIDE_TEXT,
+        extra_args=["--enforce-eager"],
     )

--- a/vllm/model_executor/layers/fused_moe/trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/trtllm_moe.py
@@ -132,5 +132,11 @@ class TrtLlmGenExperts(mk.FusedMoEPermuteExpertsUnpermute):
 
         from flashinfer import trtllm_fp4_block_scale_routed_moe
 
-        trtllm_fp4_block_scale_routed_moe(**kwargs)
+        from vllm.utils.flashinfer import autotune
+
+        with autotune(False):
+            # Skipping flashinfer auto-tune for this function as the autotuner
+            # throws a "Cannot pack tensors on meta" error.
+            trtllm_fp4_block_scale_routed_moe(**kwargs)
+
         return output

--- a/vllm/model_executor/layers/fused_moe/trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/trtllm_moe.py
@@ -135,8 +135,9 @@ class TrtLlmGenExperts(mk.FusedMoEPermuteExpertsUnpermute):
         from vllm.utils.flashinfer import autotune
 
         with autotune(False):
-            # Skipping flashinfer auto-tune for this function as the autotuner
-            # throws a "Cannot pack tensors on meta" error.
+            # Enable autotune when,
+            # https://github.com/flashinfer-ai/flashinfer/issues/2023 is
+            # resolved.
             trtllm_fp4_block_scale_routed_moe(**kwargs)
 
         return output

--- a/vllm/model_executor/layers/fused_moe/trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/trtllm_moe.py
@@ -127,7 +127,7 @@ class TrtLlmGenExperts(mk.FusedMoEPermuteExpertsUnpermute):
             "routing_method_type": 1,
             "do_finalize": True,
             "output": output,
-            "tune_max_num_tokens": self.max_capture_size,
+            "tune_max_num_tokens": max(self.max_capture_size, 1),
         }
 
         from flashinfer import trtllm_fp4_block_scale_routed_moe

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -1047,7 +1047,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 None,
                 1 if renormalize else 0,  # routing_method_type, renormalize
                 True,  # do finalize
-                tune_max_num_tokens=self.max_capture_size,
+                tune_max_num_tokens=max(self.max_capture_size, 1),
             )[0]
             return trtllm_gen_output
         elif (
@@ -1122,7 +1122,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 tp_rank=self.moe.tp_rank,
                 ep_size=self.moe.ep_size,
                 ep_rank=self.moe.ep_rank,
-                tune_max_num_tokens=self.max_capture_size,
+                tune_max_num_tokens=max(self.max_capture_size, 1),
                 **extra_kwargs,
             )
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 import torch
 
 import vllm.envs as envs
-from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.warmup.deep_gemm_warmup import deep_gemm_warmup
 from vllm.platforms import current_platform
@@ -23,26 +22,6 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
 
 logger = init_logger(__name__)
-
-
-def flashinfer_autotune_supported(vllm_config: VllmConfig) -> bool:
-    """
-    Record known issues with vllm + flashinfer autotune here. Return True if
-    and only if flashinfer autotune will run through without issues.
-    """
-    is_tp_or_dp = (vllm_config.parallel_config.data_parallel_size > 1) or (
-        vllm_config.parallel_config.tensor_parallel_size > 1
-    )
-    is_fi_mxfp4_backend = (
-        envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8
-        or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16
-        or envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS
-    ) or (
-        current_platform.is_cuda() and current_platform.is_device_capability(100)
-    )  # on >=sm100, default mxfp4 backend is flashinfer
-    is_eager = vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
-
-    return not (is_tp_or_dp and is_fi_mxfp4_backend and is_eager)
 
 
 def kernel_warmup(worker: "Worker"):
@@ -58,11 +37,7 @@ def kernel_warmup(worker: "Worker"):
         deep_gemm_warmup(model, max_tokens)
 
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
-    if (
-        has_flashinfer()
-        and current_platform.has_device_capability(90)
-        and flashinfer_autotune_supported(worker.vllm_config)
-    ):
+    if has_flashinfer() and current_platform.has_device_capability(90):
         flashinfer_autotune(worker.model_runner)
 
     # FlashInfer attention warmup


### PR DESCRIPTION
## Purpose

Bug: 
on `main` + B200 : `vllm serve openai/gpt-oss-20b --enforce-eager` fails.
on `main` + H100 : `VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1 vllm serve openai/gpt-oss-20b --enforce-eager` fails.

Both failures are asserts in the flashinfer code base, 
```
(EngineCore_DP0 pid=3490083)   File "/home/varun/code/vllm/vllm/model_executor/layers/quantization/mxfp4.py", line 1109, in apply
(EngineCore_DP0 pid=3490083)     _ = flashinfer_cutlass_fused_moe(
(EngineCore_DP0 pid=3490083)   File "/home/varun/code/vllm/vllm/utils/flashinfer.py", line 84, in wrapper
(EngineCore_DP0 pid=3490083)     return impl(*args, **kwargs)
(EngineCore_DP0 pid=3490083)   File "/home/varun/code/vllm/vllm-test/lib/python3.10/site-packages/flashinfer/fused_moe/core.py", line 790, in cutlass_fused_moe
(EngineCore_DP0 pid=3490083)     return get_cutlass_fused_moe_module(device_arch).cutlass_fused_moe(
(EngineCore_DP0 pid=3490083)   File "/home/varun/code/vllm/vllm-test/lib/python3.10/site-packages/flashinfer/fused_moe/core.py", line 460, in cutlass_fused_moe
(EngineCore_DP0 pid=3490083)     _, gemm_tactic_1 = tuner.choose_one(
(EngineCore_DP0 pid=3490083)   File "/home/varun/code/vllm/vllm-test/lib/python3.10/site-packages/flashinfer/autotuner.py", line 457, in choose_one
(EngineCore_DP0 pid=3490083)     profiles = self._generate_optimization_profiles(tuning_config, inputs)
(EngineCore_DP0 pid=3490083)   File "/home/varun/code/vllm/vllm-test/lib/python3.10/site-packages/flashinfer/autotuner.py", line 643, in _generate_optimization_profiles
(EngineCore_DP0 pid=3490083)     assert len(opt_shapes) > 0, "Empty tuning buckets are not allowed"
(EngineCore_DP0 pid=3490083) AssertionError: Empty tuning buckets are not allowed
```
Note that this is the same error reported in https://github.com/vllm-project/vllm/issues/27751 

Fix: 
Our calls to the flashinfer MoE kernels, set `tune_max_num_tokens` to the CUDAGraph capture size. When CUDAGraph was disabled, `max_capture_size` is set 0 and the autotuner asserts. This PR sets `tune_max_num_tokens` to 1 when CUDAGraphs are disabled (i.e. eager-mode)

Note: 
Initially, this issue was thought to manifest in specific scenarios and we resorted to skipping autotuning for those cases in PRs, https://github.com/vllm-project/vllm/pull/27762 and https://github.com/vllm-project/vllm/pull/26729 . This PR reverts the skip logic introduced in those PRs.

Fixes  https://github.com/vllm-project/vllm/issues/27751 

## Test Plan
manually run `vllm serve openai/gpt-oss-20b --enforce-eager` on B200. 
CI 

## Test Result
Tests Pass 

