### PR TITLE
[Frontend][2/n] remove empty content from _parse_tool_calls_from_content

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1375,6 +1375,8 @@ class OpenAIServing:
                     for tool_call in tool_call_info.tool_calls
                 )
                 content = tool_call_info.content
+                if content and content.strip() == "":
+                    content = None
             else:
                 # No tool calls.
                 return None, content


### PR DESCRIPTION
## Purpose

I noticed that our tool parser often times may leave whitespace after the tool call, which gets outputted to the user. We should strip it out.

## Test Plan

qwen3 example:
```
vllm serve Qwen/Qwen3-1.7B --reasoning-parser qwen3       --structured-outputs-config.backend xgrammar       --enable-auto-tool-choice --tool-call-parser hermes
```

client
```
 curl -X POST "http://localhost:8000/v1/responses"   -H "Content-Type: application/json"   -H "Authorization: Bearer dummy-api-key"   -d '{
        "model": "Qwen/Qwen3-1.7B",
        "input": "Whats the weather like in San Francisco? use celsius.",
        "tools": [{
            "type": "function",
            "name": "get_weather",
            "description": "Get the current weather in a given location",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {"type": "string"},
                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
                },
                "required": ["location", "unit"]
            }
        }]
      }'
```

## Test Result

```
{
    "id": "resp_3814bea59f4449a7a29c9a406b50ab4e",
    "created_at": 1762398952,
    "incomplete_details": null,
    "instructions": null,
    "metadata": null,
    "model": "Qwen/Qwen3-1.7B",
    "object": "response",
    "output": [
        {
            "id": "rs_8a39e9f4178d40abac111d595d801126",
            "summary": [],
            "type": "reasoning",
            "content": [
                {
                    "text": "\nOkay, the user is asking for the weather in San Francisco using Celsius. Let me check the tools provided. There's a function called get_weather that requires location and unit. The parameters are location (string) and unit (enum: celsius or fahrenheit). The user specified San Francisco and Celsius, so I need to call get_weather with those arguments. I should make sure the arguments are in the correct format. Let me structure the JSON accordingly.\n",
                    "type": "reasoning_text"
                }
            ],
            "encrypted_content": null,
            "status": null
        },
### BELOW GETS REMOVED AFTER THIS PR ####
        {
            "id": "msg_33be381a036e49e8abc0faead1e05752",
            "content": [
                {
                    "annotations": [],
                    "text": "\n\n",
                    "type": "output_text",
                    "logprobs": null
                }
            ],
            "role": "assistant",
            "status": "completed",
            "type": "message"
        },
### ABOVE GETS REMOVED AFTER THIS PR ####
        {
            "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}",
            "call_id": "call_62165488d94f43f1ab949be8f63ab20f",
            "name": "get_weather",
            "type": "function_call",
            "id": "fc_9e77818e2fee464ea9853758d198ee01",
            "status": "completed"
        }
    ],
    "parallel_tool_calls": true,
    "temperature": 0.6,
    "tool_choice": "auto",
    "tools": [
        {
            "name": "get_weather",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string"
                    },
                    "unit": {
                        "type": "string",
                        "enum": [
                            "celsius",
                            "fahrenheit"
                        ]
                    }
                },
                "required": [
                    "location",
                    "unit"
                ]
            },
            "strict": null,
            "type": "function",
            "description": "Get the current weather in a given location"
        }
    ],
    "top_p": 0.95,
    "background": false,
    "max_output_tokens": 40766,
    "max_tool_calls": null,
    "previous_response_id": null,
    "prompt": null,
    "reasoning": null,
    "service_tier": "auto",
    "status": "completed",
    "text": null,
    "top_logprobs": null,
    "truncation": "disabled",
    "usage": {
        "input_tokens": 194,
        "input_tokens_details": {
            "cached_tokens": 0,
            "input_tokens_per_turn": [],
            "cached_tokens_per_turn": []
        },
        "output_tokens": 123,
        "output_tokens_details": {
            "reasoning_tokens": 0,
            "tool_output_tokens": 0,
            "output_tokens_per_turn": [],
            "tool_output_tokens_per_turn": []
        },
        "total_tokens": 317
    },
    "user": null,
    "input_messages": null,
    "output_messages": null
}
```