### PR TITLE
[Kernel] Fuse computation of g and beta for Gated Delta Net

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -551,10 +551,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             mixed_qkv_non_spec
         )
 
-        beta = b.sigmoid()
         # g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-        g = fused_gdn_gating(self.A_log, a, self.dt_bias)
-        g, beta = map(lambda x: rearrange(x, "l d -> 1 l d"), (g, beta))
+        g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)
 
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
@@ -1297,11 +1295,15 @@ direct_register_custom_op(
 
 
 # g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+# beta_output = b.sigmoid()
+# TODO maybe use torch.compile to replace this triton kernel
 @triton.jit
 def fused_gdn_gating_kernel(
     g,
+    beta_output,
     A_log,
     a,
+    b,
     dt_bias,
     seq_len,
     NUM_HEADS: tl.constexpr,
@@ -1315,6 +1317,7 @@ def fused_gdn_gating_kernel(
     mask = head_off < NUM_HEADS
     blk_A_log = tl.load(A_log + head_off, mask=mask)
     blk_a = tl.load(a + off, mask=mask)
+    blk_b = tl.load(b + off, mask=mask)
     blk_bias = tl.load(dt_bias + head_off, mask=mask)
     # If the model is loaded in fp16, without the .float() here, A might be -inf
     x = blk_a.to(tl.float32) + blk_bias.to(tl.float32)
@@ -1323,20 +1326,36 @@ def fused_gdn_gating_kernel(
     )
     blk_g = -tl.exp(blk_A_log.to(tl.float32)) * softplus_x
     tl.store(g + off, blk_g.to(g.dtype.element_ty), mask=mask)
+    # compute beta_output = sigmoid(b)
+    blk_beta = 1.0 / (1.0 + tl.exp(-blk_b.to(tl.float32)))
+    tl.store(beta_output + off, blk_beta.to(beta_output.dtype.element_ty), mask=mask)
 
 
 def fused_gdn_gating(
     A_log: torch.Tensor,
     a: torch.Tensor,
+    b: torch.Tensor,
     dt_bias: torch.Tensor,
     beta: float = 1.0,
     threshold: float = 20.0,
-) -> torch.Tensor:
+) -> tuple[torch.Tensor, torch.Tensor]:
     batch, num_heads = a.shape
     seq_len = 1
     grid = (batch, seq_len, triton.cdiv(num_heads, 8))
-    g = torch.empty_like(a, dtype=torch.float32)
+    g = torch.empty(1, batch, num_heads, dtype=torch.float32, device=a.device)
+    beta_output = torch.empty(1, batch, num_heads, dtype=torch.float32, device=b.device)
     fused_gdn_gating_kernel[grid](
-        g, A_log, a, dt_bias, seq_len, num_heads, beta, threshold, 8, num_warps=1
+        g,
+        beta_output,
+        A_log,
+        a,
+        b,
+        dt_bias,
+        seq_len,
+        num_heads,
+        beta,
+        threshold,
+        8,
+        num_warps=1,
     )
-    return g
+    return g, beta_output


### PR DESCRIPTION
## Purpose
Fuse computation of g and beta into one triton kernel for Gated Delta Net and avoid `rearrange`

## Perf test
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct --enable-expert-parallel -tp 4
```
```
vllm bench serve \
--model Qwen/Qwen3-Next-80B-A3B-Instruct \
--dataset-name random \
--num-prompts 32 \
--random-input-len 2048 \
--random-output-len 1024
```

hardware setup: H20
TLDR: throughput 6123.13 -> 6237.58
this pr
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Benchmark duration (s):                  15.54     
Total input tokens:                      65536     
Total generated tokens:                  31377     
Request throughput (req/s):              2.06      
Output token throughput (tok/s):         2019.51   
Peak output token throughput (tok/s):    2356.00   
Peak concurrent requests:                32.00     
Total Token throughput (tok/s):          6237.58   
---------------Time to First Token----------------
Mean TTFT (ms):                          1101.49   
Median TTFT (ms):                        1112.77   
P99 TTFT (ms):                           1848.29   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.09     
Median TPOT (ms):                        13.96     
P99 TPOT (ms):                           15.35     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.07     
Median ITL (ms):                         13.38     
P99 ITL (ms):                            14.00     
==================================================
```
main
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Benchmark duration (s):                  15.82     
Total input tokens:                      65536     
Total generated tokens:                  31310     
Request throughput (req/s):              2.02      
Output token throughput (tok/s):         1979.59   
Peak output token throughput (tok/s):    2325.00   
Peak concurrent requests:                32.00     
Total Token throughput (tok/s):          6123.13   
---------------Time to First Token----------------
Mean TTFT (ms):                          1109.19   
Median TTFT (ms):                        1120.40   
P99 TTFT (ms):                           1858.64   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.35     
Median TPOT (ms):                        14.22     
P99 TPOT (ms):                           15.31     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.34     
Median ITL (ms):                         13.66     
P99 ITL (ms):                            14.08     
==================================================
```

## Accuracy test
```
lm_eval --model local-completions --model_args model=Qwen/Qwen3-Next-80B-A3B-Instruct,base_url=http://localhost:8000/v1/completions -t gsm8k --num_fewshot 5 --batch_size 250
```
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8499|±  |0.0098|
|     |       |strict-match    |     5|exact_match|↑  |0.8067|±  |0.0109|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

