### PR TITLE
Remove weight_scale.T special case for SM90 Block FP8 CUTLASS kernel

### DIFF
--- a/csrc/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm90_fp8_dispatch.cuh
+++ b/csrc/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm90_fp8_dispatch.cuh
@@ -48,7 +48,8 @@ struct cutlass_3x_gemm_fp8_blockwise {
   using ElementBlockScale = float;
 
   using ScaleConfig = cutlass::detail::Sm90BlockwiseScaleConfig<
-        ScaleGranularityM, ScaleGranularityN, ScaleGranularityK>;
+        ScaleGranularityM, ScaleGranularityN, ScaleGranularityK,
+        cute::GMMA::Major::MN, cute::GMMA::Major::K>;
 
   using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
   using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -173,7 +173,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
             layer.input_scale = None
 
         if self.strategy == QuantizationStrategy.BLOCK:
-            maybe_post_process_fp8_weight_block(layer, self.cutlass_block_fp8_supported)
+            maybe_post_process_fp8_weight_block(layer)
 
     def apply_weights(
         self,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -543,7 +543,7 @@ class Fp8LinearMethod(LinearMethodBase):
             return
 
         if self.block_quant:
-            maybe_post_process_fp8_weight_block(layer, self.cutlass_block_fp8_supported)
+            maybe_post_process_fp8_weight_block(layer)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -55,17 +55,13 @@ def cutlass_scaled_mm(
     Bs: torch.Tensor,
     block_size: list[int],
     output_dtype: torch.dtype = torch.float16,
-    is_hopper: bool | None = None,
 ) -> torch.Tensor:
-    if is_hopper is None:
-        is_hopper = current_platform.is_device_capability(90)
     return ops.cutlass_scaled_mm(
         A,
         B.T,
         out_dtype=output_dtype,
         scale_a=As,
-        # SM90 block FP8 requires row-major scale_b, which we do ahead of time
-        scale_b=Bs if block_size is not None and is_hopper else Bs.T,
+        scale_b=Bs.T,
     )
 
 
@@ -130,7 +126,7 @@ def _padded_cutlass(
     padded_x_scale[0 : x_scale.shape[0], ...].copy_(x_scale)
 
     output = cutlass_scaled_mm(
-        padded_qx, weight, padded_x_scale, weight_scale, block_size, output_dtype, True
+        padded_qx, weight, padded_x_scale, weight_scale, block_size, output_dtype
     )
     return output[0 : qx.shape[0], ...]
 
@@ -303,7 +299,6 @@ class W8A8BlockFp8LinearOp:
                 weight_scale,
                 list(self.weight_group_shape),
                 input_2d.dtype,
-                False,
             )
 
     def _run_aiter(
@@ -1124,9 +1119,7 @@ def process_fp8_weight_block_strategy(
     return weight, weight_scale
 
 
-def maybe_post_process_fp8_weight_block(
-    layer: torch.nn.Module, cutlass_block_fp8_supported: bool
-):
+def maybe_post_process_fp8_weight_block(layer: torch.nn.Module):
     assert layer.weight_block_size is not None
 
     from vllm.utils.deep_gemm import (
@@ -1144,15 +1137,6 @@ def maybe_post_process_fp8_weight_block(
         block_sz = tuple(layer.weight_block_size)
         requant_weight_ue8m0_inplace(
             layer.weight.data, layer.weight_scale.data, block_sz
-        )
-    # SM90 Block FP8 CUTLASS requires row-major weight scales
-    elif (
-        current_platform.is_device_capability(90)
-        and cutlass_block_fp8_supported
-        and not should_use_deepgemm
-    ):
-        layer.weight_scale = torch.nn.Parameter(
-            layer.weight_scale.data.T.contiguous(), requires_grad=False
         )
 
 


### PR DESCRIPTION
## Purpose

We can remove the requirement for the special case weight_scale layout for the SM90 Block FP8 CUTLASS kernel so it uses the same format as SM100 and SM120. This was done by updating the scale config
```cpp
  using ScaleConfig = cutlass::detail::Sm90BlockwiseScaleConfig<
        ScaleGranularityM, ScaleGranularityN, ScaleGranularityK,
        cute::GMMA::Major::MN, cute::GMMA::Major::K>;
```


Additional work still needs to be done to remove the `M % 4 == 0` requirement which means we need to pad the GEMM

## Benchmark Result

Left is old kernel, right is new kernel. Looks to be equal

<img width="1908" height="1451" alt="Screenshot 2025-11-11 at 10 47 51 AM" src="https://github.com/user-attachments/assets/eece90ee-46b7-4679-811e-d6629a2576d9" />

<img width="1908" height="1451" alt="Screenshot 2025-11-11 at 10 48 06 AM" src="https://github.com/user-attachments/assets/ff332c31-fd64-4666-8ae1-f6c31e0fd717" />


## Test Result

Lm-eval

```
# Main
vllm (pretrained=Qwen/Qwen3-8B-FP8,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8825|±  |0.0089|
|     |       |strict-match    |     5|exact_match|↑  |0.8787|±  |0.0090|

# PR
vllm (pretrained=Qwen/Qwen3-8B-FP8,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8825|±  |0.0089|
|     |       |strict-match    |     5|exact_match|↑  |0.8787|±  |0.0090|
```

Ran `VLLM_USE_DEEP_GEMM=0 python examples/offline_inference/basic/basic.py` with `Qwen/Qwen3-0.6B-FP8` on H100

Main:
```
------------------------------------------------------------
Prompt:    'Hello, my name is'
Output:    " Josh and I'm in the middle of a project to develop a hybrid mobile app"
------------------------------------------------------------
Prompt:    'The president of the United States is'
Output:    ' the most important official in the country, but what about the president of the United'
------------------------------------------------------------
Prompt:    'The capital of France is'
Output:    ' Paris, and the capital of Japan is Tokyo. The capital of Italy is Rome'
------------------------------------------------------------
Prompt:    'The future of AI is'
Output:    ' promising, but it also carries significant risks. As technology advances, the lines between'
------------------------------------------------------------
```

Result with this PR python changes but not updated CUTLASS kernel:
```
Generated Outputs:
------------------------------------------------------------
Prompt:    'Hello, my name is'
Output:    'held Nob jerkwebkitakesyles.hosthoresдавzel fallodont rock gratuitement荣誉吠'
------------------------------------------------------------
Prompt:    'The president of the United States is'
Output:    'в2�回 종есп Sto2igrams Fontsnop toc toc9핵�_ios'
------------------------------------------------------------
Prompt:    'The capital of France is'
Output:    'ylene nguyên�finityfinity sắclic(secondslá都�叉ot_sptcc'
------------------------------------------------------------
Prompt:    'The future of AI is'
Output:    ' percentagesodontodontINOodont-toggler Neo sortingscriptionensorssocialodontodontстр đẩysocial'
------------------------------------------------------------
```

Result with this PR:
```
------------------------------------------------------------
Prompt:    'Hello, my name is'
Output:    " Josh and I'm in the middle of a project to develop a hybrid mobile app"
------------------------------------------------------------
Prompt:    'The president of the United States is'
Output:    ' the most important official in the country, but what about the president of the United'
------------------------------------------------------------
Prompt:    'The capital of France is'
Output:    ' Paris, and the capital of Japan is Tokyo. The capital of Italy is Rome'
------------------------------------------------------------
Prompt:    'The future of AI is'
Output:    ' promising, but it also carries significant risks. As technology advances, the lines between'
------------------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

