### PR TITLE
[Qwen3-Next][Perf][Attention] Replace torch.zeros with torch.empty to reduce overhead

### DIFF
--- a/vllm/model_executor/layers/kda.py
+++ b/vllm/model_executor/layers/kda.py
@@ -274,7 +274,7 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
         g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
 
-        core_attn_out = torch.empty(
+        core_attn_out = torch.zeros(
             (1, num_tokens, self.local_num_heads, self.head_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
@@ -307,8 +307,7 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         attn_metadata: AttentionMetadata = forward_context.attn_metadata
 
         if attn_metadata is None:
-            # V1 profile run
-            core_attn_out.fill_(0)
+            #     # V1 profile run
             return
 
         assert isinstance(attn_metadata, dict)

--- a/vllm/model_executor/layers/kda.py
+++ b/vllm/model_executor/layers/kda.py
@@ -274,7 +274,7 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
         g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
 
-        core_attn_out = torch.zeros(
+        core_attn_out = torch.empty(
             (1, num_tokens, self.local_num_heads, self.head_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
@@ -307,7 +307,8 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         attn_metadata: AttentionMetadata = forward_context.attn_metadata
 
         if attn_metadata is None:
-            #     # V1 profile run
+            # V1 profile run
+            core_attn_out.fill_(0)
             return
 
         assert isinstance(attn_metadata, dict)

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -462,7 +462,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         # ============================================================
         # Part 2: Core Attention (Custom Op)
         # ============================================================
-        core_attn_out = torch.zeros(
+        core_attn_out = torch.empty(
             (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
@@ -503,6 +503,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         if attn_metadata is None:
             # V1 profile run
+            core_attn_out.fill_(0)
             return
 
         assert isinstance(attn_metadata, dict)


### PR DESCRIPTION
## Purpose
As https://github.com/vllm-project/vllm/pull/26680 and https://github.com/vllm-project/vllm/pull/19784 mentioned, using `torch.zeros` to allocate attention output buffer will introduce an unnecessary kernel overhead.

> w/ torch.empty, we allocate but do not initialize. CUDAGraph would remove this allocation time.
w/ torch.zero, we allocate AND initialize, which requires an extra cuda/triton kernel. CUDAGraph cannot remove this kernel. This kernel adds ~1 us latency, which is on-par with a layer norm or rope kernel (~1.6 us).

qwen3-next as an example:
main
<img width="879" height="75" alt="image" src="https://github.com/user-attachments/assets/08b49b47-a82f-4cb3-95b9-b93d0294e26e" />
this pr
<img width="794" height="75" alt="image" src="https://github.com/user-attachments/assets/557886f3-e4b9-4009-b64d-b2a3a177509b" />

A triton kernel was eliminated

## accuracy test

```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct --enable-expert-parallel -tp 4
lm_eval --model local-completions --model_args model=Qwen/Qwen3-Next-80B-A3B-Instruct,base_url=http://localhost:8000/v1/completions -t gsm8k --num_fewshot 5 --batch_size 250
```

Tasks | Version | Filter | n-shot | Metric |   | Value |   | Stderr
-- | -- | -- | -- | -- | -- | -- | -- | --
gsm8k | 3 | flexible-extract | 5 | exact_match | ↑ | 0 | ± | 0
  |   | strict-match | 5 | exact_match | ↑ | 0 | ± | 0


## Perf test

### qwen3-next

TL;DR: throughput 6340.16 -> 6756.52

```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct --enable-expert-parallel -tp 4
vllm bench serve \
--model Qwen/Qwen3-Next-80B-A3B-Instruct \
--dataset-name random \
--num-prompts 32 \
--random-input-len 2048 \
--random-output-len 1024
```
this pr
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Benchmark duration (s):                  14.55     
Total input tokens:                      65536     
Total generated tokens:                  32768     
Request throughput (req/s):              2.20      
Output token throughput (tok/s):         2252.17   
Peak output token throughput (tok/s):    2912.00   
Peak concurrent requests:                32.00     
Total Token throughput (tok/s):          6756.52   
---------------Time to First Token----------------
Mean TTFT (ms):                          1819.22   
Median TTFT (ms):                        1847.39   
P99 TTFT (ms):                           2960.06   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.39     
Median TPOT (ms):                        12.38     
P99 TPOT (ms):                           13.63     
---------------Inter-token Latency----------------
Mean ITL (ms):                           12.40     
Median ITL (ms):                         11.33     
P99 ITL (ms):                            12.00     
==================================================
```

main
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Benchmark duration (s):                  15.14     
Total input tokens:                      65536     
Total generated tokens:                  30472     
Request throughput (req/s):              2.11      
Output token throughput (tok/s):         2012.31   
Peak output token throughput (tok/s):    2400.00   
Peak concurrent requests:                32.00     
Total Token throughput (tok/s):          6340.16   
---------------Time to First Token----------------
Mean TTFT (ms):                          1355.49   
Median TTFT (ms):                        1365.46   
P99 TTFT (ms):                           2122.49   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.42     
Median TPOT (ms):                        13.32     
P99 TPOT (ms):                           14.34     
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.46     
Median ITL (ms):                         12.74     
P99 ITL (ms):                            13.36     
==================================================
```

<details>
<summary> kimi linear has performance regression </summary>
### kimi linear

```
vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct --trust-remote-code -tp 4 --enable-expert-parallel
vllm bench serve \
--model moonshotai/Kimi-Linear-48B-A3B-Instruct \
--dataset-name random \
--num-prompts 32 \
--random-input-len 2048 \
--random-output-len 1024 \
--trust-remote-code
```
this pr
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Benchmark duration (s):                  11.18     
Total input tokens:                      65536     
Total generated tokens:                  31784     
Request throughput (req/s):              2.86      
Output token throughput (tok/s):         2843.43   
Peak output token throughput (tok/s):    3424.00   
Peak concurrent requests:                32.00     
Total Token throughput (tok/s):          8706.36   
---------------Time to First Token----------------
Mean TTFT (ms):                          1028.07   
Median TTFT (ms):                        1031.84   
P99 TTFT (ms):                           1634.19   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.95      
Median TPOT (ms):                        9.89      
P99 TPOT (ms):                           11.42     
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.91      
Median ITL (ms):                         9.32      
P99 ITL (ms):                            10.10     
==================================================
```

main
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Benchmark duration (s):                  11.06     
Total input tokens:                      65536     
Total generated tokens:                  32206     
Request throughput (req/s):              2.89      
Output token throughput (tok/s):         2911.00   
Peak output token throughput (tok/s):    3552.00   
Peak concurrent requests:                32.00     
Total Token throughput (tok/s):          8834.59   
---------------Time to First Token----------------
Mean TTFT (ms):                          1179.73   
Median TTFT (ms):                        1196.33   
P99 TTFT (ms):                           1800.05   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.65      
Median TPOT (ms):                        9.62      
P99 TPOT (ms):                           10.65     
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.64      
Median ITL (ms):                         9.05      
P99 ITL (ms):                            9.59      
==================================================
```
```
vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct --trust-remote-code -tp 4
lm_eval --model local-completions --model_args model=moonshotai/Kimi-Linear-48B-A3B-Instruct,base_url=http://localhost:8000/v1/completions,trust_remote_code=True -t gsm8k --num_fewshot 5 --batch_size 250
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8939|±  |0.0085|
|     |       |strict-match    |     5|exact_match|↑  |0.8764|±  |0.0091|

</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

