### PR TITLE
[torchao] fix safetensors for sharding

### DIFF
--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -225,13 +225,12 @@ def test_reload_weights():
 @pytest.mark.skip(
     reason="since torchao nightly is only compatible with torch nightly"
     "currently https://github.com/pytorch/ao/issues/2919, we'll have to skip "
-    "torchao tests that requires newer versions (0.14.0.dev+) for now"
+    "torchao tests that requires newer versions (0.15.0.dev+) for now"
 )
-def test_opt_125m_float8_weight_only_safetensors_model_loading_with_params(vllm_runner):
+def test_safetensors_model_loading_with_params(vllm_runner):
     torch._dynamo.reset()
-    model_name = (
-        "torchao-testing/opt-125m-Float8WeightOnlyConfig-v2-0.14.0.dev-safetensors"
-    )
+    # using this model to test safetensors loading with file sharding
+    model_name = "torchao-testing/Qwen3-8B-INT4-0.15.0dev-safetensors"
     with vllm_runner(model_name=model_name, dtype="bfloat16") as llm:
         output = llm.generate_greedy(["The capital of France is"], max_tokens=4)
 

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -455,25 +455,8 @@ class VocabParallelEmbedding(CustomOp):
 
         # Copy the data. Select chunk corresponding to current shard.
         loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
-
-        # Handle TorchAO tensor subclass
-        if type(loaded_weight) is not torch.Tensor:
-            param_name, device = None, None
-            for name, p in self.named_parameters():
-                if p is param:
-                    param_name = name
-                    device = p.device
-                    break
-
-            if param_name is not None:
-                delattr(self, param_name)
-                new_param = Parameter(
-                    loaded_weight.to(device), requires_grad=loaded_weight.requires_grad
-                )
-                self.register_parameter(param_name, new_param)
-        else:
-            param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
-            param[loaded_weight.shape[0] :].data.fill_(0)
+        param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
+        param[loaded_weight.shape[0] :].data.fill_(0)
 
     def forward_native(self, input_):
         if self.tp_size > 1:

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -279,7 +279,7 @@ class DefaultModelLoader(BaseModelLoader):
             if (
                 hasattr(quant_config, "is_checkpoint_torchao_serialized")
                 and quant_config.is_checkpoint_torchao_serialized
-                and torchao_version_at_least("0.14.0")
+                and torchao_version_at_least("0.15.0")
             ):
                 self.load_config.safetensors_load_strategy = "torchao"
 


### PR DESCRIPTION
**Summary** 

Previously, our safetensors implementation for tensor subclasses didn't consider the possibility of different tensor attributes for one instance of a tensor subclass (ie `qdata` or `scale` for `Float8Tensor`) being sharded to different files.

This PR handles that case by: 

1. Defining the state dict outside of the loop that iterates through shard files 
2. After processing a full tensor subclass in `unflatten_tensor_state_dict`, we delete the corresponding tensor attributes (ie `qdata`, `scale`) from the original state dict passed in 
3. Whatever is remaining is saved in the state dict for the next iteration 

**Testing**
`pytest tests/quantization/test_torchao.py::test_safetensors_model_loading_with_params -s`
