### PR TITLE
[Frontend] Make RequestIdMiddleware return the internal request_id

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -14,7 +14,6 @@ import secrets
 import signal
 import socket
 import tempfile
-import uuid
 from argparse import Namespace
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
@@ -71,6 +70,7 @@ from vllm.entrypoints.openai.protocol import (
     PoolingBytesResponse,
     PoolingRequest,
     PoolingResponse,
+    RequestResponseMetadata,
     RerankRequest,
     RerankResponse,
     ResponsesRequest,
@@ -1403,9 +1403,10 @@ class AuthenticationMiddleware:
 
 class XRequestIdMiddleware:
     """
-    Middleware the set's the X-Request-Id header for each response
-    to a random uuid4 (hex) value if the header isn't already
-    present in the request, otherwise use the provided request id.
+    Middleware the sets the X-Request-Id header for each response
+    to the request ID used internally and included log messages.
+    If the header is present in the request, the provided request
+    ID will be included in this internal request ID.
     """
 
     def __init__(self, app: ASGIApp) -> None:
@@ -1415,18 +1416,23 @@ class XRequestIdMiddleware:
         if scope["type"] not in ("http", "websocket"):
             return self.app(scope, receive, send)
 
-        # Extract the request headers.
-        request_headers = Headers(scope=scope)
-
         async def send_with_request_id(message: Message) -> None:
             """
             Custom send function to mutate the response headers
             and append X-Request-Id to it.
+
+            The internal request_id is obtained from RequestResponseMetadata
+            in scope state.
             """
-            if message["type"] == "http.response.start":
+            if (
+                message["type"] == "http.response.start"
+                and "state" in scope
+                and "request_metadata" in scope["state"]
+            ):
+                metadata = scope["state"]["request_metadata"]
+                assert isinstance(metadata, RequestResponseMetadata)
                 response_headers = MutableHeaders(raw=message["headers"])
-                request_id = request_headers.get("X-Request-Id", uuid.uuid4().hex)
-                response_headers.append("X-Request-Id", request_id)
+                response_headers.append("X-Request-Id", metadata.request_id)
             await send(message)
 
         return self.app(scope, receive, send_with_request_id)


### PR DESCRIPTION
`RequestIdMiddleware` (added by #19946) can be enabled using `--enable-request-id-headers` and it will add an `X-Request-ID` header to the response. Currently:

- If an `X-Request-ID` header is provided in the client request, we prepend a prefix ('cmpl-' for example) but we do not include this in the response header.
- If the client does not provide a request ID, we include a random ID in the response that has no relation to the request ID internally and therefore is useless for correlating logs.

In #8672 we added `RequestResponseMetadata` for external middlewares and we do not use this internally currently. We can rely on it to allow us to return the actual internal request ID in the response header.

Example:

```
$ curl -v http://127.0.0.1:8000/v1/completions ...
...
< x-request-id: cmpl-f7fee54511494349b0f0e5c6a079573a
```
