### PR TITLE
Only register rocm_aiter_ops if aiter is found

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -937,5 +937,5 @@ class rocm_aiter_ops:
 
         return tuple(shuffle_weight(tensor, layout=layout) for tensor in tensors)
 
-
-rocm_aiter_ops.register_ops_once()
+if IS_AITER_FOUND:
+    rocm_aiter_ops.register_ops_once()

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -937,5 +937,6 @@ class rocm_aiter_ops:
 
         return tuple(shuffle_weight(tensor, layout=layout) for tensor in tensors)
 
+
 if IS_AITER_FOUND:
     rocm_aiter_ops.register_ops_once()

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -12,7 +12,6 @@ import torch
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -313,6 +312,8 @@ class W8A8BlockFp8LinearOp:
         weight_scale: torch.Tensor,
         input_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        from vllm._aiter_ops import rocm_aiter_ops
+
         assert self.act_quant_group_shape == GroupShape(1, 128)
 
         n, k = weight.shape

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -10,9 +10,9 @@ from typing import Any
 
 import torch
 
-from vllm._aiter_ops import rocm_aiter_ops
 import vllm.envs as envs
 from vllm import _custom_ops as ops
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import torch
 
+from vllm._aiter_ops import rocm_aiter_ops
 import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
@@ -312,8 +313,6 @@ class W8A8BlockFp8LinearOp:
         weight_scale: torch.Tensor,
         input_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        from vllm._aiter_ops import rocm_aiter_ops
-
         assert self.act_quant_group_shape == GroupShape(1, 128)
 
         n, k = weight.shape


### PR DESCRIPTION
## Purpose

In https://github.com/vllm-project/vllm/pull/24490 there was an addition of a new import for rocm.py

Without this change, you can see the rocm import warnings on nvidia devices by default
```
WARNING 11-10 22:31:06 [rocm.py:39] Failed to import from amdsmi with ModuleNotFoundError("No module named 'amdsmi'")
WARNING 11-10 22:31:06 [rocm.py:50] Failed to import from vllm._rocm_C with ModuleNotFoundError("No module named 'vllm._rocm_C'")
```

Thanks to @tjtanaa, he pointed out there was an oversight and the ops class should act as a no-op when it is on non-ROCm platform and aiter is not installed.

I found the culprit using 
```
import traceback
print(traceback.print_stack())
```
Output:
```
python benchmarks/kernels/bench_block_fp8_gemm.py
Printing stack trace
  File "/home/mgoin/code/vllm/benchmarks/kernels/bench_block_fp8_gemm.py", line 6, in <module>
    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 15, in <module>
    from vllm._aiter_ops import rocm_aiter_ops
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/mgoin/code/vllm/vllm/_aiter_ops.py", line 941, in <module>
    rocm_aiter_ops.register_ops_once()
  File "/home/mgoin/code/vllm/vllm/_aiter_ops.py", line 35, in wrapper
    from vllm.platforms.rocm import on_gfx9
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/mgoin/code/vllm/vllm/platforms/rocm.py", line 27, in <module>
    print(traceback.print_stack())
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

