### PR TITLE
[ROCm] Add missing gemm_a8w8_blockscale import

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -323,9 +323,9 @@ class W8A8BlockFp8LinearOp:
         )
 
         if use_triton:
-            gemm_w8a8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
+            gemm_a8w8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
         else:
-            gemm_w8a8_blockscale_op = rocm_aiter_ops.gemm_w8a8_blockscale
+            gemm_a8w8_blockscale_op = rocm_aiter_ops.gemm_w8a8_blockscale
 
         if input_scale is not None:
             q_input = input_2d
@@ -341,7 +341,7 @@ class W8A8BlockFp8LinearOp:
         else:
             q_input, input_scale = rocm_aiter_ops.per_1x128_fp8_quant(input_2d)
 
-        return gemm_w8a8_blockscale_op(
+        return gemm_a8w8_blockscale_op(
             q_input,
             weight,
             input_scale,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -316,46 +316,38 @@ class W8A8BlockFp8LinearOp:
         assert self.act_quant_group_shape == GroupShape(1, 128)
 
         n, k = weight.shape
-        if input_scale is not None:
-            q_input = input_2d
 
-            return rocm_aiter_ops.gemm_w8a8_blockscale(
-                q_input,
-                weight,
-                input_scale,
-                weight_scale,
-                input_2d.dtype,
-            )
-
-        # MI350 case uses triton kernel
-        if (
+        use_triton = (
             not current_platform.is_fp8_fnuz()
             and rocm_aiter_ops.is_triton_gemm_w8a8_tuned(n, k)
-        ):
+        )
+
+        if use_triton:
+            gemm_w8a8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
+        else:
+            gemm_w8a8_blockscale_op = rocm_aiter_ops.gemm_a8w8_blockscale
+
+        if input_scale is not None:
+            q_input = input_2d
+        # MI350 case uses triton kernel
+        if use_triton:
             q_input, input_scale = per_token_group_quant_fp8(
                 input_2d,
                 self.act_quant_group_shape.col,
                 column_major_scales=False,
                 use_ue8m0=False,
             )
-            return rocm_aiter_ops.triton_gemm_a8w8_blockscale(
-                q_input,
-                weight,
-                input_scale,
-                weight_scale,
-                input_2d.dtype,
-            )
-
         # MI300 uses tuned AITER ASM/C++ kernel
         else:
             q_input, input_scale = rocm_aiter_ops.per_1x128_fp8_quant(input_2d)
-            return rocm_aiter_ops.gemm_w8a8_blockscale(
-                q_input,
-                weight,
-                input_scale,
-                weight_scale,
-                input_2d.dtype,
-            )
+
+        return gemm_w8a8_blockscale_op(
+            q_input,
+            weight,
+            input_scale,
+            weight_scale,
+            input_2d.dtype,
+        )
 
     def _run_triton(
         self,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -330,7 +330,7 @@ class W8A8BlockFp8LinearOp:
         if input_scale is not None:
             q_input = input_2d
         # MI350 case uses triton kernel
-        if use_triton:
+        elif use_triton:
             q_input, input_scale = per_token_group_quant_fp8(
                 input_2d,
                 self.act_quant_group_shape.col,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -319,6 +319,14 @@ class W8A8BlockFp8LinearOp:
         if input_scale is not None:
             q_input = input_2d
 
+            return rocm_aiter_ops.gemm_w8a8_blockscale(
+                q_input,
+                weight,
+                input_scale,
+                weight_scale,
+                input_2d.dtype,
+            )
+
         # MI350 case uses triton kernel
         if (
             not current_platform.is_fp8_fnuz()

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -346,6 +346,7 @@ class W8A8BlockFp8LinearOp:
             weight,
             input_scale,
             weight_scale,
+            list(self.weight_group_shape),
             output_dtype=input_2d.dtype,
         )
 

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -325,7 +325,7 @@ class W8A8BlockFp8LinearOp:
         if use_triton:
             gemm_w8a8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
         else:
-            gemm_w8a8_blockscale_op = rocm_aiter_ops.gemm_a8w8_blockscale
+            gemm_w8a8_blockscale_op = rocm_aiter_ops.gemm_w8a8_blockscale
 
         if input_scale is not None:
             q_input = input_2d
@@ -346,7 +346,7 @@ class W8A8BlockFp8LinearOp:
             weight,
             input_scale,
             weight_scale,
-            input_2d.dtype,
+            output_dtype=input_2d.dtype,
         )
 
     def _run_triton(


### PR DESCRIPTION
## Purpose

BugFix: https://github.com/vllm-project/vllm/pull/27058 seems to have missed import for `aiter.gemm_a8w8_blockscale` 

BugFix: https://github.com/vllm-project/vllm/pull/24490 changed it so that we always do quant op. Fix to do quant op only if the input_scale is None:

https://github.com/vllm-project/vllm/blob/d0e186c16f0d62af8c128e2dc7c94cde1387ac02/vllm/model_executor/layers/quantization/utils/fp8_utils.py#L319-L350

BugFix: correct invocation of aiter ops

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

