### PR TITLE
[Model] fix ernie45 reasoning_parser

### DIFF
--- a/vllm/reasoning/ernie45_reasoning_parser.py
+++ b/vllm/reasoning/ernie45_reasoning_parser.py
@@ -36,8 +36,8 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
         """The token that ends reasoning content."""
         return "</think>"
 
-    def __init__(self, tokenizer: PreTrainedTokenizerBase):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: PreTrainedTokenizerBase, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
 
         if not self.model_tokenizer:
             raise ValueError(


### PR DESCRIPTION
## Purpose
Fix the following issues with ernie45 reasoning parser
```text
packages/starlette/responses.py", line 254, in stream_response
(APIServer pid=1533093)     async for chunk in self.body_iterator:
(APIServer pid=1533093)   File "/root/paddlejob/wangyafeng/myGithub/vllm/vllm/entrypoints/openai/serving_chat.py", line 575, in chat_completion_stream_generator
(APIServer pid=1533093)     reasoning_parser = self.reasoning_parser(
(APIServer pid=1533093)                        ^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1533093) TypeError: Ernie45ReasoningParser.__init__() got an unexpected keyword argument 'chat_template_kwargs'
```