### PR TITLE
Fix rotary embedding benchmark script

### DIFF
--- a/benchmarks/kernels/benchmark_rope.py
+++ b/benchmarks/kernels/benchmark_rope.py
@@ -1,97 +1,76 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from itertools import accumulate
+import itertools
 
-import nvtx
 import torch
 
-from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding, get_rope
-from vllm.platforms import current_platform
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.triton_utils import triton
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
+batch_size_range = [2**i for i in range(0, 8, 2)]
+seq_len_range = [2**i for i in range(6, 10, 1)]
+num_heads_range = [32, 48]
+configs = list(itertools.product(batch_size_range, seq_len_range, num_heads_range))
 
-def benchmark_rope_kernels_multi_lora(
-    is_neox_style: bool,
-    batch_size: int,
-    seq_len: int,
-    num_heads: int,
-    head_size: int,
-    rotary_dim: int | None,
-    dtype: torch.dtype,
-    seed: int,
-    device: str,
-    max_position: int = 8192,
-    base: float = 10000,
-) -> None:
-    current_platform.seed_everything(seed)
-    torch.set_default_device(device)
-    if rotary_dim is None:
-        rotary_dim = head_size
-    # silulating serving 4 LoRAs
-    scaling_factors = [1, 2, 4, 8]
-    # batched RoPE can take multiple scaling factors
-    batched_rope = get_rope(
-        head_size,
-        rotary_dim,
-        max_position,
-        base,
-        is_neox_style,
-        {"rope_type": "linear", "factor": tuple(scaling_factors)},
-    )
-    # non-batched RoPE takes only one scaling factor, we create multiple
-    # instances to simulate the same behavior
-    non_batched_ropes: list[RotaryEmbedding] = []
-    for scaling_factor in scaling_factors:
-        non_batched_ropes.append(
-            get_rope(
-                head_size,
-                rotary_dim,
-                max_position,
-                base,
-                is_neox_style,
-                {"rope_type": "linear", "factor": (scaling_factor,)},
-            )
-        )
 
-    positions = torch.randint(0, max_position, (batch_size, seq_len))
-    query = torch.randn(batch_size, seq_len, num_heads * head_size, dtype=dtype)
-    key = torch.randn_like(query)
-
-    # create query offsets for batched RoPE, we concat multiple kv cache
-    # together and each query needs to find the right kv cache of its type
-    offset_map = torch.tensor(
-        list(
-            accumulate(
-                [0]
-                + [
-                    max_position * scaling_factor * 2
-                    for scaling_factor in scaling_factors[:-1]
-                ]
-            )
+def get_benchmark(head_size, rotary_dim, is_neox_style, device):
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["batch_size", "seq_len", "num_heads"],
+            x_vals=[list(_) for _ in configs],
+            line_arg="provider",
+            line_vals=["torch", "flashinfer", "vllm"],
+            line_names=["PyTorch", "FlashInfer", "vLLM"],
+            styles=[("blue", "-"), ("green", "-"), ("red", "-")],
+            ylabel="us",
+            plot_name=f"rope-perf{'-neox-style' if is_neox_style else ''}",
+            args={},
         )
     )
-    query_types = torch.randint(
-        0, len(scaling_factors), (batch_size, seq_len), device=device
-    )
-    # map query types to offsets
-    query_offsets = offset_map[query_types]
-    # the kernel takes flattened offsets
-    flatten_offsets = query_offsets.flatten()
+    def benchmark(batch_size, seq_len, num_heads, provider):
+        dtype = torch.bfloat16
+        max_position = 8192
+        base = 10000
+        rope = get_rope(head_size, rotary_dim, max_position, base, is_neox_style)
+        rope = rope.to(dtype=dtype, device=device)
+        cos_sin_cache = rope.cos_sin_cache.to(dtype=torch.float, device=device)
 
-    # batched queries of the same type together for non-batched RoPE
-    queries = [query[query_types == i] for i in range(len(scaling_factors))]
-    keys = [key[query_types == i] for i in range(len(scaling_factors))]
-    packed_qkr = zip(queries, keys, non_batched_ropes)
-    # synchronize before start timing
-    torch.cuda.synchronize()
-    with nvtx.annotate("non-batched", color="yellow"):
-        for q, k, r in packed_qkr:
-            r.forward(positions, q, k)
-    torch.cuda.synchronize()
-    with nvtx.annotate("batched", color="green"):
-        batched_rope.forward(positions, query, key, flatten_offsets)
-    torch.cuda.synchronize()
+        positions = torch.randint(0, max_position, (batch_size, seq_len), device=device)
+        query = torch.randn(
+            (batch_size, seq_len, num_heads * head_size), dtype=dtype, device=device
+        )
+        key = torch.randn_like(query)
+
+        quantiles = [0.5, 0.2, 0.8]
+
+        if provider == "torch":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: rope.forward_native(positions, query.clone(), key.clone()),
+                quantiles=quantiles,
+            )
+        elif provider == "flashinfer":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: torch.ops.vllm.flashinfer_rotary_embedding(
+                    positions,
+                    query.clone(),
+                    key.clone(),
+                    head_size,
+                    cos_sin_cache,
+                    is_neox_style,
+                ),
+                quantiles=quantiles,
+            )
+        else:
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: rope.forward_cuda(positions, query.clone(), key.clone()),
+                quantiles=quantiles,
+            )
+
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
 
 
 if __name__ == "__main__":
@@ -116,17 +95,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--device", type=str, choices=["cuda:0", "cuda:1"], default="cuda:0"
     )
+    parser.add_argument("--save-path", type=str, default="./configs/rope/")
     args = parser.parse_args()
-    print(args)
 
-    benchmark_rope_kernels_multi_lora(
-        is_neox_style=args.is_neox_style,
-        batch_size=args.batch_size,
-        seq_len=args.seq_len,
-        num_heads=args.num_heads,
-        head_size=args.head_size,
-        rotary_dim=args.rotary_dim,
-        dtype=getattr(torch, args.dtype),
-        seed=args.seed,
-        device=args.device,
+    # Get the benchmark function
+    benchmark = get_benchmark(
+        args.head_size, args.rotary_dim, args.is_neox_style, args.device
     )
+    # Run performance benchmark
+    benchmark.run(print_data=True, save_path=args.save_path)


### PR DESCRIPTION
## Purpose

Currently running the `benchmark_rope.py` script failed with the error (error pasted below). This PR fixes the benchmark script:

* Fixed error
* Remove batched rope benchmark, because `batched_rotary_embedding` kernel was removed in https://github.com/vllm-project/vllm/pull/24789
* Compare kernel differences between pytorch, flashinfer and vllm custom op

Error:

```
Traceback (most recent call last):
  File "/root/workspace/vllm-project/vllm/benchmarks/kernels/benchmark_rope.py", line 192, in <module>
    benchmark_rope_kernels_multi_lora(
  File "/root/workspace/vllm-project/vllm/benchmarks/kernels/benchmark_rope.py", line 96, in benchmark_rope_kernels_multi_lora
    r.forward(positions, q, k)
  File "/root/workspace/vllm-project/vllm/vllm/model_executor/custom_op.py", line 46, in forward
    return self._forward_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/workspace/vllm-project/vllm/vllm/model_executor/layers/rotary_embedding/base.py", line 165, in forward_cuda
    ops.rotary_embedding(
  File "/root/workspace/vllm-project/vllm/vllm/_custom_ops.py", line 322, in rotary_embedding
    torch.ops._C.rotary_embedding(
  File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1255, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_device.py", line 103, in __torch_function__
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1255, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: query, key and positions must have the same batch_size and seq_len
```

## Test Plan

```
python3 benchmarks/kernels/benchmark_rope.py
```

## Test Result

Benchmark script is able to generate benchmark result after the change.

```
rope-perf-neox-style:
    batch_size  seq_len  num_heads      PyTorch  FlashInfer        vLLM
0          1.0     64.0       32.0   238.848001   22.175999   12.352000
1          1.0     64.0       48.0   237.103999   19.743999   13.696000
2          1.0    128.0       32.0   234.863997   20.959999   15.552000
3          1.0    128.0       48.0   235.328004   23.232000   18.048000
4          1.0    256.0       32.0   235.344000   26.432000   16.672000
5          1.0    256.0       48.0   235.136002   31.392001   20.800000
6          1.0    512.0       32.0   234.959997   37.184000   21.984000
7          1.0    512.0       48.0   233.424000   53.183999   25.184000
8          4.0     64.0       32.0   235.551998   20.256000   16.736001
9          4.0     64.0       48.0   235.487998   21.088000   18.112000
10         4.0    128.0       32.0   234.847993   24.320001   19.296000
11         4.0    128.0       48.0   234.528005   31.199999   25.184000
12         4.0    256.0       32.0   233.903997   33.280000   27.424000
13         4.0    256.0       48.0   235.679999   44.032000   35.071999
14         4.0    512.0       32.0   240.656003   55.712000   43.423999
15         4.0    512.0       48.0   245.503999   77.280000   59.567999
16        16.0     64.0       32.0   234.608002   29.696001   28.767999
17        16.0     64.0       48.0   235.023998   38.816001   35.071999
18        16.0    128.0       32.0   242.160000   50.207999   43.391999
19        16.0    128.0       48.0   245.951995   71.135998   60.959999
20        16.0    256.0       32.0   317.375988   90.623997   78.592002
21        16.0    256.0       48.0   437.824011  129.280001  109.327998
22        16.0    512.0       32.0   572.303981  168.479994  140.223995
23        16.0    512.0       48.0   821.743995  244.128004  200.800002
24        64.0     64.0       32.0   314.943999   92.352003   77.280000
25        64.0     64.0       48.0   440.064013  133.407995  108.239997
26        64.0    128.0       32.0   568.607986  169.504002  143.232003
27        64.0    128.0       48.0   819.648027  247.263998  202.335998
28        64.0    256.0       32.0  1069.247961  324.544013  265.248001
29        64.0    256.0       48.0  1547.855973  480.832011  384.992003
30        64.0    512.0       32.0  2040.031910  631.232023  514.464021
31        64.0    512.0       48.0  3005.200028  938.271999  755.136013
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

