### PR TITLE
Milestone 1 of Internal Process-level Fault Tolerance (RFC #27866)

### DIFF
--- a/tests/v1/engine/test_client_guard.py
+++ b/tests/v1/engine/test_client_guard.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+import threading
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+import zmq
+
+from vllm.utils.collection_utils import ThreadSafeDict
+from vllm.v1.engine.core_client import ClientGuard
+from vllm.v1.engine.utils import FaultHandler, FaultInfo
+
+FAULT_RECEIVER_ADDR = "tcp://127.0.0.1:8844"
+CMD_ADDR = "tcp://127.0.0.1:8845"
+FAULT_PUB_ADDR = "tcp://127.0.0.1:8846"
+FAULT_PUB_TOPIC = "vllm_fault"
+
+
+def create_test_thread_safe_dict(initial_data=None):
+    if initial_data is None:
+        initial_data = {1: "Healthy"}
+    if initial_data is None:
+        initial_data = {1: "Healthy"}
+    tsd = ThreadSafeDict()
+    if initial_data:
+        for k, v in initial_data.items():
+            tsd[k] = v
+    return tsd
+
+
+def create_client_guard(
+    engine_exception_q: asyncio.Queue, engine_status_dict: ThreadSafeDict[int, str]
+):
+    return ClientGuard(
+        fault_receiver_addr=FAULT_RECEIVER_ADDR,
+        cmd_addr=CMD_ADDR,
+        engine_registry=[b"engine_identity"],
+        engine_exception_q=engine_exception_q,
+        engine_exception_q_lock=asyncio.Lock(),
+        fault_pub_addr=FAULT_PUB_ADDR,
+        engine_status_dict=engine_status_dict,
+    )
+
+
+def test_client_guard_initialization():
+    engine_exception_q: asyncio.Queue[FaultInfo] = asyncio.Queue()
+    engine_status_dict = create_test_thread_safe_dict({1: "Healthy"})
+    guard = create_client_guard(engine_exception_q, engine_status_dict)
+
+    assert guard.engine_registry == [b"engine_identity"]
+    assert not guard.client_guard_dead
+    assert isinstance(guard.fault_handler, FaultHandler)
+    assert guard.engine_exception_q is engine_exception_q
+
+    assert guard.fault_receiver_socket.type == zmq.ROUTER
+    assert guard.cmd_socket.type == zmq.ROUTER
+    assert guard.fault_pub_socket.type == zmq.PUB
+
+    guard.shutdown_guard()
+
+
+@pytest.mark.asyncio
+async def test_handle_fault():
+    engine_exception_q: asyncio.Queue[FaultInfo] = asyncio.Queue()
+    engine_status_dict = create_test_thread_safe_dict({1: "Healthy"})
+    guard = create_client_guard(engine_exception_q, engine_status_dict)
+
+    engine_exception_q.put_nowait(
+        FaultInfo(engine_id="1", message="test exception", type="test")
+    )
+
+    guard.fault_handler.handle_fault = AsyncMock(return_value=True)
+
+    result = await guard.handle_fault("pause", 5)
+    assert result is True
+    guard.fault_handler.handle_fault.assert_awaited_once_with("pause", 5)
+
+    guard.shutdown_guard()
+
+
+def test_fault_receiver():
+    engine_exception_q: asyncio.Queue[FaultInfo] = asyncio.Queue()
+    engine_status_dict = create_test_thread_safe_dict({1: "Healthy"})
+    guard = create_client_guard(engine_exception_q, engine_status_dict)
+
+    def send_test_message():
+        ctx = zmq.Context()
+        socket = ctx.socket(zmq.DEALER)
+        socket.setsockopt(zmq.IDENTITY, b"test_sender")
+        socket.connect(FAULT_RECEIVER_ADDR)
+
+        test_fault = FaultInfo(engine_id="1", type="dead", message="test error")
+        socket.send_multipart([b"", test_fault.serialize().encode("utf-8")])
+        socket.close()
+        ctx.term()
+
+    sender_thread = threading.Thread(target=send_test_message)
+    sender_thread.start()
+
+    def check_published_message():
+        ctx = zmq.Context()
+        sub_socket = ctx.socket(zmq.SUB)
+        sub_socket.connect(FAULT_PUB_ADDR)
+        sub_socket.setsockopt_string(zmq.SUBSCRIBE, FAULT_PUB_TOPIC)
+
+        message = sub_socket.recv_string()
+        sub_socket.close()
+        ctx.term()
+
+        prefix, data = message.split("|", 1)
+        assert prefix == FAULT_PUB_TOPIC
+        assert json.loads(data) == {"1": "Dead"}
+
+    check_thread = threading.Thread(target=check_published_message)
+    check_thread.start()
+
+    time.sleep(0.1)
+
+    assert not engine_exception_q.empty()
+    received_fault = engine_exception_q.get_nowait()
+    assert received_fault.engine_id == "1"
+    assert received_fault.type == "dead"
+
+    assert engine_status_dict[1] == "Dead"
+
+    guard.shutdown_guard()
+
+
+def test_fault_receiver_unhealthy():
+    engine_exception_q: asyncio.Queue[FaultInfo] = asyncio.Queue()
+    engine_status_dict = create_test_thread_safe_dict({1: "Healthy"})
+    guard = create_client_guard(engine_exception_q, engine_status_dict)
+
+    def send_unhealthy_message():
+        ctx = zmq.Context()
+        socket = ctx.socket(zmq.DEALER)
+        socket.setsockopt(zmq.IDENTITY, b"engine_identity")
+        socket.connect(FAULT_RECEIVER_ADDR)
+
+        test_fault = FaultInfo(engine_id="1", type="error", message="test error")
+        socket.send_multipart([b"", test_fault.serialize().encode()])
+        socket.close()
+        ctx.term()
+
+    threading.Thread(target=send_unhealthy_message).start()
+    time.sleep(0.1)
+
+    assert engine_status_dict[1] == "Unhealthy"
+
+    guard.shutdown_guard()
+
+
+def test_shutdown_guard():
+    engine_exception_q: asyncio.Queue[FaultInfo] = asyncio.Queue()
+    engine_status_dict = create_test_thread_safe_dict({1: "Healthy"})
+    guard = create_client_guard(engine_exception_q, engine_status_dict)
+
+    original_fault_sock = guard.fault_receiver_socket
+    original_cmd_sock = guard.cmd_socket
+    original_pub_sock = guard.fault_pub_socket
+    original_ctx = guard.zmq_ctx
+
+    guard.shutdown_guard()
+
+    assert guard.client_guard_dead is True
+
+    with pytest.raises(zmq.ZMQError):
+        original_fault_sock.recv()
+
+    with pytest.raises(zmq.ZMQError):
+        original_cmd_sock.recv()
+
+    with pytest.raises(zmq.ZMQError):
+        original_pub_sock.send(b"test")
+
+    assert original_ctx.closed
+
+
+@pytest.mark.asyncio
+async def test_handle_fault_async():
+    engine_exception_q: asyncio.Queue[FaultInfo] = asyncio.Queue()
+    engine_status_dict = create_test_thread_safe_dict({1: "Unhealthy"})
+    guard = create_client_guard(engine_exception_q, engine_status_dict)
+
+    time.sleep(0.1)
+    ctx = zmq.Context().instance()
+    cmd_socket = ctx.socket(zmq.DEALER)
+    cmd_socket.setsockopt(zmq.IDENTITY, b"engine_identity")
+    cmd_socket.connect(CMD_ADDR)
+
+    uuid = None
+
+    def receive_cmd(cmd_socket):
+        nonlocal uuid
+        time.sleep(0.1)
+
+        identity, msg = cmd_socket.recv_multipart()
+        cmd_dict = json.loads(msg.decode("utf-8"))
+        assert cmd_dict["method"] == "retry"
+        assert cmd_dict["timeout"] == 3
+        uuid = cmd_dict["method_uuid"]
+
+    def response_cmd(cmd_socket):
+        nonlocal uuid
+        while uuid is None:
+            time.sleep(0.1)
+        execute_result = {"engine_index": 1, "success": True, "method_uuid": uuid}
+        cmd_socket.send_multipart([b"", json.dumps(execute_result).encode("utf-8")])
+
+    threading.Thread(target=receive_cmd, args=(cmd_socket,)).start()
+    threading.Thread(target=response_cmd, args=(cmd_socket,)).start()
+
+    result = await guard.handle_fault("retry", 3)
+
+    assert result is True
+    assert engine_status_dict[1] == "Healthy"
+
+    guard.shutdown_guard()

--- a/tests/v1/engine/test_engine_core_guard.py
+++ b/tests/v1/engine/test_engine_core_guard.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import logging
+import queue
+import threading
+import time
+
+import pytest
+import zmq
+
+from vllm.utils.network_utils import make_zmq_socket
+from vllm.v1.engine.core import (
+    EngineCoreGuard,
+    EngineLoopPausedError,
+)
+from vllm.v1.serial_utils import serialize_method_call
+
+CLIENT_CMD_ADDR = "tcp://127.0.0.1:8844"
+WORKER_CMD_ADDR = "tcp://127.0.0.1:8845"
+FAULT_REPORT_ADDR = "tcp://127.0.0.1:8846"
+GUARD_IDENTITY = b"engine_guard_0"
+
+
+def create_engine_core_guard(
+    fault_signal_q: queue.Queue, busy_loop_active: threading.Event
+):
+    return EngineCoreGuard(
+        engine_index=0,
+        fault_signal_q=fault_signal_q,
+        cmd_q=queue.Queue(),
+        busy_loop_active=busy_loop_active,
+        engine_input_q=queue.Queue(),
+        client_cmd_addr=CLIENT_CMD_ADDR,
+        worker_cmd_addr=WORKER_CMD_ADDR,
+        fault_report_addr=FAULT_REPORT_ADDR,
+        guard_identity=GUARD_IDENTITY,
+        tp_size=1,
+        pp_size=1,
+    )
+
+
+def test_engine_core_guard_initialization():
+    fault_signal_q: queue.Queue = queue.Queue()
+    busy_loop_active = threading.Event()
+
+    guard = create_engine_core_guard(fault_signal_q, busy_loop_active)
+
+    assert guard.engine_index == 0
+    assert guard.tp_size == 1
+    assert guard.pp_size == 1
+    assert not guard.communicator_aborted
+    assert guard.engine_running is True
+    assert guard.daemon is True
+
+    assert guard.fault_report_socket.type == zmq.DEALER
+    assert guard.client_cmd_socket.type == zmq.DEALER
+    assert guard.worker_cmd_socket.type == zmq.ROUTER
+
+    guard.shutdown()
+
+
+@pytest.mark.parametrize("instruction", ["pause", "retry"])
+def test_run_handle_instruction(instruction):
+    fault_signal_q: queue.Queue = queue.Queue()
+    busy_loop_active = threading.Event()
+
+    client_socket = make_zmq_socket(
+        ctx=zmq.Context(), path=CLIENT_CMD_ADDR, socket_type=zmq.ROUTER, bind=True
+    )
+
+    time.sleep(0.1)
+
+    guard = create_engine_core_guard(fault_signal_q, busy_loop_active)
+    time.sleep(0.1)
+
+    ctx = zmq.Context()
+    worker_cmd_socket = ctx.socket(zmq.DEALER)
+    worker_cmd_socket.setsockopt(zmq.IDENTITY, b"0_0")
+    worker_cmd_socket.connect(WORKER_CMD_ADDR)
+
+    def mock_worker_receiver(cmd_socket):
+        time.sleep(0.1)
+        logging.info("start worker")
+        identity, msg = cmd_socket.recv_multipart()
+        logging.info(identity)
+        cmd_dict = json.loads(msg.decode("utf-8"))
+        assert (
+            cmd_dict["method"] == "pause_by_signal"
+            if instruction == "pause"
+            else "retry"
+        )
+        response_dict = {"success": True, "method_uuid": cmd_dict["method_uuid"]}
+        logging.info(identity)
+        cmd_socket.send_multipart([b"", json.dumps(response_dict).encode("utf-8")])
+
+    threading.Thread(target=guard.run, daemon=True).start()
+    time.sleep(0.1)
+
+    param = {"timeout": 3}
+    if instruction == "pause":
+        param["soft_pause"] = True
+    serial_instruction = serialize_method_call(instruction, **param)
+    client_socket.send_multipart(
+        [GUARD_IDENTITY, b"", serial_instruction.encode("utf-8")]
+    )
+    if instruction == "pause":
+        fault_signal_q.put(EngineLoopPausedError(Exception("test error")))
+    elif instruction == "retry":
+        busy_loop_active.set()
+
+    threading.Thread(target=mock_worker_receiver, args=(worker_cmd_socket,)).start()
+
+    time.sleep(0.1)
+    identity, _, msg = client_socket.recv_multipart()
+    result_dict = json.loads(msg.decode("utf-8"))
+    assert result_dict["engine_index"] == 0
+    assert result_dict["success"]
+
+    time.sleep(0.1)
+
+    client_socket.close()
+    worker_cmd_socket.close()
+    guard.shutdown()

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -9,6 +9,7 @@ from vllm.config.compilation import (
     PassConfig,
 )
 from vllm.config.device import DeviceConfig
+from vllm.config.fault_tolerance import FaultToleranceConfig
 from vllm.config.kv_events import KVEventsConfig
 from vllm.config.kv_transfer import KVTransferConfig
 from vllm.config.load import LoadConfig
@@ -83,6 +84,8 @@ __all__ = [
     "SpeechToTextConfig",
     # From vllm.config.structured_outputs
     "StructuredOutputsConfig",
+    # From vllm.config.fault_tolerance
+    "FaultToleranceConfig",
     # From vllm.config.utils
     "ConfigType",
     "SupportsMetricsInfo",

--- a/vllm/config/fault_tolerance.py
+++ b/vllm/config/fault_tolerance.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import hashlib
+from typing import Any
+
+from pydantic.dataclasses import dataclass
+
+from vllm.config.utils import config
+
+
+@config
+@dataclass
+class FaultToleranceConfig:
+    """Configuration for distributed KV cache transfer."""
+
+    enable_fault_tolerance: bool = False
+    """Enable fault tolerance for detailed error recovery,
+    such as scaling down fault DPEngineCore.
+    """
+
+    engine_recovery_timeout: int = 60
+    """Timeout (in seconds) to wait for error handling instructions
+    before raising an exception. If the EngineCore encounters an
+    error, it waits up to this many seconds for instructions on how
+    to handle the error. If no instructions are received within this
+    time, the original error is raised.
+    """
+
+    internal_fault_report_port: int = 22866
+    """
+    The port to use for internal fault reporting.
+    """
+
+    external_fault_notify_port: int = 22867
+    """
+    The port to use for external fault notify.
+    """
+
+    engine_core_cmd_addr: str = ""
+    """
+    The ZMQ address between engine_core_guard and worker_guard.
+    It will be initialized and assigned in EngineCore, then passed
+    to the Worker via vllm_config—this is required for the Worker
+    to spin up the WorkerGuard.
+    """
+
+    gloo_comm_timeout: int = 30
+    """
+    The timeout for gloo communication.
+    """
+
+    def compute_hash(self) -> str:
+        """
+        WARNING: Whenever a new field is added to this config,
+        ensure that it is included in the factors list if
+        it affects the computation graph.
+        Provide a hash that uniquely identifies all the configs
+        that affect the structure of the computation
+        graph from input ids/embeddings to the final hidden states,
+        excluding anything before input ids/embeddings and after
+        the final hidden states.
+        """
+        # no factors to consider.
+        # this config will not affect the computation graph.
+        factors: list[Any] = []
+        hash_str = hashlib.md5(str(factors).encode(), usedforsecurity=False).hexdigest()
+        return hash_str
+
+    def __post_init__(self) -> None:
+        pass

--- a/vllm/config/fault_tolerance.py
+++ b/vllm/config/fault_tolerance.py
@@ -12,7 +12,7 @@ from vllm.config.utils import config
 @config
 @dataclass
 class FaultToleranceConfig:
-    """Configuration for distributed KV cache transfer."""
+    """Configurations for fault tolerance."""
 
     enable_fault_tolerance: bool = False
     """Enable fault tolerance for detailed error recovery,

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -314,7 +314,11 @@ class ParallelConfig:
 
         return answer
 
-    def stateless_init_dp_group(self) -> ProcessGroup:
+    def stateless_init_dp_group(
+        self,
+        gloo_comm_timeout: int = 30,
+        enable_fault_tolerance: bool = False,
+    ) -> ProcessGroup:
         # NOTE: In high-concurrency scenarios multiple processes
         # can pick the same (currently free) port through a race
         # condition when calling `get_open_port()`. When the first
@@ -339,6 +343,8 @@ class ParallelConfig:
                     self.data_parallel_rank,
                     self.data_parallel_size,
                     backend=current_platform.dist_backend,
+                    gloo_comm_timeout=gloo_comm_timeout,
+                    enable_fault_tolerance=enable_fault_tolerance,
                 )
             except DistNetworkError as e:
                 # We only want to retry when the root cause is EADDRINUSE.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 import time
 from contextlib import contextmanager
-from dataclasses import replace
+from dataclasses import field, replace
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
@@ -28,6 +28,7 @@ from vllm.utils import random_uuid
 from .cache import CacheConfig
 from .compilation import CompilationConfig, CompilationMode, CUDAGraphMode
 from .device import DeviceConfig
+from .fault_tolerance import FaultToleranceConfig
 from .kv_events import KVEventsConfig
 from .kv_transfer import KVTransferConfig
 from .load import LoadConfig
@@ -103,6 +104,10 @@ class VllmConfig:
     """The configurations for distributed KV cache transfer."""
     kv_events_config: KVEventsConfig | None = None
     """The configurations for event publishing."""
+    fault_tolerance_config: FaultToleranceConfig = field(
+        default_factory=FaultToleranceConfig
+    )
+    """The configurations for fault tolerance."""
     # some opaque config, only used to provide additional information
     # for the hash computation, mainly used for testing, debugging or out of
     # tree config registration.
@@ -964,7 +969,8 @@ class VllmConfig:
             f"enable_prefix_caching={self.cache_config.enable_prefix_caching}, "
             f"chunked_prefill_enabled={self.scheduler_config.chunked_prefill_enabled}, "  # noqa
             f"pooler_config={self.model_config.pooler_config!r}, "
-            f"compilation_config={self.compilation_config!r}"
+            f"compilation_config={self.compilation_config!r},"
+            f"fault_tolerance_config={self.fault_tolerance_config!r}, "
         )
 
     @model_validator(mode="after")

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -236,7 +236,7 @@ class PyNcclCommunicator:
                 cudaStream_t(stream.cuda_stream),
             )
             split_offset += split_size
-        self.nccl.ncclGroupEnd()
+        self.nccl.ncclGroupEnd(self.comm)
 
     def reduce_scatter(
         self,
@@ -301,7 +301,7 @@ class PyNcclCommunicator:
                 cudaStream_t(stream.cuda_stream),
             )
             split_offset += split_size
-        self.nccl.ncclGroupEnd()
+        self.nccl.ncclGroupEnd(self.comm)
 
     def send(self, tensor: torch.Tensor, dst: int, stream=None):
         if self.disabled:
@@ -369,7 +369,10 @@ class PyNcclCommunicator:
         self.nccl.ncclGroupStart()
 
     def group_end(self):
-        self.nccl.ncclGroupEnd()
+        self.nccl.ncclGroupEnd(self.comm)
+
+    def nccl_abort_comm(self):
+        self.nccl.ncclCommAbort(self.comm)
 
     def register_comm_window(self, tensor: torch.Tensor):
         return self.nccl.ncclCommWindowRegister(

--- a/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -136,6 +136,15 @@ class NCCLLibrary:
         Function("ncclGetVersion", ncclResult_t, [ctypes.POINTER(ctypes.c_int)]),
         # ncclResult_t ncclGetUniqueId(ncclUniqueId* uniqueId);
         Function("ncclGetUniqueId", ncclResult_t, [ctypes.POINTER(ncclUniqueId)]),
+        # ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError)
+        Function(
+            "ncclCommGetAsyncError",
+            ncclResult_t,
+            [
+                ncclComm_t,
+                ctypes.POINTER(ncclResult_t),
+            ],
+        ),
         # ncclResult_t  ncclCommInitRank(
         #   ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank);
         # note that ncclComm_t is a pointer type, so the first argument
@@ -274,6 +283,8 @@ class NCCLLibrary:
         # it is better not to call it at all.
         # ncclResult_t  ncclCommDestroy(ncclComm_t comm);
         Function("ncclCommDestroy", ncclResult_t, [ncclComm_t]),
+        # ncclResult_t ncclCommAbort(ncclComm_t comm)
+        Function("ncclCommAbort", ncclResult_t, [ncclComm_t]),
         # ncclResult_t ncclGroupStart();
         Function("ncclGroupStart", ncclResult_t, []),
         # ncclResult_t ncclGroupEnd();
@@ -360,10 +371,32 @@ class NCCLLibrary:
     def ncclGetErrorString(self, result: ncclResult_t) -> str:
         return self._funcs["ncclGetErrorString"](result).decode("utf-8")
 
-    def NCCL_CHECK(self, result: ncclResult_t) -> None:
-        if result != 0:
-            error_str = self.ncclGetErrorString(result)
-            raise RuntimeError(f"NCCL error: {error_str}")
+    def NCCL_CHECK(self, result: ncclResult_t, comm: ncclComm_t | None = None) -> None:
+        ncclSuccess = 0
+        ncclInProgress = 7
+
+        if result == ncclSuccess:
+            return
+
+        # Handle non-blocking communicators
+        if result == ncclInProgress:
+            if comm is None:
+                raise RuntimeError(
+                    "NCCL_CHECK: ncclInProgress returned but no communicator "
+                    "provided (required for non-blocking NCCL checks)."
+                )
+            while True:
+                result = self.ncclCommGetAsyncError(comm)
+                result_value = result.value
+                if result_value == ncclSuccess:
+                    # Operation has completed successfully
+                    return
+                if result_value != ncclInProgress:
+                    # Now a definite error occurred
+                    break
+
+        error_str = self.ncclGetErrorString(result)
+        raise RuntimeError(f"NCCL_CHECK failed: {error_str} (code={result})")
 
     def ncclGetRawVersion(self) -> int:
         version = ctypes.c_int()
@@ -384,6 +417,11 @@ class NCCLLibrary:
         self.NCCL_CHECK(self._funcs["ncclGetUniqueId"](ctypes.byref(unique_id)))
         return unique_id
 
+    def ncclCommGetAsyncError(self, comm: ncclComm_t) -> ncclResult_t:
+        async_error = ncclResult_t()
+        self._funcs["ncclCommGetAsyncError"](comm, ctypes.byref(async_error))
+        return async_error
+
     def unique_id_from_bytes(self, data: bytes) -> ncclUniqueId:
         if len(data) != 128:
             raise ValueError(
@@ -400,7 +438,8 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclCommInitRank"](
                 ctypes.byref(comm), world_size, unique_id, rank
-            )
+            ),
+            comm,
         )
         return comm
 
@@ -422,7 +461,8 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclAllReduce"](
                 sendbuff, recvbuff, count, datatype, op, comm, stream
-            )
+            ),
+            comm,
         )
 
     def ncclReduce(
@@ -444,7 +484,8 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclReduce"](
                 sendbuff, recvbuff, count, datatype, op, root, comm, stream
-            )
+            ),
+            comm,
         )
 
     def ncclReduceScatter(
@@ -465,7 +506,8 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclReduceScatter"](
                 sendbuff, recvbuff, count, datatype, op, comm, stream
-            )
+            ),
+            comm,
         )
 
     def ncclAllGather(
@@ -484,7 +526,8 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclAllGather"](
                 sendbuff, recvbuff, count, datatype, comm, stream
-            )
+            ),
+            comm,
         )
 
     def ncclSend(
@@ -497,7 +540,7 @@ class NCCLLibrary:
         stream: cudaStream_t,
     ) -> None:
         self.NCCL_CHECK(
-            self._funcs["ncclSend"](sendbuff, count, datatype, dest, comm, stream)
+            self._funcs["ncclSend"](sendbuff, count, datatype, dest, comm, stream), comm
         )
 
     def ncclRecv(
@@ -510,7 +553,7 @@ class NCCLLibrary:
         stream: cudaStream_t,
     ) -> None:
         self.NCCL_CHECK(
-            self._funcs["ncclRecv"](recvbuff, count, datatype, src, comm, stream)
+            self._funcs["ncclRecv"](recvbuff, count, datatype, src, comm, stream), comm
         )
 
     def ncclBroadcast(
@@ -526,17 +569,21 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclBroadcast"](
                 sendbuff, recvbuff, count, datatype, root, comm, stream
-            )
+            ),
+            comm,
         )
 
     def ncclCommDestroy(self, comm: ncclComm_t) -> None:
-        self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm))
+        self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm), comm)
+
+    def ncclCommAbort(self, comm: ncclComm_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclCommAbort"](comm), comm)
 
     def ncclGroupStart(self) -> None:
         self.NCCL_CHECK(self._funcs["ncclGroupStart"]())
 
-    def ncclGroupEnd(self) -> None:
-        self.NCCL_CHECK(self._funcs["ncclGroupEnd"]())
+    def ncclGroupEnd(self, comm) -> None:
+        self.NCCL_CHECK(self._funcs["ncclGroupEnd"](), comm)
 
     def ncclCommWindowRegister(
         self, comm: ncclComm_t, buff: buffer_type, size: int, win_flags: int
@@ -545,12 +592,13 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclCommWindowRegister"](
                 comm, buff, size, ctypes.byref(window), win_flags
-            )
+            ),
+            comm,
         )
         return window
 
     def ncclCommWindowDeregister(self, comm: ncclComm_t, window: ncclWindow_t) -> None:
-        self.NCCL_CHECK(self._funcs["ncclCommWindowDeregister"](comm, window))
+        self.NCCL_CHECK(self._funcs["ncclCommWindowDeregister"](comm, window), comm)
 
 
 __all__ = [

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -25,6 +25,7 @@ If you only need to use the distributed environment without model/pipeline
 
 import contextlib
 import gc
+import os
 import pickle
 import weakref
 from collections import namedtuple
@@ -312,6 +313,8 @@ class GroupCoordinator:
         use_device_communicator: bool,  # whether to use device communicator
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
+        enable_fault_tolerance: bool = False,
+        gloo_comm_timeout: timedelta | None = None,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -323,13 +326,30 @@ class GroupCoordinator:
         self_device_group = None
         self_cpu_group = None
 
+        if torch_distributed_backend == "nccl":
+            options = torch._C._distributed_c10d.ProcessGroupNCCL.Options()
+            if enable_fault_tolerance:
+                # need to set communicators as nonblocking to abort safely
+                options.config.blocking = 0
+                os.environ["NCCL_COMM_BLOCKING"] = "0"
+
         for ranks in group_ranks:
-            device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
-            )
+            if torch_distributed_backend == "nccl":
+                device_group = torch.distributed.new_group(
+                    ranks, backend=torch_distributed_backend, pg_options=options
+                )
+            else:
+                device_group = torch.distributed.new_group(
+                    ranks, backend=torch_distributed_backend
+                )
             # a group with `gloo` backend, to allow direct coordination between
             # processes through the CPU.
-            cpu_group = torch.distributed.new_group(ranks, backend="gloo")
+            if not enable_fault_tolerance:
+                cpu_group = torch.distributed.new_group(ranks, backend="gloo")
+            else:
+                cpu_group = torch.distributed.new_group(
+                    ranks, backend="gloo", timeout=gloo_comm_timeout
+                )
             if self.rank in ranks:
                 self.ranks = ranks
                 self.world_size = len(ranks)
@@ -1006,7 +1026,11 @@ def get_world_group() -> GroupCoordinator:
 
 
 def init_world_group(
-    ranks: list[int], local_rank: int, backend: str
+    ranks: list[int],
+    local_rank: int,
+    backend: str,
+    enable_fault_tolerance: bool = False,
+    gloo_comm_timeout: timedelta | None = None,
 ) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=[ranks],
@@ -1014,6 +1038,8 @@ def init_world_group(
         torch_distributed_backend=backend,
         use_device_communicator=False,
         group_name="world",
+        enable_fault_tolerance=enable_fault_tolerance,
+        gloo_comm_timeout=gloo_comm_timeout,
     )
 
 
@@ -1021,6 +1047,8 @@ def init_model_parallel_group(
     group_ranks: list[list[int]],
     local_rank: int,
     backend: str,
+    enable_fault_tolerance: bool = False,
+    gloo_comm_timeout: timedelta | None = None,
     use_message_queue_broadcaster: bool = False,
     group_name: str | None = None,
 ) -> GroupCoordinator:
@@ -1031,6 +1059,8 @@ def init_model_parallel_group(
         use_device_communicator=True,
         use_message_queue_broadcaster=use_message_queue_broadcaster,
         group_name=group_name,
+        enable_fault_tolerance=enable_fault_tolerance,
+        gloo_comm_timeout=gloo_comm_timeout,
     )
 
 
@@ -1094,6 +1124,31 @@ def get_pipeline_model_parallel_group():
     return get_pp_group()
 
 
+def get_all_model_groups() -> list[GroupCoordinator]:
+    group_list = []
+    global _TP
+    if _TP:
+        group_list.append(_TP)
+
+    global _PP
+    if _PP:
+        group_list.append(_PP)
+
+    global _DCP
+    if _DCP:
+        group_list.append(_DCP)
+
+    global _DP
+    if _DP:
+        group_list.append(_DP)
+
+    global _EP
+    if _EP:
+        group_list.append(_EP)
+
+    return group_list
+
+
 @contextmanager
 def graph_capture(device: torch.device):
     """
@@ -1130,6 +1185,7 @@ def init_distributed_environment(
     distributed_init_method: str = "env://",
     local_rank: int = -1,
     backend: str = "nccl",
+    enable_fault_tolerance: bool = False,
     timeout: timedelta | None = None,
 ):
     logger.debug(
@@ -1195,7 +1251,9 @@ def init_distributed_environment(
     global _WORLD, _NODE_COUNT
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))
-        _WORLD = init_world_group(ranks, local_rank, backend)
+        _WORLD = init_world_group(
+            ranks, local_rank, backend, enable_fault_tolerance, timeout
+        )
         _NODE_COUNT = _node_count(_WORLD.cpu_group)
         logger.debug("Detected %d nodes in the distributed environment", _NODE_COUNT)
     else:
@@ -1207,6 +1265,8 @@ def init_distributed_environment(
 def initialize_model_parallel(
     tensor_model_parallel_size: int = 1,
     pipeline_model_parallel_size: int = 1,
+    enable_fault_tolerance: bool = False,
+    gloo_comm_timeout: timedelta | None = None,
     decode_context_model_parallel_size: int | None = 1,
     backend: str | None = None,
 ) -> None:
@@ -1270,6 +1330,8 @@ def initialize_model_parallel(
         group_ranks,
         get_world_group().local_rank,
         backend,
+        enable_fault_tolerance,
+        gloo_comm_timeout,
         use_message_queue_broadcaster=True,
         group_name="tp",
     )
@@ -1287,6 +1349,8 @@ def initialize_model_parallel(
         group_ranks,
         get_world_group().local_rank,
         backend,
+        enable_fault_tolerance,
+        gloo_comm_timeout,
         use_message_queue_broadcaster=True,
         group_name="dcp",
     )
@@ -1299,7 +1363,12 @@ def initialize_model_parallel(
     )
     group_ranks = [x.tolist() for x in group_ranks]
     _PP = init_model_parallel_group(
-        group_ranks, get_world_group().local_rank, backend, group_name="pp"
+        group_ranks,
+        get_world_group().local_rank,
+        backend,
+        enable_fault_tolerance,
+        gloo_comm_timeout,
+        group_name="pp",
     )
 
     global _DP
@@ -1307,7 +1376,12 @@ def initialize_model_parallel(
     group_ranks = all_ranks.transpose(1, 3).reshape(-1, data_parallel_size).unbind(0)
     group_ranks = [x.tolist() for x in group_ranks]
     _DP = init_model_parallel_group(
-        group_ranks, get_world_group().local_rank, backend, group_name="dp"
+        group_ranks,
+        get_world_group().local_rank,
+        backend,
+        enable_fault_tolerance,
+        gloo_comm_timeout,
+        group_name="dp",
     )
 
     global _EP
@@ -1319,7 +1393,12 @@ def initialize_model_parallel(
     )
     group_ranks = [x.tolist() for x in group_ranks]
     _EP = init_model_parallel_group(
-        group_ranks, get_world_group().local_rank, backend, group_name="ep"
+        group_ranks,
+        get_world_group().local_rank,
+        backend,
+        enable_fault_tolerance,
+        gloo_comm_timeout,
+        group_name="ep",
     )
 
     logger.info_once(
@@ -1338,6 +1417,8 @@ def ensure_model_parallel_initialized(
     tensor_model_parallel_size: int,
     pipeline_model_parallel_size: int,
     decode_context_model_parallel_size: int | None = 1,
+    enable_fault_tolerance: bool = False,
+    gloo_comm_timeout: timedelta | None = None,
     backend: str | None = None,
 ) -> None:
     """Helper to initialize model parallel groups if they are not initialized,
@@ -1349,6 +1430,8 @@ def ensure_model_parallel_initialized(
         initialize_model_parallel(
             tensor_model_parallel_size,
             pipeline_model_parallel_size,
+            enable_fault_tolerance,
+            gloo_comm_timeout,
             decode_context_model_parallel_size,
             backend,
         )

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -458,7 +458,13 @@ def init_gloo_process_group(
 
 
 def stateless_init_torch_distributed_process_group(
-    host: str, port: int, rank: int, world_size: int, backend: str
+    host: str,
+    port: int,
+    rank: int,
+    world_size: int,
+    backend: str,
+    gloo_comm_timeout: int,
+    enable_fault_tolerance: bool = False,
 ) -> ProcessGroup:
     """
     A replacement for `torch.distributed.init_process_group` that does not
@@ -493,7 +499,10 @@ def stateless_init_torch_distributed_process_group(
     """
     init_method = get_tcp_uri(host, port)
     backend = Backend(backend)  # it is basically string
-    timeout = _get_default_timeout(backend)
+    if enable_fault_tolerance:
+        timeout = timedelta(seconds=gloo_comm_timeout)
+    else:
+        timeout = _get_default_timeout(backend)
 
     store, rank, world_size = next(
         rendezvous(init_method, rank, world_size, timeout=timeout)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -39,6 +39,7 @@ from vllm.config import (
     ConfigType,
     DeviceConfig,
     EPLBConfig,
+    FaultToleranceConfig,
     KVEventsConfig,
     KVTransferConfig,
     LoadConfig,
@@ -555,6 +556,13 @@ class EngineArgs:
     async_scheduling: bool = SchedulerConfig.async_scheduling
 
     kv_sharing_fast_prefill: bool = CacheConfig.kv_sharing_fast_prefill
+
+    # fault tolerance fields
+    enable_fault_tolerance: bool = FaultToleranceConfig.enable_fault_tolerance
+    engine_recovery_timeout: int = FaultToleranceConfig.engine_recovery_timeout
+    internal_fault_report_port: int = FaultToleranceConfig.internal_fault_report_port
+    external_fault_notify_port: int = FaultToleranceConfig.external_fault_notify_port
+    gloo_comm_timeout: int = FaultToleranceConfig.gloo_comm_timeout
 
     kv_offloading_size: float | None = CacheConfig.kv_offloading_size
     kv_offloading_backend: KVOffloadingBackend | None = (
@@ -1110,6 +1118,32 @@ class EngineArgs:
             "--structured-outputs-config", **vllm_kwargs["structured_outputs_config"]
         )
 
+        # fault tolerance arguments
+        fault_tolerance_kwargs = get_kwargs(FaultToleranceConfig)
+        fault_tolerance_group = parser.add_argument_group(
+            title="FaultToleranceConfig",
+            description=FaultToleranceConfig.__doc__,
+        )
+        fault_tolerance_group.add_argument(
+            "--enable-fault-tolerance",
+            **fault_tolerance_kwargs["enable_fault_tolerance"],
+        )
+        fault_tolerance_group.add_argument(
+            "--engine-recovery-timeout",
+            **fault_tolerance_kwargs["engine_recovery_timeout"],
+        )
+        fault_tolerance_group.add_argument(
+            "--internal-fault-report-port",
+            **fault_tolerance_kwargs["internal_fault_report_port"],
+        )
+        fault_tolerance_group.add_argument(
+            "--external-fault-notify-port",
+            **fault_tolerance_kwargs["external_fault_notify_port"],
+        )
+        fault_tolerance_group.add_argument(
+            "--gloo-comm-timeout",
+            **fault_tolerance_kwargs["gloo_comm_timeout"],
+        )
         # Other arguments
         parser.add_argument(
             "--disable-log-stats",
@@ -1634,6 +1668,16 @@ class EngineArgs:
             collect_detailed_traces=self.collect_detailed_traces,
         )
 
+        fault_tolerance_config = FaultToleranceConfig(
+            enable_fault_tolerance=self.enable_fault_tolerance,
+            engine_recovery_timeout=self.engine_recovery_timeout,
+            internal_fault_report_port=self.internal_fault_report_port
+            or FaultToleranceConfig.internal_fault_report_port,
+            external_fault_notify_port=self.external_fault_notify_port
+            or FaultToleranceConfig.external_fault_notify_port,
+            gloo_comm_timeout=self.gloo_comm_timeout,
+        )
+
         # Compilation config overrides
         if self.cuda_graph_sizes is not None:
             logger.warning(
@@ -1680,6 +1724,7 @@ class EngineArgs:
             compilation_config=self.compilation_config,
             kv_transfer_config=self.kv_transfer_config,
             kv_events_config=self.kv_events_config,
+            fault_tolerance_config=fault_tolerance_config,
             additional_config=self.additional_config,
         )
 

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -165,6 +165,19 @@ class EngineClient(ABC):
         """Perform a collective RPC call to the given path."""
         raise NotImplementedError
 
+    async def handle_fault(
+        self, instruction: str, timeout: int = 300, **kwargs
+    ) -> bool:
+        """send fault tolerance instruction to the engine"""
+        raise NotImplementedError
+
+    async def exception_reporter(self):
+        """report exception from engine_core"""
+        raise NotImplementedError
+
     async def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         """Get supported tasks"""
+        raise NotImplementedError
+
+    def shutdown(self) -> None:
         raise NotImplementedError

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -130,7 +130,10 @@ def run_headless(args: argparse.Namespace):
     )
 
     try:
-        engine_manager.join_first()
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            engine_manager.start_engine_core_monitor()
+        else:
+            engine_manager.join_first()
     finally:
         logger.info("Shutting down.")
         engine_manager.close()

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1231,6 +1231,88 @@ INVOCATION_TYPES: list[tuple[RequestType, tuple[GetHandlerFn, EndpointFn]]] = [
     (PoolingRequest, (pooling, create_pooling)),
 ]
 
+
+@router.post(
+    "/fault_tolerance/apply",
+    dependencies=[Depends(validate_json_request)],
+    responses={
+        HTTPStatus.OK.value: {"model": dict},
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+        HTTPStatus.REQUEST_TIMEOUT.value: {"model": ErrorResponse},
+        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+    },
+)
+async def send_fault_tolerance_instruction(raw_request: Request):
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail="Invalid JSON format") from e
+
+    client = engine_client(raw_request)
+
+    fault_tolerance_instruction = body.get("fault_tolerance_instruction")
+    fault_tolerance_timeout = body.get("fault_tolerance_timeout")
+    dynamic_fault_tolerance_params = body.get("fault_tolerance_params", {})
+
+    if fault_tolerance_instruction is None or fault_tolerance_timeout is None:
+        raise HTTPException(
+            status_code=400,
+            detail="fault_tolerance_instruction and"
+            " fault_tolerance_timeout is required",
+        )
+
+    if not isinstance(fault_tolerance_instruction, str):
+        raise HTTPException(
+            status_code=400, detail="fault_tolerance_instruction must be a str"
+        )
+    # Currently, only two types of instructions are supported: [pause, retry].
+    # Additional descaling instructions will be supported in future updates.
+    elif fault_tolerance_instruction not in ["pause", "retry"]:
+        raise HTTPException(
+            status_code=400, detail="not a valid fault_tolerance_instruction"
+        )
+
+    if not isinstance(fault_tolerance_timeout, int) or fault_tolerance_timeout <= 0:
+        raise HTTPException(
+            status_code=400, detail="fault_tolerance_timeout must be a positive integer"
+        )
+    try:
+        execute_result = await client.handle_fault(
+            fault_tolerance_instruction,
+            fault_tolerance_timeout,
+            **dynamic_fault_tolerance_params,
+        )
+        if execute_result:
+            return JSONResponse(
+                {
+                    "message": "instruction has been executed successfully",
+                }
+            )
+        else:
+            logger.error("Fault tolerance failed, shutdown the app.")
+            client.shutdown()
+            raise HTTPException(
+                status_code=400,
+                detail="Instruction execution failed.",
+            )
+
+    except Exception as e:
+        logger.error("Handle fault failed: %s", e)
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            detail="Handle fault failed",
+        ) from e
+
+
+@router.get("/fault_tolerance/status")
+async def get_fault_info(
+    raw_request: Request,
+):
+    client = engine_client(raw_request)
+    engine_exception_dict = await client.exception_reporter()
+    return JSONResponse(content=engine_exception_dict)
+
+
 # NOTE: Construct the TypeAdapters only once
 INVOCATION_VALIDATORS = [
     (pydantic.TypeAdapter(request_type), (get_handler, endpoint))

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -6,6 +6,7 @@ Contains helpers that are applied to collections.
 This is similar in concept to the `collections` module.
 """
 
+import threading
 from collections import UserDict, defaultdict
 from collections.abc import Callable, Generator, Hashable, Iterable, Mapping
 from typing import Generic, Literal, TypeVar
@@ -137,3 +138,211 @@ def swap_dict_values(obj: dict[_K, _V], key1: _K, key2: _K) -> None:
         obj[key1] = v2
     else:
         obj.pop(key1, None)
+
+
+# Define type variables for generic key and value types
+KT = TypeVar("KT")  # Key type variable
+VT = TypeVar("VT")  # Value type variable
+
+
+class ThreadSafeDict(Generic[KT, VT]):
+    """
+    A thread-safe generic dictionary implementation.
+    Supports all basic dictionary operations with proper synchronization
+    using a reentrant lock, and maintains type safety through generics.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty thread-safe dictionary with an internal lock."""
+        self._storage: dict[KT, VT] = {}  # Underlying storage structure
+        self._lock = threading.RLock()  # Reentrant lock for synchronization
+
+    def __setitem__(self, key: KT, value: VT) -> None:
+        """
+        Thread-safe implementation of dictionary item assignment.
+        Equivalent to dict[key] = value.
+
+        Args:
+            key: The key to associate with the value
+            value: The value to store
+        """
+        with self._lock:
+            self._storage[key] = value
+
+    def __getitem__(self, key: KT) -> VT:
+        """
+        Thread-safe implementation of dictionary item retrieval.
+        Equivalent to dict[key].
+
+        Args:
+            key: The key to look up
+
+        Returns:
+            The value associated with the key
+
+        Raises:
+            KeyError: If the key is not found
+        """
+        with self._lock:
+            return self._storage[key]
+
+    def __delitem__(self, key: KT) -> None:
+        """
+        Thread-safe implementation of dictionary item deletion.
+        Equivalent to del dict[key].
+
+        Args:
+            key: The key to remove
+
+        Raises:
+            KeyError: If the key is not found
+        """
+        with self._lock:
+            del self._storage[key]
+
+    def get(self, key: KT, default: VT | None = None) -> VT | None:
+        """
+        Thread-safe implementation of dict.get().
+
+        Args:
+            key: The key to look up
+            default: Value to return if key is not found (default: None)
+
+        Returns:
+            The value associated with the key, or default if not found
+        """
+        with self._lock:
+            return self._storage.get(key, default)
+
+    def setdefault(self, key: KT, default: VT) -> VT:
+        """
+        Thread-safe implementation of dict.setdefault().
+        Inserts key with default value if key is not present.
+
+        Args:
+            key: The key to check/insert
+            default: Value to insert if key is not found
+
+        Returns:
+            The existing value or the inserted default value
+        """
+        with self._lock:
+            return self._storage.setdefault(key, default)
+
+    def update(self, items: Iterable[tuple[KT, VT]]) -> None:
+        """
+        Thread-safe implementation of dict.update().
+        Updates dictionary with multiple key-value pairs.
+
+        Args:
+            items: Iterable of (key, value) tuples to add/update
+        """
+        with self._lock:
+            self._storage.update(items)
+
+    def pop(self, key: KT, default: VT | None = None) -> VT | None:
+        """
+        Thread-safe implementation of dict.pop().
+        Removes and returns value associated with key.
+
+        Args:
+            key: The key to remove
+            default: Value to return if key is not found (optional)
+
+        Returns:
+            The removed value or default if key not found
+
+        Raises:
+            KeyError: If key not found and no default provided
+        """
+        with self._lock:
+            return self._storage.pop(key, default)
+
+    def __contains__(self, key: KT) -> bool:
+        """
+        Thread-safe implementation of 'key in dict' check.
+
+        Args:
+            key: The key to check for existence
+
+        Returns:
+            True if key exists, False otherwise
+        """
+        with self._lock:
+            return key in self._storage
+
+    def __len__(self) -> int:
+        """
+        Thread-safe implementation of len(dict).
+
+        Returns:
+            Number of key-value pairs in the dictionary
+        """
+        with self._lock:
+            return len(self._storage)
+
+    def clear(self) -> None:
+        """Thread-safe implementation of dict.clear(). Removes all items."""
+        with self._lock:
+            self._storage.clear()
+
+    def keys(self) -> list[KT]:
+        """
+        Thread-safe implementation of dict.keys().
+        Returns a copy of all keys to prevent concurrent modification issues.
+
+        Returns:
+            List of all keys in the dictionary
+        """
+        with self._lock:
+            return list(self._storage.keys())
+
+    def values(self) -> list[VT]:
+        """
+        Thread-safe implementation of dict.values().
+        Returns a copy of all values to prevent concurrent modification issues.
+
+        Returns:
+            List of all values in the dictionary
+        """
+        with self._lock:
+            return list(self._storage.values())
+
+    def items(self) -> list[tuple[KT, VT]]:
+        """
+        Thread-safe implementation of dict.items().
+        Returns a copy of all key-value pairs to prevent concurrent modification issues.
+
+        Returns:
+            List of (key, value) tuples
+        """
+        with self._lock:
+            return list(self._storage.items())
+
+    def __str__(self) -> str:
+        """
+        Thread-safe string representation.
+
+        Returns:
+            String representation of the dictionary
+        """
+        with self._lock:
+            return str(self._storage)
+
+    def __repr__(self) -> str:
+        """
+        Thread-safe representation for debugging.
+
+        Returns:
+            Debug-friendly string representation
+        """
+        with self._lock:
+            return f"ThreadSafeDict({self._storage!r})"
+
+    # ------------------------------
+    # Critical: JSON serialization support
+    # ------------------------------
+    def to_dict(self) -> dict[KT, VT]:
+        """Convert ThreadSafeDict to a standard Python dict (thread-safe)."""
+        with self._lock:
+            return self._storage.copy()  # Return a copy of internal data

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -329,3 +329,47 @@ def zmq_socket_ctx(
 
     finally:
         ctx.destroy(linger=linger)
+
+
+def recv_router_dealer_message(
+    socket: zmq.Socket,
+    use_poller: bool = False,
+    poll_timeout: int = 1000,
+) -> tuple[bool, None | bytes, None | str]:
+    """
+    Receive multipart ZMQ messages, automatically inferring message format
+    based on socket type (ROUTER or DEALER).
+
+    Returns:
+        (success, identity, message)
+        - identity is only set for ROUTER sockets
+        - success=False on timeout or error
+    """
+    sock_type = socket.getsockopt(zmq.TYPE)
+
+    # optional non-blocking receive
+    if use_poller:
+        poller = zmq.Poller()
+        poller.register(socket, zmq.POLLIN)
+        socks = dict(poller.poll(poll_timeout))
+        if socket not in socks:
+            return (False, None, None)
+
+    parts = socket.recv_multipart()
+
+    if sock_type == zmq.ROUTER:
+        # ROUTER message: [identity, empty, message]
+        assert len(parts) == 3, f"expected 3 parts, got {len(parts)}"
+        identity_bytes, empty_frame, message_bytes = parts
+        identity = identity_bytes
+    elif sock_type == zmq.DEALER:
+        # DEALER message: [empty, message]
+        assert len(parts) == 2, f"expected 2 parts, got {len(parts)}"
+        empty_frame, message_bytes = parts
+        identity = None
+    else:
+        raise ValueError(f"Unsupported socket type: {sock_type}")
+
+    assert empty_frame == b"", f"empty frame invalid: {empty_frame}"
+    message = message_bytes.decode("utf-8")
+    return (True, identity, message)

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -4,13 +4,15 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional
 
+from vllm.v1.request import Request, RequestStatus
+
 if TYPE_CHECKING:
     from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorBase_V1
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm.v1.engine import EngineCoreOutputs
     from vllm.v1.metrics.stats import SchedulerStats
     from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
-    from vllm.v1.request import Request, RequestStatus
+    # from vllm.v1.request import Request, RequestStatus
 
 
 class SchedulerInterface(ABC):
@@ -44,6 +46,30 @@ class SchedulerInterface(ABC):
     def get_grammar_bitmask(
         self, scheduler_output: "SchedulerOutput"
     ) -> "GrammarOutput | None":
+        raise NotImplementedError
+
+    @abstractmethod
+    def preempt_request(
+        self,
+        scheduled_timestamp: float | None = None,
+        preempted_req: Request | None = None,
+    ) -> Request:
+        """
+        Preempt a running request and move it back to the waiting queue.
+
+        This method removes the specified request from the running queue (or the
+        last running request if none is specified), updates its status and statistics,
+        and moves it back to the waiting queue. Optionally records a preemption event
+        if logging is enabled.
+
+        Args:
+            scheduled_timestamp: Optional timestamp for logging the preemption event.
+            preempted_req: Specific request to preempt. If None, preempt the last
+                request in the running queue.
+
+        Returns:
+            The request that was preempted and returned to the waiting queue.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -31,7 +31,11 @@ from vllm.v1.core.sched.output import (
 )
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.utils import check_stop, remove_all
-from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
+from vllm.v1.engine import (
+    EngineCoreEventType,
+    EngineCoreOutput,
+    EngineCoreOutputs,
+)
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
@@ -277,27 +281,16 @@ class Scheduler(SchedulerInterface):
                         self.running,
                         key=lambda r: (r.priority, r.arrival_time),
                     )
-                    self.running.remove(preempted_req)
                     if preempted_req in scheduled_running_reqs:
                         scheduled_running_reqs.remove(preempted_req)
                         token_budget += num_scheduled_tokens[preempted_req.request_id]
                         req_to_new_blocks.pop(preempted_req.request_id)
                         num_scheduled_tokens.pop(preempted_req.request_id)
-                        req_index -= 1
+                    self.preempt_request(scheduled_timestamp, preempted_req)
+                    req_index -= 1
                 else:
-                    preempted_req = self.running.pop()
+                    preempted_req = self.preempt_request(scheduled_timestamp)
 
-                self.kv_cache_manager.free(preempted_req)
-                self.encoder_cache_manager.free(preempted_req)
-                preempted_req.status = RequestStatus.PREEMPTED
-                preempted_req.num_computed_tokens = 0
-                preempted_req.num_preemptions += 1
-                if self.log_stats:
-                    preempted_req.record_event(
-                        EngineCoreEventType.PREEMPTED, scheduled_timestamp
-                    )
-
-                self.waiting.prepend_request(preempted_req)
                 preempted_reqs.append(preempted_req)
                 if preempted_req == request:
                     # No more request to preempt. Cannot schedule this request.
@@ -649,6 +642,31 @@ class Scheduler(SchedulerInterface):
 
         self._update_after_schedule(scheduler_output)
         return scheduler_output
+
+    def preempt_request(
+        self,
+        scheduled_timestamp: float | None = None,
+        preempted_req: Request | None = None,
+    ) -> Request:
+        # Preempt a running request and move it back to the waiting queue.
+        if preempted_req is not None:
+            self.running.remove(preempted_req)
+        else:
+            preempted_req = self.running.pop()
+
+        self.kv_cache_manager.free(preempted_req)
+        self.encoder_cache_manager.free(preempted_req)
+        preempted_req.status = RequestStatus.PREEMPTED
+        preempted_req.num_computed_tokens = 0
+        preempted_req.num_preemptions += 1
+        if self.log_stats:
+            preempted_req.record_event(
+                EngineCoreEventType.PREEMPTED, scheduled_timestamp
+            )
+
+        self.waiting.prepend_request(preempted_req)
+
+        return preempted_req
 
     def _update_after_schedule(
         self,

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -193,6 +193,7 @@ class EngineCoreRequestType(enum.Enum):
     UTILITY = b"\x03"
     # Sentinel used within EngineCoreProc.
     EXECUTOR_FAILED = b"\x04"
+    PAUSE = b"\x05"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -778,6 +778,16 @@ class AsyncLLM(EngineClient):
                 custom_stat_loggers=None,
             )
 
+    async def handle_fault(
+        self, instruction: str, timeout: int = 300, **kwargs
+    ) -> bool:
+        """send fault tolerance instruction to the engine"""
+        return await self.engine_core.handle_fault(instruction, timeout, **kwargs)
+
+    async def exception_reporter(self):
+        """report exception in engine core"""
+        return await self.engine_core.fault_reporter()
+
     @property
     def is_running(self) -> bool:
         # Is None before the loop is started.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -359,11 +359,11 @@ def busy_loop_wrapper(busy_loop_func):
                         "Suspended and waiting for fault tolerance "
                         "instructions."
                     )
-                    # Put running requests into waiting list.
-                    # todo Changed to non-preemptive mode
 
-                    self.engine_finish_requests()
-                    # After pausing, discard the request
+                    # Put running requests into waiting list.
+                    for req in list(self.scheduler.running):
+                        self.scheduler.preempt_request(preempted_req=req)
+                    self.scheduler.prev_step_scheduled_req_ids.clear()
 
                     try:
                         # Block until recovery command received

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import gc
+import json
 import os
 import queue
 import signal
 import threading
 import time
+import traceback
 from collections import deque
 from collections.abc import Callable, Generator
 from concurrent.futures import Future
@@ -30,7 +32,7 @@ from vllm.transformers_utils.config import maybe_register_config_serialize_by_va
 from vllm.utils.gc_utils import maybe_attach_gc_debug_callback
 from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.utils.import_utils import resolve_obj_by_qualname
-from vllm.utils.network_utils import make_zmq_socket
+from vllm.utils.network_utils import make_zmq_socket, recv_router_dealer_message
 from vllm.utils.system_utils import decorate_logs, set_process_title
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -43,25 +45,36 @@ from vllm.v1.core.sched.interface import SchedulerInterface
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler as V1Scheduler
 from vllm.v1.engine import (
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     EngineCoreRequestType,
+    FinishReason,
     ReconfigureDistributedRequest,
     ReconfigureRankType,
     UtilityOutput,
     UtilityResult,
 )
+from vllm.v1.engine.exceptions import EngineLoopPausedError, FaultInfo
 from vllm.v1.engine.utils import (
     EngineHandshakeMetadata,
     EngineZmqAddresses,
+    broadcast_instruction,
     get_device_indices,
+    wait_for_instruction_result,
 )
 from vllm.v1.executor import Executor
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
+from vllm.v1.serial_utils import (
+    MsgpackDecoder,
+    MsgpackEncoder,
+    deserialize_method_call,
+    run_method,
+    serialize_method_call,
+)
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.version import __version__ as VLLM_VERSION
 
@@ -71,6 +84,318 @@ POLLING_TIMEOUT_S = 2.5
 HANDSHAKE_TIMEOUT_MINS = 5
 
 _R = TypeVar("_R")  # Return type for collective_rpc
+
+
+class EngineCoreGuard(threading.Thread):  # changed
+    """
+    EngineCoreGuard monitors a single EngineCore instance, responsible for:
+      1. Receiving fault signals (exceptions raised in EngineCore busy loop)
+      2. Receiving and executing commands from ClientGuard
+      3. Reporting execution results or faults back to the ClientGuard
+    """
+
+    def __init__(
+        self,
+        engine_index: int,
+        fault_signal_q: queue.Queue,
+        cmd_q: queue.Queue,
+        busy_loop_active: threading.Event,
+        engine_input_q: queue.Queue,
+        client_cmd_addr: str,
+        worker_cmd_addr: str,
+        fault_report_addr: str,
+        guard_identity: bytes,
+        tp_size: int,
+        pp_size: int,
+        dp_size: int,
+    ):
+        super().__init__(daemon=True)
+        self.engine_index = engine_index
+        self.fault_signal_q = fault_signal_q
+        self.cmd_q = cmd_q
+        self.busy_loop_active = busy_loop_active
+        self.engine_input_q = engine_input_q
+        self.tp_size = tp_size
+        self.pp_size = pp_size
+        self.dp_size = dp_size
+
+        self.ctx = zmq.Context()
+        # Client <-> EngineCoreGuard sockets
+        self.fault_report_socket = make_zmq_socket(
+            self.ctx,
+            fault_report_addr,
+            zmq.DEALER,
+            bind=False,
+            identity=guard_identity,
+        )
+
+        self.client_cmd_socket = make_zmq_socket(
+            self.ctx, client_cmd_addr, zmq.DEALER, bind=False, identity=guard_identity
+        )
+        # EngineCoreGuard <-> WorkerGuard sockets
+        self.worker_cmd_socket = make_zmq_socket(
+            self.ctx, worker_cmd_addr, zmq.ROUTER, bind=True
+        )
+        self.poller = zmq.Poller()
+        self.communicator_aborted = False
+        self.engine_running = True
+        self.engine_core_guard_dead = False
+        self.logger = self._make_engine_core_guard_logger()
+
+    def _make_engine_core_guard_logger(self):
+        prefix = f"[EngineCoreGuard_{self.engine_index}] "
+
+        def log(msg, *args, level="info", **kwargs):
+            """
+            level: "info", "warning", "error", "debug"
+            msg: log message
+            """
+            getattr(logger, level)(prefix + msg, *args, **kwargs)
+
+        return log
+
+    def run(self) -> None:
+        """
+        Run the main monitoring loop for EngineCoreGuard.
+        """
+        poll_timeout_ms = 100
+        while not self.engine_core_guard_dead:
+            # Check for engine fault signals
+            try:
+                engine_exception = self.fault_signal_q.get_nowait()
+                if isinstance(engine_exception, EngineLoopPausedError):
+                    # The busy loop stopped due to another critical exception,
+                    # put it back
+                    self.logger("Engine paused", level="info")
+                else:
+                    self.logger(
+                        "[EngineCoreGuard] Detected exception %s: %s\n Call Stack:\n%s",
+                        type(engine_exception).__name__,
+                        engine_exception,
+                        "".join(traceback.format_tb(engine_exception.__traceback__)),
+                        level="error",
+                    )
+                    self._report_client_exception(engine_exception)
+                self.engine_running = False
+            except queue.Empty:
+                pass
+
+            if self.client_cmd_socket.closed:
+                self.logger("Client socket closed", level="info")
+                break
+            has_msg, _, cmd_str = recv_router_dealer_message(
+                self.client_cmd_socket, use_poller=True, poll_timeout=poll_timeout_ms
+            )
+            if has_msg:
+                self.logger("Received cmd: %s", cmd_str, level="info")
+                self._execute_cmd(cmd_str)
+
+    def _stop_worker_execution(self, soft_pause: bool, timeout: int = 2) -> bool:
+        if soft_pause:
+            pause_method = "pause_by_signal"
+        else:
+            pause_method = "pause_by_abort_communicators"
+            self.communicator_aborted = True
+
+        success = self._execute_worker_method(pause_method, timeout=timeout)
+        return success
+
+    def _execute_worker_method(self, method_name, timeout: int = 5, **kwargs) -> bool:
+        identities = set()
+        for tp_rank in range(self.tp_size):
+            for pp_rank in range(self.pp_size):
+                identity = f"{tp_rank}_{pp_rank}".encode()
+                identities.add(identity)
+
+        method_uuid = broadcast_instruction(
+            self.worker_cmd_socket, identities, method_name, **kwargs
+        )
+
+        all_success = True
+        worker_responses = wait_for_instruction_result(
+            self.worker_cmd_socket, identities, method_name, timeout, method_uuid
+        )
+        for identity in identities:
+            response = worker_responses.get(identity)
+            if response is None or not response.get("success", False):
+                all_success = False
+
+        return all_success
+
+    def _report_client_exception(self, exception: Exception) -> None:
+        msg = FaultInfo.from_exception(exception, self.engine_index).serialize()
+        msg_bytes = msg.encode("utf-8")
+        self.fault_report_socket.send_multipart([b"", msg_bytes])
+
+    def _execute_cmd(self, cmd_str):
+        """
+        Execute a command received from ClientGuard.
+        """
+        method, method_uuid, method_params = deserialize_method_call(cmd_str)
+        self.logger("Executing command: %s", method, level="info")
+        try:
+            success = run_method(self, method, args=(), kwargs=method_params)
+            self.logger("Command (%s) succeeded: %s", method, success, level="info")
+
+        except Exception as e:
+            self.logger(
+                "Error executing method %s: %s %s",
+                method,
+                type(e).__name__,
+                e,
+                level="error",
+            )
+            success = False
+
+        self._send_execution_result(success, method_uuid)
+
+    def pause(self, timeout: int = 1, soft_pause: bool = True) -> bool:
+        """
+        Pause the busy loop safely.
+        Args:
+            timeout:wait for the busy loop to acknowledge the pause signal
+            soft_pause: if True, perform a soft pause using a flag; otherwise
+            abort the communicator
+        """
+        self.logger("Start pausing EngineCore", level="info")
+        start_time = time.monotonic()
+        if self.engine_running:
+            # Clear the flag to signal busy loop should pause
+            self.busy_loop_active.clear()
+            # Put a sentinel (empty request) to unblock the busy loop
+            # if it's blocked on input_queue.get()
+            self.engine_input_q.put((EngineCoreRequestType.PAUSE, None))
+            success = self._stop_worker_execution(
+                soft_pause=soft_pause,
+                timeout=timeout,
+            )
+            elapsed = time.monotonic() - start_time
+            if success:
+                remaining_timeout = max(0, timeout - elapsed)
+                try:
+                    # Wait for engine to acknowledge the pause via fault_signal_q
+                    exception = self.fault_signal_q.get(timeout=remaining_timeout)
+                    self.fault_signal_q.put(exception)
+                    success = True
+                    self.engine_running = False
+                except queue.Empty:
+                    # Timeout waiting for pause acknowledgment
+                    success = False
+        else:
+            # already paused
+            success = True
+            if not soft_pause:
+                # abort the communicators
+                self._stop_worker_execution(soft_pause=False, timeout=timeout)
+        return success
+
+    def retry(self, timeout: int = 1):
+        """
+        Handle the retry instruction from the ClientGuard.
+        This instruction tells the EngineCore to continue its busy loop
+        after being suspended due to an exception.
+        """
+        start_time = time.monotonic()
+
+        success = self._execute_worker_method("restart_worker", timeout=timeout)
+        if not success:
+            return success
+
+        if self.dp_size > 1:
+            # If the Gloo communication times out
+            # the data parallel group (dp_group) needs to be reinitialized
+            command = "reinit_dp_group_on_fault_tolerance"
+            self.cmd_q.put(serialize_method_call(command))
+        else:
+            self.cmd_q.put(None)
+
+        # Ensure busy loop has been recovered.
+        elapsed = time.monotonic() - start_time
+        remaining_timeout = max(0, timeout - elapsed)
+        success = self.busy_loop_active.wait(timeout=remaining_timeout)
+        self.engine_running = success
+        return success
+
+    def _send_execution_result(self, success: bool, method_uuid: str):
+        msg = {
+            "engine_index": self.engine_index,
+            "success": success,
+            "method_uuid": method_uuid,
+        }
+        msg_bytes = json.dumps(msg).encode("utf-8")
+        self.client_cmd_socket.send_multipart([b"", msg_bytes])
+
+    def shutdown(self):
+        if self.fault_report_socket is not None:
+            self.fault_report_socket.close()
+        if self.client_cmd_socket is not None:
+            self.client_cmd_socket.close()
+        if self.worker_cmd_socket is not None:
+            self.worker_cmd_socket.close()
+        if self.ctx is not None:
+            self.ctx.term()
+        self.engine_core_guard_dead = True
+
+
+def busy_loop_wrapper(busy_loop_func):
+    """
+    Wrap the busy loop function to perform fault tolerance.
+    """
+
+    def run_with_fault_tolerance(self):
+        while True:
+            try:
+                if self.enable_fault_tolerance:
+                    self.busy_loop_active.set()
+                busy_loop_func(self)
+            except SystemExit:
+                raise
+            except Exception as original_exc:
+                if self.enable_fault_tolerance:
+                    self.busy_loop_active.clear()
+                    self.fault_signal_q.put(original_exc)
+                    logger.warning(
+                        "[BusyLoopWrapper] EngineCore busy loop raised an exception. "
+                        "Suspended and waiting for fault tolerance "
+                        "instructions."
+                    )
+                    # Put running requests into waiting list.
+                    # todo Changed to non-preemptive mode
+
+                    self.engine_finish_requests()
+                    # After pausing, discard the request
+
+                    try:
+                        # Block until recovery command received
+                        cmd_str = self.cmd_q.get(timeout=self.engine_recovery_timeout)
+                        logger.debug(
+                            "[BusyLoopWrapper] Received fault tolerance command: %s",
+                            cmd_str,
+                        )
+                        if cmd_str is not None:
+                            method, _, params = deserialize_method_call(cmd_str)
+                            run_method(self, method, args=(), kwargs=params)
+                        # recovery succeeded; restart the busy loop
+                        continue
+                    except queue.Empty:
+                        # No handling instruction received within predefined
+                        # timeout period.
+                        logger.error(
+                            "[BusyLoopWrapper] Fault tolerance instruction not received"
+                            " within timeout. Proceeding with default exception "
+                            "handling."
+                        )
+                    except Exception as cmd_exc:
+                        raise RuntimeError(
+                            "Fault tolerance execution failed."
+                        ) from cmd_exc
+
+                # Fault tolerance not enabled OR no instruction received
+                # before timeout. Re-raise the original exception
+                # for upper level handling.
+                raise original_exc
+
+    return run_with_fault_tolerance
 
 
 class EngineCore:
@@ -563,10 +888,6 @@ class EngineCoreProc(EngineCore):
     ):
         self.input_queue = queue.Queue[tuple[EngineCoreRequestType, Any]]()
         self.output_queue = queue.Queue[tuple[int, EngineCoreOutputs] | bytes]()
-        executor_fail_callback = lambda: self.input_queue.put_nowait(
-            (EngineCoreRequestType.EXECUTOR_FAILED, b"")
-        )
-
         self.engine_index = engine_index
         identity = self.engine_index.to_bytes(length=2, byteorder="little")
         self.engines_running = False
@@ -598,6 +919,50 @@ class EngineCoreProc(EngineCore):
             )
 
             self._init_data_parallel(vllm_config)
+
+            # Initialize fault tolerance settings.
+            ft_config = vllm_config.fault_tolerance_config
+            self.enable_fault_tolerance = ft_config.enable_fault_tolerance
+            if self.enable_fault_tolerance:
+                # Track whether the busy loop is currently active.
+                self.busy_loop_active = threading.Event()
+                self.fault_signal_q: queue.Queue[Exception] = queue.Queue()
+                self.cmd_q: queue.Queue[str | None] = queue.Queue()
+                self.engine_recovery_timeout = ft_config.engine_recovery_timeout
+                engine_core_guard_ids = addresses.engine_core_guard_identities
+                assert engine_core_guard_ids is not None
+                assert addresses.fault_report_addr is not None
+                assert addresses.client_cmd_addr is not None
+                assert addresses.engine_core_cmd_addrs is not None
+                engine_core_cmd_addr = addresses.engine_core_cmd_addrs[
+                    vllm_config.parallel_config.data_parallel_rank
+                ]
+                self.engine_core_guard = EngineCoreGuard(
+                    engine_index=self.engine_index,
+                    fault_signal_q=self.fault_signal_q,
+                    cmd_q=self.cmd_q,
+                    busy_loop_active=self.busy_loop_active,
+                    engine_input_q=self.input_queue,
+                    fault_report_addr=addresses.fault_report_addr,
+                    client_cmd_addr=addresses.client_cmd_addr,
+                    worker_cmd_addr=engine_core_cmd_addr,
+                    guard_identity=engine_core_guard_ids[self.engine_index],
+                    tp_size=vllm_config.parallel_config.tensor_parallel_size,
+                    pp_size=vllm_config.parallel_config.pipeline_parallel_size,
+                    dp_size=vllm_config.parallel_config.data_parallel_size,
+                )
+                self.engine_core_guard.start()
+                vllm_config.fault_tolerance_config.engine_core_cmd_addr = (
+                    engine_core_cmd_addr
+                )
+                # Do not shut down the engine immediately upon failure.
+                executor_fail_callback = lambda: self.fault_signal_q.put(
+                    RuntimeError(f"Executor on EngineCore {self.engine_index} failed.")
+                )
+            else:
+                executor_fail_callback = lambda: self.input_queue.put_nowait(
+                    (EngineCoreRequestType.EXECUTOR_FAILED, b"")
+                )
 
             super().__init__(
                 vllm_config, executor_class, log_stats, executor_fail_callback
@@ -852,15 +1217,22 @@ class EngineCoreProc(EngineCore):
     def _init_data_parallel(self, vllm_config: VllmConfig):
         pass
 
+    @busy_loop_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore."""
 
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
             # 1) Poll the input queue until there is work to do.
+            self._check_busy_loop_active()
             self._process_input_queue()
             # 2) Step the engine core and return the outputs.
+            self._check_busy_loop_active()
             self._process_engine_step()
+
+    def _check_busy_loop_active(self):
+        if self.enable_fault_tolerance and not self.busy_loop_active.is_set():
+            raise EngineLoopPausedError("Engine busy loop is paused.")
 
     def _process_input_queue(self):
         """Exits when an engine step needs to be performed."""
@@ -908,6 +1280,8 @@ class EngineCoreProc(EngineCore):
             self.add_request(req, request_wave)
         elif request_type == EngineCoreRequestType.ABORT:
             self.abort_requests(request)
+        elif request_type == EngineCoreRequestType.PAUSE:
+            self._check_busy_loop_active()
         elif request_type == EngineCoreRequestType.UTILITY:
             client_idx, call_id, method_name, args = request
             output = UtilityOutput(call_id)
@@ -1100,6 +1474,26 @@ class EngineCoreProc(EngineCore):
                     # Limit the number of buffers to reuse.
                     reuse_buffers.append(buffer)
 
+    def engine_finish_requests(self):
+        assert isinstance(self.scheduler, V1Scheduler)
+        engine_finish_outputs = EngineCoreOutputs()
+        engine_finish_outputs.engine_index = self.engine_index
+        for request_id in list(self.scheduler.requests.keys()):
+            self.scheduler.finish_requests(request_id, RequestStatus.FINISHED_ABORTED)
+            engine_finish_outputs.outputs.append(
+                EngineCoreOutput(
+                    request_id=request_id,
+                    finish_reason=FinishReason.ABORT,
+                    new_token_ids=[],
+                )
+            )
+        self.output_queue.put((0, engine_finish_outputs))
+
+    def shutdown(self):
+        super().shutdown()
+        if self.vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            self.engine_core_guard.shutdown()
+
 
 class DPEngineCoreProc(EngineCoreProc):
     """ZMQ-wrapper for running EngineCore in background process
@@ -1154,7 +1548,10 @@ class DPEngineCoreProc(EngineCoreProc):
             )
 
         self.dp_rank = dp_rank
-        self.dp_group = vllm_config.parallel_config.stateless_init_dp_group()
+        self.dp_group = vllm_config.parallel_config.stateless_init_dp_group(
+            vllm_config.fault_tolerance_config.gloo_comm_timeout,
+            vllm_config.fault_tolerance_config.enable_fault_tolerance,
+        )
 
     def shutdown(self):
         super().shutdown()
@@ -1202,15 +1599,18 @@ class DPEngineCoreProc(EngineCoreProc):
             )
             self.output_queue.put_nowait((-1, EngineCoreOutputs(scheduler_stats=stats)))
 
+    @busy_loop_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore for data parallel case."""
 
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
             # 1) Poll the input queue until there is work to do.
+            self._check_busy_loop_active()
             self._process_input_queue()
 
             # 2) Step the engine core.
+            self._check_busy_loop_active()
             executed = self._process_engine_step()
             self._maybe_publish_request_counts()
 
@@ -1222,9 +1622,11 @@ class DPEngineCoreProc(EngineCoreProc):
 
                 # We are in a running state and so must execute a dummy pass
                 # if the model didn't execute any ready requests.
+                self._check_busy_loop_active()
                 self.execute_dummy_batch()
 
             # 3) All-reduce operation to determine global unfinished reqs.
+            self._check_busy_loop_active()
             self.engines_running = self._has_global_unfinished_reqs(
                 local_unfinished_reqs
             )
@@ -1256,6 +1658,13 @@ class DPEngineCoreProc(EngineCoreProc):
             return True
 
         return ParallelConfig.has_unfinished_dp(self.dp_group, local_unfinished)
+
+    def reinit_dp_group_on_fault_tolerance(self):
+        stateless_destroy_torch_distributed_process_group(self.dp_group)
+        self.dp_group = self.vllm_config.parallel_config.stateless_init_dp_group(
+            self.vllm_config.fault_tolerance_config.gloo_comm_timeout,
+            self.vllm_config.fault_tolerance_config.enable_fault_tolerance,
+        )
 
     def reinitialize_distributed(
         self, reconfig_request: ReconfigureDistributedRequest

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -2,9 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import contextlib
+import json
 import multiprocessing
 import queue
 import sys
+import time
 import uuid
 import weakref
 from abc import ABC, abstractmethod
@@ -18,17 +20,20 @@ from typing import Any, TypeAlias, TypeVar
 import msgspec.msgpack
 import zmq
 import zmq.asyncio
+from ray.util.state import get_actor
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.tasks import SupportedTask
 from vllm.utils.async_utils import in_loop
+from vllm.utils.collection_utils import ThreadSafeDict
 from vllm.utils.network_utils import (
     close_sockets,
     get_open_port,
     get_open_zmq_inproc_path,
     make_zmq_socket,
+    recv_router_dealer_message,
 )
 from vllm.v1.engine import (
     EngineCoreOutputs,
@@ -40,14 +45,15 @@ from vllm.v1.engine import (
 )
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.engine.core import EngineCore, EngineCoreProc
-from vllm.v1.engine.exceptions import EngineDeadError
+from vllm.v1.engine.exceptions import EngineDeadError, FaultInfo
 from vllm.v1.engine.utils import (
     CoreEngineActorManager,
     CoreEngineProcManager,
+    FaultHandler,
     launch_core_engines,
 )
 from vllm.v1.executor import Executor
-from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr
+from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr, run_method
 
 logger = init_logger(__name__)
 
@@ -249,6 +255,12 @@ class EngineCoreClient(ABC):
     ) -> list[_R]:
         raise NotImplementedError
 
+    async def handle_fault(self, instruction: str, timeout: int) -> bool:
+        raise NotImplementedError
+
+    async def fault_reporter(self):
+        raise NotImplementedError
+
 
 class InprocClient(EngineCoreClient):
     """
@@ -332,6 +344,127 @@ class InprocClient(EngineCoreClient):
         return False
 
 
+class ClientGuard:
+    def __init__(
+        self,
+        fault_receiver_addr: str,
+        cmd_addr: str,
+        engine_registry: list[bytes],
+        engine_exception_q: asyncio.Queue[FaultInfo],
+        engine_exception_q_lock: asyncio.Lock,
+        fault_pub_addr: str,
+        engine_status_dict: ThreadSafeDict[int, str],
+    ):
+        self.engine_registry = engine_registry
+        self.zmq_ctx = zmq.Context()
+        self.fault_receiver_socket = make_zmq_socket(
+            ctx=self.zmq_ctx,
+            path=fault_receiver_addr,
+            socket_type=zmq.ROUTER,
+            bind=True,
+        )
+        self.cmd_socket = make_zmq_socket(
+            ctx=self.zmq_ctx, path=cmd_addr, socket_type=zmq.ROUTER, bind=True
+        )
+
+        self.fault_pub_socket = make_zmq_socket(
+            ctx=self.zmq_ctx, path=fault_pub_addr, socket_type=zmq.PUB, bind=True
+        )
+
+        self.engine_exception_q: asyncio.Queue[FaultInfo] = engine_exception_q
+
+        self.engine_exception_q_lock = engine_exception_q_lock
+
+        self.engine_status_dict: ThreadSafeDict[int, str] = engine_status_dict
+
+        self.fault_handler = FaultHandler(
+            self.cmd_socket,
+            self.engine_registry,
+            self.engine_exception_q,
+            self.engine_exception_q_lock,
+            self.engine_status_dict,
+        )
+
+        self.logger = self._make_client_guard_logger()
+
+        self.client_guard_dead = False
+        Thread(
+            target=self.fault_receiver, daemon=True, name="EngineCoreFaultReceiver"
+        ).start()
+
+    def _make_client_guard_logger(self):
+        prefix = "[client_guard] "
+
+        def log(msg, *args, level="info", **kwargs):
+            """
+            level: "info", "warning", "error", "debug"
+            msg: log message
+            """
+            getattr(logger, level)(prefix + msg, *args, **kwargs)
+
+        return log
+
+    async def handle_fault(self, instruction: str, timeout: int, **kwargs) -> bool:
+        """
+        Executes fault tolerance measures based on the fault tolerance instructions
+         received from the api_server.
+
+        This method processes the fault tolerance commands/instructions passed by the
+        api_server, then implements corresponding fault tolerance strategies or actions
+        to handle system anomalies, ensuring stable operation or graceful degradation
+        of the relevant components.
+        """
+        return await run_method(
+            self.fault_handler,
+            "handle_fault",
+            args=(instruction, timeout),
+            kwargs=kwargs,
+        )
+
+    def fault_receiver(self):
+        """
+        Continuously listens for exception/error information sent from the engine_core.
+
+        This method maintains a persistent listening state to capture and process
+        fault-related data, exceptions, or error notifications emitted by the
+        engine_core component. It is designed to run continuously to ensure no critical
+        error information from the engine core is missed.
+        """
+        while True:
+            _, sender_identity, message = recv_router_dealer_message(
+                self.fault_receiver_socket
+            )
+            if self.client_guard_dead:
+                self.logger("client guard dead, stop receiving fault")
+                break
+            assert message is not None, (
+                "message should not be None at fault tolerance scenario"
+            )
+
+            fault_info = FaultInfo.from_json(message)
+            self.engine_exception_q.put_nowait(fault_info)
+            engine_status = "Dead" if "dead" in fault_info.type else "Unhealthy"
+            self.engine_status_dict[int(fault_info.engine_id)] = engine_status
+            self.fault_pub_socket.send_string(
+                f"vllm_fault|{json.dumps(self.engine_status_dict.to_dict())}"
+            )
+            # TODO Asynchronous issuance of pause commands and design of engine
+            #  core status
+            # Pause healthy engines on fault.
+            # Pause will be invoked again during fault-tolerance handling,
+            # so it's unnecessary to track whether all engines are currently
+            # paused.
+            self.fault_handler.submit_fault("pause", 5, soft_pause=False)
+
+    def shutdown_guard(self):
+        self.client_guard_dead = True
+        self.fault_receiver_socket.close()
+        self.cmd_socket.close()
+        self.fault_pub_socket.close()
+        self.zmq_ctx.term()
+        self.logger("ClientGuard is closed.", level="info")
+
+
 @dataclass
 class BackgroundResources:
     """Used as a finalizer for clean shutdown, avoiding
@@ -350,6 +483,7 @@ class BackgroundResources:
     output_queue_task: asyncio.Task | None = None
     stats_update_task: asyncio.Task | None = None
     shutdown_path: str | None = None
+    client_guard: ClientGuard | None = None
 
     # Set if any of the engines are dead. Here so that the output
     # processing threads can access it without holding a ref to the client.
@@ -363,6 +497,8 @@ class BackgroundResources:
             self.engine_manager.close()
         if self.coordinator is not None:
             self.coordinator.close()
+        if self.client_guard is not None:
+            self.client_guard.shutdown_guard()
 
         if isinstance(self.output_socket, zmq.asyncio.Socket):
             # Async case.
@@ -454,6 +590,7 @@ class MPClient(EngineCoreClient):
         self.resources = BackgroundResources(ctx=sync_ctx)
         self._finalizer = weakref.finalize(self, self.resources)
         success = False
+
         try:
             # State used for data parallel.
             self.engines_running = False
@@ -536,8 +673,41 @@ class MPClient(EngineCoreClient):
             self.pending_messages = deque[tuple[zmq.MessageTracker, Any]]()
 
             # Start monitoring engine core processes for unexpected failures
-            self.start_engine_core_monitor()
+            if self.vllm_config.parallel_config.data_parallel_backend == "ray":
+                self.start_engine_core_actor_monitor()
+            else:
+                self.start_engine_core_monitor()
 
+            if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+                self.engine_exception_q: asyncio.Queue[FaultInfo] = asyncio.Queue()
+                assert addresses.fault_report_addr is not None, (
+                    "addresses.fault_report_addr should not be None at fault tolerance"
+                    " scenario"
+                )
+                assert addresses.client_cmd_addr is not None, (
+                    "addresses.client_cmd_addr should not be None at fault tolerance"
+                    " scenario"
+                )
+                self.engine_registry = addresses.engine_core_guard_identities
+                self.engine_exception_q_lock = asyncio.Lock()
+                assert self.engine_registry is not None
+                assert addresses.fault_pub_socket_addr is not None, (
+                    "addresses.fault_pub_socket_addr should not be None at"
+                    "fault tolerance scenario"
+                )
+                self.engine_status_dict: ThreadSafeDict[int, str] = ThreadSafeDict()
+                for engine_id in range(vllm_config.parallel_config.data_parallel_size):
+                    self.engine_status_dict[engine_id] = "Healthy"
+                self.client_guard = ClientGuard(
+                    addresses.fault_report_addr,
+                    addresses.client_cmd_addr,
+                    self.engine_registry,
+                    self.engine_exception_q,
+                    self.engine_exception_q_lock,
+                    addresses.fault_pub_socket_addr,
+                    self.engine_status_dict,
+                )
+                self.resources.client_guard = self.client_guard
             success = True
         finally:
             if not success:
@@ -568,6 +738,51 @@ class MPClient(EngineCoreClient):
     def dp_engines_running(self) -> bool:
         return self.engines_running
 
+    def start_engine_core_actor_monitor(self):
+        engine_manager = self.resources.engine_manager
+        if (
+            not isinstance(engine_manager, CoreEngineActorManager)
+            or not self.vllm_config.fault_tolerance_config.enable_fault_tolerance
+        ):
+            return
+
+        def monitor_actors():
+            all_actors = (
+                engine_manager.local_engine_actors + engine_manager.remote_engine_actors
+            )
+            if not all_actors:
+                return
+            while True:
+                for actor in all_actors:
+                    actor_id = actor._actor_id.hex()
+                    if actor in engine_manager.local_engine_actors:
+                        actor_index = engine_manager.local_engine_actors.index(actor)
+                    elif actor in engine_manager.remote_engine_actors:
+                        actor_index = engine_manager.remote_engine_actors.index(
+                            actor
+                        ) + len(engine_manager.local_engine_actors)
+                    else:
+                        logger.error("Unknown actor (ID: %s)", actor_id)
+                        continue
+
+                    actor_info = get_actor(actor_id)
+                    if actor_info.state == "DEAD":
+                        fault_info = FaultInfo(
+                            type="engine_actor dead",
+                            message=str(actor_info.death_cause),
+                            engine_id=str(actor_index),
+                            additional_info=None,
+                        )
+                        all_actors.remove(actor)
+                        engine_manager.engine_down_socket.send_multipart(
+                            [b"", fault_info.serialize().encode("utf-8")]
+                        )
+
+                time.sleep(3)
+                # Implements the "check once every 3 seconds" frequency control
+
+        Thread(target=monitor_actors, daemon=True, name="MPClientEngineMonitor").start()
+
     def start_engine_core_monitor(self):
         """Start a monitor thread for engine core processes."""
         engine_manager = self.resources.engine_manager
@@ -587,19 +802,49 @@ class MPClient(EngineCoreClient):
         # callback to inform the engine.
         def monitor_engine_cores():
             sentinels = [proc.sentinel for proc in engine_processes]
-            died = multiprocessing.connection.wait(sentinels)
+
             _self = self_ref()
-            if not _self or _self.resources.engine_dead:
-                return
-            _self.resources.engine_dead = True
-            proc_name = next(
-                proc.name for proc in engine_processes if proc.sentinel == died[0]
-            )
-            logger.error(
-                "Engine core proc %s died unexpectedly, shutting down client.",
-                proc_name,
-            )
-            _self.shutdown()
+            if self.vllm_config.fault_tolerance_config.enable_fault_tolerance:
+                while sentinels:
+                    died = multiprocessing.connection.wait(sentinels)
+                    for sentinel in died:
+                        died_proc = next(
+                            proc
+                            for proc in engine_processes
+                            if proc.sentinel == sentinel
+                        )
+                        fault_info = FaultInfo(
+                            type="engine_core dead",
+                            message=f"Engine core proc {died_proc.pid} "
+                            f"(PID: {died_proc.name}) died unexpectedly.",
+                            engine_id=died_proc.name[-1],
+                            additional_info=None,
+                        )
+                        engine_manager.engine_down_socket.send_multipart(
+                            [b"", fault_info.serialize().encode("utf-8")]
+                        )
+
+                        sentinels.remove(sentinel)
+
+                        logger.error(
+                            "Engine core proc %s died unexpectedly",
+                            died_proc.name,
+                        )
+            else:
+                died = multiprocessing.connection.wait(sentinels)
+                _self = self_ref()
+                if not _self or _self.resources.engine_dead:
+                    return
+                proc_name = next(
+                    proc.name for proc in engine_processes if proc.sentinel == died[0]
+                )
+                logger.error(
+                    "Engine core proc %s died unexpectedly, shutting down client.",
+                    proc_name,
+                )
+            if _self and _self.resources:
+                _self.resources.engine_dead = True
+                _self.shutdown()
             # Note: For MPClient, we don't have a failure callback mechanism
             # like MultiprocExecutor, but we set engine_dead flag which will
             # cause subsequent operations to raise EngineDeadError
@@ -607,6 +852,13 @@ class MPClient(EngineCoreClient):
         Thread(
             target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
         ).start()
+
+    async def handle_fault(self, instruction: str, timeout: int, **kwargs) -> bool:
+        """handle fault of current instance by instruction"""
+        return await self.client_guard.handle_fault(instruction, timeout, **kwargs)
+
+    async def fault_reporter(self):
+        return self.engine_status_dict.to_dict()
 
 
 def _process_utility_output(

--- a/vllm/v1/engine/exceptions.py
+++ b/vllm/v1/engine/exceptions.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import time
+from dataclasses import dataclass
+
+
 class EngineGenerateError(Exception):
     """Raised when a AsyncLLM.generate() fails. Recoverable."""
 
@@ -16,3 +21,69 @@ class EngineDeadError(Exception):
         # Make stack trace clearer when using with LLMEngine by
         # silencing irrelevant ZMQError.
         self.__suppress_context__ = suppress_context
+
+
+class EngineLoopPausedError(Exception):
+    """
+    Raised when the EngineCore loop is temporarily paused on purpose,
+    e.g., to handle fault-tolerance.
+    """
+
+    pass
+
+
+@dataclass
+class FaultInfo:
+    type: str
+    message: str
+    engine_id: str
+    timestamp: str | None = None
+    additional_info: dict | None = None
+
+    def __post_init__(self):
+        # If no exit time is specified, the current timestamp will be used by default.
+
+        local_time = time.localtime(time.time())
+        if self.timestamp is None:
+            self.timestamp = time.strftime("%H:%M:%S", local_time)
+
+    @classmethod
+    def from_exception(
+        cls,
+        exception: Exception,
+        engine_id: str | int,
+        additional_info: dict | None = None,
+    ) -> "FaultInfo":
+        """Create FaultInfo from an exception."""
+        return cls(
+            type=type(exception).__name__,
+            message=str(exception),
+            engine_id=str(engine_id),
+            additional_info=additional_info or {},
+        )
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        return {
+            "type": self.type,
+            "message": self.message,
+            "timestamp": self.timestamp,
+            "engine_id": self.engine_id,
+            "additional_info": self.additional_info,
+        }
+
+    def serialize(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "FaultInfo":
+        """Create FaultInfo from JSON string."""
+        data = json.loads(json_str)
+        return cls(
+            type=data["type"],
+            message=data["message"],
+            timestamp=data["timestamp"],
+            engine_id=data["engine_id"],
+            additional_info=data["additional_info"],
+        )

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1477,7 +1477,7 @@ class FaultHandler:
 
     def submit_fault(self, instruction: str, timeout: int, **kwargs) -> None:
         """
-        hread-safe fire-and-forget submission of a fault handling task.
+        thread-safe fire-and-forget submission of a fault handling task.
         This method can be called from **any thread**
         """
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
+import asyncio
 import contextlib
+import json
+import multiprocessing
 import os
+import time
+import uuid
 import weakref
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -20,10 +24,18 @@ from vllm.config import CacheConfig, ParallelConfig, VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
-from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
+from vllm.utils.collection_utils import ThreadSafeDict
+from vllm.utils.network_utils import (
+    get_open_zmq_ipc_path,
+    make_zmq_socket,
+    recv_router_dealer_message,
+    zmq_socket_ctx,
+)
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
+from vllm.v1.engine.exceptions import FaultInfo
 from vllm.v1.executor import Executor
+from vllm.v1.serial_utils import serialize_method_call
 from vllm.v1.utils import get_engine_client_zmq_addr, shutdown
 
 if TYPE_CHECKING:
@@ -56,6 +68,8 @@ class EngineZmqAddresses:
     inputs: list[str]
     # ZMQ output socket addresses for each front-end client (responses)
     outputs: list[str]
+
+    engine_core_cmd_addrs: list[str] | None = None
     # ZMQ input socket address of DP coordinator if applicable
     coordinator_input: str | None = None
     # ZMQ output socket address of DP coordinator if applicable
@@ -64,6 +78,14 @@ class EngineZmqAddresses:
     # Not used by engine, just relayed to front-end in handshake response.
     # Only required for external DP LB case.
     frontend_stats_publish_address: str | None = None
+    #
+    fault_report_addr: str | None = None
+    # ZMQ client_cmd socket address of client guard
+    client_cmd_addr: str | None = None
+    # identities of engine_core_guard
+    engine_core_guard_identities: list[bytes] | None = None
+    # ZMQ fault_pub_socket address of client guard
+    fault_pub_socket_addr: str | None = None
 
 
 @dataclass
@@ -105,7 +127,23 @@ class CoreEngineProcManager:
             "executor_class": executor_class,
             "log_stats": log_stats,
         }
-
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            zmq_ctx = zmq.Context()
+            identity = generate_identity_group(
+                "core_engine_proc_manager", "client_guard", "report", 1
+            )[0]
+            zmq_addr = get_engine_client_zmq_addr(
+                local_only=False,
+                host=vllm_config.parallel_config.data_parallel_master_ip,
+                port=vllm_config.fault_tolerance_config.internal_fault_report_port,
+            )
+            self.engine_down_socket = make_zmq_socket(
+                ctx=zmq_ctx,
+                path=zmq_addr,
+                socket_type=zmq.DEALER,
+                bind=False,
+                identity=identity,
+            )
         if client_handshake_address:
             common_kwargs["client_handshake_address"] = client_handshake_address
 
@@ -131,6 +169,8 @@ class CoreEngineProcManager:
 
         self._finalizer = weakref.finalize(self, shutdown, self.processes)
 
+        self.vllm_config = vllm_config
+
         data_parallel = vllm_config.parallel_config.data_parallel_size > 1
         try:
             for proc, local_dp_rank in zip(self.processes, local_dp_ranks):
@@ -154,12 +194,49 @@ class CoreEngineProcManager:
             if self.finished_procs():
                 self.close()
 
+    def _report_engine_dead(self, dead_message):
+        """Send engine dead message to ClientGuard"""
+        try:
+            self.engine_down_socket.send_multipart(
+                [
+                    b"",  # Empty frame separator
+                    dead_message.encode("utf-8"),
+                ]
+            )
+            logger.info("Sent message to ClientGuard: %s", dead_message)
+        except Exception as e:
+            logger.error("Failed to send message: %s", e)
+
     def close(self):
         """Shutdown all procs."""
         self._finalizer()
 
+    def start_engine_core_monitor(self):
+        sentinels = [proc.sentinel for proc in self.processes]
+        while self.processes:
+            died = multiprocessing.connection.wait(sentinels)
+            for sentinel in died:
+                died_proc = next(
+                    proc for proc in self.processes if proc.sentinel == sentinel
+                )
+                fault_info = FaultInfo(
+                    type="engine_core dead",
+                    message=f"Engine core proc {died_proc.pid} "
+                    f"(PID: {died_proc.name}) died unexpectedly.",
+                    engine_id=died_proc.name[-1],
+                    additional_info=None,
+                )
+                self.engine_down_socket.send_multipart(
+                    [b"", fault_info.serialize().encode("utf-8")]
+                )
+                if isinstance(sentinel, int) and sentinel in sentinels:
+                    sentinels.remove(sentinel)
+                logger.error(
+                    "Engine core proc %s died unexpectedly",
+                    died_proc,
+                )
+
     def join_first(self):
-        """Wait for any process to exit."""
         connection.wait(proc.sentinel for proc in self.processes)
 
     def sentinels(self) -> list:
@@ -258,6 +335,24 @@ class CoreEngineActorManager:
         local_engine_count = vllm_config.parallel_config.data_parallel_size_local
         world_size = vllm_config.parallel_config.world_size
 
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            zmq_ctx = zmq.Context()
+            zmq_addr = get_engine_client_zmq_addr(
+                local_only=False,
+                host=vllm_config.parallel_config.data_parallel_master_ip,
+                port=vllm_config.fault_tolerance_config.internal_fault_report_port,
+            )
+            identity = generate_identity_group(
+                "core_engine_actor_manager", "clinet_guard", "report", 1
+            )[0]
+            self.engine_down_socket = make_zmq_socket(
+                ctx=zmq_ctx,
+                path=zmq_addr,
+                socket_type=zmq.DEALER,
+                bind=False,
+                identity=identity,
+            )
+
         if ray.is_initialized():
             logger.info("Ray is already initialized. Skipping Ray initialization.")
         else:
@@ -323,6 +418,7 @@ class CoreEngineActorManager:
                     local_dp_rank=local_index,
                 )
             )
+
             if local_client:
                 self.local_engine_actors.append(actor)
             else:
@@ -799,6 +895,30 @@ def launch_core_engines(
         ],
     )
 
+    if vllm_config.fault_tolerance_config.enable_fault_tolerance is True:
+        addresses.engine_core_cmd_addrs = [
+            get_engine_client_zmq_addr(client_local_only, host) for _ in range(dp_size)
+        ]
+        addresses.fault_report_addr = get_engine_client_zmq_addr(
+            local_only=False,
+            host=vllm_config.parallel_config.data_parallel_master_ip,
+            port=vllm_config.fault_tolerance_config.internal_fault_report_port,
+        )
+        addresses.client_cmd_addr = get_engine_client_zmq_addr(
+            local_only=client_local_only, host=host
+        )
+        addresses.engine_core_guard_identities = generate_identity_group(
+            peer1="client",
+            peer2="engine_core_guard",
+            use="report and cmd",
+            n=dp_size,
+        )
+        addresses.fault_pub_socket_addr = get_engine_client_zmq_addr(
+            local_only=False,
+            host="0.0.0.0",
+            port=vllm_config.fault_tolerance_config.external_fault_notify_port,
+        )
+
     # Run the DP Coordinator process with rank 0 when in
     # online DP mode.
     run_coordinator = dp_size > 1 and not offline_mode and dp_rank == 0
@@ -1061,3 +1181,308 @@ def wait_for_engine_startup(
             "local" if local else "remote",
             eng_index,
         )
+
+
+def generate_unique_uuids(n: int):
+    """Generate a set of unique UUID v4 objects.
+
+    Generates a specified number of unique UUID (version 4) objects.
+    UUID v4 uses cryptographically strong random numbers, ensuring
+    an extremely low probability of collisions.
+
+    Args:
+        n: The number of unique UUIDs to generate
+
+    Returns:
+        A set containing 'n' unique UUID objects
+    """
+    uuids: set[uuid.UUID] = set()
+    while len(uuids) < n:
+        # Generate a random UUID (version 4) and add to the set
+        uuids.add(uuid.uuid4())
+    return uuids
+
+
+def generate_identity_group(peer1, peer2, use, n):
+    """
+    Generate n unique identities for ZMQ ROUTER nodes
+
+    Format: peer1_peer2_use_random number
+    Return: list with identities in byte type as elements
+    """
+    identitys = list()
+    uuids = generate_unique_uuids(n)
+    for id in uuids:
+        identity_str = f"{peer1}_{peer2}_{use}_{id}".encode()
+        identitys.append(identity_str)
+    return identitys
+
+
+async def get_queue_snapshot(queue: asyncio.Queue, queue_lock: asyncio.Lock) -> list:
+    """Thread-safe snapshot of the exception queue."""
+    async with queue_lock:
+        items = []
+        # get item at first
+        while not queue.empty():
+            item = queue.get_nowait()
+            items.append(item)
+        # put item into queue again
+        for item in items:
+            queue.put_nowait(item)
+    return items
+
+
+def broadcast_instruction(
+    cmd_socket,
+    target_identities: set[bytes] | list[bytes],
+    method_name: str,
+    method_uuid: str | None = None,
+    **kwargs,
+) -> str:
+    """
+    Broadcast an instruction message to multiple remote endpoints.
+    It serializes the specified method_name along with its parameters and
+    dispatches it to all target identities via the provided ZeroMQ socket.
+    """
+    if method_uuid is None:
+        method_uuid = str(uuid.uuid4())
+
+    for identity in target_identities:
+        serialized_instruction = serialize_method_call(
+            method_name, method_uuid, **kwargs
+        )
+        cmd_socket.send_multipart(
+            [identity, b"", serialized_instruction.encode("utf-8")]
+        )
+
+    return method_uuid
+
+
+def wait_for_instruction_result(
+    cmd_socket,
+    target_identities: set[bytes] | list[bytes],
+    method_name: str,
+    timeout: int,
+    method_uuid: str,
+) -> dict[bytes, dict]:
+    """
+    Wait for acknowledgment or result messages from multiple endpoints.
+    This function listens for responses corresponding to a previously broadcasted
+    instruction, identified by the given `method_uuid`.
+
+    Args:
+        cmd_socket: The socket used to receive responses.
+        target_identities: Identities that are expected to respond.
+        method_name: The name of the method_name (used for logging).
+        timeout: The maximum wait time (in seconds).
+        method_uuid: The unique identifier associated with the method_name.
+
+    Notes:
+        - This function does not raise exceptions for timeouts or parsing errors.
+          Instead, it logs the issue and returns whatever responses have been collected.
+    """
+    start = time.monotonic()
+    responses: dict[bytes, dict] = {}
+
+    target_identities = set(target_identities)
+
+    while target_identities:
+        remaining = timeout - (time.monotonic() - start)
+        if remaining <= 0:
+            logger.debug(
+                'Timeout while waiting for responses of command "%s" '
+                "from identities: %s",
+                method_name,
+                target_identities,
+            )
+            # Return partial results collected so far
+            return responses
+
+        try:
+            has_msg, identity, response = recv_router_dealer_message(
+                cmd_socket,
+                use_poller=True,
+                poll_timeout=int(remaining * 1000),
+            )
+
+            # Skip if no message was received during this polling period
+            if not has_msg:
+                continue
+
+            assert identity is not None
+            assert response is not None
+            response_dict = json.loads(response)
+            recv_uuid = response_dict.get("method_uuid")
+
+            # Ignore outdated or unrelated messages
+            if recv_uuid != method_uuid:
+                logger.debug(
+                    "Discarding outdated response: expected method_uuid=%s, got %s",
+                    method_uuid,
+                    recv_uuid,
+                )
+                continue
+
+            # Record this engine's response
+            responses[identity] = response_dict
+            target_identities.discard(identity)
+
+        except Exception as e:
+            logger.error("Error while processing engine response: %s", e)
+            # Return partial results even on exception to avoid data loss
+            return responses
+
+    return responses
+
+
+class FaultHandler:
+    def __init__(
+        self,
+        cmd_socket: zmq.Socket,
+        client_cmd_registry: list[bytes],
+        engine_exception_q: asyncio.Queue[FaultInfo],
+        engine_exception_q_lock: asyncio.Lock,
+        engine_status_dict: ThreadSafeDict[int, str],
+    ) -> None:
+        self.cmd_socket = cmd_socket
+        self.engine_exception_q = engine_exception_q
+        self.engine_exception_q_lock = engine_exception_q_lock
+        self.engine_status_dict: ThreadSafeDict[int, str] = engine_status_dict
+        self.engine_identity_to_index: dict[bytes, int] = {
+            identity: i for i, identity in enumerate(client_cmd_registry)
+        }
+        # ensure handle_fault is executed sequentially
+        self._task_queue: asyncio.Queue = asyncio.Queue()
+        self._loop = asyncio.get_event_loop()
+        self._dispatcher_task = self._loop.create_task(self._dispatcher())
+
+        self.logger = self._make_fault_handler_logger()
+
+    def _make_fault_handler_logger(self):
+        prefix = "[FaultHandler] "
+
+        def log(msg, *args, level="info", **kwargs):
+            """
+            level: "info", "warning", "error", "debug"
+            msg: log message
+            """
+            getattr(logger, level)(prefix + msg, *args, **kwargs)
+
+        return log
+
+    async def _dispatcher(self):
+        while True:
+            # each elements in the queue contains:
+            # (instruction, timeout, kwargs, future)
+            instruction, timeout, kwargs, fut = await self._task_queue.get()
+            try:
+                result = await self._handle_fault_internal(
+                    instruction, timeout, **kwargs
+                )
+                if fut:
+                    fut.set_result(result)
+            except Exception as e:
+                if fut:
+                    fut.set_exception(e)
+
+    async def _handle_fault_internal(
+        self, instruction: str, timeout: int, **kwargs
+    ) -> bool:
+        if instruction == "retry" and "Dead" in self.engine_status_dict.values():
+            self.logger(
+                "engine_core dead unexpectedly, retry is impossible,"
+                "shutdown will be performed",
+                level="info",
+            )
+            return False
+
+        if instruction == "pause":
+            logger.warning(
+                "Pause operation is best-effort only. Due to the complexity of "
+                "collective communications (e.g., timing dependencies and "
+                "synchronization barriers), pausing may not always succeed. If "
+                "the process remains unresponsive or collective operations "
+                "cannot be interrupted, consider shutting down and restarting "
+                "the instance."
+            )
+
+            dead_engine_indices = {
+                index
+                for index, status in self.engine_status_dict.items()
+                if status == "Dead"
+            }
+
+            target_engines = {
+                identity
+                for identity, index in self.engine_identity_to_index.items()
+                if index not in dead_engine_indices
+            }
+        else:
+            target_engines = set(self.engine_identity_to_index.keys())
+
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
+        method_uuid = broadcast_instruction(
+            self.cmd_socket,
+            target_engines,
+            instruction,
+            **kwargs,
+        )
+
+        engine_responses = wait_for_instruction_result(
+            self.cmd_socket, target_engines, instruction, timeout, method_uuid
+        )
+
+        # check the execution results
+        all_success = True
+        for engine_id in target_engines:
+            engine_index = self.engine_identity_to_index.get(engine_id, "?")
+            response = engine_responses.get(engine_id)
+
+            if response is None:
+                self.logger(
+                    "EngineCoreGuard[%s] did not respond"
+                    ' to command "%s" within timeout.',
+                    engine_index,
+                    instruction,
+                    level="info",
+                )
+                all_success = False
+            elif not response.get("success", False):
+                self.logger(
+                    'EngineCoreGuard[%s] failed to execute command "%s" (reason: %s)',
+                    engine_index,
+                    instruction,
+                    response.get("reason", "unknown"),
+                    level="error",
+                )
+                all_success = False
+
+        if instruction == "retry" and all_success:
+            for engine_index, _ in self.engine_status_dict.items():
+                self.engine_status_dict[engine_index] = "Healthy"
+            # todo: should we also clear the engine_exception_q here?
+        return all_success
+
+    async def handle_fault(self, instruction: str, timeout: int, **kwargs) -> bool:
+        """
+        Async interface for run_method, returns a Future that can be awaited.
+        This method **must be called from the event loop thread** where this
+        FaultHandler was created.
+        """
+        fut = self._loop.create_future()
+        await self._task_queue.put((instruction, timeout, kwargs, fut))
+        return await fut
+
+    def submit_fault(self, instruction: str, timeout: int, **kwargs) -> None:
+        """
+        hread-safe fire-and-forget submission of a fault handling task.
+        This method can be called from **any thread**
+        """
+
+        def _enqueue():
+            fut = self._loop.create_future()
+            self._task_queue.put_nowait((instruction, timeout, kwargs, fut))
+
+        self._loop.call_soon_threadsafe(_enqueue)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3,6 +3,7 @@
 
 import gc
 import itertools
+import threading
 import time
 from collections import defaultdict
 from collections.abc import Iterator
@@ -92,6 +93,7 @@ from vllm.v1.attention.backends.utils import (
     split_attn_metadata,
 )
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
+from vllm.v1.engine.exceptions import EngineLoopPausedError
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     ChunkedLocalAttentionSpec,
@@ -532,6 +534,12 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Ephemeral state transferred between execute_model() and sample_tokens().
         self.execute_model_state: ExecuteModelState | None = None
+
+        self.pause_event = threading.Event()
+
+    def _check_pause_event(self):
+        if self.pause_event.is_set():
+            raise EngineLoopPausedError("Worker is paused.")
 
     def reset_mm_cache(self) -> None:
         if self.mm_budget:
@@ -2433,6 +2441,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         Returns:
             Model output tensor
         """
+        self._check_pause_event()
         return self.model(
             input_ids=input_ids,
             positions=positions,
@@ -3566,6 +3575,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     ubatch_slices=ubatch_slices,
                 ),
             ):
+                self._check_pause_event()
                 outputs = self.model(
                     input_ids=input_ids,
                     positions=positions,


### PR DESCRIPTION


**Co-authored with:** @zWaNg3 @a798347923 @205150940
## Purpose

### Summary

This PR implements **Milestone 1** of RFC #27866, introducing a fault tolerance framework for vLLM.  
It provides mechanisms to **detect runtime exceptions**, **pause execution**, **report fault events**, and allow upper orchestration layers to **apply fault tolerance methods** (initially supporting retry).

### Supported Functionality

- Detect exceptions raised inside a vLLM instance and pause its execution.  
- Publish fault events and expose rank/EngineCore status to the upper orchestration framework.  
- Provide a retry API for transient and recoverable faults (e.g., network jitter).

### Usage

Enable the Fault Tolerance feature via configuration, for example:

```bash
vllm serve \
  --model xxxxx \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --tensor-parallel-size 1 \
  --enforce-eager \
  --enable-fault-tolerance \
  --engine-recovery-timeout 120 \
  --external-fault-notify-port 23456
```
- When an exception is raised in any rank (tested via code injection or killing a worker process), vLLM reports the event via a ZMQ PUB socket.

  - Example: Subscribe to port 23456 on topic vllm_fault to receive events.
- The status of each EngineCore can be queried via API:
```bash
GET /fault_tolerance/status
```
- Retry can be triggered via API:
```css
POST /fault_tolerance/apply
Body: {"fault_tolerance_instruction": "retry", "fault_tolerance_timeout": 30}
```

### Implementation Notes
- We actually implemented two approaches to pause healthy ranks. Due to the complexity of collective communications, we currently adopt the hard pause method as the default.
  - Soft pause: set pause flag variables for EngineCore/Worker to check.
  - Hard pause (default): set flags and abort process groups/communicators.
  
- NCCL: All communicators are set as nonblocking when fault tolerance is enabled, allowing safe use of [ncclCommAbort](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#c.ncclCommAbort) as suggested by [NCCL](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#fault-tolerance).

- Currently, when querying EngineCore status via the API: EngineCores paused using the signal flag are reported as healthy. EngineCores paused due to aborted communicators are reported as unhealthy. Further refinements to the status reporting will be implemented in follow-ups.

We believe that **this implementation is compatible with RFC #27774 and #27908** to isolate fault ranks through scale_down. This implementation  establishes the overall fault tolerance framework within vLLM, providing mechanisms for detecting, pausing, reporting, and performing fault tolerance. Within this framework, **fault isolation through elastic expert parallelism (#20323)** is treated as **one of the fault tolerance methods**. As a result, this implementation and the elastic expert parallelism proposal are designed to be compatible.

We welcome further discussion and feedback from the community to refine and extend these fault tolerance mechanisms.


## Test Plan

- Tested with DT
  - pytest tests/v1/engine/test_client_guard.py
  - pytest tests/v1/engine/test_engine_core_guard.py
- End-to-end tests.
  - End-to-end tests conducted on Qwen3-30B-A3B with configurations: DP4/TP2 and DP8/TP1.
  - Two fault injection types:
    - Manually raising exceptions at different code locations.
    - Killing certain worker processes.
  - Verified:
    - Pause behavior
    - Fault reporting
    - Retry functionality (for code injections)

## Test Result
**DT results**

- pytest tests/v1/engine/test_client_guard.py
  - tests/v1/engine/test_client_guard.py::test_client_guard_initialization PASSED
  - tests/v1/engine/test_client_guard.py::test_handle_fault PASSED
  - tests/v1/engine/test_client_guard.py::test_fault_receiver PASSED
  - tests/v1/engine/test_client_guard.py::test_fault_receiver_unhealthy PASSED
  - tests/v1/engine/test_client_guard.py::test_shutdown_guard PASSED
  - tests/v1/engine/test_client_guard.py::test_handle_fault_async PASSED
- pytest tests/v1/engine/test_engine_core_guard.py
  - tests/v1/engine/test_engine_core_guard.py::test_engine_core_guard_initialization PASSED
  - tests/v1/engine/test_engine_core_guard.py::test_run_handle_instruction[pause] PASSED
  - tests/v1/engine/test_engine_core_guard.py::test_run_handle_instruction[retry] PASSED
  

**End-to-end Test Results**
We validated both the **functional correctness** and **model precision** after applying the retry-based fault tolerance mechanism. All fault tolerance features behaved as expected — including fault detection, pause/resume, event reporting, and retry recovery.

The precision tests showed no regression, indicating that the retry mechanism does not affect the model’s output quality.



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

