### PR TITLE
[V1] [Hybrid] Lighter Mamba Prefix Caching for Hybrid Models

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1387,6 +1387,15 @@ class EngineArgs:
             f"dcp_size={self.decode_context_parallel_size}."
         )
 
+        if (envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+            and self.enable_prefix_caching 
+            and model_config.is_hybrid
+        ):
+            assert envs.VLLM_USE_V1, (
+                "Prefix caching for hybrid models requires the V1 engine.")
+            assert self.enable_chunked_prefill, (
+                "Prefix caching for hybrid models requires chunked prefill.")
+
         cache_config = CacheConfig(
             block_size=self.block_size,
             gpu_memory_utilization=self.gpu_memory_utilization,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -219,7 +219,7 @@ if TYPE_CHECKING:
     VLLM_GC_DEBUG: str = ""
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
-
+    VLLM_USE_LIGHTER_MAMBA_CACHE: bool = False
 
 def get_default_cache_root():
     return os.getenv(
@@ -1452,6 +1452,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_COMPILE_CACHE_SAVE_FORMAT": env_with_choices(
         "VLLM_COMPILE_CACHE_SAVE_FORMAT", "binary", ["binary", "unpacked"]
     ),
+    "VLLM_USE_LIGHTER_MAMBA_CACHE": lambda: os.getenv(
+        "VLLM_USE_LIGHTER_MAMBA_CACHE", False
+    ),
 }
 
 # --8<-- [end:env-vars-definition]
@@ -1577,6 +1580,7 @@ def compute_hash() -> str:
         "VLLM_USE_FBGEMM",
         "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE",
         "VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL",
+        "VLLM_USE_LIGHTER_MAMBA_CACHE"
     ]
     for key in environment_variables_to_hash:
         # if this goes out of sync with environment_variables,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -3,6 +3,8 @@
 
 from typing import TYPE_CHECKING
 
+from vllm import envs
+
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionBackend
 
@@ -592,7 +594,7 @@ class MambaMixer2(MambaBase, CustomOp):
             dim=0,
         )
 
-        if prefix_caching_enabled:
+        if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE and prefix_caching_enabled:
             # If prefix caching is enabled, retrieve the relevant variables
             # for prefill and decode
             block_idx_last_computed_token_d, block_idx_last_computed_token_p = (
@@ -793,7 +795,7 @@ class MambaMixer2(MambaBase, CustomOp):
 
         # Process decode requests
         if has_decode:
-            if prefix_caching_enabled:
+            if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE and prefix_caching_enabled:
                 state_indices_tensor_d_input = state_indices_tensor_d.gather(
                     1, block_idx_last_computed_token_d.unsqueeze(1)
                 ).squeeze(1)

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -296,18 +296,25 @@ class MambaModelConfig(VerifyAndUpdateConfig):
             cache_config.mamba_block_size = model_config.max_model_len
 
         if cache_config.enable_prefix_caching:
-            if model_config.supports_mamba_prefix_caching:
-                logger.info(
-                    "Warning: Prefix caching is currently enabled. "
-                    "Its support for Mamba layers is experimental. "
-                    "Please report any issues you may observe."
-                )
+            if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+                if model_config.supports_mamba_prefix_caching:
+                    logger.info(
+                        "Warning: Prefix caching is currently enabled. "
+                        "Its support for Mamba layers is experimental. "
+                        "Please report any issues you may observe."
+                    )
+                else:
+                    logger.info(
+                        "Hybrid or mamba-based model detected without "
+                        "support for prefix caching: disabling."
+                    )
+                    cache_config.enable_prefix_caching = False
             else:
                 logger.info(
-                    "Hybrid or mamba-based model detected without "
-                    "support for prefix caching: disabling."
-                )
-                cache_config.enable_prefix_caching = False
+                    "Warning: Lighter Mamba Prefix caching is currently"
+                    " enabled. Its support is experimental. "
+                    "Please report any issues you may observe."
+                )        
 
         # TODO(tdoublep): remove once cascade attention is supported
         logger.info(
@@ -390,7 +397,8 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         if mamba_page_size == 0:
             return
 
-        if cache_config.enable_prefix_caching:
+        if (cache_config.enable_prefix_caching 
+            and not envs.VLLM_USE_LIGHTER_MAMBA_CACHE):
             # With prefix caching, select attention block size to
             # optimize for mamba kernel performance
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -380,7 +380,8 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         mamba_page_size = MambaSpec(
             shapes=model_cls.get_mamba_state_shape_from_config(vllm_config),
             dtypes=model_cls.get_mamba_state_dtype_from_config(vllm_config),
-            block_size=model_config.max_model_len,
+            block_size=model_config.max_model_len if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE else cache_config.block_size,
+            enable_caching=cache_config.enable_prefix_caching,
         ).page_size_bytes
 
         # Model may be marked as is_hybrid

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -10,6 +10,7 @@ from einops import rearrange
 from torch import nn
 from transformers.activations import ACT2FN
 
+from vllm import envs
 from vllm.attention import Attention, AttentionBackend, AttentionMetadata
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import (
@@ -1148,6 +1149,10 @@ class Qwen3NextForCausalLM(
         cache_config = vllm_config.cache_config
         lora_config = vllm_config.lora_config
         scheduler_config = vllm_config.scheduler_config
+        if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            assert not cache_config.enable_prefix_caching, (
+                "Qwen3NextMTP currently does not support prefix caching"
+            )
         assert not cache_config.enable_prefix_caching, (
             "Qwen3Next currently does not support prefix caching"
         )

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -1153,9 +1153,6 @@ class Qwen3NextForCausalLM(
             assert not cache_config.enable_prefix_caching, (
                 "Qwen3NextMTP currently does not support prefix caching"
             )
-        assert not cache_config.enable_prefix_caching, (
-            "Qwen3Next currently does not support prefix caching"
-        )
         self.quant_config = vllm_config.quant_config
 
         super().__init__()

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 import torch
 from torch import nn
 
+from vllm import envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_pp_group
@@ -240,9 +241,10 @@ class Qwen3NextMTP(nn.Module, SupportsPP):
         config = vllm_config.model_config.hf_config
         self.vllm_config = vllm_config
         cache_config = vllm_config.cache_config
-        assert not cache_config.enable_prefix_caching, (
-            "Qwen3NextMTP currently does not support prefix caching"
-        )
+        if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            assert not cache_config.enable_prefix_caching, (
+                "Qwen3NextMTP currently does not support prefix caching"
+            )
 
         self.quant_config = vllm_config.quant_config
 

--- a/vllm/v1/attention/backends/linear_attn.py
+++ b/vllm/v1/attention/backends/linear_attn.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import torch
 
+from vllm import envs
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.config import VllmConfig
 from vllm.v1.attention.backends.utils import (
@@ -55,6 +56,8 @@ class LinearAttentionMetadataBuilder(AttentionMetadataBuilder[LinearAttentionMet
         seq_lens = common_attn_metadata.seq_lens
 
         state_indices_tensor = common_attn_metadata.block_table_tensor[:, 0]
+        if envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            state_indices_tensor = state_indices_tensor.contiguous()
 
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import torch
 
+from vllm import envs
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
@@ -173,7 +174,9 @@ class Mamba2AttentionMetadataBuilder(
         block_idx_first_scheduled_token = None
         block_idx_first_scheduled_token_p = None
 
-        if self.vllm_config.cache_config.enable_prefix_caching:
+        if (not envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+            and self.vllm_config.cache_config.enable_prefix_caching
+        ):
             # Return a tensor of shape (#requests, #max blocks)
             state_indices_tensor = common_attn_metadata.block_table_tensor
             # Additional cache-related varaiables:
@@ -191,6 +194,11 @@ class Mamba2AttentionMetadataBuilder(
         else:
             # Always return just a single block per each request:
             state_indices_tensor = common_attn_metadata.block_table_tensor[:, 0]
+            if envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+                # NOTE: With Mamba prefix-caching support, a request can consist of
+                # multiple blocks. This makes the state_indices non-contiguous, so
+                # we must explicitly make them contiguous here.
+                state_indices_tensor = state_indices_tensor.contiguous()
             # Additional cache-related varaiables:
             block_idx_last_scheduled_token = None
             block_idx_last_computed_token = None
@@ -220,7 +228,9 @@ class Mamba2AttentionMetadataBuilder(
                 - num_decode_tokens
             )
 
-            if self.vllm_config.cache_config.enable_prefix_caching:
+            if (not envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+                and self.vllm_config.cache_config.enable_prefix_caching
+            ):
                 assert num_computed_tokens is not None
                 num_computed_tokens_p = num_computed_tokens[
                     num_reqs - num_prefills : num_reqs
@@ -312,7 +322,9 @@ class Mamba2AttentionMetadataBuilder(
             state_indices_tensor = self.state_indices_tensor[:num_input_tokens]
             state_indices_tensor[num_decodes:] = PAD_SLOT_ID
 
-            if self.vllm_config.cache_config.enable_prefix_caching:
+            if (not envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+                and self.vllm_config.cache_config.enable_prefix_caching
+            ):
                 self.block_idx_last_scheduled_token[:num_decodes].copy_(
                     block_idx_last_scheduled_token, non_blocking=True
                 )

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -6,6 +6,7 @@ from typing import ClassVar, TypeVar
 
 import torch
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import (
@@ -40,7 +41,9 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             self.compilation_config.max_cudagraph_capture_size,
         )
 
-        if self.vllm_config.cache_config.enable_prefix_caching:
+        if (not envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+            and self.vllm_config.cache_config.enable_prefix_caching
+        ):
             self.state_indices_tensor = torch.empty(
                 (
                     self.decode_cudagraph_max_bs,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -215,8 +215,7 @@ class BlockPool:
         block_hash_with_group_id: BlockHashWithGroupId = make_block_hash_with_group_id(
             new_block_hash, kv_cache_group_id)
         block.block_hash = block_hash_with_group_id
-        self.cached_block_hash_to_block[block_hash_with_group_id][
-            block.block_id] = block
+        self.cached_block_hash_to_block.insert(block_hash_with_group_id, block)
         if new_hashes is not None:
             new_hashes.append(maybe_convert_block_hash(new_block_hash))
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, overload
 
+from vllm import envs
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
@@ -306,7 +307,9 @@ class KVCacheManager:
                 "Computed blocks should be empty when prefix caching is disabled"
             )
 
-        if new_computed_block_list is not self.empty_kv_cache_blocks.blocks:
+        if (envs.VLLM_USE_LIGHTER_MAMBA_CACHE 
+            or new_computed_block_list is not self.empty_kv_cache_blocks.blocks
+        ):
             # Append the new computed blocks to the request blocks until now to
             # avoid the case where the new blocks cannot be allocated.
             self.coordinator.save_new_computed_blocks(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from typing import Any
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import EventPublisherFactory, KVEventBatch
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
@@ -32,7 +33,7 @@ from vllm.v1.core.sched.output import (
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.utils import check_stop, remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
@@ -174,6 +175,12 @@ class Scheduler(SchedulerInterface):
         )
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
 
+    def _has_mamba_spec(self) -> bool:
+        has_mamba: bool = any(isinstance(spec.kv_cache_spec, MambaSpec) 
+                              for spec in self.kv_cache_config.kv_cache_groups) 
+        assert not has_mamba or self.vllm_config.model_config.is_hybrid
+        return has_mamba
+
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
@@ -208,14 +215,47 @@ class Scheduler(SchedulerInterface):
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
 
-            num_new_tokens = (
-                request.num_tokens_with_spec
-                + request.num_output_placeholders
-                - request.num_computed_tokens
-            )
-            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
-                num_new_tokens = self.scheduler_config.long_prefill_token_threshold
-            num_new_tokens = min(num_new_tokens, token_budget)
+            # Ensure new tokens for a request in the prefill phase do not contain 
+            # sps tokens, especially in the last prefill chunk. For a hybrid-model, 
+            # extra sps tokens would corrupt the generated Mamba state.
+            # TODO: This logic does not yet handle resumed requests.
+            if request.num_computed_tokens < request.num_prompt_tokens:
+                num_new_tokens = min(request.num_tokens_with_spec 
+                                     + request.num_output_placeholders, 
+                                     request.num_prompt_tokens) - request.num_computed_tokens
+            else:
+                num_new_tokens = (request.num_tokens_with_spec +
+                                  request.num_output_placeholders -
+                                  request.num_computed_tokens)
+
+            if (0 < self.scheduler_config.long_prefill_token_threshold <
+                    num_new_tokens):
+                num_new_tokens = (
+                    self.scheduler_config.long_prefill_token_threshold)
+
+            if (envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+                and self.cache_config.enable_prefix_caching
+                and self._has_mamba_spec()):
+                # To enable block-aligned caching of the Mamba state, `num_new_tokens`
+                # must be a multiple of `block_size`.
+                # As an exception, if `num_new_tokens` is less than `block_size`, the
+                # state is simply not cached, requiring no special handling.
+                # Additionally, when Eagle mode is enabled, FullAttn prunes the last
+                # matching block. To prevent this from causing a Mamba cache miss, the
+                # last chunk must be larger than `block_size`.
+                block_size = self.block_size
+                max_last_chunk = block_size * (2 if self.use_eagle else 1)
+                if num_new_tokens < max_last_chunk:
+                    num_new_tokens = min(num_new_tokens, token_budget)
+                else:
+                    ori_num_new_tokens = num_new_tokens
+                    num_new_tokens = min(num_new_tokens, token_budget)
+                    num_new_tokens = num_new_tokens // block_size * block_size
+                    if self.use_eagle and ori_num_new_tokens - num_new_tokens < block_size:
+                        assert num_new_tokens >= block_size
+                        num_new_tokens -= block_size
+            else:
+                num_new_tokens = min(num_new_tokens, token_budget)
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -248,6 +288,8 @@ class Scheduler(SchedulerInterface):
                 #    its max_total_tokens or max_model_len.
                 # 2. The encoder budget is exhausted.
                 # 3. The encoder cache is exhausted.
+                # 4. Insufficient budget for a block-aligned chunk in hybrid 
+                #    models with lighter mamba prefix caching.
                 # NOTE(woosuk): Here, by doing `continue` instead of `break`,
                 # we do not strictly follow the FCFS scheduling policy and
                 # allow the lower-priority requests to be scheduled.
@@ -460,7 +502,25 @@ class Scheduler(SchedulerInterface):
                         skipped_waiting_requests.prepend_request(request)
                         continue
 
-                    num_new_tokens = min(num_new_tokens, token_budget)
+                    if (envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+                        and self.cache_config.enable_prefix_caching
+                        and self._has_mamba_spec()):
+                        block_size = self.block_size
+                        max_last_chunk = block_size * (2 if self.use_eagle else 1)
+                        if num_new_tokens < max_last_chunk:
+                            num_new_tokens = min(num_new_tokens, token_budget)
+                        else:
+                            ori_num_new_tokens = num_new_tokens
+                            num_new_tokens = min(num_new_tokens, token_budget)
+                            num_new_tokens = num_new_tokens // block_size * block_size
+                            if self.use_eagle and ori_num_new_tokens - num_new_tokens < block_size:
+                                assert num_new_tokens >= block_size
+                                num_new_tokens -= block_size
+                            if num_new_tokens == 0:
+                                token_budget = 0
+                                break
+                    else:
+                        num_new_tokens = min(num_new_tokens, token_budget)
                     assert num_new_tokens > 0
 
                     # Schedule encoder inputs.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
 
+from vllm import envs
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
@@ -554,6 +555,13 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
 
 
 class MambaManager(SingleTypeKVCacheManager):
+
+    def __init__(self, kv_cache_spec: MambaSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        if envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            self._req_to_computed_tokens: dict[str, int] = {}
+            self._req_to_new_tokens: dict[str, int] = {}
+
     @classmethod
     def find_longest_cache_hit(
         cls,
@@ -590,11 +598,38 @@ class MambaManager(SingleTypeKVCacheManager):
 
         return computed_blocks
 
-    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
-        # Here unused blocks may be freed up for running requests.
-        # TODO(@s3woz) Free up all blocks that aren't needed by Mamba2
-        #  (for which find_longest_cache_hit returns block_pool.null_block)
-        pass
+    def remove_skipped_blocks(self, request_id: str,
+                              num_computed_tokens: int) -> None:
+        if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            # Here unused blocks may be freed up for running requests.
+            # TODO(@s3woz) Free up all blocks that aren't needed by Mamba2
+            #  (for which find_longest_cache_hit returns block_pool.null_block)
+            pass
+        else:
+            assert isinstance(self.kv_cache_spec, MambaSpec)
+            self._req_to_computed_tokens[request_id] = num_computed_tokens
+            # Each request will always have 1 block at this moment, so no need to
+            # remove blocks.
+            if not self.kv_cache_spec.enable_caching:
+                return
+            blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            num_blocks = len(blocks)
+            if num_blocks > 0:
+                prefix_block: KVCacheBlock = blocks[0]
+                assert self._req_to_computed_tokens[request_id] != 0
+                if not prefix_block.is_null:
+                    self.block_pool.free_blocks([prefix_block])
+                    blocks[0] = self.block_pool.null_block
+            
+            if num_blocks > 2 + self.kv_cache_spec.num_speculative_blocks:
+                assert num_blocks == 3 + self.kv_cache_spec.num_speculative_blocks
+                last_new_tokens = self._req_to_new_tokens[request_id]
+                assert last_new_tokens % self.block_size == 0
+                assert last_new_tokens >= self.block_size
+                self.block_pool.free_blocks(blocks[-1:])
+                blocks.pop()
+            else:
+                assert num_blocks == 0 or num_blocks == 2 + self.kv_cache_spec.num_speculative_blocks
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """
@@ -611,14 +646,55 @@ class MambaManager(SingleTypeKVCacheManager):
         # Allocate extra `num_speculative_blocks` blocks for
         # speculative decoding (MTP/EAGLE) with linear attention.
         assert isinstance(self.kv_cache_spec, MambaSpec)
-        if self.kv_cache_spec.num_speculative_blocks > 0:
-            num_tokens += (
-                self.kv_cache_spec.block_size
-                * self.kv_cache_spec.num_speculative_blocks
+        if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            if self.kv_cache_spec.num_speculative_blocks > 0:
+                num_tokens += (
+                    self.kv_cache_spec.block_size
+                    * self.kv_cache_spec.num_speculative_blocks
+                )
+            return super().get_num_blocks_to_allocate(
+                request_id, num_tokens, new_computed_blocks
             )
-        return super().get_num_blocks_to_allocate(
-            request_id, num_tokens, new_computed_blocks
-        )
+        else:
+            num_computed_tokens = self._req_to_computed_tokens.get(request_id, 0)
+            if num_computed_tokens == 0:
+                num_new_blocks = 1 + (self.kv_cache_spec.num_speculative_blocks 
+                                        if self.kv_cache_spec.num_speculative_blocks > 0 else 0)
+            else:
+                num_new_blocks = 0
+
+            if self.kv_cache_spec.enable_caching:
+                num_new_tokens = num_tokens - num_computed_tokens - len(new_computed_blocks) * self.block_size
+                if num_computed_tokens != 0:
+                    num_new_tokens -= self.kv_cache_spec.num_speculative_blocks
+                self._req_to_new_tokens[request_id] = num_new_tokens
+                # NOTE: last chunk may larger than block_size when using eagle.
+                if num_new_tokens >= self.block_size and num_new_tokens % self.block_size == 0:
+                    num_new_blocks += 1
+
+            # If a computed block of a request is an eviction candidate (in the
+            # free queue and ref_cnt == 0), it will be changed from a free block
+            # to a computed block when the request is allocated, so we also count
+            # it as needed to be allocated.
+            num_evictable_computed_blocks = sum(
+                blk.ref_cnt == 0 and not blk.is_null
+                for blk in new_computed_blocks)
+            return num_new_blocks + num_evictable_computed_blocks
+
+    def save_new_computed_blocks(
+            self, request_id: str,
+            new_computed_blocks: list[KVCacheBlock]) -> None:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            if not self.kv_cache_spec.enable_caching:
+                return
+            if request_id not in self.num_cached_block:
+                if new_computed_blocks:
+                    assert len(new_computed_blocks) == 1 or new_computed_blocks[-2].is_null
+                    new_computed_blocks = new_computed_blocks[-1:]
+                else:
+                    new_computed_blocks = [self.block_pool.null_block]
+        super().save_new_computed_blocks(request_id, new_computed_blocks)
 
     def allocate_new_blocks(
         self, request_id: str, num_tokens: int
@@ -626,13 +702,63 @@ class MambaManager(SingleTypeKVCacheManager):
         # Allocate extra `num_speculative_blocks` blocks for
         # speculative decoding (MTP/EAGLE) with linear attention.
         assert isinstance(self.kv_cache_spec, MambaSpec)
-        if self.kv_cache_spec.num_speculative_blocks > 0:
-            num_tokens += (
-                self.kv_cache_spec.block_size
-                * self.kv_cache_spec.num_speculative_blocks
-            )
-        return super().allocate_new_blocks(request_id, num_tokens)
+        if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            if self.kv_cache_spec.num_speculative_blocks > 0:
+                num_tokens += (
+                    self.kv_cache_spec.block_size
+                    * self.kv_cache_spec.num_speculative_blocks
+                )
+            return super().allocate_new_blocks(request_id, num_tokens)
+        else:
+            num_computed_tokens = self._req_to_computed_tokens.get(request_id, 0)
+            if num_computed_tokens == 0:
+                num_new_blocks = 1 + (self.kv_cache_spec.num_speculative_blocks
+                                        if self.kv_cache_spec.num_speculative_blocks > 0 else 0)
+            else:
+                assert num_tokens >= num_computed_tokens
+                num_new_blocks = 0
 
+            if self.kv_cache_spec.enable_caching:
+                num_new_tokens = self._req_to_new_tokens[request_id]
+                if num_new_tokens >= self.block_size and num_new_tokens % self.block_size == 0:
+                    num_new_blocks += 1
+
+            req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            if num_new_blocks <= 0:
+                return []
+            else:
+                new_blocks: list[KVCacheBlock] = self.block_pool.get_new_blocks(num_new_blocks)
+                req_blocks.extend(new_blocks)
+                return new_blocks
+            
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            num_computed_tokens = request.num_computed_tokens
+            num_new_tokens = self._req_to_new_tokens[request.request_id]
+            # NOTE:For sps, an extra block may be allocated but not cached
+            if (num_new_tokens >= self.block_size 
+                and num_new_tokens % self.block_size == 0
+                and num_tokens % self.block_size == 0):
+                assert num_new_tokens % self.block_size == 0
+                assert num_computed_tokens % self.block_size == 0
+                assert len(self.req_to_blocks[request.request_id]) == 3 + self.kv_cache_spec.num_speculative_blocks
+                self.block_pool.cache_full_block(
+                    request=request,
+                    block=self.req_to_blocks[request.request_id][-1],
+                    cached_block_index=(num_tokens // self.block_size - 1),
+                    block_size=self.block_size,
+                    kv_cache_group_id=self.kv_cache_group_id
+                )
+                self.num_cached_block[request.request_id] += 1 
+        else:
+            super().cache_blocks(request, num_tokens)
+
+    def free(self, request_id: str) -> None:
+        if envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            self._req_to_computed_tokens.pop(request_id, None)
+            self._req_to_new_tokens.pop(request_id, None)
+        super().free(request_id)
 
 class CrossAttentionManager(SingleTypeKVCacheManager):
     """Manager for cross-attention KV cache in encoder-decoder models."""

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -8,6 +8,7 @@ from math import prod
 import torch
 from typing_extensions import Self
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
@@ -246,6 +247,7 @@ class MambaSpec(KVCacheSpec):
     page_size_padded: int | None = None
     mamba_type: str = "mamba2"
     num_speculative_blocks: int = 0
+    enable_caching: bool = False
 
     @property
     def page_size_bytes(self) -> int:
@@ -259,8 +261,19 @@ class MambaSpec(KVCacheSpec):
         return page_size
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        max_model_len = vllm_config.model_config.max_model_len
-        return cdiv(max_model_len, self.block_size) * self.page_size_bytes
+        # We allocate 1 block for each request now, so max_memory_usage_bytes is
+        # the same as page_size_bytes.
+        # Need to update this when supporting prefix caching.
+        if not envs.VLLM_USE_LIGHTER_MAMBA_CACHE:
+            max_model_len = vllm_config.model_config.max_model_len
+            return cdiv(max_model_len, self.block_size) * self.page_size_bytes
+        else:
+            # NOTE: We allocate 1 block per request by default. With prefix
+            # caching enabled, up to 2 additional blocks are required: one 
+            # for reading the matched prefix and one for caching the current 
+            # state. 
+            return self.page_size_bytes * (3 if self.enable_caching else 1)
+
 
 
 @dataclass(frozen=True)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from functools import reduce
 from itertools import product
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, TypeAlias, cast
 
 import numpy as np
 import torch
@@ -91,6 +91,7 @@ from vllm.v1.attention.backends.utils import (
     reorder_batch_to_split_decodes_and_prefills,
     split_attn_metadata,
 )
+from vllm.v1.core.sched.output import CachedRequestData, NewRequestData
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -1358,6 +1359,13 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 num_common_prefix_blocks = scheduler_output.num_common_prefix_blocks[
                     kv_cache_group_id
                 ]
+                
+                if (envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+                    and self.cache_config.enable_prefix_caching
+                    and isinstance(kv_cache_group_spec.kv_cache_spec, MambaSpec)
+                ):
+                    blk_table_tensor = blk_table_tensor[:, 1:]
+                    self._preprocess_mamba_prefix(scheduler_output, kv_cache_group_id, kv_cache_group_spec)
 
             common_attn_metadata = CommonAttentionMetadata(
                 query_start_loc=query_start_loc,
@@ -2442,6 +2450,84 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             **model_kwargs,
         )
 
+    def _mamba_copy_block(self, kv_cache_group_spec: KVCacheGroupSpec,
+                          src_block_id: int, dest_block_id: int):
+        forward_context = self.compilation_config.static_forward_context
+        for layer_name in kv_cache_group_spec.layer_names:
+            kv_caches: list[list[torch.Tensor]] = forward_context[layer_name].kv_cache
+            for kv_cache in kv_caches:
+                if isinstance(kv_cache, torch.Tensor):
+                    kv_cache[dest_block_id].copy_(kv_cache[src_block_id])
+                elif isinstance(kv_cache, list):
+                    for kv_cache_part in kv_cache:
+                        kv_cache_part[dest_block_id].copy_(kv_cache_part[src_block_id])
+
+    def _preprocess_mamba_prefix(self, scheduler_output: "SchedulerOutput", 
+                                 kv_cache_group_id: int,
+                                 kv_cache_group_spec: KVCacheGroupSpec,
+                                 ):
+        assert isinstance(kv_cache_group_spec.kv_cache_spec, MambaSpec)
+        assert self.cache_config.enable_prefix_caching
+        new_reqs: list[NewRequestData] = scheduler_output.scheduled_new_reqs
+        for new_req in new_reqs:
+            if new_req.num_computed_tokens == 0:
+                continue
+            block_ids: list[int] = new_req.block_ids[kv_cache_group_id]
+            assert block_ids[0] != 0, f'{block_ids=}'
+            prefix_block_id, dest_block_id = block_ids[0], block_ids[1]
+            self._mamba_copy_block(kv_cache_group_spec, prefix_block_id, dest_block_id)
+        cached_reqs: CachedRequestData = scheduler_output.scheduled_cached_reqs
+        for i, resumed in enumerate(cached_reqs.resumed_from_preemption):
+            if not resumed:
+                continue
+            group_block_ids: Optional[tuple[list[int], ...]] = cached_reqs.new_block_ids[i]
+            assert group_block_ids is not None
+            new_block_ids: list[int] = group_block_ids[kv_cache_group_id]
+            assert len(new_block_ids) >= 2 + kv_cache_group_spec.kv_cache_spec.num_speculative_blocks
+            if cached_reqs.num_computed_tokens[i] == 0:
+                continue
+            assert new_block_ids[0] != 0, f'{new_block_ids=}'
+            prefix_block_id, dest_block_id = new_block_ids[0], new_block_ids[1]
+            self._mamba_copy_block(kv_cache_group_spec, prefix_block_id, dest_block_id)     
+
+
+    def _postprocess_mamba_cache(self, scheduler_output: "SchedulerOutput"):
+        assert self.cache_config.enable_prefix_caching
+        for kv_cache_group_id, kv_cache_group_spec in enumerate(
+                self.kv_cache_config.kv_cache_groups):
+            if not isinstance(kv_cache_group_spec.kv_cache_spec, MambaSpec):
+                continue
+            new_reqs: list[NewRequestData] = scheduler_output.scheduled_new_reqs
+            num_speculative_blocks = kv_cache_group_spec.kv_cache_spec.num_speculative_blocks
+            for new_req in new_reqs:
+                block_ids: list[int] = new_req.block_ids[kv_cache_group_id]
+                if len(block_ids) <= 2 + num_speculative_blocks:
+                    continue
+                assert len(block_ids) == 3 + num_speculative_blocks
+                src_block_id, dest_block_id = block_ids[1], block_ids[-1]
+                self._mamba_copy_block(kv_cache_group_spec, src_block_id, dest_block_id)
+            cached_reqs: CachedRequestData = scheduler_output.scheduled_cached_reqs
+            for i, req_id in enumerate(cached_reqs.req_ids):
+                group_block_ids: Optional[tuple[list[int], ...]] = cached_reqs.new_block_ids[i]
+                if group_block_ids is None:
+                    assert not cached_reqs.resumed_from_preemption[i]
+                    continue
+                new_block_ids: list[int] = group_block_ids[kv_cache_group_id]
+                if not new_block_ids:
+                    assert not cached_reqs.resumed_from_preemption[i]
+                    continue
+                if not cached_reqs.resumed_from_preemption[i]:
+                    assert len(new_block_ids) == 1
+                    block_ids: list[int] = self.requests[req_id].block_ids[kv_cache_group_id]
+                    src_block_id, dest_block_id = block_ids[1], new_block_ids[0]
+                else:
+                    if len(new_block_ids) == 2 + num_speculative_blocks:
+                        continue
+                    assert len(new_block_ids) == 3 + num_speculative_blocks
+                    src_block_id, dest_block_id = new_block_ids[1], new_block_ids[-1]
+                self._mamba_copy_block(kv_cache_group_spec, src_block_id, dest_block_id)
+
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -2651,6 +2737,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             apply_grammar_bitmask(
                 scheduler_output, grammar_output, self.input_batch, logits
             )
+
+            if (envs.VLLM_USE_LIGHTER_MAMBA_CACHE
+                and self.cache_config.enable_prefix_caching
+            ):
+                self._postprocess_mamba_cache(scheduler_output)
 
         with record_function_or_nullcontext("Sample"):
             sampler_output = self._sample(logits, spec_decode_metadata)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Currently, Automatic Prefix Caching for Mamba-based hybrid models does not support architectures such as GDN. To address this, we propose a lightweight Mamba Prefix Caching design called **Lighter-Mamba-Prefix-Cache**.  
Its core idea is to directly cache Mamba states using a block-aligned scheduling approach, enabling rapid support for Prefix Caching in Mamba models **without modifying any kernel code**, while maintaining compatibility with SPS, MTP, and Eagle.  
This solution has already been validated on Qwen3-Next-80B-A3B-Instruct.

### Design Details
#### Block Allocation Design
For each request, the number of blocks allocated per Mamba group is changed from the original fixed `1 + sps` to `2 + sps + N`, where:
* The 1st block: Used to **load the Mamba state from a prefix-caching hit**. If there is no cache hit, a null-block is used as a placeholder.
* The next `1 + sps` blocks: **Reserved for runtime usage**, identical to the original `1 + sps` blocks without prefix caching.
* The following N blocks: Used to **cache Mamba states**.

<img width="738" height="249" alt="block_alloc" src="https://github.com/user-attachments/assets/b5e4cce4-bd41-4cf0-b8e7-8fc3bc45e59c" />

#### Prefix Matching Logic
<img width="1185" height="757" alt="scheduler_logic" src="https://github.com/user-attachments/assets/e2849130-2f4c-46ab-8b49-55047074efb9" />

<img width="572" height="363" alt="worker_logic" src="https://github.com/user-attachments/assets/e1aae2b6-00f4-4daa-ae46-e75757e74e63" />

#### Block-Aligned Scheduling
Since requests are hashed at the granularity of `block_size`, **Mamba states must be aligned to `block_size`** boundaries before caching. This ensures that each Mamba state corresponds to exactly one block hash.  
Lighter prefix cache stores variable-length chunk states—i.e., the number of tokens (or the incremental length) associated with **each cached Mamba state may vary, but it is always a multiple of `block_size`**.

With Mamba Prefix Caching enabled, the scheduler behaves as follows:
* Decode requests: Scheduling logic remains unchanged (Lighter prefix caching is not yet supported for decode).
* Prefill requests: 
    * **The number of tokens scheduled per step must be an integer multiple of `block_size`**, except for the final chunk of the request.
    * **The last prefill chunk is split to align with `block_size`**, ensuring its size is `≤ block_size`. This maximizes the length of the prompt that can be cached during the prefill phase.


## Test Plan
TODO

## Test Result
TODO

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

