### PR TITLE
[Core] MoE timeout-based error detection and graceful degradation. (Phase 0 of RFC #27774) 

### DIFF
--- a/docker/Dockerfile.wheel
+++ b/docker/Dockerfile.wheel
@@ -1,0 +1,188 @@
+# Dockerfile.wheel - Build vLLM image from pre-built wheel with local changes
+# This Dockerfile uses a pre-built vLLM wheel and overlays local Python changes
+# for much faster builds compared to building from scratch.
+#
+# Usage:
+#   docker build -f docker/Dockerfile.wheel -t vllm-custom:latest .
+#
+# With custom wheel version:
+#   docker build --build-arg VLLM_WHEEL_VERSION=0.11.0 -f docker/Dockerfile.wheel -t vllm-custom:latest .
+#
+# With custom CUDA/torch backend (default cu128 for CUDA 12.8):
+#   docker build --build-arg CUDA_VERSION=12.4.1 --build-arg TORCH_BACKEND=cu124 -f docker/Dockerfile.wheel -t vllm-custom:latest .
+#
+# With wheel from URL:
+#   docker build --build-arg VLLM_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/v0.11.0/vllm-0.11.0-cp38-abi3-manylinux1_x86_64.whl \
+#                -f docker/Dockerfile.wheel -t vllm-custom:latest .
+
+ARG CUDA_VERSION=12.8.1
+ARG PYTHON_VERSION=3.12
+ARG TORCH_BACKEND=cu128
+
+# By parameterizing the base images, we allow third-party to use their own base images
+ARG FINAL_BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
+
+#################### vLLM installation from wheel ####################
+FROM ${FINAL_BASE_IMAGE} AS vllm-base
+ARG CUDA_VERSION
+ARG PYTHON_VERSION
+ARG TORCH_BACKEND
+WORKDIR /vllm-workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-c"]
+
+ARG GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
+ARG DEADSNAKES_MIRROR_URL
+ARG DEADSNAKES_GPGKEY_URL
+
+# Install Python and system dependencies
+RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
+    && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
+    && apt-get update -y \
+    && apt-get install -y ccache software-properties-common git curl wget sudo vim python3-pip \
+    && apt-get install -y ffmpeg libsm6 libxext6 libgl1 libibverbs-dev libnuma-dev \
+    && if [ ! -z ${DEADSNAKES_MIRROR_URL} ] ; then \
+        if [ ! -z "${DEADSNAKES_GPGKEY_URL}" ] ; then \
+            mkdir -p -m 0755 /etc/apt/keyrings ; \
+            curl -L ${DEADSNAKES_GPGKEY_URL} | gpg --dearmor > /etc/apt/keyrings/deadsnakes.gpg ; \
+            sudo chmod 644 /etc/apt/keyrings/deadsnakes.gpg ; \
+            echo "deb [signed-by=/etc/apt/keyrings/deadsnakes.gpg] ${DEADSNAKES_MIRROR_URL} $(lsb_release -cs) main" > /etc/apt/sources.list.d/deadsnakes.list ; \
+        fi ; \
+    else \
+        for i in 1 2 3; do \
+            add-apt-repository -y ppa:deadsnakes/ppa && break || \
+            { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }; \
+        done ; \
+    fi \
+    && apt-get update -y \
+    && apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+    && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
+    && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
+    && curl -sS ${GET_PIP_URL} | python${PYTHON_VERSION} \
+    && python3 --version && python3 -m pip --version
+
+ARG PIP_INDEX_URL
+ARG PIP_EXTRA_INDEX_URL
+ARG PYTORCH_CUDA_INDEX_BASE_URL=https://download.pytorch.org/whl
+
+# Install uv for faster pip installs
+RUN python3 -m pip install uv
+
+# Configure uv
+ENV UV_HTTP_TIMEOUT=500
+ENV UV_INDEX_STRATEGY="unsafe-best-match"
+ENV UV_LINK_MODE=copy
+
+# Workaround for https://github.com/openai/triton/issues/2507
+RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
+
+# Build vLLM from source (instead of using pre-built wheel)
+# This ensures C++ extensions are compiled against the runtime PyTorch version
+ARG VLLM_VERSION=v0.11.0
+
+# Copy vLLM source code
+COPY . /vllm-workspace/
+WORKDIR /vllm-workspace
+
+# Install build dependencies FIRST (includes setuptools with distutils for Python 3.12)
+COPY requirements/build.txt requirements/build.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    echo "Installing build dependencies with TORCH_BACKEND=${TORCH_BACKEND}" \
+    && uv pip install --system -r requirements/build.txt --torch-backend=${TORCH_BACKEND}
+
+# Install vLLM from source with torch backend
+# This will compile C++ extensions against the installed PyTorch
+RUN --mount=type=cache,target=/root/.cache/uv \
+    echo "Building vLLM from source (TORCH_BACKEND=${TORCH_BACKEND})"; \
+    # TODO: remove apache-tvm-ffi once FlashInfer is fixed
+    uv pip install --system --pre apache-tvm-ffi==0.1.0b15 \
+    && MAX_JOBS=16 uv pip install --system -e . \
+        --verbose --torch-backend=${TORCH_BACKEND}
+
+# Install FlashInfer pre-compiled kernel cache and binaries
+# https://docs.flashinfer.ai/installation.html
+RUN --mount=type=cache,target=/root/.cache/uv \
+    echo "Installing FlashInfer components for TORCH_BACKEND=${TORCH_BACKEND}" \
+    && uv pip install --system flashinfer-cubin==0.4.1 \
+    && uv pip install --system flashinfer-jit-cache==0.4.1 \
+        --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.') \
+    && (which flashinfer && flashinfer show-config || echo "FlashInfer installed (CLI not available)")
+
+# Note: No need to copy Python files since we're using editable install (-e)
+# The source is already in /vllm-workspace and linked
+
+# Copy examples and benchmarks for convenience
+COPY examples /vllm-workspace/examples
+COPY benchmarks /vllm-workspace/benchmarks
+
+# Note: Build dependencies already installed above before building vLLM
+
+# Install DeepGEMM from source
+ARG DEEPGEMM_GIT_REF
+COPY tools/install_deepgemm.sh /tmp/install_deepgemm.sh
+RUN --mount=type=cache,target=/root/.cache/uv \
+    VLLM_DOCKER_BUILD_CONTEXT=1 TORCH_CUDA_ARCH_LIST="9.0a 10.0a" /tmp/install_deepgemm.sh --cuda-version "${CUDA_VERSION}" ${DEEPGEMM_GIT_REF:+--ref "$DEEPGEMM_GIT_REF"}
+
+# Install gdrcopy
+ARG TARGETPLATFORM
+ARG GDRCOPY_CUDA_VERSION=12.8
+ARG GDRCOPY_OS_VERSION=Ubuntu22_04
+COPY tools/install_gdrcopy.sh install_gdrcopy.sh
+RUN set -eux; \
+    case "${TARGETPLATFORM}" in \
+      linux/arm64) UUARCH="aarch64" ;; \
+      linux/amd64) UUARCH="x64" ;; \
+      *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    ./install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "${GDRCOPY_CUDA_VERSION}" "${UUARCH}"; \
+    rm ./install_gdrcopy.sh
+
+# Install EP kernels (pplx-kernels and DeepEP)
+COPY tools/ep_kernels/install_python_libraries.sh install_python_libraries.sh
+ENV CUDA_HOME=/usr/local/cuda
+RUN export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-9.0a 10.0a+PTX}" \
+    && bash install_python_libraries.sh
+
+# CUDA library path workaround
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
+# Verify installation and show package versions
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip list
+
+#################### vLLM installation from wheel ####################
+
+
+#################### OPENAI API SERVER ####################
+FROM vllm-base AS vllm-openai-base
+ARG TARGETPLATFORM
+
+ARG PIP_INDEX_URL
+ARG PIP_EXTRA_INDEX_URL
+
+ENV UV_HTTP_TIMEOUT=500
+
+# Install additional dependencies for OpenAI API server
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        BITSANDBYTES_VERSION="0.42.0"; \
+    else \
+        BITSANDBYTES_VERSION="0.46.1"; \
+    fi; \
+    uv pip install --system accelerate hf_transfer modelscope "bitsandbytes>=${BITSANDBYTES_VERSION}" 'timm>=1.0.17' 'runai-model-streamer[s3,gcs]>=0.15.0'
+
+ENV VLLM_USAGE_SOURCE production-docker-image
+
+# SageMaker variant
+FROM vllm-openai-base AS vllm-sagemaker
+COPY examples/online_serving/sagemaker-entrypoint.sh .
+RUN chmod +x sagemaker-entrypoint.sh
+ENTRYPOINT ["./sagemaker-entrypoint.sh"]
+
+# OpenAI API server variant (default)
+FROM vllm-openai-base AS vllm-openai
+ENTRYPOINT ["vllm", "serve"]
+#################### OPENAI API SERVER ####################
+

--- a/tests/distributed/test_eplb_coverage.py
+++ b/tests/distributed/test_eplb_coverage.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for EPLB coverage enforcement and redistribution algorithm.
+
+Tests verify that the rebalance_experts algorithm correctly ensures
+all logical experts have at least one physical replica.
+"""
+
+import pytest
+import torch
+
+from vllm.distributed.eplb.rebalance_algo import rebalance_experts
+
+
+def test_redistribute_after_masking_sufficient_redundancy():
+    """
+    Test that rebalance_experts can redistribute to ensure coverage
+    when we have sufficient redundant experts.
+    
+    Scenario: ep=4, 64 logical experts, 88 physical (24 redundant)
+    Simulate masking rank 0 (removes 22 experts) → 66 remain for 64 logical
+    This should be sufficient to cover all logical experts.
+    """
+    num_layers = 1
+    num_logical_experts = 64
+    num_physical_experts = 88  # 24 redundant
+    ep_size = 4
+    num_groups = 64  # Typically num_logical_experts for MoE
+    num_nodes = 1
+    
+    # Create expert load representing some usage pattern
+    expert_load = torch.randint(10, 200, (num_layers, num_logical_experts))
+    
+    # Simulate BEFORE masking: all 88 physical experts available
+    phy2log_before, log2phy_before, logcnt_before = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_experts,
+        num_groups=num_groups,
+        num_nodes=num_nodes,
+        num_gpus=ep_size,
+    )
+    
+    # Verify all logical experts have coverage before masking
+    assert torch.all(logcnt_before >= 1), (
+        "Before masking: all logical experts should have at least 1 replica"
+    )
+    
+    # Simulate AFTER masking rank 0: only 66 physical experts remain
+    # (88 - 22 = 66, where 22 = 88/4 experts per rank)
+    num_physical_after_masking = 66
+    
+    phy2log_after, log2phy_after, logcnt_after = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_after_masking,
+        num_groups=num_groups,
+        num_nodes=num_nodes,
+        num_gpus=ep_size - 1,  # Only 3 GPUs remain
+    )
+    
+    # KEY TEST: All logical experts should STILL have at least 1 replica
+    assert torch.all(logcnt_after >= 1), (
+        f"After masking: all {num_logical_experts} logical experts should have at least 1 replica. "
+        f"Got counts: min={logcnt_after.min()}, max={logcnt_after.max()}, "
+        f"zeros={torch.sum(logcnt_after == 0)}"
+    )
+    
+    # Total replicas should equal remaining physical experts
+    assert torch.sum(logcnt_after) == num_physical_after_masking, (
+        f"Total replicas should equal {num_physical_after_masking}"
+    )
+
+
+def test_redistribute_insufficient_experts_fails():
+    """
+    Test that when we don't have enough physical experts, some logical
+    experts will have 0 replicas (which should trigger error in actual code).
+    
+    Scenario: ep=4, 64 logical experts, 64 physical (0 redundant)
+    Mask rank 0 (removes 16 experts) → only 48 remain for 64 logical
+    This is INSUFFICIENT - some logical experts will have 0 replicas.
+    """
+    num_layers = 1
+    num_logical_experts = 64
+    num_physical_experts = 48
+    ep_size = 4
+    num_groups = 64
+    num_nodes = 1
+    
+    expert_load = torch.randint(10, 200, (num_layers, num_logical_experts))
+    
+    
+    phy2log_after, log2phy_after, logcnt_after = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_experts,
+        num_groups=num_groups,
+        num_nodes=num_nodes,
+        num_gpus=ep_size - 1,  # Only 3 GPUs remain
+    )
+    
+    # With only 48 physical experts for 64 logical experts,
+    # some logical experts MUST have 0 replicas
+    num_uncovered = torch.sum(logcnt_after == 0).item()
+    
+    assert num_uncovered > 0, (
+        f"With {num_physical_experts} physical experts for {num_logical_experts} logical experts, "
+        f"some should have 0 replicas. Got {num_uncovered} uncovered."
+    )
+    
+    # Should have at least 64 - 48 = 16 uncovered experts
+    assert num_uncovered >= (num_logical_experts - num_physical_experts), (
+        f"Expected at least {num_logical_experts - num_physical_experts} "
+        f"uncovered, got {num_uncovered}"
+    )
+
+
+def test_redistribute_with_24_redundant_ep2():
+    """
+    Test redistribution for ep=2 with 24 redundant experts.
+    Verifies the specific case from user's question.
+    
+    Scenario: ep=2, 64 logical, 88 physical (24 redundant)
+    Mask rank 0 → 44 physical remain for 64 logical
+    This is INSUFFICIENT.
+    """
+    num_layers = 1
+    num_logical_experts = 64
+    num_redundant = 24
+    num_physical_experts = num_logical_experts + num_redundant  # 88
+    ep_size = 2
+    num_groups = 64
+    num_nodes = 1
+    
+    expert_load = torch.ones(num_layers, num_logical_experts) * 100
+    
+    # After masking rank 0: 44 experts remain (88/2 = 44 per rank)
+    num_physical_after_masking = num_physical_experts // 2
+    
+    assert num_physical_after_masking == 44
+    assert num_logical_experts == 64
+    
+    # Try to rebalance with only 44 physical experts
+    phy2log_after, log2phy_after, logcnt_after = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_after_masking,
+        num_groups=num_groups,
+        num_nodes=num_nodes,
+        num_gpus=1,  # Only 1 GPU remains after masking
+    )
+    
+    # With 44 physical for 64 logical, at least 20 logical experts must be uncovered
+    num_uncovered = torch.sum(logcnt_after == 0).item()
+    
+    assert num_uncovered >= 20, (
+        f"With 44 physical for 64 logical, expected at least 20 uncovered. "
+        f"Got {num_uncovered}"
+    )
+
+
+def test_redistribute_with_64_redundant_ep4():
+    """
+    Test that 64 redundant experts provides good fault tolerance for ep=4.
+    
+    Scenario: ep=4, 64 logical, 128 physical (64 redundant)
+    Mask rank 0 → 96 physical remain for 64 logical
+    This SHOULD be sufficient.
+    """
+    num_layers = 1
+    num_logical_experts = 64
+    num_redundant = 64
+    num_physical_experts = num_logical_experts + num_redundant  # 128
+    ep_size = 4
+    num_groups = 64
+    num_nodes = 1
+    
+    expert_load = torch.randint(50, 150, (num_layers, num_logical_experts))
+    
+    # After masking rank 0: 96 experts remain (128 - 32 = 96)
+    experts_per_rank = num_physical_experts // ep_size  # 32
+    num_physical_after_masking = num_physical_experts - experts_per_rank  # 96
+    
+    phy2log_after, log2phy_after, logcnt_after = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_after_masking,
+        num_groups=num_groups,
+        num_nodes=num_nodes,
+        num_gpus=ep_size - 1,  # 3 GPUs remain
+    )
+    
+    # All logical experts should have coverage
+    assert torch.all(logcnt_after >= 1), (
+        f"With 96 physical for 64 logical, all should be covered. "
+        f"Uncovered: {torch.sum(logcnt_after == 0)}"
+    )
+    
+    # Total replicas should equal remaining physical experts
+    assert torch.sum(logcnt_after) == num_physical_after_masking
+
+
+def test_rebalance_preserves_all_logical_experts():
+    """
+    Test that rebalance_experts maps to ALL logical experts when possible.
+    """
+    num_layers = 1
+    num_logical_experts = 64
+    num_redundant = 24
+    num_physical_experts = num_logical_experts + num_redundant
+    
+    expert_load = torch.randint(10, 200, (num_layers, num_logical_experts))
+    
+    phy2log, log2phy, logcnt = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_experts,
+        num_groups=64,
+        num_nodes=1,
+        num_gpus=4,
+    )
+    
+    # Verify all logical experts appear in the mapping
+    unique_logical_experts = torch.unique(phy2log[0])
+    
+    assert len(unique_logical_experts) == num_logical_experts, (
+        f"All {num_logical_experts} logical experts should appear in mapping. "
+        f"Got {len(unique_logical_experts)}"
+    )
+    
+    # All logical experts should have at least 1 replica
+    assert torch.all(logcnt >= 1), "All logical experts should have >= 1 replica"
+
+
+def test_masking_then_redistribute_validates_coverage():
+    """
+    Test the actual masking logic: mask experts, then check if
+    redistribution is possible.
+    
+    This tests the ACTUAL logic without mocking.
+    """
+    num_layers = 1
+    num_logical_experts = 64
+    num_redundant = 24
+    num_physical_experts = 88
+    ep_size = 4
+    experts_per_rank = num_physical_experts // ep_size  # 22
+    
+    # Create initial mapping (all 88 experts active)
+    expert_load = torch.randint(50, 150, (num_layers, num_logical_experts))
+    
+    phy2log_initial, log2phy_initial, logcnt_initial = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_experts,
+        num_groups=64,
+        num_nodes=1,
+        num_gpus=ep_size,
+    )
+    
+    # Verify initial coverage
+    assert torch.all(logcnt_initial >= 1), "Initially all should be covered"
+    
+    # Simulate masking rank 0 by reducing physical experts
+    rank_to_mask = 0
+    num_physical_after_mask = num_physical_experts - experts_per_rank  # 66
+    num_gpus_after_mask = ep_size - 1  # 3
+    
+    # Redistribute with reduced experts
+    phy2log_after, log2phy_after, logcnt_after = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_after_mask,
+        num_groups=64,
+        num_nodes=1,
+        num_gpus=num_gpus_after_mask,
+    )
+    
+    # Check if redistribution maintained coverage
+    num_uncovered = torch.sum(logcnt_after == 0).item()
+    
+    # With 66 physical for 64 logical, coverage should be possible
+    assert num_uncovered == 0, (
+        f"With {num_physical_after_mask} physical experts for {num_logical_experts} logical, "
+        f"all should be covered. Found {num_uncovered} uncovered."
+    )
+    
+    # Verify total replicas
+    assert torch.sum(logcnt_after) == num_physical_after_mask
+
+
+def test_minimum_redundancy_for_single_rank_failure():
+    """
+    Test minimum redundancy needed to survive single rank failure.
+    
+    For ep=4 with 64 logical experts:
+    - Need at least 64 / 3 ≈ 22 redundant experts
+    - So 64 + 24 = 88 total should work
+    - After removing 1 rank: 88 - 22 = 66 remain for 64 logical ✓
+    """
+    num_logical_experts = 64
+    ep_size = 4
+    experts_per_rank_initial = 22
+    num_physical_initial = ep_size * experts_per_rank_initial  # 88
+    num_redundant = num_physical_initial - num_logical_experts  # 24
+    
+    expert_load = torch.ones(1, num_logical_experts) * 100
+    
+    # After removing 1 rank
+    num_physical_after = num_physical_initial - experts_per_rank_initial  # 66
+    num_gpus_after = ep_size - 1  # 3
+    
+    # Can we cover all 64 logical experts with 66 physical?
+    assert num_physical_after >= num_logical_experts, (
+        f"Need at least {num_logical_experts}, have {num_physical_after}"
+    )
+    
+    phy2log, log2phy, logcnt = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_after,
+        num_groups=64,
+        num_nodes=1,
+        num_gpus=num_gpus_after,
+    )
+    
+    # All should be covered
+    assert torch.all(logcnt >= 1), (
+        f"With 24 redundant experts (88 total), should survive 1 rank failure. "
+        f"Uncovered: {torch.sum(logcnt == 0)}"
+    )
+
+
+def test_two_rank_failure_with_insufficient_redundancy():
+    """
+    Test that masking 2 ranks out of 4 with only 24 redundant fails.
+    
+    ep=4, 64 logical, 88 physical (24 redundant)
+    Mask 2 ranks → only 44 remain for 64 logical
+    This is INSUFFICIENT.
+    """
+    num_logical_experts = 64
+    num_redundant = 24
+    num_physical_initial = 88
+    ep_size = 4
+    
+    expert_load = torch.ones(1, num_logical_experts) * 100
+    
+    # After masking 2 ranks: only 44 experts remain
+    experts_per_rank = num_physical_initial // ep_size  # 22
+    num_physical_after = experts_per_rank * 2  # 44
+    num_gpus_after = 2
+    
+    phy2log, log2phy, logcnt = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_after,
+        num_groups=64,
+        num_nodes=1,
+        num_gpus=num_gpus_after,
+    )
+    
+    # With 44 physical for 64 logical, at least 20 must be uncovered
+    num_uncovered = torch.sum(logcnt == 0).item()
+    
+    assert num_uncovered >= 20, (
+        f"With 44 physical for 64 logical, expected at least 20 uncovered. "
+        f"Got {num_uncovered}"
+    )
+
+
+def test_redistribute_preserves_high_load_experts():
+    """
+    Test that high-load experts get more replicas after redistribution.
+    """
+    num_logical_experts = 64
+    num_physical = 88
+    
+    # Create load with some experts very popular
+    expert_load = torch.ones(1, num_logical_experts) * 50
+    expert_load[0, 0] = 1000  # Expert 0 very popular
+    expert_load[0, 10] = 800  # Expert 10 popular
+    expert_load[0, 20] = 600  # Expert 20 popular
+    
+    phy2log, log2phy, logcnt = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical,
+        num_groups=64,
+        num_nodes=1,
+        num_gpus=4,
+    )
+    
+    # High-load experts should have more replicas
+    assert logcnt[0, 0] > logcnt[0, 30], (
+        "Expert 0 (load=1000) should have more replicas than expert 30 (load=50)"
+    )
+    assert logcnt[0, 10] > logcnt[0, 40], (
+        "Expert 10 (load=800) should have more replicas than expert 40 (load=50)"
+    )
+
+
+def test_edge_case_exact_match():
+    """
+    Test edge case where physical experts exactly match logical experts.
+    """
+    num_logical_experts = 64
+    num_physical_experts = 64  # Exact match, no redundancy
+    
+    expert_load = torch.ones(1, num_logical_experts) * 100
+    
+    phy2log, log2phy, logcnt = rebalance_experts(
+        expert_load,
+        num_replicas=num_physical_experts,
+        num_groups=64,
+        num_nodes=1,
+        num_gpus=4,
+    )
+    
+    # Each logical expert should have exactly 1 replica
+    assert torch.all(logcnt == 1), (
+        "With no redundancy, each logical expert should have exactly 1 replica"
+    )
+    
+    # All logical experts should appear
+    unique_logical = set(phy2log[0].tolist())
+    assert len(unique_logical) == num_logical_experts
+
+
+def test_valid_redundant_values_for_deepseek_v2_lite():
+    """
+    Test the valid redundant expert values identified for DeepSeek-V2-Lite.
+    Validates that 0, 24, 64, 112, 192 all work and provide proper coverage.
+    """
+    num_logical_experts = 64
+    ep_sizes_to_test = [2, 4, 8]
+    redundant_values = [0, 24, 64]  # Valid for all ep sizes
+    
+    for ep_size in ep_sizes_to_test:
+        for num_redundant in redundant_values:
+            num_physical = num_logical_experts + num_redundant
+            
+            # Should be divisible by ep_size
+            assert num_physical % ep_size == 0, (
+                f"ep={ep_size}, redundant={num_redundant}: "
+                f"{num_physical} not divisible by {ep_size}"
+            )
+            
+            expert_load = torch.ones(1, num_logical_experts) * 100
+            
+            # Test full configuration
+            phy2log, log2phy, logcnt = rebalance_experts(
+                expert_load,
+                num_replicas=num_physical,
+                num_groups=64,
+                num_nodes=1,
+                num_gpus=ep_size,
+            )
+            
+            # All logical experts should have coverage
+            assert torch.all(logcnt >= 1), (
+                f"ep={ep_size}, redundant={num_redundant}: "
+                f"all logical experts should have coverage"
+            )
+            
+            # Test after masking 1 rank
+            experts_per_rank = num_physical // ep_size
+            num_physical_after = num_physical - experts_per_rank
+            
+            if num_physical_after >= num_logical_experts:
+                # Should still have coverage
+                phy2log_after, log2phy_after, logcnt_after = rebalance_experts(
+                    expert_load,
+                    num_replicas=num_physical_after,
+                    num_groups=64,
+                    num_nodes=1,
+                    num_gpus=ep_size - 1,
+                )
+                
+                coverage = torch.all(logcnt_after >= 1).item()
+                print(
+                    f"ep={ep_size}, redundant={num_redundant}: "
+                    f"After 1 rank failure: {num_physical_after} physical, "
+                    f"coverage={'✓' if coverage else '✗'}"
+                )
+
+
+if __name__ == "__main__":
+    # Run a quick sanity check
+    test_redistribute_after_masking_sufficient_redundancy()
+    test_redistribute_insufficient_experts_fails()
+    test_redistribute_with_24_redundant_ep2()
+    test_redistribute_with_64_redundant_ep4()
+    test_valid_redundant_values_for_deepseek_v2_lite()
+    print("All tests passed!")

--- a/tests/distributed/test_eplb_health.py
+++ b/tests/distributed/test_eplb_health.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.config import EPLBConfig
+from vllm.distributed.eplb.eplb_state import EplbState
+
+
+def create_mock_eplb_state(
+    num_layers: int,
+    num_experts: int,
+    config: EPLBConfig,
+) -> EplbState:
+    """Create a mock EPLB state for testing."""
+
+    # Create minimal required tensors
+    physical_to_logical_map = torch.arange(num_experts).unsqueeze(0).expand(
+        num_layers, -1
+    )
+    logical_to_physical_map = (
+        torch.arange(num_experts).unsqueeze(1).unsqueeze(0).expand(num_layers, -1, -1)
+    )
+    logical_replica_count = torch.ones(num_layers, num_experts, dtype=torch.long)
+    expert_load_pass = torch.zeros(num_layers, num_experts, dtype=torch.int32)
+    expert_load_window = torch.zeros(
+        config.window_size, num_layers, num_experts, dtype=torch.int32
+    )
+
+    # Health monitoring tensors
+    expert_latency_window = torch.zeros(
+        config.window_size, num_layers, num_experts, dtype=torch.float32
+    )
+    expert_health_mask = torch.ones(num_layers, num_experts, dtype=torch.bool)
+
+    return EplbState(
+        physical_to_logical_map=physical_to_logical_map,
+        logical_to_physical_map=logical_to_physical_map,
+        logical_replica_count=logical_replica_count,
+        expert_load_pass=expert_load_pass,
+        expert_load_window=expert_load_window,
+        expert_load_window_step=0,
+        expert_load_window_size=config.window_size,
+        expert_rearrangement_step=0,
+        expert_rearrangement_step_interval=config.step_interval,
+        expert_latency_window=expert_latency_window,
+        expert_health_mask=expert_health_mask,
+        health_latency_threshold=config.health_latency_threshold,
+        health_penalty_factor=config.health_penalty_factor,
+    )
+
+
+def test_basic_health_detection():
+    """Test that unhealthy experts are detected when latency exceeds threshold."""
+
+    # Setup
+    num_layers = 2
+    num_experts = 8
+    window_size = 100
+    threshold = 3.0
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=threshold,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Simulate normal operation (all experts healthy)
+    for step in range(50):
+        # All experts active with similar latency (10ms)
+        state.expert_latency_window[step, :, :] = 10.0
+
+    state.expert_load_window_step = 50
+
+    # Test with normal latency
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # All experts should be healthy
+    assert (
+        state.expert_health_mask.all()
+    ), "All experts should be healthy with normal latency"
+
+    # Inject failure: Expert 3 in layer 0 suddenly slow (100ms)
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    current_latency[0, 3] = 100.0
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 3 should be unhealthy (100 > 3.0 * 10)
+    assert not state.expert_health_mask[0, 3], "Expert 3 layer 0 should be unhealthy"
+    # Other experts should remain healthy
+    assert state.expert_health_mask[0, :3].all(), "Other experts should remain healthy"
+    assert state.expert_health_mask[0, 4:].all(), "Other experts should remain healthy"
+    assert state.expert_health_mask[1, :].all(), "Layer 1 experts should remain healthy"
+
+
+def test_sparse_activation():
+    """Test that inactive experts (0 latency) are handled correctly."""
+
+    # Setup
+    num_layers = 1
+    num_experts = 8
+    window_size = 30
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=3.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Simulate sparse activation pattern
+    # Expert 0: Active in 15/20 passes with 10ms
+    # Expert 1: Active in 5/20 passes with 12ms
+    # Expert 2: Active in 15/20 passes with 10ms, then becomes inactive
+
+    for step in range(15):
+        state.expert_latency_window[step, 0, 0] = 10.0  # Expert 0 active
+        state.expert_latency_window[step, 0, 1] = 0.0  # Expert 1 inactive
+        state.expert_latency_window[step, 0, 2] = 10.0  # Expert 2 active
+
+    for step in range(15, 20):
+        state.expert_latency_window[step, 0, 0] = 0.0  # Expert 0 inactive
+        state.expert_latency_window[step, 0, 1] = 12.0  # Expert 1 active
+        state.expert_latency_window[step, 0, 2] = 10.0  # Expert 2 active
+
+    state.expert_load_window_step = 20
+
+    # Test with Expert 2 slow (50ms)
+    current_latency = torch.zeros(num_layers, num_experts)
+    current_latency[0, 0] = 10.0
+    current_latency[0, 2] = 50.0  # Expert 2 slow!
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 2 should be unhealthy (50 > 3 * 10, and has 20 activations)
+    assert (
+        not state.expert_health_mask[0, 2]
+    ), "Expert 2 should be unhealthy after spike"
+
+    # Write to window
+    state.expert_latency_window[20, 0, 0] = 10.0
+    state.expert_latency_window[20, 0, 2] = 50.0
+
+    # Step 20: Expert 2 becomes inactive (0 latency)
+    current_latency = torch.zeros(num_layers, num_experts)
+    current_latency[0, 0] = 10.0  # Expert 0 active
+    current_latency[0, 2] = 0.0  # Expert 2 NOW INACTIVE (key test!)
+
+    state.expert_load_window_step = 21
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 2 should become healthy again (current_latency = 0 means not active)
+    # The check is: (current_latency > 0) & (current_latency > threshold)
+    # Since current_latency = 0, first condition is False → not unhealthy
+    assert state.expert_health_mask[0, 2], (
+        "Expert 2 should be healthy when inactive (current=0), "
+        "even though it has >10 activations and was unhealthy before"
+    )
+
+    # Expert 0: mean = 10ms, active 16 times (>10), current = 10ms → healthy
+    assert state.expert_health_mask[0, 0], "Expert 0 should be healthy"
+
+    # Expert 1: active only 5 times (<10), insufficient history → healthy
+    assert state.expert_health_mask[0, 1], (
+        "Expert 1 should be healthy (insufficient history)"
+    )
+
+
+def test_expert_recovery():
+    """Test that experts can recover from unhealthy state."""
+
+    # Setup
+    num_layers = 1
+    num_experts = 4
+    window_size = 50
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=3.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Phase 1: Normal operation (10ms baseline)
+    for step in range(30):
+        state.expert_latency_window[step, 0, :] = 10.0
+
+    state.expert_load_window_step = 30
+    
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    state._update_health_mask(current_latency, log_stats=False)
+    assert state.expert_health_mask.all(), "All healthy initially"
+
+    # Write to window
+    state.expert_latency_window[30, 0, :] = 10.0
+
+    # Phase 2: Expert 1 becomes slow (50ms)
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    current_latency[0, 1] = 50.0
+    state.expert_load_window_step = 31
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert not state.expert_health_mask[0, 1], "Expert 1 should be unhealthy"
+
+    # Write to window
+    state.expert_latency_window[31, 0, :] = 10.0
+    state.expert_latency_window[31, 0, 1] = 50.0
+
+    # Phase 3: Expert 1 recovers immediately (back to 10ms in next step)
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    state.expert_load_window_step = 32
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Expert 1 should recover immediately
+    # historical_mean now includes the 50ms spike in window
+    # current = 10ms should be < threshold → healthy
+    assert state.expert_health_mask[0, 1], "Expert 1 should recover to healthy"
+
+
+def test_multi_layer_health():
+    """Test that health detection works independently per layer."""
+
+    num_layers = 3
+    num_experts = 8
+    window_size = 20
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=3.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Setup baseline (10ms for all)
+    for step in range(15):
+        state.expert_latency_window[step, :, :] = 10.0
+
+    state.expert_load_window_step = 15
+
+    # Inject failures in different layers
+    current_latency = torch.full((num_layers, num_experts), 10.0)
+    current_latency[0, 2] = 50.0  # Layer 0, Expert 2: slow
+    current_latency[1, 5] = 60.0  # Layer 1, Expert 5: slow
+    # Layer 2: all healthy (10.0)
+
+    state._update_health_mask(current_latency, log_stats=False)
+
+    # Verify layer 0
+    assert not state.expert_health_mask[0, 2], "Layer 0 Expert 2 should be unhealthy"
+    assert state.expert_health_mask[0, :2].all(), "Layer 0 other experts healthy"
+    assert state.expert_health_mask[0, 3:].all(), "Layer 0 other experts healthy"
+
+    # Verify layer 1
+    assert not state.expert_health_mask[1, 5], "Layer 1 Expert 5 should be unhealthy"
+    assert state.expert_health_mask[1, :5].all(), "Layer 1 other experts healthy"
+    assert state.expert_health_mask[1, 6:].all(), "Layer 1 other experts healthy"
+
+    # Verify layer 2
+    assert state.expert_health_mask[2, :].all(), "Layer 2 all experts should be healthy"
+
+
+def test_historical_mean_calculation():
+    """Test that historical mean is calculated correctly with sparse activations."""
+
+    num_layers = 1
+    num_experts = 4
+    window_size = 10
+
+    eplb_config = EPLBConfig(
+        window_size=window_size,
+        health_check_enabled=True,
+        health_latency_threshold=2.0,
+    )
+
+    state = create_mock_eplb_state(
+        num_layers=num_layers,
+        num_experts=num_experts,
+        config=eplb_config,
+    )
+
+    # Expert 0 active pattern: Need min(10, 20*0.5) = 10 active passes
+    # Pattern: [10, 10, 10, 15, 15, 20, 20, 20, 12, 12, ...]
+    # Mean should be (10*3 + 15*2 + 20*3 + 12*2) / 10 = 154 / 10 = 15.4ms
+
+    active_steps = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    latencies = [10.0, 10.0, 10.0, 15.0, 15.0, 20.0, 20.0, 20.0, 12.0, 12.0]
+
+    for i, step in enumerate(active_steps):
+        state.expert_latency_window[step, 0, 0] = latencies[i]
+
+    state.expert_load_window_step = 10
+
+    # Test current latency 30.9ms against historical (steps 0-9)
+    # Historical mean = (10*3 + 15*2 + 20*3 + 12*2) / 10 = 154/10 = 15.4ms
+    # threshold = 2 * 15.4 = 30.8ms
+    # current = 30.9ms > 30.8ms → unhealthy
+    current_latency = torch.zeros(1, num_experts, dtype=torch.float32)
+    current_latency[0, 0] = 30.9
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert (
+        not state.expert_health_mask[0, 0]
+    ), "Expert should be unhealthy (30.9 > 30.8)"
+
+    # Now write the 30.9 to window and test next step
+    state.expert_latency_window[10 % window_size, 0, 0] = 30.9
+    state.expert_load_window_step = 11
+
+    # Test current latency 31ms against historical
+    # (now includes 30.9 at step 0)
+    # Historical = steps 1-9 + step 0(30.9)
+    # = (10*2 + 15*2 + 20*3 + 12*2 + 30.9) / 10 = 174.9/10 = 17.49ms
+    # threshold = 2 * 17.49 = 34.98ms
+    # current = 31ms < 34.98ms → healthy
+    current_latency[0, 0] = 31.0
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert state.expert_health_mask[0, 0], "Expert should be healthy (31 < 34.98)"
+
+    # Test current latency 35ms against historical
+    current_latency[0, 0] = 35.0
+    state._update_health_mask(current_latency, log_stats=False)
+
+    assert not state.expert_health_mask[0, 0], "Expert should be unhealthy (35 > 34.98)"
+
+

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -63,14 +63,11 @@ class EPLBConfig:
     """
 
     health_check_enabled: bool = True
-    """Enable per-expert health monitoring based on latency."""
+    """Enable per-expert health monitoring based on timeout."""
 
-    health_latency_threshold: float = 3.0
-    """Latency threshold multiplier. Expert is unhealthy if current latency
-    exceeds threshold * historical_mean_latency within a window for that expert."""
-
-    health_penalty_factor: float = 10.0
-    """Weight multiplier for unhealthy experts during rebalancing."""
+    health_timeout_threshold: float = 100.0
+    """Absolute timeout threshold in milliseconds. Expert is unhealthy and will be
+    immediately masked out if current latency exceeds this threshold."""
 
 
 @config

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -62,6 +62,16 @@ class EPLBConfig:
     This is turned off by default since it will cause communication overhead.
     """
 
+    health_check_enabled: bool = True
+    """Enable per-expert health monitoring based on latency."""
+
+    health_latency_threshold: float = 3.0
+    """Latency threshold multiplier. Expert is unhealthy if current latency
+    exceeds threshold * historical_mean_latency within a window for that expert."""
+
+    health_penalty_factor: float = 10.0
+    """Weight multiplier for unhealthy experts during rebalancing."""
+
 
 @config
 @dataclass

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -69,6 +69,16 @@ class EPLBConfig:
     """Absolute timeout threshold in milliseconds. Expert is unhealthy and will be
     immediately masked out if current latency exceeds this threshold."""
 
+    mask_out_gpu_after: list[int] = Field(default_factory=list)
+    """List of step counts after which to mask out each GPU rank.
+    For example, [100, 200] will mask out rank 0 after 100 steps
+    and rank 1 after 200 steps. Empty list means no GPUs will be masked out.
+    This is used for testing fault tolerance.
+    
+    Note: Uses the same step counter as periodic rearrangement (expert_rearrangement_step),
+    which ensures all ranks (including dummy ranks) stay synchronized.
+    After masking, coverage enforcement runs on all ranks collectively."""
+
 
 @config
 @dataclass

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass
 import torch
 from torch.distributed import ProcessGroup, all_reduce
 
-from vllm.config import ModelConfig, ParallelConfig
+from vllm.config import ParallelConfig
 from vllm.distributed.parallel_state import (
     get_ep_group,
     get_node_count,
@@ -50,7 +50,7 @@ logger = init_logger(__name__)
 
 
 @dataclass
-class EplbModelState:
+class EplbState:
     """EPLB metrics."""
 
     physical_to_logical_map: torch.Tensor
@@ -130,46 +130,56 @@ class EplbModelState:
     See:
     https://github.com/vllm-project/vllm/pull/22167#pullrequestreview-3086143856
     """
-    model_name: str
-    model: MixtureOfExperts
-
-
-class EplbState:
+    expert_load_window_step: int = 0
     """
-    EplbState of each expert parallel model. Key is the model config hash.
+    Current step in the sliding window.
+
+    Different from `expert_rearrangement_step`, each EP rank may have its own
+    `expert_load_window_step`.
+    """
+    expert_load_window_size: int = 0
+    """
+    Size of the expert load sliding window.
+    This is a constant and is taken from the config.
     """
 
-    def __init__(self, parallel_config: ParallelConfig, device: torch.device):
-        self.parallel_config = parallel_config
-        self.device = device
-        self.model_states: dict[str, EplbModelState] = {}
-        """
-        Current step in the sliding window.
+    expert_rearrangement_step: int = 0
+    """
+    Steps after last rearrangement.
+    Will trigger a rearrangement if it exceeds the threshold.
 
-        Different from `expert_rearrangement_step`, 
-        each EP rank may have its own `expert_load_window_step`.
-        """
-        self.expert_load_window_step: int = 0
-        """
-        Size of the expert load sliding window.
-        This is a constant and is taken from the config.
-        """
-        self.expert_load_window_size: int = 0
-        """
-        Steps after last rearrangement.
-        Will trigger a rearrangement if it exceeds the threshold.
+    NOTE: Keep in mind that all EP ranks need to have the same
+    `expert_rearrangement_step` value to ensure synchronization.
+    Otherwise, the rearrangement will hang at collective
+    communication calls.
+    """
+    expert_rearrangement_step_interval: int = 0
+    """
+    Interval for expert rearrangement steps.
+    This is a constant and is taken from the config.
+    """
 
-        NOTE: Keep in mind that all EP ranks need to have the same
-        `expert_rearrangement_step` value to ensure synchronization.
-        Otherwise, the rearrangement will hang at collective
-        communication calls.
-        """
-        self.expert_rearrangement_step: int = 0
-        """
-        Interval for expert rearrangement steps.
-        This is a constant and is taken from the config.
-        """
-        self.expert_rearrangement_step_interval: int = 0
+    expert_latency_window: torch.Tensor | None = None
+    """
+    Sliding window of per-expert latency (in milliseconds).
+    Shape: (window_size, num_moe_layers, num_physical_experts)
+    Value: latency if expert was active, 0.0 if inactive.
+    Only allocated if health_check_enabled=True.
+    """
+
+    expert_health_mask: torch.Tensor | None = None
+    """
+    Boolean mask indicating which experts are healthy.
+    Shape: (num_moe_layers, num_physical_experts)
+    True = healthy, False = unhealthy.
+    Only allocated if health_check_enabled=True.
+    """
+
+    health_latency_threshold: float = 3.0
+    """Threshold multiplier from EPLBConfig."""
+
+    health_penalty_factor: float = 10.0
+    """Weight penalty factor from EPLBConfig."""
 
     @staticmethod
     def build_initial_global_physical_to_logical_map(
@@ -191,63 +201,26 @@ class EplbState:
         ]
         return global_physical_to_logical_map
 
-    def validate_ep_configuration(self, new_model: MixtureOfExperts):
-        """
-        Validate that the expert parallel configuration of
-        the new model is the same as the existing models.
-        """
-        if len(self.model_states) > 0:
-            model = next(iter(self.model_states.values())).model
-            if (
-                model.num_routed_experts != new_model.num_routed_experts
-                or model.num_redundant_experts != new_model.num_redundant_experts
-                or model.num_physical_experts != new_model.num_physical_experts
-                or model.num_logical_experts != new_model.num_logical_experts
-                or model.num_expert_groups != new_model.num_expert_groups
-            ):
-                raise RuntimeError(
-                    "Model: {} "
-                    "with config {} "
-                    "{} {} {} {} "
-                    "mismatch with new model {} "
-                    "with config {} "
-                    "{} {} {} {}".format(
-                        type(model),
-                        model.num_routed_experts,
-                        model.num_redundant_experts,
-                        model.num_physical_experts,
-                        model.num_logical_experts,
-                        model.num_expert_groups,
-                        type(new_model),
-                        new_model.num_routed_experts,
-                        new_model.num_redundant_experts,
-                        new_model.num_physical_experts,
-                        new_model.num_logical_experts,
-                        new_model.num_expert_groups,
-                    )
-                )
-
-    def add_model(
-        self,
+    @classmethod
+    def build(
+        cls,
         model: MixtureOfExperts,
-        model_config: ModelConfig,
+        device: torch.device,
+        parallel_config: ParallelConfig,
         global_expert_load: torch.Tensor | None = None,
         old_global_expert_indices: torch.Tensor | None = None,
         rank_mapping: dict[int, int] | None = None,
-    ):
+    ) -> "EplbState":
         """
         Build the initial EPLB state.
         """
-        self.validate_ep_configuration(model)
-        physical_to_logical_map_list = (
-            EplbState.build_initial_global_physical_to_logical_map(
-                model.num_routed_experts,
-                model.num_redundant_experts,
-            )
+        physical_to_logical_map_list = cls.build_initial_global_physical_to_logical_map(
+            model.num_routed_experts,
+            model.num_redundant_experts,
         )
         physical_to_logical_map = torch.tensor(
             physical_to_logical_map_list,
-            device=self.device,
+            device=device,
         )
         # Assuming 8 GPUs per node, this supports up to
         # (1023 + 1) / 8 = 128 nodes for now.
@@ -261,11 +234,11 @@ class EplbState:
         logical_to_physical_map = torch.full(
             (model.num_logical_experts, max_slots_per_logical_expert),
             -1,
-            device=self.device,
+            device=device,
         )
         logical_replica_count = torch.zeros(
             (model.num_logical_experts,),
-            device=self.device,
+            device=device,
             dtype=torch.long,
         )
 
@@ -304,25 +277,51 @@ class EplbState:
         expert_load_pass = torch.zeros(
             (model.num_moe_layers, model.num_physical_experts),
             dtype=torch.int32,
-            device=self.device,
+            device=device,
         )
-        self.expert_load_window_size = self.parallel_config.eplb_config.window_size
+        expert_load_window_size = parallel_config.eplb_config.window_size
         expert_load_window = torch.zeros(
-            (
-                self.expert_load_window_size,
-                model.num_moe_layers,
-                model.num_physical_experts,
-            ),
+            (expert_load_window_size, model.num_moe_layers, model.num_physical_experts),
             dtype=torch.int32,
-            device=self.device,
+            device=device,
         )
 
+        # Initialize health monitoring if enabled
+        eplb_config = parallel_config.eplb_config
+        expert_latency_window = None
+        expert_health_mask = None
+
+        # Create shared latency view for layers to write to (like expert_load_pass)
+        expert_latency_pass = None
+        if eplb_config.health_check_enabled:
+            expert_latency_window = torch.zeros(
+                (
+                    expert_load_window_size,
+                    model.num_moe_layers,
+                    model.num_physical_experts,
+                ),
+                dtype=torch.float32,  # Latency in milliseconds
+                device=device,
+            )
+            expert_health_mask = torch.ones(
+                (model.num_moe_layers, model.num_physical_experts),
+                dtype=torch.bool,
+                device=device,
+            )
+            expert_latency_pass = torch.zeros(
+                (model.num_moe_layers, model.num_physical_experts),
+                dtype=torch.float32,
+                device=device,
+            )
+            logger.info(
+                "EPLB health monitoring enabled: threshold=%.1fx, penalty=%.1fx",
+                eplb_config.health_latency_threshold,
+                eplb_config.health_penalty_factor,
+            )
+
         # Set the initial progress of rearrangement to 3/4
-        eplb_step_interval = self.parallel_config.eplb_config.step_interval
-        self.expert_rearrangement_step = max(
-            0, eplb_step_interval - eplb_step_interval // 4
-        )
-        self.expert_rearrangement_step_interval = eplb_step_interval
+        eplb_step_interval = eplb_config.step_interval
+        expert_rearrangement_step = max(0, eplb_step_interval - eplb_step_interval // 4)
 
         if global_expert_load is not None:
             ep_group = get_ep_group().device_group
@@ -365,7 +364,7 @@ class EplbState:
                 (0, logical_to_physical_map.shape[-1] - max_physical_slots),
                 value=-1,
             )
-            physical_to_logical_map = new_physical_to_logical_map.to(self.device)
+            physical_to_logical_map = new_physical_to_logical_map.to(device)
             logical_to_physical_map.copy_(new_logical_to_physical_map)
             logical_replica_count.copy_(new_logical_replica_count)
 
@@ -373,6 +372,7 @@ class EplbState:
             expert_load_pass,
             logical_to_physical_map,
             logical_replica_count,
+            expert_latency_pass,
         )
         if global_expert_load is not None:
             rearrange_expert_weights_inplace(
@@ -383,20 +383,26 @@ class EplbState:
                 False,
                 rank_mapping,
             )
-            self.expert_rearrangement_step = 0
+            expert_rearrangement_step = 0
 
-        self.model_states[model_config.compute_hash()] = EplbModelState(
+        return cls(
             physical_to_logical_map,
             logical_to_physical_map,
             logical_replica_count,
             expert_load_pass,
             expert_load_window,
-            model_config.model,
-            model,
+            expert_load_window_size=expert_load_window_size,
+            expert_rearrangement_step=expert_rearrangement_step,
+            expert_rearrangement_step_interval=eplb_step_interval,
+            expert_latency_window=expert_latency_window,
+            expert_health_mask=expert_health_mask,
+            health_latency_threshold=eplb_config.health_latency_threshold,
+            health_penalty_factor=eplb_config.health_penalty_factor,
         )
 
     def step(
         self,
+        model: MixtureOfExperts,
         is_dummy: bool = False,
         is_profile: bool = False,
         log_stats: bool = False,
@@ -405,6 +411,7 @@ class EplbState:
         Step the EPLB state.
 
         Args:
+            model (MixtureOfExperts): The MoE model.
             is_dummy (bool): If `True`, this is a dummy step and the load
                 metrics recorded in this forward pass will not count.
                 Defaults to `False`.
@@ -422,66 +429,72 @@ class EplbState:
         """
 
         if is_profile:
-            self.rearrange(is_profile=True)
+            self.rearrange(model, is_profile=True)
             return
 
         if is_dummy:
             # Do not record load metrics for dummy steps
-            for eplb_model_state in self.model_states.values():
-                eplb_model_state.expert_load_pass.zero_()
+            self.expert_load_pass.zero_()
 
         if log_stats:
-            # Sync the expert load pass for each model (main and drafter).
-            # expert_load_pass: (num_moe_layers, num_physical_experts)
-            expert_load_pass_list = self._sync_load_pass()
+            # total_expert_load_pass: (num_moe_layers, num_physical_experts)
+            total_expert_load_pass = self.expert_load_pass.clone()
+
+            # Collect load metrics from all ranks
             ep_group = get_ep_group().device_group
-            for expert_load_pass, eplb_model_state in zip(
-                expert_load_pass_list, self.model_states.values()
-            ):
-                # num_tokens_per_rank: (num_moe_layers, num_ranks)
-                num_tokens_per_rank = (
-                    expert_load_pass.reshape(
-                        expert_load_pass.shape[0], ep_group.size(), -1
-                    )
-                    .sum(dim=-1)
-                    .float()
+            all_reduce(total_expert_load_pass, group=ep_group)
+
+            # num_tokens_per_rank: (num_moe_layers, num_ranks)
+            num_tokens_per_rank = (
+                total_expert_load_pass.reshape(
+                    total_expert_load_pass.shape[0], ep_group.size(), -1
+                )
+                .sum(dim=-1)
+                .float()
+            )
+
+            # Compute balancedness ratio:
+            # for each layer:
+            #   (mean load across ranks) / (max load across ranks)
+            avg_tokens_tensor = num_tokens_per_rank.mean(dim=0).sum(dim=0)
+            max_tokens_tensor = num_tokens_per_rank.max(dim=0).values.sum(dim=0)
+
+            # Just to make type checker happy
+            tokens_tensors: list[float] = torch.stack(
+                [avg_tokens_tensor, max_tokens_tensor]
+            ).tolist()
+            avg_tokens, max_tokens = tokens_tensors
+            balancedness = avg_tokens / max_tokens if max_tokens > 0 else 0.0
+
+            if ep_group.rank() == 0:
+                logger.info(
+                    "EPLB step: avg_tokens=%.2f, max_tokens=%d, balancedness=%.4f",
+                    avg_tokens,
+                    max_tokens,
+                    balancedness,
                 )
 
-                # Compute balancedness ratio:
-                # for each layer:
-                #   (mean load across ranks) / (max load across ranks)
-                avg_tokens_tensor = num_tokens_per_rank.mean(dim=0).sum(dim=0)
-                max_tokens_tensor = num_tokens_per_rank.max(dim=0).values.sum(dim=0)
-
-                # Just to make type checker happy
-                tokens_tensors: list[float] = torch.stack(
-                    [avg_tokens_tensor, max_tokens_tensor]
-                ).tolist()
-                avg_tokens, max_tokens = tokens_tensors
-                balancedness = avg_tokens / max_tokens if max_tokens > 0 else 0.0
-
-                if ep_group.rank() == 0:
-                    logger.info(
-                        "EPLB step: %d for model %s: avg_tokens=%.2f, "
-                        "max_tokens=%d, balancedness=%.4f",
-                        self.expert_rearrangement_step,
-                        eplb_model_state.model_name,
-                        avg_tokens,
-                        max_tokens,
-                        balancedness,
-                    )
+        # Record expert latencies (layers write directly to expert_latency_pass)
+        if self.expert_latency_window is not None and not is_dummy:
+            expert_latency_pass = model.get_expert_latencies()
+            if expert_latency_pass is not None:
+                # Update health mask BEFORE overwriting window
+                self._update_health_mask(expert_latency_pass, log_stats)
+                self.expert_latency_window[self.expert_load_window_step] = (
+                    expert_latency_pass.clone()
+                )
+                # Reset for next pass
+                expert_latency_pass.zero_()
 
         # Update the expert load sliding window
         if not is_dummy:
-            for eplb_model_state in self.model_states.values():
-                eplb_model_state.expert_load_window[self.expert_load_window_step] = (
-                    eplb_model_state.expert_load_pass.clone()
-                )
-                eplb_model_state.expert_load_pass.zero_()
-
+            self.expert_load_window[self.expert_load_window_step] = (
+                self.expert_load_pass.clone()
+            )
             self.expert_load_window_step += 1
             if self.expert_load_window_step >= self.expert_load_window_size:
                 self.expert_load_window_step = 0
+            self.expert_load_pass.zero_()
 
         # Step the expert rearrangement step
         # Note that even if this is a dummy step, we still increment the
@@ -490,30 +503,95 @@ class EplbState:
         self.expert_rearrangement_step += 1
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:
             self.expert_rearrangement_step = 0
-            self.rearrange()
+            self.rearrange(model)
+
+    def _update_health_mask(
+        self, current_latency: torch.Tensor, log_stats: bool = False
+    ) -> None:
+        """
+        Update expert health mask based on per-expert historical latency.
+
+        Strategy: Compare current latency to threshold * historical mean.
+        0 latency means expert was inactive (ignored in mean calculation).
+        Threshold is configurable via health_latency_threshold (default 3.0).
+
+        Args:
+            current_latency: Current per-expert latency (before adding to window).
+                Shape: (num_moe_layers, num_physical_experts)
+            log_stats: Whether to log health status changes.
+        """
+        if self.expert_latency_window is None or self.expert_health_mask is None:
+            return
+
+        # Calculate historical mean from existing window (excluding current)
+        # Count active passes in history
+        # Shape: (num_moe_layers, num_physical_experts)
+        active_count = (self.expert_latency_window > 0).sum(dim=0)
+
+        # Sum of historical latencies
+        latency_sum = self.expert_latency_window.sum(dim=0)
+
+        # Historical mean (only for experts with sufficient history)
+        # Require at least min(10, window_size * 0.5) active passes
+        min_active_count = min(10, int(self.expert_load_window_size * 0.5))
+        historical_mean = torch.where(
+            active_count >= min_active_count,
+            latency_sum / active_count,
+            torch.zeros_like(latency_sum),
+        )
+
+        threshold = self.health_latency_threshold * historical_mean
+
+        # Expert is unhealthy if:
+        # 1. Currently active (current_latency > 0)
+        # 2. Exceeds threshold (already 0 if insufficient history)
+        is_unhealthy = (
+            (current_latency > 0)
+            & (current_latency > threshold)
+            & (historical_mean > 0)
+        )
+
+        new_health_mask = ~is_unhealthy
+
+        if log_stats:
+            newly_unhealthy = is_unhealthy & self.expert_health_mask
+            if newly_unhealthy.any():
+                unhealthy_coords = newly_unhealthy.nonzero(as_tuple=False)
+                for layer_idx, expert_idx in unhealthy_coords:
+                    current_lat = current_latency[layer_idx, expert_idx].item()
+                    baseline = historical_mean[layer_idx, expert_idx].item()
+                    logger.warning(
+                        "Expert [layer=%d, expert=%d] unhealthy: "
+                        "current=%.3fms > %.1fx * baseline=%.3fms",
+                        layer_idx,
+                        expert_idx,
+                        current_lat,
+                        self.health_latency_threshold,
+                        baseline,
+                    )
+
+            total_unhealthy = (~new_health_mask).sum().item()
+            total_experts = new_health_mask.numel()
+            if total_unhealthy > 0:
+                logger.info(
+                    "EPLB health summary: %d/%d experts unhealthy (%.1f%%)",
+                    total_unhealthy,
+                    total_experts,
+                    100.0 * total_unhealthy / total_experts,
+                )
+
+        self.expert_health_mask = new_health_mask
 
     def rearrange(
         self,
+        model: MixtureOfExperts,
         is_profile: bool = False,
         execute_shuffle: bool = True,
-        global_expert_loads: list[torch.Tensor] | None = None,
+        global_expert_load: torch.Tensor | None = None,
         rank_mapping: dict[int, int] | None = None,
     ) -> torch.Tensor | None:
         """
         Rearrange the experts according to the current load.
-
-        Args:
-            is_profile (bool): If `True`, perform a dummy rearrangement.
-                This is used in `profile_run` to reserve enough memory,
-                no memory movement will be performed. Default is False.
-            execute_shuffle (bool): If `True`, execute the shuffle
-                in elastic expert parallel (EEP). Default is True.
-            global_expert_loads (list[torch.Tensor] | None): The global expert
-                loads when scaling is done in EEP.
-                List of expert loads for the main and drafter
-                (when spec decode is used) models.
-            rank_mapping (dict[int, int] | None): The rank mapping
-                when scaling is done in EEP.
         """
 
         ep_group = get_ep_group().device_group
@@ -526,71 +604,53 @@ class EplbState:
             time_start = time.perf_counter()
             logger.info("Rearranging experts %s...", "(profile)" if is_profile else "")
 
-        if global_expert_loads is None:
+        if global_expert_load is None:
             # Map the physical expert load to global logical experts
-            global_expert_load_windows = []
+            logical_expert_load_window = torch.zeros(
+                self.expert_load_window_size,
+                model.num_moe_layers,
+                model.num_logical_experts,
+                dtype=self.expert_load_window.dtype,
+                device=self.expert_load_window.device,
+            )
+            logical_expert_load_window.scatter_add_(
+                dim=-1,
+                index=self.physical_to_logical_map.unsqueeze(0)
+                .expand_as(self.expert_load_window)
+                .long(),
+                src=self.expert_load_window,
+            )
+
             if not execute_shuffle:
-                num_models = torch.tensor(
-                    [len(self.model_states)], dtype=torch.int32, device="cpu"
+                metadata = torch.tensor(
+                    [
+                        model.num_moe_layers,
+                        model.num_logical_experts,
+                        self.physical_to_logical_map.shape[1],
+                    ],
+                    dtype=torch.int32,
+                    device="cpu",
                 )
                 torch.distributed.broadcast(
-                    num_models, group=get_ep_group().cpu_group, group_src=0
+                    metadata, group=get_ep_group().cpu_group, group_src=0
                 )
 
-            for eplb_model_state in self.model_states.values():
-                logical_expert_load_window = torch.zeros(
-                    self.expert_load_window_size,
-                    eplb_model_state.model.num_moe_layers,
-                    eplb_model_state.model.num_logical_experts,
-                    dtype=eplb_model_state.expert_load_window.dtype,
-                    device=eplb_model_state.expert_load_window.device,
-                )
-                logical_expert_load_window.scatter_add_(
-                    dim=-1,
-                    index=eplb_model_state.physical_to_logical_map.unsqueeze(0)
-                    .expand_as(eplb_model_state.expert_load_window)
-                    .long(),
-                    src=eplb_model_state.expert_load_window,
-                )
+            # Perform all-reduce to get the expert load across all ranks
+            global_expert_load_window = logical_expert_load_window.sum(dim=0)
+            all_reduce(global_expert_load_window, group=ep_group)
 
-                if not execute_shuffle:
-                    metadata = torch.tensor(
-                        [
-                            eplb_model_state.model.num_moe_layers,
-                            eplb_model_state.model.num_logical_experts,
-                            eplb_model_state.physical_to_logical_map.shape[1],
-                        ],
-                        dtype=torch.int32,
-                        device="cpu",
-                    )
-                    torch.distributed.broadcast(
-                        metadata, group=get_ep_group().cpu_group, group_src=0
-                    )
-
-                global_expert_load_window = logical_expert_load_window.sum(dim=0)
-                global_expert_load_windows.append(global_expert_load_window)
-            # Perform all-reduce to get the expert load across all ranks for each model
-            global_expert_load_windows = self._allreduce_list(
-                global_expert_load_windows
-            )
             if not execute_shuffle:
-                for eplb_model_state, global_expert_load_window in zip(
-                    self.model_states.values(), global_expert_load_windows
-                ):
-                    # (num_moe_layers, old_num_physical_experts)
-                    old_global_expert_indices = eplb_model_state.physical_to_logical_map
-                    torch.distributed.broadcast(
-                        old_global_expert_indices, group=ep_group, group_src=0
-                    )
-            if not execute_shuffle:
-                return global_expert_load_windows
+                # (num_moe_layers, old_num_physical_experts)
+                old_global_expert_indices = self.physical_to_logical_map
+                torch.distributed.broadcast(
+                    old_global_expert_indices, group=ep_group, group_src=0
+                )
+                return global_expert_load_window
         else:
             assert execute_shuffle
-            global_expert_load_windows = global_expert_loads
+            global_expert_load_window = global_expert_load
 
         # TODO(bowen): Treat differently for prefill and decode nodes
-        eplb_model_state = next(iter(self.model_states.values()))
-        model = eplb_model_state.model
         num_replicas = model.num_physical_experts
         num_groups = model.num_expert_groups
         if rank_mapping is not None and len(rank_mapping) == ep_group.size():
@@ -615,64 +675,48 @@ class EplbState:
                 f"{num_gpus=}, {num_nodes=}"
             )
 
-        for eplb_model_state, global_expert_load_window in zip(
-            self.model_states.values(), global_expert_load_windows
-        ):
-            # Get new expert mappings for the model
-            (
-                new_physical_to_logical_map,
+        # Get new expert mappings
+        (
+            new_physical_to_logical_map,
+            new_logical_to_physical_map,
+            new_logical_replica_count,
+        ) = rebalance_experts(
+            global_expert_load_window,
+            num_replicas,
+            num_groups,
+            num_nodes,
+            num_gpus,
+        )
+
+        # Update expert weights
+        rearrange_expert_weights_inplace(
+            self.physical_to_logical_map,
+            new_physical_to_logical_map,
+            model.expert_weights,
+            ep_group,
+            is_profile,
+            rank_mapping,
+        )
+
+        if not is_profile:
+            if (
+                self.physical_to_logical_map.shape[1]
+                != new_physical_to_logical_map.shape[1]
+            ):
+                self.physical_to_logical_map = new_physical_to_logical_map.to(
+                    self.physical_to_logical_map.device
+                )
+            else:
+                self.physical_to_logical_map.copy_(new_physical_to_logical_map)
+            max_physical_slots = new_logical_to_physical_map.shape[-1]
+            assert max_physical_slots <= self.logical_to_physical_map.shape[-1]
+            new_logical_to_physical_map = torch.nn.functional.pad(
                 new_logical_to_physical_map,
-                new_logical_replica_count,
-            ) = rebalance_experts(
-                global_expert_load_window,
-                num_replicas,
-                num_groups,
-                num_nodes,
-                num_gpus,
+                (0, self.logical_to_physical_map.shape[-1] - max_physical_slots),
+                value=-1,
             )
-
-            # Update expert weights
-            rearrange_expert_weights_inplace(
-                eplb_model_state.physical_to_logical_map,
-                new_physical_to_logical_map,
-                eplb_model_state.model.expert_weights,
-                ep_group,
-                is_profile,
-                rank_mapping,
-            )
-
-            if not is_profile:
-                if (
-                    eplb_model_state.physical_to_logical_map.shape[1]
-                    != new_physical_to_logical_map.shape[1]
-                ):
-                    eplb_model_state.physical_to_logical_map = (
-                        new_physical_to_logical_map.to(
-                            eplb_model_state.physical_to_logical_map.device
-                        )
-                    )
-                else:
-                    eplb_model_state.physical_to_logical_map.copy_(
-                        new_physical_to_logical_map
-                    )
-                max_physical_slots = new_logical_to_physical_map.shape[-1]
-                assert (
-                    max_physical_slots
-                    <= eplb_model_state.logical_to_physical_map.shape[-1]
-                )
-                new_logical_to_physical_map = torch.nn.functional.pad(
-                    new_logical_to_physical_map,
-                    (
-                        0,
-                        eplb_model_state.logical_to_physical_map.shape[-1]
-                        - max_physical_slots,
-                    ),
-                    value=-1,
-                )
-                eplb_model_state.logical_to_physical_map.copy_(
-                    new_logical_to_physical_map
-                )
-                eplb_model_state.logical_replica_count.copy_(new_logical_replica_count)
+            self.logical_to_physical_map.copy_(new_logical_to_physical_map)
+            self.logical_replica_count.copy_(new_logical_replica_count)
 
         if is_main_rank:
             assert time_start is not None
@@ -686,118 +730,32 @@ class EplbState:
         return None
 
     @staticmethod
-    def recv_state() -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    def recv_state() -> tuple[torch.Tensor, torch.Tensor]:
         """
         Receive the expert load and old placement from the master rank.
         """
         ep_group = get_ep_group()
-        num_models = torch.empty(1, dtype=torch.int32, device="cpu")
-        torch.distributed.broadcast(num_models, group=ep_group.cpu_group, group_src=0)
-        num_models = num_models.item()
-        global_expert_loads = []
-        old_global_expert_indices_per_model = []
-        for _ in range(num_models):
-            metadata = torch.empty(3, dtype=torch.int32, device="cpu")
-            torch.distributed.broadcast(metadata, group=ep_group.cpu_group, group_src=0)
-            num_moe_layers, num_logical_experts, num_old_physical_experts = (
-                metadata.tolist()
-            )
-            global_expert_load = torch.zeros(
-                (num_moe_layers, num_logical_experts),
-                dtype=torch.int64,
-                device=ep_group.device,
-            )
-            all_reduce(global_expert_load, group=ep_group.device_group)
-            old_global_expert_indices = torch.empty(
-                (num_moe_layers, num_old_physical_experts),
-                dtype=torch.int64,
-                device=ep_group.device,
-            )
-            torch.distributed.broadcast(
-                old_global_expert_indices,
-                group=ep_group.device_group,
-                group_src=0,
-            )
-            global_expert_loads.append(global_expert_load)
-            old_global_expert_indices_per_model.append(old_global_expert_indices)
-        return global_expert_loads, old_global_expert_indices_per_model
-
-    @classmethod
-    def get_eep_state(
-        cls, parallel_config: ParallelConfig
-    ) -> tuple[
-        list[torch.Tensor] | None,
-        list[torch.Tensor] | None,
-        dict[int, int] | None,
-    ]:
-        num_local_physical_experts = torch.empty(1, dtype=torch.int32, device="cpu")
+        metadata = torch.empty(3, dtype=torch.int32, device="cpu")
+        torch.distributed.broadcast(metadata, group=ep_group.cpu_group, group_src=0)
+        num_moe_layers, num_logical_experts, num_old_physical_experts = (
+            metadata.tolist()
+        )
+        global_expert_load = torch.zeros(
+            (num_moe_layers, num_logical_experts),
+            dtype=torch.int64,
+            device=ep_group.device,
+        )
+        all_reduce(global_expert_load, group=ep_group.device_group)
+        old_global_expert_indices = torch.empty(
+            (num_moe_layers, num_old_physical_experts),
+            dtype=torch.int64,
+            device=ep_group.device,
+        )
         torch.distributed.broadcast(
-            num_local_physical_experts,
-            group=get_ep_group().cpu_group,
-            group_src=0,
-        )
-        num_local_physical_experts = int(num_local_physical_experts.item())
-        new_ep_size = get_ep_group().world_size
-        global_expert_loads, old_global_expert_indices_per_model = (
-            EplbState.recv_state()
+            old_global_expert_indices, group=ep_group.device_group, group_src=0
         )
 
-        # EP configuration for all models has to be the same so as eplb config
-        num_logical_experts = global_expert_loads[0].shape[1]
-        parallel_config.eplb_config.num_redundant_experts = (
-            num_local_physical_experts * new_ep_size - num_logical_experts
-        )
-        assert (
-            old_global_expert_indices_per_model[0].shape[1] % num_local_physical_experts
-            == 0
-        )
-        old_ep_size = (
-            old_global_expert_indices_per_model[0].shape[1]
-            // num_local_physical_experts
-        )
-        rank_mapping = {old_ep_rank: old_ep_rank for old_ep_rank in range(old_ep_size)}
-        return (
-            global_expert_loads,
-            old_global_expert_indices_per_model,
-            rank_mapping,
-        )
-
-    def _allreduce_list(self, tensor_list: list[torch.Tensor]) -> list[torch.Tensor]:
-        """
-        All-reduce a list of tensors.
-        """
-        if len(tensor_list) == 1:
-            all_reduce(tensor_list[0], group=get_ep_group().device_group)
-            return tensor_list
-        assert all(t.dim() == 2 for t in tensor_list), "All tensors must be 2D."
-        assert all(t.shape[1] == tensor_list[0].shape[1] for t in tensor_list), (
-            "All tensors must have the same shape[1]."
-        )
-        # Concatenate, all_reduce, then unpack to original shapes.
-        # We assume all tensors are 2D and shape[1] (num_physical_experts)
-        # is the same across all models.
-        shapes = [t.shape for t in tensor_list]
-        concat_tensor = torch.cat(tensor_list, dim=0)
-
-        ep_group = get_ep_group().device_group
-        all_reduce(concat_tensor, group=ep_group)
-
-        all_reduce_list = []
-        offset = 0
-        for shape in shapes:
-            all_reduce_list.append(concat_tensor[offset : offset + shape[0], :])
-            offset += shape[0]
-        return all_reduce_list
-
-    def _sync_load_pass(self) -> list[torch.Tensor]:
-        """
-        Sync the expert load pass across all ranks for log stats.
-        Doesn't update the expert load pass in eplb_model_state.
-        """
-        load_pass_list = []
-        for eplb_model_state in self.model_states.values():
-            load_pass_list.append(eplb_model_state.expert_load_pass.clone())
-        return self._allreduce_list(load_pass_list)
+        return global_expert_load, old_global_expert_indices
 
 
 def _node_count_with_rank_mapping(

--- a/vllm/distributed/eplb/rebalance_algo.py
+++ b/vllm/distributed/eplb/rebalance_algo.py
@@ -16,6 +16,113 @@ import numpy as np
 import torch
 
 
+def get_effective_ep_size(
+    rank_mapping: dict[int, int],
+) -> int:
+    """
+    Calculate the effective number of active ranks from rank_mapping.
+    
+    Args:
+        rank_mapping: Mapping from physical rank to new rank, -1 for masked ranks
+        
+    Returns:
+        Number of active (non-masked) ranks
+    """
+    return sum(1 for new_rank in rank_mapping.values() if new_rank != -1)
+
+
+def rebalance_masked_experts(
+    weight: torch.Tensor,
+    full_num_replicas: int,
+    num_groups: int,
+    num_nodes: int,
+    full_ep_size: int,
+    rank_mapping: dict[int, int],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Rebalance experts with masked ranks, maintaining full ep_size representation.
+    
+    For health-based masking where some ranks are masked but ep_size stays constant.
+    Returns full-size tensors with -1 for masked rank slots.
+    
+    Args:
+        weight: Load statistics [layers, num_logical_experts]
+                NOT affected by masking - always same size (model constant)
+        full_num_replicas: Full number of physical experts INCLUDING masked ranks
+                          = full_ep_size * experts_per_rank
+                          e.g., 8 (not 6) for 4 ranks with 1 masked
+        num_groups: Number of expert groups (model architecture constant)
+                   NOT affected by masking - e.g., 8 groups always
+        num_nodes: Number of physical server nodes
+                  May be affected if entire nodes are masked (calculated externally)
+        full_ep_size: Full ep_group.size() INCLUDING masked ranks
+                     e.g., 4 (not 3) even with 1 rank masked
+        rank_mapping: Mapping from physical rank to new rank (active rank index)
+                     INCLUDING masked ranks: {0:0, 1:1, 2:-1, 3:2}
+                     Keys 0-3 (all physical ranks), value -1 means masked
+        
+    Returns:
+        Tensors with full ep_size representation (masked slots filled with -1):
+        - physical_to_logical_map: [layers, full_num_replicas] e.g., (layers, 8)
+        - logical_to_physical_map: [layers, num_logical, X] (unchanged)
+        - logical_replica_count: [layers, num_logical] (counts active replicas only)
+    """
+    # Calculate active counts (EXCLUDING masked ranks)
+    effective_ep_size = get_effective_ep_size(rank_mapping)  # e.g., 3 (not 4)
+    experts_per_rank = full_num_replicas // full_ep_size      # e.g., 8 // 4 = 2
+    active_num_replicas = effective_ep_size * experts_per_rank # e.g., 3 * 2 = 6
+    
+    # Call standard rebalance with ACTIVE counts only (as if we only have 3 ranks)
+    # This returns tensors of size 6 (for 3 active ranks * 2 experts/rank)
+    (
+        active_phy2log,   # (layers, active_num_replicas=6)
+        active_log2phy,   # (layers, num_logical, max_replicas_per_expert)
+                         # where max = num_redundant_experts + 1
+        active_logcnt,    # (layers, num_logical) - actual replica count per expert
+    ) = rebalance_experts(
+        weight,                  # [layers, num_logical] - unchanged
+        active_num_replicas,     # 6 (active only)
+        num_groups,              # Model constant (NOT affected by masking)
+        num_nodes,               # May be reduced if whole nodes masked
+        effective_ep_size,       # 3 (active ranks only)
+    )
+    
+    # Expand from active representation (size 6) to full ep_size representation (size 8)
+    num_layers = active_phy2log.shape[0]
+    
+    # Create full-size physical_to_logical_map with -1 for masked slots
+    # Output: (layers, full_num_replicas=8) filled with -1
+    full_phy2log = torch.full(
+        (num_layers, full_num_replicas),
+        -1,
+        dtype=active_phy2log.dtype,
+        device=active_phy2log.device,
+    )
+    
+    # Map active ranks to their physical positions
+    # Example: rank_mapping = {0:0, 1:1, 2:-1, 3:2} with experts_per_rank=2
+    # Physical rank 0 → new rank 0 → copy active[0:2] to full[0:2]
+    # Physical rank 1 → new rank 1 → copy active[2:4] to full[2:4]
+    # Physical rank 2 → masked (-1) → full[4:6] stays as -1
+    # Physical rank 3 → new rank 2 → copy active[4:6] to full[6:8]
+    for physical_rank in range(full_ep_size):  # 0, 1, 2, 3
+        new_rank = rank_mapping[physical_rank]
+        if new_rank != -1:
+            # This physical rank is active - copy its expert assignments from active tensor
+            phys_start = physical_rank * experts_per_rank  # Physical position in output
+            phys_end = (physical_rank + 1) * experts_per_rank
+            active_start = new_rank * experts_per_rank     # Active position in input
+            active_end = (new_rank + 1) * experts_per_rank
+            
+            full_phy2log[:, phys_start:phys_end] = active_phy2log[:, active_start:active_end]
+        # else: masked rank, leave as -1 (already initialized above)
+    
+    # For log2phy and logcnt, we can use the active versions directly
+    # since they map logical experts to physical indices (which are the same)
+    # These remain unchanged because logical expert IDs don't change due to masking
+    return full_phy2log, active_log2phy, active_logcnt
+
+
 def balanced_packing(
     weight: torch.Tensor, num_packs: int
 ) -> tuple[torch.Tensor, torch.Tensor]:

--- a/vllm/distributed/eplb/rebalance_execute.py
+++ b/vllm/distributed/eplb/rebalance_execute.py
@@ -298,6 +298,12 @@ def rearrange_expert_weights_inplace(
 
     ep_rank = ep_group.rank()
     ep_size = ep_group.size()
+    # After mapping transformations, num_physical_experts includes slots for all ranks
+    # (including masked ones), so it should equal ep_size * local_experts
+    # For health-based masking: rebalance_masked_experts() maintains full ep_size representation
+    # For scale-up: _map_old_expert_indices_with_rank_mapping() expands old to match new ep_size
+    # For scale-down: _map_new_expert_indices_with_rank_mapping() expands new to match old
+    # For normal rearrangement: both tensors already at full ep_size
     assert num_physical_experts == ep_size * num_local_physical_experts
 
     # A buffer to hold the expert weights in one layer during the exchange.

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -411,6 +411,10 @@ class FusedMoE(CustomOp):
             self.cuda_start_event = torch.cuda.Event(enable_timing=True)
             self.cuda_end_event = torch.cuda.Event(enable_timing=True)
 
+        # Deferred latency measurement: store data from forward pass
+        self._pending_active_experts: torch.Tensor | None = None
+        self._has_pending_measurement: bool = False
+
         # ROCm aiter shared experts fusion
         self.rocm_aiter_fmoe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
         self.aiter_fmoe_shared_expert_enabled = (
@@ -1799,24 +1803,19 @@ class FusedMoE(CustomOp):
                 logical_replica_count=self.logical_replica_count,
             )
 
-            # Health monitoring: Record latency for active experts
+            # Health monitoring: Record end event and store active experts
+            # Synchronization is deferred until measure_and_update_latency() is called
             if self.cuda_end_event is not None and self.expert_latency_view is not None:
                 self.cuda_end_event.record()
-                self.cuda_end_event.synchronize()
-
-                # Calculate layer latency in milliseconds
-                layer_latency_ms = self.cuda_start_event.elapsed_time(
-                    self.cuda_end_event
-                )
 
                 # Determine which experts were active from router logits
                 # router_logits shape: (num_tokens, num_experts)
                 _, selected_experts = torch.topk(router_logits, self.top_k, dim=-1)
                 active_experts = selected_experts.unique()
 
-                # Write to latency view: 0 for inactive, latency for active
-                self.expert_latency_view.zero_()  # Reset all to 0
-                self.expert_latency_view[active_experts] = layer_latency_ms
+                # Store for deferred measurement (move to CPU to free GPU memory)
+                self._pending_active_experts = active_experts.cpu()
+                self._has_pending_measurement = True
 
             if has_separate_shared_experts:
                 assert self.shared_experts is not None
@@ -1908,6 +1907,45 @@ class FusedMoE(CustomOp):
             tracking is not enabled.
         """
         return self.expert_latency_view
+
+    def measure_and_update_latency(self) -> None:
+        """
+        Synchronize CUDA events and update expert latency view.
+
+        This method performs the deferred synchronization and measurement
+        that was initiated during forward_impl(). It should be called
+        AFTER the forward pass is complete, typically by EplbState.step().
+
+        The synchronization is moved out of the forward pass to avoid
+        stalling the GPU pipeline during model execution.
+        """
+        if not self._has_pending_measurement:
+            return
+
+        if (
+            self.cuda_end_event is None
+            or self.expert_latency_view is None
+            or self._pending_active_experts is None
+        ):
+            return
+
+        # NOW we synchronize (outside the forward pass)
+        self.cuda_end_event.synchronize()
+
+        # Calculate layer latency in milliseconds
+        layer_latency_ms = self.cuda_start_event.elapsed_time(self.cuda_end_event)
+
+        # Update latency view
+        self.expert_latency_view.zero_()  # Reset all to 0
+        # Move active experts back to GPU device for indexing
+        active_experts_gpu = self._pending_active_experts.to(
+            self.expert_latency_view.device
+        )
+        self.expert_latency_view[active_experts_gpu] = layer_latency_ms
+
+        # Clear pending state
+        self._has_pending_measurement = False
+        self._pending_active_experts = None
 
     def extra_repr(self) -> str:
         s = (

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -401,6 +401,16 @@ class FusedMoE(CustomOp):
         self.logical_to_physical_map: torch.Tensor | None = None
         self.logical_replica_count: torch.Tensor | None = None
 
+        # Health monitoring: Shared latency view (layers write directly to this)
+        self.expert_latency_view: torch.Tensor | None = None
+        self.layer_idx: int = 0  # MoE layer index (set in set_eplb_state)
+        self.cuda_start_event: torch.cuda.Event | None = None
+        self.cuda_end_event: torch.cuda.Event | None = None
+        if enable_eplb and vllm_config.parallel_config.eplb_config.health_check_enabled:
+            # CUDA events measure layer execution time
+            self.cuda_start_event = torch.cuda.Event(enable_timing=True)
+            self.cuda_end_event = torch.cuda.Event(enable_timing=True)
+
         # ROCm aiter shared experts fusion
         self.rocm_aiter_fmoe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
         self.aiter_fmoe_shared_expert_enabled = (
@@ -1255,6 +1265,7 @@ class FusedMoE(CustomOp):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
     ) -> None:
         """
         Register the EPLB state in this layer.
@@ -1262,9 +1273,14 @@ class FusedMoE(CustomOp):
         This is used later in forward pass, where we get the expert mapping
         and record the load metrics in `expert_load_view`.
         """
+        self.layer_idx = moe_layer_idx
         self.expert_load_view = expert_load_view[moe_layer_idx]
         self.logical_to_physical_map = logical_to_physical_map[moe_layer_idx]
         self.logical_replica_count = logical_replica_count[moe_layer_idx]
+
+        # Health monitoring
+        if expert_latency_view is not None:
+            self.expert_latency_view = expert_latency_view[moe_layer_idx]
 
     def ensure_moe_quant_config_init(self):
         if self.quant_method.moe_quant_config is None:
@@ -1753,6 +1769,10 @@ class FusedMoE(CustomOp):
                     hidden_states, router_logits, self.is_sequence_parallel
                 )
 
+            # Health monitoring: Record start time
+            if self.cuda_start_event is not None:
+                self.cuda_start_event.record()
+
             # Matrix multiply.
             final_hidden_states = self.quant_method.apply(
                 layer=self,
@@ -1778,6 +1798,25 @@ class FusedMoE(CustomOp):
                 logical_to_physical_map=self.logical_to_physical_map,
                 logical_replica_count=self.logical_replica_count,
             )
+
+            # Health monitoring: Record latency for active experts
+            if self.cuda_end_event is not None and self.expert_latency_view is not None:
+                self.cuda_end_event.record()
+                self.cuda_end_event.synchronize()
+
+                # Calculate layer latency in milliseconds
+                layer_latency_ms = self.cuda_start_event.elapsed_time(
+                    self.cuda_end_event
+                )
+
+                # Determine which experts were active from router logits
+                # router_logits shape: (num_tokens, num_experts)
+                _, selected_experts = torch.topk(router_logits, self.top_k, dim=-1)
+                active_experts = selected_experts.unique()
+
+                # Write to latency view: 0 for inactive, latency for active
+                self.expert_latency_view.zero_()  # Reset all to 0
+                self.expert_latency_view[active_experts] = layer_latency_ms
 
             if has_separate_shared_experts:
                 assert self.shared_experts is not None
@@ -1858,6 +1897,17 @@ class FusedMoE(CustomOp):
                 ("w3", ckpt_up_proj_name),
             ]
         ]
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get this layer's slice of the expert latency tensor.
+
+        Returns:
+            Tensor of shape (num_physical_experts,) containing latency in
+            milliseconds (0 if expert was inactive), or None if latency
+            tracking is not enabled.
+        """
+        return self.expert_latency_view
 
     def extra_repr(self) -> str:
         s = (

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1933,6 +1933,7 @@ class FusedMoE(CustomOp):
         self.cuda_end_event.synchronize()
 
         # Calculate layer latency in milliseconds
+        assert self.cuda_start_event is not None
         layer_latency_ms = self.cuda_start_event.elapsed_time(self.cuda_end_event)
 
         # Update latency view

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -33,7 +33,6 @@ import torch
 from torch import nn
 from transformers import DeepseekV2Config, DeepseekV3Config
 
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.attention import Attention
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.attention.ops.common import pack_seq_triton, unpack_seq_triton
@@ -51,11 +50,14 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.fused_moe import SharedFusedMoE
+from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+    is_rocm_aiter_fusion_shared_expert_enabled,
+    is_rocm_aiter_moe_enabled,
+)
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
-    QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -100,92 +102,6 @@ elif current_platform.is_xpu():
     from vllm._ipex_ops import ipex_ops as ops
 
 logger = init_logger(__name__)
-
-
-class DeepseekAttention(nn.Module):
-    """Normal MHA implementation used by Deepseek v1."""
-
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        config: DeepseekV2Config | DeepseekV3Config,
-        hidden_size: int,
-        num_heads: int,
-        rope_theta: float = 10000,
-        rope_scaling: dict[str, Any] | None = None,
-        max_position_embeddings: int = 8192,
-        cache_config: CacheConfig | None = None,
-        quant_config: QuantizationConfig | None = None,
-        prefix: str = "",
-        **kwargs,
-    ) -> None:
-        super().__init__()
-        self.hidden_size = hidden_size
-        tp_size = get_tensor_model_parallel_world_size()
-        self.total_num_heads = num_heads
-        assert self.total_num_heads % tp_size == 0
-        self.num_heads = self.total_num_heads // tp_size
-        self.total_num_kv_heads = config.num_key_value_heads
-        if self.total_num_kv_heads >= tp_size:
-            # Number of KV heads is greater than TP size, so we partition
-            # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
-        else:
-            # Number of KV heads is less than TP size, so we replicate
-            # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
-        self.head_dim = hidden_size // self.total_num_heads
-        self.q_size = self.num_heads * self.head_dim
-        self.kv_size = self.num_kv_heads * self.head_dim
-        self.scaling = self.head_dim**-0.5
-        self.rope_theta = rope_theta
-        self.max_position_embeddings = max_position_embeddings
-
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size,
-            self.head_dim,
-            self.total_num_heads,
-            self.total_num_kv_heads,
-            bias=False,
-            quant_config=quant_config,
-        )
-
-        self.o_proj = RowParallelLinear(
-            self.total_num_heads * self.head_dim,
-            hidden_size,
-            bias=False,
-            quant_config=quant_config,
-        )
-
-        self.rotary_emb = get_rope(
-            self.head_dim,
-            rotary_dim=self.head_dim,
-            max_position=max_position_embeddings,
-            base=rope_theta,
-            rope_scaling=rope_scaling,
-        )
-        self.attn = Attention(
-            self.num_heads,
-            self.head_dim,
-            self.scaling,
-            num_kv_heads=self.num_kv_heads,
-            cache_config=cache_config,
-            quant_config=quant_config,
-            prefix=f"{prefix}.attn",
-        )
-
-    def forward(
-        self,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v)
-        output, _ = self.o_proj(attn_output)
-        return output
 
 
 class DeepseekV2MLP(nn.Module):
@@ -247,10 +163,10 @@ class DeepseekV2MoE(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
 
-        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+        self.routed_scaling_factor = config.routed_scaling_factor
 
         self.ep_group = get_ep_group().device_group
-        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_rank = self.ep_group.rank()
         self.ep_size = self.ep_group.size()
         self.n_routed_experts: int = config.n_routed_experts
         self.n_shared_experts: int = config.n_shared_experts
@@ -270,7 +186,7 @@ class DeepseekV2MoE(nn.Module):
             quant_config=None,
             prefix=f"{prefix}.gate",
         )
-        if getattr(config, "topk_method", None) == "noaux_tc":
+        if config.topk_method == "noaux_tc":
             self.gate.e_score_correction_bias = nn.Parameter(
                 torch.empty(config.n_routed_experts, dtype=torch.float32)
             )
@@ -291,8 +207,10 @@ class DeepseekV2MoE(nn.Module):
             self.physical_expert_start + self.n_local_physical_experts
         )
 
-        self.is_rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
-        if config.n_shared_experts is None or self.is_rocm_aiter_moe_enabled:
+        if (
+            config.n_shared_experts is None
+            or is_rocm_aiter_fusion_shared_expert_enabled()
+        ):
             self.shared_experts = None
         else:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
@@ -318,21 +236,21 @@ class DeepseekV2MoE(nn.Module):
             renormalize=config.norm_topk_prob,
             quant_config=quant_config,
             use_grouped_topk=True,
-            num_expert_group=getattr(config, "n_group", 1),
-            topk_group=getattr(config, "topk_group", 1),
+            num_expert_group=config.n_group,
+            topk_group=config.topk_group,
             prefix=f"{prefix}.experts",
-            scoring_func=getattr(config, "scoring_func", "softmax"),
+            scoring_func=config.scoring_func,
             # we do scaling outside, set factor to 1.0 to avoid double mul
             # aiter applies routed_scaling_factor internally
             routed_scaling_factor=1.0
-            if not self.is_rocm_aiter_moe_enabled
+            if not is_rocm_aiter_moe_enabled()
             else self.routed_scaling_factor,
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
             n_shared_experts=config.n_shared_experts
-            if rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+            if is_rocm_aiter_fusion_shared_expert_enabled()
             else None,
         )
 
@@ -366,7 +284,7 @@ class DeepseekV2MoE(nn.Module):
         # Fix FP16 overflow
         # See DeepseekV2DecoderLayer for more details.
         if hidden_states.dtype != torch.float16:
-            if not self.is_rocm_aiter_moe_enabled:
+            if not is_rocm_aiter_moe_enabled():
                 final_hidden_states *= self.routed_scaling_factor
         elif self.shared_experts is not None:
             assert shared_output is not None
@@ -1076,24 +994,11 @@ class DeepseekV2DecoderLayer(nn.Module):
         rope_theta = getattr(config, "rope_theta", 10000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
-        moe_layer_freq = getattr(config, "moe_layer_freq", 1)
         # DecoderLayers are created with `make_layers` which passes the prefix
         # with the layer's index.
         layer_idx = int(prefix.split(sep=".")[-1])
         self.layer_idx = layer_idx
-
-        # verify MLA attention specific fields
-        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
-        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
-        v_head_dim = getattr(config, "v_head_dim", 0)
-        kv_lora_rank = getattr(config, "kv_lora_rank", 0)
-        use_mha = config.model_type == "deepseek" or all(
-            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
-        )
-
-        if use_mha:
-            attn_cls = DeepseekAttention
-        elif model_config.use_mla:
+        if model_config.use_mla:
             attn_cls = DeepseekV2MLAAttention
         else:
             attn_cls = DeepseekV2Attention
@@ -1102,11 +1007,11 @@ class DeepseekV2DecoderLayer(nn.Module):
             config=config,
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
-            qk_nope_head_dim=qk_nope_head_dim,
-            qk_rope_head_dim=qk_rope_head_dim,
-            v_head_dim=v_head_dim,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
             q_lora_rank=config.q_lora_rank if hasattr(config, "q_lora_rank") else None,
-            kv_lora_rank=kv_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,
             max_position_embeddings=max_position_embeddings,
@@ -1119,7 +1024,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         if (
             config.n_routed_experts is not None
             and layer_idx >= config.first_k_dense_replace
-            and layer_idx % moe_layer_freq == 0
+            and layer_idx % config.moe_layer_freq == 0
         ):
             self.mlp = DeepseekV2MoE(
                 config=config,
@@ -1139,7 +1044,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
-        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+        self.routed_scaling_factor = config.routed_scaling_factor
 
     def forward(
         self,
@@ -1158,10 +1063,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states=hidden_states,
         )
 
-        if (
-            not isinstance(self.self_attn, DeepseekAttention)
-            and hidden_states.dtype == torch.float16
-        ):
+        if hidden_states.dtype == torch.float16:
             # Fix FP16 overflow
             # We scale both hidden_states and residual before
             # rmsnorm, and rmsnorm result would not affect by scale.
@@ -1220,6 +1122,7 @@ class DeepseekV2Model(nn.Module):
             )
         else:
             self.embed_tokens = PPMissingLayer()
+
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
             lambda prefix: DeepseekV2DecoderLayer(
@@ -1236,7 +1139,7 @@ class DeepseekV2Model(nn.Module):
             ["hidden_states", "residual"], config.hidden_size
         )
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -1250,7 +1153,7 @@ class DeepseekV2Model(nn.Module):
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
-                hidden_states = self.embed_input_ids(input_ids)
+                hidden_states = self.get_input_embeddings(input_ids)
             residual = None
         else:
             assert intermediate_tensors is not None
@@ -1269,50 +1172,7 @@ class DeepseekV2Model(nn.Module):
         return hidden_states
 
 
-class DeepseekV2MixtureOfExperts(MixtureOfExperts):
-    moe_mlp_layers: list[DeepseekV2MoE]
-    """
-    List of MoE MLP layers in the model.
-    """
-
-    def extract_moe_parameters(self, example_moe: DeepseekV2MoE | None):
-        if example_moe is None:
-            self.num_moe_layers = 0
-            self.num_expert_groups = 0
-            self.num_logical_experts = 0
-            self.num_physical_experts = 0
-            self.num_local_physical_experts = 0
-            self.num_routed_experts = 0
-            self.num_shared_experts = 0
-            self.num_redundant_experts = 0
-            logger.warning("DeepSeekV2: No DeepseekV2MoE layer found in model.layers.")
-        else:
-            self.num_logical_experts = example_moe.n_logical_experts
-            self.num_physical_experts = example_moe.n_physical_experts
-            self.num_local_physical_experts = example_moe.n_local_physical_experts
-            self.num_routed_experts = example_moe.n_routed_experts
-            self.num_shared_experts = example_moe.n_shared_experts
-            self.num_redundant_experts = example_moe.n_redundant_experts
-
-    def update_physical_experts_metadata(
-        self,
-        num_physical_experts: int,
-        num_local_physical_experts: int,
-    ) -> None:
-        assert self.num_local_physical_experts == num_local_physical_experts
-        self.num_physical_experts = num_physical_experts
-        self.num_local_physical_experts = num_local_physical_experts
-        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
-        for moe in self.moe_mlp_layers:
-            moe.n_local_physical_experts = num_local_physical_experts
-            moe.n_physical_experts = num_physical_experts
-            moe.n_redundant_experts = self.num_redundant_experts
-            moe.experts.update_expert_map()
-
-
-class DeepseekV2ForCausalLM(
-    nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA
-):
+class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoRA):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
@@ -1323,15 +1183,6 @@ class DeepseekV2ForCausalLM(
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
-
-        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
-        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
-        self.use_mha = config.model_type == "deepseek" or all(
-            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
-        )
-
-        if self.use_mha:
-            self.packed_modules_mapping["qkv_proj"] = ["q_proj", "k_proj", "v_proj"]
 
         # `packed_modules_mapping` needs to be modified before
         # initializing DeepseekV2Model, as it is passed inplace to
@@ -1362,19 +1213,13 @@ class DeepseekV2ForCausalLM(
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors
         )
-        # Set MoE hyperparameters
-        self.num_moe_layers = (
-            self.config.num_hidden_layers - self.config.first_k_dense_replace
-        )
-        self.set_moe_parameters()
-
-    def set_moe_parameters(self):
         self.expert_weights = []
 
-        self.num_expert_groups = getattr(self.config, "n_group", 1)
+        # Set MoE hyperparameters
+        self.num_moe_layers = config.num_hidden_layers - config.first_k_dense_replace
+        self.num_expert_groups = config.n_group
 
-        self.moe_layers = []
-        self.moe_mlp_layers = []
+        self.moe_layers: list[SharedFusedMoE] = []
         example_moe = None
         for layer in self.model.layers:
             if isinstance(layer, PPMissingLayer):
@@ -1384,13 +1229,56 @@ class DeepseekV2ForCausalLM(
             if isinstance(layer.mlp, DeepseekV2MoE):
                 # Pick last one layer since the first ones may be dense layers.
                 example_moe = layer.mlp
-                self.moe_mlp_layers.append(layer.mlp)
                 self.moe_layers.append(layer.mlp.experts)
 
-        self.extract_moe_parameters(example_moe)
+        if example_moe is None:
+            raise RuntimeError("No DeepseekV2MoE layer found in model.layers.")
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
+    ) -> None:
+        self.expert_latency_view = expert_latency_view
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
+            )
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for layer in self.model.layers:
+            if isinstance(layer.mlp, DeepseekV2MoE):
+                moe = layer.mlp
+                moe.n_local_physical_experts = num_local_physical_experts
+                moe.n_physical_experts = num_physical_experts
+                moe.n_redundant_experts = self.num_redundant_experts
+                moe.experts.update_expert_map()
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,
@@ -1422,28 +1310,25 @@ class DeepseekV2ForCausalLM(
             num_redundant_experts=0,
         )
 
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        rocm_aiter_moe_shared_expert_enabled = (
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
-        )
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
-        ]
-        mla_params_mapping = [
             ("fused_qkv_a_proj", "q_a_proj", 0),
             ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
         ]
-        mha_params_mapping = [
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-        ]
-        if self.use_mha:
-            stacked_params_mapping.extend(mha_params_mapping)
-        else:
-            stacked_params_mapping.extend(mla_params_mapping)
 
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
@@ -1454,7 +1339,7 @@ class DeepseekV2ForCausalLM(
             num_experts=self.config.n_routed_experts
             + (
                 self.config.n_shared_experts
-                if rocm_aiter_moe_shared_expert_enabled
+                if is_rocm_aiter_fusion_shared_expert_enabled()
                 else 0
             ),
             num_redundant_experts=self.num_redundant_experts,
@@ -1470,8 +1355,9 @@ class DeepseekV2ForCausalLM(
             if spec_layer is not None:
                 continue  # skip spec decode layers for main model
 
-            is_fuse_shared_experts_layer = rocm_aiter_moe_shared_expert_enabled and (
-                "mlp.shared_experts" in name
+            is_fuse_shared_experts_layer = (
+                is_rocm_aiter_fusion_shared_expert_enabled()
+                and ("mlp.shared_experts" in name)
             )
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -1623,10 +1509,6 @@ class DeepseekV2ForCausalLM(
                 loaded_params.add(name)
 
         return loaded_params
-
-
-class DeepseekForCausalLM(DeepseekV2ForCausalLM):
-    pass
 
 
 class DeepseekV3ForCausalLM(DeepseekV2ForCausalLM):

--- a/vllm/model_executor/models/ernie45_moe.py
+++ b/vllm/model_executor/models/ernie45_moe.py
@@ -133,7 +133,7 @@ class Ernie4_5_MoeMoE(nn.Module):
 
         self.moe_num_shared_experts = getattr(config, "moe_num_shared_experts", None)
         self.ep_group = get_ep_group().device_group
-        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_rank = self.ep_group.rank()
         self.ep_size = self.ep_group.size()
         self.n_routed_experts: int = config.moe_num_experts
         self.n_shared_experts: int = self.moe_num_shared_experts
@@ -465,7 +465,7 @@ class Ernie4_5_MoeModel(nn.Module):
             ["hidden_states", "residual"], config.hidden_size
         )
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -479,7 +479,7 @@ class Ernie4_5_MoeModel(nn.Module):
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
-                hidden_states = self.embed_input_ids(input_ids)
+                hidden_states = self.get_input_embeddings(input_ids)
             residual = None
         else:
             assert intermediate_tensors is not None
@@ -709,6 +709,25 @@ class Ernie4_5_MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExpe
             self.num_shared_experts = example_moe.n_shared_experts
             self.num_redundant_experts = example_moe.n_redundant_experts
 
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
+    ) -> None:
+        self.expert_latency_view = expert_latency_view
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
+            )
+
     def update_physical_experts_metadata(
         self,
         num_physical_experts: int,
@@ -726,8 +745,8 @@ class Ernie4_5_MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExpe
                 moe.n_redundant_experts = self.num_redundant_experts
                 moe.experts.update_expert_map()
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,
@@ -757,3 +776,14 @@ class Ernie4_5_MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExpe
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -62,7 +62,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import MixtureOfExperts, SupportsLoRA, SupportsPP
+from .interfaces import SupportsLoRA, SupportsPP
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -127,7 +127,7 @@ class Glm4MoE(nn.Module):
         self.routed_scaling_factor = config.routed_scaling_factor
 
         self.ep_group = get_ep_group().device_group
-        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_rank = self.ep_group.rank()
         self.ep_size = self.ep_group.size()
         self.n_routed_experts: int = config.n_routed_experts
         self.n_shared_experts: int = config.n_shared_experts
@@ -455,7 +455,7 @@ class Glm4MoeModel(nn.Module):
             ["hidden_states", "residual"], config.hidden_size
         )
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -469,7 +469,7 @@ class Glm4MoeModel(nn.Module):
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
-                hidden_states = self.embed_input_ids(input_ids)
+                hidden_states = self.get_input_embeddings(input_ids)
             residual = None
         else:
             assert intermediate_tensors is not None
@@ -616,35 +616,7 @@ class Glm4MoeModel(nn.Module):
         return loaded_params
 
 
-class Glm4MixtureOfExperts(MixtureOfExperts):
-    def extract_moe_parameters(self, example_moe: Glm4MoE | None) -> None:
-        if example_moe is None:
-            raise RuntimeError("No Glm4MoE layer found in model.layers.")
-        else:
-            self.num_logical_experts = example_moe.n_logical_experts
-            self.num_physical_experts = example_moe.n_physical_experts
-            self.num_local_physical_experts = example_moe.n_local_physical_experts
-            self.num_routed_experts = example_moe.n_routed_experts
-            self.num_shared_experts = example_moe.n_shared_experts
-            self.num_redundant_experts = example_moe.n_redundant_experts
-
-    def update_physical_experts_metadata(
-        self,
-        num_physical_experts: int,
-        num_local_physical_experts: int,
-    ) -> None:
-        assert self.num_local_physical_experts == num_local_physical_experts
-        self.num_physical_experts = num_physical_experts
-        self.num_local_physical_experts = num_local_physical_experts
-        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
-        for moe in self.moe_mlp_layers:
-            moe.n_local_physical_experts = num_local_physical_experts
-            moe.n_physical_experts = num_physical_experts
-            moe.n_redundant_experts = self.num_redundant_experts
-            moe.experts.update_expert_map()
-
-
-class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, Glm4MixtureOfExperts):
+class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -687,9 +659,7 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, Glm4MixtureOfExper
         self.num_moe_layers = config.num_hidden_layers - config.first_k_dense_replace
         self.num_expert_groups = config.n_group
 
-        self.moe_layers = []
-        self.moe_mlp_layers: list[Glm4MoE] = []
-
+        self.moe_layers: list[SharedFusedMoE] = []
         example_moe = None
         for layer in self.model.layers:
             if isinstance(layer, PPMissingLayer):
@@ -699,13 +669,39 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, Glm4MixtureOfExper
             if isinstance(layer.mlp, Glm4MoE):
                 # Pick last one layer since the first ones may be dense layers.
                 example_moe = layer.mlp
-                self.moe_mlp_layers.append(layer.mlp)
                 self.moe_layers.append(layer.mlp.experts)
 
-        self.extract_moe_parameters(example_moe)
+        if example_moe is None:
+            raise RuntimeError("No Glm4MoE layer found in model.layers.")
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
+    ) -> None:
+        self.expert_latency_view = expert_latency_view
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
+            )
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,
@@ -732,6 +728,17 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, Glm4MixtureOfExper
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
 
 def get_spec_layer_idx_from_weight_name(

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -662,6 +662,7 @@ class MixtureOfExperts(Protocol):
         expert_load_view: Tensor,
         logical_to_physical_map: Tensor,
         logical_replica_count: Tensor,
+        expert_latency_view: Tensor | None = None,
     ) -> None:
         """
         Register the EPLB state in the MoE model.
@@ -678,6 +679,7 @@ class MixtureOfExperts(Protocol):
             expert_load_view: A view of the expert load metrics tensor.
             logical_to_physical_map: Mapping from logical to physical experts.
             logical_replica_count: Count of replicas for each logical expert.
+            expert_latency_view: A view for tracking per-expert latency (optional).
         """
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
@@ -694,6 +696,20 @@ class MixtureOfExperts(Protocol):
         num_physical_experts: int,
         num_local_physical_experts: int,
     ) -> None: ...
+
+    def get_expert_latencies(self) -> Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Each MoE layer writes its per-expert latency to a slice of this tensor.
+        This follows the same pattern as expert_load_view in EPLB.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        ...
 
 
 def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -98,7 +98,7 @@ class MixtralMoE(nn.Module):
         self.hidden_size = hidden_size
 
         self.ep_group = get_ep_group().device_group
-        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_rank = self.ep_group.rank()
         self.ep_size = self.ep_group.size()
 
         # Expert Parallelism Load balancing settings.
@@ -345,7 +345,7 @@ class MixtralModel(nn.Module):
             ["hidden_states", "residual"], config.hidden_size
         )
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -359,7 +359,7 @@ class MixtralModel(nn.Module):
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
-                hidden_states = self.embed_input_ids(input_ids)
+                hidden_states = self.get_input_embeddings(input_ids)
             residual = None
         else:
             assert intermediate_tensors is not None
@@ -546,7 +546,7 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
         )
 
         self.expert_weights = []
-        self.moe_layers = []
+        self.moe_layers: list[FusedMoE] = []
         example_moe = None
 
         for layer in self.model.layers:
@@ -572,6 +572,25 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
         self.num_expert_groups = 1
         self.num_shared_experts = 0
 
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
+    ) -> None:
+        self.expert_latency_view = expert_latency_view
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
+            )
+
     def update_physical_experts_metadata(
         self,
         num_physical_experts: int,
@@ -591,8 +610,8 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
                 moe.n_redundant_experts = self.num_redundant_experts
                 moe.experts.update_expert_map()
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,
@@ -619,3 +638,14 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -753,7 +753,7 @@ class OpenPanguModel(nn.Module):
             ["hidden_states", "residual"], config.hidden_size
         )
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -767,7 +767,7 @@ class OpenPanguModel(nn.Module):
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
-                hidden_states = self.embed_input_ids(input_ids)
+                hidden_states = self.get_input_embeddings(input_ids)
             residual = None
         else:
             assert intermediate_tensors is not None
@@ -969,8 +969,8 @@ class OpenPanguModelBase(nn.Module, SupportsPP, SupportsLoRA):
             self.model.make_empty_intermediate_tensors
         )
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,
@@ -1009,7 +1009,7 @@ class OpenPanguMoEModel(OpenPanguModelBase, MixtureOfExperts):
         self.num_moe_layers = config.num_hidden_layers - config.first_k_dense_replace
         self.num_expert_groups = 1
 
-        self.moe_layers = []
+        self.moe_layers: list[SharedFusedMoE] = []
         example_moe = None
         for layer in self.model.layers:
             if isinstance(layer, PPMissingLayer):
@@ -1031,6 +1031,25 @@ class OpenPanguMoEModel(OpenPanguModelBase, MixtureOfExperts):
         self.n_shared_experts = example_moe.n_shared_experts
         self.num_redundant_experts = example_moe.n_redundant_experts
 
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
+    ) -> None:
+        self.expert_latency_view = expert_latency_view
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
+            )
+
     def update_physical_experts_metadata(
         self,
         num_physical_experts: int,
@@ -1047,6 +1066,17 @@ class OpenPanguMoEModel(OpenPanguModelBase, MixtureOfExperts):
                 moe.n_physical_experts = num_physical_experts
                 moe.n_redundant_experts = self.num_redundant_experts
                 moe.experts.update_expert_map()
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
 
 class OpenPanguEmbeddedModel(OpenPanguModelBase):

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -43,7 +43,6 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe import FusedMoE
-from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
@@ -133,7 +132,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
 
         self.ep_group = get_ep_group().device_group
-        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_rank = self.ep_group.rank()
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.num_experts
 
@@ -172,7 +171,6 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
-            routing_method_type=RoutingMethodType.Renormalize,
         )
 
         self.gate = ReplicatedLinear(
@@ -427,7 +425,7 @@ class Qwen3MoeModel(nn.Module):
         # Track layers for auxiliary hidden state outputs (EAGLE3)
         self.aux_hidden_state_layers: tuple[int, ...] = ()
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -441,7 +439,7 @@ class Qwen3MoeModel(nn.Module):
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
-                hidden_states = self.embed_input_ids(input_ids)
+                hidden_states = self.get_input_embeddings(input_ids)
             residual = None
         else:
             assert intermediate_tensors is not None
@@ -667,7 +665,7 @@ class Qwen3MoeForCausalLM(
         # Set MoE hyperparameters
         self.expert_weights = []
 
-        self.moe_layers = []
+        self.moe_layers: list[FusedMoE] = []
         example_layer = None
         for layer in self.model.layers:
             if isinstance(layer, PPMissingLayer):
@@ -689,6 +687,25 @@ class Qwen3MoeForCausalLM(
         self.num_local_physical_experts = example_layer.n_local_physical_experts
         self.num_routed_experts = example_layer.n_routed_experts
         self.num_redundant_experts = example_layer.n_redundant_experts
+
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
+    ) -> None:
+        self.expert_latency_view = expert_latency_view
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
+            )
 
     def update_physical_experts_metadata(
         self,
@@ -714,8 +731,8 @@ class Qwen3MoeForCausalLM(
         num_layers = len(self.model.layers)
         return (2, num_layers // 2, num_layers - 3)
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,
@@ -739,6 +756,17 @@ class Qwen3MoeForCausalLM(
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
+
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -34,7 +34,6 @@ from vllm.model_executor.layers.fla.ops import (
     fused_recurrent_gated_delta_rule,
 )
 from vllm.model_executor.layers.fused_moe import SharedFusedMoE
-from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.layernorm import (
     GemmaRMSNorm as Qwen3NextRMSNorm,
 )
@@ -59,6 +58,7 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
+    DEFAULT_VOCAB_PADDING_SIZE,
     ParallelLMHead,
     VocabParallelEmbedding,
 )
@@ -109,7 +109,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
 
         self.ep_group = get_ep_group().device_group
-        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_rank = self.ep_group.rank()
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.num_experts
 
@@ -173,7 +173,6 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
-            routing_method_type=RoutingMethodType.Renormalize,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -463,8 +462,6 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         # ============================================================
         # Part 2: Core Attention (Custom Op)
         # ============================================================
-        # Note: we should not use torch.empty here like other attention backends,
-        # see discussions in https://github.com/vllm-project/vllm/pull/28182
         core_attn_out = torch.zeros(
             (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
             dtype=hidden_states.dtype,
@@ -586,7 +583,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 self.conv1d.bias,
                 self.activation,
                 conv_state_indices=non_spec_state_indices_tensor[
-                    : attn_metadata.num_actual_tokens
+                    : attn_metadata.num_decodes
                 ],
                 validate_data=True,
             )
@@ -598,7 +595,10 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             mixed_qkv_non_spec
         )
 
-        g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+        beta = b.sigmoid()
+        # g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+        g = fused_gdn_gating(self.A_log, a, self.dt_bias)
+        g, beta = map(lambda x: rearrange(x, "l d -> 1 l d"), (g, beta))
 
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
@@ -966,17 +966,22 @@ class Qwen3NextModel(nn.Module):
 
         config: Qwen3NextConfig = vllm_config.model_config.hf_config
         parallel_config = vllm_config.parallel_config
-
+        lora_config = vllm_config.lora_config
         eplb_config = parallel_config.eplb_config
         self.num_redundant_experts = eplb_config.num_redundant_experts
 
         self.config = config
-
-        self.vocab_size = config.vocab_size
+        lora_vocab = (
+            (lora_config.lora_extra_vocab_size * (lora_config.max_loras or 1))
+            if lora_config
+            else 0
+        )
+        self.vocab_size = config.vocab_size + lora_vocab
 
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            org_num_embeddings=config.vocab_size,
         )
 
         def get_layer(prefix: str):
@@ -998,7 +1003,7 @@ class Qwen3NextModel(nn.Module):
         else:
             self.norm = PPMissingLayer()
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -1012,7 +1017,7 @@ class Qwen3NextModel(nn.Module):
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
-                hidden_states = self.embed_input_ids(input_ids)
+                hidden_states = self.get_input_embeddings(input_ids)
             residual = None
         else:
             assert intermediate_tensors is not None
@@ -1124,7 +1129,102 @@ class Qwen3NextModel(nn.Module):
         return loaded_params
 
 
-class QwenNextMixtureOfExperts(MixtureOfExperts):
+class Qwen3NextForCausalLM(
+    nn.Module, HasInnerState, SupportsLoRA, SupportsPP, MixtureOfExperts, IsHybrid
+):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        config = vllm_config.model_config.hf_config
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        lora_config = vllm_config.lora_config
+        scheduler_config = vllm_config.scheduler_config
+        assert not cache_config.enable_prefix_caching, (
+            "Qwen3Next currently does not support prefix caching"
+        )
+        self.quant_config = vllm_config.quant_config
+
+        super().__init__()
+        self.config = config
+        self.scheduler_config = scheduler_config
+        self.model = Qwen3NextModel(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.unpadded_vocab_size = config.vocab_size
+        if lora_config:
+            self.unpadded_vocab_size += lora_config.lora_extra_vocab_size
+        self.lm_head = ParallelLMHead(
+            self.unpadded_vocab_size,
+            config.hidden_size,
+            org_num_embeddings=config.vocab_size,
+            padding_size=DEFAULT_VOCAB_PADDING_SIZE
+            # We need bigger padding if using lora for kernel
+            # compatibility
+            if not lora_config
+            else lora_config.lora_vocab_padding_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(
+            self.unpadded_vocab_size, config.vocab_size
+        )
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+        # Set MoE hyperparameters
+        self.expert_weights = []
+
+        self.moe_layers: list[SharedFusedMoE] = []
+        example_layer = None
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+
+            assert isinstance(layer, Qwen3NextDecoderLayer)
+            if isinstance(layer.mlp, Qwen3NextSparseMoeBlock):
+                example_layer = layer.mlp
+                self.moe_layers.append(layer.mlp.experts)
+
+        if example_layer is None:
+            raise RuntimeError("No Qwen3Next layer found in the model.layers.")
+
+        self.num_moe_layers = len(self.moe_layers)
+        self.num_expert_groups = 1
+        self.num_shared_experts = 0
+        self.num_logical_experts = example_layer.n_logical_experts
+        self.num_physical_experts = example_layer.n_physical_experts
+        self.num_local_physical_experts = example_layer.n_local_physical_experts
+        self.num_routed_experts = example_layer.n_routed_experts
+        self.num_redundant_experts = example_layer.n_redundant_experts
+
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        expert_latency_view: torch.Tensor | None = None,
+    ) -> None:
+        self.expert_latency_view = expert_latency_view
+        for layer_idx, layer in enumerate(self.moe_layers):
+            # Register the expert weights.
+            self.expert_weights.append(layer.get_expert_weights())
+            layer.set_eplb_state(
+                moe_layer_idx=layer_idx,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count,
+                expert_latency_view=expert_latency_view,
+            )
+
     def update_physical_experts_metadata(
         self,
         num_physical_experts: int,
@@ -1142,83 +1242,8 @@ class QwenNextMixtureOfExperts(MixtureOfExperts):
                 moe.n_redundant_experts = self.num_redundant_experts
                 moe.experts.update_expert_map()
 
-    def set_moe_parameters(self):
-        self.expert_weights = []
-
-        self.moe_layers = []
-        example_moe = None
-        for layer in self.model.layers:
-            if isinstance(layer, Qwen3NextDecoderLayer) and isinstance(
-                layer.mlp, Qwen3NextSparseMoeBlock
-            ):
-                example_moe = layer.mlp
-                self.moe_layers.append(layer.mlp.experts)
-
-            if example_moe is None:
-                raise RuntimeError("No Qwen3Next layer found in the model.layers.")
-
-        # Set MoE hyperparameters
-        self.num_moe_layers = len(self.moe_layers)
-        self.num_expert_groups = 1
-        self.num_shared_experts = 0
-        self.num_logical_experts = example_moe.n_logical_experts
-        self.num_physical_experts = example_moe.n_physical_experts
-        self.num_local_physical_experts = example_moe.n_local_physical_experts
-        self.num_routed_experts = example_moe.n_routed_experts
-        self.num_redundant_experts = example_moe.n_redundant_experts
-
-
-class Qwen3NextForCausalLM(
-    nn.Module,
-    HasInnerState,
-    SupportsLoRA,
-    SupportsPP,
-    QwenNextMixtureOfExperts,
-    IsHybrid,
-):
-    packed_modules_mapping = {
-        "qkv_proj": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-        ],
-        "gate_up_proj": ["gate_proj", "up_proj"],
-    }
-
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        config = vllm_config.model_config.hf_config
-        self.vllm_config = vllm_config
-        self.model_config = vllm_config.model_config
-        cache_config = vllm_config.cache_config
-
-        scheduler_config = vllm_config.scheduler_config
-        assert not cache_config.enable_prefix_caching, (
-            "Qwen3Next currently does not support prefix caching"
-        )
-        self.quant_config = vllm_config.quant_config
-
-        super().__init__()
-        self.config = config
-        self.scheduler_config = scheduler_config
-        self.model = Qwen3NextModel(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
-        )
-
-        self.lm_head = ParallelLMHead(
-            config.vocab_size,
-            config.hidden_size,
-            prefix=maybe_prefix(prefix, "lm_head"),
-        )
-        self.logits_processor = LogitsProcessor(config.vocab_size)
-        self.make_empty_intermediate_tensors = (
-            self.model.make_empty_intermediate_tensors
-        )
-
-        # Set MoE hyperparameters
-        self.set_moe_parameters()
-
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
 
     def forward(
         self,
@@ -1281,6 +1306,17 @@ class Qwen3NextForCausalLM(
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
 
+    def get_expert_latencies(self) -> torch.Tensor | None:
+        """
+        Get the expert latency tensor for all MoE layers.
+
+        Returns:
+            Tensor of shape (num_moe_layers, num_physical_experts) containing
+            latency in milliseconds (0 if expert was inactive), or None if
+            latency tracking is not enabled.
+        """
+        return self.expert_latency_view
+
 
 def gdn_attention_core(
     mixed_qkv: torch.Tensor,
@@ -1323,13 +1359,12 @@ direct_register_custom_op(
 )
 
 
+# g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
 @triton.jit
 def fused_gdn_gating_kernel(
     g,
-    beta_output,
     A_log,
     a,
-    b,
     dt_bias,
     seq_len,
     NUM_HEADS: tl.constexpr,
@@ -1343,7 +1378,6 @@ def fused_gdn_gating_kernel(
     mask = head_off < NUM_HEADS
     blk_A_log = tl.load(A_log + head_off, mask=mask)
     blk_a = tl.load(a + off, mask=mask)
-    blk_b = tl.load(b + off, mask=mask)
     blk_bias = tl.load(dt_bias + head_off, mask=mask)
     # If the model is loaded in fp16, without the .float() here, A might be -inf
     x = blk_a.to(tl.float32) + blk_bias.to(tl.float32)
@@ -1352,44 +1386,20 @@ def fused_gdn_gating_kernel(
     )
     blk_g = -tl.exp(blk_A_log.to(tl.float32)) * softplus_x
     tl.store(g + off, blk_g.to(g.dtype.element_ty), mask=mask)
-    # compute beta_output = sigmoid(b)
-    blk_beta_output = tl.sigmoid(blk_b.to(tl.float32))
-    tl.store(
-        beta_output + off, blk_beta_output.to(beta_output.dtype.element_ty), mask=mask
-    )
 
 
 def fused_gdn_gating(
     A_log: torch.Tensor,
     a: torch.Tensor,
-    b: torch.Tensor,
     dt_bias: torch.Tensor,
     beta: float = 1.0,
     threshold: float = 20.0,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Fused computation of g and beta for Gated Delta Net.
-    g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-    beta_output = b.sigmoid()
-    TODO maybe use torch.compile to replace this triton kernel
-    """
+) -> torch.Tensor:
     batch, num_heads = a.shape
     seq_len = 1
     grid = (batch, seq_len, triton.cdiv(num_heads, 8))
-    g = torch.empty(1, batch, num_heads, dtype=torch.float32, device=a.device)
-    beta_output = torch.empty(1, batch, num_heads, dtype=b.dtype, device=b.device)
+    g = torch.empty_like(a, dtype=torch.float32)
     fused_gdn_gating_kernel[grid](
-        g,
-        beta_output,
-        A_log,
-        a,
-        b,
-        dt_bias,
-        seq_len,
-        num_heads,
-        beta,
-        threshold,
-        8,
-        num_warps=1,
+        g, A_log, a, dt_bias, seq_len, num_heads, beta, threshold, 8, num_warps=1
     )
-    return g, beta_output
+    return g

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import torch
 
+from vllm.logger import init_logger
 from vllm.outputs import (
     CompletionOutput,
     PoolingOutput,
@@ -28,6 +29,8 @@ from vllm.v1.metrics.stats import (
     RequestStateStats,
     SchedulerStats,
 )
+
+logger = init_logger(__name__)
 
 
 class RequestOutputCollector:
@@ -499,6 +502,11 @@ class OutputProcessor:
             ):
                 if req_state.queue is not None:
                     # AsyncLLM: put into queue for handling by generate().
+                    logger.error(
+                        "TzuLing OutputProcessor: Putting request_output for req %s into queue (finished: %s)",
+                        req_id,
+                        request_output.finished
+                    )
                     req_state.queue.put(request_output)
                 else:
                     # LLMEngine: return list of RequestOutputs.


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR implements a timeout-based health monitoring system for the Expert Parallel Load Balancer (EPLB) to detect and gracefully degrade unhealthy MoE experts in real-time. The system tracks per-expert latency and immediately masks out experts exceeding configurable timeout thresholds, without waiting for the periodic rebalancing interval.


## Test Plan
**Unit tests:**
```bash
pytest tests/distributed/test_eplb_health.py -v
```
**Integration test (requires GPU cluster):**
```bash
# Test with DeepSeek-V3 on 8 GPUs with EPLB and health monitoring
vllm serve deepseek-ai/DeepSeek-V3-0324 \
    --tensor-parallel-size 1 \
    --data-parallel-size 8 \
    --enable-expert-parallel \
    --enable-eplb \
    --eplb-config '{"num_redundant_experts": 2, "health_check_enabled": true, "health_timeout_threshold": 100.0}'
```

## Test Result

tests/distributed/test_eplb_health.py::test_basic_health_detection PASSED
tests/distributed/test_eplb_health.py::test_sparse_activation PASSED
tests/distributed/test_eplb_health.py::test_expert_recovery PASSED
tests/distributed/test_eplb_health.py::test_multi_layer_health PASSED
tests/distributed/test_eplb_health.py::test_timeout_threshold_boundary PASSED
tests/distributed/test_eplb_health.py::test_immediate_masking PASSED
tests/distributed/test_eplb_health.py::test_fusedmoe_has_measure_method PASSED
tests/distributed/test_eplb_health.py::test_fusedmoe_health_monitoring_disabled PASSED
tests/distributed/test_eplb_health.py::test_fusedmoe_deferred_measurement_state_management PASSED

---
<details>
**Key Features:**
- **Immediate detection**: Experts exceeding `health_timeout_threshold` are masked out instantly
- **Automatic recovery**: Experts are automatically re-enabled when latency drops below the threshold
- **Deferred measurement**: CUDA synchronization is deferred to the EPLB bookkeeping phase to avoid blocking the forward pass
- **Zero overhead when disabled**: Health monitoring can be toggled via `health_check_enabled` config flag

**Motivation:**In production deployments with EP across multiple nodes or during network congestion, individual experts may experience transient slowdowns. Without health monitoring, slow experts block the critical path and degrade overall serving latency. This PR enables graceful degradation by routing around unhealthy experts using existing redundant expert replicas.

**Related Changes:**
- Adds `EPLBConfig.health_check_enabled` (default: `True`)
- Adds `EPLBConfig.health_timeout_threshold` (default: `100.0` ms)
- Implements `_update_health_mask()` in `EplbState` for immediate masking
- Adds `measure_and_update_latency()` interface to `FusedMoE` layer
- Integrates deferred measurement into all MoE model architectures (DeepSeek V2, Mixtral, Qwen3 MoE, etc.)

