### PR TITLE
Revert "[PerfFix] Avoid separate thread for MP executor shm spin (#28012)"

### DIFF
--- a/tests/v1/executor/test_executor.py
+++ b/tests/v1/executor/test_executor.py
@@ -4,7 +4,6 @@
 import asyncio
 import os
 from collections.abc import Callable
-from concurrent.futures import Future
 from typing import Any
 
 import pytest
@@ -28,7 +27,7 @@ class CustomMultiprocExecutor(MultiprocExecutor):
         kwargs: dict | None = None,
         non_block: bool = False,
         unique_reply_rank: int | None = None,
-    ) -> Any | list[Any] | Future[Any | list[Any]]:
+    ) -> list[Any]:
         # Drop marker to show that this was run
         with open(".marker", "w"):
             ...

--- a/tests/v1/kv_connector/unit/test_output_aggregator.py
+++ b/tests/v1/kv_connector/unit/test_output_aggregator.py
@@ -89,12 +89,14 @@ def test_aggregate_workers_output():
 def test_async_aggregate_workers_output():
     aggregator = KVOutputAggregator(expected_finished_count=2)
 
-    future: Future[list[DummyModelRunnerOutput]] = Future()
-    result_future = aggregator.async_aggregate(future)
+    future1: Future[DummyModelRunnerOutput] = Future()
+    future2: Future[DummyModelRunnerOutput] = Future()
+    result_future = aggregator.async_aggregate([future1, future2])
 
     output1 = DummyModelRunnerOutput()
     output2 = DummyModelRunnerOutput()
-    future.set_result([output1, output2])
+    future1.set_result(output1)
+    future2.set_result(output2)
 
     assert result_future.done()
     aggregated = result_future.result()
@@ -104,14 +106,16 @@ def test_async_aggregate_workers_output():
     assert aggregated.finished_recving is None
     assert not aggregated.invalid_block_ids
 
-    future = Future()
-    result_future = aggregator.async_aggregate(future)
+    future1 = Future()
+    future2 = Future()
+    result_future = aggregator.async_aggregate([future1, future2])
 
     output1 = DummyModelRunnerOutput(
         finished_sending={"req1"}, finished_recving={"req2"}
     )
     output2 = DummyModelRunnerOutput(invalid_block_ids={1})
-    future.set_result([output1, output2])
+    future1.set_result(output1)
+    future2.set_result(output2)
 
     assert result_future.done()
     aggregated = result_future.result()
@@ -121,12 +125,14 @@ def test_async_aggregate_workers_output():
     assert aggregated.finished_recving is None
     assert aggregated.invalid_block_ids == {1}
 
-    future = Future()
-    result_future = aggregator.async_aggregate(future)
+    future1 = Future()
+    future2 = Future()
+    result_future = aggregator.async_aggregate([future1, future2])
 
     output1 = DummyModelRunnerOutput(invalid_block_ids={2})
     output2 = DummyModelRunnerOutput(finished_sending={"req1"})
-    future.set_result([output1, output2])
+    future1.set_result(output1)
+    future2.set_result(output2)
 
     assert result_future.done()
     aggregated = result_future.result()
@@ -136,14 +142,16 @@ def test_async_aggregate_workers_output():
     assert aggregated.finished_recving is None
     assert aggregated.invalid_block_ids == {2}
 
-    future = Future()
-    result_future = aggregator.async_aggregate(future)
+    future1 = Future()
+    future2 = Future()
+    result_future = aggregator.async_aggregate([future1, future2])
 
     output1 = DummyModelRunnerOutput(invalid_block_ids={3, 4})
     output2 = DummyModelRunnerOutput(
         finished_recving={"req2"}, invalid_block_ids={4, 5}
     )
-    future.set_result([output1, output2])
+    future1.set_result(output1)
+    future2.set_result(output2)
 
     assert result_future.done()
     aggregated = result_future.result()

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -171,7 +171,7 @@ class Executor(ABC):
         args: tuple = (),
         kwargs: dict | None = None,
         non_block: Literal[True] = True,
-    ) -> Future[list[_R]]:
+    ) -> list[Future[_R]]:
         pass
 
     @abstractmethod
@@ -219,7 +219,7 @@ class Executor(ABC):
 
     def sample_tokens(
         self, grammar_output: GrammarOutput | None, non_block: bool = False
-    ) -> ModelRunnerOutput | None | Future[ModelRunnerOutput | None]:
+    ) -> ModelRunnerOutput | Future[ModelRunnerOutput]:
         output = self.collective_rpc(  # type: ignore[call-overload]
             "sample_tokens", args=(grammar_output,), non_block=non_block
         )

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -141,19 +141,19 @@ class FutureWrapper(Future):
     the result() call. If not only the first worker's output is returned.
     """
 
-    def __init__(self, ref_or_refs, aggregator: KVOutputAggregator | None = None):
+    def __init__(self, refs, aggregator: KVOutputAggregator | None = None):
         super().__init__()
-        self.ref_or_refs = ref_or_refs
+        self.refs = refs
         self.aggregator = aggregator
 
     def result(self, timeout=None):
         if timeout is not None:
             raise NotImplementedError("timeout is not supported")
 
-        outputs = ray.get(self.ref_or_refs, timeout=timeout)
         if self.aggregator is None:
-            return outputs
+            return self.refs[0].get()
 
+        outputs = [ref.get() for ref in self.refs]
         return self.aggregator.aggregate(outputs, output_rank=0)
 
 

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -13,10 +13,9 @@ import torch.distributed as dist
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
-from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
 from vllm.v1.executor.abstract import Executor
-from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
+from vllm.v1.outputs import AsyncModelRunnerOutput
 from vllm.v1.serial_utils import run_method
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
@@ -59,60 +58,32 @@ class UniProcExecutor(Executor):
     def max_concurrent_batches(self) -> int:
         return 2 if self.scheduler_config.async_scheduling else 1
 
-    def collective_rpc(  # type: ignore[override]
+    def collective_rpc(
         self,
         method: str | Callable,
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict | None = None,
         non_block: bool = False,
-        single_value: bool = False,
-    ) -> Any | list[Any] | Future[Any | list[Any]]:
+    ) -> list[Any]:
         if kwargs is None:
             kwargs = {}
 
         if not non_block:
-            result = run_method(self.driver_worker, method, args, kwargs)
-            return result if single_value else [result]
+            return [run_method(self.driver_worker, method, args, kwargs)]
 
         try:
             result = run_method(self.driver_worker, method, args, kwargs)
             if isinstance(result, AsyncModelRunnerOutput):
                 if (async_thread := self.async_output_thread) is not None:
-                    get_output = result.get_output
-                    if not single_value:
-                        get_output = lambda: [get_output()]
-                    return async_thread.submit(get_output)
+                    return [async_thread.submit(result.get_output)]
                 result = result.get_output()
             future = Future[Any]()
-            future.set_result(result if single_value else [result])
+            future.set_result(result)
         except Exception as e:
             future = Future[Any]()
             future.set_exception(e)
-        return future
-
-    def execute_model(  # type: ignore[override]
-        self, scheduler_output: SchedulerOutput, non_block: bool = False
-    ) -> ModelRunnerOutput | None | Future[ModelRunnerOutput | None]:
-        return self.collective_rpc(
-            "execute_model",
-            args=(scheduler_output,),
-            non_block=non_block,
-            single_value=True,
-        )
-
-    def sample_tokens(  # type: ignore[override]
-        self, grammar_output: GrammarOutput | None, non_block: bool = False
-    ) -> ModelRunnerOutput | None | Future[ModelRunnerOutput | None]:
-        return self.collective_rpc(
-            "sample_tokens",
-            args=(grammar_output,),
-            non_block=non_block,
-            single_value=True,
-        )
-
-    def take_draft_token_ids(self) -> DraftTokenIds | None:
-        return self.collective_rpc("take_draft_token_ids", single_value=True)
+        return [future]
 
     def check_health(self) -> None:
         # UniProcExecutor will always be healthy as long as

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -524,7 +524,7 @@ class Worker(WorkerBase):
 
     @torch.inference_mode()
     def sample_tokens(
-        self, grammar_output: "GrammarOutput | None"
+        self, grammar_output: "GrammarOutput"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
         return self.model_runner.sample_tokens(grammar_output)
 


### PR DESCRIPTION
This PR https://github.com/vllm-project/vllm/pull/28012 is breaking PD deployments with TP>1.

```
# Spin up P TP=2
vllm serve Qwen/Qwen3-0.6B --port $(just port 8100) --enforce-eager --enable-log-requests --tensor-parallel-size 2 --gpu-memory-utilization 0.4 --trust-remote-code --max-model-len 32768 --block-size 128 --data_parallel_size 1 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
# spin up toy_proxy_server in the bg..

# send test request 
  curl -X POST http://localhost:$(just port 8192)/v1/completions \
    -H "Content-Type: application/json" \
    -d '{ \
      "model": "{{MODEL}}", \
      "prompt": "Can you complete this latin sentence: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", \
      "max_tokens": 150, \
      "temperature": 0.2 \
    }'

# Observe request getting stuck 
(APIServer pid=2822821) INFO 11-07 11:08:44 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=2822821) INFO 11-07 11:08:44 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=2822821) INFO:     Started server process [2822821]
(APIServer pid=2822821) INFO:     Waiting for application startup.
(APIServer pid=2822821) INFO:     Application startup complete.
(APIServer pid=2822821) INFO 11-07 11:10:17 [logger.py:47] Received request cmpl-700daa72-8cc7-4a65-9bff-cb83c40b16a7-0: params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.2, top_p=0.95, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=1, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, structured_outputs=None, extra_args={'kv_transfer_params': {'do_remote_decode': True, 'do_remote_prefill': False, 'remote_engine_id': None, 'remote_block_ids': None, 'remote_host': None, 'remote_port': None}}), lora_request: None.
(APIServer pid=2822821) INFO 11-07 11:10:17 [async_llm.py:343] Added request cmpl-700daa72-8cc7-4a65-9bff-cb83c40b16a7-0.
```
