### PR TITLE
[Perf] Use np.ndarray instead of list[list[int]] to reduce GC overhead

### DIFF
--- a/tests/v1/engine/utils.py
+++ b/tests/v1/engine/utils.py
@@ -5,6 +5,7 @@ import random
 from dataclasses import dataclass
 from typing import TypeAlias
 
+import numpy as np
 import torch
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
@@ -369,9 +370,9 @@ class MockEngineCore:
                         self.generated_logprobs_raw[req_idx][token_idx]
                     )
                     logprobs = LogprobsLists(
-                        [logprobs_token_ids_],
-                        [logprobs_],
-                        [sampled_token_ranks_],
+                        np.array([logprobs_token_ids_]),
+                        np.array([logprobs_]),
+                        np.array([sampled_token_ranks_]),
                     )
                 else:
                     logprobs = None

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -74,7 +74,12 @@ class LogprobsProcessor:
 
         token_ids_lst, logprobs_lst, ranks_lst, _ = logprobs_lists
 
-        for rank, logprobs, token_ids in zip(ranks_lst, logprobs_lst, token_ids_lst):
+        for rank_np, logprobs_np, token_ids_np in zip(
+            ranks_lst, logprobs_lst, token_ids_lst
+        ):
+            rank = rank_np.tolist()
+            logprobs = logprobs_np.tolist()
+            token_ids = token_ids_np.tolist()
             # Detokenize (non-incrementally).
             decoded_tokens = (
                 NONES

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NamedTuple
 
+import numpy as np
 import torch
 
 if TYPE_CHECKING:
@@ -15,11 +16,11 @@ else:
 
 class LogprobsLists(NamedTuple):
     # [num_reqs x num_generated_tokens, max_num_logprobs + 1]
-    logprob_token_ids: list[list[int]]
+    logprob_token_ids: np.ndarray
     # [num_reqs x num_generated_tokens, max_num_logprobs + 1]
-    logprobs: list[list[float]]
+    logprobs: np.ndarray
     # [num_reqs x num_generated_tokens]
-    sampled_token_ranks: list[int]
+    sampled_token_ranks: np.ndarray
     # [num_reqs]
     # Used for slicing the logprobs in cases like speculative
     # decoding where the number of generated tokens may be
@@ -60,9 +61,9 @@ class LogprobsTensors(NamedTuple):
 
     def tolists(self, cu_num_generated_tokens: list[int] | None = None):
         return LogprobsLists(
-            self.logprob_token_ids.tolist(),
-            self.logprobs.tolist(),
-            self.selected_token_ranks.tolist(),
+            self.logprob_token_ids.numpy(),
+            self.logprobs.numpy(),
+            self.selected_token_ranks.numpy(),
             cu_num_generated_tokens,
         )
 

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -61,9 +61,9 @@ class LogprobsTensors(NamedTuple):
 
     def tolists(self, cu_num_generated_tokens: list[int] | None = None):
         return LogprobsLists(
-            self.logprob_token_ids.to("cpu").numpy(),
-            self.logprobs.to("cpu").numpy(),
-            self.selected_token_ranks.to("cpu").numpy(),
+            self.logprob_token_ids.cpu().numpy(),
+            self.logprobs.cpu().numpy(),
+            self.selected_token_ranks.cpu().numpy(),
             cu_num_generated_tokens,
         )
 

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -61,9 +61,9 @@ class LogprobsTensors(NamedTuple):
 
     def tolists(self, cu_num_generated_tokens: list[int] | None = None):
         return LogprobsLists(
-            self.logprob_token_ids.numpy(),
-            self.logprobs.numpy(),
-            self.selected_token_ranks.numpy(),
+            self.logprob_token_ids.to("cpu").numpy(),
+            self.logprobs.to("cpu").numpy(),
+            self.selected_token_ranks.to("cpu").numpy(),
             cu_num_generated_tokens,
         )
 


### PR DESCRIPTION
## Purpose
LogprobsLists would introduced 3 nested list[list[int]] which would invoke severe GC costs for large batch size use cases.

In this PR, we're simply changing the nested list to np.ndarray, and ideally the interface should be mostly identical compared to the original one.

## Test Plan & Test Result
Ensure logprob e2e testing is still running, and we've confirmed the types are changed in LogprobsProcessor._update_sample_logprobs.
```
HF_HUB_DISABLE_XET=1 pytest -s tests/samplers/test_ranks.py 
```

<img width="1233" height="313" alt="Screenshot 2025-11-06 at 12 43 28 PM" src="https://github.com/user-attachments/assets/3c918d09-c3c3-4601-b4a9-2d3ade03f529" />

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

