### PR TITLE
[Model][Qwen3VL] Simplify `get_mrope_input_positions` using numpy

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1432,13 +1432,11 @@ class Qwen3VLForConditionalGeneration(
         vision_start_token_id = hf_config.vision_start_token_id
         spatial_merge_size = hf_config.vision_config.spatial_merge_size
 
-        input_tokens_tensor = torch.tensor(input_tokens)
-        vision_start_indices = torch.argwhere(
-            input_tokens_tensor == vision_start_token_id
-        ).squeeze(1)
-        vision_tokens = input_tokens_tensor[vision_start_indices + 1]
-        image_nums = (vision_tokens == image_token_id).sum()
-        video_nums = (vision_tokens == video_token_id).sum()
+        input_tokens_array = np.array(input_tokens)
+        vision_start_mask = input_tokens_array == vision_start_token_id
+        vision_tokens = input_tokens_array[vision_start_mask.nonzero()[0] + 1]
+        image_nums = np.count_nonzero(vision_tokens == image_token_id)
+        video_nums = np.count_nonzero(vision_tokens == video_token_id)
         llm_pos_ids_list: list = []
 
         st = 0
@@ -1474,43 +1472,23 @@ class Qwen3VLForConditionalGeneration(
 
             st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
             llm_pos_ids_list.append(
-                torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                np.broadcast_to(np.arange(text_len), (3, text_len)) + st_idx
             )
 
-            t_index = (
-                torch.arange(llm_grid_t)
-                .view(-1, 1)
-                .expand(-1, llm_grid_h * llm_grid_w)
-                .flatten()
-            )
-            h_index = (
-                torch.arange(llm_grid_h)
-                .view(1, -1, 1)
-                .expand(llm_grid_t, -1, llm_grid_w)
-                .flatten()
-            )
-            w_index = (
-                torch.arange(llm_grid_w)
-                .view(1, 1, -1)
-                .expand(llm_grid_t, llm_grid_h, -1)
-                .flatten()
-            )
-            llm_pos_ids_list.append(
-                torch.stack([t_index, h_index, w_index]) + text_len + st_idx
-            )
+            grid_indices = np.indices((llm_grid_t, llm_grid_h, llm_grid_w))
+            llm_pos_ids_list.append(grid_indices.reshape(3, -1) + text_len + st_idx)
             st = ed + llm_grid_t * llm_grid_h * llm_grid_w
 
         if st < len(input_tokens):
             st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
             text_len = len(input_tokens) - st
             llm_pos_ids_list.append(
-                torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                np.broadcast_to(np.arange(text_len), (3, text_len)) + st_idx
             )
 
-        llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+        llm_positions = np.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
         mrope_position_delta = (llm_positions.max() + 1 - len(input_tokens)).item()
-
-        return llm_positions, mrope_position_delta
+        return torch.from_numpy(llm_positions), mrope_position_delta
 
     def get_language_model(self) -> torch.nn.Module:
         return self.language_model


### PR DESCRIPTION
## Purpose

This PR simplifies the Qwen3VL `get_mrope_input_positions` computation by using `np.indices` to make the code more readable.

In a profile I also noticed that the torch CPUs ops, especially `torch.tensor(list[int])` are slower than their numpy equivalents so this PR also changes the computation to numpy.

**Before:**

<img width="538" height="156" alt="Screenshot 2025-11-07 at 15 14 40" src="https://github.com/user-attachments/assets/a9daeafa-36fb-436e-9b3c-b3b4751728c6" />
<img width="999" height="147" alt="Screenshot 2025-11-07 at 15 15 10" src="https://github.com/user-attachments/assets/6c2ae024-9ccb-47e4-a754-b61a1b0b79fa" />

**After:**

<img width="961" height="114" alt="Screenshot 2025-11-07 at 15 15 24" src="https://github.com/user-attachments/assets/c2401391-7b9b-4d2d-8066-799a809c2dec" />
<img width="534" height="157" alt="Screenshot 2025-11-07 at 15 14 53" src="https://github.com/user-attachments/assets/b83d87b9-a552-4dc3-b25d-523c253a08b1" />


## Test Plan

```
VLLM_WORKER_MULTIPROC_METHOD=spawn lm_eval --model vllm-vlm --model_args "pretrained=Qwen/Qwen3-VL-30B-A3B-Instruct-FP8,max_model_len=10000" --tasks chartqa --batch_size auto --apply_chat_template
```

## Test Result

**Before:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8680 | ±   | 0.0068 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6340 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8572 | ±   | 0.0070 |

**After:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8672 | ±   | 0.0068 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6324 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8576 | ±   | 0.0070 |

