### PR TITLE
[NIXL] Generalize block-first backend layouts (FlashInfer-like)

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import msgspec
 import numpy as np
 import torch
+from vllm.attention import AttentionBackend
 import zmq
 
 from vllm import envs
@@ -669,6 +670,25 @@ class NixlConnectorWorker:
         remote_tp_size: dict[EngineId, int]
         is_mla: bool
         total_num_kv_heads: int
+        attn_backend: type[AttentionBackend]
+
+        def __post_init__(self):
+            # Figure out whether the first dimension of the cache is K/V 
+            # or num_blocks. This is used to register the memory regions correctly.
+            self.kv_cache_shape = self.attn_backend.get_kv_cache_shape(num_blocks=1, block_size=16, num_kv_heads=1, head_size=1)
+            backend_name = self.attn_backend.get_name()
+            attn_backend = AttentionBackendEnum[backend_name]
+            self._use_pallas = attn_backend == AttentionBackendEnum.PALLAS
+        
+        @property
+        def is_kv_layout_blocks_first(self) -> bool:
+            # Non-MLA backends have 5 dims [2, num_blocks, H,N,D]
+            return len(self.kv_cache_shape) == 5 and self.kv_cache_shape[0] == 1
+
+        @property
+        def split_k_and_v(self) -> bool:
+            # Whether to register regions for K and V separately (when present).
+            return not (self.is_mla or self._use_pallas or self.is_kv_layout_blocks_first)
 
         def tp_ratio(
             self,
@@ -876,9 +896,6 @@ class NixlConnectorWorker:
             use_mla=self.use_mla,
         )
         self.backend_name = backend.get_name()
-        attn_backend = AttentionBackendEnum[self.backend_name]
-        self._use_flashinfer = attn_backend == AttentionBackendEnum.FLASHINFER
-        self._use_pallas = attn_backend == AttentionBackendEnum.PALLAS
         self.kv_cache_layout = get_kv_cache_layout()
         self.host_buffer_kv_cache_layout = self.kv_cache_layout
         logger.debug("Detected attention backend %s", self.backend_name)
@@ -897,6 +914,7 @@ class NixlConnectorWorker:
             is_mla=self.use_mla,
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
         )
+        self._use_pallas = self.kv_topo._use_pallas
 
     def _nixl_handshake(
         self,
@@ -1076,7 +1094,7 @@ class NixlConnectorWorker:
         # (roughly 8KB vs 5KB).
         # Conversely for FlashInfer, K and V are registered in the same region
         # to better exploit the memory layout (ie num_blocks is the first dim).
-        split_k_and_v = not (self.use_mla or self._use_pallas or self._use_flashinfer)
+        split_k_and_v = self.kv_topo.split_k_and_v
         tensor_size_bytes = None
         # Enable different block lengths for different layers when MLA is used.
         self.block_len_per_layer = list[int]()
@@ -1141,7 +1159,7 @@ class NixlConnectorWorker:
 
         self.device_kv_caches = kv_caches
         self.dst_num_blocks[self.engine_id] = self.num_blocks
-        if self._use_flashinfer:
+        if self.kv_topo.is_kv_layout_blocks_first:
             for i in range(len(self.slot_size_per_layer)):
                 assert self.slot_size_per_layer[i] % 2 == 0
                 self.slot_size_per_layer[i] //= 2
@@ -1169,7 +1187,7 @@ class NixlConnectorWorker:
                 # (addr, len, device id)
                 blocks_data.append((addr, kv_block_len, self.device_id))
 
-            if self._use_flashinfer:
+            if self.kv_topo.is_kv_layout_blocks_first:
                 # Separate and interleave K/V regions to maintain the same
                 # descs ordering. This is needed for selecting contiguous heads
                 # when split across TP ranks.
@@ -1331,7 +1349,7 @@ class NixlConnectorWorker:
                 # (addr, len, device id)
                 blocks_data.append((addr, kv_block_len, nixl_agent_meta.device_id))
 
-            if self._use_flashinfer:
+            if self.kv_topo.is_kv_layout_blocks_first:
                 # With FlashInfer index V separately to allow head splitting.
                 for block_id in range(nixl_agent_meta.num_blocks):
                     block_offset = block_id * nixl_agent_meta.block_lens[i]
@@ -1414,7 +1432,7 @@ class NixlConnectorWorker:
             remote_block_size = remote_block_len // (
                 self.slot_size_per_layer[0] * tp_ratio
             )
-            if self._use_flashinfer:
+            if self.kv_topo.is_kv_layout_blocks_first:
                 # With flashinfer, KV are sent in the same message.
                 remote_block_size //= 2
 
@@ -1494,7 +1512,7 @@ class NixlConnectorWorker:
         - cache.index_copy_(0, indices, permuted_blocks) # copy permuted kv back
 
         """
-        split_k_and_v = not (self.use_mla or self._use_pallas or self._use_flashinfer)
+        split_k_and_v = self.kv_topo.split_k_and_v
         inv_order = [0, 2, 1, 3]
         sample_cache = list(self.device_kv_caches.values())[0][0]
         target_shape = list(sample_cache.shape)
@@ -1874,7 +1892,7 @@ class NixlConnectorWorker:
         For FlashInfer, this is half the length of the whole block, as K and V
         share the same region.
         """
-        if self._use_flashinfer:
+        if self.kv_topo.is_kv_layout_blocks_first:
             # For indexing only half (either just the K or V part).
             block_len = self.block_len_per_layer[layer_idx] // 2
         else:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -673,13 +673,14 @@ class NixlConnectorWorker:
         attn_backend: type[AttentionBackend]
 
         def __post_init__(self):
-            # Figure out whether the first dimension of the cache is K/V 
+            # Figure out whether the first dimension of the cache is K/V
             # or num_blocks. This is used to register the memory regions correctly.
-            self.kv_cache_shape = self.attn_backend.get_kv_cache_shape(num_blocks=1, block_size=16, num_kv_heads=1, head_size=1)
-            backend_name = self.attn_backend.get_name()
-            attn_backend = AttentionBackendEnum[backend_name]
+            self.kv_cache_shape = self.attn_backend.get_kv_cache_shape(
+                num_blocks=1, block_size=16, num_kv_heads=1, head_size=1
+            )
+            attn_backend = AttentionBackendEnum[self.attn_backend.get_name()]
             self._use_pallas = attn_backend == AttentionBackendEnum.PALLAS
-        
+
         @property
         def is_kv_layout_blocks_first(self) -> bool:
             # Non-MLA backends have 5 dims [2, num_blocks, H,N,D]
@@ -688,7 +689,9 @@ class NixlConnectorWorker:
         @property
         def split_k_and_v(self) -> bool:
             # Whether to register regions for K and V separately (when present).
-            return not (self.is_mla or self._use_pallas or self.is_kv_layout_blocks_first)
+            return not (
+                self.is_mla or self._use_pallas or self.is_kv_layout_blocks_first
+            )
 
         def tp_ratio(
             self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -18,10 +18,10 @@ from typing import TYPE_CHECKING, Any, Optional
 import msgspec
 import numpy as np
 import torch
-from vllm.attention import AttentionBackend
 import zmq
 
 from vllm import envs
+from vllm.attention import AttentionBackend
 from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.attention.selector import get_attn_backend
 from vllm.config import VllmConfig

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -913,6 +913,7 @@ class NixlConnectorWorker:
             remote_tp_size=self._tp_size,  # shared state
             is_mla=self.use_mla,
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
+            attn_backend=backend,
         )
         self._use_pallas = self.kv_topo._use_pallas
 


### PR DESCRIPTION
This PR generalizes the handling of attention backends that make use of a "swapped" layout wrt the historically default one (ie FlashAttn).
To clarify:
```
# "Default" layout (FlashAttn)
2, num_blocks, N, H, D
# "Swapped" layout (FlashInfer)
num_blocks, 2, N, H, D
```
Mind that in the latter case we're able to register num_layers physical memory regions and handle the K/V splitting only logically.

This PR should hence enable the use of other FlashInfer-like backends with NixlConnector (Triton backend for AMD to name one).

I also followed-up with some minor refactor into the Topology helper class.

## Test

```
FLASHINFER=1 bash v1/kv_connector/nixl_integration/tp_config_sweep_accuracy_test.sh
```

I've also added a test for the Triton backend to ensure nixl registration has a minimal test coverage. 