### PR TITLE
[Bugfix][ROCm] Fix AITER attention backend for deepseek-ocr model

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -31,6 +31,9 @@ if current_platform.is_rocm():
     from vllm.triton_utils import tl, triton
     from vllm.utils.torch_utils import direct_register_custom_op
 
+    def next_power_of_2(x: int):
+        return 1 if x == 0 else 2 ** ((x - 1).bit_length())
+
     @triton.jit
     def _vllm_layout_trans_kernel(
         k_buffer_ptr,
@@ -44,6 +47,7 @@ if current_platform.is_rocm():
         k_scale,
         v_scale,
         output_dtype: tl.constexpr,
+        PAD_E_DIM: tl.constexpr,
         E_DIM: tl.constexpr,
         BLOCK_SIZE: tl.constexpr,
     ):
@@ -53,6 +57,8 @@ if current_platform.is_rocm():
         batch_query_indexes = tl.load(b_query_lens_loc + batch_idx + tl.arange(0, 2))
         batch_query_start, batch_query_end = tl.split(batch_query_indexes)
         query_len = batch_query_end - batch_query_start
+
+        valid = tl.arange(0, PAD_E_DIM) < E_DIM
 
         if query_len <= 1:
             return
@@ -73,7 +79,7 @@ if current_platform.is_rocm():
             kv_buffer_off = (
                 kv_idx * BLOCK_SIZE * E_DIM
                 + tl.arange(0, BLOCK_SIZE)[:, None] * E_DIM
-                + tl.arange(0, E_DIM)[None, :]
+                + tl.arange(0, PAD_E_DIM)[valid][None, :]
             )
             k_vals = tl.load(k_buffer_ptr + kv_buffer_off, mask=block_mask, other=0.0)
             if k_vals.dtype.is_fp8():
@@ -90,7 +96,7 @@ if current_platform.is_rocm():
                 batch_token_start * E_DIM
                 + block_idx * BLOCK_SIZE * E_DIM
                 + tl.arange(0, BLOCK_SIZE)[:, None] * E_DIM
-                + tl.arange(0, E_DIM)[None, :]
+                + tl.arange(0, PAD_E_DIM)[valid][None, :]
             )
             tl.store(k_values_ptr + kv_values_off, k_vals, mask=block_mask)
             tl.store(v_values_ptr + kv_values_off, v_vals, mask=block_mask)
@@ -144,6 +150,7 @@ if current_platform.is_rocm():
             v_scale,
             output_dtype=output_dtype,
             E_DIM=H_KV * D,
+            PAD_E_DIM=next_power_of_2(H_KV * D),
             BLOCK_SIZE=BLOCK_SIZE,
         )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR fixes an issue that occurs when running DeepSeek-OCR using the AITER MHA backend.

The error log:

```
(EngineCore_DP0 pid=44307)   File "/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py", line 83, in make_ir
(EngineCore_DP0 pid=44307)     return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
(EngineCore_DP0 pid=44307) triton.compiler.errors.CompilationError: at 42:14:
(EngineCore_DP0 pid=44307)         block_mask = (
(EngineCore_DP0 pid=44307)             block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)[:, None]
(EngineCore_DP0 pid=44307)         ) < seq_len
(EngineCore_DP0 pid=44307) 
(EngineCore_DP0 pid=44307)         kv_idx = tl.load(
(EngineCore_DP0 pid=44307)             block_table + batch_idx * block_table_stride_0 + block_idx
(EngineCore_DP0 pid=44307)         ).to(tl.int64)
(EngineCore_DP0 pid=44307) 
(EngineCore_DP0 pid=44307)         kv_buffer_off = (
(EngineCore_DP0 pid=44307)             kv_idx * BLOCK_SIZE * E_DIM
(EngineCore_DP0 pid=44307)             + tl.arange(0, BLOCK_SIZE)[:, None] * E_DIM
(EngineCore_DP0 pid=44307)             + tl.arange(0, E_DIM)[None, :]
(EngineCore_DP0 pid=44307)               ^
```

This issue occurs because the model uses 10 attention heads, which is not a power of two. The Triton kernel used as a preprocessing step for the KV cache tensor layout fails under these conditions.

This PR resolves the problem by padding `E_DIM` (calculated as v_cache.shape[2] * v_cache.shape[3] , the number of KV heads multiplied by the embedding dimension) to the nearest power of two for use in `tl.arange`.


## Test Plan
Test using offline inference:

`VLLM_ROCM_USE_AITER=1
python3 examples/offline_inference/vision_language_multi_image.py --model-type deepseek_ocr`

## Test Result


"The image contains a lion and a lioness."


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

