### PR TITLE
[CLI] fix unicode encode error for `vllm chat/complete` command input

### DIFF
--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import readline  # noqa: F401 # fix unicode encode eror for multi-byte characters
 import signal
 import sys
 from typing import TYPE_CHECKING


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When using the `vllm chat` or `vllm complete` command to input **Chinese** or other **multi-byte characters**, pressing the **Backspace key** to delete characters may cause encoding errors in the input.

This issue can be resolved by simply importing the readline module.

## Test Plan
```bash
$ vllm chat
> 你好
你好呀！有什么可以帮助你的吗？ 😊
> 今天过的怎么样，可以<Backspace Key>
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 349-350: surrogates not allowed
```

fixed:
```bash
$ vllm chat
> 你好
你好！有什么可以帮助你的吗？
> 今天过的怎么样呢啊<Backspace Key><Backspace Key>
今天过得怎么样呢？有什么想分享的吗？
```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

