### PR TITLE
[CI/Build] Fix flaky test_transcription_validation.py::test_basic_audio_gemma

### DIFF
--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -72,7 +72,9 @@ async def test_basic_audio_gemma(foscolo):
     model_name = "google/gemma-3n-E2B-it"
     server_args = ["--enforce-eager"]
 
-    with RemoteOpenAIServer(model_name, server_args) as remote_server:
+    with RemoteOpenAIServer(
+        model_name, server_args, max_wait_seconds=480
+    ) as remote_server:
         client = remote_server.get_async_client()
         transcription = await client.audio.transcriptions.create(
             model=model_name,


### PR DESCRIPTION
## Purpose

The test was failing intermittently in CI with "RuntimeError: Server failed to start in time." The Gemma model (google/gemma-3n-E2B-it) takes longer than the default 240s timeout to load.

Increased max_wait_seconds to 480s to give the model adequate time to load during CI runs.

Fixes #27576

## Test Plan

This test passed locally for me before, as well as after. The real test will be to see if it flakes less in CI. All the flakes I've personally observed so far were because it just needed more time for this model to load, which is what this PR does.

`pytest -sv tests/entrypoints/openai/test_transcription_validation.py::test_basic_audio_gemma`


