### PR TITLE
Normalize OpenPangu RoPE scaling defaults

### DIFF
--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -91,6 +91,7 @@ def _normalize_rope_scaling_defaults(
 ) -> dict[str, Any]:
     """Return a DeepSeek-YaRN compatible rope_scaling dict."""
     rope_scaling = dict(rope_scaling_config) if rope_scaling_config is not None else {}
+    original_scaling_type = rope_scaling.get("type")
 
     rope_scaling.setdefault("beta_fast", 32)
     rope_scaling.setdefault("beta_slow", 1)
@@ -99,7 +100,11 @@ def _normalize_rope_scaling_defaults(
     rope_scaling.setdefault("mscale_all_dim", 1.0)
     rope_scaling.setdefault("type", "yarn")
     rope_scaling.setdefault("original_max_position_embeddings", max_position_embeddings)
-    rope_scaling.setdefault("rope_type", "deepseek_yarn")
+    if "rope_type" not in rope_scaling:
+        if original_scaling_type is not None:
+            rope_scaling["rope_type"] = original_scaling_type
+        else:
+            rope_scaling["rope_type"] = "deepseek_yarn"
 
     return rope_scaling
 

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -90,9 +90,7 @@ def _normalize_rope_scaling_defaults(
     rope_scaling_config: dict[str, Any] | None, max_position_embeddings: int
 ) -> dict[str, Any]:
     """Return a DeepSeek-YaRN compatible rope_scaling dict."""
-    rope_scaling = (
-        dict(rope_scaling_config) if rope_scaling_config is not None else {}
-    )
+    rope_scaling = dict(rope_scaling_config) if rope_scaling_config is not None else {}
 
     rope_scaling.setdefault("beta_fast", 32)
     rope_scaling.setdefault("beta_slow", 1)
@@ -100,9 +98,7 @@ def _normalize_rope_scaling_defaults(
     rope_scaling.setdefault("mscale", 1.0)
     rope_scaling.setdefault("mscale_all_dim", 1.0)
     rope_scaling.setdefault("type", "yarn")
-    rope_scaling.setdefault(
-        "original_max_position_embeddings", max_position_embeddings
-    )
+    rope_scaling.setdefault("original_max_position_embeddings", max_position_embeddings)
     rope_scaling.setdefault("rope_type", "deepseek_yarn")
 
     return rope_scaling

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -338,17 +338,21 @@ class OpenPanguMLAAttention(nn.Module):
             prefix=f"{prefix}.o_proj",
         )
 
-        # TODO: remove hard coding
-        rope_scaling = {
-            "beta_fast": 32,
-            "beta_slow": 1,
-            "factor": 1,
-            "mscale": 1.0,
-            "mscale_all_dim": 1.0,
-            "original_max_position_embeddings": max_position_embeddings,
-            "type": "yarn",
-            "rope_type": "deepseek_yarn",
-        }
+        rope_scaling_config = getattr(config, "rope_scaling", None)
+        if rope_scaling_config is not None:
+            rope_scaling = dict(rope_scaling_config)
+        else:
+            rope_scaling = {}
+        rope_scaling.setdefault("beta_fast", 32)
+        rope_scaling.setdefault("beta_slow", 1)
+        rope_scaling.setdefault("factor", 1)
+        rope_scaling.setdefault("mscale", 1.0)
+        rope_scaling.setdefault("mscale_all_dim", 1.0)
+        rope_scaling.setdefault("type", "yarn")
+        rope_scaling.setdefault(
+            "original_max_position_embeddings", max_position_embeddings
+        )
+        rope_scaling["rope_type"] = "deepseek_yarn"
         self.rotary_emb = get_rope(
             qk_rope_head_dim,
             rotary_dim=qk_rope_head_dim,

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -90,10 +90,9 @@ def _normalize_rope_scaling_defaults(
     rope_scaling_config: dict[str, Any] | None, max_position_embeddings: int
 ) -> dict[str, Any]:
     """Return a DeepSeek-YaRN compatible rope_scaling dict."""
-    if rope_scaling_config is not None:
-        rope_scaling = dict(rope_scaling_config)
-    else:
-        rope_scaling = {}
+    rope_scaling = (
+        dict(rope_scaling_config) if rope_scaling_config is not None else {}
+    )
 
     rope_scaling.setdefault("beta_fast", 32)
     rope_scaling.setdefault("beta_slow", 1)


### PR DESCRIPTION
### Summary

- Remove hard-coded RoPE scaling defaults and load values from model config.
- When instantiating OpenPanguEmbeddedAttention/OpenPanguMLAAttention, clone config.rope_scaling if it exists, otherwise start from {} and use default.
- Backfill all DeepSeek YaRN defaults (beta_fast, beta_slow, factor, mscale, mscale_all_dim, type, original_max_position_embeddings) .

### Verification
- config.json add rope_scaling_config:
```
"rope_scaling": {
  "type": "yarn",
  "beta_fast": 48,
  "factor": 1.25,
  "mscale": 0.9,
  "mscale_all_dim": 0.5,
  "original_max_position_embeddings": 8192
}
```

- `CUDA_VISIBLE_DEVICES=0 vllm serve FreedomIntelligence/openPangu-Embedded-7B --port 8818 --trust_remote_code --served-model-name openPangu-Embedded-7B` – logs show every OpenPanguEmbeddedAttention layer printing the resolved rope_scaling_config, confirming it was read from the config (see screenshot).
<img width="2350" height="1064" alt="wechat_2025-11-09_172031_136" src="https://github.com/user-attachments/assets/a5cccbd2-fbe1-4eaf-b7cd-2e8c41954a49" />

- `curl http://localhost:8818/v1/chat/completions … `– inference succeeds with expected response, proving the model loads and serves normally (see screenshot).
<img width="2366" height="638" alt="wechat_2025-11-09_172038_981" src="https://github.com/user-attachments/assets/1570473d-57a9-4a39-8a40-d321df44760a" />

- After verification passed, the debug log was removed.
<img width="1386" height="292" alt="image" src="https://github.com/user-attachments/assets/1682ba00-9c20-4154-9ea7-c8e64c939a73" />





