### PR TITLE
[build] fix: only build FA3 for Hopper

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -37,8 +37,9 @@ if(VLLM_FLASH_ATTN_SRC_DIR)
 else()
   FetchContent_Declare(
           vllm-flash-attn
-          GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG a893712401d70362fbb299cd9c4b3476e8e9ed54
+          # temporary until vllm-project/flash-attention#105 is merged
+          GIT_REPOSITORY https://github.com/AlpinDale/flash-attention.git
+          GIT_TAG 3e16ec5054dca0b5f62ff58e76977d07e24ac55f
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/setup.py
+++ b/setup.py
@@ -587,8 +587,8 @@ def _has_sm90_or_higher() -> bool:
             if torch.cuda.is_available():
                 capability = torch.cuda.get_device_capability(0)
                 return capability[0] >= 9
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to get device capability: %s", e)
         return False
 
     archs = arch_list.split()

--- a/setup.py
+++ b/setup.py
@@ -658,12 +658,10 @@ if _is_hip():
 
 if _is_cuda():
     ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
-    if (
-        envs.VLLM_USE_PRECOMPILED
-        or get_nvcc_cuda_version() >= Version("12.3")
-        or _has_sm90_or_higher()
+    if _has_sm90_or_higher() and (
+        envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.3")
     ):
-        # FA3 requires CUDA 12.3 or later
+        # FA3 requires CUDA 12.3 or later and Hopper architecture
         ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
         # Optional since this doesn't get built (produce an .so file) when
         # not targeting a hopper system


### PR DESCRIPTION
## Purpose
FA3 is only used for Hopper, yet it's built for every Ampere (sm_80, sm_87, sm_89) and Ada (sm_89) arches. This needlessly increases build times, and inflates the wheel size. FA3 technically supports A100 (sm_80), but as discussed offline with @mgoin, it's not stable and vLLM does not actually enable it.

vLLM FA PR: vllm-project/flash-attention#105


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

