### PR TITLE
Adds Dockerfile arg for VLLM_PRECOMPILED_WHEEL_LOCATION

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,6 +188,7 @@ ARG SCCACHE_S3_NO_CREDENTIALS=0
 
 # Flag to control whether to use pre-built vLLM wheels
 ARG VLLM_USE_PRECOMPILED=""
+ARG VLLM_PRECOMPILED_WHEEL_LOCATION=""
 ARG VLLM_MAIN_CUDA_VERSION=""
 
 # if USE_SCCACHE is set, use sccache to speed up compilation
@@ -206,6 +207,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         && export SCCACHE_IDLE_TIMEOUT=0 \
         && export CMAKE_BUILD_TYPE=Release \
         && export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED}" \
+        && export VLLM_PRECOMPILED_WHEEL_LOCATION="${VLLM_PRECOMPILED_WHEEL_LOCATION}" \
         && export VLLM_MAIN_CUDA_VERSION="${VLLM_MAIN_CUDA_VERSION}" \
         && export VLLM_DOCKER_BUILD_CONTEXT=1 \
         && sccache --show-stats \
@@ -224,6 +226,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
         rm -rf .deps && \
         mkdir -p .deps && \
         export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED}" && \
+        export VLLM_PRECOMPILED_WHEEL_LOCATION="${VLLM_PRECOMPILED_WHEEL_LOCATION}" && \
         export VLLM_DOCKER_BUILD_CONTEXT=1 && \
         python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38; \
     fi

--- a/setup.py
+++ b/setup.py
@@ -660,7 +660,7 @@ package_data = {
 if envs.VLLM_USE_PRECOMPILED:
     assert _is_cuda(), "VLLM_USE_PRECOMPILED is only supported for CUDA builds"
     wheel_location = os.getenv("VLLM_PRECOMPILED_WHEEL_LOCATION", None)
-    if wheel_location is not None:
+    if wheel_location:
         wheel_url = wheel_location
     else:
         import platform

--- a/setup.py
+++ b/setup.py
@@ -659,33 +659,39 @@ package_data = {
 # If using precompiled, extract and patch package_data (in advance of setup)
 if envs.VLLM_USE_PRECOMPILED:
     assert _is_cuda(), "VLLM_USE_PRECOMPILED is only supported for CUDA builds"
+
+    import platform
+
+    arch = platform.machine()
+    if arch == "x86_64":
+        wheel_tag = "manylinux1_x86_64"
+    elif arch == "aarch64":
+        wheel_tag = "manylinux2014_aarch64"
+    else:
+        raise ValueError(f"Unsupported architecture: {arch}")
+
+    # Determine the wheel URL
     wheel_location = os.getenv("VLLM_PRECOMPILED_WHEEL_LOCATION", None)
     if wheel_location:
         wheel_url = wheel_location
     else:
-        import platform
-
-        arch = platform.machine()
-        if arch == "x86_64":
-            wheel_tag = "manylinux1_x86_64"
-        elif arch == "aarch64":
-            wheel_tag = "manylinux2014_aarch64"
-        else:
-            raise ValueError(f"Unsupported architecture: {arch}")
         base_commit = precompiled_wheel_utils.get_base_commit_in_main_branch()
         wheel_url = f"https://wheels.vllm.ai/{base_commit}/vllm-1.0.0.dev-cp38-abi3-{wheel_tag}.whl"
-        nightly_wheel_url = (
-            f"https://wheels.vllm.ai/nightly/vllm-1.0.0.dev-cp38-abi3-{wheel_tag}.whl"
-        )
-        from urllib.request import urlopen
 
-        try:
-            with urlopen(wheel_url) as resp:
-                if resp.status != 200:
-                    wheel_url = nightly_wheel_url
-        except Exception as e:
-            print(f"[warn] Falling back to nightly wheel: {e}")
-            wheel_url = nightly_wheel_url
+    # Always validate the wheel URL and fall back to nightly if it doesn't exist
+    nightly_wheel_url = (
+        f"https://wheels.vllm.ai/nightly/vllm-1.0.0.dev-cp38-abi3-{wheel_tag}.whl"
+    )
+    from urllib.request import urlopen
+
+    try:
+        with urlopen(wheel_url) as resp:
+            if resp.status != 200:
+                print(f"[warn] Wheel URL returned status {resp.status}, falling back to nightly wheel")
+                wheel_url = nightly_wheel_url
+    except Exception as e:
+        print(f"[warn] Failed to access wheel URL: {e}, falling back to nightly wheel")
+        wheel_url = nightly_wheel_url
 
     patch = precompiled_wheel_utils.extract_precompiled_and_patch_package(wheel_url)
     for pkg, files in patch.items():


### PR DESCRIPTION
- Add VLLM_PRECOMPILED_WHEEL_LOCATION as a Docker build ARG
- Pass VLLM_PRECOMPILED_WHEEL_LOCATION to setup.py in both build paths (with and without sccache)
- Fix bug in setup.py where empty VLLM_PRECOMPILED_WHEEL_LOCATION="" would be treated as a valid URL (changed check from 'is not None' to truthy check)

Additionally -- this adds a fallback to the nightly wheel if you use an invalid `VLLM_PRECOMPILED_WHEEL_LOCATION` location.

## Purpose

Use case:
  The ci-infra repo can now specify a precompiled wheel from the LCA of a commit by passing `--build-arg VLLM_PRECOMPILED_WHEEL_LOCATION=<url>`, avoiding unreliable git-based wheel URL computation during CI builds. This particularly presents a problem because we're often calling the latest commit on main, and it's not finished building yet -- it's currently being built. If the specified wheel doesn't exist, setup.py automatically falls back to the nightly wheel.

## Test Plan

* Passes docker build image step in CI

## Test Result

[See CI]

---
<details>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [n/a] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [n/a] (Optional) Release notes update.
- 