### PR TITLE
[Core][Spec Decode] prevent negative num_accepted tokens

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -951,7 +951,7 @@ class Scheduler(SchedulerInterface):
             )
             if scheduled_spec_token_ids:
                 num_draft_tokens = len(scheduled_spec_token_ids)
-                num_accepted = len(generated_token_ids) - 1
+                num_accepted = max(0, len(generated_token_ids) - 1)
                 num_rejected = num_draft_tokens - num_accepted
                 # num_computed_tokens represents the number of tokens
                 # processed in the current step, considering scheduled


### PR DESCRIPTION



## Purpose
In the case of request preemption or abortion, `generated_token_ids` will be cleared but `scheduled_spec_token_ids` can still be non-empty. `num_accepted` will become -1 in this case.

As a result, we will crash with the following exception:
```
ERROR 11-10 13:09:12 [async_llm.py:522] AsyncLLM output_handler failed.
ERROR 11-10 13:09:12 [async_llm.py:522] Traceback (most recent call last):
ERROR 11-10 13:09:12 [async_llm.py:522]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm.persistent/service-inplace#link-tree/vllm/v1/engine/async_llm.py", line 515, in output_handler
ERROR 11-10 13:09:12 [async_llm.py:522]     logger_manager.record(
ERROR 11-10 13:09:12 [async_llm.py:522]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm.persistent/service-inplace#link-tree/vllm/v1/metrics/loggers.py", line 1064, in record
ERROR 11-10 13:09:12 [async_llm.py:522]     logger.record(
ERROR 11-10 13:09:12 [async_llm.py:522]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm.persistent/service-inplace#link-tree/vllm/v1/metrics/loggers.py", line 869, in record
ERROR 11-10 13:09:12 [async_llm.py:522]     self.spec_decoding_prom.observe(
ERROR 11-10 13:09:12 [async_llm.py:522]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm.persistent/service-inplace#link-tree/vllm/v1/spec_decode/metrics.py", line 208, in observe
ERROR 11-10 13:09:12 [async_llm.py:522]     self.counter_spec_decode_num_accepted_tokens[engine_idx].inc(
ERROR 11-10 13:09:12 [async_llm.py:522]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm.persistent/service-inplace#link-tree/prometheus_client/metrics.py", line 297, in inc
ERROR 11-10 13:09:12 [async_llm.py:522]     raise ValueError('Counters can only be incremented by non-negative amounts.')
ERROR 11-10 13:09:12 [async_llm.py:522] ValueError: Counters can only be incremented by non-negative amounts.
```

## Test Plan

Shadowed production traffic.

## Test Result

The errors are gone after this change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

