### PR TITLE
when model_runner not ensure_kv_transfer_shutdown this method, it wil…

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -860,8 +860,10 @@ class Worker(WorkerBase):
         )
 
     def shutdown(self) -> None:
-        if runner := getattr(self, "model_runner", None):
-            runner.ensure_kv_transfer_shutdown()
+        if hasattr(self, "model_runner") and hasattr(
+            self.model_runner, "ensure_kv_transfer_shutdown"
+        ):
+            self.model_runner.ensure_kv_transfer_shutdown()
 
 
 def init_worker_distributed_environment(


### PR DESCRIPTION


When i test other model_runner, find if EngineCore because oom crash, but it error info is `AttributeError: 'NoneType' object has no attribute 'ensure_kv_transfer_shutdown'`.

So we should it check model_runner wether this method.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

