### PR TITLE
[FixBug]Aeala/ShareGPT_Vicuna_unfiltered marked as multimodal benchmark

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -1712,6 +1712,11 @@ def get_samples(args, tokenizer) -> list[SampleRequest]:
             dataset_class = MTBenchDataset
             args.hf_split = "train"
         elif (
+            args.dataset_path in MultiModalConversationDataset.SUPPORTED_DATASET_PATHS
+            or args.hf_name in MultiModalConversationDataset.SUPPORTED_DATASET_PATHS
+        ):
+            dataset_class = MultiModalConversationDataset
+        elif (
             args.dataset_path in ConversationDataset.SUPPORTED_DATASET_PATHS
             or args.hf_name in ConversationDataset.SUPPORTED_DATASET_PATHS
         ):
@@ -2272,11 +2277,70 @@ class HuggingFaceDataset(BenchmarkDataset):
 
 
 class ConversationDataset(HuggingFaceDataset):
-    """Dataset for conversation data with multimodal support."""
+    """Dataset for text-only conversation data."""
+
+    SUPPORTED_DATASET_PATHS = {
+        "Aeala/ShareGPT_Vicuna_unfiltered",
+    }
+    IS_MULTIMODAL = False
+
+    def sample(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        num_requests: int,
+        output_len: int | None = None,
+        enable_multimodal_chat: bool = False,
+        request_id_prefix: str = "",
+        no_oversample: bool = False,
+        **kwargs,
+    ) -> list:
+        # Filter examples with at least 2 conversations
+        filtered_data = self.data.filter(lambda x: len(x["conversations"]) >= 2)
+        sampled_requests = []
+        ind = 0
+        dynamic_output = output_len is None
+
+        for item in filtered_data:
+            if len(sampled_requests) >= num_requests:
+                break
+            conv = item["conversations"]
+            prompt, completion = conv[0]["value"], conv[1]["value"]
+
+            prompt_ids = tokenizer(prompt).input_ids
+            completion_ids = tokenizer(completion).input_ids
+            prompt_len = len(prompt_ids)
+            completion_len = len(completion_ids)
+            output_len = completion_len if dynamic_output else output_len
+            assert isinstance(output_len, int) and output_len > 0
+            if dynamic_output and not is_valid_sequence(prompt_len, completion_len):
+                continue
+            mm_content = process_image(item["image"]) if "image" in item else None
+            if enable_multimodal_chat:
+                # Note: when chat is enabled the request prompt_len is no longer
+                # accurate and we will be using request output to count the
+                # actual prompt len and output len
+                prompt = self.apply_multimodal_chat_transformation(prompt, mm_content)
+            sampled_requests.append(
+                SampleRequest(
+                    prompt=prompt,
+                    prompt_len=prompt_len,
+                    expected_output_len=output_len,
+                    multi_modal_data=mm_content,
+                    request_id=request_id_prefix + str(ind),
+                )
+            )
+            ind += 1
+        self.maybe_oversample_requests(
+            sampled_requests, num_requests, request_id_prefix, no_oversample
+        )
+        return sampled_requests
+
+
+class MultiModalConversationDataset(HuggingFaceDataset):
+    """Dataset for multimodal conversation data."""
 
     SUPPORTED_DATASET_PATHS = {
         "lmms-lab/LLaVA-OneVision-Data",
-        "Aeala/ShareGPT_Vicuna_unfiltered",
     }
     IS_MULTIMODAL = True
 

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -21,6 +21,7 @@ from vllm.benchmarks.datasets import (
     BurstGPTDataset,
     ConversationDataset,
     InstructCoderDataset,
+    MultiModalConversationDataset,
     PrefixRepetitionRandomDataset,
     RandomDataset,
     SampleRequest,
@@ -367,6 +368,11 @@ def get_requests(args, tokenizer):
         elif args.dataset_path in InstructCoderDataset.SUPPORTED_DATASET_PATHS:
             dataset_cls = InstructCoderDataset
             common_kwargs["dataset_split"] = "train"
+        elif args.dataset_path in MultiModalConversationDataset.SUPPORTED_DATASET_PATHS:
+            dataset_cls = MultiModalConversationDataset
+            common_kwargs["dataset_subset"] = args.hf_subset
+            common_kwargs["dataset_split"] = args.hf_split
+            sample_kwargs["enable_multimodal_chat"] = True
         elif args.dataset_path in ConversationDataset.SUPPORTED_DATASET_PATHS:
             dataset_cls = ConversationDataset
             common_kwargs["dataset_subset"] = args.hf_subset
@@ -456,6 +462,7 @@ def validate_args(args):
     elif args.dataset_name == "hf":
         if args.dataset_path in (
             VisionArenaDataset.SUPPORTED_DATASET_PATHS.keys()
+            | MultiModalConversationDataset.SUPPORTED_DATASET_PATHS
             | ConversationDataset.SUPPORTED_DATASET_PATHS
         ):
             assert args.backend == "vllm-chat", (


### PR DESCRIPTION
## Purpose

Fix bug where `Aeala/ShareGPT_Vicuna_unfiltered` dataset was incorrectly marked as multimodal, causing benchmark failures with non-multimodal backends.

Resolves #28091

## Changes

- Split `ConversationDataset` into two separate classes:
  - `ConversationDataset`: For text-only conversation datasets (e.g., `Aeala/ShareGPT_Vicuna_unfiltered`) with `IS_MULTIMODAL = False`
  - `MultiModalConversationDataset`: For multimodal conversation datasets (e.g., `lmms-lab/LLaVA-OneVision-Data`) with `IS_MULTIMODAL = True`
- Updated dataset registration logic in `get_samples()` to check for `MultiModalConversationDataset` before `ConversationDataset`

## Test Plan
Start the server:

```
vllm serve gpt2 --gpu_memory_utilization 0.1
```

Run benchmark with the previously failing command:

```bash
vllm bench serve \
  --backend vllm \
  --model gpt2 \
  --dataset-name hf \
  --dataset-path Aeala/ShareGPT_Vicuna_unfiltered \
  --hf-split train \
  --num-prompts 10
```

## Test Result

**Before the fix:**
<img width="835" height="786" alt="image" src="https://github.com/user-attachments/assets/c59c04cc-e4f7-4c07-8363-8c03ae1297c5" />

**After the fix:**
<img width="838" height="786" alt="image" src="https://github.com/user-attachments/assets/e19e18c7-416b-44dd-b8cf-ffdacdbb8365" />

**Test throughput**
```
vllm bench throughput --model Qwen/Qwen2.5-0.5B-Instruct --backend vllm-chat --dataset-name hf --dataset-path Aeala/ShareGPT_Vicuna_unfiltered --hf-split train --num-prompts 5 --gpu-memory-utilization 0.1
```

**Result:**
<img width="1550" height="991" alt="image" src="https://github.com/user-attachments/assets/5487adb4-9114-461a-be5c-f0e1569dcd18" />

<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".

- [x] The test plan, such as providing test command.

- [x] The test results, such as pasting the results comparison before and after, or e2e results

- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).

