### PR TITLE
[Bugfix] Fix MoE Routing Simulation

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
@@ -159,7 +159,6 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         )
 
         print(expert_num_tokens_per_expert_list)
-        print(token_data)
 
         # record the handle for this ubatch
         a2a_idx = dbo_current_ubatch_id()

--- a/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
@@ -159,7 +159,7 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         )
 
         print(expert_num_tokens_per_expert_list)
-        print(token_data.shape)
+        print(token_data)
 
         # record the handle for this ubatch
         a2a_idx = dbo_current_ubatch_id()

--- a/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
@@ -159,6 +159,7 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         )
 
         print(expert_num_tokens_per_expert_list)
+        print(token_data.shape)
 
         # record the handle for this ubatch
         a2a_idx = dbo_current_ubatch_id()

--- a/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
@@ -158,8 +158,6 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             allocate_on_comm_stream=False,
         )
 
-        print(expert_num_tokens_per_expert_list)
-
         # record the handle for this ubatch
         a2a_idx = dbo_current_ubatch_id()
         self.handles[a2a_idx] = handle

--- a/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py
@@ -158,6 +158,8 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             allocate_on_comm_stream=False,
         )
 
+        print(expert_num_tokens_per_expert_list)
+
         # record the handle for this ubatch
         a2a_idx = dbo_current_ubatch_id()
         self.handles[a2a_idx] = handle

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -2066,7 +2066,7 @@ class FusedMoE(CustomOp):
             )
 
         # DeepSeekv2 uses grouped_top_k
-        if use_grouped_topk:
+        elif use_grouped_topk:
             assert topk_group is not None
             assert num_expert_group is not None
             if is_rocm_aiter_moe_enabled():

--- a/vllm/model_executor/layers/fused_moe/routing_simulator.py
+++ b/vllm/model_executor/layers/fused_moe/routing_simulator.py
@@ -14,6 +14,10 @@ from typing import Any
 
 import torch
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 
 class RoutingStrategy(ABC):
     """Base class for token-to-expert routing strategies."""
@@ -290,6 +294,12 @@ class RoutingSimulator:
                 f"Available strategies: "
                 f"{list(RoutingSimulator._routing_strategies.keys())}"
             )
+        logger.warning_once(
+            "Simulating MoE routing using a %s strategy. "
+            "This should only be used for performance testing. "
+            "Model outputs will not be valid.",
+            strategy_name,
+        )
 
         strategy = RoutingSimulator._routing_strategies[strategy_name]
         return strategy.route_tokens(


### PR DESCRIPTION
On current main, the routing simulation has no effect (besides overhead).

After calling `RoutingSimulator.simulate_routing` when `VLLM_MOE_ROUTING_SIMULATION_STRATEGY` is set, `select_experts` continues to call the top_k kernel as if nothing has happened.

This PR fixes that, and adds some logging warning the user that their output will not be correct.