### PR TITLE
Alternative way to obtain GPU inventory. // .buildkite/test-amd.yaml:L589

### DIFF
--- a/.buildkite/lm-eval-harness/configs/DeepSeek-R1.yaml
+++ b/.buildkite/lm-eval-harness/configs/DeepSeek-R1.yaml
@@ -1,0 +1,15 @@
+# For vllm script, with -t option (tensor parallel size).
+# bash .buildkite/lm-eval-harness/run-lm-eval-mmlupro-vllm-baseline.sh -m deepseek-ai/DeepSeek-R1 -b 128 -l 250 -f 5 -t 8
+model_name: "deepseek-ai/DeepSeek-R1"
+tasks:
+- name: "mmlu_pro"
+  metrics:
+  - name: "exact_match,custom-extract"
+    value: 0.80
+limit: 2 # will run on 250 * 14 subjects = 3500 samples
+num_fewshot: 5
+trust_remote_code: True
+rtol: 0.05
+vllm_args:
+  enable_expert_parallel: true
+  gpu_memory_utilization: 0.95

--- a/.buildkite/lm-eval-harness/configs/models-large-rocm.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large-rocm.txt
@@ -1,0 +1,1 @@
+DeepSeek-R1.yaml

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -186,7 +186,7 @@ if [[ $commands == *"--shard-id="* ]]; then
         --device /dev/kfd $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES \
         --network=host \
         --shm-size=16gb \
-	--group-add render \
+	--group-add $(getent group render | cut -d: -f3) \
         --rm \
         -e HIP_VISIBLE_DEVICES="${GPU}" \
         -e HF_TOKEN \
@@ -218,7 +218,7 @@ else
           --device /dev/kfd $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES \
           --network=host \
           --shm-size=16gb \
-          --group-add render \
+          --group-add $(getent group render | cut -d: -f3) \
 	  --rm \
           -e HIP_VISIBLE_DEVICES=0 \
           -e HF_TOKEN \

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -220,7 +220,6 @@ else
           --shm-size=16gb \
           --group-add $(getent group render | cut -d: -f3) \
 	  --rm \
-          -e HIP_VISIBLE_DEVICES=0 \
           -e HF_TOKEN \
           -e AWS_ACCESS_KEY_ID \
           -e AWS_SECRET_ACCESS_KEY \

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -186,6 +186,7 @@ if [[ $commands == *"--shard-id="* ]]; then
         --device /dev/kfd $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES \
         --network=host \
         --shm-size=16gb \
+	--group-add render \
         --rm \
         -e HIP_VISIBLE_DEVICES="${GPU}" \
         -e HF_TOKEN \

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -217,7 +217,8 @@ else
           --device /dev/kfd $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES \
           --network=host \
           --shm-size=16gb \
-          --rm \
+          --group-add render \
+	  --rm \
           -e HIP_VISIBLE_DEVICES=0 \
           -e HF_TOKEN \
           -e AWS_ACCESS_KEY_ID \

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -577,6 +577,22 @@ steps:
   commands:
   - bash scripts/run-benchmarks.sh
 
+- label: ROCM LM Eval Large Models
+  mirror_hardwares: [amdproduction]
+  agent_pool: mi325_8
+  num_gpus: 8
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+    # GPU diagnostics
+  - echo '=== GPU Diagnostics ==='
+  - rocm-smi --showid
+  - printenv HIP_VISIBLE_DEVICES
+  - python3 -c 'import torch; print(torch.cuda.device_count())'
+  - ls -la /dev/dri/
+  - echo '=== End GPU Diagnostics ==='
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-mi300.txt --tp-size=8
+
 - label: Benchmarks CLI Test # 7min
   timeout_in_minutes: 20
   mirror_hardwares: [amdexperimental, amdproduction]

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -591,7 +591,7 @@ steps:
   - ls -la /dev/dri/
   - echo '=== End GPU Diagnostics ==='
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-mi300.txt --tp-size=8
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
 
 - label: Benchmarks CLI Test # 7min
   timeout_in_minutes: 20

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -586,6 +586,7 @@ steps:
     # GPU diagnostics
     #- echo '=== GPU Diagnostics ==='
     #- rocm-smi --showid
+    amd-smi list
     #- printenv HIP_VISIBLE_DEVICES
     #- python3 -c 'import torch; print(torch.cuda.device_count())'
     #- ls -la /dev/dri/

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -584,12 +584,12 @@ steps:
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
     # GPU diagnostics
-  - echo '=== GPU Diagnostics ==='
-  - rocm-smi --showid
-  - printenv HIP_VISIBLE_DEVICES
-  - python3 -c 'import torch; print(torch.cuda.device_count())'
-  - ls -la /dev/dri/
-  - echo '=== End GPU Diagnostics ==='
+    #- echo '=== GPU Diagnostics ==='
+    #- rocm-smi --showid
+    #- printenv HIP_VISIBLE_DEVICES
+    #- python3 -c 'import torch; print(torch.cuda.device_count())'
+    #- ls -la /dev/dri/
+    #- echo '=== End GPU Diagnostics ==='
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
 

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -586,7 +586,7 @@ steps:
     # GPU diagnostics
     #- echo '=== GPU Diagnostics ==='
     #- rocm-smi --showid
-    - amd-smi list
+  - amd-smi list
     #- printenv HIP_VISIBLE_DEVICES
     #- python3 -c 'import torch; print(torch.cuda.device_count())'
     #- ls -la /dev/dri/

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -586,7 +586,7 @@ steps:
     # GPU diagnostics
     #- echo '=== GPU Diagnostics ==='
     #- rocm-smi --showid
-    amd-smi list
+    - amd-smi list
     #- printenv HIP_VISIBLE_DEVICES
     #- python3 -c 'import torch; print(torch.cuda.device_count())'
     #- ls -la /dev/dri/


### PR DESCRIPTION
Alternative way to obtain GPU inventory. // .buildkite/test-amd.yaml:L589

Signed-off-by: Alexei V. Ivanov <alexei.ivanov@amd.com>

