### PR TITLE
[torch.compile] Include value of `VLLM_ALLREDUCE_USE_SYMM_MEM` in Cache Key

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1607,6 +1607,7 @@ def compute_hash() -> str:
         "VLLM_USE_FBGEMM",
         "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE",
         "VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL",
+        "VLLM_ALLREDUCE_USE_SYMM_MEM",
     ]
     for key in environment_variables_to_hash:
         # if this goes out of sync with environment_variables,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- I have had issues with `VLLM_ALLREDUCE_USE_SYMM_MEM` with torch.compile cache
- Add the key to ensure cache miss if we flip this env var

## Test Plan

- launching these one after the other should work

```bash
launch_vllm:
    VLLM_ALLREDUCE_USE_SYMM_MEM=0 VLLM_TORCH_PROFILER_DIR=$(pwd)/profiles_baseline chg run --gpus 8 -- vllm serve \
        {{MODEL}} --tensor-parallel-size 8

launch_vllm_symm_mem:
    VLLM_ALLREDUCE_USE_SYMM_MEM=1 VLLM_TORCH_PROFILER_DIR=$(pwd)/profiles_symm_mem chg run --gpus 8 -- vllm serve \
        {{MODEL}} --tensor-parallel-size 8
```


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

