### PR TITLE
[CI/Build] Loosen STT LoRA Translate Check (Flaky Test)

### DIFF
--- a/tests/entrypoints/openai/test_translation_validation.py
+++ b/tests/entrypoints/openai/test_translation_validation.py
@@ -79,7 +79,7 @@ async def test_basic_audio_with_lora(mary_had_lamb):
             temperature=0.0,
         )
     out = json.loads(translation)["text"].strip().lower()
-    assert "pequeño" in out
+    assert "pequeño" in out.split(" ")
 
 
 # NOTE: (NickLucche) the large-v3-turbo model was not trained on translation!

--- a/tests/entrypoints/openai/test_translation_validation.py
+++ b/tests/entrypoints/openai/test_translation_validation.py
@@ -79,7 +79,7 @@ async def test_basic_audio_with_lora(mary_had_lamb):
             temperature=0.0,
         )
     out = json.loads(translation)["text"].strip().lower()
-    assert "mary tenía un pequeño cordero" in out
+    assert "pequeño" in out
 
 
 # NOTE: (NickLucche) the large-v3-turbo model was not trained on translation!


### PR DESCRIPTION


## Purpose
Loosens the check in the stt translation with lora test, which appears to be flaky, e.g., in [this build](https://buildkite.com/vllm/ci/builds/37789/steps/canvas?jid=019a5740-b172-4c97-8e48-d52b604573b3) which despite temp 0 fails with:
```
AssertionError: assert 'mary tenía un pequeño cordero' in 'las primeras palabras que hablé en el original son un poco de poesía práctica mary tuvo un pequeño cordero, que brillaba como la nieve, y dondequiera que mary fue, el cordero seguía a ella.'
```

Changing the check to just look for `pequeño` to hopefully stabilize things here for currently builds. If it still seems flaky, we can look into potentially using the 8b model for hopefully better stability or dig deeper into the nondeterminism, but the main purpose of this test is to check if lora is compatible with stt translate in general.

@chaunceyjiang @NickLucche @DarkLight1337 could one you please take a look?

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

