### PR TITLE
[BUGFIX]:  qwen3-omni handle 0-dim audio input scalar

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -777,7 +777,9 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             hf_inputs["feature_attention_mask"] = [
                 torch.ones(num_frame) for num_frame in audio_num_frames
             ]
-            hf_inputs["audio_feature_lengths"] = torch.tensor(audio_num_frames)
+            hf_inputs["audio_feature_lengths"] = [
+                torch.tensor([num_frame]) for num_frame in audio_num_frames
+            ]
         return hf_inputs
 
     def _maybe_apply_prompt_updates(
@@ -913,7 +915,7 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             audio_output_lengths = []
         elif audio_feature_lengths is not None:
             _, audio_output_lens = _get_feat_extract_output_lengths(
-                audio_feature_lengths
+                audio_feature_lengths.flatten()
             )
             audio_output_lengths = audio_output_lens.tolist()
         elif feature_attention_mask is not None:


### PR DESCRIPTION
single audio input results in 0 dim scalars that will panic on index out of bound in later processing


## Purpose
fix handling of scalars by collecting every audio input in a list

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

