### PR TITLE
Fix: tool call streaming when both reasoning and tool parsers are enabled #28297

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1003,15 +1003,7 @@ class OpenAIServingChat(OpenAIServing):
                         # handle tool calls after reasoning is done or when tool call
                         # tokens are detected
                         else:
-                            # If entering here due to tool call detection, mark
-                            # reasoning as ended and prepare state for tool parsing
-                            if not reasoning_end_arr[i]:
-                                reasoning_end_arr[i] = True
-                                if not added_content_delta_arr[i]:
-                                    added_content_delta_arr[i] = True
-                                    previous_text = ""
-                                    previous_token_ids = []
-
+                            reasoning_end_arr[i] = True
                             delta_token_ids = output_token_ids
                             # First time to tool call,
                             # add the remaining text and token ids


### PR DESCRIPTION
 
#28297
- Add early detection of tool call tokens in streaming mode
- Skip reasoning phase when tool calls are present
- Fixes issue #28297 where hermes tool parser fails in streaming mode when used together with qwen3 reasoning parser

<!-- markdownlint-disable -->

## Purpose

## Test Plan
pytest tests/reasoning/test_qwen3_reasoning_parser.py -v
 

 python -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen3-VL-32B-Instruct \
  --port 8000 \
  --tensor-parallel-size 8 \
  --gpu-memory-utilization 0.9 \
  --tool-call-parser hermes \
  --enable-auto-tool-choice \
  --limit-mm-per-prompt.video 0 \
  --limit-mm-per-prompt.image 0 \
  --async-scheduling \
  --enable-log-outputs \
  --enable-log-requests
(vllm) root@de44d613f1e7:~/vllm# cat test_tool_call_streaming.py
from openai import OpenAI

client = OpenAI(
    base_url="http://localhost:8000/v1",
    api_key="dummy"
)

tools = [
    {
        "type": "function",
        "function": {
            "name": "search_products_general",
            "description": "Search for products",
            "parameters": {
                "type": "object",
                "properties": {
                    "description": {"type": "string"},
                    "config": {"type": "object"}
                }
            }
        }
    }
]

messages = [
    {"role": "user", "content": "pc hp 16gb ram"}
]

print("=== Testing with streaming ===")
stream = client.chat.completions.create(
    model="Qwen/Qwen3-VL-32B-Instruct",
    messages=messages,
    tools=tools,
    stream=True
)

for chunk in stream:
    if chunk.choices[0].delta.content:
        print(f"Chunk: {chunk.choices[0].delta.content}")
    if chunk.choices[0].delta.tool_calls:
        print(f"Tool calls chunk: {chunk.choices[0].delta.tool_calls}")

print("\n=== Testing without streaming ===")
response = client.chat.completions.create(
    model="Qwen/Qwen3-VL-32B-Instruct",
    messages=messages,
    tools=tools,
    stream=False
)

print(f"Response: {response.choices[0].message}")
if response.choices[0].message.tool_calls:
    print(f"Tool calls: {response.choices[0].message.tool_calls}")
## Test Result
<img width="1725" height="774" alt="image" src="https://github.com/user-attachments/assets/330882a5-0723-432f-9d40-78f9864ff01d" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

