### PR TITLE
[Fix] optimize visual token mask with caching and multi-token support

### DIFF
--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -1404,7 +1404,7 @@ class Ernie4_5_VLMoeForConditionalGeneration(
             return
 
         # Cache the visual token IDs tensor to avoid recreating it
-        if not hasattr(self, "_visual_token_ids_cache"):
+        if not hasattr(self, "_visual_token_ids_tensor_cache"):
             visual_token_ids = [
                 token_id for token_id in [
                     self.config.im_patch_id,
@@ -1414,14 +1414,15 @@ class Ernie4_5_VLMoeForConditionalGeneration(
                     getattr(self.config, "video_end_token_id", None)
                 ] if token_id is not None
             ]
-            self._visual_token_ids_cache = visual_token_ids
+            self._visual_token_ids_tensor_cache = torch.tensor(
+                visual_token_ids, dtype=torch.long)
 
         # Create tensor on the correct device
-        visual_token_ids_tensor = torch.tensor(
-            self._visual_token_ids_cache,
-            dtype=input_ids.dtype, 
-            device=input_ids.device
+        visual_token_ids_tensor = self._visual_token_ids_tensor_cache.to(
+            device=input_ids.device,
+            dtype=input_ids.dtype,
         )
+
         
         self.visual_token_mask = torch.isin(
             input_ids, 

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -1406,16 +1406,19 @@ class Ernie4_5_VLMoeForConditionalGeneration(
         # Cache the visual token IDs tensor to avoid recreating it
         if not hasattr(self, "_visual_token_ids_tensor_cache"):
             visual_token_ids = [
-                token_id for token_id in [
+                token_id
+                for token_id in [
                     self.config.im_patch_id,
                     getattr(self.config, "image_start_token_id", None),
                     getattr(self.config, "image_end_token_id", None),
                     getattr(self.config, "video_start_token_id", None),
-                    getattr(self.config, "video_end_token_id", None)
-                ] if token_id is not None
+                    getattr(self.config, "video_end_token_id", None),
+                ]
+                if token_id is not None
             ]
             self._visual_token_ids_tensor_cache = torch.tensor(
-                visual_token_ids, dtype=torch.long)
+                visual_token_ids, dtype=torch.long
+            )
 
         # Create tensor on the correct device
         visual_token_ids_tensor = self._visual_token_ids_tensor_cache.to(
@@ -1423,11 +1426,9 @@ class Ernie4_5_VLMoeForConditionalGeneration(
             dtype=input_ids.dtype,
         )
 
-        
-        self.visual_token_mask = torch.isin(
-            input_ids, 
-            visual_token_ids_tensor
-        ).reshape(-1, 1)
+        self.visual_token_mask = torch.isin(input_ids, visual_token_ids_tensor).reshape(
+            -1, 1
+        )
 
     def get_mrope_input_positions(
         self,


### PR DESCRIPTION
## Purpose
Optimize `_set_visual_token_mask` function to improve performance and extend functionality for multimodal models.

**Changes:**
- Add caching mechanism for visual token IDs to reduce repeated list creation overhead
- Extend support to handle multiple visual token types (image/video start/end tokens, not just `im_patch_id`)
- Replace multiple equality comparisons with `torch.isin` for efficient multi-token matching