### PR TITLE
[CPU] Enable torch profiling

### DIFF
--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -37,6 +37,28 @@ class CPUWorker(Worker):
 
         self.parallel_config.disable_custom_all_reduce = True
 
+        if envs.VLLM_TORCH_PROFILER_DIR:
+            torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
+            worker_name = f"{vllm_config.instance_id}-rank-{self.rank}"
+            logger.info(
+                "Profiling enabled. Traces will be saved to: %s",
+                torch_profiler_trace_dir,
+            )
+            self.profiler = torch.profiler.profile(
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                ],
+                record_shapes=envs.VLLM_TORCH_PROFILER_RECORD_SHAPES,
+                profile_memory=envs.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY,
+                with_stack=envs.VLLM_TORCH_PROFILER_WITH_STACK,
+                with_flops=envs.VLLM_TORCH_PROFILER_WITH_FLOPS,
+                on_trace_ready=torch.profiler.tensorboard_trace_handler(
+                    torch_profiler_trace_dir, worker_name=worker_name, use_gzip=False
+                ),
+            )
+        else:
+            self.profiler = None
+
     def init_device(self):
         # Setup OpenMP threads affinity.
         omp_cpuids = envs.VLLM_CPU_OMP_THREADS_BIND
@@ -166,3 +188,17 @@ class CPUWorker(Worker):
             [(x.id, x.physical_core) for x in logical_cpu_list],
         )
         return ",".join([str(x.id) for x in logical_cpu_list])
+
+    def profile(self, is_start: bool = True):
+        if self.profiler is None:
+            raise RuntimeError("Profiler is not enabled.")
+        if is_start:
+            self.profiler.start()
+        else:
+            self.profiler.stop()
+            if self.local_rank == 0:
+                logger.info(
+                    self.profiler.key_averages().table(
+                        sort_by="self_cpu_time_total", row_limit=50
+                    )
+                )


### PR DESCRIPTION
## Purpose
The PR  enables profiling for vllm models using `torch.profile` on CPU 


## Usage

export VLLM_TORCH_PROFILER_DIR=example_directory

## Example

```
VLLM_TORCH_PROFILER_DIR=vllm_profile vllm bench throughput --num-prompts 1 --seed 0   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --input_len 128 --load-format  dummy   --profile
```

Example output for reference: 
```
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210] -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                                  Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210] -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                         _C::onednn_mm        48.73%        1.022s        48.73%        1.022s      89.669us         11392  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                       _C_cache_ops::reshape_and_cache        16.46%     345.077ms        16.46%     345.077ms     122.542us          2816  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                               vllm::unified_attention        14.39%     301.668ms        38.74%     812.062ms     288.374us          2816  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                            Torch-Compiled Region: 1/0         4.47%      93.724ms         4.77%      99.913ms     780.568us           128  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                _C::paged_attention_v1         2.88%      60.405ms         2.88%      60.405ms      21.620us          2794  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                           aten::slice         1.77%      37.093ms         2.25%      47.086ms       3.124us         15074  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                          aten::select         1.16%      24.366ms         1.41%      29.556ms       5.247us          5633  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                            aten::view         0.95%      19.870ms         0.96%      20.107ms       1.161us         17326  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                   aten::empty_strided         0.88%      18.352ms         0.88%      18.352ms       5.446us          3370  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                       bytecode_tracing (dynamo_timed)         0.84%      17.627ms         2.97%      62.195ms      62.195ms             1  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]         OutputGraph.call_user_compiler (dynamo_timed)         0.80%      16.811ms         1.18%      24.666ms      24.666ms             1  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                      aten::empty_like         0.79%      16.526ms         1.35%      28.325ms       9.818us          2885  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                      aten::as_strided         0.76%      15.902ms         0.76%      15.902ms       0.740us         21492  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                           build_guards (dynamo_timed)         0.68%      14.249ms         0.68%      14.249ms      14.249ms             1  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                     Pregraph bytecode         0.47%       9.781ms         0.47%       9.781ms      38.209us           256  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                                           aten::copy_         0.39%       8.224ms         0.45%       9.451ms       6.399us          1477  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]                      compile_attempt_0 (dynamo_timed)         0.38%       8.031ms         4.53%      94.892ms      94.892ms             1  
(EngineCore_DP0 pid=44565) INFO 11-05 13:22:49 [cpu_worker.py:210]           PyCodeCache.load_by_key_path (dynamo_timed)         0.27%       5.634ms         0.27%       5.634ms       5.634ms             1  
```