### PR TITLE
[FlashInfer] Avoid FlashInfer block_size 16 + head_size 256 on blackwell

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.models import ModelRegistry
+from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, MLAAttentionSpec
@@ -364,6 +365,17 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
             ).page_size_bytes
         else:
             kernel_block_alignment_size = 16
+            if (
+                current_platform.is_device_capability(100)
+                and model_config.get_head_size() == 256
+                and (
+                    envs.VLLM_ATTENTION_BACKEND is None
+                    or envs.VLLM_ATTENTION_BACKEND == "FLASHINFER"
+                )
+            ):
+                # https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that`
+                # head size 256 and block size 16 is not supported on blackwell.
+                kernel_block_alignment_size = 32
             attn_page_size_1_token = FullAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -405,9 +405,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         if self.head_dim == 256 and current_platform.is_device_capability(100):
             # https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that
             # head size 256 and block size 16 is not supported on blackwell.
-            assert kv_cache_spec.block_size != 16, "There is a bug in FlashInfer "
-            "block_size 16 head size 256 support. Please avoid this combination by "
-            "passing --block-size 32 or --block-size 64."
+            assert kv_cache_spec.block_size != 16, (
+                "There is a bug in FlashInfer "
+                "block_size 16 head size 256 support. Please avoid this combination by "
+                "passing --block-size 32 or --block-size 64."
+            )
 
     def _get_workspace_buffer(self):
         if self._workspace_buffer is None:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -402,6 +402,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
         self.paged_kv_last_page_len_np = self.paged_kv_last_page_len_cpu.numpy()
 
+        if self.head_dim == 256 and current_platform.is_device_capability(100):
+            # https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that
+            # head size 256 and block size 16 is not supported on blackwell.
+            assert kv_cache_spec.block_size != 16, "There is a bug in FlashInfer "
+            "block_size 16 head size 256 support. Please avoid this combination by "
+            "passing --block-size 32 or --block-size 64."
+
     def _get_workspace_buffer(self):
         if self._workspace_buffer is None:
             buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Avoid this combination as https://github.com/flashinfer-ai/flashinfer/issues/1993 reports this combination is not correct.

For most models with head_size 256, users now need --block_size 32 / --block_size 64

For hybrid mamba like qwen3-next, the block_size can be resolved automatically 

Thanks @vadiklyutiy for the exploration on this problem https://github.com/vllm-project/vllm/pull/27704

## Test Plan

Test non-hybrid case and hybrid case

## Test Result
All tests are on B200

### Normal model

I don't know a model with head_size 256. I've changed the 256 in this PR to 64 and test opt-125m
```
vllm serve facebook/opt-125m
```
will result in
```
AssertionError: There is a bug in FlashInfer block_size 16 head size 256 support. Please avoid this combination by passing --block-size 32 or --block-size 64.
```


```
vllm serve facebook/opt-125m --block-size 64
```
works

### Hybrid
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp 4
lm_eval --model local-completions --model_args model=Qwen/Qwen3-Next-80B-A3B-Instruct,base_url=http://localhost:8000/v1/completions -t gsm8k --num_fewshot 5 --batch_size 250
```
before this PR
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.2123|±  |0.0113|
|     |       |strict-match    |     5|exact_match|↑  |0.1933|±  |0.0109|
```
after this PR
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8491|±  |0.0099|
|     |       |strict-match    |     5|exact_match|↑  |0.8120|±  |0.0108|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

