### PR TITLE
[Bugfix] Update device name for H200 detection

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -819,7 +819,7 @@ def get_config_file_name(
 ) -> str:
     device_name = current_platform.get_device_name().replace(" ", "_")
     # Set device_name to H200 if a device from the H200 family is detected
-    if "H200" in device_name:
+    if "H200" in device_name.split("_"):
         device_name = "NVIDIA_H200"
     dtype_selector = "" if not dtype else f",dtype={dtype}"
     block_shape_selector = (

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -820,7 +820,7 @@ def get_config_file_name(
     device_name = current_platform.get_device_name().replace(" ", "_")
     # Set device_name to H200 if a device from the H200 family is detected
     if "H200" in device_name:
-        device_name = "H200"
+        device_name = "NVIDIA_H200"
     dtype_selector = "" if not dtype else f",dtype={dtype}"
     block_shape_selector = (
         "" if not block_shape or not all(block_shape) else f",block_shape={block_shape}"


### PR DESCRIPTION
## Purpose
- config lookup is broken due to #23642
- fix it

## Test Plan

launch:

```
VLLM_DISABLE_SHARED_EXPERTS_STREAM=1 VLLM_TORCH_PROFILER_DIR=$(pwd)/profiles VLLM_USE_DEEP_GEMM=0 vllm serve {{MODEL}} --tensor-parallel-size 8 --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}' --no-enable-prefix-caching
```


## Test Result

result:
```
(Worker_TP3 pid=1190105) INFO 11-08 16:50:53 [fused_moe.py:876] Using configuration from /home/robertgshaw2-redhat/vllm/vllm/model_executor/layers/fused_moe/configs/E=256,N=256,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[128,128].json for MoE layer.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

