### PR TITLE
[CI] Fix and enable compile/test_config.py in CI

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -440,6 +440,7 @@ steps:
     - vllm/
     - tests/compile
   commands:
+    - pytest -v -s compile/test_config.py
     - pytest -v -s compile/test_pass_manager.py
     - pytest -v -s compile/test_fusion.py
     - pytest -v -s compile/test_fusion_attn.py
@@ -1223,7 +1224,7 @@ steps:
     - pytest -v -s tests/compile/test_fusions_e2e.py::test_tp2_attn_quant_allreduce_rmsnorm
     - pytest -v -s tests/distributed/test_context_parallel.py
     - CUDA_VISIBLE_DEVICES=1,2 VLLM_ALL2ALL_BACKEND=deepep_high_throughput VLLM_USE_DEEP_GEMM=1 VLLM_LOGGING_LEVEL=DEBUG python3 examples/offline_inference/data_parallel.py --model Qwen/Qwen1.5-MoE-A2.7B --tp-size=1  --dp-size=2 --max-model-len 2048
-    - pytest -v -s tests/v1/distributed/test_dbo.py  
+    - pytest -v -s tests/v1/distributed/test_dbo.py
 
 ##### B200 test #####
 - label: Distributed Tests (B200) # optional


### PR DESCRIPTION
- Deleted test_use_cudagraphs_dynamic as use_cudagraph flag is deprecated and its default value (True) is donflicting with cudagraph_mode default value (None)
- Updated number of cudagraph captured count in test_use_cudagraphs
- Updated test_splitting_ops_dynamic to follow latest behavior of cuda graph: enable_attn_fusion is incompatible with piecewise cudagraphs, splitting_ops is set to empty list, and cudagraph_mode is set to FULL.
- Fixed test_cudagraph_sizes_post_init. It used to not respect max_num_seqs and had incorrect assumption about max_num_batched_tokens. Specifically, max_num_batched_tokens should not override explicitly passed cudagraph_capture_sizes.
- Improved test_cudagraph_sizes_post_init to take an additional dedicated argument representing expected exceptions to make the test clearer.


Signed off by: Yanan Cao gmagogsfm@gmail.com

