### PR TITLE
Added disable rule to track files under benchmarks/lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ csrc/moe/marlin_moe_wna16/kernel_*
 
 # Ignore ep_kernels_workspace folder
 ep_kernels_workspace/
+
+# Allow tracked library source folders under submodules (e.g., benchmarks/lib)
+!vllm/benchmarks/lib/


### PR DESCRIPTION

### Fix .gitignore rule that unintentionally excludes vllm/benchmarks/lib

The `.gitignore` currently contains an unanchored pattern:

`lib/`


This pattern ignores any directory named lib at any depth, not just the build output directory at the repository root.
As a result, all files under `vllm/benchmarks/lib/` — including the Python source file `endpoint_request_func.py` — are being ignored by Git, even though they are part of the source tree.