### PR TITLE
[Bug] Fix cpu disable shared_experts `VLLM_DISABLE_SHARED_EXPERTS_STREAM`

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -299,7 +299,7 @@ class CpuPlatform(Platform):
         os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
 
         # Disable multi-stream for shared experts as no Stream on CPU
-        os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "0"
+        os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
         # Intel OpenMP setting
         ld_preload_str = os.getenv("LD_PRELOAD", "")


### PR DESCRIPTION
## Purpose

We want to disable multi-stream for shared experts as no Stream on CPU, but currently it is set to 0.

This PR fixes this issue

