### PR TITLE
[Bugfix] Fix encoder-only model support for transformers backend

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -886,27 +886,27 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
 
 _TRANSFORMERS_BACKEND_MODELS = {
     "TransformersEmbeddingModel": _HfExamplesInfo(
-        "BAAI/bge-base-en-v1.5", min_transformers_version="5.0.0"
+        "BAAI/bge-base-en-v1.5", min_transformers_version="5.0.0.dev"
     ),
     "TransformersForSequenceClassification": _HfExamplesInfo(
         "papluca/xlm-roberta-base-language-detection",
-        min_transformers_version="5.0.0",
+        min_transformers_version="5.0.0.dev",
     ),
     "TransformersForCausalLM": _HfExamplesInfo(
         "hmellor/Ilama-3.2-1B", trust_remote_code=True
     ),
     "TransformersMultiModalForCausalLM": _HfExamplesInfo("BAAI/Emu3-Chat-hf"),
     "TransformersMoEForCausalLM": _HfExamplesInfo(
-        "allenai/OLMoE-1B-7B-0924", min_transformers_version="5.0.0"
+        "allenai/OLMoE-1B-7B-0924", min_transformers_version="5.0.0.dev"
     ),
     "TransformersMultiModalMoEForCausalLM": _HfExamplesInfo(
-        "Qwen/Qwen3-VL-30B-A3B-Instruct", min_transformers_version="5.0.0"
+        "Qwen/Qwen3-VL-30B-A3B-Instruct", min_transformers_version="5.0.0.dev"
     ),
     "TransformersMoEEmbeddingModel": _HfExamplesInfo(
-        "Qwen/Qwen3-30B-A3B", min_transformers_version="5.0.0"
+        "Qwen/Qwen3-30B-A3B", min_transformers_version="5.0.0.dev"
     ),
     "TransformersMoEForSequenceClassification": _HfExamplesInfo(
-        "Qwen/Qwen3-30B-A3B", min_transformers_version="5.0.0"
+        "Qwen/Qwen3-30B-A3B", min_transformers_version="5.0.0.dev"
     ),
     "TransformersMultiModalEmbeddingModel": _HfExamplesInfo("google/gemma-3-4b-it"),
     "TransformersMultiModalForSequenceClassification": _HfExamplesInfo(

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -82,7 +82,7 @@ def test_models(
     from packaging.version import Version
 
     installed = Version(transformers.__version__)
-    required = Version("5.0.0")
+    required = Version("5.0.0.dev")
     if model == "allenai/OLMoE-1B-7B-0924" and installed < required:
         pytest.skip(
             "MoE models with the Transformers backend require "

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -318,7 +318,7 @@ class Base(nn.Module, VllmModel, SupportsQuant, SupportsLoRA, SupportsPP):
         # vLLM does not support encoder-decoder models, so if any encoder layer is
         # found in a text only model, we assume the whole model is an encoder model
         if has_encoder(self.model) and not is_multimodal(self.config):
-            self.check_version("4.57.0.dev0", "encoder models support")
+            self.check_version("5.0.0.dev0", "encoder models support")
             attn_type = AttentionType.ENCODER_ONLY
         else:
             attn_type = AttentionType.DECODER

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -28,6 +28,7 @@ from transformers import AutoModel
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
 from vllm.attention import Attention, AttentionType
+from vllm.attention.layers.encoder_only_attention import EncoderOnlyAttention
 from vllm.config.utils import getattr_iter
 from vllm.distributed import get_pp_group, get_tp_group
 from vllm.distributed.utils import get_pp_indices
@@ -336,7 +337,12 @@ class Base(nn.Module, VllmModel, SupportsQuant, SupportsLoRA, SupportsPP):
             ):
                 per_layer_sliding_window = self.config.sliding_window
 
-            attention_instances[i] = Attention(
+            attn_cls = (
+                EncoderOnlyAttention
+                if attn_type == AttentionType.ENCODER_ONLY
+                else Attention
+            )
+            attention_instances[i] = attn_cls(
                 num_heads=num_heads,
                 head_size=head_size,
                 # NOTE: We use Llama scale as default, if it's set by

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -115,7 +115,7 @@ direct_register_custom_op(
 
 class MoEMixin(MixtureOfExperts):
     def __init__(self, *, vllm_config: "VllmConfig", prefix: str = ""):
-        self.check_version("4.57.0.dev0", "MoE models support")
+        self.check_version("5.0.0.dev0", "MoE models support")
         # Skip MixtureOfExperts.__init__ and call the next class in MRO
         super(MixtureOfExperts, self).__init__(vllm_config=vllm_config, prefix=prefix)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix broken encoder-only model support on transformers backend after #26587
```
(EngineCore_DP0 pid=5260) INFO 11-04 03:34:52 [base.py:120] Using Transformers backend.
(EngineCore_DP0 pid=5260) INFO 11-04 03:34:52 [cuda.py:414] Using FlexAttention backend.
(EngineCore_DP0 pid=5260) [2025-11-04 03:34:54] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/papluca/xlm-roberta-base-language-detection "HTTP/1.1 200 OK"
(EngineCore_DP0 pid=5260) [2025-11-04 03:34:54] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/papluca/xlm-roberta-base-language-detection/tree/main?recursive=false&expand=false "HTTP/1.1 200 OK"
(EngineCore_DP0 pid=5260) [2025-11-04 03:34:54] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/papluca/xlm-roberta-base-language-detection/revision/main "HTTP/1.1 200 OK"
(EngineCore_DP0 pid=5260) [2025-11-04 03:34:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/papluca/xlm-roberta-base-language-detection/resolve/main/model.safetensors.index.json "HTTP/1.1 404 Not Found"
(EngineCore_DP0 pid=5260) INFO 11-04 03:34:55 [weight_utils.py:480] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.94it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.93it/s]
(EngineCore_DP0 pid=5260) 
(EngineCore_DP0 pid=5260) INFO 11-04 03:34:55 [default_loader.py:314] Loading weights took 0.65 seconds
(EngineCore_DP0 pid=5260) INFO 11-04 03:34:56 [gpu_model_runner.py:2997] Model loading took 0.5192 GiB and 3.491527 seconds
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843] EngineCore failed to start.
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843] Traceback (most recent call last):
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/engine/core.py", line 834, in run_engine_core
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/engine/core.py", line 602, in __init__
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     super().__init__(
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/engine/core.py", line 109, in __init__
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/engine/core.py", line 223, in _initialize_kv_caches
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     kv_cache_specs = self.model_executor.get_kv_cache_specs()
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/executor/abstract.py", line 129, in get_kv_cache_specs
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     return self.collective_rpc("get_kv_cache_spec")
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/executor/uniproc_executor.py", line 73, in collective_rpc
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     return [run_method(self.driver_worker, method, args, kwargs)]
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/serial_utils.py", line 459, in run_method
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     return func(*args, **kwargs)
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/worker/gpu_worker.py", line 373, in get_kv_cache_spec
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     return self.model_runner.get_kv_cache_spec()
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/v1/worker/gpu_model_runner.py", line 4746, in get_kv_cache_spec
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     if spec := attn_module.get_kv_cache_spec(self.vllm_config):
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]   File "/kaggle/working/vllm/vllm/attention/layer.py", line 462, in get_kv_cache_spec
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]     assert self.attn_type == AttentionType.DECODER
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=5260) ERROR 11-04 03:34:56 [core.py:843] AssertionError
```

## Test Plan
```
pytest -s -v tests/models/test_initialization.py -k TransformersForSequenceClassification
```

## Test Result
Test should pass with nightly Transformers now

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

