### PR TITLE
[CI/Build] Fix OpenAI API correctness on AMD CI

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -636,8 +636,9 @@ steps:
   - csrc/
   - vllm/entrypoints/openai/
   - vllm/model_executor/models/whisper.py
-  commands: # LMEval+Transcription WER check
-  - pytest -s entrypoints/openai/correctness/
+  commands: # LMEval
+  # Transcription WER check is skipped due to encoder-decoder model is suppported on ROCM, see https://github.com/vllm-project/vllm/issues/27442
+  - pytest -s entrypoints/openai/correctness/  --ignore entrypoints/openai/correctness/test_transcription_api_correctness.py
 
 - label: OpenAI-Compatible Tool Use # 23 min
   timeout_in_minutes: 35

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -629,7 +629,7 @@ steps:
 
 - label: OpenAI API correctness # 22min
   timeout_in_minutes: 30
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -637,7 +637,7 @@ steps:
   - vllm/entrypoints/openai/
   - vllm/model_executor/models/whisper.py
   commands: # LMEval
-  # Transcription WER check is skipped due to encoder-decoder model is suppported on ROCM, see https://github.com/vllm-project/vllm/issues/27442
+  # Transcription WER check is skipped because encoder-decoder models are not supported on ROCm, see https://github.com/vllm-project/vllm/issues/27442
   - pytest -s entrypoints/openai/correctness/  --ignore entrypoints/openai/correctness/test_transcription_api_correctness.py
 
 - label: OpenAI-Compatible Tool Use # 23 min


### PR DESCRIPTION
## Purpose
OpenAI API correctness is failing on AMD CI consistently([example](https://buildkite.com/vllm/ci/builds/37251#019a42b9-e23d-450d-8ef1-77df04f6cfde)) because in encoder-decoder model `openai/whisper-large-v3` is used in test: `entrypoints/openai/correctness/test_transcription_api_correctness`.

Since AMD doesn't support encoder models(see https://github.com/vllm-project/vllm/issues/27442), this PR skips the test from the test suite
## Test Plan
```
 pytest -s tests/entrypoints/openai/correctness/ (manual skip)
...
================================================================== warnings summary ==================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
tests/entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
  /home/zhewenli/uv_env/vllm-fork/lib64/python3.12/site-packages/lm_eval/models/vllm_causallms.py:38: DeprecationWarning: vllm.utils.get_open_port is deprecated and will be removed in a future version. Use vllm.utils.network_utils.get_open_port instead.
    from vllm.utils import get_open_port

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================ 1 passed, 1 skipped, 4 warnings in 133.91s (0:02:13) ================================================
````

CI: https://buildkite.com/vllm/amd-ci/builds/874
