### PR TITLE
[ROCm] [Bugfix] Bugfix when invoking aiter flash attn in GLM4V ViT

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -370,7 +370,7 @@ class Glm4vVisionAttention(nn.Module):
                 cu_seqlens_k=cu_seqlens,
                 max_seqlen_q=max_seqlen,
                 max_seqlen_k=max_seqlen,
-                dropout_p=0,
+                dropout_p=0.0,  # AITER FA only supports float dtype
                 causal=False,
             )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Bugfix the usage of `aiter.flash_attn_varlen_func` in GLM4V model. It expects the `dropout_p` to be a float datatype

## Test Plan

ChartQA lm-eval score of `zai-org/GLM-4.1V-9B-Thinking`

## Test Result

```
For detailed information on this command, run:
  run.py eval_vllm --model_name zai-org/GLM-4.1V-9B-Thinking --url http://0.0.0.0:7899 --output_dir ./chartqa --eval_name chartqa - --help
================================================================================
Metrics:
{
    "explicit_prompt_relaxed_correctness": 0.6312,
    "anywhere_in_answer_relaxed_correctness": 0.666
}
================================================================================

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

