### PR TITLE
[CI Failure] Fix Gemma3MultiModalProcessor unit tests

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -273,6 +273,15 @@ class Gemma3DummyInputsBuilder(BaseDummyInputsBuilder[Gemma3ProcessingInfo]):
 
 
 class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
+    def _hf_processor_applies_updates(
+        self,
+        prompt_text: str,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+    ) -> bool:
+        return False
+
     def _call_hf_processor(
         self,
         prompt: str,


### PR DESCRIPTION
## Purpose

`Multi-Modal Models Test (Extended) 3` is failing on nightly (sample run https://buildkite.com/vllm/ci/builds/37798/steps/canvas?sid=019a578a-37eb-43e2-99bb-e85883b55583) on 3 tests
```
FAILED models/multimodal/generation/test_common.py::test_single_image_models[gemma3-test_case94]
FAILED models/multimodal/generation/test_common.py::test_multi_image_models[gemma3-test_case80]
FAILED models/multimodal/generation/test_common.py::test_custom_inputs_models[llava_onevision-multiple-images-test_case5]
```

This PR is fixing the gemma3 tests due to the following error msg
```

[2025-11-06T06:04:28Z] FAILED models/multimodal/generation/test_common.py::test_single_image_models[gemma3-test_case94] - RuntimeError: Expected there to be 1 prompt placeholders corresponding to 1 image items, but instead found 0 prompt placeholders! Make sure the implementation of `_call_hf_processor` and `_get_mm_fields_config` are consistent with each other.
[2025-11-06T06:04:28Z] FAILED models/multimodal/generation/test_common.py::test_multi_image_models[gemma3-test_case80] - RuntimeError: Expected there to be 2 prompt placeholders corresponding to 2 image items, but instead found 1 prompt placeholders! Make sure the implementation of `_call_hf_processor` and `_get_mm_fields_config` are consistent with each other.
```

**NOTE** - this PR does not fix the llava_onevision one - so I suspect CI will still show red


## Test Plan

```
pytest tests/models/multimodal/generation/test_common.py::test_single_image_models[gemma3-test_case94]
pytest tests/models/multimodal/generation/test_common.py::test_multi_image_models[gemma3-test_case80]
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

