### PR TITLE
[Bugfix] fix NaiveAll2All incorrect GroupCoordinator usage

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -48,6 +48,7 @@ class NaiveAll2AllManager(All2AllManagerBase):
 
         rank = self.rank if is_sequence_parallel else self.dp_rank
         world_size = self.world_size if is_sequence_parallel else self.dp_world_size
+        dist_group = get_ep_group() if is_sequence_parallel else get_dp_group()
 
         start = 0 if rank == 0 else cu_tokens_across_sp_cpu[rank - 1]
         end = cu_tokens_across_sp_cpu[rank]
@@ -55,7 +56,7 @@ class NaiveAll2AllManager(All2AllManagerBase):
         for idx in range(world_size):
             start = 0 if idx == 0 else cu_tokens_across_sp_cpu[idx - 1]
             end = cu_tokens_across_sp_cpu[idx]
-            get_ep_group().broadcast(buffer[start:end, :], idx)
+            dist_group.broadcast(buffer[start:end, :], idx)
 
         return buffer
 
@@ -90,8 +91,9 @@ class NaiveAll2AllManager(All2AllManagerBase):
 
         start = 0 if ep_rank == 0 else cu_tokens_across_sp_cpu[ep_rank - 1]
         end = cu_tokens_across_sp_cpu[ep_rank]
+        dist_group = get_ep_group() if is_sequence_parallel else get_dp_group()
 
-        all_hidden_states = get_ep_group().all_reduce(hidden_states)
+        all_hidden_states = dist_group.all_reduce(hidden_states)
         hidden_states = all_hidden_states[start:end, :]
         return hidden_states
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix NaiveAll2All incorrect GroupCoordinator usage. When dp used but ep disabled, the Dp GroupCoordinator may should be used rather than EP Group in NaiveAll2All backend

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

