### PR TITLE
[Bugfix]: missing partial content if openai tool calling is enabled

### DIFF
--- a/vllm/tool_parsers/openai_tool_parser.py
+++ b/vllm/tool_parsers/openai_tool_parser.py
@@ -79,6 +79,16 @@ class OpenAIToolParser(ToolParser):
                 elif msg.channel == "commentary" and not msg.recipient:
                     commentary_content = msg_text
 
+            # Check for partial responses:
+            # current content without recipient and final channel
+            if (
+                parser.current_content
+                and final_content is None
+                and parser.current_recipient is None
+                and parser.current_channel in [None, "final"]
+            ):
+                final_content = parser.current_content
+
         return ExtractedToolCallInformation(
             tools_called=len(tool_calls) > 0,
             tool_calls=tool_calls,

--- a/vllm/tool_parsers/openai_tool_parser.py
+++ b/vllm/tool_parsers/openai_tool_parser.py
@@ -80,7 +80,7 @@ class OpenAIToolParser(ToolParser):
                     commentary_content = msg_text
 
             # Check for partial responses:
-            # current content without recipient and final channel
+            # current content in final channel without recipient and final content.
             if (
                 parser.current_content
                 and final_content is None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The OpenAIToolParser overrides the code of regular response parsing when enabled. This breaks partial responses when the token limit is reached and harmony does not generate a final message but only `current_content` is left, which is ignored.

To solve this, return the parsers `current_content` as it is also done in the non-tool calling case.

The code should probably be refactored such that the logic from [parse_chat_output()](https://github.com/vllm-project/vllm/blob/ab2eb27b74da0e6846749c11a68179d27a78d963/vllm/entrypoints/harmony_utils.py#L516) is not duplicated here. Actually, most of the parsing is already done there and repeated here. Leaving this refactoring for a separate PR.

## Test Plan
- Manually tested with chat requests with limited max_tokens while the parser is enabled.
- Added test cases.

## Test Result
`max_completion_tokens=5`, stopping in reasoning
```
--- Request: Tell me something about confidential computing. ---
(Need to)
```

`max_completion_tokens=50`, stopping in final message
```
--- Request: Tell me something about confidential computing. ---
(Need explain concept.)

### What is Confidential Computing?

Confidential computing is a set of hardware‑enforced
```

