### PR TITLE
[bugfix] fix siglip batch text output error

### DIFF
--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -418,7 +418,7 @@ class SiglipAttention(nn.Module):
         self.num_heads_per_partition = divide(self.num_heads, self.tp_size)
 
         if attn_cls == EncoderOnlyAttention:
-            self.attn = attn_cls(
+            self.attn = EncoderOnlyAttention(
                 self.num_heads_per_partition,
                 self.head_dim,
                 self.scale,


### PR DESCRIPTION
## Purpose

Fix SigLIP text embedding batch processing error when batch size > 1, as reported in [#27566](https://github.com/vllm-project/vllm/pull/27566).

**Root Cause:** Text embeddings flatten batch sequences into a single sequence and use `MultiHeadAttention`, which incorrectly handles batch attention. Additionally, the previous implementation used `flip(0)` on the entire batch tensor, mixing features across different sequences.

**Solution:** 
- Switch text encoder to use `EncoderOnlyAttention` for proper batch handling
- Implement `_flip_sequences_by_position_ids()` to flip each sequence individually based on position_ids boundaries

## Test Plan
```bash
vllm serve google/siglip2-base-patch16-224 --runner pooling --enforce-eager
```

```python
import os
from openai import OpenAI

openai_api_key = os.environ.get("OPENAI_API_KEY", "EMPTY")
openai_api_base = os.environ.get("OPENAI_API_BASE", "http://localhost:8000/v1")

def batch_text_request():
    """Send batch text embedding request to SigLIP model."""
    client = OpenAI(
        api_key=openai_api_key,
        base_url=openai_api_base,
    )
    
    # Get the served model ID
    model_id = client.models.list().data[0].id
    
    # Create test prompts
    words = ['hi', "how old are you?"]
    prompts = []
    for i in range(10):
        content = words[i % 2]
        prompts.append("a photo of a cat " + content)

    response = client.embeddings.create(
        model=model_id,
        input=prompts, 
        encoding_format="float"
    )

    results = []
    for idx, embedding_obj in enumerate(response.data):
        prompt = prompts[idx]
        embedding_preview = embedding_obj.embedding[:5]
        print(f"Request {idx+1} ('{prompt}'): {embedding_preview}")
        results.append((idx, prompt, embedding_preview))
    
    return results

if __name__ == "__main__":
    batch_text_request()
```

## Test Result
Before fix
``` bash
Request 1 ('a photo of a cat hi'): [-0.013481298461556435, 0.032701071351766586, -0.003023682162165642, -0.022816617041826248, 0.27149301767349243]
Request 2 ('a photo of a cat how old are you?'): [-0.021391602233052254, 0.030925685539841652, -0.005404650699347258, -0.012358256615698338, 0.2850077152252197]
Request 3 ('a photo of a cat hi'): [-0.015912294387817383, 0.03907473012804985, -0.009924817830324173, -0.009802624583244324, 0.2923952043056488]
Request 4 ('a photo of a cat how old are you?'): [-0.007564036641269922, 0.014619219116866589, -0.015609420835971832, -0.02005157247185707, 0.2704349458217621]
Request 5 ('a photo of a cat hi'): [-0.015912294387817383, 0.03907473012804985, -0.009924817830324173, -0.009802624583244324, 0.2923952043056488]
Request 6 ('a photo of a cat how old are you?'): [-0.007564036641269922, 0.014619219116866589, -0.015609420835971832, -0.02005157247185707, 0.2704349458217621]
Request 7 ('a photo of a cat hi'): [-0.015912294387817383, 0.03907473012804985, -0.009924817830324173, -0.009802624583244324, 0.2923952043056488]
Request 8 ('a photo of a cat how old are you?'): [-0.04892544820904732, 0.03389119729399681, -0.006240752525627613, 0.019908834248781204, 0.3164888918399811]
Request 9 ('a photo of a cat hi'): [-0.007564036641269922, 0.014619219116866589, -0.015609420835971832, -0.02005157247185707, 0.2704349458217621]
Request 10 ('a photo of a cat how old are you?'): [-0.04892544820904732, 0.03389119729399681, -0.006240752525627613, 0.019908834248781204, 0.3164888918399811]
``` 

After fix

``` bash
Request 1 ('a photo of a cat hi'): [-0.013481298461556435, 0.032701071351766586, -0.003023682162165642, -0.022816617041826248, 0.27149301767349243]
Request 2 ('a photo of a cat how old are you?'): [-0.04890233278274536, 0.03391861915588379, -0.006237870082259178, 0.01992269791662693, 0.3165053427219391]
Request 3 ('a photo of a cat hi'): [-0.013506860472261906, 0.032723937183618546, -0.003055858425796032, -0.022827142849564552, 0.27145496010780334]
Request 4 ('a photo of a cat how old are you?'): [-0.04890233278274536, 0.03391861915588379, -0.006237870082259178, 0.01992269791662693, 0.3165053427219391]
Request 5 ('a photo of a cat hi'): [-0.013506860472261906, 0.032723937183618546, -0.003055858425796032, -0.022827142849564552, 0.27145496010780334]
Request 6 ('a photo of a cat how old are you?'): [-0.04890233278274536, 0.03391861915588379, -0.006237870082259178, 0.01992269791662693, 0.3165053427219391]
Request 7 ('a photo of a cat hi'): [-0.013506860472261906, 0.032723937183618546, -0.003055858425796032, -0.022827142849564552, 0.27145496010780334]
Request 8 ('a photo of a cat how old are you?'): [-0.04890233278274536, 0.03391861915588379, -0.006237870082259178, 0.01992269791662693, 0.3165053427219391]
Request 9 ('a photo of a cat hi'): [-0.013506860472261906, 0.032723937183618546, -0.003055858425796032, -0.022827142849564552, 0.27145496010780334]
Request 10 ('a photo of a cat how old are you?'): [-0.04890233278274536, 0.03391861915588379, -0.006237870082259178, 0.01992269791662693, 0.3165053427219391]
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>