### PR TITLE
[CI/Build] Update checking logic in cutlass_group_gemm_supported 

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -836,7 +836,11 @@ def cutlass_sparse_scaled_mm_supported(cuda_device_capability: int) -> bool:
 
 
 def cutlass_group_gemm_supported(cuda_device_capability: int) -> bool:
-    return torch.ops._C.cutlass_group_gemm_supported(cuda_device_capability)
+    try:
+        return torch.ops._C.cutlass_group_gemm_supported(cuda_device_capability)
+    except AttributeError:
+        # Return False on non-CUDA platforms where it is not available
+        return False
 
 
 def cutlass_sparse_compress(a: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION

## Purpose
This PR updates checking logic `cutlass_group_gemm_supported` used in tests under `tests/kernels/moe`, such that tests can be skipped correctly on platforms where CUTLASS is not supported.

## Test Plan
before: 
```
======================================================================= ERRORS =======================================================================
____________________________________________ ERROR collecting tests/kernels/moe/test_pplx_cutlass_moe.py _____________________________________________
tests/kernels/moe/test_pplx_cutlass_moe.py:278: in <module>
    (lambda x: x is None or not ops.cutlass_group_gemm_supported(x.to_int()))(
tests/kernels/moe/test_pplx_cutlass_moe.py:278: in <lambda>
    (lambda x: x is None or not ops.cutlass_group_gemm_supported(x.to_int()))(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vllm/_custom_ops.py:839: in cutlass_group_gemm_supported
    return torch.ops._C.cutlass_group_gemm_supported(cuda_device_capability)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/zhewenli/uv_env/vllm-fork/lib64/python3.12/site-packages/torch/_ops.py:1353: in __getattr__
    raise AttributeError(
E   AttributeError: '_OpNamespace' '_C' object has no attribute 'cutlass_group_gemm_supported
```
after:
```
pytest -v -s tests/kernels/moe/test_pplx_cutlass_moe.py
...

================================================================== warnings summary ==================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 32 skipped, 2 warnings in 1.49s ===========================================================




