### PR TITLE
[Test] Add non-MoE DP test coverage

### DIFF
--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -62,7 +62,7 @@ async def generate(
     "model",
     [
         "ibm-research/PowerMoE-3b",
-        "meta-llama/Meta-Llama-3-8B-Instruct",
+        "meta-llama/Llama-3.2-1B-Instruct",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -20,13 +20,6 @@ from vllm.v1.metrics.stats import IterationStats, MultiModalCacheStats, Schedule
 
 DP_SIZE = int(os.getenv("DP_SIZE", 2))
 
-engine_args = AsyncEngineArgs(
-    model="ibm-research/PowerMoE-3b",
-    enforce_eager=True,
-    tensor_parallel_size=int(os.getenv("TP_SIZE", 1)),
-    data_parallel_size=DP_SIZE,
-)
-
 
 async def generate(
     engine: AsyncLLM,
@@ -66,6 +59,13 @@ async def generate(
 
 
 @pytest.mark.parametrize(
+    "model",
+    [
+        "ibm-research/PowerMoE-3b",
+        "meta-llama/Meta-Llama-3-8B-Instruct",
+    ],
+)
+@pytest.mark.parametrize(
     "output_kind",
     [
         RequestOutputKind.DELTA,
@@ -76,7 +76,10 @@ async def generate(
 @pytest.mark.parametrize("async_scheduling", [True, False])
 @pytest.mark.asyncio
 async def test_load(
-    output_kind: RequestOutputKind, data_parallel_backend: str, async_scheduling: bool
+    model: str,
+    output_kind: RequestOutputKind,
+    data_parallel_backend: str,
+    async_scheduling: bool,
 ):
     if async_scheduling and data_parallel_backend == "ray":
         # TODO(NickLucche) Re-enable when async scheduling is supported
@@ -107,8 +110,14 @@ async def test_load(
     with ExitStack() as after:
         prompt = "This is a test of data parallel"
 
-        engine_args.data_parallel_backend = data_parallel_backend
-        engine_args.async_scheduling = async_scheduling
+        engine_args = AsyncEngineArgs(
+            model=model,
+            enforce_eager=True,
+            tensor_parallel_size=int(os.getenv("TP_SIZE", 1)),
+            data_parallel_size=DP_SIZE,
+            data_parallel_backend=data_parallel_backend,
+            async_scheduling=async_scheduling,
+        )
         engine = AsyncLLM.from_engine_args(
             engine_args, stat_loggers=[SimpleStatsLogger]
         )

--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -62,7 +62,7 @@ async def generate(
     "model",
     [
         "ibm-research/PowerMoE-3b",
-        "meta-llama/Llama-3.2-1B-Instruct",
+        "hmellor/tiny-random-LlamaForCausalLM",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION

## Purpose
DP serving of non-MoE models is not currently tested. This PR adds such a case to `test_async_llm_dp.py`

## Test Plan
`pytest tests/v1/distributed/test_async_llm_dp.py`

## Test Result
Should pass in CI: Distributed Tests (2 GPUs)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

