### PR TITLE
[Bugfix] Fix Qwen3-Reranker-8B load

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -439,9 +439,9 @@ def load_weights_using_from_2_way_softmax(
 
     # ModelForPooling is dynamically defined inside the _create_pooling_model_cls
     # function, so we need use this hacky method to obtain it.
-    pooling_model_cls = [
+    pooling_model_cls = next(
         x for x in type(model).__mro__ if x.__name__ == "ModelForPooling"
-    ][0]
+    )
     loaded_weights = pooling_model_cls.load_weights(model, weights, load_lm_head=True)
 
     from vllm.transformers_utils.tokenizer import get_tokenizer

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -186,15 +186,21 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
         def _init_pooler(self, vllm_config: "VllmConfig", prefix: str = ""):
             raise NotImplementedError
 
-        def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        def load_weights(
+            self,
+            weights: Iterable[tuple[str, torch.Tensor]],
+            load_lm_head: bool = False,
+        ):
             # TODO: Support uninitialized params tracking
 
-            # We have deleted this attribute, so don't load it
-            weights = (
-                (name, data)
-                for name, data in weights
-                if not name.startswith("lm_head.")
-            )
+            # For most pooling models: We have deleted this attribute, so don't load it.
+            # For converting an LLM into a seq cls model, we need the lm_head.
+            if not load_lm_head:
+                weights = (
+                    (name, data)
+                    for name, data in weights
+                    if not name.startswith("lm_head.")
+                )
 
             # If `*ForCausalLM` defines `load_weights` on the inner model
             # and there are no other inner modules with parameters,
@@ -431,8 +437,12 @@ def load_weights_using_from_2_way_softmax(
         )
         model.lm_head = model.lm_head.tie_weights(embed_tokens)
 
-    # Skip ModelForSequenceClassification in MRO to avoid infinite recursion
-    loaded_weights = type(model).__mro__[1].load_weights(model, weights)
+    # ModelForPooling is dynamically defined inside the _create_pooling_model_cls
+    # function, so we need use this hacky method to obtain it.
+    pooling_model_cls = [
+        x for x in type(model).__mro__ if x.__name__ == "ModelForPooling"
+    ][0]
+    loaded_weights = pooling_model_cls.load_weights(model, weights, load_lm_head=True)
 
     from vllm.transformers_utils.tokenizer import get_tokenizer
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix #27857

cc @hmellor @DarkLight1337

Thanks @zhcn000000 for reporting this issue.



## Test Plan

https://github.com/noooop/snippet/blob/main/debug/qwen3_reranker/offline.py

## Test Result

main

```
Qwen/Qwen3-Reranker-8B
0 0.5
1 0.5
2 0.5
3 0.5
4 0.5
```
lm_head has not been loaded, so score.weight is all zeros.


this pr

```
Qwen/Qwen3-Reranker-8B
0 0.7413856983184814
1 0.5680668354034424
2 0.6483641266822815
3 0.8447531461715698
4 0.44366133213043213
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

