### PR TITLE
[CI] Fix Bad_words test for tokenizer encode/decode asymmetry

### DIFF
--- a/tests/v1/sample/test_sampling_params_e2e.py
+++ b/tests/v1/sample/test_sampling_params_e2e.py
@@ -106,6 +106,25 @@ def test_detokenize_false(llm):
 def test_bad_words(llm):
     """Check that we respect bad words."""
 
+    tokenizer = llm.get_tokenizer()
+
+    def contains_bad_word(text: str, tokens: list[int], bad_word: str) -> bool:
+        """Check if word appears in BOTH text and token sequence."""
+        if bad_word not in text:
+            return False
+
+        for add_prefix_space in [False, True]:
+            prefix = " " if add_prefix_space else ""
+            bad_words_token = tokenizer.encode(
+                prefix + bad_word.lstrip(), add_special_tokens=False
+            )
+            if not bad_words_token:
+                continue
+            for i in range(len(tokens) - len(bad_words_token) + 1):
+                if tokens[i : i + len(bad_words_token)] == bad_words_token:
+                    return True
+        return False
+
     output = llm.generate(PROMPT, SamplingParams(temperature=0))
     split_text = output[0].outputs[0].text.split()
 
@@ -113,14 +132,16 @@ def test_bad_words(llm):
     params = SamplingParams(temperature=0, bad_words=[bad_words_1])
     output = llm.generate(PROMPT, params)
     new_text = output[0].outputs[0].text
-    assert bad_words_1 not in new_text
+    new_tokens = output[0].outputs[0].token_ids
+    assert not contains_bad_word(new_text, new_tokens, bad_words_1)
 
     bad_words_2 = new_text.split()[-1]
     params = SamplingParams(temperature=0, bad_words=[bad_words_1, bad_words_2])
     output = llm.generate(PROMPT, params)
     new_text = output[0].outputs[0].text
-    assert bad_words_1 not in new_text
-    assert bad_words_2 not in new_text
+    new_tokens = output[0].outputs[0].token_ids
+    assert not contains_bad_word(new_text, new_tokens, bad_words_1)
+    assert not contains_bad_word(new_text, new_tokens, bad_words_2)
 
 
 def test_logits_processor(llm):


### PR DESCRIPTION
## Purpose

Fix flaky `test_bad_words` test caused by tokenizer encode/decode asymmetry.

The test was failing on AMD CI (see [#27945](https://github.com/vllm-project/vllm/issues/27945)) because modern tokenizers (e.g., LLaMA's SentencePiece) use positional markers (like `▁` prefix) that distinguish tokens in different contexts. When these tokens are decoded, the positional information is lost, causing `encode(decode(tokens))` to produce different token sequences.

**Example of the issue:**
```python
from transformers import AutoTokenizer
MODEL = "hmellor/tiny-random-LlamaForCausalLM"
tokenizer = AutoTokenizer.from_pretrained(MODEL)
tokens = [10122, 2892, 1355]  # "▁presence", "lambda", "imes" in vocab
text = tokenizer.decode(tokens)  # "presencelambdaimes"
re_encoded = tokenizer.encode(text)  # [2225, 264, 2242, 2269, 1355] ≠ original
```

**Root cause from #27945:**
The test assertion `assert bad_words_2 not in new_text` was failing because:
- `bad_words_2 = "presencelambdaimes"` (decoded from tokens)
- The string appeared in generated text, but used different tokens due to context
- This is not a real filter failure, just tokenizer asymmetry

**Solution:**
Modified the test to validate bad_words filtering at both text and token levels. The test now only fails if the bad word appears in **BOTH** the generated text **AND** the token sequence, avoiding false failures from asymmetry.

Fixes #27945

## Test Plan

Run the bad_words test:
```bash
pytest tests/v1/sample/test_sampling_params_e2e.py::test_bad_words -v
```

The test now:
1. Generates baseline text with `temperature=0`
2. Applies `bad_words` filter with one word, verifies it's filtered
3. Applies `bad_words` filter with two words, verifies both are filtered
4. Uses `contains_bad_word()` helper to check both text-level and token-level presence

## Test Result

✅ Test passes consistently on both x86 and AMD platforms

**Before:** 
- Test failed on AMD CI with `AssertionError: assert 'presencelambdaimes' not in '...'`
- String appeared in text but with different token encoding

**After:** 
- Test only fails when bad_word is truly present (both text and tokens match)
- Handles tokenizer asymmetry gracefully

The `contains_bad_word()` function:
- Checks string presence in decoded text
- Checks token sequence presence (with/without space prefix)
- Matches vLLM's internal `update_from_tokenizer()` logic