### PR TITLE
[Chore] Separate out attention backend constants from vllm.utils

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -6,8 +6,11 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from vllm.attention.constants import (STR_BACKEND_ENV_VAR, STR_FLASH_ATTN_VAL,
-                                       STR_INVALID_VAL)
+from vllm.attention.constants import (
+    STR_BACKEND_ENV_VAR,
+    STR_FLASH_ATTN_VAL,
+    STR_INVALID_VAL,
+)
 from vllm.attention.selector import _cached_get_attn_backend, get_attn_backend
 from vllm.platforms.cpu import CpuPlatform
 from vllm.platforms.cuda import CudaPlatform

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -6,11 +6,12 @@ from unittest.mock import patch
 import pytest
 import torch
 
+from vllm.attention.constants import (STR_BACKEND_ENV_VAR, STR_FLASH_ATTN_VAL,
+                                       STR_INVALID_VAL)
 from vllm.attention.selector import _cached_get_attn_backend, get_attn_backend
 from vllm.platforms.cpu import CpuPlatform
 from vllm.platforms.cuda import CudaPlatform
 from vllm.platforms.rocm import RocmPlatform
-from vllm.utils import STR_BACKEND_ENV_VAR, STR_FLASH_ATTN_VAL, STR_INVALID_VAL
 
 
 @pytest.fixture(autouse=True)

--- a/tests/kernels/attention/test_rocm_attention_selector.py
+++ b/tests/kernels/attention/test_rocm_attention_selector.py
@@ -4,9 +4,9 @@
 import pytest
 import torch
 
+from vllm.attention.constants import STR_BACKEND_ENV_VAR
 from vllm.attention.selector import _cached_get_attn_backend, get_attn_backend
 from vllm.platforms.rocm import RocmPlatform
-from vllm.utils import STR_BACKEND_ENV_VAR
 
 
 @pytest.fixture(autouse=True)

--- a/tests/kernels/utils.py
+++ b/tests/kernels/utils.py
@@ -16,13 +16,13 @@ from torch._prims_common import TensorLikeType
 from tests.kernels.quant_utils import native_w8a8_block_matmul
 from vllm.attention import AttentionBackend, AttentionMetadata, AttentionType
 from vllm.attention.backends.registry import _Backend
-from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
-from vllm.utils import (
+from vllm.attention.constants import (
     STR_BACKEND_ENV_VAR,
     STR_FLASH_ATTN_VAL,
     STR_XFORMERS_ATTN_VAL,
 )
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
 from vllm.utils.torch_utils import make_tensor_with_pad
 
 # For now, disable "test_aot_dispatch_dynamic" since there are some

--- a/tests/models/quantization/test_fp8.py
+++ b/tests/models/quantization/test_fp8.py
@@ -9,9 +9,9 @@ Note: these tests will only pass on L4 GPU.
 import pytest
 
 from tests.quantization.utils import is_quant_method_supported
+from vllm.attention.constants import STR_BACKEND_ENV_VAR
 from vllm.attention.utils.fa_utils import flash_attn_supports_fp8
 from vllm.platforms import current_platform
-from vllm.utils import STR_BACKEND_ENV_VAR
 from ..utils import check_logprobs_close
 
 

--- a/vllm/attention/constants.py
+++ b/vllm/attention/constants.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Constants related to attention backend selection."""
+
+# Environment variable name used to force selection of a specific
+# attention backend by the Attention wrapper
+STR_BACKEND_ENV_VAR: str = "VLLM_ATTENTION_BACKEND"
+
+# Possible string values for STR_BACKEND_ENV_VAR environment variable,
+# corresponding to available attention backends
+STR_FLASHINFER_ATTN_VAL: str = "FLASHINFER"
+STR_TORCH_SDPA_ATTN_VAL: str = "TORCH_SDPA"
+STR_XFORMERS_ATTN_VAL: str = "XFORMERS"
+STR_FLASH_ATTN_VAL: str = "FLASH_ATTN"
+STR_INVALID_VAL: str = "INVALID"

--- a/vllm/attention/selector.py
+++ b/vllm/attention/selector.py
@@ -12,8 +12,8 @@ import torch
 import vllm.envs as envs
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.attention.backends.registry import _Backend, backend_name_to_enum
+from vllm.attention.constants import STR_BACKEND_ENV_VAR
 from vllm.logger import init_logger
-from vllm.utils import STR_BACKEND_ENV_VAR
 from vllm.utils.import_utils import resolve_obj_by_qualname
 
 logger = init_logger(__name__)

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -16,13 +16,16 @@ _DEPRECATED_MAPPINGS = {
     "cprofile_context": "profiling",
     # Used by lm-eval
     "get_open_port": "network_utils",
-    # Attention backend constants
-    "STR_BACKEND_ENV_VAR": "attention.constants",
-    "STR_FLASHINFER_ATTN_VAL": "attention.constants",
-    "STR_TORCH_SDPA_ATTN_VAL": "attention.constants",
-    "STR_XFORMERS_ATTN_VAL": "attention.constants",
-    "STR_FLASH_ATTN_VAL": "attention.constants",
-    "STR_INVALID_VAL": "attention.constants",
+    # Attention backend constants - TEMPORARILY COMMENTED OUT FOR TESTING
+    # Temporarily disabled to verify all internal vLLM code uses new import paths.
+    # Will be uncommented after tests pass to provide backward compatibility
+    # for downstream code. See: https://github.com/vllm-project/vllm/pull/28066
+    # "STR_BACKEND_ENV_VAR": "attention.constants",
+    # "STR_FLASHINFER_ATTN_VAL": "attention.constants",
+    # "STR_TORCH_SDPA_ATTN_VAL": "attention.constants",
+    # "STR_XFORMERS_ATTN_VAL": "attention.constants",
+    # "STR_FLASH_ATTN_VAL": "attention.constants",
+    # "STR_INVALID_VAL": "attention.constants",
 }
 
 

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -16,6 +16,13 @@ _DEPRECATED_MAPPINGS = {
     "cprofile_context": "profiling",
     # Used by lm-eval
     "get_open_port": "network_utils",
+    # Attention backend constants
+    "STR_BACKEND_ENV_VAR": "attention.constants",
+    "STR_FLASHINFER_ATTN_VAL": "attention.constants",
+    "STR_TORCH_SDPA_ATTN_VAL": "attention.constants",
+    "STR_XFORMERS_ATTN_VAL": "attention.constants",
+    "STR_FLASH_ATTN_VAL": "attention.constants",
+    "STR_INVALID_VAL": "attention.constants",
 }
 
 
@@ -47,20 +54,7 @@ DEFAULT_MAX_NUM_BATCHED_TOKENS = 2048
 POOLING_MODEL_MAX_NUM_BATCHED_TOKENS = 32768
 MULTIMODAL_MODEL_MAX_NUM_BATCHED_TOKENS = 5120
 
-# Constants related to forcing the attention backend selection
-
-# String name of register which may be set in order to
-# force auto-selection of attention backend by Attention
-# wrapper
-STR_BACKEND_ENV_VAR: str = "VLLM_ATTENTION_BACKEND"
-
-# Possible string values of STR_BACKEND_ENV_VAR
-# register, corresponding to possible backends
-STR_FLASHINFER_ATTN_VAL: str = "FLASHINFER"
-STR_TORCH_SDPA_ATTN_VAL: str = "TORCH_SDPA"
-STR_XFORMERS_ATTN_VAL: str = "XFORMERS"
-STR_FLASH_ATTN_VAL: str = "FLASH_ATTN"
-STR_INVALID_VAL: str = "INVALID"
+# Attention backend constants moved to vllm.attention.constants
 
 
 T = TypeVar("T")

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -16,16 +16,13 @@ _DEPRECATED_MAPPINGS = {
     "cprofile_context": "profiling",
     # Used by lm-eval
     "get_open_port": "network_utils",
-    # Attention backend constants - TEMPORARILY COMMENTED OUT FOR TESTING
-    # Temporarily disabled to verify all internal vLLM code uses new import paths.
-    # Will be uncommented after tests pass to provide backward compatibility
-    # for downstream code. See: https://github.com/vllm-project/vllm/pull/28066
-    # "STR_BACKEND_ENV_VAR": "attention.constants",
-    # "STR_FLASHINFER_ATTN_VAL": "attention.constants",
-    # "STR_TORCH_SDPA_ATTN_VAL": "attention.constants",
-    # "STR_XFORMERS_ATTN_VAL": "attention.constants",
-    # "STR_FLASH_ATTN_VAL": "attention.constants",
-    # "STR_INVALID_VAL": "attention.constants",
+    # Attention backend constants
+    "STR_BACKEND_ENV_VAR": "attention.constants",
+    "STR_FLASHINFER_ATTN_VAL": "attention.constants",
+    "STR_TORCH_SDPA_ATTN_VAL": "attention.constants",
+    "STR_XFORMERS_ATTN_VAL": "attention.constants",
+    "STR_FLASH_ATTN_VAL": "attention.constants",
+    "STR_INVALID_VAL": "attention.constants",
 }
 
 


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/26900

Separate out attention backend constants from the monolithic `vllm/utils/__init__.py` into a dedicated `vllm/attention/constants.py` module.

The following constants have been moved:
- `vllm.utils.STR_BACKEND_ENV_VAR` -> `vllm.attention.constants.STR_BACKEND_ENV_VAR`
- `vllm.utils.STR_FLASHINFER_ATTN_VAL` -> `vllm.attention.constants.STR_FLASHINFER_ATTN_VAL`
- `vllm.utils.STR_TORCH_SDPA_ATTN_VAL` -> `vllm.attention.constants.STR_TORCH_SDPA_ATTN_VAL`
- `vllm.utils.STR_XFORMERS_ATTN_VAL` -> `vllm.attention.constants.STR_XFORMERS_ATTN_VAL`
- `vllm.utils.STR_FLASH_ATTN_VAL` -> `vllm.attention.constants.STR_FLASH_ATTN_VAL`
- `vllm.utils.STR_INVALID_VAL` -> `vllm.attention.constants.STR_INVALID_VAL`

Backward compatibility is maintained through deprecation warnings.

## Test Plan

Run existing attention-related tests:
```bash
pytest tests/kernels/attention/test_attention_selector.py
pytest tests/kernels/attention/test_rocm_attention_selector.py
pytest tests/models/quantization/test_fp8.py
```

## Test Result

- Verified Python syntax is valid for all modified files
- Verified import paths are correct
- Backward compatibility maintained via `__getattr__` mechanism
- CI tests will validate full compatibility