### PR TITLE
[bugfix]: Fix the issue where unsupported response format types could cause the inference service to crash, enhancing the robustness of vLLM.

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -6,7 +6,7 @@
 import json
 import time
 from http import HTTPStatus
-from typing import Annotated, Any, ClassVar, Literal, Optional, Union, Dict, Tuple
+from typing import Annotated, Any, ClassVar, Literal, Optional, Dict, Tuple, Generic, TypeAlias, TypeVar
 
 import regex as re
 import torch

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -6,7 +6,7 @@
 import json
 import time
 from http import HTTPStatus
-from typing import Annotated, Any, ClassVar, Generic, Literal, TypeAlias, TypeVar
+from typing import Annotated, Any, ClassVar, Literal, Optional, Union, Dict, Tuple
 
 import regex as re
 import torch
@@ -3094,3 +3094,51 @@ class TranslationResponseVerbose(OpenAIBaseModel):
 
     words: list[TranslationWord] | None = None
     """Extracted words and their corresponding timestamps."""
+
+
+def find_unsupported_type(schema: Any) -> Tuple[bool, Optional[str]]:
+    """
+    Whitelist mechanism: recursively check whether the JSON schema contains
+    any unsupported `type` values.
+    If an unsupported type is found, return (True, unsupported_type_name);
+    otherwise return (False, None).
+    """
+    SUPPORTED_TYPES = {"object", "array", "string", "number", "integer", "boolean"}
+    if isinstance(schema, dict):
+        t = schema.get("type")
+        if isinstance(t, str):
+            if t not in SUPPORTED_TYPES:
+                return True, t
+        elif isinstance(t, list):
+            for x in t:
+                # Composite type (type can be a list, e.g., ["string", "null"]);
+                # each element must also be validated.
+                if not isinstance(x, str) or x not in SUPPORTED_TYPES:
+                    return True, x
+        # Recursively check all nested fields
+        for v in schema.values():
+            found, unsupported = find_unsupported_type(v)
+            if found:
+                return True, unsupported
+    elif isinstance(schema, list):
+        for item in schema:
+            found, unsupported = find_unsupported_type(item)
+            if found:
+                return True, unsupported
+    return False, None
+
+
+def validate_schema_format(schema: Dict[str, Any]):
+    """Validate the given schema.
+    If it contains any types not in the whitelist, raise a ValueError.
+    """
+    if not schema:
+        return
+    try:
+        found, unsupported = find_unsupported_type(schema)
+        if found:
+            raise ValueError(f"Invalid schema: {unsupported}")
+    except ValueError:
+        raise
+    except Exception as e:
+        raise ValueError(f"Invalid schema: {str(e)}")


### PR DESCRIPTION

## Purpose
Fix the issue where unsupported response format types could cause the inference service to crash, enhancing the robustness of vLLM.

## Test Plan
1. before fix
2. after fix
bad case query
`{
    "model": "Qwen3-30B-A3B",
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful math tutor. Guide the user through the solution step by step."
        },
        {
            "role": "user",
            "content": "How Can I solve 8x + 7 = -23"
        }
    ],
    "top_p": 0.1,
    "temperature": 0.7,
    "stream": false,
    "max_tokens": 500,
    "chat_template_kwargs": {
        "enable_thinking": false
    },
    "response_format": {
        "type": "json_schema",
        "json_schema": {
            "name": "math_response",
            "schema": {
                "type": "object",
                "properties": {
                    "steps": {
                        "type": "array",
                        "items": {
                            "type": "object",
                            "properties": {
                                "explanation": {
                                    "type": "string"
                                },
                                "output": {
                                    "type": "string"
                                },
                                "emmm": {
                                    "type": "bool"
                                },
                                "emmm1": {
                                    "type": "number"
                                },
                                "emmm2": {
                                    "type": "integer"
                                }
                            },
                            "required": [
                                "explanation",
                                "output"
                            ],
                            "additionalProperties": false
                        }
                    },
                    "final_answer": {
                        "type": "string"
                    }
                },
                "required": [
                    "steps",
                    "final_answer"
                ],
                "additionalProperties": false
            },
            "strict": true
        }
    }
}`
## Test Result
1.before fix, return
`ERROR 10-13 15:54:01 [core.py:398] EngineCore encountered a fatal error.
ERROR 10-13 15:54:01 [core.py:398] Traceback (most recent call last):
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 389, in run_engine_core
ERROR 10-13 15:54:01 [core.py:398]     engine_core.run_busy_loop()
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 413, in run_busy_loop
ERROR 10-13 15:54:01 [core.py:398]     self._process_engine_step()
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 438, in _process_engine_step
ERROR 10-13 15:54:01 [core.py:398]     outputs = self.step_fn()
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 202, in step
ERROR 10-13 15:54:01 [core.py:398]     scheduler_output = self.scheduler.schedule()
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/core/sched/scheduler.py", line 305, in schedule
ERROR 10-13 15:54:01 [core.py:398]     if structured_output_req and structured_output_req.grammar:
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/request.py", line 43, in grammar
ERROR 10-13 15:54:01 [core.py:398]     completed = self._check_grammar_completion()
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/request.py", line 31, in _check_grammar_completion
ERROR 10-13 15:54:01 [core.py:398]     self._grammar = self._grammar.result(timeout=0.0001)
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 458, in result
ERROR 10-13 15:54:01 [core.py:398]     return self.__get_result()
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
ERROR 10-13 15:54:01 [core.py:398]     raise self._exception
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/concurrent/futures/thread.py", line 58, in run
ERROR 10-13 15:54:01 [core.py:398]     result = self.fn(*self.args, **self.kwargs)
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/__init__.py", line 77, in _async_create_grammar
ERROR 10-13 15:54:01 [core.py:398]     return self.backend.compile_grammar(request_type, grammar_spec)
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/backend_xgrammar.py", line 101, in compile_grammar
ERROR 10-13 15:54:01 [core.py:398]     ctx = self.compiler.compile_json_schema(
ERROR 10-13 15:54:01 [core.py:398]   File "/opt/conda/lib/python3.10/site-packages/xgrammar/compiler.py", line 122, in compile_json_schema
ERROR 10-13 15:54:01 [core.py:398]     self._handle.compile_json_schema(
ERROR 10-13 15:54:01 [core.py:398] RuntimeError: [15:54:01] /project/cpp/json_schema_converter.cc:637: Unsupported type "bool"
ERROR 10-13 15:54:01 [core.py:398] 
INFO 10-13 15:54:01 [ray_distributed_executor.py:127] Shutting down Ray distributed executor. If you see error log from logging.cc regarding SIGTERM received, please ignore because this is the expected termination process in Ray.
2025-10-13 15:54:01,824 INFO compiled_dag_node.py:2173 -- Tearing down compiled DAG
2025-10-13 15:54:01,825 INFO compiled_dag_node.py:2178 -- Cancelling compiled worker on actor: Actor(RayWorkerWrapper, f581aa2dfcb4fa7fba31bd5d01000000)
2025-10-13 15:54:01,825 INFO compiled_dag_node.py:2178 -- Cancelling compiled worker on actor: Actor(RayWorkerWrapper, 70668deea0e853d46325c59c01000000)
ERROR 10-13 15:54:01 [async_llm.py:399] AsyncLLM output_handler failed.
ERROR 10-13 15:54:01 [async_llm.py:399] Traceback (most recent call last):
ERROR 10-13 15:54:01 [async_llm.py:399]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/async_llm.py", line 357, in output_handler
ERROR 10-13 15:54:01 [async_llm.py:399]     outputs = await engine_core.get_output_async()
ERROR 10-13 15:54:01 [async_llm.py:399]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core_client.py", line 716, in get_output_async
ERROR 10-13 15:54:01 [async_llm.py:399]     raise self._format_exception(outputs) from None
ERROR 10-13 15:54:01 [async_llm.py:399] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
INFO 10-13 15:54:01 [async_llm.py:324] Request chatcmpl-47dae527be204864af9f1c1147388685 failed (engine dead).
ERROR 10-13 15:54:01 [serving_chat.py:885] Error in chat completion stream generator.
ERROR 10-13 15:54:01 [serving_chat.py:885] Traceback (most recent call last):
ERROR 10-13 15:54:01 [serving_chat.py:885]   File "/opt/conda/lib/python3.10/site-packages/vllm/entrypoints/openai/serving_chat.py", line 487, in chat_completion_stream_generator
ERROR 10-13 15:54:01 [serving_chat.py:885]     async for res in result_generator:
ERROR 10-13 15:54:01 [serving_chat.py:885]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/async_llm.py", line 306, in generate
ERROR 10-13 15:54:01 [serving_chat.py:885]     out = q.get_nowait() or await q.get()
ERROR 10-13 15:54:01 [serving_chat.py:885]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/output_processor.py", line 51, in get
ERROR 10-13 15:54:01 [serving_chat.py:885]     raise output
ERROR 10-13 15:54:01 [serving_chat.py:885]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/async_llm.py", line 357, in output_handler
ERROR 10-13 15:54:01 [serving_chat.py:885]     outputs = await engine_core.get_output_async()
ERROR 10-13 15:54:01 [serving_chat.py:885]   File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core_client.py", line 716, in get_output_async
ERROR 10-13 15:54:01 [serving_chat.py:885]     raise self._format_exception(outputs) from None
ERROR 10-13 15:54:01 [serving_chat.py:885] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
2025-10-13 15:54:01,909 INFO compiled_dag_node.py:2200 -- Waiting for worker tasks to exit
2025-10-13 15:54:01,910 INFO compiled_dag_node.py:2203 -- Teardown complete
Process EngineCore_0:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/opt/conda/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 400, in run_engine_core
    raise e
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 389, in run_engine_core
    engine_core.run_busy_loop()
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 413, in run_busy_loop
    self._process_engine_step()
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 438, in _process_engine_step
    outputs = self.step_fn()
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 202, in step
    scheduler_output = self.scheduler.schedule()
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/core/sched/scheduler.py", line 305, in schedule
    if structured_output_req and structured_output_req.grammar:
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/request.py", line 43, in grammar
    completed = self._check_grammar_completion()
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/request.py", line 31, in _check_grammar_completion
    self._grammar = self._grammar.result(timeout=0.0001)
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 458, in result
    return self.__get_result()
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/opt/conda/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/__init__.py", line 77, in _async_create_grammar
    return self.backend.compile_grammar(request_type, grammar_spec)
  File "/opt/conda/lib/python3.10/site-packages/vllm/v1/structured_output/backend_xgrammar.py", line 101, in compile_grammar
    ctx = self.compiler.compile_json_schema(
  File "/opt/conda/lib/python3.10/site-packages/xgrammar/compiler.py", line 122, in compile_json_schema
    self._handle.compile_json_schema(
RuntimeError: [15:54:01] /project/cpp/json_schema_converter.cc:637: Unsupported type "bool"

(RayWorkerWrapper pid=1867682) INFO 10-11 18:54:26 [gpu_model_runner.py:1686] Graph capturing finished in 37 secs, took 0.13 GiB
nanobind: leaked 1 instances!
 - leaked instance 0x7fd9452455a8 of type "xgrammar.xgrammar_bindings.GrammarCompiler"
nanobind: leaked 1 types!
 - leaked type "xgrammar.xgrammar_bindings.GrammarCompiler"
nanobind: leaked 9 functions!
 - leaked function "compile_regex"
 - leaked function "get_cache_size_bytes"
 - leaked function "compile_structural_tag"
 - leaked function "compile_grammar"
 - leaked function "compile_builtin_json_grammar"
 - leaked function "compile_json_schema"
 - leaked function "__init__"
 - leaked function ""
 - leaked function "clear_cache"
nanobind: this is likely caused by a reference counting issue in the binding code.
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [1865221]`

2.after fix, return：
{
    "object": "error",
    "message": "Invalid schema: bool",
    "type": "BadRequestError",
    "param": null,
    "code": 400
}
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

