### PR TITLE
Add runai model streamer e2e test for GCS

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -543,8 +543,11 @@ steps:
 
 - label: Model Executor Test # 23min
   timeout_in_minutes: 35
+  torch_nightly: true
   mirror_hardwares: [amdexperimental]
   source_file_dependencies:
+  - vllm/engine/arg_utils.py
+  - vllm/config/model.py
   - vllm/model_executor
   - tests/model_executor
   - tests/entrypoints/openai/test_tensorizer_entrypoint.py

--- a/tests/model_executor/model_loader/runai_model_streamer/test_runai_model_streamer_loader.py
+++ b/tests/model_executor/model_loader/runai_model_streamer/test_runai_model_streamer_loader.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
+
 from vllm import SamplingParams
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader import get_model_loader
 
 load_format = "runai_streamer"
 test_model = "openai-community/gpt2"
+# TODO(amacaskill): Replace with a GKE owned GCS bucket.
+test_gcs_model = "gs://vertex-model-garden-public-us/codegemma/codegemma-2b/"
 
 prompts = [
     "Hello, my name is",
@@ -30,5 +34,18 @@ def test_get_model_loader_with_runai_flag():
 
 def test_runai_model_loader_download_files(vllm_runner):
     with vllm_runner(test_model, load_format=load_format) as llm:
+        deserialized_outputs = llm.generate(prompts, sampling_params)
+        assert deserialized_outputs
+
+
+def test_runai_model_loader_download_files_gcs(
+    vllm_runner, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "fake-project")
+    monkeypatch.setenv("RUNAI_STREAMER_GCS_USE_ANONYMOUS_CREDENTIALS", "true")
+    monkeypatch.setenv(
+        "CLOUD_STORAGE_EMULATOR_ENDPOINT", "https://storage.googleapis.com"
+    )
+    with vllm_runner(test_gcs_model, load_format=load_format) as llm:
         deserialized_outputs = llm.generate(prompts, sampling_params)
         assert deserialized_outputs


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The purpose of this is to add a basic RunAI model streamer e2e test that pulls from a public GCS bucket, and add this to the CI pipeline,  to prevent regressions in the RunAI model streamer. Examples of past RunAI model streamer regressions that this e2e test would have caught is: 
- https://github.com/vllm-project/vllm/pull/27308
- https://github.com/vllm-project/vllm/pull/25250
- Issue https://github.com/vllm-project/vllm/issues/24313 (can't find PR that caused it). I believe fix was https://github.com/vllm-project/vllm/pull/24435. 

We also need code coverage for [vllm/config/model.py](https://github.com/vllm-project/vllm/blob/6cae1e53326ab89551352b926854af7cd96b688a/vllm/config/model.py#L779)

This test uses a small model, [codegemma-2b](https://huggingface.co/google/codegemma-2b/tree/main) which is around 5.6 GiB. 

## Test Plan
We plan to enable all of the RunAI model streamer tests in the CI pipeline. Particularly, we want to run the tests on changes to any of the following: 
```
  source_file_dependencies:
  - vllm/engine
  - vllm/model_executor/model_loader
  - tests/model_executor/model_loader/runai_model_streamer
```
We also want to run the tests on the torch_nightly. 

We didn't add this to `Model Executor Test` because we would like to run the RunAI model streamer tests on changes to `vllm/engine` , `tests/model_executor/runai_model_streamer`, and on the nightly build (which `Model Executor Test` doesn't currently do).  

## Test Result
```
# All runai_model_streamer tests pass (including new test I added)
pytest -s -v tests/model_executor/model_loader/runai_model_streamer
=========================================== 7 passed, 3 warnings in 76.94s (0:01:16) ===========================================

# The new test I added passes: 
pytest -s -v tests/model_executor/model_loader/runai_model_streamer/test_runai_model_streamer_loader.py::test_runai_model_loader_download_gcs_files
PASSED
======================================================= warnings summary =======================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/schemathesis/generation/coverage.py:305
  /root/vllm/.venv/lib/python3.12/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================ 1 passed, 3 warnings in 47.99s ================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
(vllm) root@vllm-g2-vm:~/vllm# 
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

