### PR TITLE
[Core] MoE degrade detection and graceful degradation. (Phase 0 of RFC #27774)

### DIFF
--- a/tests/distributed/test_eplb_health.py
+++ b/tests/distributed/test_eplb_health.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.config import EPLBConfig
+from vllm.distributed.eplb.eplb_state import EplbState
+
+
+def create_mock_eplb_state(
+    num_layers: int,
+    num_experts: int,
+    config: EPLBConfig,
+) -> EplbState:
+    """Create a mock EPLB state for testing."""
+
+    # Create minimal required tensors
+    physical_to_logical_map = torch.arange(num_experts).unsqueeze(0).expand(
+        num_layers, -1
+    )
+    logical_to_physical_map = (
+        torch.arange(num_experts).unsqueeze(1).unsqueeze(0).expand(num_layers, -1, -1)
+    )
+    logical_replica_count = torch.ones(num_layers, num_experts, dtype=torch.long)
+    expert_load_pass = torch.zeros(num_layers, num_experts, dtype=torch.int32)
+    expert_load_window = torch.zeros(
+        config.window_size, num_layers, num_experts, dtype=torch.int32
+    )
+
+    # Health monitoring tensors
+    expert_latency_window = torch.zeros(
+        config.window_size, num_layers, num_experts, dtype=torch.float32
+    )
+    expert_health_mask = torch.ones(num_layers, num_experts, dtype=torch.bool)
+
+    return EplbState(
+        physical_to_logical_map=physical_to_logical_map,
+        logical_to_physical_map=logical_to_physical_map,
+        logical_replica_count=logical_replica_count,
+        expert_load_pass=expert_load_pass,
+        expert_load_window=expert_load_window,
+        expert_load_window_step=0,
+        expert_load_window_size=config.window_size,
+        expert_rearrangement_step=0,
+        expert_rearrangement_step_interval=config.step_interval,
+        expert_latency_window=expert_latency_window,
+        expert_health_mask=expert_health_mask,
+        health_latency_threshold=config.health_latency_threshold,
+        health_penalty_factor=config.health_penalty_factor,
+    )
+
+
+def test_basic_health_detection():
+    """Test that unhealthy experts are detected when latency exceeds threshold."""
+
+    # Setup
+    num_layers = 2
+    num_experts = 8
+    window_size = 100
+    threshold = 3.0
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=threshold,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Simulate normal operation (all experts healthy)
+    for step in range(50):
+        # All experts active with similar latency (10ms)
+        state.expert_latency_window[step, :, :] = 10.0
+
+    state.expert_load_window_step = 50
+
+    # Test with normal latency
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # All experts should be healthy
+    assert (
+        state.expert_health_mask.all()
+    ), "All experts should be healthy with normal latency"
+
+    # Inject failure: Expert 3 in layer 0 suddenly slow (100ms)
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    current_latency[0, 3] = 100.0
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 3 should be unhealthy (100 > 3.0 * 10)
+    assert not state.expert_health_mask[0, 3], "Expert 3 layer 0 should be unhealthy"
+    # Other experts should remain healthy
+    assert state.expert_health_mask[0, :3].all(), "Other experts should remain healthy"
+    assert state.expert_health_mask[0, 4:].all(), "Other experts should remain healthy"
+    assert state.expert_health_mask[1, :].all(), "Layer 1 experts should remain healthy"
+
+
+def test_sparse_activation():
+    """Test that inactive experts (0 latency) are handled correctly."""
+
+    # Setup
+    num_layers = 1
+    num_experts = 8
+    window_size = 30
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=3.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Simulate sparse activation pattern
+    # Expert 0: Active in 15/20 passes with 10ms
+    # Expert 1: Active in 5/20 passes with 12ms
+    # Expert 2: Active in 15/20 passes with 10ms, then becomes inactive
+
+    for step in range(15):
+        state.expert_latency_window[step, 0, 0] = 10.0  # Expert 0 active
+        state.expert_latency_window[step, 0, 1] = 0.0  # Expert 1 inactive
+        state.expert_latency_window[step, 0, 2] = 10.0  # Expert 2 active
+
+    for step in range(15, 20):
+        state.expert_latency_window[step, 0, 0] = 0.0  # Expert 0 inactive
+        state.expert_latency_window[step, 0, 1] = 12.0  # Expert 1 active
+        state.expert_latency_window[step, 0, 2] = 10.0  # Expert 2 active
+
+    state.expert_load_window_step = 20
+
+    # Test with Expert 2 slow (50ms)
+    current_latency = torch.zeros(num_layers, num_experts)
+    current_latency[0, 0] = 10.0
+    current_latency[0, 2] = 50.0  # Expert 2 slow!
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 2 should be unhealthy (50 > 3 * 10, and has 20 activations)
+    assert (
+        not state.expert_health_mask[0, 2]
+    ), "Expert 2 should be unhealthy after spike"
+
+    # Write to window
+    state.expert_latency_window[20, 0, 0] = 10.0
+    state.expert_latency_window[20, 0, 2] = 50.0
+
+    # Step 20: Expert 2 becomes inactive (0 latency)
+    current_latency = torch.zeros(num_layers, num_experts)
+    current_latency[0, 0] = 10.0  # Expert 0 active
+    current_latency[0, 2] = 0.0  # Expert 2 NOW INACTIVE (key test!)
+
+    state.expert_load_window_step = 21
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 2 should become healthy again (current_latency = 0 means not active)
+    # The check is: (current_latency > 0) & (current_latency > threshold)
+    # Since current_latency = 0, first condition is False → not unhealthy
+    assert state.expert_health_mask[0, 2], (
+        "Expert 2 should be healthy when inactive (current=0), "
+        "even though it has >10 activations and was unhealthy before"
+    )
+
+    # Expert 0: mean = 10ms, active 16 times (>10), current = 10ms → healthy
+    assert state.expert_health_mask[0, 0], "Expert 0 should be healthy"
+
+    # Expert 1: active only 5 times (<10), insufficient history → healthy
+    assert state.expert_health_mask[0, 1], (
+        "Expert 1 should be healthy (insufficient history)"
+    )
+
+
+def test_expert_recovery():
+    """Test that experts can recover from unhealthy state."""
+
+    # Setup
+    num_layers = 1
+    num_experts = 4
+    window_size = 50
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=3.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Phase 1: Normal operation (10ms baseline)
+    for step in range(30):
+        state.expert_latency_window[step, 0, :] = 10.0
+
+    state.expert_load_window_step = 30
+    
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    state._update_health_mask(current_latency, log_stats=False)
+    assert state.expert_health_mask.all(), "All healthy initially"
+
+    # Write to window
+    state.expert_latency_window[30, 0, :] = 10.0
+
+    # Phase 2: Expert 1 becomes slow (50ms)
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    current_latency[0, 1] = 50.0
+    state.expert_load_window_step = 31
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert not state.expert_health_mask[0, 1], "Expert 1 should be unhealthy"
+
+    # Write to window
+    state.expert_latency_window[31, 0, :] = 10.0
+    state.expert_latency_window[31, 0, 1] = 50.0
+
+    # Phase 3: Expert 1 recovers immediately (back to 10ms in next step)
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    state.expert_load_window_step = 32
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 1 should recover immediately
+    # historical_mean now includes the 50ms spike in window
+    # current = 10ms should be < threshold → healthy
+    assert state.expert_health_mask[0, 1], "Expert 1 should recover to healthy"
+
+
+def test_multi_layer_health():
+    """Test that health detection works independently per layer."""
+
+    num_layers = 3
+    num_experts = 8
+    window_size = 20
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=3.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Setup baseline (10ms for all)
+    for step in range(15):
+        state.expert_latency_window[step, :, :] = 10.0
+
+    state.expert_load_window_step = 15
+
+    # Inject failures in different layers
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    current_latency[0, 2] = 50.0  # Layer 0, Expert 2: slow
+    current_latency[1, 5] = 60.0  # Layer 1, Expert 5: slow
+    # Layer 2: all healthy (10.0)
+
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Verify layer 0
+    assert not state.expert_health_mask[0, 2], "Layer 0 Expert 2 should be unhealthy"
+    assert state.expert_health_mask[0, :2].all(), "Layer 0 other experts healthy"
+    assert state.expert_health_mask[0, 3:].all(), "Layer 0 other experts healthy"
+
+    # Verify layer 1
+    assert not state.expert_health_mask[1, 5], "Layer 1 Expert 5 should be unhealthy"
+    assert state.expert_health_mask[1, :5].all(), "Layer 1 other experts healthy"
+    assert state.expert_health_mask[1, 6:].all(), "Layer 1 other experts healthy"
+
+    # Verify layer 2
+    assert state.expert_health_mask[2, :].all(), "Layer 2 all experts should be healthy"
+
+
+def test_historical_mean_calculation():
+    """Test that historical mean is calculated correctly with sparse activations."""
+
+    num_layers = 1
+    num_experts = 4
+    window_size = 10
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=2.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Expert 0 active pattern: Need min(10, 20*0.5) = 10 active passes
+    # Pattern: [10, 10, 10, 15, 15, 20, 20, 20, 12, 12, ...]
+    # Mean should be (10*3 + 15*2 + 20*3 + 12*2) / 10 = 154 / 10 = 15.4ms
+
+    active_steps = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    latencies = [10.0, 10.0, 10.0, 15.0, 15.0, 20.0, 20.0, 20.0, 12.0, 12.0]
+
+    for i, step in enumerate(active_steps):
+        state.expert_latency_window[step, 0, 0] = latencies[i]
+
+    state.expert_load_window_step = 10
+
+    # Test current latency 30.9ms against historical (steps 0-9)
+    # Historical mean = (10*3 + 15*2 + 20*3 + 12*2) / 10 = 154/10 = 15.4ms
+    # threshold = 2 * 15.4 = 30.8ms
+    # current = 30.9ms > 30.8ms → unhealthy
+    current_latency = torch.zeros(1, num_experts, dtype=torch.float32)
+    current_latency[0, 0] = 30.9
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert (
+        not state.expert_health_mask[0, 0]
+    ), "Expert should be unhealthy (30.9 > 30.8)"
+
+    # Now write the 30.9 to window and test next step
+    state.expert_latency_window[10 % window_size, 0, 0] = 30.9
+    state.expert_load_window_step = 11
+
+    # Test current latency 31ms against historical
+    # (now includes 30.9 at step 0)
+    # Historical = steps 1-9 + step 0(30.9)
+    # = (10*2 + 15*2 + 20*3 + 12*2 + 30.9) / 10 = 174.9/10 = 17.49ms
+    # threshold = 2 * 17.49 = 34.98ms
+    # current = 31ms < 34.98ms → healthy
+    current_latency[0, 0] = 31.0
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert state.expert_health_mask[0, 0], "Expert should be healthy (31 < 34.98)"
+
+    # Test current latency 35ms against historical
+    current_latency[0, 0] = 35.0
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert not state.expert_health_mask[0, 0], "Expert should be unhealthy (35 > 34.98)"
+
+

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -62,6 +62,16 @@ class EPLBConfig:
     This is turned off by default since it will cause communication overhead.
     """
 
+    health_check_enabled: bool = True
+    """Enable per-expert health monitoring based on latency."""
+
+    health_latency_threshold: float = 3.0
+    """Latency threshold multiplier. Expert is unhealthy if current latency
+    exceeds threshold * historical_mean_latency within a window for that expert."""
+
+    health_penalty_factor: float = 10.0
+    """Weight multiplier for unhealthy experts during rebalancing."""
+
 
 @config
 @dataclass

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -159,6 +159,28 @@ class EplbState:
     This is a constant and is taken from the config.
     """
 
+    expert_latency_window: torch.Tensor | None = None
+    """
+    Sliding window of per-expert latency (in milliseconds).
+    Shape: (window_size, num_moe_layers, num_physical_experts)
+    Value: latency if expert was active, 0.0 if inactive.
+    Only allocated if health_check_enabled=True.
+    """
+
+    expert_health_mask: torch.Tensor | None = None
+    """
+    Boolean mask indicating which experts are healthy.
+    Shape: (num_moe_layers, num_physical_experts)
+    True = healthy, False = unhealthy.
+    Only allocated if health_check_enabled=True.
+    """
+
+    health_latency_threshold: float = 3.0
+    """Threshold multiplier from EPLBConfig."""
+
+    health_penalty_factor: float = 10.0
+    """Weight penalty factor from EPLBConfig."""
+
     @staticmethod
     def build_initial_global_physical_to_logical_map(
         num_routed_experts: int,
@@ -264,8 +286,41 @@ class EplbState:
             device=device,
         )
 
+        # Initialize health monitoring if enabled
+        eplb_config = parallel_config.eplb_config
+        expert_latency_window = None
+        expert_health_mask = None
+
+        # Create shared latency view for layers to write to (like expert_load_pass)
+        expert_latency_pass = None
+        if eplb_config.health_check_enabled:
+            expert_latency_window = torch.zeros(
+                (
+                    expert_load_window_size,
+                    model.num_moe_layers,
+                    model.num_physical_experts,
+                ),
+                dtype=torch.float32,  # Latency in milliseconds
+                device=device,
+            )
+            expert_health_mask = torch.ones(
+                (model.num_moe_layers, model.num_physical_experts),
+                dtype=torch.bool,
+                device=device,
+            )
+            expert_latency_pass = torch.zeros(
+                (model.num_moe_layers, model.num_physical_experts),
+                dtype=torch.float32,
+                device=device,
+            )
+            logger.info(
+                "EPLB health monitoring enabled: threshold=%.1fx, penalty=%.1fx",
+                eplb_config.health_latency_threshold,
+                eplb_config.health_penalty_factor,
+            )
+
         # Set the initial progress of rearrangement to 3/4
-        eplb_step_interval = parallel_config.eplb_config.step_interval
+        eplb_step_interval = eplb_config.step_interval
         expert_rearrangement_step = max(0, eplb_step_interval - eplb_step_interval // 4)
 
         if global_expert_load is not None:
@@ -317,6 +372,7 @@ class EplbState:
             expert_load_pass,
             logical_to_physical_map,
             logical_replica_count,
+            expert_latency_pass,
         )
         if global_expert_load is not None:
             rearrange_expert_weights_inplace(
@@ -338,6 +394,10 @@ class EplbState:
             expert_load_window_size=expert_load_window_size,
             expert_rearrangement_step=expert_rearrangement_step,
             expert_rearrangement_step_interval=eplb_step_interval,
+            expert_latency_window=expert_latency_window,
+            expert_health_mask=expert_health_mask,
+            health_latency_threshold=eplb_config.health_latency_threshold,
+            health_penalty_factor=eplb_config.health_penalty_factor,
         )
 
     def step(
@@ -414,6 +474,18 @@ class EplbState:
                     balancedness,
                 )
 
+        # Record expert latencies (layers write directly to expert_latency_pass)
+        if self.expert_latency_window is not None and not is_dummy:
+            expert_latency_pass = model.get_expert_latencies()
+            if expert_latency_pass is not None:
+                # Update health mask BEFORE overwriting window
+                self._update_health_mask(expert_latency_pass, log_stats)
+                self.expert_latency_window[self.expert_load_window_step] = (
+                    expert_latency_pass.clone()
+                )
+                # Reset for next pass
+                expert_latency_pass.zero_()
+
         # Update the expert load sliding window
         if not is_dummy:
             self.expert_load_window[self.expert_load_window_step] = (
@@ -432,6 +504,83 @@ class EplbState:
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:
             self.expert_rearrangement_step = 0
             self.rearrange(model)
+
+    def _update_health_mask(
+        self, current_latency: torch.Tensor, log_stats: bool = False
+    ) -> None:
+        """
+        Update expert health mask based on per-expert historical latency.
+
+        Strategy: Compare current latency to threshold * historical mean.
+        0 latency means expert was inactive (ignored in mean calculation).
+        Threshold is configurable via health_latency_threshold (default 3.0).
+
+        Args:
+            current_latency: Current per-expert latency (before adding to window).
+                Shape: (num_moe_layers, num_physical_experts)
+            log_stats: Whether to log health status changes.
+        """
+        if self.expert_latency_window is None or self.expert_health_mask is None:
+            return
+
+        # Calculate historical mean from existing window (excluding current)
+        # Count active passes in history
+        # Shape: (num_moe_layers, num_physical_experts)
+        active_count = (self.expert_latency_window > 0).sum(dim=0)
+
+        # Sum of historical latencies
+        latency_sum = self.expert_latency_window.sum(dim=0)
+
+        # Historical mean (only for experts with sufficient history)
+        # Require at least min(10, window_size * 0.5) active passes
+        min_active_count = min(10, int(self.expert_load_window_size * 0.5))
+        historical_mean = torch.where(
+            active_count >= min_active_count,
+            latency_sum / active_count,
+            torch.zeros_like(latency_sum),
+        )
+
+        threshold = self.health_latency_threshold * historical_mean
+
+        # Expert is unhealthy if:
+        # 1. Currently active (current_latency > 0)
+        # 2. Exceeds threshold (already 0 if insufficient history)
+        is_unhealthy = (
+            (current_latency > 0)
+            & (current_latency > threshold)
+            & (historical_mean > 0)
+        )
+
+        new_health_mask = ~is_unhealthy
+
+        if log_stats:
+            newly_unhealthy = is_unhealthy & self.expert_health_mask
+            if newly_unhealthy.any():
+                unhealthy_coords = newly_unhealthy.nonzero(as_tuple=False)
+                for layer_idx, expert_idx in unhealthy_coords:
+                    current_lat = current_latency[layer_idx, expert_idx].item()
+                    baseline = historical_mean[layer_idx, expert_idx].item()
+                    logger.warning(
+                        "Expert [layer=%d, expert=%d] unhealthy: "
+                        "current=%.3fms > %.1fx * baseline=%.3fms",
+                        layer_idx,
+                        expert_idx,
+                        current_lat,
+                        self.health_latency_threshold,
+                        baseline,
+                    )
+
+            total_unhealthy = (~new_health_mask).sum().item()
+            total_experts = new_health_mask.numel()
+            if total_unhealthy > 0:
+                logger.info(
+                    "EPLB health summary: %d/%d experts unhealthy (%.1f%%)",
+                    total_unhealthy,
+                    total_experts,
+                    100.0 * total_unhealthy / total_experts,
+                )
+
+        self.expert_health_mask = new_health_mask
 
     def rearrange(
         self,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -2781,6 +2781,7 @@ class FusedMoE(CustomOp):
         self.cuda_end_event.synchronize()
 
         # Calculate layer latency in milliseconds
+        assert self.cuda_start_event is not None
         layer_latency_ms = self.cuda_start_event.elapsed_time(self.cuda_end_event)
 
         # Update latency view

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1246,7 +1246,9 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoR
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -1255,6 +1257,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoR
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -1306,6 +1309,17 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoR
             num_experts=self.config.n_routed_experts,
             num_redundant_experts=0,
         )
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -686,7 +686,9 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -695,6 +697,7 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
@@ -725,6 +728,17 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
 
 def get_spec_layer_idx_from_weight_name(

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -646,6 +646,7 @@ class MixtureOfExperts(Protocol):
         expert_load_view: Tensor,
         logical_to_physical_map: Tensor,
         logical_replica_count: Tensor,
+        expert_latency_view: Tensor | None = None,
     ) -> None:
         """
         Register the EPLB state in the MoE model.
@@ -662,6 +663,7 @@ class MixtureOfExperts(Protocol):
             expert_load_view: A view of the expert load metrics tensor.
             logical_to_physical_map: Mapping from logical to physical experts.
             logical_replica_count: Count of replicas for each logical expert.
+            expert_latency_view: A view for tracking per-expert latency (optional).
         """
         ...
 
@@ -670,6 +672,20 @@ class MixtureOfExperts(Protocol):
         num_physical_experts: int,
         num_local_physical_experts: int,
     ) -> None: ...
+
+    def get_expert_latencies(self) -> Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Each MoE layer writes its per-expert latency to a slice of this tensor.
+        This follows the same pattern as expert_load_view in EPLB.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        ...
 
 
 def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:

--- a/vllm/model_executor/models/lfm2_moe.py
+++ b/vllm/model_executor/models/lfm2_moe.py
@@ -742,7 +742,9 @@ class Lfm2MoeForCausalLM(
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -751,6 +753,7 @@ class Lfm2MoeForCausalLM(
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -796,3 +799,14 @@ class Lfm2MoeForCausalLM(
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -577,7 +577,9 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -586,6 +588,7 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -635,3 +638,14 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -829,7 +829,9 @@ class NemotronHForCausalLM(
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -838,6 +840,7 @@ class NemotronHForCausalLM(
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -884,3 +887,14 @@ class NemotronHForCausalLM(
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -1036,7 +1036,9 @@ class OpenPanguMoEModel(OpenPanguModelBase, MixtureOfExperts):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -1045,6 +1047,7 @@ class OpenPanguMoEModel(OpenPanguModelBase, MixtureOfExperts):
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -1063,6 +1066,17 @@ class OpenPanguMoEModel(OpenPanguModelBase, MixtureOfExperts):
                 moe.n_physical_experts = num_physical_experts
                 moe.n_redundant_experts = self.num_redundant_experts
                 moe.experts.update_expert_map()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
 
 class OpenPanguEmbeddedModel(OpenPanguModelBase):

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -693,7 +693,9 @@ class Qwen3MoeForCausalLM(
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -702,6 +704,7 @@ class Qwen3MoeForCausalLM(
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -753,6 +756,17 @@ class Qwen3MoeForCausalLM(
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -1211,7 +1211,9 @@ class Qwen3NextForCausalLM(
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
+        self.expert_latency_view = expert_latency_view
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
             self.expert_weights.append(layer.get_expert_weights())
@@ -1220,6 +1222,7 @@ class Qwen3NextForCausalLM(
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -1302,6 +1305,17 @@ class Qwen3NextForCausalLM(
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
 
 def gdn_attention_core(

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -124,13 +124,16 @@ class MoEMixin(MixtureOfExperts):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ):
+        self.expert_latency_view = expert_latency_view
         for moe_layer_idx, mlp_layer in enumerate(self.mlp_layers):
             mlp_layer.experts.set_eplb_state(
                 moe_layer_idx=moe_layer_idx,
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
             )
 
     def update_physical_experts_metadata(
@@ -173,6 +176,17 @@ class MoEMixin(MixtureOfExperts):
                 )
             )
         return expert_mapping
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
     def recursive_replace(self):
         """Initialize the MoE layers."""


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR implements Phase 0 of Fault-Tolerant Expert Parallelism as proposed in RFC #27774.
Goal: Add expert health monitoring to EPLB to detect unhealthy experts based on latency anomalies. This lays the foundation for automatic traffic redistribution (Phase 1 RFC #27774) and expert auto-recovery (Phase 2 RFC #27908).

### What's Implemented:

- Per-expert latency tracking in EPLB sliding window
- Health detection algorithm comparing current latency to historical baseline
- Proper handling of sparse expert activations
- Configuration options for health monitoring thresholds
- Comprehensive unit tests

## Test Plan
pytest tests/distributed/test_eplb_health.py -v

## Test Result

tests/distributed/test_eplb_health.py::test_basic_health_detection PASSED
tests/distributed/test_eplb_health.py::test_sparse_activation PASSED
tests/distributed/test_eplb_health.py::test_expert_recovery PASSED
tests/distributed/test_eplb_health.py::test_multi_layer_health PASSED
tests/distributed/test_eplb_health.py::test_historical_mean_calculation PASSED

## Key Design Decisions
1. Per-Layer Latency Assignment
Experts run in fused parallel kernels (pplx, DeepEP), cannot time individually
Solution: Measure layer latency (CUDA events), assign to all active experts
Inactive experts get 0 latency (excluded from health calculations)
Hardware-agnostic, no kernel modifications required
2. Sparse Activation Handling
Experts not active in every forward pass
Historical mean excludes inactive passes (0 latency ignored)
Requires min(10, window_size * 0.5) active passes before detection
Prevents false positives for rarely-used experts
3. Health Detection Algorithm
```
# For each expert:
historical_mean = sum(active_latencies) / count(active_passes)  # Excludes current
threshold = health_latency_threshold * historical_mean
is_unhealthy = (current_latency > threshold) & (sufficient_history)
```

