### PR TITLE
Granite4 Quantization Bug Fix

### DIFF
--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -569,52 +569,6 @@ class GraniteMoeHybridModel(nn.Module):
                         shard_id="w2",
                         expert_id=e,
                     )
-            
-            elif ('.block_sparse_moe.output_linear.experts.' in n and 
-                (n.endswith('.weight') or n.endswith('.weight_scale'))):
-                
-                # Extract expert ID from the parameter name
-                expert_idx = int(n.split('.experts.')[1].split('.')[0]) if '.experts.' in n else None
-                
-                # Generate the target w2 name
-                w2_name = n.replace(
-                    f'.block_sparse_moe.output_linear.experts.{expert_idx}.weight',
-                    f".block_sparse_moe.experts.{expert_idx}.w2.weight")
-                
-                w2_param = p
-                _load_expert(n.replace(f'.output_linear.experts.{expert_idx}.', '.experts.w2_'),
-                            w2_param,
-                            w2_name,
-                            shard_id='w2',
-                            expert_id=expert_idx)
-
-            elif ('.block_sparse_moe.input_linear.experts.' in n and 
-                (n.endswith('.weight') or n.endswith('.weight_scale'))):
-
-                # Extract expert ID from the parameter name
-                expert_idx = int(n.split('.experts.')[1].split('.')[0]) if '.experts.' in n else None
-                
-                # Generate the target w1 and w3 names
-                w1_name = n.replace(
-                    f'.block_sparse_moe.input_linear.experts.{expert_idx}.weight',
-                    f".block_sparse_moe.experts.{expert_idx}.w1.weight")
-                w3_name = n.replace(
-                    f'.block_sparse_moe.input_linear.experts.{expert_idx}.weight',
-                    f".block_sparse_moe.experts.{expert_idx}.w3.weight")
-                
-                # Split the parameter into w1 and w3
-                w1_param, w3_param = p.chunk(2, dim=0)
-
-                _load_expert(n.replace(f'.input_linear.experts.{expert_idx}.', '.experts.w13_'),
-                            w1_param,
-                            w1_name,
-                            shard_id='w1',
-                            expert_id=expert_idx)
-                _load_expert(n.replace(f'.input_linear.experts.{expert_idx}.', '.experts.w13_'),
-                            w3_param,
-                            w3_name,
-                            shard_id='w3',
-                            expert_id=expert_idx)
 
             elif n.endswith(".block_sparse_moe.router.layer.weight"):
                 gate_name = n.replace(

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -703,12 +703,6 @@ class GraniteMoeHybridForCausalLM(
 
         config = vllm_config.model_config.hf_config
         self.vllm_config = vllm_config
-
-        if hasattr(vllm_config, "quant_config"):
-            vllm_config.quant_config = self.maybe_update_quant_config(
-                vllm_config.quant_config
-            )
-
         self.model_config = vllm_config.model_config
         lora_config = vllm_config.lora_config
         scheduler_config = vllm_config.scheduler_config

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -49,7 +49,6 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
-import re
 
 class GraniteMoeHybridMambaDecoderLayer(nn.Module):
     def __init__(

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -49,7 +49,7 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
-
+import re
 
 class GraniteMoeHybridMambaDecoderLayer(nn.Module):
     def __init__(

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -652,11 +652,62 @@ class GraniteMoeHybridForCausalLM(
             conv_kernel=hf_config.mamba_d_conv,
         )
 
+    def maybe_update_quant_config(
+            self, quant_config: QuantizationConfig
+        ) -> QuantizationConfig:
+            """
+            Update quant config so that ignored module and target module names
+            match the vLLM model names.
+            Granite model specific: mamba -> mixer remapping.
+            """
+            remapping_rules = [
+                # Granite model: mamba -> mixer remapping
+                (
+                    r"model\.layers\.(\d+)\.mamba\.in_proj",
+                    r"model.layers.\1.mixer.in_proj",
+                ),
+                (
+                    r"model\.layers\.(\d+)\.mamba\.out_proj",
+                    r"model.layers.\1.mixer.out_proj",
+                ),
+            ]
+            # Update ignore list
+            if hasattr(quant_config, "ignore"):
+                updated_ignore = []
+                for name in quant_config.ignore:
+                    updated_name = name
+                    for pattern, repl in remapping_rules:
+                        if re.fullmatch(pattern, name):
+                            updated_name = re.sub(pattern, repl, name)
+                    updated_ignore.append(updated_name)
+                quant_config.ignore = updated_ignore
+            # Update target list
+            if hasattr(quant_config, "config_groups"):
+                config_groups = quant_config.config_groups
+                for group_name in config_groups:
+                    if "targets" in config_groups[group_name]:
+                        targets = []
+                        for name in config_groups[group_name]["targets"]:
+                            updated_name = name
+                            for pattern, repl in remapping_rules:
+                                if re.fullmatch(pattern, name):
+                                    updated_name = re.sub(pattern, repl, name)
+                            targets.append(updated_name)
+                    config_groups[group_name]["targets"] = targets
+                quant_config.config_groups = config_groups
+            return quant_config
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
         config = vllm_config.model_config.hf_config
         self.vllm_config = vllm_config
+
+        if hasattr(vllm_config, "quant_config"):
+            vllm_config.quant_config = self.maybe_update_quant_config(
+                vllm_config.quant_config
+            )
+
         self.model_config = vllm_config.model_config
         lora_config = vllm_config.lora_config
         scheduler_config = vllm_config.scheduler_config


### PR DESCRIPTION
# Pull Request Description

## Purpose

This PR adds quantization configuration remapping support for the GraniteMoeHybrid model to handle the naming difference between Hugging Face model checkpoints and vLLM's internal model structure.

**Problem:** The GraniteMoeHybrid model uses `mamba` naming in HF checkpoints but `mixer` naming in vLLM's implementation (inherited from MambaMixer2). This mismatch causes quantization configurations to fail when targeting specific layers, as the ignore lists and target module names don't match the actual vLLM model structure.

**Solution:** Implements a `maybe_update_quant_config()` method that remaps quantization config module names from HF format (`mamba`) to vLLM format (`mixer`) using regex patterns. This ensures quantization configurations work correctly with the model's actual layer names.

**Changes made:**
- Added `maybe_update_quant_config()` method to `GraniteMoeHybridForCausalLM` class
- Added missing `import re` statement at the top of the file
- Method updates both `ignore` lists and `config_groups.targets` lists in the quantization config
- Remapping rules handle patterns like `model.layers.{N}.mamba.in_proj` → `model.layers.{N}.mixer.in_proj`

## Test Plan

### 1. **Integration Test with FP8 Quantization**
```bash
# Test with FP8 quantization targeting specific layers
python -m vllm.entrypoints.openai.api_server \
    --model RedHatAI/granite-4.0-h-small-FP8-block \
    --max-model-len 2048
```

## Test Result

**Before the fix:**
- Quantization configs with `model.layers.{N}.mamba.*` patterns would not match any layers
- Layers would be quantized/ignored incorrectly due to name mismatch
- Potential errors or warnings during quantization initialization

**After the fix:**
- Quantization config module names are automatically remapped from `mamba` to `mixer`
- Both `ignore` lists and `config_groups.targets` are updated correctly
- Quantization applies to the correct layers as intended
- Model loads and runs successfully with quantization enabled

---

## Additional Notes

- This fix is specific to GraniteMoeHybrid model and follows similar patterns used in other vLLM model implementations
- The remapping is applied during model initialization before quantization is configured
- No changes to model behavior or performance, only fixes configuration name matching
- Follows vLLM's existing patterns for handling HF/vLLM naming discrepancies

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).

</details>