### PR TITLE
[Model][Qwen3VL] Slighly speedup `fast_pos_embed_interpolate`

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -491,8 +491,8 @@ class Qwen3_VisionTransformer(nn.Module):
             weights = weights.to(dtype=self.dtype)
 
             embeds = self.pos_embed(indices)
-            weighted_embeds = embeds * weights
-            combined = weighted_embeds.sum(dim=0)
+            embeds *= weights
+            combined = embeds.sum(dim=0)
 
             combined = combined.reshape(
                 h // m_size, m_size, w // m_size, m_size, hidden_dim


### PR DESCRIPTION
This slightly reduces the overhead of `fast_pos_embed_interpolate` by using an in-place multiplication. Followup to #26647

In a simple benchmark this speedups the function by ~20% for bfloat16 and ~30% for float32. Nothing major, but it's still a nice win.