### PR TITLE
  [Bug] Fix missing token_ids for reasoning parser models in chat completions   #28246

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1372,6 +1372,9 @@ class OpenAIServingChat(OpenAIServing):
                         else "stop"
                     ),
                     stop_reason=output.stop_reason,
+                    token_ids=(
+                        as_list(output.token_ids) if request.return_token_ids else None
+                    ),
                 )
                 choices.append(choice_data)
                 continue


### PR DESCRIPTION
 
## Purpose
Add token_id when return_token_ids:true #[28246](https://github.com/vllm-project/vllm/issues/28246)
## Test Plan
VLLM_WORKER_MULTIPROC_METHOD=spawn \
VLLM_LOGGING_LEVEL=info \
python -m vllm.entrypoints.openai.api_server \
  --model "openai/gpt-oss-120b" \
  --served-model-name "gpt-oss-120b" \
  --host 0.0.0.0 \
  --port 8015 \
  --tensor-parallel-size 8 \
  --gpu-memory-utilization 0.9 \
  --max-model-len 32768 \
  --max-num-seqs 16

curl --location 'http://localhost:8015/v1/chat/completions' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "gpt-oss-120b",
    "messages": [{"role": "user", "content": "Hello!"}],
    "temperature": 0,
    "return_token_ids": true
  }'
## Test Result
<img width="1459" height="703" alt="image" src="https://github.com/user-attachments/assets/b79ad6df-99db-4279-ba26-054036804683" />
<img width="1434" height="681" alt="image" src="https://github.com/user-attachments/assets/55f5a6f5-6058-404f-bf92-eb7851893b3d" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

