### PR TITLE
[V0 deprecation] Deprecate use_v1 parameter

### DIFF
--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_platform.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_platform.py
@@ -27,7 +27,6 @@ class DummyPlatform(Platform):
         dtype,
         kv_cache_dtype,
         block_size,
-        use_v1,
         use_mla,
         has_sink,
         use_sparse,

--- a/vllm/attention/selector.py
+++ b/vllm/attention/selector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import inspect
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -141,17 +142,35 @@ def _cached_get_attn_backend(
     # get device-specific attn_backend
     from vllm.platforms import current_platform
 
-    attention_cls = current_platform.get_attn_backend_cls(
-        selected_backend,
-        head_size,
-        dtype,
-        kv_cache_dtype,
-        block_size,
-        True,
-        use_mla,
-        has_sink,
-        use_sparse,
-    )
+    sig = inspect.signature(current_platform.get_attn_backend_cls)
+    if "use_v1" in sig.parameters:
+        logger.warning_once(
+            "use_v1 parameter for get_attn_backend_cls is deprecated and will "
+            "be removed in v0.13.0 or v1.0.0, whichever is soonest. Please "
+            "remove it from your plugin code."
+        )
+        attention_cls = current_platform.get_attn_backend_cls(
+            selected_backend,
+            head_size,
+            dtype,
+            kv_cache_dtype,
+            block_size,
+            True,  # use_v1
+            use_mla,
+            has_sink,
+            use_sparse,
+        )
+    else:
+        attention_cls = current_platform.get_attn_backend_cls(
+            selected_backend,
+            head_size,
+            dtype,
+            kv_cache_dtype,
+            block_size,
+            use_mla,
+            has_sink,
+            use_sparse,
+        )
     if not attention_cls:
         raise ValueError(
             f"Invalid attention backend for {current_platform.device_name}"

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -131,7 +131,6 @@ class CpuPlatform(Platform):
         dtype: torch.dtype,
         kv_cache_dtype: str | None,
         block_size: int,
-        use_v1: bool,
         use_mla: bool,
         has_sink: bool,
         use_sparse: bool,
@@ -144,8 +143,6 @@ class CpuPlatform(Platform):
             raise NotImplementedError("MLA is not supported on CPU.")
         if use_sparse:
             raise NotImplementedError("Sparse Attention is not supported on CPU.")
-        if not use_v1:
-            raise ValueError("CPU backend only supports V1.")
         return AttentionBackendEnum.CPU_ATTN.get_path()
 
     @classmethod

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -336,17 +336,10 @@ class CudaPlatformBase(Platform):
         dtype: torch.dtype,
         kv_cache_dtype: "CacheDType | None",
         block_size: int | None,
-        use_v1: bool,
         use_mla: bool,
         has_sink: bool,
         use_sparse: bool,
     ) -> str:
-        if not use_v1:
-            raise RuntimeError(
-                "V0 attention backends have been removed. Set VLLM_USE_V1=1 "
-                "to select a supported backend."
-            )
-
         device_capability = cls.get_device_capability()
         assert device_capability is not None
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -215,7 +215,6 @@ class Platform:
         dtype: torch.dtype,
         kv_cache_dtype: "CacheDType | None",
         block_size: int,
-        use_v1: bool,
         use_mla: bool,
         has_sink: bool,
         use_sparse: bool,

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -213,7 +213,6 @@ class RocmPlatform(Platform):
         dtype,
         kv_cache_dtype,
         block_size,
-        use_v1,
         use_mla,
         has_sink,
         use_sparse,
@@ -223,12 +222,6 @@ class RocmPlatform(Platform):
 
         if use_sparse:
             raise NotImplementedError("Sparse Attention is not supported on ROCm.")
-
-        if not use_v1:
-            raise RuntimeError(
-                "V0 attention backends have been removed. Set VLLM_USE_V1=1 "
-                "to select a supported backend."
-            )
 
         if use_mla:
             if selected_backend is None:

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -58,7 +58,6 @@ class TpuPlatform(Platform):
         dtype: torch.dtype,
         kv_cache_dtype: str | None,
         block_size: int,
-        use_v1: bool,
         use_mla: bool,
         has_sink,
         use_sparse,
@@ -70,8 +69,6 @@ class TpuPlatform(Platform):
         if selected_backend != AttentionBackendEnum.PALLAS:
             logger.info("Cannot use %s backend on TPU.", selected_backend)
 
-        if not use_v1:
-            raise ValueError("TPU backend only supports V1.")
         logger.info("Using Pallas V1 backend.")
         return AttentionBackendEnum.PALLAS.get_path()
 

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -48,7 +48,6 @@ class XPUPlatform(Platform):
         dtype: torch.dtype,
         kv_cache_dtype: str | None,
         block_size: int,
-        use_v1: bool,
         use_mla: bool,
         has_sink: bool,
         use_sparse,
@@ -77,7 +76,7 @@ class XPUPlatform(Platform):
         elif selected_backend:
             raise ValueError(
                 f"Invalid attention backend for {cls.device_name}, "
-                f"with use_v1: {use_v1} use_mla: {use_mla}"
+                f"with use_mla: {use_mla}"
             )
 
         logger.info("Using Flash Attention backend.")


### PR DESCRIPTION
## Purpose
`use_v1` for `get_attn_backend_cls` is useless now. Since this is an interface impact change, let's deprecate it  and remove it in the next release. 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

