### PR TITLE
fix(benchmarks): Remove hardcoded dtype in hf backend

### DIFF
--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -252,7 +252,7 @@ def run_hf(
     disable_detokenize: bool = False,
 ) -> float:
     llm = AutoModelForCausalLM.from_pretrained(
-        model, dtype=torch.float16, trust_remote_code=trust_remote_code
+        model, dtype="float16", trust_remote_code=trust_remote_code
     )
     if llm.config.model_type == "llama":
         # To enable padding in the HF backend.


### PR DESCRIPTION
## Purpose

Refs #27975. Change the Hugging Face throughput benchmark's `run_hf` call from `dtype=torch.float16` to `dtype="float16"` in `AutoModelForCausalLM.from_pretrained`.

The submitted change retains the explicit `dtype` keyword and selects float16. It does not remove the argument or defer dtype selection to Transformers defaults. The original report encountered `TypeError: Qwen3ForCausalLM.__init__() got an unexpected keyword argument 'dtype'`; the reported success below is specific to that historical environment and does not establish compatibility with every Transformers version or model.

## Test Plan

Use the historical benchmark command with an appropriate local Qwen3 model:

```bash
vllm bench throughput \
  --model /path/to/qwen3_model \
  --num-prompts 10 \
  --input-len 128 --output-len 128 \
  --seed 42 --max-model-len 512 \
  --backend hf --hf-max-batch-size 8
```

## Historical Test Result

The original PR's before-fix run requested 100 prompts and failed during model loading with the `dtype` TypeError. Its after-fix run requested 10 prompts and completed, reporting 0.41 requests/s, 105.75 total tokens/s, and 52.88 output tokens/s. Because the prompt counts differ, these logs are not a matched throughput comparison.

This description update did not rerun that model or dependency environment.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
