### PR TITLE
Milestone 1 of Internal Process-level Fault Tolerance (RFC #27866)

### DIFF
--- a/tests/v1/fault_tolerance/test_client_sentinel.py
+++ b/tests/v1/fault_tolerance/test_client_sentinel.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import queue
+import socket
+import threading
+import time
+import traceback
+import uuid
+from queue import Queue
+
+import msgspec
+import pytest
+import zmq
+
+from vllm.config import FaultToleranceConfig, ParallelConfig, VllmConfig
+from vllm.v1.engine import EngineStatusType
+from vllm.v1.fault_tolerance import ClientSentinel
+from vllm.v1.fault_tolerance.utils import (
+    FaultInfo,
+    FaultToleranceRequest,
+    FaultToleranceResult,
+    FaultToleranceZmqAddresses,
+)
+
+
+def _find_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def ft_addr():
+    ports = [_find_free_port() for _ in range(4)]
+    return FaultToleranceZmqAddresses(
+        fault_state_pub_socket_addr=f"tcp://127.0.0.1:{ports[0]}",
+        client_sentinel_request_addr=f"tcp://127.0.0.1:{ports[1]}",
+        engine_core_sentinel_cmd_addr=f"tcp://127.0.0.1:{ports[2]}",
+        engine_fault_socket_addr=f"tcp://127.0.0.1:{ports[3]}",
+        engine_core_sentinel_identities={0: b"engine_sentinel_identity"},
+    )
+
+
+# Helper to collect exceptions from threads and fail the test if any were raised.
+def fail_on_thread_exceptions(thread_excs: Queue) -> None:
+    if not thread_excs.empty():
+        pytest.fail("Thread raised exception:\n" + "\n".join(thread_excs.queue))
+
+
+def send_error_message(
+    fault_receiver_addr: str, engine_id: str, fault_type: str, thread_excs: queue.Queue
+):
+    # send error message to client sentinel, simulating an engine reporting an error
+    try:
+        ctx = zmq.Context()
+        socket = ctx.socket(zmq.DEALER)
+        socket.setsockopt(zmq.IDENTITY, b"test_sender")
+        socket.connect(fault_receiver_addr)
+
+        test_fault = FaultInfo(
+            engine_id=str(engine_id), type=fault_type, message="test error"
+        )
+        socket.send_multipart([b"", msgspec.msgpack.encode(test_fault)])
+        socket.close()
+        ctx.term()
+    except Exception:
+        thread_excs.put(traceback.format_exc())
+
+
+def create_client_sentinel(num_engines: int = 2, ft_addr=None):
+    if ft_addr is None:
+        ports = [_find_free_port() for _ in range(4)]
+        ft_addr = FaultToleranceZmqAddresses(
+            fault_state_pub_socket_addr=f"tcp://127.0.0.1:{ports[0]}",
+            client_sentinel_request_addr=f"tcp://127.0.0.1:{ports[1]}",
+            engine_core_sentinel_cmd_addr=f"tcp://127.0.0.1:{ports[2]}",
+            engine_fault_socket_addr=f"tcp://127.0.0.1:{ports[3]}",
+            engine_core_sentinel_identities={
+                i: f"engine_sentinel_identity_{i}".encode() for i in range(num_engines)
+            },
+        )
+
+    parallel = ParallelConfig(
+        data_parallel_size=num_engines,
+        data_parallel_size_local=num_engines,
+        data_parallel_master_ip="127.0.0.1",
+    )
+    vconfig = VllmConfig(
+        parallel_config=parallel,
+        fault_tolerance_config=FaultToleranceConfig(enable_fault_tolerance=True),
+    )
+
+    return ClientSentinel(vllm_config=vconfig, fault_tolerance_addresses=ft_addr)
+
+
+def test_client_sentinel_initialization(ft_addr):
+    sentinel = create_client_sentinel(ft_addr=ft_addr)
+
+    assert (
+        sentinel.engine_core_sentinel_identities[0]
+        == ft_addr.engine_core_sentinel_identities[0]
+    )
+    assert not sentinel.sentinel_dead
+    assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.HEALTHY
+    assert sentinel.fault_receiver_socket.type == zmq.ROUTER
+    assert sentinel.downstream_cmd_socket.type == zmq.ROUTER
+    assert sentinel.fault_state_pub_socket.type == zmq.PUB
+
+    sentinel.shutdown()
+
+
+def test_client_sentinel_receives_faults_and_publishes_status(ft_addr):
+    sentinel = create_client_sentinel(ft_addr=ft_addr)
+    thread_excs: Queue = Queue()
+
+    def decode_published_message(sub_socket):
+        # decode error messages published by client sentinel
+        if not sub_socket.poll(timeout=2000):
+            raise TimeoutError("Timeout waiting for published message")
+        frames = sub_socket.recv_multipart()
+        return frames[0].decode("utf-8"), msgspec.msgpack.decode(frames[-1])
+
+    def check_published_message():
+        # listen and verify error messages published from client sentinel
+        try:
+            ctx = zmq.Context()
+            sub_socket = ctx.socket(zmq.SUB)
+            sub_socket.connect(ft_addr.fault_state_pub_socket_addr)
+            sub_socket.setsockopt_string(
+                zmq.SUBSCRIBE, sentinel.ft_config.fault_state_pub_topic
+            )
+            # Consume the first published status update (after the first fault)
+            # without validating it here; this test only asserts on the final state
+            decode_published_message(sub_socket)
+            prefix, status_dict = decode_published_message(sub_socket)
+            sub_socket.close()
+            ctx.term()
+            assert prefix == sentinel.ft_config.fault_state_pub_topic
+            assert status_dict[1]["status"] == EngineStatusType.DEAD
+            assert status_dict[0]["status"] == EngineStatusType.UNHEALTHY
+        except Exception:
+            thread_excs.put(traceback.format_exc())
+
+    t1 = threading.Thread(target=check_published_message, daemon=True)
+    t1.start()
+    time.sleep(0.1)
+
+    threading.Thread(
+        target=send_error_message,
+        args=(ft_addr.engine_fault_socket_addr, "1", "dead", thread_excs),
+        daemon=True,
+    ).start()
+    time.sleep(0.1)
+    threading.Thread(
+        target=send_error_message,
+        args=(ft_addr.engine_fault_socket_addr, "0", "RuntimeError", thread_excs),
+        daemon=True,
+    ).start()
+
+    t1.join()
+    fail_on_thread_exceptions(thread_excs)
+
+    # Verify engine_status_dict updated
+    assert sentinel.engine_status_dict[1]["status"] == EngineStatusType.DEAD
+    assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.UNHEALTHY
+
+    sentinel.shutdown()
+
+
+def test_shutdown_sentinel(ft_addr):
+    sentinel = create_client_sentinel(ft_addr=ft_addr)
+
+    original_fault_sock = sentinel.fault_receiver_socket
+    original_cmd_sock = sentinel.downstream_cmd_socket
+    original_pub_sock = sentinel.fault_state_pub_socket
+    original_ctx = sentinel.ctx
+
+    sentinel.shutdown()
+
+    assert sentinel.sentinel_dead
+
+    with pytest.raises(zmq.ZMQError):
+        original_fault_sock.recv()
+    with pytest.raises(zmq.ZMQError):
+        original_cmd_sock.recv()
+    with pytest.raises(zmq.ZMQError):
+        original_pub_sock.send(b"test")
+
+    assert original_ctx.closed
+
+
+@pytest.mark.parametrize("instruction", ["pause", "retry"])
+def test_handle_fault_roundtrip(instruction, ft_addr):
+    """Test the full FaultToleranceRequest -> engine -> FaultToleranceResult flow
+    by talking to the sentinel's ROUTER endpoints using msgpack-encoded
+    FaultToleranceRequest/Result messages.
+    """
+    sentinel = create_client_sentinel(num_engines=1, ft_addr=ft_addr)
+    thread_excs: Queue = Queue()
+
+    # Start a DEALER that will act as the downstream engine sentinel.
+    engine_ctx = zmq.Context()
+    engine_socket = engine_ctx.socket(zmq.DEALER)
+    engine_socket.setsockopt(zmq.IDENTITY, ft_addr.engine_core_sentinel_identities[0])
+    engine_socket.connect(ft_addr.engine_core_sentinel_cmd_addr)
+
+    # Create a client DEALER that will send the FaultToleranceRequest to ClientSentinel
+    client_ctx = zmq.Context()
+    client_socket = client_ctx.socket(zmq.DEALER)
+    client_socket.setsockopt(zmq.IDENTITY, b"test_client")
+    client_socket.connect(ft_addr.client_sentinel_request_addr)
+
+    # Prepare the fault tolerance request
+    req_id = str(uuid.uuid4())
+    params = {"timeout": 3}
+    if instruction == "pause":
+        params["soft_pause"] = True
+    else:
+        params["new_stateless_dp_group_port"] = 12568
+
+    ft_req = FaultToleranceRequest(
+        request_id=req_id, instruction=instruction, params=params
+    )
+
+    def engine_loop():
+        try:
+            if not engine_socket.poll(timeout=2000):
+                raise TimeoutError(
+                    "Timeout waiting for FaultToleranceRequest from client sentinel"
+                )
+            parts = engine_socket.recv_multipart()
+            received = msgspec.msgpack.decode(parts[-1], type=FaultToleranceRequest)
+            assert received.instruction in ("pause", "retry")
+            # reply with success
+            res = FaultToleranceResult(
+                request_id=received.request_id, success=True, reason=None
+            )
+            engine_socket.send_multipart([b"", msgspec.msgpack.encode(res)])
+        except Exception:
+            thread_excs.put(traceback.format_exc())
+
+    threading.Thread(target=engine_loop, daemon=True).start()
+    client_socket.send_multipart([b"", msgspec.msgpack.encode(ft_req)])
+
+    # Wait for reply from ClientSentinel on client_socket
+    if not client_socket.poll(timeout=2000):
+        pytest.fail("Timeout waiting for FaultToleranceResult from client sentinel.")
+    parts = client_socket.recv_multipart()
+    ft_res = msgspec.msgpack.decode(parts[-1], type=FaultToleranceResult)
+    assert ft_res.request_id == req_id
+    assert ft_res.success is True
+    if instruction == "pause":
+        assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.PAUSED
+    elif instruction == "retry":
+        assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.HEALTHY
+
+    fail_on_thread_exceptions(thread_excs)
+    client_socket.close()
+    client_ctx.term()
+    engine_socket.close()
+    engine_ctx.term()
+
+    sentinel.shutdown()

--- a/tests/v1/fault_tolerance/test_client_sentinel.py
+++ b/tests/v1/fault_tolerance/test_client_sentinel.py
@@ -1,264 +1,294 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
-import queue
-import socket
-import threading
-import time
-import traceback
+import asyncio
 import uuid
-from queue import Queue
+from unittest.mock import AsyncMock, Mock, patch
 
-import msgspec
+import msgspec.msgpack
 import pytest
-import zmq
+import zmq.asyncio
 
-from vllm.config import FaultToleranceConfig, ParallelConfig, VllmConfig
+from vllm.config import FaultToleranceConfig, VllmConfig
 from vllm.v1.engine import EngineStatusType
-from vllm.v1.fault_tolerance import ClientSentinel
+from vllm.v1.fault_tolerance.client_sentinel import ClientSentinel
 from vllm.v1.fault_tolerance.utils import (
     FaultInfo,
     FaultToleranceRequest,
     FaultToleranceResult,
-    FaultToleranceZmqAddresses,
 )
 
-
-def _find_free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 @pytest.fixture
-def ft_addr():
-    ports = [_find_free_port() for _ in range(4)]
-    return FaultToleranceZmqAddresses(
-        fault_state_pub_socket_addr=f"tcp://127.0.0.1:{ports[0]}",
-        client_sentinel_request_addr=f"tcp://127.0.0.1:{ports[1]}",
-        engine_core_sentinel_cmd_addr=f"tcp://127.0.0.1:{ports[2]}",
-        engine_fault_socket_addr=f"tcp://127.0.0.1:{ports[3]}",
-        engine_core_sentinel_identities={0: b"engine_sentinel_identity"},
+def mock_vllm_config():
+    """Create mock VllmConfig object"""
+    config = Mock(spec=VllmConfig)
+    config.parallel_config = Mock(
+        data_parallel_index=0,
+        data_parallel_size=2,
+        data_parallel_size_local=2,
+    )
+    config.fault_tolerance_config = FaultToleranceConfig(gloo_comm_timeout=10)
+    return config
+
+
+@pytest.fixture
+def mock_ft_addresses():
+    """Create mock FaultToleranceZmqAddresses object"""
+    addresses = Mock()
+    addresses.all_client_input_addresses = ["tcp://127.0.0.1:5555"]
+    addresses.all_client_output_addresses = ["tcp://127.0.0.1:5556"]
+    addresses.engine_fault_socket_addr = "tcp://127.0.0.1:5557"
+    addresses.fault_state_pub_socket_addr = "tcp://127.0.0.1:5558"
+    addresses.ft_config = Mock(fault_state_pub_topic="fault_state")
+    return addresses
+
+
+@pytest.fixture
+def mock_call_utility_async():
+    """Create mock call_utility_async function"""
+    return AsyncMock(
+        return_value={"request_id": "request_id", "success": True, "reason": None}
     )
 
 
-# Helper to collect exceptions from threads and fail the test if any were raised.
-def fail_on_thread_exceptions(thread_excs: Queue) -> None:
-    if not thread_excs.empty():
-        pytest.fail("Thread raised exception:\n" + "\n".join(thread_excs.queue))
+@pytest.fixture
+def client_sentinel(mock_vllm_config, mock_ft_addresses, mock_call_utility_async):
+    """Fixed ClientSentinel fixture (mock Poller)"""
+    # 1. Mock Poller class and return mock Poller object
+    mock_poller = Mock()
+    mock_poller.register = Mock()
+    mock_poller.poll = AsyncMock(return_value=[])  # Return empty events by default
+    mock_poller_class = Mock(return_value=mock_poller)
+
+    # 2. Mock make_zmq_socket to return mock Socket
+    mock_socket = AsyncMock()
+    # Add necessary attributes to mock socket (avoid errors in other places)
+    mock_socket.fd = Mock(return_value=1)  # Mock file descriptor
+    mock_socket.getsockopt = Mock(return_value=0)
+
+    # 3. Batch mock related dependencies
+    with (
+        patch(
+            "vllm.v1.fault_tolerance.client_sentinel.make_zmq_socket",
+            return_value=mock_socket,
+        ),
+        patch("zmq.asyncio.Poller", mock_poller_class),
+        patch(
+            "vllm.v1.fault_tolerance.client_sentinel.asyncio.create_task"
+        ) as mock_create_task,
+    ):
+        # 4. Disable real async tasks (avoid run/_monitor_and_pause_on_fault execution)
+        mock_create_task.return_value = Mock()
+
+        # 5. Create ClientSentinel instance
+        sentinel = ClientSentinel(
+            vllm_config=mock_vllm_config,
+            fault_tolerance_addresses=mock_ft_addresses,
+            call_utility_async=mock_call_utility_async,
+            core_engines=[b"engine_0", b"engine_1"],
+        )
+
+        return sentinel
 
 
-def send_error_message(
-    fault_receiver_addr: str, engine_id: str, fault_type: str, thread_excs: queue.Queue
+# -------------------------- Test Cases --------------------------
+@pytest.mark.asyncio
+async def test_client_sentinel_initialization(client_sentinel: ClientSentinel):
+    """Test ClientSentinel initialization logic"""
+    # Verify engine status dictionary initialization is correct
+    assert client_sentinel.engine_status_dict == {
+        0: {"status": EngineStatusType.HEALTHY},
+        1: {"status": EngineStatusType.HEALTHY},
+    }
+
+    # Verify key attribute initialization
+    assert client_sentinel.start_rank == 0
+
+    assert not client_sentinel.is_faulted.is_set()
+
+    # Verify ZMQ sockets are created
+    assert len(client_sentinel.input_sockets) == 1
+    assert len(client_sentinel.output_sockets) == 1
+    assert client_sentinel.fault_receiver_socket is not None
+    assert client_sentinel.fault_state_pub_socket is not None
+
+
+@pytest.mark.asyncio
+async def test_retry_success(client_sentinel: ClientSentinel, mock_call_utility_async):
+    """Test retry method (success scenario)"""
+    # Mock engine to return successful result
+    mock_call_utility_async.return_value = {
+        "request_id": "request_id",
+        "success": True,
+        "reason": "success",
+    }
+
+    # Execute retry
+    result = await client_sentinel.retry(timeout=5)
+
+    # Verify result
+    assert result is True
+    assert not client_sentinel.is_faulted.is_set()
+
+    # Verify call parameters
+    mock_call_utility_async.assert_awaited()
+    call_args = mock_call_utility_async.call_args[0]
+    assert call_args[0] == "handle_fault"
+    assert isinstance(call_args[1], FaultToleranceRequest)
+    assert call_args[1].instruction == "retry"
+    assert call_args[1].params["timeout"] == 5
+
+
+@pytest.mark.asyncio
+async def test_retry_failure(client_sentinel: ClientSentinel, mock_call_utility_async):
+    """Test retry method (failure scenario)"""
+    # Mock one engine to return failure
+    mock_call_utility_async.side_effect = [
+        {"success": True},
+        {"success": False, "reason": "engine dead"},
+    ]
+
+    # Mark one engine as DEAD first
+    client_sentinel.engine_status_dict[1] = {"status": EngineStatusType.DEAD}
+
+    # Execute retry
+    result = await client_sentinel.retry()
+
+    # Verify result
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_pause_operation(
+    client_sentinel: ClientSentinel, mock_call_utility_async
 ):
-    # send error message to client sentinel, simulating an engine reporting an error
-    try:
-        ctx = zmq.Context()
-        socket = ctx.socket(zmq.DEALER)
-        socket.setsockopt(zmq.IDENTITY, b"test_sender")
-        socket.connect(fault_receiver_addr)
+    """Test pause method"""
+    # Mock all engines to pause successfully
+    mock_call_utility_async.return_value = {
+        "request_id": "request_id",
+        "success": True,
+        "reason": None,
+    }
 
-        test_fault = FaultInfo(
-            engine_id=str(engine_id), type=fault_type, message="test error"
+    # Execute pause
+    result = await client_sentinel.pause(timeout=3, soft_pause=True)
+
+    # Verify result
+    assert result is True
+    assert client_sentinel.engine_status_dict[0]["status"] == EngineStatusType.PAUSED
+    assert client_sentinel.engine_status_dict[1]["status"] == EngineStatusType.PAUSED
+
+    # Verify call parameters
+    call_args = mock_call_utility_async.call_args[0][1]
+    assert call_args.instruction == "pause"
+    assert call_args.params["timeout"] == 3
+    assert call_args.params["soft_pause"] is True
+
+
+@pytest.mark.asyncio
+async def test_monitor_and_pause_on_fault(client_sentinel: ClientSentinel):
+    """Test fault monitoring and automatic pause logic (fix parameter conflict)"""
+
+    fault_info = FaultInfo(engine_id="0", type="dead", message="dead")
+    client_sentinel.fault_receiver_socket.recv_multipart = AsyncMock(
+        return_value=[b"", b"", msgspec.msgpack.encode(fault_info)]
+    )
+
+    async def mock_poll(self, timeout):
+        if not hasattr(mock_poll, "called"):
+            mock_poll.called = True  # type: ignore[attr-defined]
+            return [(client_sentinel.fault_receiver_socket, zmq.POLLIN)]
+        else:
+            client_sentinel.sentinel_dead = True
+            return []
+
+    with (
+        patch.object(asyncio, "sleep", return_value=None),
+        patch("zmq.asyncio.Poller.poll", mock_poll),
+    ):  # Replace Poller.poll
+        await client_sentinel._monitor_and_pause_on_fault()
+
+    assert client_sentinel.engine_status_dict[0]["status"] == EngineStatusType.DEAD
+    assert client_sentinel.is_faulted.is_set()
+    client_sentinel.fault_state_pub_socket.send_multipart.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_command_from_socket(client_sentinel: ClientSentinel):
+    """Test handling external commands from ZMQ socket (fix ft_args type error)"""
+    # 1. Construct valid FaultToleranceRequest parameter dictionary
+    test_request_id = str(uuid.uuid4())
+    ft_request_dict = {
+        "request_id": test_request_id,
+        "instruction": "retry",
+        "params": {"timeout": 2},
+    }
+
+    # 2. Construct correctly formatted encoded data (core fix)
+    encode_data = [
+        0,  # client_index (int)
+        123,  # call_id (int)
+        b"",  # empty byte placeholder
+        [ft_request_dict],  # ft_args → dictionary wrapped in list (key!)
+    ]
+
+    # 3. Mock data received by socket (DEALER mode: first frame is empty)
+    mock_data = [
+        b"",  # empty frame for DEALER mode
+        msgspec.msgpack.encode(encode_data),  # encode complete data
+    ]
+
+    # 4. Mock recv_multipart method of input socket
+    client_sentinel.input_sockets[0].recv_multipart = AsyncMock(return_value=mock_data)
+
+    # 5. Mock poller.poll as AsyncMock (avoid await list error)
+    async def mock_poll(self, timeout):
+        if not hasattr(mock_poll, "called"):
+            mock_poll.called = True  # type: ignore[attr-defined]
+            return [(client_sentinel.input_sockets[0], zmq.POLLIN)]
+        else:
+            client_sentinel.sentinel_dead = True
+            return []
+
+    # 6. Mock _send_utility_result for assertion
+    client_sentinel._send_utility_result = AsyncMock()
+
+    # 7. Execute run method
+    with patch("zmq.asyncio.Poller.poll", mock_poll):
+        await client_sentinel.run()
+
+    # 8. Verify command handling result
+    client_sentinel._send_utility_result.assert_awaited_with(
+        0,  # client_index
+        123,  # call_id
+        FaultToleranceResult(
+            success=True,
+            request_id=test_request_id,
+            reason=None,  # add required fields
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown(client_sentinel: ClientSentinel):
+    """Test shutdown method"""
+    # Mock close_sockets function
+    with patch("vllm.v1.fault_tolerance.client_sentinel.close_sockets") as mock_close:
+        client_sentinel.shutdown()
+        from unittest.mock import call
+
+        mock_close.assert_has_calls(
+            [
+                call(
+                    [
+                        client_sentinel.fault_receiver_socket,
+                        client_sentinel.fault_state_pub_socket,
+                    ]
+                ),
+                call(client_sentinel.input_sockets + client_sentinel.output_sockets),
+            ],
+            any_order=True,
         )
-        socket.send_multipart([b"", msgspec.msgpack.encode(test_fault)])
-        socket.close()
-        ctx.term()
-    except Exception:
-        thread_excs.put(traceback.format_exc())
-
-
-def create_client_sentinel(num_engines: int = 2, ft_addr=None):
-    if ft_addr is None:
-        ports = [_find_free_port() for _ in range(4)]
-        ft_addr = FaultToleranceZmqAddresses(
-            fault_state_pub_socket_addr=f"tcp://127.0.0.1:{ports[0]}",
-            client_sentinel_request_addr=f"tcp://127.0.0.1:{ports[1]}",
-            engine_core_sentinel_cmd_addr=f"tcp://127.0.0.1:{ports[2]}",
-            engine_fault_socket_addr=f"tcp://127.0.0.1:{ports[3]}",
-            engine_core_sentinel_identities={
-                i: f"engine_sentinel_identity_{i}".encode() for i in range(num_engines)
-            },
-        )
-
-    parallel = ParallelConfig(
-        data_parallel_size=num_engines,
-        data_parallel_size_local=num_engines,
-        data_parallel_master_ip="127.0.0.1",
-    )
-    vconfig = VllmConfig(
-        parallel_config=parallel,
-        fault_tolerance_config=FaultToleranceConfig(enable_fault_tolerance=True),
-    )
-
-    return ClientSentinel(vllm_config=vconfig, fault_tolerance_addresses=ft_addr)
-
-
-def test_client_sentinel_initialization(ft_addr):
-    sentinel = create_client_sentinel(ft_addr=ft_addr)
-
-    assert (
-        sentinel.engine_core_sentinel_identities[0]
-        == ft_addr.engine_core_sentinel_identities[0]
-    )
-    assert not sentinel.sentinel_dead
-    assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.HEALTHY
-    assert sentinel.fault_receiver_socket.type == zmq.ROUTER
-    assert sentinel.downstream_cmd_socket.type == zmq.ROUTER
-    assert sentinel.fault_state_pub_socket.type == zmq.PUB
-
-    sentinel.shutdown()
-
-
-def test_client_sentinel_receives_faults_and_publishes_status(ft_addr):
-    sentinel = create_client_sentinel(ft_addr=ft_addr)
-    thread_excs: Queue = Queue()
-
-    def decode_published_message(sub_socket):
-        # decode error messages published by client sentinel
-        if not sub_socket.poll(timeout=2000):
-            raise TimeoutError("Timeout waiting for published message")
-        frames = sub_socket.recv_multipart()
-        return frames[0].decode("utf-8"), msgspec.msgpack.decode(frames[-1])
-
-    def check_published_message():
-        # listen and verify error messages published from client sentinel
-        try:
-            ctx = zmq.Context()
-            sub_socket = ctx.socket(zmq.SUB)
-            sub_socket.connect(ft_addr.fault_state_pub_socket_addr)
-            sub_socket.setsockopt_string(
-                zmq.SUBSCRIBE, sentinel.ft_config.fault_state_pub_topic
-            )
-            # Consume the first published status update (after the first fault)
-            # without validating it here; this test only asserts on the final state
-            decode_published_message(sub_socket)
-            prefix, status_dict = decode_published_message(sub_socket)
-            sub_socket.close()
-            ctx.term()
-            assert prefix == sentinel.ft_config.fault_state_pub_topic
-            assert status_dict[1]["status"] == EngineStatusType.DEAD
-            assert status_dict[0]["status"] == EngineStatusType.UNHEALTHY
-        except Exception:
-            thread_excs.put(traceback.format_exc())
-
-    t1 = threading.Thread(target=check_published_message, daemon=True)
-    t1.start()
-    time.sleep(0.1)
-
-    threading.Thread(
-        target=send_error_message,
-        args=(ft_addr.engine_fault_socket_addr, "1", "dead", thread_excs),
-        daemon=True,
-    ).start()
-    time.sleep(0.1)
-    threading.Thread(
-        target=send_error_message,
-        args=(ft_addr.engine_fault_socket_addr, "0", "RuntimeError", thread_excs),
-        daemon=True,
-    ).start()
-
-    t1.join()
-    fail_on_thread_exceptions(thread_excs)
-
-    # Verify engine_status_dict updated
-    assert sentinel.engine_status_dict[1]["status"] == EngineStatusType.DEAD
-    assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.UNHEALTHY
-
-    sentinel.shutdown()
-
-
-def test_shutdown_sentinel(ft_addr):
-    sentinel = create_client_sentinel(ft_addr=ft_addr)
-
-    original_fault_sock = sentinel.fault_receiver_socket
-    original_cmd_sock = sentinel.downstream_cmd_socket
-    original_pub_sock = sentinel.fault_state_pub_socket
-    original_ctx = sentinel.ctx
-
-    sentinel.shutdown()
-
-    assert sentinel.sentinel_dead
-
-    with pytest.raises(zmq.ZMQError):
-        original_fault_sock.recv()
-    with pytest.raises(zmq.ZMQError):
-        original_cmd_sock.recv()
-    with pytest.raises(zmq.ZMQError):
-        original_pub_sock.send(b"test")
-
-    assert original_ctx.closed
-
-
-@pytest.mark.parametrize("instruction", ["pause", "retry"])
-def test_handle_fault_roundtrip(instruction, ft_addr):
-    """Test the full FaultToleranceRequest -> engine -> FaultToleranceResult flow
-    by talking to the sentinel's ROUTER endpoints using msgpack-encoded
-    FaultToleranceRequest/Result messages.
-    """
-    sentinel = create_client_sentinel(num_engines=1, ft_addr=ft_addr)
-    thread_excs: Queue = Queue()
-
-    # Start a DEALER that will act as the downstream engine sentinel.
-    engine_ctx = zmq.Context()
-    engine_socket = engine_ctx.socket(zmq.DEALER)
-    engine_socket.setsockopt(zmq.IDENTITY, ft_addr.engine_core_sentinel_identities[0])
-    engine_socket.connect(ft_addr.engine_core_sentinel_cmd_addr)
-
-    # Create a client DEALER that will send the FaultToleranceRequest to ClientSentinel
-    client_ctx = zmq.Context()
-    client_socket = client_ctx.socket(zmq.DEALER)
-    client_socket.setsockopt(zmq.IDENTITY, b"test_client")
-    client_socket.connect(ft_addr.client_sentinel_request_addr)
-
-    # Prepare the fault tolerance request
-    req_id = str(uuid.uuid4())
-    params = {"timeout": 3}
-    if instruction == "pause":
-        params["soft_pause"] = True
-    else:
-        params["new_stateless_dp_group_port"] = 12568
-
-    ft_req = FaultToleranceRequest(
-        request_id=req_id, instruction=instruction, params=params
-    )
-
-    def engine_loop():
-        try:
-            if not engine_socket.poll(timeout=2000):
-                raise TimeoutError(
-                    "Timeout waiting for FaultToleranceRequest from client sentinel"
-                )
-            parts = engine_socket.recv_multipart()
-            received = msgspec.msgpack.decode(parts[-1], type=FaultToleranceRequest)
-            assert received.instruction in ("pause", "retry")
-            # reply with success
-            res = FaultToleranceResult(
-                request_id=received.request_id, success=True, reason=None
-            )
-            engine_socket.send_multipart([b"", msgspec.msgpack.encode(res)])
-        except Exception:
-            thread_excs.put(traceback.format_exc())
-
-    threading.Thread(target=engine_loop, daemon=True).start()
-    client_socket.send_multipart([b"", msgspec.msgpack.encode(ft_req)])
-
-    # Wait for reply from ClientSentinel on client_socket
-    if not client_socket.poll(timeout=2000):
-        pytest.fail("Timeout waiting for FaultToleranceResult from client sentinel.")
-    parts = client_socket.recv_multipart()
-    ft_res = msgspec.msgpack.decode(parts[-1], type=FaultToleranceResult)
-    assert ft_res.request_id == req_id
-    assert ft_res.success is True
-    if instruction == "pause":
-        assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.PAUSED
-    elif instruction == "retry":
-        assert sentinel.engine_status_dict[0]["status"] == EngineStatusType.HEALTHY
-
-    fail_on_thread_exceptions(thread_excs)
-    client_socket.close()
-    client_ctx.term()
-    engine_socket.close()
-    engine_ctx.term()
-
-    sentinel.shutdown()
+        assert client_sentinel.sentinel_dead is True

--- a/tests/v1/fault_tolerance/test_engine_core_sentinel.py
+++ b/tests/v1/fault_tolerance/test_engine_core_sentinel.py
@@ -67,7 +67,6 @@ def create_engine_core_sentinel(
         cmd_q=cmd_q,
         busy_loop_active=busy_loop_active,
         engine_input_q=queue.Queue(),
-        upstream_cmd_addr=addr_dict["client_cmd_addr"],
         downstream_cmd_addr=addr_dict["worker_cmd_addr"],
         engine_fault_socket_addr=addr_dict["engine_fault_socket_addr"],
         sentinel_identity=sentinel_identity,
@@ -85,11 +84,8 @@ def test_engine_core_sentinel_initialization(addr_dict):
     assert sentinel.tp_size == 1
     assert sentinel.pp_size == 1
     assert not sentinel.communicator_aborted
-    assert sentinel.engine_running is True
 
     assert sentinel.engine_fault_socket.type == zmq.DEALER
-    assert sentinel.upstream_cmd_socket.type == zmq.DEALER
-    assert sentinel.downstream_cmd_socket.type == zmq.ROUTER
 
     sentinel.shutdown()
 
@@ -140,12 +136,6 @@ def test_engine_core_sentinel_handles_fault_tolerance_instructions(
     thread_excs: Queue = Queue()
     cmd_q: Queue = Queue()
 
-    ctx = zmq.Context()
-    client_cmd_socket = ctx.socket(zmq.ROUTER)
-    client_cmd_socket.bind(addr_dict["client_cmd_addr"])
-
-    time.sleep(0.1)
-
     sentinel_identity = b"engine_sentinel_0"
     sentinel = create_engine_core_sentinel(
         fault_signal_q,
@@ -179,17 +169,8 @@ def test_engine_core_sentinel_handles_fault_tolerance_instructions(
         except Exception:
             thread_excs.put(traceback.format_exc())
 
-    worker_ctx = zmq.Context()
-    worker_cmd_socket = worker_ctx.socket(zmq.DEALER)
-    worker_cmd_socket.setsockopt(zmq.IDENTITY, b"PP0_TP0")
-    worker_cmd_socket.connect(addr_dict["worker_cmd_addr"])
-    threading.Thread(
-        target=mock_worker_receiver, args=(worker_cmd_socket,), daemon=True
-    ).start()
-    time.sleep(0.1)
-
     # Simulate sending fault tolerance request from client sentinel
-    param = {"timeout": 3}
+    param = {"timeout": 5}
     if instruction == "pause":
         param["soft_pause"] = False
     elif instruction == "retry":
@@ -199,33 +180,37 @@ def test_engine_core_sentinel_handles_fault_tolerance_instructions(
     ft_request = FaultToleranceRequest(
         request_id=req_id, instruction=instruction, params=param
     )
-    client_cmd_socket.send_multipart(
-        [sentinel_identity, b"", msgpack.encode(ft_request)]
-    )
+
+    worker_ctx = zmq.Context()
+    worker_cmd_socket = worker_ctx.socket(zmq.DEALER)
+    worker_cmd_socket.setsockopt(zmq.IDENTITY, b"PP0_TP0")
+    worker_cmd_socket.connect(addr_dict["worker_cmd_addr"])
+    threading.Thread(
+        target=mock_worker_receiver, args=(worker_cmd_socket,), daemon=True
+    ).start()
+    time.sleep(0.1)
 
     if instruction == "pause":
         # Simulate that pause is executed by engine core
         busy_loop_active.clear()
         fault_signal_q.put(EngineLoopPausedError("Simulated pause for testing"))
+        ft_res = sentinel.handle_fault(ft_request)
     elif instruction == "retry":
-        cmd_q.get(timeout=2000)
-        busy_loop_active.set()
+        from unittest.mock import patch
 
-    # Verify the client sentinel receives the response from the engine core sentinel
-    if not client_cmd_socket.poll(timeout=2000):
-        pytest.fail("Timeout waiting for response from sentinel")
+        # Mock busy_loop_active.wait to avoid blocking, since the busy loop
+        # isn't running in this test to consume the command and set the event.
+        with patch.object(busy_loop_active, "wait", return_value=True) as mock_wait:
+            ft_res = sentinel.handle_fault(ft_request)
+            # Verify that a command was put on the queue for the busy loop.
+            cmd_q.get(timeout=2)
+            mock_wait.assert_called()
 
-    identity, _, msg_bytes = client_cmd_socket.recv_multipart()
-    assert identity == sentinel_identity
-    ft_res = msgpack.decode(msg_bytes, type=FaultToleranceResult)
     assert ft_res.request_id == req_id
     assert ft_res.success
 
     time.sleep(0.1)
     fail_on_thread_exceptions(thread_excs)
-
-    client_cmd_socket.close()
     worker_cmd_socket.close()
     sentinel.shutdown()
-    ctx.term()
     worker_ctx.term()

--- a/tests/v1/fault_tolerance/test_engine_core_sentinel.py
+++ b/tests/v1/fault_tolerance/test_engine_core_sentinel.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import queue
+import socket
+import threading
+import time
+import traceback
+import uuid
+from queue import Queue
+
+import pytest
+import zmq
+from msgspec import msgpack
+
+from vllm.config import FaultToleranceConfig, ParallelConfig, VllmConfig
+from vllm.v1.engine.core import EngineLoopPausedError
+from vllm.v1.fault_tolerance import EngineCoreSentinel
+from vllm.v1.fault_tolerance.utils import (
+    FaultInfo,
+    FaultToleranceRequest,
+    FaultToleranceResult,
+)
+
+
+def _find_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def addr_dict():
+    ports = [_find_free_port() for _ in range(3)]
+    return {
+        "client_cmd_addr": f"tcp://127.0.0.1:{ports[0]}",
+        "worker_cmd_addr": f"tcp://127.0.0.1:{ports[1]}",
+        "engine_fault_socket_addr": f"tcp://127.0.0.1:{ports[2]}",
+    }
+
+
+# Helper to collect exceptions from threads and fail the test if any were raised.
+def fail_on_thread_exceptions(thread_excs: Queue) -> None:
+    if not thread_excs.empty():
+        pytest.fail("Thread raised exception:\n" + "\n".join(thread_excs.queue))
+
+
+def create_engine_core_sentinel(
+    fault_signal_q: queue.Queue,
+    busy_loop_active: threading.Event,
+    addr_dict: dict,
+    sentinel_identity: bytes = b"engine_sentinel_0",
+    cmd_q: queue.Queue | None = None,
+):
+    vllm_cfg = VllmConfig(
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1
+        ),
+        fault_tolerance_config=FaultToleranceConfig(enable_fault_tolerance=True),
+    )
+    if cmd_q is None:
+        cmd_q = queue.Queue()
+
+    return EngineCoreSentinel(
+        engine_index=0,
+        fault_signal_q=fault_signal_q,
+        cmd_q=cmd_q,
+        busy_loop_active=busy_loop_active,
+        engine_input_q=queue.Queue(),
+        upstream_cmd_addr=addr_dict["client_cmd_addr"],
+        downstream_cmd_addr=addr_dict["worker_cmd_addr"],
+        engine_fault_socket_addr=addr_dict["engine_fault_socket_addr"],
+        sentinel_identity=sentinel_identity,
+        vllm_config=vllm_cfg,
+    )
+
+
+def test_engine_core_sentinel_initialization(addr_dict):
+    fault_signal_q: queue.Queue = queue.Queue()
+    busy_loop_active = threading.Event()
+
+    sentinel = create_engine_core_sentinel(fault_signal_q, busy_loop_active, addr_dict)
+
+    assert sentinel.engine_index == 0
+    assert sentinel.tp_size == 1
+    assert sentinel.pp_size == 1
+    assert not sentinel.communicator_aborted
+    assert sentinel.engine_running is True
+
+    assert sentinel.engine_fault_socket.type == zmq.DEALER
+    assert sentinel.upstream_cmd_socket.type == zmq.DEALER
+    assert sentinel.downstream_cmd_socket.type == zmq.ROUTER
+
+    sentinel.shutdown()
+
+
+def test_busy_loop_exception_forwarded_to_client(addr_dict):
+    """
+    Verify that when a busy loop raises an exception, the
+    busy_loop_wrapper puts the exception into fault_signal_q and
+    EngineCoreSentinel detects it and forwards a FaultInfo message
+    to the client-facing engine fault socket.
+    """
+    fault_signal_q: queue.Queue = queue.Queue()
+    busy_loop_active = threading.Event()
+    sentinel_identity = b"engine_sentinel_0"
+    sentinel = create_engine_core_sentinel(
+        fault_signal_q, busy_loop_active, addr_dict, sentinel_identity=sentinel_identity
+    )
+
+    # Bind a ROUTER to the engine_fault_socket_addr to receive the fault report.
+    ctx = zmq.Context()
+    engine_fault_receiver = ctx.socket(zmq.ROUTER)
+    engine_fault_receiver.bind(addr_dict["engine_fault_socket_addr"])
+
+    time.sleep(0.1)
+    busy_loop_active.clear()
+    fault_signal_q.put(RuntimeError("test exception"))
+
+    # Wait for the sentinel to forward the fault to the engine_fault socket.
+    if not engine_fault_receiver.poll(timeout=5000):
+        pytest.fail("Timeout waiting for engine fault message from sentinel")
+
+    parts = engine_fault_receiver.recv_multipart()
+    assert len(parts) >= 2
+    fault_info = msgpack.decode(parts[-1], type=FaultInfo)
+    assert "test exception" in fault_info.message
+
+    engine_fault_receiver.close()
+    sentinel.shutdown()
+    ctx.term()
+
+
+@pytest.mark.parametrize("instruction", ["pause", "retry"])
+def test_engine_core_sentinel_handles_fault_tolerance_instructions(
+    instruction, addr_dict
+):
+    fault_signal_q: queue.Queue = queue.Queue()
+    busy_loop_active = threading.Event()
+    thread_excs: Queue = Queue()
+    cmd_q: Queue = Queue()
+
+    ctx = zmq.Context()
+    client_cmd_socket = ctx.socket(zmq.ROUTER)
+    client_cmd_socket.bind(addr_dict["client_cmd_addr"])
+
+    time.sleep(0.1)
+
+    sentinel_identity = b"engine_sentinel_0"
+    sentinel = create_engine_core_sentinel(
+        fault_signal_q,
+        busy_loop_active,
+        addr_dict,
+        sentinel_identity=sentinel_identity,
+        cmd_q=cmd_q,
+    )
+
+    if instruction == "retry":
+        # Simulate that an exception is raised in the busy loop,
+        # so that engine is in pause state.
+        busy_loop_active.clear()
+        fault_signal_q.put(RuntimeError("Pretest exception to trigger pause"))
+        time.sleep(0.1)
+        assert not busy_loop_active.is_set()
+
+    # Simulate the worker waiting the command and replying with a success response.
+    def mock_worker_receiver(cmd_socket):
+        try:
+            if not cmd_socket.poll(timeout=2000):
+                pytest.fail("Timeout waiting for command from engine core sentinel")
+            parts = cmd_socket.recv_multipart()
+            # DEALER gets [empty_frame, msg_bytes]
+            _, msg_bytes = parts
+
+            ft_req = msgpack.decode(msg_bytes, type=FaultToleranceRequest)
+            assert ft_req.instruction == instruction
+            ft_res = FaultToleranceResult(request_id=ft_req.request_id, success=True)
+            cmd_socket.send_multipart([b"", msgpack.encode(ft_res)])
+        except Exception:
+            thread_excs.put(traceback.format_exc())
+
+    worker_ctx = zmq.Context()
+    worker_cmd_socket = worker_ctx.socket(zmq.DEALER)
+    worker_cmd_socket.setsockopt(zmq.IDENTITY, b"PP0_TP0")
+    worker_cmd_socket.connect(addr_dict["worker_cmd_addr"])
+    threading.Thread(
+        target=mock_worker_receiver, args=(worker_cmd_socket,), daemon=True
+    ).start()
+    time.sleep(0.1)
+
+    # Simulate sending fault tolerance request from client sentinel
+    param = {"timeout": 3}
+    if instruction == "pause":
+        param["soft_pause"] = False
+    elif instruction == "retry":
+        param["new_stateless_dp_group_port"] = 23456
+    # Build a FaultToleranceRequest and send as msgpack
+    req_id = str(uuid.uuid4())
+    ft_request = FaultToleranceRequest(
+        request_id=req_id, instruction=instruction, params=param
+    )
+    client_cmd_socket.send_multipart(
+        [sentinel_identity, b"", msgpack.encode(ft_request)]
+    )
+
+    if instruction == "pause":
+        # Simulate that pause is executed by engine core
+        busy_loop_active.clear()
+        fault_signal_q.put(EngineLoopPausedError("Simulated pause for testing"))
+    elif instruction == "retry":
+        cmd_q.get(timeout=2000)
+        busy_loop_active.set()
+
+    # Verify the client sentinel receives the response from the engine core sentinel
+    if not client_cmd_socket.poll(timeout=2000):
+        pytest.fail("Timeout waiting for response from sentinel")
+
+    identity, _, msg_bytes = client_cmd_socket.recv_multipart()
+    assert identity == sentinel_identity
+    ft_res = msgpack.decode(msg_bytes, type=FaultToleranceResult)
+    assert ft_res.request_id == req_id
+    assert ft_res.success
+
+    time.sleep(0.1)
+    fail_on_thread_exceptions(thread_excs)
+
+    client_cmd_socket.close()
+    worker_cmd_socket.close()
+    sentinel.shutdown()
+    ctx.term()
+    worker_ctx.term()

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -11,6 +11,7 @@ from vllm.config.compilation import (
 )
 from vllm.config.device import DeviceConfig
 from vllm.config.ec_transfer import ECTransferConfig
+from vllm.config.fault_tolerance import FaultToleranceConfig
 from vllm.config.kernel import KernelConfig
 from vllm.config.kv_events import KVEventsConfig
 from vllm.config.kv_transfer import KVTransferConfig
@@ -111,6 +112,8 @@ __all__ = [
     "StructuredOutputsConfig",
     # From vllm.config.profiler
     "ProfilerConfig",
+    # From vllm.config.fault_tolerance
+    "FaultToleranceConfig",
     # From vllm.config.utils
     "ConfigType",
     "SupportsMetricsInfo",

--- a/vllm/config/fault_tolerance.py
+++ b/vllm/config/fault_tolerance.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import hashlib
+from typing import Any
+
+from vllm.config.utils import config
+
+
+@config
+class FaultToleranceConfig:
+    """Configuration for fault tolerance."""
+
+    enable_fault_tolerance: bool = False
+    """Enable fault tolerance for detailed error recovery,
+    such as scaling down fault DPEngineCore.
+    """
+
+    shutdown_on_fault_tolerance_failure: bool = False
+    """Whether to shut down vLLM when a fault tolerance action fails.
+    """
+
+    engine_recovery_timeout_sec: int = 60
+    """Timeout (in seconds) to wait for error handling instructions
+    before raising an exception. If the EngineCore encounters an
+    error, it waits up to this many seconds for instructions on how
+    to handle the error. If no instructions are received within this
+    time, the original error is raised.
+    """
+
+    internal_fault_report_port: int = 22866
+    """
+    The port to use for engines to report fault to client sentinel.
+    """
+
+    external_fault_notify_port: int = 22867
+    """
+    Port used to publish engine fault and status change notifications.
+    """
+
+    gloo_comm_timeout: int = 30
+    """
+    The timeout (in seconds) for gloo communication.
+    """
+
+    worker_cmd_addr: str | None = None
+    """
+    ZMQ address used by EngineCoreSentinel to dispatch instructions to 
+    WorkerSentinel instances. This address is assigned dynamically during 
+    runtime.
+    """
+
+    fault_state_pub_topic: str = "vllm_fault"
+    """
+    The topic string to use for publishing fault state messages via ZMQ.
+    """
+
+    def compute_hash(self) -> str:
+        """
+        WARNING: Whenever a new field is added to this config,
+        ensure that it is included in the factors list if
+        it affects the computation graph.
+        Provide a hash that uniquely identifies all the configs
+        that affect the structure of the computation
+        graph from input ids/embeddings to the final hidden states,
+        excluding anything before input ids/embeddings and after
+        the final hidden states.
+        """
+        # no factors to consider.
+        # this config will not affect the computation graph.
+        factors: list[Any] = []
+        hash_str = hashlib.md5(str(factors).encode(), usedforsecurity=False).hexdigest()
+        return hash_str
+
+    def __post_init__(self) -> None:
+        pass

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -11,6 +11,7 @@ from torch.distributed import ProcessGroup, ReduceOp, Store
 from typing_extensions import Self
 
 import vllm.envs as envs
+from vllm.config import FaultToleranceConfig
 from vllm.config.utils import config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.batch_invariant import (
@@ -520,14 +521,23 @@ class ParallelConfig:
 
     @overload
     def stateless_init_dp_group(
-        self, return_store: Literal[False] = ...
+        self,
+        return_store: Literal[False] = ...,
+        dp_init_port: int | None = ...,
+        fault_tolerance_config: FaultToleranceConfig | None = ...,
     ) -> ProcessGroup: ...
     @overload
     def stateless_init_dp_group(
-        self, return_store: Literal[True] = ...
+        self,
+        return_store: Literal[True] = ...,
+        dp_init_port: int | None = ...,
+        fault_tolerance_config: FaultToleranceConfig | None = ...,
     ) -> tuple[ProcessGroup, Store]: ...
     def stateless_init_dp_group(
-        self, return_store: bool = False
+        self,
+        return_store: bool = False,
+        dp_init_port: int | None = None,
+        fault_tolerance_config: FaultToleranceConfig | None = None,
     ) -> ProcessGroup | tuple[ProcessGroup, Store]:
         # NOTE: In high-concurrency scenarios multiple processes
         # can pick the same (currently free) port through a race
@@ -544,22 +554,26 @@ class ParallelConfig:
 
         max_retries = 5
         last_exc: Exception | None = None
+        if dp_init_port is None:
+            dp_init_port = self.get_next_dp_init_port()
         for _ in range(max_retries):
             try:
                 # use gloo since the engine process might not have cuda device
                 return stateless_init_torch_distributed_process_group(
                     self.data_parallel_master_ip,
-                    self.get_next_dp_init_port(),
+                    dp_init_port,
                     self.data_parallel_rank,
                     self.data_parallel_size,
                     backend="gloo",
                     return_store=return_store,
+                    fault_tolerance_config=fault_tolerance_config,
                 )
             except DistNetworkError as e:
                 # We only want to retry when the root cause is EADDRINUSE.
                 if "EADDRINUSE" in str(e):
                     logger.warning("Address already in use. Retrying with a new port.")
                     last_exc = e
+                    dp_init_port = self.get_next_dp_init_port()
                     continue  # try again with a new port
                 raise e
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -30,6 +30,7 @@ from .cache import CacheConfig
 from .compilation import CompilationConfig, CompilationMode, CUDAGraphMode
 from .device import DeviceConfig
 from .ec_transfer import ECTransferConfig
+from .fault_tolerance import FaultToleranceConfig
 from .kernel import KernelConfig
 from .kv_events import KVEventsConfig
 from .kv_transfer import KVTransferConfig
@@ -302,6 +303,10 @@ class VllmConfig:
     """The configurations for event publishing."""
     ec_transfer_config: ECTransferConfig | None = None
     """The configurations for distributed EC cache transfer."""
+    fault_tolerance_config: FaultToleranceConfig = Field(
+        default_factory=FaultToleranceConfig
+    )
+    """The configurations for fault tolerance."""
     # some opaque config, only used to provide additional information
     # for the hash computation, mainly used for testing, debugging or out of
     # tree config registration.
@@ -1625,7 +1630,8 @@ class VllmConfig:
             f"enable_prefix_caching={self.cache_config.enable_prefix_caching}, "
             f"enable_chunked_prefill={self.scheduler_config.enable_chunked_prefill}, "  # noqa
             f"pooler_config={self.model_config.pooler_config!r}, "
-            f"compilation_config={self.compilation_config!r}"
+            f"compilation_config={self.compilation_config!r},"
+            f"fault_tolerance_config={self.fault_tolerance_config!r}, "
         )
 
     def validate_block_size(self) -> None:

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -234,7 +234,7 @@ class PyNcclCommunicator:
                 cudaStream_t(stream.cuda_stream),
             )
             split_offset += split_size
-        self.nccl.ncclGroupEnd()
+        self.nccl.ncclGroupEnd(self.comm)
 
     def reduce_scatter(
         self,
@@ -299,7 +299,7 @@ class PyNcclCommunicator:
                 cudaStream_t(stream.cuda_stream),
             )
             split_offset += split_size
-        self.nccl.ncclGroupEnd()
+        self.nccl.ncclGroupEnd(self.comm)
 
     def send(self, tensor: torch.Tensor, dst: int, stream=None):
         if self.disabled:
@@ -385,7 +385,10 @@ class PyNcclCommunicator:
         self.nccl.ncclGroupStart()
 
     def group_end(self):
-        self.nccl.ncclGroupEnd()
+        self.nccl.ncclGroupEnd(self.comm)
+
+    def nccl_abort_comm(self):
+        self.nccl.ncclCommAbort(self.comm)
 
     def register_comm_window(self, tensor: torch.Tensor):
         return self.nccl.ncclCommWindowRegister(

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -131,6 +131,7 @@ class ElasticEPScalingExecutor:
     def __init__(self, worker):
         self.worker_ref = weakref.ref(worker)
         self.reconfig_request = None
+        # todo: add fault tolerance related states to support elastic EP
 
     @property
     def worker(self):

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -25,6 +25,7 @@ If you only need to use the distributed environment without model/pipeline
 
 import contextlib
 import gc
+import os
 import pickle
 import weakref
 from collections import namedtuple
@@ -43,6 +44,7 @@ import torch.distributed._symmetric_memory
 from torch.distributed import Backend, ProcessGroup
 
 import vllm.envs as envs
+from vllm.config import FaultToleranceConfig
 from vllm.distributed.device_communicators.base_device_communicator import (
     DeviceCommunicatorBase,
 )
@@ -321,6 +323,7 @@ class GroupCoordinator:
         use_device_communicator: bool,  # whether to use device communicator
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
+        fault_tolerance_config: FaultToleranceConfig | None = None,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -332,14 +335,31 @@ class GroupCoordinator:
         self_device_group = None
         self_cpu_group = None
 
+        gloo_comm_timeout = None
+        options = None
+        if torch_distributed_backend == "nccl":
+            options = torch._C._distributed_c10d.ProcessGroupNCCL.Options()
+            if (
+                fault_tolerance_config is not None
+                and fault_tolerance_config.enable_fault_tolerance
+            ):
+                gloo_comm_timeout = timedelta(
+                    seconds=fault_tolerance_config.gloo_comm_timeout
+                )
+                # need to set communicators as nonblocking to abort safely
+                options.config.blocking = 0
+                os.environ["NCCL_COMM_BLOCKING"] = "0"
+
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
+                ranks, backend=torch_distributed_backend, pg_options=options
             )
             # a group with `gloo` backend, to allow direct coordination between
             # processes through the CPU.
             with suppress_stdout():
-                cpu_group = torch.distributed.new_group(ranks, backend="gloo")
+                cpu_group = torch.distributed.new_group(
+                    ranks, backend="gloo", timeout=gloo_comm_timeout
+                )
             if self.rank in ranks:
                 self.ranks = ranks
                 self.world_size = len(ranks)
@@ -1132,7 +1152,10 @@ def get_inner_dp_world_group() -> GroupCoordinator:
 
 
 def init_world_group(
-    ranks: list[int], local_rank: int, backend: str
+    ranks: list[int],
+    local_rank: int,
+    backend: str,
+    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=[ranks],
@@ -1140,6 +1163,7 @@ def init_world_group(
         torch_distributed_backend=backend,
         use_device_communicator=False,
         group_name="world",
+        fault_tolerance_config=fault_tolerance_config,
     )
 
 
@@ -1150,6 +1174,7 @@ def init_model_parallel_group(
     use_message_queue_broadcaster: bool = False,
     group_name: str | None = None,
     use_device_communicator: bool = True,
+    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=group_ranks,
@@ -1158,6 +1183,7 @@ def init_model_parallel_group(
         use_device_communicator=use_device_communicator,
         use_message_queue_broadcaster=use_message_queue_broadcaster,
         group_name=group_name,
+        fault_tolerance_config=fault_tolerance_config,
     )
 
 
@@ -1168,6 +1194,7 @@ def _init_stateless_group(
     host: str,
     backend: str,
     use_device_communicator: bool = True,
+    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> "StatelessGroupCoordinator":
     """Create a StatelessGroupCoordinator with the given parameters."""
     from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
@@ -1183,6 +1210,7 @@ def _init_stateless_group(
         group_ports=group_ports,
         global_rank=world.rank,
         global_world_size=world.world_size,
+        fault_tolerance_config=fault_tolerance_config,
     )
 
 
@@ -1277,6 +1305,10 @@ def get_pcp_group() -> GroupCoordinator:
     return _PCP
 
 
+def get_all_model_groups() -> list[GroupCoordinator]:
+    return [g for g in (_TP, _PP, _DCP, _DP, _EP, _PCP) if g is not None]
+
+
 @contextmanager
 def graph_capture(device: torch.device):
     """
@@ -1347,6 +1379,7 @@ def init_distributed_environment(
     local_rank: int = -1,
     backend: str = "nccl",
     timeout: timedelta | None = None,
+    fault_tolerance_config: FaultToleranceConfig | None = None,
 ):
     logger.debug(
         "world_size=%d rank=%d local_rank=%d distributed_init_method=%s backend=%s",
@@ -1446,7 +1479,9 @@ def init_distributed_environment(
         return
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))
-        _WORLD = init_world_group(ranks, local_rank, backend)
+        _WORLD = init_world_group(
+            ranks, local_rank, backend, fault_tolerance_config=fault_tolerance_config
+        )
         if config is not None and config.parallel_config.nnodes > 1:
             _NODE_COUNT = config.parallel_config.nnodes
         else:
@@ -1481,6 +1516,7 @@ def initialize_model_parallel(
     prefill_context_model_parallel_size: int = 1,
     decode_context_model_parallel_size: int | None = 1,
     backend: str | None = None,
+    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> None:
     """
     Initialize model parallel groups.
@@ -1567,6 +1603,7 @@ def initialize_model_parallel(
         backend,
         use_message_queue_broadcaster=True,
         group_name="tp",
+        fault_tolerance_config=fault_tolerance_config,
     )
 
     # Build the DCP model-parallel groups.
@@ -1589,6 +1626,7 @@ def initialize_model_parallel(
         backend,
         use_message_queue_broadcaster=True,
         group_name="dcp",
+        fault_tolerance_config=fault_tolerance_config,
     )
 
     global _PCP
@@ -1625,7 +1663,11 @@ def initialize_model_parallel(
         )
         group_ranks = [x.tolist() for x in group_ranks]
     _PP = init_model_parallel_group(
-        group_ranks, get_world_group().local_rank, backend, group_name="pp"
+        group_ranks,
+        get_world_group().local_rank,
+        backend,
+        group_name="pp",
+        fault_tolerance_config=fault_tolerance_config,
     )
 
     global _DP
@@ -1643,10 +1685,15 @@ def initialize_model_parallel(
             dp_ports,
             parallel_config.data_parallel_master_ip,
             backend,
+            fault_tolerance_config=fault_tolerance_config,
         )
     else:
         _DP = init_model_parallel_group(
-            group_ranks, get_world_group().local_rank, backend, group_name="dp"
+            group_ranks,
+            get_world_group().local_rank,
+            backend,
+            group_name="dp",
+            fault_tolerance_config=fault_tolerance_config,
         )
 
     global _EP
@@ -1675,10 +1722,15 @@ def initialize_model_parallel(
                 ep_ports,
                 parallel_config.data_parallel_master_ip,
                 backend,
+                fault_tolerance_config=fault_tolerance_config,
             )
         else:
             _EP = init_model_parallel_group(
-                group_ranks, get_world_group().local_rank, backend, group_name="ep"
+                group_ranks,
+                get_world_group().local_rank,
+                backend,
+                group_name="ep",
+                fault_tolerance_config=fault_tolerance_config,
             )
 
         # Create EPLB group with the same ranks as EP if EPLB is enabled.
@@ -1735,6 +1787,7 @@ def ensure_model_parallel_initialized(
     prefill_context_model_parallel_size: int = 1,
     decode_context_model_parallel_size: int | None = 1,
     backend: str | None = None,
+    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> None:
     """Helper to initialize model parallel groups if they are not initialized,
     or ensure tensor-parallel and pipeline-parallel sizes are equal to expected
@@ -1752,6 +1805,7 @@ def ensure_model_parallel_initialized(
             prefill_context_model_parallel_size,
             decode_context_model_parallel_size,
             backend,
+            fault_tolerance_config=fault_tolerance_config,
         )
         return
 

--- a/vllm/distributed/stateless_coordinator.py
+++ b/vllm/distributed/stateless_coordinator.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed import Backend, ProcessGroup
 
+from vllm.config import FaultToleranceConfig
 from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
 from vllm.distributed.parallel_state import (
     GroupCoordinator,
@@ -45,6 +46,7 @@ class StatelessGroupCoordinator(GroupCoordinator):
         group_ports: list[list[int]] | None = None,
         global_rank: int = 0,
         global_world_size: int = 1,
+        fault_tolerance_config: FaultToleranceConfig | None = None,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -88,6 +90,7 @@ class StatelessGroupCoordinator(GroupCoordinator):
                     world_size=self.world_size,
                     backend="gloo",
                     group_name=f"{self.unique_name}_cpu",
+                    fault_tolerance_config=fault_tolerance_config,
                 )
                 tcp_store_group = StatelessProcessGroup.create(
                     host=host,

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -28,6 +28,7 @@ from torch.distributed.distributed_c10d import (
 from torch.distributed.rendezvous import rendezvous
 
 import vllm.envs as envs
+from vllm.config import FaultToleranceConfig
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_tcp_uri
 from vllm.utils.system_utils import suppress_stdout
@@ -504,6 +505,7 @@ def stateless_init_torch_distributed_process_group(
     backend: str,
     group_name: str | None = None,
     return_store: bool = False,
+    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> ProcessGroup | tuple[ProcessGroup, Store]:
     """
     A replacement for `torch.distributed.init_process_group` that does not
@@ -538,7 +540,15 @@ def stateless_init_torch_distributed_process_group(
     """
     init_method = get_tcp_uri(host, port)
     backend = Backend(backend)  # it is basically string
-    timeout = _get_default_timeout(backend)
+
+    if (
+        fault_tolerance_config is not None
+        and fault_tolerance_config.enable_fault_tolerance
+        and backend == "gloo"
+    ):
+        timeout = timedelta(seconds=fault_tolerance_config.gloo_comm_timeout)
+    else:
+        timeout = _get_default_timeout(backend)
 
     store, rank, world_size = next(
         rendezvous(init_method, rank, world_size, timeout=timeout)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -40,6 +40,7 @@ from vllm.config import (
     DeviceConfig,
     ECTransferConfig,
     EPLBConfig,
+    FaultToleranceConfig,
     KernelConfig,
     KVEventsConfig,
     KVTransferConfig,
@@ -601,6 +602,16 @@ class EngineArgs:
     kv_sharing_fast_prefill: bool = CacheConfig.kv_sharing_fast_prefill
     optimization_level: OptimizationLevel = VllmConfig.optimization_level
     performance_mode: PerformanceMode = VllmConfig.performance_mode
+
+    # fault tolerance fields
+    enable_fault_tolerance: bool = FaultToleranceConfig.enable_fault_tolerance
+    engine_recovery_timeout_sec: int = FaultToleranceConfig.engine_recovery_timeout_sec
+    internal_fault_report_port: int = FaultToleranceConfig.internal_fault_report_port
+    external_fault_notify_port: int = FaultToleranceConfig.external_fault_notify_port
+    gloo_comm_timeout: int = FaultToleranceConfig.gloo_comm_timeout
+    shutdown_on_fault_tolerance_failure: bool = (
+        FaultToleranceConfig.shutdown_on_fault_tolerance_failure
+    )
 
     kv_offloading_size: float | None = CacheConfig.kv_offloading_size
     kv_offloading_backend: KVOffloadingBackend = CacheConfig.kv_offloading_backend
@@ -1290,6 +1301,37 @@ class EngineArgs:
             "--weight-transfer-config", **vllm_kwargs["weight_transfer_config"]
         )
 
+        # fault tolerance arguments
+        fault_tolerance_kwargs = get_kwargs(FaultToleranceConfig)
+        fault_tolerance_group = parser.add_argument_group(
+            title="FaultToleranceConfig",
+            description=FaultToleranceConfig.__doc__,
+        )
+        fault_tolerance_group.add_argument(
+            "--enable-fault-tolerance",
+            **fault_tolerance_kwargs["enable_fault_tolerance"],
+        )
+        fault_tolerance_group.add_argument(
+            "--shutdown-on-fault-tolerance-failure",
+            **fault_tolerance_kwargs["shutdown_on_fault_tolerance_failure"],
+        )
+        fault_tolerance_group.add_argument(
+            "--engine-recovery-timeout-sec",
+            **fault_tolerance_kwargs["engine_recovery_timeout_sec"],
+        )
+        fault_tolerance_group.add_argument(
+            "--internal-fault-report-port",
+            **fault_tolerance_kwargs["internal_fault_report_port"],
+        )
+        fault_tolerance_group.add_argument(
+            "--external-fault-notify-port",
+            **fault_tolerance_kwargs["external_fault_notify_port"],
+        )
+        fault_tolerance_group.add_argument(
+            "--gloo-comm-timeout",
+            **fault_tolerance_kwargs["gloo_comm_timeout"],
+        )
+
         # Other arguments
         parser.add_argument(
             "--disable-log-stats",
@@ -1878,6 +1920,15 @@ class EngineArgs:
             enable_logging_iteration_details=self.enable_logging_iteration_details,
         )
 
+        fault_tolerance_config = FaultToleranceConfig(
+            enable_fault_tolerance=self.enable_fault_tolerance,
+            shutdown_on_fault_tolerance_failure=self.shutdown_on_fault_tolerance_failure,
+            engine_recovery_timeout_sec=self.engine_recovery_timeout_sec,
+            internal_fault_report_port=self.internal_fault_report_port,
+            external_fault_notify_port=self.external_fault_notify_port,
+            gloo_comm_timeout=self.gloo_comm_timeout,
+        )
+
         # Compilation config overrides
         compilation_config = copy.deepcopy(self.compilation_config)
         if self.cudagraph_capture_sizes is not None:
@@ -1933,6 +1984,7 @@ class EngineArgs:
             kv_events_config=self.kv_events_config,
             ec_transfer_config=self.ec_transfer_config,
             profiler_config=self.profiler_config,
+            fault_tolerance_config=fault_tolerance_config,
             additional_config=self.additional_config,
             optimization_level=self.optimization_level,
             performance_mode=self.performance_mode,

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -247,6 +247,3 @@ class EngineClient(ABC):
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
         """Batched weight update for RL training."""
         raise NotImplementedError
-
-    def shutdown(self) -> None:
-        raise NotImplementedError

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -19,8 +19,11 @@ from vllm.pooling_params import PoolingParams
 from vllm.renderers import BaseRenderer
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
-from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine import (
+    EngineCoreRequest,
+)
 from vllm.v1.engine.input_processor import InputProcessor
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest, FaultToleranceResult
 
 if TYPE_CHECKING:
     from vllm.v1.engine import PauseMode
@@ -221,6 +224,16 @@ class EngineClient(ABC):
         """Perform a collective RPC call to the given path."""
         raise NotImplementedError
 
+    async def handle_fault(
+        self, fault_tolerance_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        """send fault tolerance instruction to the engine"""
+        raise NotImplementedError
+
+    async def get_fault_info(self):
+        """report exception from engine_core"""
+        raise NotImplementedError
+
     async def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         """Get supported tasks"""
         raise NotImplementedError
@@ -233,4 +246,7 @@ class EngineClient(ABC):
 
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
         """Batched weight update for RL training."""
+        raise NotImplementedError
+
+    def shutdown(self) -> None:
         raise NotImplementedError

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -221,7 +221,12 @@ def run_headless(args: argparse.Namespace):
     )
 
     try:
-        engine_manager.join_first()
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            engine_manager.monitor_engine_liveness(
+                engine_down_callback=engine_manager.notify_engine_down
+            )
+        else:
+            engine_manager.join_first()
     finally:
         timeout = None
         if shutdown_requested:
@@ -294,6 +299,7 @@ def run_multi_api_server(args: argparse.Namespace):
             stats_update_address=coordinator.get_stats_publish_address()
             if coordinator
             else None,
+            fault_tolerance_addresses=addresses.fault_tolerance_addresses,
         )
 
         # For dp ranks > 0 in external/hybrid DP LB modes, we must delay the

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -44,6 +44,7 @@ from vllm.entrypoints.sagemaker.api_router import sagemaker_standards_bootstrap
 from vllm.entrypoints.serve.elastic_ep.middleware import (
     ScalingMiddleware,
 )
+from vllm.entrypoints.serve.fault_tolerance.middleware import FaultToleranceMiddleware
 from vllm.entrypoints.serve.tokenize.serving import OpenAIServingTokenization
 from vllm.entrypoints.utils import (
     cli_env_setup,
@@ -185,7 +186,7 @@ def build_app(
 
     from vllm.entrypoints.serve import register_vllm_serve_api_routers
 
-    register_vllm_serve_api_routers(app)
+    register_vllm_serve_api_routers(app, args=args)
 
     from vllm.entrypoints.openai.models.api_router import (
         attach_router as register_models_api_router,
@@ -278,6 +279,11 @@ def build_app(
 
     # Add scaling middleware to check for scaling state
     app.add_middleware(ScalingMiddleware)
+
+    if args.enable_fault_tolerance:
+        # Add fault-tolerance middleware to short-circuit requests when the
+        # engine's ClientSentinel reports a faulted state.
+        app.add_middleware(FaultToleranceMiddleware)
 
     if "realtime" in supported_tasks:
         # Add WebSocket metrics middleware

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from argparse import Namespace
+
 from fastapi import FastAPI
 
 import vllm.envs as envs
@@ -9,7 +11,7 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
-def register_vllm_serve_api_routers(app: FastAPI):
+def register_vllm_serve_api_routers(app: FastAPI, args: Namespace | None = None):
     if envs.VLLM_SERVER_DEV_MODE:
         logger.warning(
             "SECURITY WARNING: Development endpoints are enabled! "
@@ -55,3 +57,15 @@ def register_vllm_serve_api_routers(app: FastAPI):
     from .instrumentator import register_instrumentator_api_routers
 
     register_instrumentator_api_routers(app)
+
+    # Attach fault tolerance routes only if enabled by the server args.
+    enable_ft = False
+    if args is not None:
+        enable_ft = bool(getattr(args, "enable_fault_tolerance", False))
+
+    if enable_ft:
+        from vllm.entrypoints.serve.fault_tolerance.api_router import (
+            attach_router as attach_fault_tolerance_router,
+        )
+
+        attach_fault_tolerance_router(app)

--- a/vllm/entrypoints/serve/fault_tolerance/api_router.py
+++ b/vllm/entrypoints/serve/fault_tolerance/api_router.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import json
+import uuid
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.utils import validate_json_request
+from vllm.logger import init_logger
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+
+logger = init_logger(__name__)
+
+
+def engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+router = APIRouter()
+
+
+@router.post(
+    "/fault_tolerance/apply",
+    dependencies=[Depends(validate_json_request)],
+    responses={
+        HTTPStatus.OK.value: {"model": dict},
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+        HTTPStatus.REQUEST_TIMEOUT.value: {"model": ErrorResponse},
+        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+    },
+)
+async def process_fault_tolerance_instruction(raw_request: Request):
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail="Invalid JSON format") from e
+
+    client = engine_client(raw_request)
+
+    fault_tolerance_instruction = body.get("fault_tolerance_instruction")
+    fault_tolerance_timeout = body.get("fault_tolerance_timeout")
+    fault_tolerance_params = body.get("fault_tolerance_params", {})
+
+    if fault_tolerance_instruction is None or fault_tolerance_timeout is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Both 'fault_tolerance_instruction' and "
+            "'fault_tolerance_timeout' are required.",
+        )
+
+    if not isinstance(fault_tolerance_instruction, str):
+        raise HTTPException(
+            status_code=400, detail="'fault_tolerance_instruction' must be a string."
+        )
+    # Supported instructions: ["pause", "retry"].
+    # More instruction types may be added in future updates.
+    elif fault_tolerance_instruction not in ["pause", "retry"]:
+        raise HTTPException(
+            status_code=400, detail="Invalid 'fault_tolerance_instruction' value."
+        )
+
+    if not isinstance(fault_tolerance_timeout, int) or fault_tolerance_timeout <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="'fault_tolerance_timeout' must be a positive integer.",
+        )
+    try:
+        fault_tolerance_params["timeout"] = fault_tolerance_timeout
+        ft_request = FaultToleranceRequest(
+            str(uuid.uuid4()), fault_tolerance_instruction, fault_tolerance_params
+        )
+
+        ft_result = await client.handle_fault(ft_request)
+        success, reason = ft_result.success, ft_result.reason
+        if success:
+            return JSONResponse(
+                {
+                    "message": "Instruction executed successfully.",
+                }
+            )
+        else:
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+                detail=f"Instruction execution failed. Reason: {reason}",
+            )
+
+    except Exception as e:
+        logger.error("Failed to handle fault: %s", e)
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            detail="Failed to handle fault.",
+        ) from e
+
+
+@router.get("/fault_tolerance/status")
+async def get_fault_info(
+    raw_request: Request,
+):
+    client = engine_client(raw_request)
+    engine_status_dict = await client.get_fault_info()
+    return JSONResponse(content=engine_status_dict)
+
+
+def attach_router(app: FastAPI):
+    app.include_router(router)

--- a/vllm/entrypoints/serve/fault_tolerance/middleware.py
+++ b/vllm/entrypoints/serve/fault_tolerance/middleware.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import logging
+from collections.abc import Awaitable
+
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+class FaultToleranceMiddleware:
+    """
+    ASGI middleware that short-circuits ordinary HTTP requests with a 503
+    response when the engine is in a faulted state.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        # Allowed management endpoint prefixes: these paths are permitted even
+        # if the service is marked faulted.
+        self._allowed_prefixes = ("/fault_tolerance",)
+
+    def __call__(self, scope: Scope, receive: Receive, send: Send) -> Awaitable[None]:
+        # Only apply to HTTP requests; forward other types unchanged.
+        if scope.get("type") != "http":
+            return self.app(scope, receive, send)
+
+        # Allow management endpoints through so faults can be inspected/cleared.
+        path = scope.get("path", "") or ""
+        for prefix in self._allowed_prefixes:
+            if path.startswith(prefix):
+                return self.app(scope, receive, send)
+
+        try:
+            app_obj = scope.get("app")
+            if app_obj is None:
+                return self.app(scope, receive, send)
+
+            # Engine client is attached to FastAPI app.state.engine_client by
+            # the server initialization code. Be defensive in case it's not set.
+            engine_client = getattr(app_obj.state, "engine_client", None)
+            if engine_client is None:
+                return self.app(scope, receive, send)
+            is_faulted_event = getattr(engine_client.engine_core, "is_faulted", None)
+            # Check engine is_faulted event.
+            if is_faulted_event is not None and is_faulted_event.is_set():
+                response = JSONResponse(
+                    content={
+                        "error": "Service is in faulted state, cannot process requests."
+                    },
+                    status_code=503,
+                )
+                return response(scope, receive, send)
+
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.warning("FaultToleranceMiddleware unexpected error: %s", e)
+            # Fail-open: allow requests to proceed.
+
+        return self.app(scope, receive, send)

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -80,6 +80,19 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def preempt_request(
+        self,
+        request: "Request",
+        timestamp: float,
+    ) -> None:
+        """Preempt a request and put it back to the waiting queue.
+
+        NOTE: The request should be popped from the running queue outside of this
+        method.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def update_from_output(
         self,
         scheduler_output: "SchedulerOutput",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -489,7 +489,7 @@ class Scheduler(SchedulerInterface):
                     else:
                         preempted_req = self.running.pop()
 
-                    self._preempt_request(preempted_req, scheduled_timestamp)
+                    self.preempt_request(preempted_req, scheduled_timestamp)
                     preempted_reqs.append(preempted_req)
                     if preempted_req == request:
                         # No more request to preempt. Cannot schedule this request.
@@ -926,7 +926,7 @@ class Scheduler(SchedulerInterface):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
 
-    def _preempt_request(self, request: Request, timestamp: float) -> None:
+    def preempt_request(self, request: Request, timestamp: float) -> None:
         """Preempt a request and put it back to the waiting queue.
 
         NOTE: The request should be popped from the running queue outside of this
@@ -1852,7 +1852,7 @@ class Scheduler(SchedulerInterface):
             # running queue in FIFO order.
             while self.running:
                 request = self.running.pop()
-                self._preempt_request(request, timestamp)
+                self.preempt_request(request, timestamp)
                 # NOTE(zhuohan): For async scheduling, we need to discard the latest
                 # output token on the fly to avoid a redundant repetitive output token.
                 request.num_output_placeholders = 0

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -231,7 +231,6 @@ class EngineCoreRequestType(enum.Enum):
     PAUSE = b"\x06"
 
 
-
 class ReconfigureDistributedRequest(msgspec.Struct):
     new_data_parallel_size: int
     new_data_parallel_rank: int

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -228,6 +228,8 @@ class EngineCoreRequestType(enum.Enum):
     EXECUTOR_FAILED = b"\x04"
     # Sentinel to wake up input_queue.get() during shutdown.
     WAKEUP = b"\x05"
+    PAUSE = b"\x06"
+
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):
@@ -250,3 +252,10 @@ class ReconfigureRankType(enum.IntEnum):
 
     KEEP_CURRENT_RANK = -1
     SHUTDOWN_CURRENT_RANK = -2
+
+
+class EngineStatusType(enum.IntEnum):
+    HEALTHY = 0
+    DEAD = 1
+    UNHEALTHY = 2
+    PAUSED = 3

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -38,13 +38,17 @@ from vllm.transformers_utils.config import maybe_register_config_serialize_by_va
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.async_utils import cancel_task_threadsafe
 from vllm.utils.collection_utils import as_list
-from vllm.v1.engine import EngineCoreRequest, PauseMode
+from vllm.v1.engine import (
+    EngineCoreRequest,
+    PauseMode,
+)
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 from vllm.v1.engine.input_processor import InputProcessor
 from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
 from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.executor import Executor
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest, FaultToleranceResult
 from vllm.v1.metrics.loggers import (
     StatLoggerFactory,
     StatLoggerManager,
@@ -1012,6 +1016,16 @@ class AsyncLLM(EngineClient):
             self.vllm_config.parallel_config.data_parallel_size = new_data_parallel_size
         finally:
             set_scaling_elastic_ep(False)
+
+    async def handle_fault(
+        self, fault_tolerance_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        """send fault tolerance instruction to the engine"""
+        return await self.engine_core.handle_fault(fault_tolerance_request)
+
+    async def get_fault_info(self):
+        """report exception in engine core"""
+        return await self.engine_core.fault_reporter()
 
     @property
     def is_running(self) -> bool:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -59,6 +59,7 @@ from vllm.v1.engine import (
     UtilityOutput,
     UtilityResult,
 )
+from vllm.v1.engine.exceptions import EngineLoopPausedError
 from vllm.v1.engine.utils import (
     EngineHandshakeMetadata,
     EngineZmqAddresses,
@@ -66,13 +67,21 @@ from vllm.v1.engine.utils import (
     get_device_indices,
 )
 from vllm.v1.executor import Executor
+from vllm.v1.fault_tolerance.engine_core_sentinel import (
+    EngineCoreSentinel,
+    busy_loop_wrapper,
+)
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
+from vllm.v1.serial_utils import (
+    MsgpackDecoder,
+    MsgpackEncoder,
+)
 from vllm.v1.structured_output import StructuredOutputManager
-from vllm.v1.utils import compute_iteration_details
+from vllm.v1.utils import compute_iteration_details, get_engine_client_zmq_addr
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
@@ -793,10 +802,6 @@ class EngineCoreProc(EngineCore):
     ):
         self.input_queue = queue.Queue[tuple[EngineCoreRequestType, Any]]()
         self.output_queue = queue.Queue[tuple[int, EngineCoreOutputs] | bytes]()
-        executor_fail_callback = lambda: self.input_queue.put_nowait(
-            (EngineCoreRequestType.EXECUTOR_FAILED, b"")
-        )
-
         self.engine_index = engine_index
         identity = self.engine_index.to_bytes(length=2, byteorder="little")
         self.engines_running = False
@@ -835,6 +840,44 @@ class EngineCoreProc(EngineCore):
                     vllm_config=vllm_config,
                 )
             self._init_data_parallel(vllm_config)
+
+            # Initialize fault tolerance settings.
+            ft_config = vllm_config.fault_tolerance_config
+            self.enable_fault_tolerance = ft_config.enable_fault_tolerance
+            if self.enable_fault_tolerance:
+                # Track whether the busy loop is currently active.
+                self.busy_loop_active = threading.Event()
+                self.fault_signal_q: queue.Queue[Exception] = queue.Queue()
+                self.cmd_q: queue.Queue[FaultToleranceRequest | None] = queue.Queue(
+                    maxsize=1
+                )
+                self.engine_recovery_timeout_sec = ft_config.engine_recovery_timeout_sec
+                assert addresses.fault_tolerance_addresses is not None
+                ft_addresses = addresses.fault_tolerance_addresses
+                engine_core_sentinel_ids = ft_addresses.engine_core_sentinel_identities
+
+                # The ZMQ address between engine_core_sentinel and worker_sentinel.
+                worker_cmd_addr = get_engine_client_zmq_addr(True, "0.0.0.0")
+                self.engine_core_sentinel = EngineCoreSentinel(
+                    engine_index=self.engine_index,
+                    fault_signal_q=self.fault_signal_q,
+                    cmd_q=self.cmd_q,
+                    busy_loop_active=self.busy_loop_active,
+                    engine_input_q=self.input_queue,
+                    engine_fault_socket_addr=ft_addresses.engine_fault_socket_addr,
+                    downstream_cmd_addr=worker_cmd_addr,
+                    sentinel_identity=engine_core_sentinel_ids[self.engine_index],
+                    vllm_config=vllm_config,
+                )
+                vllm_config.fault_tolerance_config.worker_cmd_addr = worker_cmd_addr
+                # Do not shut down the engine immediately upon failure.
+                executor_fail_callback = lambda: self.fault_signal_q.put(
+                    RuntimeError(f"Executor on EngineCore {self.engine_index} failed.")
+                )
+            else:
+                executor_fail_callback = lambda: self.input_queue.put_nowait(
+                    (EngineCoreRequestType.EXECUTOR_FAILED, b"")
+                )
 
             super().__init__(
                 vllm_config,
@@ -1124,15 +1167,22 @@ class EngineCoreProc(EngineCore):
         """Returns true if shutdown has not been requested."""
         return self.shutdown_state == EngineShutdownState.RUNNING
 
+    @busy_loop_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore."""
         while self._handle_shutdown():
             # 1) Poll the input queue until there is work to do.
+            self._check_busy_loop_active()
             self._process_input_queue()
             # 2) Step the engine core and return the outputs.
+            self._check_busy_loop_active()
             self._process_engine_step()
 
         raise SystemExit
+
+    def _check_busy_loop_active(self):
+        if self.enable_fault_tolerance and not self.busy_loop_active.is_set():
+            raise EngineLoopPausedError("Engine busy loop is paused.")
 
     def _process_input_queue(self):
         """Exits when an engine step needs to be performed."""
@@ -1240,6 +1290,8 @@ class EngineCoreProc(EngineCore):
             self.add_request(req, request_wave)
         elif request_type == EngineCoreRequestType.ABORT:
             self.abort_requests(request)
+        elif request_type == EngineCoreRequestType.PAUSE:
+            self._check_busy_loop_active()
         elif request_type == EngineCoreRequestType.UTILITY:
             client_idx, call_id, method_name, args = request
             if self._reject_utility_in_shutdown(client_idx, call_id, method_name):
@@ -1404,6 +1456,12 @@ class EngineCoreProc(EngineCore):
                         except Exception:
                             self._handle_request_preproc_error(req)
                             continue
+                    elif request_type == EngineCoreRequestType.UTILITY:
+                        request = generic_decoder.decode(data_frames)
+                        client_index, call_id, method, args = request
+                        if method == "handle_fault":
+                            self.handle_fault(call_id, client_index, args[0])
+                            continue
                     else:
                         request = generic_decoder.decode(data_frames)
 
@@ -1487,6 +1545,20 @@ class EngineCoreProc(EngineCore):
                     # Limit the number of buffers to reuse.
                     reuse_buffers.append(buffer)
 
+    def handle_fault(self, call_id: int, client_index: int, args: dict):
+        """Call engine_core_sentinel to perform fault tolerance."""
+        uo = UtilityOutput(call_id=call_id)
+        try:
+            ft_result = self.engine_core_sentinel.handle_fault(
+                FaultToleranceRequest(**args)
+            )
+            uo.result = UtilityResult(ft_result)
+        except Exception as e:
+            logger.exception("Call to handle_fault method failed")
+            uo.failure_message = f"Call to handle_fault method failed: {e}"
+        outputs = EngineCoreOutputs(utility_output=uo)
+        self.output_queue.put_nowait((client_index, outputs))
+
     def _handle_request_preproc_error(self, request: EngineCoreRequest) -> None:
         """Log and return a request-scoped error response for exceptions raised
         from the add request preprocessing in the input socket processing thread.
@@ -1567,6 +1639,11 @@ class EngineCoreProc(EngineCore):
             for client_index, req_ids in by_client.items():
                 self._send_abort_outputs_to_client(list(req_ids), client_index)
 
+    def shutdown(self):
+        super().shutdown()
+        if self.vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            self.engine_core_sentinel.shutdown()
+
 
 class DPEngineCoreProc(EngineCoreProc):
     """ZMQ-wrapper for running EngineCore in background process
@@ -1619,7 +1696,9 @@ class DPEngineCoreProc(EngineCoreProc):
         assert 0 <= local_dp_rank <= dp_rank < dp_size
 
         self.dp_rank = dp_rank
-        dp_group, dp_store = parallel_config.stateless_init_dp_group(return_store=True)
+        dp_group, dp_store = parallel_config.stateless_init_dp_group(
+            return_store=True, fault_tolerance_config=vllm_config.fault_tolerance_config
+        )
         self.dp_group, self.dp_store = dp_group, dp_store
 
     def shutdown(self):
@@ -1679,14 +1758,17 @@ class DPEngineCoreProc(EngineCoreProc):
             )
             self.output_queue.put_nowait((-1, EngineCoreOutputs(scheduler_stats=stats)))
 
+    @busy_loop_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore for data parallel case."""
 
         # Loop until process is sent a SIGINT or SIGTERM
         while self._handle_shutdown():
             # 1) Poll the input queue until there is work to do.
+            self._check_busy_loop_active()
             self._process_input_queue()
 
+            self._check_busy_loop_active()
             if self.eep_scaling_state is not None:
                 _ = self.eep_scaling_state.progress()
                 if self.eep_scaling_state.is_complete():
@@ -1704,9 +1786,11 @@ class DPEngineCoreProc(EngineCoreProc):
 
                 # We are in a running state and so must execute a dummy pass
                 # if the model didn't execute any ready requests.
+                self._check_busy_loop_active()
                 self.execute_dummy_batch()
 
             # 3) All-reduce operation to determine global unfinished reqs.
+            self._check_busy_loop_active()
             self.engines_running = self._has_global_unfinished_reqs(
                 local_unfinished_reqs
             )
@@ -1740,6 +1824,14 @@ class DPEngineCoreProc(EngineCoreProc):
             return True
 
         return ParallelConfig.has_unfinished_dp(self.dp_group, local_unfinished)
+
+    def reinit_dp_group_on_fault_tolerance(self, new_stateless_dp_group_port: int):
+        stateless_destroy_torch_distributed_process_group(self.dp_group)
+        self.dp_group = self.vllm_config.parallel_config.stateless_init_dp_group(
+            fault_tolerance_config=self.vllm_config.fault_tolerance_config,
+            dp_init_port=new_stateless_dp_group_port,
+        )
+        self.step_counter = 0
 
     def reinitialize_distributed(
         self, reconfig_request: ReconfigureDistributedRequest

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import contextlib
-import multiprocessing
 import queue
 import sys
+import threading
 import uuid
 import weakref
 from abc import ABC, abstractmethod
@@ -37,6 +37,7 @@ from vllm.v1.engine import (
     EngineCoreOutputs,
     EngineCoreRequest,
     EngineCoreRequestType,
+    EngineStatusType,
     PauseMode,
     ReconfigureDistributedRequest,
     ReconfigureRankType,
@@ -52,6 +53,12 @@ from vllm.v1.engine.utils import (
     launch_core_engines,
 )
 from vllm.v1.executor import Executor
+from vllm.v1.fault_tolerance import ClientSentinel
+from vllm.v1.fault_tolerance.utils import (
+    FaultToleranceRequest,
+    FaultToleranceResult,
+    FaultToleranceZmqAddresses,
+)
 from vllm.v1.pool.late_interaction import get_late_interaction_engine_index
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr
 
@@ -268,6 +275,14 @@ class EngineCoreClient(ABC):
     ) -> list[_R]:
         raise NotImplementedError
 
+    async def handle_fault(
+        self, fault_tolerance_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        raise NotImplementedError
+
+    async def fault_reporter(self):
+        raise NotImplementedError
+
 
 class InprocClient(EngineCoreClient):
     """
@@ -380,6 +395,8 @@ class BackgroundResources:
     output_queue_task: asyncio.Task | None = None
     stats_update_task: asyncio.Task | None = None
     shutdown_path: str | None = None
+    client_sentinel: ClientSentinel | None = None
+    fault_state_sub_socket: zmq.Socket | None = None
 
     # Set if any of the engines are dead. Here so that the output
     # processing threads can access it without holding a ref to the client.
@@ -389,6 +406,8 @@ class BackgroundResources:
         """Clean up background resources."""
 
         self.engine_dead = True
+        if self.client_sentinel is not None:
+            self.client_sentinel.shutdown()
         if self.engine_manager is not None:
             self.engine_manager.shutdown()
         if self.coordinator is not None:
@@ -404,6 +423,7 @@ class BackgroundResources:
                 self.first_req_send_socket,
                 self.first_req_rcv_socket,
                 self.stats_update_socket,
+                self.fault_state_sub_socket,
             )
 
             tasks = (self.output_queue_task, self.stats_update_task)
@@ -551,6 +571,7 @@ class MPClient(EngineCoreClient):
             enable_input_socket_handover = parallel_config.enable_elastic_ep
 
             self.stats_update_address: str | None = None
+            self.addresses = None
             if client_addresses:
                 # Engines are managed externally to this client.
                 input_address = client_addresses["input_address"]
@@ -586,7 +607,15 @@ class MPClient(EngineCoreClient):
                     self.resources.coordinator = coordinator
                     self.resources.engine_manager = engine_manager
 
+                self.addresses = addresses
                 self.stats_update_address = addresses.frontend_stats_publish_address
+                if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+                    assert client_addresses is not None
+                    assert addresses.fault_tolerance_addresses is not None
+                    client_addresses["fault_tolerance_addresses"] = (
+                        addresses.fault_tolerance_addresses.to_str()
+                    )
+
                 if coordinator is not None:
                     assert self.stats_update_address == (
                         coordinator.get_stats_publish_address()
@@ -675,43 +704,41 @@ class MPClient(EngineCoreClient):
         return self.engines_running
 
     def start_engine_core_monitor(self):
-        """Start a monitor thread for engine core processes."""
+        """Start a monitor thread for engine core processes or actors."""
         engine_manager = self.resources.engine_manager
-        if (
-            engine_manager is None
-            or not hasattr(engine_manager, "processes")
-            or not engine_manager.processes
-        ):
-            # No engine processes to monitor
+        if engine_manager is None:
             return
-
-        engine_processes = engine_manager.processes
         self_ref = weakref.ref(self)
 
-        # Monitor engine core process liveness. If any die unexpectedly,
-        # logs an error, shuts down the client and invokes the failure
-        # callback to inform the engine.
-        def monitor_engine_cores():
-            sentinels = [proc.sentinel for proc in engine_processes]
-            died = multiprocessing.connection.wait(sentinels)
+        def shutdown_callback(engine_rank, target):
             _self = self_ref()
             if not _self or not _self._finalizer.alive or _self.resources.engine_dead:
                 return
-            _self.resources.engine_dead = True
-            proc_name = next(
-                proc.name for proc in engine_processes if proc.sentinel == died[0]
-            )
+            target_desc = getattr(target, "name", target)
             logger.error(
-                "Engine core proc %s died unexpectedly, shutting down client.",
-                proc_name,
+                "Engine core %s died unexpectedly, shutting down client.",
+                target_desc,
             )
+            engine_manager.shutdown_monitor = True
+            _self.resources.engine_dead = True
             _self.shutdown()
-            # Note: For MPClient, we don't have a failure callback mechanism
-            # like MultiprocExecutor, but we set engine_dead flag which will
-            # cause subsequent operations to raise EngineDeadError
+
+        if isinstance(engine_manager, CoreEngineProcManager) and not getattr(
+            engine_manager, "processes", None
+        ):
+            # No engine processes to monitor
+            return
+        engine_down_callback = (
+            shutdown_callback
+            if not self.vllm_config.fault_tolerance_config.enable_fault_tolerance
+            else engine_manager.notify_engine_down
+        )
 
         Thread(
-            target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
+            target=engine_manager.monitor_engine_liveness,
+            args=(engine_down_callback,),
+            daemon=True,
+            name="ClientEngineMonitor",
         ).start()
 
 
@@ -921,6 +948,8 @@ class AsyncMPClient(MPClient):
         client_count: int = 1,
         client_index: int = 0,
     ):
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            client_addresses = client_addresses or {}
         super().__init__(
             asyncio_mode=True,
             vllm_config=vllm_config,
@@ -928,10 +957,46 @@ class AsyncMPClient(MPClient):
             log_stats=log_stats,
             client_addresses=client_addresses,
         )
-
         self.client_count = client_count
         self.client_index = client_index
         self.outputs_queue = asyncio.Queue[EngineCoreOutputs | Exception]()
+
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            assert client_addresses is not None
+            self.is_faulted = threading.Event()
+            ft_addr = FaultToleranceZmqAddresses.from_str(
+                client_addresses["fault_tolerance_addresses"]
+            )
+            if self.client_index == 0:
+                self.client_sentinel = ClientSentinel(
+                    vllm_config=vllm_config,
+                    fault_tolerance_addresses=ft_addr,
+                    call_utility_async=self._call_utility_async,
+                    core_engines=self.core_engines,
+                )
+                self.resources.client_sentinel = self.client_sentinel
+            self.engine_status_dict: dict[int, dict[str, EngineStatusType]] = {
+                engine_index: {"status": EngineStatusType.HEALTHY}
+                for engine_index in self.engine_ranks_managed
+            }
+            self.engine_status_lock = threading.Lock()
+            self.fault_state_sub_socket = make_zmq_socket(
+                self.resources.ctx,
+                ft_addr.fault_state_pub_socket_addr,
+                zmq.SUB,
+                bind=False,
+            )
+            self.fault_state_sub_socket.setsockopt(
+                zmq.SUBSCRIBE,
+                self.vllm_config.fault_tolerance_config.fault_state_pub_topic.encode(),
+            )
+            self.resources.fault_state_sub_socket = self.fault_state_sub_socket
+            threading.Thread(
+                target=self._engine_status_listener,
+                daemon=True,
+                name="EngineStatusListenerThread",
+            ).start()
+
         try:
             # If we are running in an asyncio event loop, start the queue task.
             # Otherwise, it will be started lazily. If it is not started here,
@@ -1156,6 +1221,45 @@ class AsyncMPClient(MPClient):
         return await self.call_utility_async(
             "collective_rpc", method, timeout, args, kwargs
         )
+
+    async def handle_fault(
+        self, ft_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        res = await self._call_utility_async(
+            ft_request.instruction, ft_request, engine=b"client_sentinel"
+        )
+        return FaultToleranceResult(**res)
+
+    def _engine_status_listener(self):
+        decoder = msgspec.msgpack.Decoder()
+        while True:
+            try:
+                # Expect multipart: [topic, payload].
+                frames = self.fault_state_sub_socket.recv_multipart()
+                payload = frames[-1]
+                status_dict = decoder.decode(payload)
+                with self.engine_status_lock:
+                    self.engine_status_dict.clear()
+                    self.engine_status_dict.update(status_dict)
+                healthy = all(
+                    v["status"] == EngineStatusType.HEALTHY
+                    for v in status_dict.values()
+                )
+                if healthy:
+                    self.is_faulted.clear()
+                else:
+                    self.is_faulted.set()
+            except zmq.ZMQError:
+                break
+
+    async def fault_reporter(self):
+        with self.engine_status_lock:
+            raw = self.engine_status_dict.copy()
+        result = {}
+        for engine_id, status_value in raw.items():
+            status_enum = EngineStatusType(status_value["status"])
+            result[engine_id] = {"status": status_enum.name.title()}
+        return result
 
 
 class DPAsyncMPClient(AsyncMPClient):

--- a/vllm/v1/engine/exceptions.py
+++ b/vllm/v1/engine/exceptions.py
@@ -16,3 +16,12 @@ class EngineDeadError(Exception):
         # Make stack trace clearer when using with LLMEngine by
         # silencing irrelevant ZMQError.
         self.__suppress_context__ = suppress_context
+
+
+class EngineLoopPausedError(Exception):
+    """
+    Raised when the EngineCore loop is temporarily paused on purpose,
+    e.g., to handle fault-tolerance.
+    """
+
+    pass

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1,19 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
 import contextlib
 import os
 import threading
+import uuid
 import weakref
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum, auto
 from multiprocessing import Process, connection
 from multiprocessing.process import BaseProcess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import msgspec
+import regex as re
 import zmq
 
 from vllm import envs
@@ -21,10 +22,15 @@ from vllm.config import CacheConfig, ParallelConfig, VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
-from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
+from vllm.utils.network_utils import (
+    get_open_zmq_ipc_path,
+    make_zmq_socket,
+    zmq_socket_ctx,
+)
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.executor import Executor
+from vllm.v1.fault_tolerance.utils import FaultInfo, FaultToleranceZmqAddresses
 from vllm.v1.utils import get_engine_client_zmq_addr, shutdown
 
 if TYPE_CHECKING:
@@ -65,6 +71,8 @@ class EngineZmqAddresses:
     # Not used by engine, just relayed to front-end in handshake response.
     # Only required for external DP LB case.
     frontend_stats_publish_address: str | None = None
+    # ZMQ socket addresses for fault tolerance if applicable
+    fault_tolerance_addresses: FaultToleranceZmqAddresses | None = None
 
 
 @dataclass
@@ -104,7 +112,20 @@ class CoreEngineProcManager:
             "executor_class": executor_class,
             "log_stats": log_stats,
         }
-
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            zmq_ctx = zmq.Context()
+            zmq_addr = get_engine_client_zmq_addr(
+                local_only=False,
+                host=vllm_config.parallel_config.data_parallel_master_ip,
+                port=vllm_config.fault_tolerance_config.internal_fault_report_port,
+            )
+            self.engine_down_socket = make_zmq_socket(
+                ctx=zmq_ctx,
+                path=zmq_addr,
+                socket_type=zmq.DEALER,
+                bind=False,
+                identity=str(uuid.uuid4()).encode("utf8"),
+            )
         if client_handshake_address:
             common_kwargs["client_handshake_address"] = client_handshake_address
 
@@ -130,6 +151,8 @@ class CoreEngineProcManager:
             )
 
         self._finalizer = weakref.finalize(self, shutdown, self.processes)
+        self.shutdown_monitor = False
+        self.vllm_config = vllm_config
 
         try:
             for proc, local_dp_rank in zip(self.processes, local_dp_ranks):
@@ -153,6 +176,39 @@ class CoreEngineProcManager:
         """Shutdown engine core processes with configurable timeout."""
         if self._finalizer.detach() is not None:
             shutdown(self.processes, timeout=timeout)
+
+    def notify_engine_down(self, engine_rank, died_proc):
+        """
+        Send fault notification to the engine_down_socket
+        and log the failure event.
+        """
+        fault_info = FaultInfo(
+            type="EngineDeadError",
+            message=f"Engine core proc {died_proc.name} died unexpectedly.",
+            engine_id=engine_rank,
+            additional_info=None,
+        )
+
+        self.engine_down_socket.send_multipart(
+            [b"", msgspec.msgpack.encode(fault_info)]
+        )
+        logger.error("Engine core proc %s died unexpectedly", died_proc.name)
+
+    def monitor_engine_liveness(self, engine_down_callback):
+        """
+        Monitor engine core process liveness.
+        """
+        sentinels = [proc.sentinel for proc in self.processes]
+        while sentinels and not self.shutdown_monitor:
+            died = connection.wait(sentinels)
+            for sentinel in died:
+                sentinel = cast(int, sentinel)
+                died_proc = next(
+                    proc for proc in self.processes if proc.sentinel == sentinel
+                )
+                engine_rank = re.match(r"EngineCore_DP(\d+)", died_proc.name).group(1)
+                engine_down_callback(engine_rank, died_proc)
+                sentinels.remove(sentinel)
 
     def join_first(self):
         """Wait for any process to exit."""
@@ -280,7 +336,7 @@ class CoreEngineActorManager:
             if dp_size > 1 and vllm_config.model_config.is_moe
             else EngineCoreActor
         )
-
+        self.vllm_config = vllm_config
         self.local_engine_actors: list[ray.ActorHandle] = []
         self.remote_engine_actors: list[ray.ActorHandle] = []
 
@@ -295,6 +351,21 @@ class CoreEngineActorManager:
         self.log_stats = log_stats
         local_engine_count = vllm_config.parallel_config.data_parallel_size_local
         world_size = vllm_config.parallel_config.world_size
+
+        if vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            zmq_ctx = zmq.Context()
+            zmq_addr = get_engine_client_zmq_addr(
+                local_only=False,
+                host=vllm_config.parallel_config.data_parallel_master_ip,
+                port=vllm_config.fault_tolerance_config.internal_fault_report_port,
+            )
+            self.engine_down_socket = make_zmq_socket(
+                ctx=zmq_ctx,
+                path=zmq_addr,
+                socket_type=zmq.DEALER,
+                bind=False,
+                identity=str(uuid.uuid4()).encode("utf8"),
+            )
 
         if ray.is_initialized():
             logger.info("Ray is already initialized. Skipping Ray initialization.")
@@ -370,6 +441,7 @@ class CoreEngineActorManager:
                     local_dp_rank=local_index,
                 )
             )
+
             if local_client:
                 self.local_engine_actors.append(actor)
             else:
@@ -379,6 +451,7 @@ class CoreEngineActorManager:
 
         ray.get(refs)
         self.run_refs = []
+        self.shutdown_monitor = False
         for actor in self.local_engine_actors + self.remote_engine_actors:
             self.run_refs.append(actor.run.remote())
 
@@ -792,6 +865,44 @@ class CoreEngineActorManager:
     def get_run_refs(self):
         return self.run_refs
 
+    def notify_engine_down(self, engine_rank, actor_ref):
+        fault_info = FaultInfo(
+            type="EngineDeadError",
+            message="Engine_actor died unexpectedly.",
+            engine_id=str(engine_rank),
+            additional_info=None,
+        )
+
+        self.engine_down_socket.send_multipart(
+            [b"", msgspec.msgpack.encode(fault_info)]
+        )
+        logger.error("Engine actor %s died unexpectedly", engine_rank)
+
+    def monitor_engine_liveness(self, engine_down_callback):
+        import ray
+
+        processed_done_refs = set()
+        while not self.shutdown_monitor:
+            actor_run_refs = self.get_run_refs()
+            if not actor_run_refs:
+                logger.info(
+                    "There are no actors to monitor currently."
+                    " The monitoring function is about to terminate."
+                )
+                return
+            ref_to_index_mapping = {
+                ref: index for index, ref in enumerate(actor_run_refs)
+            }
+            actor_done_refs, _ = ray.wait(actor_run_refs, timeout=5)
+            if not actor_done_refs:
+                continue
+            for actor_ref in actor_done_refs:
+                if actor_ref in processed_done_refs:
+                    continue
+                error_engine_id = ref_to_index_mapping[actor_ref]
+                engine_down_callback(error_engine_id, actor_ref)
+                processed_done_refs.add(actor_ref)
+
     def shutdown(self, timeout: float | None = None) -> None:
         import ray
 
@@ -864,7 +975,6 @@ def launch_core_engines(
     local_engines_only = parallel_config.local_engines_only
 
     offline_mode = local_start_index is not None
-
     # Run the DP Coordinator process with rank 0 when in online DP mode.
     # The coordinator is needed for:
     # 1. Internal/hybrid LB: collecting and publishing queue stats for load balancing
@@ -889,6 +999,16 @@ def launch_core_engines(
         logger.info("Started DP Coordinator process (PID: %d)", coordinator.proc.pid)
     else:
         coordinator = None
+
+    if vllm_config.fault_tolerance_config.enable_fault_tolerance is True:
+        addresses.fault_tolerance_addresses = FaultToleranceZmqAddresses.build(
+            host,
+            local_engines_only,
+            dp_size,
+            addresses.inputs,
+            addresses.outputs,
+            vllm_config.fault_tolerance_config,
+        )
 
     if parallel_config.data_parallel_backend == "ray":
         logger.info("Starting ray-based data parallel backend")

--- a/vllm/v1/fault_tolerance/__init__.py
+++ b/vllm/v1/fault_tolerance/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .client_sentinel import ClientSentinel
+from .engine_core_sentinel import EngineCoreSentinel
+from .sentinel import BaseSentinel
+
+__all__ = [
+    "BaseSentinel",
+    "ClientSentinel",
+    "EngineCoreSentinel",
+]

--- a/vllm/v1/fault_tolerance/client_sentinel.py
+++ b/vllm/v1/fault_tolerance/client_sentinel.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
+import traceback
+import uuid
+from collections.abc import Callable
+
+import msgspec.msgpack
+import zmq.asyncio
+
+from vllm.config import VllmConfig
+from vllm.utils.network_utils import close_sockets, get_open_port, make_zmq_socket
+from vllm.v1.engine import EngineCoreOutputs as FTUtilityOutputs
+from vllm.v1.engine import EngineStatusType, UtilityOutput
+from vllm.v1.fault_tolerance.sentinel import BaseSentinel
+from vllm.v1.fault_tolerance.utils import (
+    FaultInfo,
+    FaultToleranceRequest,
+    FaultToleranceResult,
+    FaultToleranceZmqAddresses,
+)
+from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, UtilityResult
+
+
+class ClientSentinel(BaseSentinel):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        fault_tolerance_addresses: FaultToleranceZmqAddresses,
+        call_utility_async: Callable,
+        core_engines: list[bytes],
+    ):
+        self.engine_identities = core_engines
+        super().__init__(
+            vllm_config=vllm_config, sentinel_tag=None, identity=b"client_sentinel"
+        )
+
+        self.call_utility_async = call_utility_async
+        self.ctx_async = zmq.asyncio.Context()
+
+        self.sentinel_dead = False
+        self.logger = self._make_logger()
+
+        self.input_sockets = [
+            make_zmq_socket(
+                self.ctx_async,
+                input_address,
+                zmq.DEALER,
+                identity=self.identity,
+                bind=False,
+            )
+            for input_address in fault_tolerance_addresses.all_client_input_addresses
+        ]
+
+        self.output_sockets = [
+            make_zmq_socket(self.ctx_async, output_address, zmq.PUSH, linger=4000)
+            for output_address in fault_tolerance_addresses.all_client_output_addresses
+        ]
+
+        self.is_faulted = asyncio.Event()
+        self.fault_receiver_socket = make_zmq_socket(
+            ctx=self.ctx_async,
+            path=fault_tolerance_addresses.engine_fault_socket_addr,
+            socket_type=zmq.ROUTER,
+            bind=True,
+        )
+
+        self.fault_state_pub_socket = make_zmq_socket(
+            ctx=self.ctx_async,
+            path=fault_tolerance_addresses.fault_state_pub_socket_addr,
+            socket_type=zmq.PUB,
+            bind=True,
+        )
+
+        self._utility_encoder = MsgpackEncoder()
+
+        self.start_rank = vllm_config.parallel_config.data_parallel_index
+        dp_size = vllm_config.parallel_config.data_parallel_size
+        dp_local_size = vllm_config.parallel_config.data_parallel_size_local
+        num_dp_managed = (
+            dp_local_size if vllm_config.parallel_config.local_engines_only else dp_size
+        )
+        self.engine_status_dict: dict[int, dict[str, EngineStatusType]] = {
+            engine_index: {"status": EngineStatusType.HEALTHY}
+            for engine_index in range(self.start_rank, self.start_rank + num_dp_managed)
+        }
+
+        asyncio.create_task(self.run())
+        asyncio.create_task(self._monitor_and_pause_on_fault())
+
+    async def _send_utility_result(
+        self,
+        client_index: int,
+        call_id: int,
+        result: FaultToleranceResult,
+    ) -> None:
+        uo = UtilityOutput(call_id=call_id)
+        uo.result = UtilityResult(result)
+        outputs = FTUtilityOutputs(utility_output=uo)
+        buffers = self._utility_encoder.encode(outputs)
+        await self.output_sockets[client_index].send_multipart(buffers, copy=False)
+
+    async def retry(self, timeout: int = 1, **kwargs) -> bool:  # type: ignore[override]
+        for engine_status in self.engine_status_dict.values():
+            if engine_status["status"] == EngineStatusType.DEAD:
+                self.logger(
+                    "Engine core is dead; retry won't work.",
+                    level="warning",
+                )
+                return False
+        kwargs["timeout"] = timeout
+        if "new_stateless_dp_group_port" not in kwargs:
+            kwargs["new_stateless_dp_group_port"] = get_open_port()
+        ft_results = await self._execute_cmd_on_engines(
+            ft_request=FaultToleranceRequest(
+                request_id=str(uuid.uuid4()), instruction="retry", params=kwargs
+            ),
+            target_engines=self.engine_identities,
+        )
+
+        for i, res in enumerate(ft_results):
+            if res.success:
+                self.engine_status_dict[i + self.start_rank] = {
+                    "status": EngineStatusType.HEALTHY
+                }
+
+        success = all([res.success for res in ft_results])
+        if success:
+            self.is_faulted.clear()
+        await self._pub_engine_status()
+        return success
+
+    async def pause(self, timeout: int = 1, **kwargs) -> bool:  # type: ignore[override]
+        """Pause engine cores, return True if successful. Best-effort operation."""
+        self.logger(
+            "Pause operation is best-effort only. Due to the complexity of "
+            "collective communications (e.g., timing dependencies and "
+            "synchronization barriers), pausing may not always succeed. If "
+            "the process remains unresponsive or collective operations "
+            "cannot be interrupted, consider shutting down and restarting "
+            "the instance.",
+            level="warning",
+        )
+        exclude_engine_index = kwargs.get("exclude_engine_index")
+        soft_pause = kwargs.get("soft_pause", False)
+        alive_engines = [
+            i
+            for i, status in self.engine_status_dict.items()
+            if status["status"] != EngineStatusType.DEAD
+            and (exclude_engine_index is None or i not in exclude_engine_index)
+        ]
+
+        kwargs["timeout"] = timeout
+        kwargs["soft_pause"] = soft_pause
+
+        ft_results = await self._execute_cmd_on_engines(
+            ft_request=FaultToleranceRequest(
+                request_id=str(uuid.uuid4()),
+                instruction="pause",
+                params=kwargs,
+            ),
+            target_engines=[
+                self.engine_identities[i - self.start_rank] for i in alive_engines
+            ],
+        )
+
+        return all([res.success for res in ft_results])
+
+    async def _pub_engine_status(self):
+        # No lock needed since we're single-threaded in asyncio
+        engine_status = self.engine_status_dict.copy()
+        topic = self.ft_config.fault_state_pub_topic.encode()
+        await self.fault_state_pub_socket.send_multipart(
+            (topic, msgspec.msgpack.encode(engine_status))
+        )
+
+    async def _execute_cmd_on_engines(
+        self, ft_request: FaultToleranceRequest, target_engines: list[bytes]
+    ) -> list[FaultToleranceResult]:
+        coroutines = []
+        for core_engine in target_engines:
+            coro = self.call_utility_async(
+                "handle_fault", ft_request, engine=core_engine
+            )
+            coroutines.append(coro)
+        results = await asyncio.gather(*coroutines)
+        results = [FaultToleranceResult(**res) for res in results]
+        return results
+
+    async def _monitor_and_pause_on_fault(self):
+        """Receive fault info from engine and pause engines if happened."""
+        try:
+            while not self.sentinel_dead:
+                _, _, message = await self.fault_receiver_socket.recv_multipart(
+                    copy=False
+                )  # type: ignore
+                fault_info = msgspec.msgpack.decode(message, type=FaultInfo)
+                if fault_info.type == "EngineLoopPausedError":
+                    engine_status = EngineStatusType.PAUSED
+                elif fault_info.type == "EngineDeadError":
+                    engine_status = EngineStatusType.DEAD
+                else:
+                    engine_status = EngineStatusType.UNHEALTHY
+                # Update engine status
+                self.engine_status_dict[int(fault_info.engine_id)] = {
+                    "status": engine_status
+                }
+
+                await self._pub_engine_status()
+                if not self.is_faulted.is_set():
+                    self.is_faulted.set()
+                    await self.pause(timeout=self.ft_config.gloo_comm_timeout + 5)
+
+        except zmq.ZMQError:
+            self.logger("Fault receiver socket closed, stopping async monitor.")
+
+    async def run(self):
+        """Poll and execute fault tolerance commands."""
+        generic_decoder = MsgpackDecoder()
+        # Initialize input sockets
+        for input_socket in self.input_sockets:
+            await input_socket.send(b"")
+
+        poller = zmq.asyncio.Poller()
+        for sock in self.input_sockets:
+            poller.register(sock, zmq.POLLIN)
+
+        while not self.sentinel_dead:
+            try:
+                events = await poller.poll(timeout=100)
+                if not events:
+                    continue
+                for sock, event in events:
+                    _, *msg = await sock.recv_multipart(copy=False)
+                    client_index, call_id, _, ft_args = generic_decoder.decode(msg)
+                    ft_request = FaultToleranceRequest(**ft_args[0])
+                    ft_result = await self._execute_cmd(ft_request)
+                    await self._send_utility_result(client_index, call_id, ft_result)
+            except zmq.ZMQError:
+                self.logger("Sockets closed, terminating.")
+                self.sentinel_dead = True
+
+    async def _execute_cmd(self, ft_request):
+        success, reason = False, None
+        try:
+            success = await getattr(self, ft_request.instruction)(**ft_request.params)
+        except Exception as e:
+            self.logger(f"Error processing command: {e}", level="error")
+            reason = f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
+        return FaultToleranceResult(
+            success=success,
+            request_id=ft_request.request_id,
+            reason=reason if not success else None,
+        )
+
+    def shutdown(self):
+        self.sentinel_dead = True
+        close_sockets([self.fault_receiver_socket, self.fault_state_pub_socket])
+        close_sockets(self.input_sockets + self.output_sockets)
+        self.ctx_async.term()
+        super().shutdown()

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import queue
+import threading
+import time
+import traceback
+import uuid
+
+import msgspec.msgpack
+import zmq
+
+from vllm.config import VllmConfig
+from vllm.utils.network_utils import close_sockets, make_zmq_socket
+from vllm.v1.engine import EngineCoreRequestType
+from vllm.v1.engine.exceptions import EngineLoopPausedError
+from vllm.v1.fault_tolerance.sentinel import BaseSentinel
+from vllm.v1.fault_tolerance.utils import (
+    FaultInfo,
+    FaultToleranceRequest,
+    FaultToleranceResult,
+)
+from vllm.v1.serial_utils import run_method
+
+
+class EngineCoreSentinel(BaseSentinel):
+    """
+    EngineCoreSentinel monitors a single EngineCore instance, responsible for:
+      1. Receiving fault signals (exceptions raised in EngineCore busy loop)
+      2. Receiving and executing commands from ClientSentinel
+      3. Reporting execution results or faults back to the ClientSentinel
+    """
+
+    def __init__(
+        self,
+        engine_index: int,
+        fault_signal_q: queue.Queue,
+        cmd_q: queue.Queue,
+        busy_loop_active: threading.Event,
+        engine_input_q: queue.Queue,
+        downstream_cmd_addr: str,
+        engine_fault_socket_addr: str,
+        sentinel_identity: bytes,
+        vllm_config: VllmConfig,
+    ):
+        self.engine_index = engine_index
+        super().__init__(
+            sentinel_tag=f"DP_{engine_index}",
+            vllm_config=vllm_config,
+            identity=sentinel_identity,
+        )
+
+        self.fault_signal_q = fault_signal_q
+        self.cmd_q = cmd_q
+        self.busy_loop_active = busy_loop_active
+        self.engine_input_q = engine_input_q
+        parallel_config = vllm_config.parallel_config
+        self.tp_size = parallel_config.tensor_parallel_size
+        self.pp_size = parallel_config.pipeline_parallel_size
+        self.dp_size = parallel_config.data_parallel_size
+
+        self.worker_cmd_socket = make_zmq_socket(
+            ctx=self.ctx,
+            path=downstream_cmd_addr,
+            socket_type=zmq.ROUTER,
+            bind=True,
+        )
+        self.worker_cmd_poller = zmq.Poller()
+        self.worker_cmd_poller.register(self.worker_cmd_socket, zmq.POLLIN)
+
+        # Client <-> EngineCoreSentinel sockets
+        self.engine_fault_socket = make_zmq_socket(
+            self.ctx,
+            engine_fault_socket_addr,
+            zmq.DEALER,
+            bind=False,
+            identity=sentinel_identity,
+        )
+
+        self.communicator_aborted = False
+        self.engine_paused = threading.Event()
+        threading.Thread(
+            target=self.run, daemon=True, name="EngineCoreSentinelMonitorThread"
+        ).start()
+
+    def run(self):
+        """Continuously poll for fault signals and report to client sentinel."""
+        while not self.sentinel_dead:
+            # poll and report fault events
+            engine_exception = self.fault_signal_q.get()
+            self.engine_paused.set()
+            if isinstance(engine_exception, EngineLoopPausedError):
+                self.logger("Engine paused", level="info")
+            else:
+                self.logger(
+                    "Detected exception %s: %s\n Call Stack:\n%s",
+                    type(engine_exception).__name__,
+                    engine_exception,
+                    "".join(traceback.format_tb(engine_exception.__traceback__)),
+                    level="error",
+                )
+            msg = FaultInfo.from_exception(engine_exception, self.engine_index)
+            msg_bytes = msgspec.msgpack.encode(msg)
+            self.engine_fault_socket.send_multipart([b"", msg_bytes])
+
+    def handle_fault(self, ft_request: FaultToleranceRequest) -> FaultToleranceResult:
+        return self._execute_cmd(ft_request)
+
+    def pause(self, timeout: int = 1, **kwargs) -> bool:
+        """
+        Pause the busy loop of engine core safely.
+        """
+        self.logger("Start pausing EngineCore", level="info")
+        soft_pause = kwargs.get("soft_pause", False)
+        deadline = time.monotonic() + timeout
+        # Clear the flag to signal busy loop should pause
+        self.busy_loop_active.clear()
+        success, _ = self._execute_command_on_workers(
+            "pause",
+            self._get_target_worker_identity(),
+            timeout=timeout,
+            soft_pause=soft_pause,
+        )
+        if success and not self.engine_paused.is_set():
+            # Put a sentinel (empty request) to unblock the busy loop
+            # if it's blocked on input_queue.get()
+            self.engine_input_q.put((EngineCoreRequestType.PAUSE, None))
+            remaining_timeout = max(0, deadline - time.monotonic())
+            success = self.engine_paused.wait(remaining_timeout)
+        return success
+
+    def retry(self, timeout: int = 1, **kwargs) -> bool:
+        """
+        Handle the retry instruction from the ClientSentinel.
+        This instruction tells the EngineCore to continue its busy loop
+        after being suspended due to an exception.
+        """
+        if not self.engine_paused.is_set():
+            return True
+        new_stateless_dp_group_port = kwargs.get("new_stateless_dp_group_port")
+        deadline = time.monotonic() + timeout
+        identities = self._get_target_worker_identity()
+        success, _ = self._execute_command_on_workers(
+            "retry", identities, timeout=timeout
+        )
+        if not success:
+            return success
+
+        if self.dp_size > 1:
+            # If the Gloo communication times out,
+            # the data parallel group (dp_group) needs to be reinitialized
+            reinit_request = FaultToleranceRequest(
+                instruction="reinit_dp_group_on_fault_tolerance",
+                request_id=str(uuid.uuid4()),
+                params={"new_stateless_dp_group_port": new_stateless_dp_group_port},
+            )
+            self.cmd_q.put(reinit_request)
+        else:
+            self.cmd_q.put(None)
+
+        # Ensure busy loop has been recovered.
+        remaining_timeout = max(0, deadline - time.monotonic())
+        success = self.busy_loop_active.wait(timeout=remaining_timeout)
+        if success:
+            self.engine_paused.clear()
+        return success
+
+    def _get_target_worker_identity(self):
+        return {
+            f"PP{pp_rank}_TP{tp_rank}".encode()
+            for tp_rank in range(self.tp_size)
+            for pp_rank in range(self.pp_size)
+        }
+
+    def _execute_command_on_workers(
+        self,
+        method_name: str,
+        target_worker_sentinels: set[bytes],
+        timeout: int = 5,
+        **kwargs,
+    ) -> tuple[bool, dict[bytes, FaultToleranceResult]]:
+        """
+        Broadcast a command to worker sentinels and collect responses.
+        """
+        # Create fault tolerance request
+        kwargs["timeout"] = timeout
+        ft_request = FaultToleranceRequest(
+            request_id=str(uuid.uuid4()),
+            instruction=method_name,
+            params=kwargs,
+        )
+        # Broadcast the instruction
+        msg_bytes = msgspec.msgpack.encode(ft_request)
+        for identity in target_worker_sentinels:
+            self.worker_cmd_socket.send_multipart([identity, b"", msg_bytes])
+        # Wait for responses
+        responses = self._wait_for_execution_result(
+            target_worker_sentinels,
+            timeout,
+            ft_request,
+        )
+        # check the execution results
+        for sentinel_identity in target_worker_sentinels:
+            response = responses.get(sentinel_identity)
+            if response is None:
+                self.logger(
+                    'Worker sentinels timed out on "%s".',
+                    method_name,
+                    level="error",
+                )
+                return False, responses
+            elif not response.success:
+                self.logger(
+                    'Worker sentinels failed to "%s" (reason: %s)',
+                    method_name,
+                    response.reason or "unknown",
+                    level="error",
+                )
+                return False, responses
+
+        return True, responses
+
+    def _wait_for_execution_result(
+        self,
+        target_identities: set[bytes] | list[bytes],
+        timeout: int,
+        ft_request: "FaultToleranceRequest",
+    ) -> dict[bytes, "FaultToleranceResult"]:
+        """Collect responses for the given request.
+        Returns partial results on timeout or error.
+        """
+        assert self.worker_cmd_socket is not None
+        deadline = time.monotonic() + timeout
+        responses: dict[bytes, FaultToleranceResult] = {}
+        pending = set(target_identities)
+        while pending:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                events = self.worker_cmd_poller.poll(int(remaining * 1000))
+                if not events:
+                    break
+                identity, _, payload = self.worker_cmd_socket.recv_multipart()
+                result = msgspec.msgpack.decode(payload, type=FaultToleranceResult)
+                # Ignore unrelated responses
+                if result.request_id != ft_request.request_id:
+                    self.logger(
+                        "Discarding outdated response: %s", result, level="warning"
+                    )
+                    continue
+
+                responses[identity] = result
+                pending.discard(identity)
+            except Exception as e:
+                self.logger(
+                    "Error while processing engine response: %s", e, level="error"
+                )
+                break
+
+        return responses
+
+    def shutdown(self):
+        close_sockets([self.engine_fault_socket, self.worker_cmd_socket])
+        super().shutdown()
+
+
+def busy_loop_wrapper(busy_loop_func):
+    """
+    Wrap the busy loop function to perform fault tolerance.
+    """
+    from vllm.v1.engine.core import logger
+
+    def run_with_fault_tolerance(self):
+        while True:
+            try:
+                if self.enable_fault_tolerance:
+                    self.busy_loop_active.set()
+                busy_loop_func(self)
+            except SystemExit:
+                raise
+            except Exception as original_exc:
+                if self.enable_fault_tolerance:
+                    self.busy_loop_active.clear()
+                    self.fault_signal_q.put(original_exc)
+                    logger.warning(
+                        "[BusyLoopWrapper] EngineCore busy loop raised an exception. "
+                        "Suspended and waiting for fault tolerance "
+                        "instructions."
+                    )
+
+                    # Put running requests into waiting list.
+                    timestamp = time.monotonic()
+                    while self.scheduler.running:
+                        request = self.scheduler.running.pop()
+                        self.scheduler.preempt_request(request, timestamp)
+                    self.scheduler.prev_step_scheduled_req_ids.clear()
+                    if self.batch_queue is not None:
+                        self.batch_queue.clear()
+
+                    try:
+                        # Block until recovery command received
+                        ft_request = self.cmd_q.get(
+                            timeout=self.engine_recovery_timeout_sec
+                        )
+
+                        if ft_request is not None:
+                            logger.debug(
+                                "[BusyLoopWrapper] Received fault tolerance "
+                                "command: %s",
+                                ft_request.instruction,
+                            )
+                            method, params = (ft_request.instruction, ft_request.params)
+                            run_method(self, method, args=(), kwargs=params)
+                        # recovery succeeded; restart the busy loop
+                        continue
+                    except queue.Empty:
+                        # No handling instruction received within predefined
+                        # timeout period.
+                        logger.error(
+                            "[BusyLoopWrapper] Fault tolerance instruction not received"
+                            " within timeout. Proceeding with default exception "
+                            "handling."
+                        )
+                    except Exception as cmd_exc:
+                        raise RuntimeError(
+                            "Fault tolerance execution failed."
+                        ) from cmd_exc
+
+                # Fault tolerance not enabled OR no instruction received
+                # before timeout. Re-raise the original exception
+                # for upper level handling.
+                raise original_exc
+
+    return run_with_fault_tolerance

--- a/vllm/v1/fault_tolerance/sentinel.py
+++ b/vllm/v1/fault_tolerance/sentinel.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import traceback
+from abc import abstractmethod
+
+import zmq
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.fault_tolerance.utils import (
+    FaultToleranceRequest,
+    FaultToleranceResult,
+)
+from vllm.v1.serial_utils import run_method
+
+logger = init_logger(__name__)
+
+
+class BaseSentinel:
+    """
+    Core functionalities of the sentinel covered:
+    - Fault listening
+    - Fault tolerance instruction reception
+    - Fault tolerance instruction execution
+    - Upstream and downstream communication
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        sentinel_tag: str | None,
+        identity: bytes,
+    ):
+        self.sentinel_dead = False
+        self.ctx = zmq.Context()
+        self.sentinel_tag = sentinel_tag
+        self.logger = self._make_logger()
+        self.vllm_config = vllm_config
+        self.ft_config = vllm_config.fault_tolerance_config
+        self.identity = identity
+
+    def _make_logger(self):
+        def log(msg, *args, level="info", **kwargs):
+            """msg: log message"""
+            prefix = self.sentinel_name
+            getattr(logger, level)(prefix + msg, *args, **kwargs)
+
+        return log
+
+    @property
+    def sentinel_name(self) -> str:
+        if self.sentinel_tag is None:
+            return f"[{self.__class__.__name__}] "
+        return f"[{self.__class__.__name__}_{self.sentinel_tag}] "
+
+    @abstractmethod
+    def run(self) -> None:
+        """
+        Run continuously to listen for control commands or error signals;
+        on receipt, execute the command or report the result.
+        """
+        raise NotImplementedError
+
+    def _execute_cmd(self, ft_request: FaultToleranceRequest) -> FaultToleranceResult:
+        method = ft_request.instruction
+        self.logger("Executing command: %s", ft_request, level="info")
+        try:
+            success: bool = run_method(self, method, args=(), kwargs=ft_request.params)
+            self.logger("Command (%s) succeeded: %s", method, success, level="info")
+            reason = None
+        except Exception as e:
+            self.logger("Error executing ft request: %s", ft_request, level="error")
+            success = False
+            reason = f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
+        return FaultToleranceResult(
+            success=success, request_id=ft_request.request_id, reason=reason
+        )
+
+    @abstractmethod
+    def pause(self, timeout: int = 1, **kwargs) -> bool:
+        """
+        Pause the vLLM instance to enter fault-tolerance mode.
+        This method should be called when a fault is detected. It pauses the
+        execution, allowing the system to wait for fault-tolerance instructions
+        (e.g., retry, scale-down, or other control commands).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def retry(self, timeout: int = 1, **kwargs) -> bool:
+        """
+        Retry execution after a transient recoverable fault.
+        """
+        raise NotImplementedError
+
+    def shutdown(self):
+        self.ctx.term()
+        self.sentinel_dead = True

--- a/vllm/v1/fault_tolerance/utils.py
+++ b/vllm/v1/fault_tolerance/utils.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import msgspec
+
+from vllm.config import FaultToleranceConfig
+from vllm.v1.utils import get_engine_client_zmq_addr
+
+
+class FaultInfo(msgspec.Struct):
+    type: str
+    message: str
+    engine_id: str
+    timestamp: str | None = None
+    additional_info: dict | None = None
+
+    def __post_init__(self):
+        # If no exit time is specified, the current timestamp will be used by default.
+
+        local_time = time.localtime(time.time())
+        if self.timestamp is None:
+            self.timestamp = time.strftime("%H:%M:%S", local_time)
+
+    @classmethod
+    def from_exception(
+        cls,
+        exception: Exception,
+        engine_id: str | int,
+        additional_info: dict | None = None,
+    ) -> "FaultInfo":
+        """Create FaultInfo from an exception."""
+        return cls(
+            type=type(exception).__name__,
+            message=str(exception),
+            engine_id=str(engine_id),
+            additional_info=additional_info or {},
+        )
+
+
+class FaultToleranceResult(msgspec.Struct):
+    """
+    Result of applying fault tolerance instructions.
+    """
+
+    request_id: str
+    success: bool
+    reason: str | None = None
+
+
+class FaultToleranceRequest(msgspec.Struct):
+    """
+    Request for fault tolerance instructions, used in the fault tolerance protocol.
+    """
+
+    request_id: str
+    instruction: str
+    params: dict[str, Any]
+
+    @classmethod
+    def builder(
+        cls, request_id: str, instruction: str, params: dict[str, Any]
+    ) -> "FaultToleranceRequest":
+        return cls(request_id=request_id, instruction=instruction, params=params)
+
+
+@dataclass
+class FaultToleranceZmqAddresses:
+    all_client_input_addresses: list[str]
+    all_client_output_addresses: list[str]
+    # ZMQ fault_state_pub_socket address of client sentinel
+    fault_state_pub_socket_addr: str
+    # ZMQ client_sentinel_request socket address of client sentinel
+    client_sentinel_request_addr: str
+    # ZMQ engine_core_sentinel_cmd socket address of engine_core sentinel
+    engine_core_sentinel_cmd_addr: str
+    # ZMQ engine_fault socket address of EngineCoreSentinel
+    engine_fault_socket_addr: str
+    # Identities of engine core DEALER sockets, keyed by engine index.
+    # These identities are used by the ClientSentinel (ROUTER) to route
+    # messages to the corresponding engine core.
+    engine_core_sentinel_identities: dict[int, bytes]
+
+    @classmethod
+    def build(
+        cls,
+        host,
+        local_engines_only,
+        dp_size,
+        inputs,
+        outputs,
+        ft_config: FaultToleranceConfig,
+    ):
+        engine_fault_socket_addr = get_engine_client_zmq_addr(
+            local_only=False,
+            host=host,
+            port=ft_config.internal_fault_report_port,
+        )
+        client_sentinel_request_addr = get_engine_client_zmq_addr(
+            local_only=True, host=host
+        )
+        engine_core_sentinel_cmd_addr = get_engine_client_zmq_addr(
+            local_only=local_engines_only, host=host
+        )
+        identity_group = [str(uuid.uuid4()).encode("utf8") for _ in range(dp_size)]
+        engine_core_sentinel_identities = {
+            rank: identity for rank, identity in enumerate(identity_group)
+        }
+        fault_state_pub_socket_addr = get_engine_client_zmq_addr(
+            local_only=False,
+            host=host,
+            port=ft_config.external_fault_notify_port,
+        )
+        return cls(
+            fault_state_pub_socket_addr=fault_state_pub_socket_addr,
+            client_sentinel_request_addr=client_sentinel_request_addr,
+            engine_core_sentinel_cmd_addr=engine_core_sentinel_cmd_addr,
+            engine_fault_socket_addr=engine_fault_socket_addr,
+            engine_core_sentinel_identities=engine_core_sentinel_identities,
+            all_client_input_addresses=inputs,
+            all_client_output_addresses=outputs,
+        )
+
+    def to_str(self) -> str:
+        payload = {
+            "fault_state_pub_socket_addr": self.fault_state_pub_socket_addr,
+            "client_sentinel_request_addr": self.client_sentinel_request_addr,
+            "engine_core_sentinel_cmd_addr": self.engine_core_sentinel_cmd_addr,
+            "engine_fault_socket_addr": self.engine_fault_socket_addr,
+            "all_client_input_addresses": self.all_client_input_addresses,
+            "all_client_output_addresses": self.all_client_output_addresses,
+            "engine_core_sentinel_identities": {
+                str(rank): identity.hex()
+                for rank, identity in self.engine_core_sentinel_identities.items()
+            },
+        }
+        return json.dumps(payload, separators=(",", ":"))
+
+    @classmethod
+    def from_str(cls, s: str) -> "FaultToleranceZmqAddresses":
+        payload = json.loads(s)
+
+        identities = {
+            int(rank): bytes.fromhex(identity_hex)
+            for rank, identity_hex in payload["engine_core_sentinel_identities"].items()
+        }
+
+        return cls(
+            all_client_input_addresses=payload["all_client_input_addresses"],
+            all_client_output_addresses=payload["all_client_output_addresses"],
+            fault_state_pub_socket_addr=payload["fault_state_pub_socket_addr"],
+            client_sentinel_request_addr=payload["client_sentinel_request_addr"],
+            engine_core_sentinel_cmd_addr=payload["engine_core_sentinel_cmd_addr"],
+            engine_fault_socket_addr=payload["engine_fault_socket_addr"],
+            engine_core_sentinel_identities=identities,
+        )

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -10,6 +10,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from multiprocessing import connection
 from multiprocessing.process import BaseProcess
+from threading import Thread
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
 
     from vllm.v1.engine.coordinator import DPCoordinator
     from vllm.v1.engine.utils import CoreEngineActorManager, CoreEngineProcManager
+    from vllm.v1.fault_tolerance.utils import FaultToleranceZmqAddresses
 
 logger = init_logger(__name__)
 
@@ -173,6 +175,7 @@ class APIServerProcessManager:
         input_addresses: list[str],
         output_addresses: list[str],
         stats_update_address: str | None = None,
+        fault_tolerance_addresses: "FaultToleranceZmqAddresses|None|str" = None,
     ):
         """Initialize and start API server worker processes.
 
@@ -205,6 +208,12 @@ class APIServerProcessManager:
             }
             if stats_update_address is not None:
                 client_config["stats_update_address"] = stats_update_address
+            if fault_tolerance_addresses is not None:
+                from vllm.v1.fault_tolerance.utils import FaultToleranceZmqAddresses
+
+                if isinstance(fault_tolerance_addresses, FaultToleranceZmqAddresses):
+                    fault_tolerance_addresses = fault_tolerance_addresses.to_str()
+                client_config["fault_tolerance_addresses"] = fault_tolerance_addresses
 
             proc = spawn_context.Process(
                 target=target_server_fn,
@@ -258,11 +267,22 @@ def wait_for_completion_or_failure(
             sentinel_to_proc[coordinator.proc.sentinel] = coordinator.proc
 
         actor_run_refs = []
-        if isinstance(engine_manager, CoreEngineProcManager):
-            for proc in engine_manager.processes:
-                sentinel_to_proc[proc.sentinel] = proc
-        elif isinstance(engine_manager, CoreEngineActorManager):
-            actor_run_refs = engine_manager.get_run_refs()
+        assert engine_manager is not None
+        if engine_manager.vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            # Start a thread to monitor engine liveness.
+            # Do not exit when engine is down.
+            Thread(
+                target=engine_manager.monitor_engine_liveness,
+                args=(engine_manager.notify_engine_down,),
+                daemon=True,
+                name="ClientEngineMonitor",
+            ).start()
+        else:
+            if isinstance(engine_manager, CoreEngineProcManager):
+                for proc in engine_manager.processes:
+                    sentinel_to_proc[proc.sentinel] = proc
+            elif isinstance(engine_manager, CoreEngineActorManager):
+                actor_run_refs = engine_manager.get_run_refs()
 
         # Check if any process terminates
         while sentinel_to_proc or actor_run_refs:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -128,6 +128,7 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
+from vllm.v1.engine.exceptions import EngineLoopPausedError
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     ChunkedLocalAttentionSpec,
@@ -822,6 +823,12 @@ class GPUModelRunner(
         self.mamba_state_idx: dict[str, int] = {}
         self._mamba_copy_bufs: mamba_utils.MambaCopyBuffers | None = None
         self.layerwise_nvtx_hooks_registered = False
+
+        self.pause_event = threading.Event()
+
+    def _check_pause_event(self):
+        if self.pause_event.is_set():
+            raise EngineLoopPausedError("Worker is paused.")
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
@@ -3279,6 +3286,7 @@ class GPUModelRunner(
         Returns:
             Model output tensor
         """
+        self._check_pause_event()
         return self.model(
             input_ids=input_ids,
             positions=positions,
@@ -5218,6 +5226,7 @@ class GPUModelRunner(
                     slot_mapping=slot_mappings,
                 ),
             ):
+                self._check_pause_event()
                 outputs = self.model(
                     input_ids=input_ids,
                     positions=positions,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -7,6 +7,7 @@ import os
 from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from datetime import timedelta
+from functools import partial
 from types import NoneType
 from typing import TYPE_CHECKING, Any
 
@@ -55,6 +56,7 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
 )
 from vllm.v1.utils import compute_iteration_details, report_usage_stats
+from vllm.v1.worker.sentinel.gpu_worker_sentinel import WorkerSentinel
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm.v1.worker.worker_base import WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -126,7 +128,7 @@ class Worker(WorkerBase):
         from vllm.distributed.elastic_ep.elastic_execute import ElasticEPScalingExecutor
 
         self.elastic_ep_executor = ElasticEPScalingExecutor(self)
-
+        self.worker_sentinel: WorkerSentinel | None = None
         # Buffers saved before sleep
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
 
@@ -312,6 +314,30 @@ class Worker(WorkerBase):
         if self.rank == 0:
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
+
+        if self.vllm_config.fault_tolerance_config.enable_fault_tolerance:
+            with set_current_vllm_config(self.vllm_config):
+                init_distributed_env_callback = partial(
+                    init_worker_distributed_environment,
+                    self.vllm_config,
+                    self.rank,
+                    self.distributed_init_method,
+                    self.local_rank,
+                )
+
+            def clear_input_batch_callback():
+                input_batch = self.model_runner.input_batch
+                cached_req_ids = input_batch.req_id_to_index.keys()
+                for req_id in list(cached_req_ids):
+                    input_batch.remove_request(req_id)
+
+            self.worker_sentinel = WorkerSentinel(
+                self.vllm_config,
+                self.model_runner.pause_event,
+                init_distributed_env_callback,
+                clear_input_batch_callback,
+                self.device,
+            )
 
     # FIXME(youkaichao & ywang96): Use TorchDispatchMode instead of memory pool
     # to hijack tensor allocation.
@@ -1016,6 +1042,8 @@ class Worker(WorkerBase):
             ensure_kv_transfer_shutdown()
         if self.profiler is not None:
             self.profiler.shutdown()
+        if self.worker_sentinel is not None:
+            self.worker_sentinel.shutdown()
 
         if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
             weight_transfer_engine.shutdown()
@@ -1053,6 +1081,7 @@ def init_worker_distributed_environment(
         local_rank,
         backend,
         timeout,
+        fault_tolerance_config=vllm_config.fault_tolerance_config,
     )
 
     ensure_model_parallel_initialized(
@@ -1060,6 +1089,7 @@ def init_worker_distributed_environment(
         parallel_config.pipeline_parallel_size,
         parallel_config.prefill_context_parallel_size,
         parallel_config.decode_context_parallel_size,
+        fault_tolerance_config=vllm_config.fault_tolerance_config,
     )
 
     # Init ec connector here before KV caches init

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -47,7 +47,7 @@ class WorkerSentinel(BaseSentinel):
 
         self.pause_event = pause_event
         self.communicator_aborted = False
-        torch.cuda.set_device(self.device)
+        torch.accelerator.set_device_index(self.device)
 
         assert vllm_config.fault_tolerance_config.worker_cmd_addr is not None
         self.engine_core_cmd_socket = make_zmq_socket(
@@ -98,7 +98,7 @@ class WorkerSentinel(BaseSentinel):
             return True
         self.pause_event.set()
         self._set_device_communicator_status(False)
-        torch.cuda.set_device(self.device)
+        torch.accelerator.set_device_index(self.device)
         model_groups = get_all_model_groups()
         futures = []
 
@@ -159,7 +159,7 @@ class WorkerSentinel(BaseSentinel):
 
     def retry(self, timeout: int = 1, **kwargs) -> bool:
         if self.communicator_aborted:
-            torch.cuda.set_device(self.device)
+            torch.accelerator.set_device_index(self.device)
             with set_current_vllm_config(self.vllm_config):
                 self.init_distributed_env_callback()
                 self.communicator_aborted = False

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+from collections.abc import Callable
+from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
+from typing import cast
+
+import msgspec
+import torch
+import zmq
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed import (
+    GroupCoordinator,
+    cleanup_dist_env_and_memory,
+    get_all_model_groups,
+    get_pp_group,
+    get_tp_group,
+)
+from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
+from vllm.utils.network_utils import close_sockets, make_zmq_socket
+from vllm.v1.fault_tolerance import BaseSentinel
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+
+
+class WorkerSentinel(BaseSentinel):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        pause_event: threading.Event,
+        init_distributed_env_callback: Callable,
+        clear_input_batch_callback: Callable,
+        device: torch.device,
+    ):
+        dp_rank = vllm_config.parallel_config.data_parallel_rank
+        tp_rank = get_tp_group().rank_in_group
+        pp_rank = get_pp_group().rank_in_group
+        identity_str = f"PP{pp_rank}_TP{tp_rank}"
+        super().__init__(
+            sentinel_tag=f"{dp_rank}_{identity_str}",
+            vllm_config=vllm_config,
+            identity=identity_str.encode(),
+        )
+        self.init_distributed_env_callback = init_distributed_env_callback
+        self.clear_input_batch_callback = clear_input_batch_callback
+        self.device = device
+
+        self.pause_event = pause_event
+        self.communicator_aborted = False
+        torch.cuda.set_device(self.device)
+
+        assert vllm_config.fault_tolerance_config.worker_cmd_addr is not None
+        self.engine_core_cmd_socket = make_zmq_socket(
+            self.ctx,
+            vllm_config.fault_tolerance_config.worker_cmd_addr,
+            zmq.DEALER,
+            bind=False,
+            identity=self.identity,
+        )
+        self.engine_core_cmd_socket.setsockopt(zmq.RCVTIMEO, 100)
+
+        threading.Thread(
+            target=self.run, daemon=True, name="WorkerSentinelMonitorThread"
+        ).start()
+
+    def run(self):
+        # Wait for fault tolerance instructions from EngineCoreSentinel
+        while not self.sentinel_dead:
+            self.poll_and_execute_upstream_cmd()
+
+    def poll_and_execute_upstream_cmd(self):
+        """
+        Receive and execute a command from upstream sentinel and send back
+        the execution result.
+        """
+        try:
+            _, msg = self.engine_core_cmd_socket.recv_multipart()
+            ft_request = msgspec.msgpack.decode(msg, type=FaultToleranceRequest)
+            ft_result = self._execute_cmd(ft_request)
+            msg_bytes = msgspec.msgpack.encode(ft_result)
+            self.engine_core_cmd_socket.send_multipart([b"", msg_bytes])
+        except zmq.Again:
+            pass
+        except zmq.ZMQError:
+            self.logger("Socket closed, terminating.")
+            self.sentinel_dead = True
+
+    def pause(self, timeout: int = 1, **kwargs) -> bool:
+        soft_pause = kwargs.get("soft_pause", False)
+        if soft_pause:
+            self._set_device_communicator_status(False)
+            self.pause_event.set()
+            self.logger("Pause signal sent.")
+            return True
+        # Abort all NCCL communicators and
+        # process groups in parallel using a thread pool.
+        if self.communicator_aborted:
+            return True
+        self.pause_event.set()
+        self._set_device_communicator_status(False)
+        torch.cuda.set_device(self.device)
+        model_groups = get_all_model_groups()
+        futures = []
+
+        def _abort_nccl_comm(group: GroupCoordinator):
+            if group.device_communicator is not None:
+                device_comm = cast(CudaCommunicator, group.device_communicator)
+                nccl_comm = device_comm.pynccl_comm
+                assert nccl_comm is not None
+                nccl_comm.nccl_abort_comm()
+
+        def _abort_process_group(group: GroupCoordinator):
+            backend = group.device_group._get_backend(self.device)
+            backend.abort()
+
+        executor = ThreadPoolExecutor(max_workers=len(model_groups) * 2)
+        try:
+            for group in model_groups:
+                futures.append(executor.submit(_abort_nccl_comm, group))
+                futures.append(executor.submit(_abort_process_group, group))
+
+            done, not_done = wait(futures, timeout=timeout, return_when=FIRST_EXCEPTION)
+            if not_done:
+                self.logger(
+                    "%d abort calls did not finish in total %s seconds",
+                    len(not_done),
+                    timeout,
+                    level="warning",
+                )
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+
+        exception_count = sum(1 for f in done if f.exception() is not None)
+        self.communicator_aborted = len(not_done) == 0 and exception_count == 0
+        if self.communicator_aborted:
+            cleanup_dist_env_and_memory()
+            self.logger("Communicators are aborted.")
+        else:
+            self.logger(
+                "Communicator abort failed: %d NCCL comm abort calls timed out,"
+                " %d tasks threw exceptions. This may leave NCCL communicators "
+                "or process groups in an inconsistent state. Subsequent "
+                "distributed operations could be unsafe.",
+                len(not_done),
+                exception_count,
+                level="error",
+            )
+        return self.communicator_aborted
+
+    def _set_device_communicator_status(self, active: bool):
+        model_groups = get_all_model_groups()
+        for group in model_groups:
+            if group.device_communicator is not None:
+                device_comm = cast(CudaCommunicator, group.device_communicator)
+                nccl_comm = device_comm.pynccl_comm
+                assert nccl_comm is not None
+                nccl_comm.available = active
+                nccl_comm.disabled = not active
+
+    def retry(self, timeout: int = 1, **kwargs) -> bool:
+        if self.communicator_aborted:
+            torch.cuda.set_device(self.device)
+            with set_current_vllm_config(self.vllm_config):
+                self.init_distributed_env_callback()
+                self.communicator_aborted = False
+        self.clear_input_batch_callback()
+        self.pause_event.clear()
+        return True
+
+    def shutdown(self):
+        close_sockets([self.engine_core_cmd_socket])
+        super().shutdown()


### PR DESCRIPTION
**Co-authored with:** @zWaNg3 @a798347923 @205150940
## Purpose

### Summary

This PR implements **Milestone 1** of RFC #27866, introducing a fault tolerance framework for vLLM.
It provides mechanisms to **detect runtime exceptions**, **pause execution**, **report fault events**, and allow upper orchestration layers to **apply fault tolerance methods** (initially supporting retry).

**（Updates 18/2/2026）**
Since the complete fault tolerance framework introduces substantial code changes, we also plan to split the original PR into three smaller and more reviewable parts: fault reporting, pause-on-error, and fault handling interface.
The detailed split plan can be found [here](https://docs.google.com/document/d/1o0uAP_MpjyU4aN0CEZ6PUgt88KLap1jccQKlJo4-TE4/edit?usp=sharing).
Links to the split PRs:
- Fault reporting: https://github.com/vllm-project/vllm/pull/34833
- Pause-on-error: https://github.com/vllm-project/vllm/pull/38534
- Fault handling interface: https://github.com/vllm-project/vllm/pull/40468

### Supported Functionality

- Detect exceptions raised inside a vLLM instance and pause its execution.
- Publish fault events and expose rank/EngineCore status to the upper orchestration framework.
- Provide a retry API for transient and recoverable faults (e.g., network jitter).

### Usage

Enable the Fault Tolerance feature via configuration, for example:

```bash
vllm serve \
  --model xxxxx \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --tensor-parallel-size 1 \
  --enforce-eager \
  --enable-fault-tolerance \
  --engine-recovery-timeout 120 \
  --external-fault-notify-port 23456
```
- When an exception is raised in any rank (tested via code injection or killing a worker process), vLLM reports the event via a ZMQ PUB socket.

  - Example: Subscribe to port 23456 on topic vllm_fault to receive events.
- The status of each EngineCore can be queried via API:
```bash
GET /fault_tolerance/status
```
- Retry can be triggered via API:
```css
POST /fault_tolerance/apply
Body: {"fault_tolerance_instruction": "retry", "fault_tolerance_timeout": 30}
```

### Implementation Notes
Overall architecture:
![Framework of vLLM Internal Fault Tolerance](https://github.com/user-attachments/assets/bb673db0-e923-422e-88ee-409bab455213)

```
**ClientSentinel (for MPClient)**
  ├─ Receives:
  │    - Exception / failure reports from EngineCoreSentinel
  │    - Fault-tolerance commands from the API Server
  ├─ Provides:
  │    - Query & subscription interface for upper-level frameworks
  └─ Forwards:
       - Fault-tolerance commands to EngineCoreSentinel
    ↓ ZMQ ROUTER/DEALER
**EngineCoreSentinel (per DP rank)**
  ├─ Monitors:
  │    - EngineCore busy_loop via a shared fault_signal_q
  ├─ Controls:
  │    - busy_loop_active flag
  └─ Commands:
       - WorkerSentinel via ZMQ
    ↓ ZMQ ROUTER/DEALER
**WorkerSentinel (per worker)**
  ├─ Monitors:
  │    - N/A (passive, command-driven)
  ├─ Executes received commands:
  │    - pause_by_signal
  │    - pause_by_abort_communicators
  |    -  ...
  └─ Reports:
       - Success / failure back to EngineCoreSentinel
```

- We actually implemented two approaches to pause healthy ranks. Due to the complexity of collective communications, we currently adopt the hard pause method as the default.
  - Soft pause: set pause flag variables for EngineCore/Worker to check.
  - Hard pause (default): set flags and abort process groups/communicators.

- NCCL: All communicators are set as nonblocking when fault tolerance is enabled, allowing safe use of [ncclCommAbort](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#c.ncclCommAbort) as suggested by [NCCL](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#fault-tolerance).

- Currently, when querying EngineCore status via the API: EngineCores paused using the signal flag are reported as healthy. EngineCores paused due to aborted communicators are reported as unhealthy. Further refinements to the status reporting will be implemented in follow-ups.

We believe that **this implementation is compatible with RFC #27774 and #27908** to isolate fault ranks through scale_down. This implementation  establishes the overall fault tolerance framework within vLLM, providing mechanisms for detecting, pausing, reporting, and performing fault tolerance. Within this framework, **fault isolation through elastic expert parallelism (#20323)** is treated as **one of the fault tolerance methods**. As a result, this implementation and the elastic expert parallelism proposal are designed to be compatible.

We welcome further discussion and feedback from the community to refine and extend these fault tolerance mechanisms.


## Test Plan

- Tested with DT
  - pytest tests/v1/engine/test_client_guard.py
  - pytest tests/v1/engine/test_engine_core_guard.py
- End-to-end tests.
  - End-to-end tests conducted on Qwen3-30B-A3B with configurations: DP4/TP2 and DP8/TP1.
  - Two fault injection types:
    - Manually raising exceptions at different code locations.
    - Killing certain worker processes.
  - Verified:
    - Pause behavior
    - Fault reporting
    - Retry functionality (for code injections)

## Test Result
**DT results**

- pytest tests/v1/engine/test_client_guard.py
  - tests/v1/engine/test_client_guard.py::test_client_guard_initialization PASSED
  - tests/v1/engine/test_client_guard.py::test_handle_fault PASSED
  - tests/v1/engine/test_client_guard.py::test_fault_receiver PASSED
  - tests/v1/engine/test_client_guard.py::test_fault_receiver_unhealthy PASSED
  - tests/v1/engine/test_client_guard.py::test_shutdown_guard PASSED
  - tests/v1/engine/test_client_guard.py::test_handle_fault_async PASSED
- pytest tests/v1/engine/test_engine_core_guard.py
  - tests/v1/engine/test_engine_core_guard.py::test_engine_core_guard_initialization PASSED
  - tests/v1/engine/test_engine_core_guard.py::test_run_handle_instruction[pause] PASSED
  - tests/v1/engine/test_engine_core_guard.py::test_run_handle_instruction[retry] PASSED


**End-to-end Test Results**
We validated both the **functional correctness** and **model precision** after applying the retry-based fault tolerance mechanism. All fault tolerance features behaved as expected — including fault detection, pause/resume, event reporting, and retry recovery.

The precision tests showed no regression, indicating that the retry mechanism does not affect the model’s output quality.

Here are some vLLM log demonstrations from the end-to-end tests:
**1. Simulated Exception**
[DP4_TP2_Exception_Retry.log](https://github.com/user-attachments/files/23495720/DP4_TP2_Exception_Retry.log)
A fault was manually triggered by raising a `RuntimeError("Test Error")` inside `gpu_model_runner.execute_model` on DP rank0.
- The instance started at **23:02:12** and finished the initialization at **23:02:44**, taking roughly **32 seconds** to startup, and serving requests afterwards.
- At **23:03:02**, the exception was raised and propagated to the client. The ClientGuard immediately began executing the Pause operation (_"[FaultHandler] Pause operation is best-effort ..."_).
- By **23:03:03**, all EngineCore components had stopped computation and entered the paused state (_"[EngineCoreGuard_x] Command (pause) succeeded: True"_), and the runtime status could be queried via GET /fault_tolerance/status.
- At **23:03:14**, an external Retry command was issued, and by **23:03:16**, the instance successfully resumed service (_"[EngineCoreGuard_x] Command (retry) succeeded: True"_)

**The recovery process took only 2 seconds, compared with 32 seconds for a full restart recovery**, demonstrating significantly improved fault recovery efficiency. After retry, normal inference resumed (_"Engine 000: Avg prompt throughput: 3.9 tokens/s, Avg generation throughput: 4.3 tokens/s, ..."_).

We also tested with ray backend with DP8/TP1, and here is the log:
[Ray_DP8_TP1_Exception_Retry.log](https://github.com/user-attachments/files/23496306/Ray_DP8_TP1_Exception_Retry.log)

**2. Random process kill simulation**
[DP8_TP1_KillProcess.log](https://github.com/user-attachments/files/23496205/DP8_TP1_KillProcess.log)
In another test, we simulated faults by randomly killing one of the worker processes (23:23:49, EngineCore DP4). 
After the kill, the instance automatically entered the paused state. 
As no fault-tolerance command was received within the pre-defined timeout (engine-recovery-timeout, 120s), the instance exited gracefully(_"23:25:49 [core.py:389] [BusyLoopWrapper] Fault tolerance instruction not received within timeout. Proceeding with default exception handling."_).


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>