### PR TITLE
Flashinfer: TopK+TopP sampling from probs

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -282,8 +282,9 @@ def flashinfer_sample(
         )
     else:
         # Both top-k and top-p.
-        next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_logits(
-            logits, k, p, deterministic=True
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+            probs, k, p, deterministic=True
         )
 
     return next_token_ids.view(-1)


### PR DESCRIPTION
Recent Flashinfer versions of `top_k_top_p_sampling_from_logits` are much slower on different systems:

 GPU | from logits (tokens/s) | from probs (tokens/s) | Improvement (%)
-- | -- | -- | --
SPARK | 19.78 | 28.50 | 44.1%
GB200 | 144.84 | 216.60 | 49.5%
H100 | 97.19 | 130.65 | 34.4%




