### PR TITLE
[Kernel] Optimization of the mm_k operator.

### DIFF
--- a/vllm/lora/ops/triton_ops/kernel_utils.py
+++ b/vllm/lora/ops/triton_ops/kernel_utils.py
@@ -23,6 +23,7 @@ def mm_k(
     CAST_TYPE: tl.constexpr,
     b_dtype: tl.constexpr,
     USE_GDC: tl.constexpr,
+    base_k,
 ):
     """
     Given a_ptr and b_ptr, that identify the rows of A (m x k) and columns of
@@ -47,32 +48,62 @@ def mm_k(
           matrix dtype.
         b_dtype: datatype of the B matrix
         USE_GDC: Whether to use PDL. True indicates use.
+        base_k: Base offset along K dimension for current SPLIT_K group
     """
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in range(tl.cdiv(K, BLOCK_K * SPLIT_K)):
+
+    # Step size along K for each iteration
+    STEP_K = BLOCK_K * SPLIT_K
+
+    # Total number of iterations (compile-time constant)
+    num_iters = tl.cdiv(K, STEP_K)
+
+    for k in range(num_iters):
+        # Current iteration's global K offset
+        iter_k = k * STEP_K + base_k
+
+        # Check if this iteration is completely valid (no masking needed)
+        block_end = iter_k + BLOCK_K
+
         if EVEN_K:
-            # pre-fetech lora weight
+            # K is divisible by BLOCK_K, no masking ever needed
+            # pre-fetch lora weight
             tiled_b = tl.load(b_ptr)
             if USE_GDC:
                 tl.extra.cuda.gdc_wait()
             tiled_a = tl.load(a_ptr)
+            if CAST_TYPE:
+                tiled_a = tiled_a.to(b_dtype)
+            accumulator += tl.dot(tiled_a, tiled_b)
         else:
-            tiled_b = tl.load(
-                b_ptr, mask=offset_k[:, None] < K - k * (BLOCK_K * SPLIT_K), other=0
-            )
-            if USE_GDC:
-                tl.extra.cuda.gdc_wait()
-            tiled_a = tl.load(
-                a_ptr, mask=offset_k[None, :] < K - k * (BLOCK_K * SPLIT_K), other=0
-            )
-        if CAST_TYPE:
-            tiled_a = tiled_a.to(b_dtype)
-        accumulator += tl.dot(
-            tiled_a,
-            tiled_b,
-        )
-        a_ptr += BLOCK_K * SPLIT_K * ak_stride
-        b_ptr += BLOCK_K * SPLIT_K * bk_stride
+            # Check if we need element-wise masking
+            if iter_k >= K:
+                # Entire block out of range, skip
+                pass
+            elif block_end <= K:
+                # Entire block in range, no masking needed (fast path)
+                tiled_b = tl.load(b_ptr)
+                if USE_GDC:
+                    tl.extra.cuda.gdc_wait()
+                tiled_a = tl.load(a_ptr)
+                if CAST_TYPE:
+                    tiled_a = tiled_a.to(b_dtype)
+                accumulator += tl.dot(tiled_a, tiled_b)
+            else:
+                # Partial block, need masking (only last iteration)
+                k_offsets = tl.arange(0, BLOCK_K)
+                mask = iter_k + k_offsets < K
+                tiled_b = tl.load(b_ptr, mask=mask[:, None], other=0.0)
+                if USE_GDC:
+                    tl.extra.cuda.gdc_wait()
+                tiled_a = tl.load(a_ptr, mask=mask[None, :], other=0.0)
+                if CAST_TYPE:
+                    tiled_a = tiled_a.to(b_dtype)
+                accumulator += tl.dot(tiled_a, tiled_b)
+
+        a_ptr += STEP_K * ak_stride
+        b_ptr += STEP_K * bk_stride
+
     return accumulator
 
 
@@ -178,6 +209,7 @@ def do_expand_kernel(
         CAST_TYPE,
         cur_lora_ptr.dtype.element_ty,
         USE_GDC,
+        base_k=0,
     )
 
     tiled_c = accumulator.to(cur_lora_ptr.dtype.element_ty)
@@ -284,6 +316,7 @@ def do_shrink_kernel(
         False,
         cur_lora_ptr.dtype.element_ty,
         False,  # USE_GDC is always False in shrink kernel
+        base_k=pid_sk * BLOCK_K,
     )
     # GDC launch dependents hints the runtime system to launch dependent kernels.
     if USE_GDC:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The most significant change lies in the handling of the not `EVEN_K` scenario. In the main branch implementation, each loop iteration in this case incurs additional masking operations and `tl.dot()` calls. However, my analysis reveals that masking is only necessary for partially out-of-bound accesses. The other two scenarios are:

1. Completely within bounds: This case avoids the overhead of masking and requires only the `tl.dot()` operation.
2. Completely out of bounds: This can be skipped entirely, with no need for masking or `tl.dot()` operations.

By reducing redundant masking and `tl.dot()` operations, this modification improves computational speed. The optimization is particularly effective and friendly for GPUs with less advanced architectures. Performance results on the Metax C500 and H800 GPUs are as follows:

---

### use C500
**main**
```text
============ Serving Benchmark Result ============
Successful requests:                     100
Benchmark duration (s):                  37.34
Total input tokens:                      14351
Total generated tokens:                  10000
Request throughput (req/s):              2.68
Output token throughput (tok/s):         267.82
Total Token throughput (tok/s):          652.17
---------------Time to First Token----------------
Mean TTFT (ms):                          726.72
Median TTFT (ms):                        738.68
P99 TTFT (ms):                           817.86
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          67.93
Median TPOT (ms):                        67.48
P99 TPOT (ms):                           72.62
---------------Inter-token Latency----------------
Mean ITL (ms):                           67.26
Median ITL (ms):                         67.19
P99 ITL (ms):                            74.41
==================================================
```

**this PR**
```text
============ Serving Benchmark Result ============
Successful requests:                     100
Benchmark duration (s):                  33.68
Total input tokens:                      14351
Total generated tokens:                  10000
Request throughput (req/s):              2.97
Output token throughput (tok/s):         296.95
Total Token throughput (tok/s):          723.10
---------------Time to First Token----------------
Mean TTFT (ms):                          610.68
Median TTFT (ms):                        697.51
P99 TTFT (ms):                           799.74
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          61.74
Median TPOT (ms):                        60.56
P99 TPOT (ms):                           66.31
---------------Inter-token Latency----------------
Mean ITL (ms):                           61.12
Median ITL (ms):                         60.00
P99 ITL (ms):                            66.01
==================================================
```

---

### use H800
**main**
```text
============ Serving Benchmark Result ============
Successful requests:                     200
Failed requests:                         0
Maximum request concurrency:             20
Benchmark duration (s):                  19.24
Total input tokens:                      28840
Total generated tokens:                  20000
Request throughput (req/s):              10.40
Output token throughput (tok/s):         1039.72
Peak output token throughput (tok/s):    1176.00
Peak concurrent requests:                40.00
Total Token throughput (tok/s):          2539.00
---------------Time to First Token----------------
Mean TTFT (ms):                          138.79
Median TTFT (ms):                        157.32
P99 TTFT (ms):                           197.43
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.95
Median TPOT (ms):                        17.76
P99 TPOT (ms):                           19.06
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.77
Median ITL (ms):                         17.53
P99 ITL (ms):                            27.64
==================================================
```

**this PR**
```text
============ Serving Benchmark Result ============
Successful requests:                     200
Failed requests:                         0
Maximum request concurrency:             20
Benchmark duration (s):                  18.98
Total input tokens:                      28840
Total generated tokens:                  20000
Request throughput (req/s):              10.54
Output token throughput (tok/s):         1053.84
Peak output token throughput (tok/s):    1160.00
Peak concurrent requests:                40.00
Total Token throughput (tok/s):          2573.47
---------------Time to First Token----------------
Mean TTFT (ms):                          120.86
Median TTFT (ms):                        103.84
P99 TTFT (ms):                           198.83
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.91
Median TPOT (ms):                        17.98
P99 TPOT (ms):                           18.68
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.74
Median ITL (ms):                         17.39
P99 ITL (ms):                            30.92
==================================================
```

---

## Test plan
```bash
pytest /vllm/tests/lora/test_punica_ops.py -v
```

## Test result
All test cases passed.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

