### PR TITLE
[Performance] Cache loaded custom logitsprocs to avoid overheads

### DIFF
--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -223,6 +223,9 @@ def validate_logits_processors_parameters(
     logits_processors: Sequence[str | type[LogitsProcessor]] | None,
     sampling_params: SamplingParams,
 ):
+    logits_processors = (
+        tuple(logits_processors) if logits_processors is not None else None
+    )
     for logits_procs in cached_load_custom_logitsprocs(logits_processors):
         logits_procs.validate_params(sampling_params)
 

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -5,7 +5,7 @@ import inspect
 import itertools
 from abc import abstractmethod
 from collections.abc import Sequence
-from functools import partial
+from functools import lru_cache, partial
 from typing import TYPE_CHECKING
 
 import torch
@@ -216,11 +216,14 @@ def build_logitsprocs(
     )
 
 
+cached_load_custom_logitsprocs = lru_cache(_load_custom_logitsprocs)
+
+
 def validate_logits_processors_parameters(
     logits_processors: Sequence[str | type[LogitsProcessor]] | None,
     sampling_params: SamplingParams,
 ):
-    for logits_procs in _load_custom_logitsprocs(logits_processors):
+    for logits_procs in cached_load_custom_logitsprocs(logits_processors):
         logits_procs.validate_params(sampling_params)
 
 


### PR DESCRIPTION

## Purpose
Discussion: https://vllm-dev.slack.com/archives/C08U97ZRC0J/p1762826798388249
- `_load_custom_logitsprocs` can cause significant performance regression when validating sampling params, because it will try to import custom logitsprocs each time.
- This PR use `lru_cache` to cache the loaded custom logits processors to avoid duplicated import.

## Test Plan
```
vllm serve Qwen/Qwen3-0.6B --enforce-eager
```
```
vllm bench serve   --backend vllm   --model Qwen/Qwen3-0.6B   --endpoint /v1/completions   --dataset-name sharegpt   --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json   --num-prompts 1000
```

## Test Result
**Main**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  40.25     
Total input tokens:                      217393    
Total generated tokens:                  201847    
Request throughput (req/s):              24.85     
Output token throughput (tok/s):         5015.16   
Peak output token throughput (tok/s):    22751.00  
Peak concurrent requests:                1000.00   
Total Token throughput (tok/s):          10416.59  
---------------Time to First Token----------------
Mean TTFT (ms):                          13626.51  
Median TTFT (ms):                        14087.92  
P99 TTFT (ms):                           28310.02  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          40.77     
Median TPOT (ms):                        37.58     
P99 TPOT (ms):                           156.15    
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.98     
Median ITL (ms):                         20.86     
P99 ITL (ms):                            363.41    
==================================================
```

**PR**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  39.53     
Total input tokens:                      217393    
Total generated tokens:                  201847    
Request throughput (req/s):              25.29     
Output token throughput (tok/s):         5105.56   
Peak output token throughput (tok/s):    7680.00   
Peak concurrent requests:                1000.00   
Total Token throughput (tok/s):          10604.35  
---------------Time to First Token----------------
Mean TTFT (ms):                          11136.58  
Median TTFT (ms):                        9902.20   
P99 TTFT (ms):                           27619.44  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          42.25     
Median TPOT (ms):                        41.89     
P99 TPOT (ms):                           65.23     
---------------Inter-token Latency----------------
Mean ITL (ms):                           38.48     
Median ITL (ms):                         35.05     
P99 ITL (ms):                            77.71     
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

