### PR TITLE
[Performance][gpt-oss] Revert gpt-oss max cudagraph size to 1024

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -268,8 +268,6 @@ class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
             compilation_config.cudagraph_capture_sizes is None
             and compilation_config.max_cudagraph_capture_size is None
         ):
-            # FIXME(woosuk): When using full cuda graph with FA3, the max
-            # supported size is 1024.
             compilation_config.max_cudagraph_capture_size = 1024
             logger.info(
                 "Overriding max cuda graph capture size to %d for performance.", 1024

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -258,9 +258,9 @@ class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
         if structured_outputs_config.reasoning_parser == "":
             structured_outputs_config.reasoning_parser = "openai_gptoss"
 
-        # Increase the max capture size from 512 to 992 for performance.
+        # Increase the max capture size from 512 to 1024 for performance.
         # NOTE(woosuk): This will increase the number of CUDA graphs
-        # from 67 to 81.
+        # from 67 to 83.
         compilation_config = vllm_config.compilation_config
         # Only override when the user has not set either of
         # cudagraph_capture_sizes or max_cudagraph_capture_size.
@@ -269,10 +269,10 @@ class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
             and compilation_config.max_cudagraph_capture_size is None
         ):
             # FIXME(woosuk): When using full cuda graph with FA3, the max
-            # supported size is 992.
-            compilation_config.max_cudagraph_capture_size = 992
+            # supported size is 1024.
+            compilation_config.max_cudagraph_capture_size = 1024
             logger.info(
-                "Overriding max cuda graph capture size to %d for performance.", 992
+                "Overriding max cuda graph capture size to %d for performance.", 1024
             )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Now that #27840 is merged, can we also revert gpt-oss max cudagraph size to 1024? Basically reverts #25508.

cc @mgoin 

## Test Plan

Tested

## Test Result

Works

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

