### PR TITLE
[ROCM] Fix ROCm warnings, environment flag access, and GEMM kernel naming for consistency in `_aiter_ops.py`

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -494,7 +494,9 @@ class rocm_aiter_ops:
     @if_aiter_supported
     def is_triton_rotary_embed_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._TRITON_ROTARY_EMBED
-    
+
+    @classmethod
+    @if_aiter_supported
     def is_triton_gemm_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._TRITON_UNQUANT_GEMM
 

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -32,13 +32,13 @@ def if_aiter_supported(func: Callable) -> Callable:
     def wrapper(*args, **kwargs):
         # checks the platform, device arch and aiter library existance.
 
-        from vllm.platforms.rocm import on_gfx9
+        if current_platform.is_rocm() and IS_AITER_FOUND:
+            from vllm.platforms.rocm import on_gfx9
 
-        if current_platform.is_rocm() and on_gfx9() and IS_AITER_FOUND:
-            return func(*args, **kwargs)
-        else:
-            # Return None or do nothing if not supported
-            return None
+            if on_gfx9():
+                return func(*args, **kwargs)
+    
+        return None
 
     return wrapper
 
@@ -296,7 +296,7 @@ def _rocm_aiter_mla_decode_fwd_fake(
     pass
 
 
-def _rocm_aiter_gemm_w8a8_impl(
+def _rocm_aiter_gemm_a8w8_impl(
     A: torch.Tensor,
     B: torch.Tensor,
     As: torch.Tensor,
@@ -313,7 +313,7 @@ def _rocm_aiter_gemm_w8a8_impl(
     return gemm_a8w8_CK(A, B, As, Bs, bias, output_dtype)
 
 
-def _rocm_aiter_gemm_w8a8_fake(
+def _rocm_aiter_gemm_a8w8_fake(
     A: torch.Tensor,
     B: torch.Tensor,
     As: torch.Tensor,
@@ -327,7 +327,7 @@ def _rocm_aiter_gemm_w8a8_fake(
     return Y
 
 
-def _rocm_aiter_gemm_w8a8_blockscale_impl(
+def _rocm_aiter_gemm_a8w8_blockscale_impl(
     A: torch.Tensor,
     B: torch.Tensor,
     As: torch.Tensor,
@@ -339,7 +339,7 @@ def _rocm_aiter_gemm_w8a8_blockscale_impl(
     return gemm_a8w8_blockscale(A, B, As, Bs, dtype=output_dtype)
 
 
-def _rocm_aiter_gemm_w8a8_blockscale_fake(
+def _rocm_aiter_gemm_a8w8_blockscale_fake(
     A: torch.Tensor,
     B: torch.Tensor,
     As: torch.Tensor,
@@ -419,6 +419,7 @@ class rocm_aiter_ops:
     _FP4_GEMM_DYNAMIC_QUANT_ASM = envs.VLLM_ROCM_USE_AITER_FP4_ASM_GEMM
     _TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
     _MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
+    _TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
 
     @classmethod
     @if_aiter_supported
@@ -493,6 +494,9 @@ class rocm_aiter_ops:
     @if_aiter_supported
     def is_triton_rotary_embed_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._TRITON_ROTARY_EMBED
+    
+    def is_triton_gemm_enabled(cls) -> bool:
+        return cls._AITER_ENABLED and cls._TRITON_UNQUANT_GEMM
 
     @staticmethod
     @if_aiter_supported
@@ -555,18 +559,18 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
-                op_name="rocm_aiter_gemm_w8a8",
-                op_func=_rocm_aiter_gemm_w8a8_impl,
+                op_name="rocm_aiter_gemm_a8w8",
+                op_func=_rocm_aiter_gemm_a8w8_impl,
                 mutates_args=[],
-                fake_impl=_rocm_aiter_gemm_w8a8_fake,
+                fake_impl=_rocm_aiter_gemm_a8w8_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
 
             direct_register_custom_op(
-                op_name="rocm_aiter_gemm_w8a8_blockscale",
-                op_func=_rocm_aiter_gemm_w8a8_blockscale_impl,
+                op_name="rocm_aiter_gemm_a8w8_blockscale",
+                op_func=_rocm_aiter_gemm_a8w8_blockscale_impl,
                 mutates_args=[],
-                fake_impl=_rocm_aiter_gemm_w8a8_blockscale_fake,
+                fake_impl=_rocm_aiter_gemm_a8w8_blockscale_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
 
@@ -606,7 +610,7 @@ class rocm_aiter_ops:
         return torch.ops.vllm.rocm_aiter_rms_norm(x, weight, variance_epsilon)
 
     @staticmethod
-    def gemm_w8a8(
+    def gemm_a8w8(
         A: torch.Tensor,
         B: torch.Tensor,
         As: torch.Tensor,
@@ -614,10 +618,10 @@ class rocm_aiter_ops:
         bias: torch.Tensor | None = None,
         output_dtype: torch.dtype = torch.float16,
     ) -> torch.Tensor:
-        return torch.ops.vllm.rocm_aiter_gemm_w8a8(A, B, As, Bs, bias, output_dtype)
+        return torch.ops.vllm.rocm_aiter_gemm_a8w8(A, B, As, Bs, bias, output_dtype)
 
     @staticmethod
-    def gemm_w8a8_blockscale(
+    def gemm_a8w8_blockscale(
         A: torch.Tensor,
         B: torch.Tensor,
         As: torch.Tensor,
@@ -625,7 +629,7 @@ class rocm_aiter_ops:
         block_size: list[int],
         output_dtype: torch.dtype = torch.float16,
     ) -> torch.Tensor:
-        return torch.ops.vllm.rocm_aiter_gemm_w8a8_blockscale(
+        return torch.ops.vllm.rocm_aiter_gemm_a8w8_blockscale(
             A, B, As, Bs, output_dtype
         )
 
@@ -938,5 +942,4 @@ class rocm_aiter_ops:
         return tuple(shuffle_weight(tensor, layout=layout) for tensor in tensors)
 
 
-if IS_AITER_FOUND:
-    rocm_aiter_ops.register_ops_once()
+rocm_aiter_ops.register_ops_once()

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -37,7 +37,7 @@ def if_aiter_supported(func: Callable) -> Callable:
 
             if on_gfx9():
                 return func(*args, **kwargs)
-    
+
         return None
 
     return wrapper

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
@@ -117,4 +117,4 @@ class AiterScaledMMLinearKernel(CutlassScaledMMLinearKernel):
         # a to be [M, K]
         # b to be [N, K]
         # CutlassScaledMMLinearKernel prepare weight `w_q` in [K, N] format
-        return rocm_aiter_ops.gemm_w8a8(x_q, w_q.t(), x_s, w_s, bias, out_dtype)
+        return rocm_aiter_ops.gemm_a8w8(x_q, w_q.t(), x_s, w_s, bias, out_dtype)

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -325,7 +325,7 @@ class W8A8BlockFp8LinearOp:
         if use_triton:
             gemm_a8w8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
         else:
-            gemm_a8w8_blockscale_op = rocm_aiter_ops.gemm_w8a8_blockscale
+            gemm_a8w8_blockscale_op = rocm_aiter_ops.gemm_a8w8_blockscale
 
         if input_scale is not None:
             q_input = input_2d

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -7,8 +7,8 @@ from collections.abc import Callable
 import torch
 
 from vllm import _custom_ops as ops
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm import envs
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import direct_register_custom_op

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -105,24 +105,24 @@ def default_unquantized_gemm(
 
 
 def use_aiter_triton_gemm(n, m, k, dtype):
+    if (
+        not rocm_aiter_ops.is_triton_gemm_enabled()
+        # MI300's - fp8nuz=True
+        or current_platform.is_fp8_fnuz()
+        or dtype not in [torch.float16, torch.bfloat16]
+    ):
+        return False
+
     # use hipblaslt for the larger GEMMs
     if n > 2048 and m > 512:
         return False
-
-    dtype_matches = dtype in [torch.float16, torch.bfloat16]
-    shape_matches = (
+    return (
         (m == 5120 and k == 2880)
         or (m == 2880 and k == 4096)
         or (m == 128 and k == 2880)
         or (m == 640 and k == 2880)
         or (m == 2880 and k == 512)
     )
-    platform_envs_matches = (rocm_aiter_ops.is_triton_gemm_enabled() 
-                             and not current_platform.is_fp8_fnuz())
-
-    return (platform_envs_matches and
-        shape_matches and
-         dtype_matches)
 
 
 def rocm_unquantized_gemm_impl(

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -350,8 +350,8 @@ class RocmPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
-        from vllm.config.compilation import CUDAGraphMode
         from vllm._aiter_ops import rocm_aiter_ops
+        from vllm.config.compilation import CUDAGraphMode
 
         cache_config = vllm_config.cache_config
         compilation_config = vllm_config.compilation_config

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -351,15 +351,14 @@ class RocmPlatform(Platform):
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         from vllm.config.compilation import CUDAGraphMode
+        from vllm._aiter_ops import rocm_aiter_ops
 
         cache_config = vllm_config.cache_config
         compilation_config = vllm_config.compilation_config
         parallel_config = vllm_config.parallel_config
         is_eager_execution = compilation_config == CUDAGraphMode.NONE
 
-        use_aiter_rms_norm = (
-            envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_RMSNORM
-        )
+        use_aiter_rms_norm = rocm_aiter_ops.is_rmsnorm_enabled()
 
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = 16


### PR DESCRIPTION

## Purpose
This PR includes several minor updates:
1. Fixed a ROCm-related warning issue in rocm.py.
2. Updated files that used `aiter`-related environment flags to access them from `aiter_ops.py` instead of `envs.py`.
3. Renamed the GEMM kernels in `aiter_ops.py` from `w8a8 ` to `a8w8` to maintain consistency with the naming convention used in the `aiter` package.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

