### PR TITLE
[Bugfix]lora replace_layer support custom op

### DIFF
--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -155,9 +155,21 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is ColumnParallelLinear or (
-            type(source_layer) is MergedColumnParallelLinear
-            and len(packed_modules_list) == 1
+        return (
+            type(source_layer) is ColumnParallelLinear
+            or (
+                type(source_layer) is MergedColumnParallelLinear
+                and len(packed_modules_list) == 1
+            )
+            or type(source_layer)
+            is ColumnParallelLinear.op_registry_oot[ColumnParallelLinear.__name__]
+            or (
+                type(source_layer)
+                is MergedColumnParallelLinear.op_registry_oot[
+                    MergedColumnParallelLinear.__name__
+                ]
+                and len(packed_modules_list) == 1
+            )
         )
 
 
@@ -278,6 +290,12 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         return (
             type(source_layer) is MergedColumnParallelLinear
             and len(packed_modules_list) == 2
+        ) or (
+            type(source_layer)
+            is MergedColumnParallelLinear.op_registry_oot[
+                MergedColumnParallelLinear.__name__
+            ]
+            and len(packed_modules_list) == 2
         )
 
 
@@ -341,7 +359,13 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is QKVParallelLinear and len(packed_modules_list) == 1
+        return (
+            type(source_layer) is QKVParallelLinear and len(packed_modules_list) == 1
+        ) or (
+            type(source_layer)
+            is QKVParallelLinear.op_registry_oot[QKVParallelLinear.__name__]
+            and len(packed_modules_list) == 1
+        )
 
 
 class MergedQKVParallelLinearWithLoRA(MergedColumnParallelLinearWithLoRA):
@@ -399,7 +423,13 @@ class MergedQKVParallelLinearWithLoRA(MergedColumnParallelLinearWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is QKVParallelLinear and len(packed_modules_list) == 3
+        return (
+            type(source_layer) is QKVParallelLinear and len(packed_modules_list) == 3
+        ) or (
+            type(source_layer)
+            is QKVParallelLinear.op_registry_oot[QKVParallelLinear.__name__]
+            and len(packed_modules_list) == 3
+        )
 
 
 # These following layers are based on the tensor parallelism strategy given in

--- a/vllm/lora/layers/replicated_linear.py
+++ b/vllm/lora/layers/replicated_linear.py
@@ -55,7 +55,11 @@ class ReplicatedLinearWithLoRA(BaseLinearLayerWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is ReplicatedLinear
+        return (
+            type(source_layer) is ReplicatedLinear
+            or type(source_layer)
+            is ReplicatedLinear.op_registry_oot[ReplicatedLinear.__name__]
+        )
 
     def slice_lora_a(
         self, lora_a: torch.Tensor | list[torch.Tensor | None]

--- a/vllm/lora/layers/row_parallel_linear.py
+++ b/vllm/lora/layers/row_parallel_linear.py
@@ -94,7 +94,11 @@ class RowParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is RowParallelLinear
+        return (
+            type(source_layer) is RowParallelLinear
+            or type(source_layer)
+            is RowParallelLinear.op_registry_oot[RowParallelLinear.__name__]
+        )
 
 
 # The following layer is based on the tensor parallelism strategy given in

--- a/vllm/lora/layers/vocal_parallel_embedding.py
+++ b/vllm/lora/layers/vocal_parallel_embedding.py
@@ -159,7 +159,11 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is VocabParallelEmbedding
+        return (
+            type(source_layer) is VocabParallelEmbedding
+            or type(source_layer)
+            is VocabParallelEmbedding.op_registry_oot[VocabParallelEmbedding.__name__]
+        )
 
     @property
     def weight(self):


### PR DESCRIPTION

## Purpose
When I use vLLM in plugin mode, I use a custom op（@RowParallelLinear.register_oot
class RowParallelLinear_OOT(RowParallelLinear, LinearBase_OOT)）, at which point the network structure `RowParallelLinear` is replaced with `RowParallelLinear_OOT`. However, in the current `def can_replace_layer` function of LoRA, a layer can only be replaced when `type(source_layer) is RowParallelLinear`. This causes the replacement to fail and prevents the network layer from being successfully replaced with the LoRA-enabled layer (`RowParallelLinearWithLoRA`), resulting in an assertion error in `register_module` at line 591 of `vllm/vllm/lora/models.py`.

This PR updates the logic, adding support for LoRA replacement for custom ops, so that layers wrapped for custom operation support can be handled correctly.

This
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

