### PR TITLE
[LoRA] Allow ColumnParallelLinearWithLoRA if layer not in packed_modules

### DIFF
--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -157,7 +157,7 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
     ) -> bool:
         return type(source_layer) is ColumnParallelLinear or (
             type(source_layer) is MergedColumnParallelLinear
-            and len(packed_modules_list) == 1
+            and len(packed_modules_list) < 2
         )
 
 


### PR DESCRIPTION
## Purpose

Solves #27620 

It looks like there are two LoRA classes that can be used to replace MergedColumnParallelLinear layers.
1. `ColumnParallelLinearWithLoRA`
2. `MergedColumnParallelLinearWithLoRA`

(2) will be used if there are [two sub-layers packed together](https://github.com/vllm-project/vllm/blob/main/vllm/lora/layers/column_parallel_linear.py#L280) and I think that (1) should be used otherwise. However (1) is [explicitly checking](https://github.com/vllm-project/vllm/blob/main/vllm/lora/layers/column_parallel_linear.py#L160) that `len(packed_modules_list) == 1`. This seems wrong to me, because it assume the modeling code should also list layers that are not packed together. 

This one-line fix allows to replace with (1) also if the layer is missing from packed_modules. 

## Test Plan

```
vllm serve ibm-granite/granite-4.0-micro --enable-lora
```

## Test Result

Works fine

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

