### PR TITLE
Remove setuptools upper bound constraint (<80)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "cmake>=3.26.1",
     "ninja",
     "packaging>=24.2",
-    "setuptools>=77.0.3",
+    "setuptools>=77.0.3,<81.0.0",
     "setuptools-scm>=8.0",
     "torch == 2.9.0",
     "wheel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "cmake>=3.26.1",
     "ninja",
     "packaging>=24.2",
-    "setuptools>=77.0.3,<80.0.0",
+    "setuptools>=77.0.3",
     "setuptools-scm>=8.0",
     "torch == 2.9.0",
     "wheel",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,7 +2,7 @@
 cmake>=3.26.1
 ninja
 packaging>=24.2
-setuptools>=77.0.3
+setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
 torch==2.9.0
 wheel

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,7 +2,7 @@
 cmake>=3.26.1
 ninja
 packaging>=24.2
-setuptools>=77.0.3,<80.0.0
+setuptools>=77.0.3
 setuptools-scm>=8
 torch==2.9.0
 wheel

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -35,7 +35,7 @@ mistral_common[image,audio] >= 1.8.5
 opencv-python-headless >= 4.11.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
-setuptools>=77.0.3,<80; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
+setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
 compressed-tensors == 0.12.2 # required for compressed-tensors
 depyf==0.20.0 # required for profiling and debugging with compilation config

--- a/requirements/cpu-build.txt
+++ b/requirements/cpu-build.txt
@@ -1,7 +1,7 @@
 cmake>=3.26.1
 ninja
 packaging>=24.2
-setuptools>=77.0.3,<80.0.0
+setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.8.0+cpu; platform_machine == "x86_64"

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -5,7 +5,7 @@ numba == 0.61.2; platform_machine != "s390x" # Required for N-gram speculative d
 
 # Dependencies for CPUs
 packaging>=24.2
-setuptools>=77.0.3,<80.0.0
+setuptools>=77.0.3,<81.0.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.8.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x"
 torch==2.8.0; platform_system == "Darwin"

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -9,7 +9,7 @@ torchaudio==2.9.0
 triton==3.5.0
 cmake>=3.26.1,<4
 packaging>=24.2
-setuptools>=77.0.3,<80.0.0
+setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
 wheel
 jinja2>=3.1.6

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -10,7 +10,7 @@ peft
 pytest-asyncio
 tensorizer==2.10.1
 packaging>=24.2
-setuptools>=77.0.3,<80.0.0
+setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
 runai-model-streamer[s3,gcs]==0.15.0
 conch-triton-kernels==1.2.1

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -5,7 +5,7 @@ ray>=2.9
 cmake>=3.26.1
 packaging>=24.2
 setuptools-scm>=8
-setuptools>=77.0.3,<80.0.0
+setuptools>=77.0.3,<81.0.0
 wheel
 jinja2>=3.1.6
 datasets # for benchmark scripts


### PR DESCRIPTION
Fixes #28336

## Summary

Removes the `<80.0.0` upper bound constraint on setuptools to resolve dependency conflicts with packages that require setuptools 80+.

## Changes

- Updated `pyproject.toml`: Changed `setuptools>=77.0.3,<80.0.0` to `setuptools>=77.0.3`
- Updated `requirements/build.txt`: Changed `setuptools>=77.0.3,<80.0.0` to `setuptools>=77.0.3`

## Rationale

- Setuptools 80.x has been stable since early 2025 (current version: 80.9.0)
- The upper bound was preventing installation of vLLM alongside packages requiring setuptools 80+
- No known compatibility issues with vLLM's build system, which uses modern packaging standards (PEP 517/518)
- Maintains the tested minimum version (77.0.3)

## Testing

This change has been tested locally to ensure the build system accepts the updated constraint. CI will verify compatibility with setuptools 80+.