### PR TITLE
map torchao quantized checkpoints to vLLM's MoE kernels

### DIFF
--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -13,6 +13,9 @@ from packaging import version
 from torch.nn.parameter import Parameter
 
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.layer import (
+    FusedMoE,
+)
 from vllm.model_executor.layers.linear import (
     LinearBase,
     LinearMethodBase,
@@ -22,6 +25,13 @@ from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
+    CompressedTensorsW8A8Fp8MoEMethod,
+)
+from vllm.model_executor.layers.quantization.torchao_utils import (
+    maybe_get_torchao_config_for_moe_layer,
+    torchao_config_to_compressed_tensors_config,
 )
 from vllm.model_executor.utils import set_weight_attrs
 
@@ -83,6 +93,31 @@ def should_skip(prefix: str, skip_modules: list[str]) -> bool:
     should_skip("model.model.layers.1.q_proj", ["layers.1"])  -> True
     should_skip("model.model.layers.11.q_proj", ["layers.1"]) -> False
     """
+
+    # Temporary hacky workaround for:
+    # 1. prefix == 'model.layers.0.self_attn.qkv_proj'
+    # 2. skip_modules containing 'model.layers.0.self_attn.q_proj',
+    #    'model.layers.0.self_attn.k_proj',
+    #    'model.layers.0.self_attn.v_proj
+    if "self_attn.qkv_proj" in prefix:
+        unfused_q = prefix.replace("qkv_proj", "q_proj")
+        unfused_k = prefix.replace("qkv_proj", "k_proj")
+        unfused_v = prefix.replace("qkv_proj", "v_proj")
+        if (
+            (unfused_q in skip_modules)
+            and (unfused_k in skip_modules)
+            and (unfused_v in skip_modules)
+        ):
+            return True
+
+    # Temporary hacky workaround for:
+    # 1. prefix == 'model.layers.0.mlp.shared_expert.gate_up_proj'
+    # 2. skip_modules containing 'model.layers.0.mlp.shared_expert.gate_proj'
+    if "gate_up_proj" in prefix:
+        unfused_gate = prefix.replace("gate_up_proj", "gate_proj")
+        if unfused_gate in skip_modules:
+            return True
+
     for s in skip_modules:
         if prefix == s:
             return True
@@ -97,6 +132,120 @@ if torchao_version_at_least("0.15.0"):
     )
 else:
     convert_to_packed_tensor_based_on_current_hardware = lambda t: t
+
+
+class TorchAOWrappingCompressedTensorsW8A8Fp8MoEMethod(
+    CompressedTensorsW8A8Fp8MoEMethod
+):
+    """
+    A thin wrapper around `CompressedTensorsW8A8Fp8MoEMethod` for compatibility
+    with torchao checkpoints.
+
+    How it works:
+    1. `super().create_weights(...)` creates layer.w13_weight,
+       layer.w13_weight_scale, layer.w2_weight, layer.w2_weight_scale as plain
+       tensors.
+    2. `self.create_weights(...)` temporarily changes layer.w13_weight and
+       layer.w2_weight to be `TorchAOBaseTensor` objects to match the
+       checkpoint format
+    3. the weights are loaded (model-specific code), torchao checkpoint weights
+       are properly loaded to layer.w13_weight and layer.w2_weight
+    4. `self.process_weights_after_loading(...)` changes layer.w13_weight and
+       layer.w2_weight back to plain tensors, and properly stashes `qdata` and
+       `scale` to their plain tensor locations (matching where compressed-tensors
+       path expects them).
+    5. `super().process_weights_after_loading(...)` proceeds as usual
+    """
+
+    torchao_config: Any
+    saved_extra_weight_attrs: Any
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        super().create_weights(
+            layer,
+            num_experts,
+            hidden_size,
+            intermediate_size_per_partition,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+
+        w13_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        w13_weight = torchao_quantize_param_data(w13_weight, self.torchao_config)
+        layer.register_parameter("w13_weight", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+
+        w2_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        w2_weight = torchao_quantize_param_data(w2_weight, self.torchao_config)
+        layer.register_parameter("w2_weight", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+        # save this so we can apply it again in process_weights_after_loading
+        self.saved_extra_weight_attrs = extra_weight_attrs
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from torchao.quantization import (
+            Float8DynamicActivationFloat8WeightConfig,
+            PerRow,
+        )
+
+        # convert from TorchAOBaseTensor (in torchao checkpoint format)
+        # to plain tensors (in compressed-tensors format).
+        if isinstance(
+            self.torchao_config, Float8DynamicActivationFloat8WeightConfig
+        ) and self.torchao_config.granularity == [PerRow(), PerRow()]:
+            # float8 per-token activation, float8 per-channel weight
+            layer.w13_weight_scale = torch.nn.Parameter(
+                layer.w13_weight.scale, requires_grad=False
+            )
+            set_weight_attrs(layer.w13_weight_scale, self.saved_extra_weight_attrs)
+
+            layer.w13_weight = torch.nn.Parameter(
+                layer.w13_weight.qdata, requires_grad=False
+            )
+            set_weight_attrs(layer.w13_weight, self.saved_extra_weight_attrs)
+
+            layer.w2_weight_scale = torch.nn.Parameter(
+                layer.w2_weight.scale, requires_grad=False
+            )
+            set_weight_attrs(layer.w2_weight_scale, self.saved_extra_weight_attrs)
+
+            layer.w2_weight = torch.nn.Parameter(
+                layer.w2_weight.qdata, requires_grad=False
+            )
+            set_weight_attrs(layer.w2_weight, self.saved_extra_weight_attrs)
+
+        else:
+            raise AssertionError(f"unsupported torchao config {self.torchao_config}")
+
+        # After this point there are no more TorchAOBaseTensor subclasses,
+        # we only have plain tensors, and vLLM owns the kernels which are
+        # going through the unmofidied compressed-tensors path.
+        super().process_weights_after_loading(layer)
 
 
 class TorchAOConfig(QuantizationConfig):
@@ -224,10 +373,42 @@ class TorchAOConfig(QuantizationConfig):
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> Optional["QuantizeMethodBase"]:
+        from torchao.quantization import ModuleFqnToConfig
+
+        if isinstance(layer, FusedMoE):
+            module_fqn = prefix
+
+            # Note: `TorchAOConfig` is not supported because for any reasonable
+            # MoE quantization we need to leave gates in high precision.
+            assert isinstance(self.torchao_config, ModuleFqnToConfig), (
+                f"unsupported type {type(self.torchao_config)}"
+            )
+
+            # Get the torchao config for all of the MoE weights.
+            first_config = maybe_get_torchao_config_for_moe_layer(
+                self.torchao_config,
+                module_fqn,
+            )
+            assert first_config is not None, "unsupported"
+
+            # map from torchao config format to compressed-tensors config format
+            compressed_tensors_quant_config = (
+                torchao_config_to_compressed_tensors_config(first_config)
+            )
+            new_method = TorchAOWrappingCompressedTensorsW8A8Fp8MoEMethod(
+                compressed_tensors_quant_config, layer.moe_config
+            )
+            logger.info(
+                "FusedMoE quant: delegating to %s for fqn %s",
+                type(new_method),
+                module_fqn,
+            )
+
+            new_method.torchao_config = first_config
+            return new_method
+
         if not isinstance(layer, LinearBase):
             return None
-
-        from torchao.quantization import ModuleFqnToConfig
 
         if should_skip(prefix, self.skip_modules):
             return UnquantizedLinearMethod()

--- a/vllm/model_executor/layers/quantization/torchao_utils.py
+++ b/vllm/model_executor/layers/quantization/torchao_utils.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import copy
+
+import regex as re
+from compressed_tensors.quantization import QuantizationArgs
+
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+    CompressedTensorsConfig,
+)
+
+
+def maybe_get_torchao_config_for_moe_layer(
+    fqn_to_config,
+    moe_prefix: str,
+):
+    """
+    Given an `fqn_to_config` and the prefix FQN of a vLLM model's MoE module,
+    returns either a single `TorchAOBaseConfig` to apply to all of the expert
+    weights, or `None` if the expert weights are not quantized.
+
+    Throws an exception if multiple configs are found.
+
+    Example moe_prefix: `model.layers.1.mlp.experts`, from
+      `Qwen/Qwen1.5-MoE-A2.7B`
+    """
+
+    from torchao.quantization import Float8DynamicActivationFloat8WeightConfig, PerRow
+
+    found_configs = []
+    for k, cur_config in fqn_to_config.fqn_to_config.items():
+        if k.startswith("re:"):
+            # regex match
+
+            # 're:pattern' -> 'pattern'
+            regex_pattern = k[3:]
+
+            # It's tricky to match regexes defined on HuggingFace's model
+            # definition against FQNs from the vLLM's model definion,
+            # as the two definitions often have mismatches.
+            #
+            # For now, do an approximation:
+            # 1. transform vLLM's prefix to include
+            #    `gate_proj`, `up_proj`, `gate_up_proj`, `down_proj` to cover
+            #    common cases.
+            # 2. match regular expressions defined on HuggingFace's model
+            #    definition against these transformed prefixes.
+
+            transformed_vllm_prefixes = [
+                f"{moe_prefix}.gate_proj",
+                f"{moe_prefix}.up_proj",
+                f"{moe_prefix}.gate_up_proj",
+                f"{moe_prefix}.down_proj",
+            ]
+
+            for transformed_vllm_prefix in transformed_vllm_prefixes:
+                is_match = re.fullmatch(regex_pattern, transformed_vllm_prefix)
+                if is_match:
+                    found_configs.append(cur_config)
+
+        else:
+            # direct match by module or parameter FQN
+            if k.startswith(moe_prefix):
+                found_configs.append(cur_config)
+
+    # all entries in found_configs have to match
+    for config_idx in range(len(found_configs)):
+        if config_idx == 0:
+            continue
+        first_config = found_configs[0]
+        cur_config = found_configs[config_idx]
+        if cur_config != first_config:
+            raise AssertionError(
+                f"inconsistent configs {first_config} and "
+                f"{cur_config} in a single MoE module, this is "
+                "not supported"
+            )
+
+    first_config = None
+    if len(found_configs):
+        first_config = found_configs[0]
+    if first_config is None:
+        first_config = fqn_to_config.fqn_to_config.get("_default", None)
+
+    if isinstance(
+        first_config, Float8DynamicActivationFloat8WeightConfig
+    ) and first_config.granularity[1] == PerRow(1):
+        # For some models, HuggingFace stores expert weights in MKN layout
+        # and vLLM loads them in MNK layout. If we detect that the
+        # Hugging weight was quantized along the K dimension, change the
+        # quantization config for vLLM to adjust for the fact that `K`'s index
+        # is different in the vLLM definition.
+
+        # deepcopy to prevent affecting other users of this config
+        first_config = copy.deepcopy(first_config)
+
+        # Change the granularity (this adjusts the quantization axis to match
+        # vLLM's weight layout).
+        first_config.granularity[-1] = PerRow()
+
+    return first_config
+
+
+def torchao_config_to_compressed_tensors_config(
+    torchao_config,
+) -> CompressedTensorsConfig:
+    """
+    Map from torchao config format to compressed-tensors config format
+    """
+
+    from torchao.quantization import (
+        Float8DynamicActivationFloat8WeightConfig,
+        PerRow,
+    )
+
+    is_float8_rowwise = isinstance(
+        torchao_config, Float8DynamicActivationFloat8WeightConfig
+    ) and torchao_config.granularity == [PerRow(), PerRow()]
+    # Special case of float8 rowwise where the HuggingFace weight is stored
+    # in MKN layout and quantized rowwise along the K dimension
+    is_float8_rowwise_for_3d_weight_mkn_layout = isinstance(
+        torchao_config, Float8DynamicActivationFloat8WeightConfig
+    ) and torchao_config.granularity == [PerRow(), PerRow(1)]
+
+    if is_float8_rowwise or is_float8_rowwise_for_3d_weight_mkn_layout:
+        # activations: float8 token-wise
+        # weights: float8 channel-wise
+
+        # source: https://gist.github.com/vkuzo/d30bcf8a2e4a1a3f3d122922f31e3572
+        target_scheme_map = {
+            "Linear": {
+                "weights": QuantizationArgs(
+                    num_bits=8,
+                    type="float",
+                    symmetric=True,
+                    group_size=None,
+                    strategy="channel",
+                    block_structure=None,
+                    dynamic=False,
+                    actorder=None,
+                    observer="minmax",
+                    observer_kwargs={},
+                ),
+                "input_activations": QuantizationArgs(
+                    num_bits=8,
+                    type="float",
+                    symmetric=True,
+                    group_size=None,
+                    strategy="token",
+                    block_structure=None,
+                    dynamic=True,
+                    actorder=None,
+                    observer="minmax",
+                    observer_kwargs={},
+                ),
+            },
+        }
+        compressed_tensors_quant_config = CompressedTensorsConfig(
+            target_scheme_map=target_scheme_map,
+            # TODO(future): fill out the ignore map / audit why it matters
+            ignore=[],
+            quant_format="float-quantized",
+            sparsity_scheme_map={},
+            sparsity_ignore_list=[],
+        )
+        return compressed_tensors_quant_config
+
+    raise AssertionError(f"unsupported {torchao_config=}")


### PR DESCRIPTION
Summary:

## Purpose

This is a POC to map `torchao`'s quantized checkpoints for Mixture-of-Experts modules to the `compressed-tensors` MoE path for w8a8 rowwise quant scheme.  We do this by:
1. subclassing `CompressedTensorsW8A8Fp8MoEMethod`, and overriding its `create_weights` and `process_weights_after_loading` methods to map from torchao quantized tensor to compressed-tensors plain tensor format.  This is the part where the "torchao -> compressed_tensor" conversion happens.  Note that for float8 w8a8 rowwise, this is a metadata-only change.
2. adding logic to `TorchAOConfig` to set the quant method to `TorchAOWrappingCompressedTensorsW8A8Fp8MoEMethod` when appropriate.

Note that there are no changes to the `compressed-tensors` path due to the existing vLLM APIs already being expressive enough to do this mapping.

For now, I only implemented one w8a8 scheme to demonstrate a proof of concept.  In the future, the following could be done:
a. map to more schemes for w8a8
b. add mappings for w4a8, etc

## Test Plan

1. integration test for correctness on 1xH100 with `Qwen/Qwen1.5-MoE-A2.7B` with experts quantized to float8 with rowwise scaling with torchao
2. tested locally on 4xH100 with `meta-llama/Llama-4-Scout-17B-16E-Instruct` with experts quantized to float8 with rowwise scaling with torchao
3. very simple performance testing, the values are essentially the same from torchao checkpoint and the corresponding compressed-tensors checkpoint.  Note that the model loading time is higher for torchao (since it is not using safetensors), but this is not captured in the serving benchmark.

```bash
> CUDA_VISIBLE_DEVICES=4,5,6,7 vllm bench throughput --model ../pytorch_scripts/hf_torchao_vllm/data/torchao/fp8-experts-only-mnk-testing-Llama-4-Scout-17B-16E-Instruct --dataset-name sonnet --dataset-path benchmarks/sonnet.txt --num-prompts 10 --tensor-parallel-size 4 --max-model-len 2048 --gpu-memory-utilization 0.8
...
Throughput: 4.07 requests/s, 2623.30 total tokens/s, 609.79 output tokens/s
Total num prompt tokens:  4953
Total num output tokens:  1500
```

## Test Result

see above, the new funtionality did not exist before this PR

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

