### PR TITLE
[FlashInfer] Disable TRTLLM for block_size 16 and head_size 256

### DIFF
--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -241,6 +241,8 @@ def use_trtllm_attention(
     kv_cache_dtype: str,
     q_dtype: torch.dtype,
     is_prefill: bool,
+    head_size: int,
+    block_size: int,
     has_sinks: bool = False,
     has_spec: bool = False,
 ) -> bool:
@@ -267,6 +269,11 @@ def use_trtllm_attention(
                 "TRTLLM attention is not supported for this combination of "
                 "query and key heads, but VLLM_USE_TRTLLM_ATTENTION is set to 1"
             )
+        return False
+
+    if head_size == 256 and block_size == 16:
+        ## https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that`
+        # head size 256 and block size 16 is incorrect on blackwell.
         return False
 
     if has_spec and not is_prefill:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -560,6 +560,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.cache_dtype,
             self.q_data_type,
             is_prefill=True,
+            head_size=self.head_dim,
+            block_size=self.page_size,
             has_sinks=self.has_sinks,
             has_spec=uses_spec_reorder,
         )
@@ -571,6 +573,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.cache_dtype,
             self.q_data_type,
             is_prefill=False,
+            head_size=self.head_dim,
+            block_size=self.page_size,
             has_sinks=self.has_sinks,
             has_spec=uses_spec_reorder,
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
https://github.com/flashinfer-ai/flashinfer/issues/1993 reports this combination is not correct, so this PR disable it.

Thanks @vadiklyutiy for the exploration on this problem https://github.com/vllm-project/vllm/pull/27704

## Test Plan
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp 4
lm_eval --model local-completions --model_args model=Qwen/Qwen3-Next-80B-A3B-Instruct,base_url=http://localhost:8000/v1/completions -t gsm8k --num_fewshot 5 --batch_size 250
```

## Test Result
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8522|±  |0.0098|
|     |       |strict-match    |     5|exact_match|↑  |0.8150|±  |0.0107|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

