### PR TITLE
[Core][WIP] Add back waterline for scheduler

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -142,6 +142,9 @@ class SchedulerConfig:
     speculative decoding and pipeline parallelism.
     """
 
+    waterline: float = 0.01
+    """Use waterline to avoid frequent kv cache eviction."""
+
     def get_scheduler_cls(self) -> type["SchedulerInterface"]:
         if self.scheduler_cls is None:
             if self.async_scheduling:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -183,6 +183,7 @@ class Scheduler(SchedulerInterface):
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
             dcp_world_size=self.dcp_world_size,
+            waterline=self.scheduler_config.waterline,
         )
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
 


### PR DESCRIPTION
## Purpose
This PR purposes to add back the `watermark` mechanism for v1 scheduler, in order to avoid frequent cache eviction. Although in v1 scheduler requests in running queue is scheduled first, there are still certain scenarios where a request may be frequently preempted and unable to complete its inference in a timely manner. For example, consider processing large amount of long requests and `max_num_seq * max_model_len > kv cache size`: 

- In step `n`, request `X` is preempted due to insufficient kv cache blocks, and added into waiting queue.
- In step `n+1`, request `X` in waiting queue is chunked and scheduled into running immediately with chunked prefill enable.
- After several rounds of scheduling, no running requests have finished while previously freed kv cache blocks of request `X` is occupied again. Then preempting again!

With watermark mechanism we can prevent scheduling waiting requests into running in scenarios where gpu memory is scarce. 

Existing issues: https://github.com/vllm-project/vllm/issues/25538

cc @WoosukKwon @njhill @wangxiyuan 

## Test Plan
If accepted, I will add ut for watermark.
## Test Result
All ci should pass.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

