### PR TITLE
[CI/Build] Fix `test_defaults_with_usage_context` in AMD CI

### DIFF
--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -53,8 +53,8 @@ def test_defaults_with_usage_context():
     vllm_config: VllmConfig = engine_args.create_engine_config(UsageContext.LLM_CLASS)
 
     from vllm.platforms import current_platform
+    from vllm.utils.mem_constants import GiB_bytes
 
-    GiB_bytes = 1024**3
     device_memory = current_platform.get_device_total_memory()
     device_name = current_platform.get_device_name().lower()
     if device_memory >= 70 * GiB_bytes and "a100" not in device_name:

--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -54,9 +54,11 @@ def test_defaults_with_usage_context():
 
     from vllm.platforms import current_platform
 
+    GiB_bytes = 1024**3
+    device_memory = current_platform.get_device_total_memory()
     device_name = current_platform.get_device_name().lower()
-    if "h100" in device_name or "h200" in device_name:
-        # For H100 and H200, we use larger default values.
+    if device_memory >= 70 * GiB_bytes and "a100" not in device_name:
+        # For GPUs like H100, H200, and MI300x with >= 70GB memory
         default_llm_tokens = 16384
         default_server_tokens = 8192
         default_max_num_seqs = 1024


### PR DESCRIPTION
## Purpose
Fixes `test_defaults_with_usage_context` test failure on AMD MI300X and other high-memory GPUs by aligning test logic with implementation.
 The test was failing on AMD CI with:
```
  assert 1024 == 256
  AssertionError: max_num_seqs expected 256, got 1024
```
It's becuase est logic didn't match implementation logic for determining default scheduler values in [vllm/engine/arg_utils.py](https://github.com/vllm-project/vllm/blob/685c99ee77b4818dcdd15b30fe0e0eff0d5d22ec/vllm/engine/arg_utils.py#L1862):
```
if device_memory >= 70 * GiB_bytes and "a100" not in device_name:
            # For GPUs like H100 and MI300x, use larger default values.
            default_max_num_batched_tokens = {
                UsageContext.LLM_CLASS: 16384,
                UsageContext.OPENAI_API_SERVER: 8192,
            }
            default_max_num_seqs = {
                UsageContext.LLM_CLASS: 1024,
                UsageContext.OPENAI_API_SERVER: 1024,
            }
```
## Test Plan
```
pytest -v -s tests/v1/engine/test_engine_args.py::test_defaults_with_usage_context
...
tests/v1/engine/test_engine_args.py::test_defaults_with_usage_context INFO 11-01 14:57:37 [model.py:668] Resolved architecture: OPTForCausalLM
INFO 11-01 14:57:37 [model.py:1773] Using max model len 2048
INFO 11-01 14:57:38 [scheduler.py:211] Chunked prefill is enabled with max_num_batched_tokens=16384.
INFO 11-01 14:57:39 [model.py:668] Resolved architecture: OPTForCausalLM
INFO 11-01 14:57:39 [model.py:1773] Using max model len 2048
INFO 11-01 14:57:39 [scheduler.py:211] Chunked prefill is enabled with max_num_batched_tokens=8192.
PASSED

================================================================== warnings summary ==================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 1 passed, 2 warnings in 2.52s ============================================================
```