### PR TITLE
[CI/Build] Temporary fix to LM Eval Small Models

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -599,6 +599,7 @@ steps:
   - csrc/
   - vllm/model_executor/layers/quantization
   commands:
+  - export VLLM_DISABLE_SHARED_EXPERTS_STREAM=1
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt --tp-size=1
 
 - label: OpenAI API correctness # 22min
@@ -1224,7 +1225,7 @@ steps:
     - pytest -v -s tests/compile/test_fusions_e2e.py::test_tp2_attn_quant_allreduce_rmsnorm
     - pytest -v -s tests/distributed/test_context_parallel.py
     - CUDA_VISIBLE_DEVICES=1,2 VLLM_ALL2ALL_BACKEND=deepep_high_throughput VLLM_USE_DEEP_GEMM=1 VLLM_LOGGING_LEVEL=DEBUG python3 examples/offline_inference/data_parallel.py --model Qwen/Qwen1.5-MoE-A2.7B --tp-size=1  --dp-size=2 --max-model-len 2048
-    - pytest -v -s tests/v1/distributed/test_dbo.py  
+    - pytest -v -s tests/v1/distributed/test_dbo.py
 
 ##### B200 test #####
 - label: Distributed Tests (B200) # optional

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -599,7 +599,6 @@ steps:
   - csrc/
   - vllm/model_executor/layers/quantization
   commands:
-  - export VLLM_DISABLE_SHARED_EXPERTS_STREAM=1
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt --tp-size=1
 
 - label: OpenAI API correctness # 22min

--- a/tests/evals/gsm8k/configs/Qwen1.5-MoE-W4A16-CT.yaml
+++ b/tests/evals/gsm8k/configs/Qwen1.5-MoE-W4A16-CT.yaml
@@ -3,3 +3,6 @@ accuracy_threshold: 0.45
 num_questions: 1319
 num_fewshot: 5
 max_model_len: 4096
+# Duo stream incompatabilbe with this model: https://github.com/vllm-project/vllm/issues/28220
+env:
+  VLLM_DISABLE_SHARED_EXPERTS_STREAM: "1"

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -62,9 +62,11 @@ def test_gsm8k_correctness_param(config_filename, tp_size):
         str(tp_size),
     ]
 
+    env_dict = eval_config.get("env", None)
+
     # Launch server and run evaluation
     with RemoteOpenAIServer(
-        eval_config["model_name"], server_args, max_wait_seconds=480
+        eval_config["model_name"], server_args, env_dict=env_dict, max_wait_seconds=480
     ) as remote_server:
         server_url = remote_server.url_for("v1")
 


### PR DESCRIPTION
## Purpose
This PR provides a temp fix to broken CI: [LM Eval Small Models](https://buildkite.com/vllm/ci/builds/37631#019a5264-3636-4617-87f8-9867066b7a78), the test is failing with GSM8K evals on `Qwen1.5-MoE-W4A16-CT-tp1`:
```

[2025-11-05T06:16:56Z]             # Verify accuracy is within tolerance
--
  | [2025-11-05T06:16:56Z] >           assert measured_accuracy >= expected_accuracy - RTOL, (
  | [2025-11-05T06:16:56Z]                 f"Accuracy too low: {measured_accuracy:.3f} < "
  | [2025-11-05T06:16:56Z]                 f"{expected_accuracy:.3f} - {RTOL:.3f}"
  | [2025-11-05T06:16:56Z]             )
  | [2025-11-05T06:16:56Z] E           AssertionError: Accuracy too low: 0.000 < 0.450 - 0.080
  | [2025-11-05T06:16:56Z] E           assert 0.0 >= (0.45 - 0.08)
  | [2025-11-05T06:16:56Z]
  | [2025-11-05T06:16:56Z] evals/gsm8k/test_gsm8k_correctness.py:86: AssertionError

```

After bisecting, we found this PR could contribute to failing tests: https://github.com/vllm-project/vllm/pull/26440/ - disabling the feature with `VLLM_DISABLE_SHARED_EXPERTS_STREAM=1` can make test passed consistently. 

Note: this is only easy to reproduce on Nvidia L4(what CI is using), H100/MI300 is very difficult to repro this: `pytest -s -v 'tests/evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness_param[Qwen1.5-MoE-W4A16-CT-tp1]'` 

Some hypothesis on why is this failing:
- Quantization Incompatibility? The test is using W4A16 quantization, so the previous PR might break tensor properties with `hidden_states.clone()`?
- It might be breaking memory layout in Qwen2 MoE model [forward pass](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/qwen2_moe.py#L170)?

## Test Plan
With `VLLM_DISABLE_SHARED_EXPERTS_STREAM=1`, tested 10 times(10/10 are passing): https://gist.github.com/zhewenl/a23ead4262f500b764ecd56c8c4c213d

Without disabling the env var, 3/3 are failing: https://gist.github.com/zhewenl/01a70feea4de15f6258dbecd76415a22



