### PR TITLE
[CI] lora/test_mixtral.py : Add additional expected outputs due to flakiness

### DIFF
--- a/tests/lora/test_mixtral.py
+++ b/tests/lora/test_mixtral.py
@@ -68,8 +68,10 @@ def test_mixtral_lora(mixtral_lora_files, tp_size):
         ],
     ]
 
-    lora_output = do_sample(llm, mixtral_lora_files, lora_id=1, prompts=prompts)
-    assert all([lora_output[i] in expected_lora_output[i] for i in range(len(prompts))])
+    def check_outputs(generated: list[str]):
+        assert len(generated) == len(expected_lora_output)
+        for gen, gt_choices in zip(generated, expected_lora_output):
+            assert gen in gt_choices
 
-    lora_output = do_sample(llm, mixtral_lora_files, lora_id=2, prompts=prompts)
-    assert all([lora_output[i] in expected_lora_output[i] for i in range(len(prompts))])
+    check_outputs(do_sample(llm, mixtral_lora_files, lora_id=1, prompts=prompts))
+    check_outputs(do_sample(llm, mixtral_lora_files, lora_id=2, prompts=prompts))

--- a/tests/lora/test_mixtral.py
+++ b/tests/lora/test_mixtral.py
@@ -56,15 +56,20 @@ def test_mixtral_lora(mixtral_lora_files, tp_size):
     )
 
     expected_lora_output = [
-        "give_opinion(name[SpellForce 3], release_year[2017], developer[Grimlore Games], rating[poor])",  # noqa: E501
-        "give_opinion(name[SpellForce 3], developer[Grimlore Games], release_year[2017], rating[poor])",  # noqa: E501
-        "inform(name[BioShock], release_year[2007], rating[good], genres[action-adventure, role-playing, shooter], platforms[PlayStation, Xbox, PC], available_on_steam[yes], has_linux_release[no], has_mac_release[yes])",  # noqa: E501
+        [
+            "give_opinion(name[SpellForce 3], release_year[2017], developer[Grimlore Games], rating[poor])"  # noqa: E501
+        ],
+        [
+            "give_opinion(name[SpellForce 3], developer[Grimlore Games], release_year[2017], rating[poor])",  # noqa: E501
+            "give_opinion(name[SpellForce 3], release_year[2017], developer[Grimlore Games], rating[poor])",  # noqa: E501
+        ],
+        [
+            "inform(name[BioShock], release_year[2007], rating[good], genres[action-adventure, role-playing, shooter], platforms[PlayStation, Xbox, PC], available_on_steam[yes], has_linux_release[no], has_mac_release[yes])"  # noqa: E501
+        ],
     ]
-    assert (
-        do_sample(llm, mixtral_lora_files, lora_id=1, prompts=prompts)
-        == expected_lora_output
-    )
-    assert (
-        do_sample(llm, mixtral_lora_files, lora_id=2, prompts=prompts)
-        == expected_lora_output
-    )
+
+    lora_output = do_sample(llm, mixtral_lora_files, lora_id=1, prompts=prompts)
+    assert all([lora_output[i] in expected_lora_output[i] for i in range(len(prompts))])
+
+    lora_output = do_sample(llm, mixtral_lora_files, lora_id=2, prompts=prompts)
+    assert all([lora_output[i] in expected_lora_output[i] for i in range(len(prompts))])


### PR DESCRIPTION
## Purpose
Distributed A100 tests fail the nightly due to `lora/test_mixtral.py` [link](https://buildkite.com/vllm/ci/builds/37953/steps/canvas?jid=019a5cb0-94f0-4403-83db-87eb1ea1b9a7)

This PR attempts to fix that test. Running the test locally, I found it to be flaky. However, the output generated by the LLM is still reasonable. As a fix, I have added an additional "expected_output" to the prompt that is flaky.

## Test Plan
CI

## Test Result

