### PR TITLE
Update delta_text and model_output format to include newline

### DIFF
--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -60,10 +60,10 @@ class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
         delta_token_ids: Sequence[int],
     ) -> DeltaMessage | None:
         if len(previous_token_ids) == 0:
-            delta_text = "<think>" + delta_text
+            delta_text = "<think>\n" + delta_text
         return DeltaMessage(content=delta_text)
 
     def extract_reasoning_content(
         self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
     ) -> tuple[str | None, str | None]:
-        return None, "<think>" + model_output
+        return None, "<think>\n" + model_output


### PR DESCRIPTION


<!-- markdownlint-disable -->


## Purpose

The current MiniMax-M2 integration in vLLM omits a newline character following the <think> token during output generation. While this behavior does not appear to violate any formal specification, certain downstream systems - such as Dify in our use case - expect a newline after <think> to correctly parse the output.

As a result, outputs can cause malformed content when consumed by these clients.

## Test Plan

Call vllm api from open webui(allready works well without the newline) and dify.

## Test Result
open webui outputs remain unchanged, while dify now parses the output correctly.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

