### PR TITLE
[Model][Qwen3VL] Cache positional embedding indices 

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -420,10 +420,12 @@ class Qwen3_VisionTransformer(nn.Module):
     @lru_cache(maxsize=1024)
     def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
         hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
+        h_div = h // spatial_merge_size
+        w_div = w // spatial_merge_size
         hpos_ids = hpos_ids.reshape(
-            h // spatial_merge_size,
+            h_div,
             spatial_merge_size,
-            w // spatial_merge_size,
+            w_div,
             spatial_merge_size,
         )
         hpos_ids = hpos_ids.transpose(0, 2, 1, 3)
@@ -431,9 +433,9 @@ class Qwen3_VisionTransformer(nn.Module):
 
         wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
         wpos_ids = wpos_ids.reshape(
-            h // spatial_merge_size,
+            h_div,
             spatial_merge_size,
-            w // spatial_merge_size,
+            w_div,
             spatial_merge_size,
         )
         wpos_ids = wpos_ids.transpose(0, 2, 1, 3)

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -25,7 +25,7 @@
 """Inference-only Qwen3VL model compatible with HuggingFace weights."""
 
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from functools import partial
+from functools import lru_cache, partial
 from itertools import islice
 from typing import Any
 
@@ -416,23 +416,25 @@ class Qwen3_VisionTransformer(nn.Module):
     def device(self) -> torch.device:
         return self.patch_embed.proj.weight.device
 
-    def rot_pos_ids(self, h: int, w: int) -> torch.Tensor:
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
         hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
         hpos_ids = hpos_ids.reshape(
-            h // self.spatial_merge_size,
-            self.spatial_merge_size,
-            w // self.spatial_merge_size,
-            self.spatial_merge_size,
+            h // spatial_merge_size,
+            spatial_merge_size,
+            w // spatial_merge_size,
+            spatial_merge_size,
         )
         hpos_ids = hpos_ids.transpose(0, 2, 1, 3)
         hpos_ids = hpos_ids.flatten()
 
         wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
         wpos_ids = wpos_ids.reshape(
-            h // self.spatial_merge_size,
-            self.spatial_merge_size,
-            w // self.spatial_merge_size,
-            self.spatial_merge_size,
+            h // spatial_merge_size,
+            spatial_merge_size,
+            w // spatial_merge_size,
+            spatial_merge_size,
         )
         wpos_ids = wpos_ids.transpose(0, 2, 1, 3)
         wpos_ids = wpos_ids.flatten()
@@ -441,7 +443,12 @@ class Qwen3_VisionTransformer(nn.Module):
 
     def rot_pos_emb(self, grid_thw: list[list[int]]):
         max_grid_size = max(max(h, w) for _, h, w in grid_thw)
-        pos_ids = [self.rot_pos_ids(h, w).repeat(t, 1) for t, h, w in grid_thw]
+        pos_ids = [
+            self.rot_pos_ids(h, w, self.spatial_merge_size)
+            if t == 1
+            else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
+            for t, h, w in grid_thw
+        ]
         pos_ids = torch.cat(pos_ids, dim=0)
         rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
         rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)


### PR DESCRIPTION
## Purpose

`rot_pos_emb` currently runs on the CPU at the beginning of the model forward pass which means that no GPU computation happens in parallel. This PR caches the index computation to help with this. I also moved the index  computation to numpy which gave a small ~25-30% improvement to uncached computations as well.

## Test Plan

```
VLLM_TORCH_PROFILER_DIR=./vllm_profile vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --limit-mm-per-prompt.video 0 --max-model-len 10000
```

## Test Result

**Before**:

<img width="335" height="284" alt="Screenshot 2025-11-11 at 16 06 12" src="https://github.com/user-attachments/assets/f9418de7-37e1-4593-b7ab-8bead0af95d4" />

**After**:

<img width="311" height="288" alt="Screenshot 2025-11-11 at 16 05 54" src="https://github.com/user-attachments/assets/bc31d3cf-2ddc-41e0-9240-d6c397a94d9c" />