### PR TITLE
[CI/Build] Update LM Eval Version in AMD CI

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -75,7 +75,6 @@ COPY --from=build_vllm ${COMMON_WORKDIR}/vllm /vllm-workspace
 RUN cd /vllm-workspace \
     && rm -rf vllm \
     && python3 -m pip install -e tests/vllm_test_utils \
-    && python3 -m pip install lm-eval[api]==0.4.4 \
     && python3 -m pip install pytest-shard
 
 # -----------------------

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -4,7 +4,7 @@ tblib==3.1.0
 bm25s==0.2.13
 pystemmer==3.0.0
 
-# entrypoints test
+# Entrypoints test
 # librosa==0.10.2.post1 # required by audio tests in entrypoints/openai
 audioread==3.0.1
 cffi==1.17.1
@@ -17,11 +17,11 @@ soundfile==0.13.1
 soxr==0.5.0.post1
 librosa==0.10.2.post1
 
-# entrypoints test
+# Entrypoints test
 #vllm[video] # required by entrypoints/openai/test_video.py
 decord==0.6.0
 
-# entrypoints test
+# Entrypoints test
 #sentence-transformers # required by entrypoints/openai/test_score.py
 sentence-transformers==3.4.1
 
@@ -32,7 +32,10 @@ matplotlib==3.10.3
 blobfile==3.0.0
 
 # Required for openai schema test.
-schemathesis==3.39.15 
+schemathesis==3.39.15
 
-# required for mteb test
-mteb[bm25s]>=1.38.11, <2 
+# Required for mteb test
+mteb[bm25s]>=1.38.11, <2
+
+# Required for eval tests
+lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d


### PR DESCRIPTION
## Purpose
This PR updates lm-eval deps used in the AMD CI to match the version used in [Nvidia](https://github.com/vllm-project/vllm/blob/main/requirements/test.txt#L444). 

## Test Plan

Before this fix, V1 Test others will complain about incompatible failure due to V0 deprecation:
```
/usr/local/lib/python3.12/dist-packages/lm_eval/models/vllm_causallms.py:268: TypeError
    outputs = self.model.generate(
        prompt_token_ids=requests,
        sampling_params=sampling_params,
        use_tqdm=True if self.batch_size == "auto" else False,
    )
E   TypeError: LLM.generate() got an unexpected keyword argument 'prompt_token_ids'
```

After the fix, the issue is gone: https://buildkite.com/vllm/amd-ci/builds/842#019a46a0-7764-4405-bd41-e50e6ceb0505 
