### PR TITLE
[Misc] Update test - add flag to enable sagemaker stateful sessions management.

### DIFF
--- a/tests/entrypoints/sagemaker/conftest.py
+++ b/tests/entrypoints/sagemaker/conftest.py
@@ -46,7 +46,10 @@ def basic_server_with_lora(smollm2_lora_files):
         "64",
     ]
 
-    envs = {"VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True"}
+    envs = {
+        "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
+        "SAGEMAKER_ENABLE_STATEFUL_SESSIONS": "True",
+    }
     with RemoteOpenAIServer(MODEL_NAME_SMOLLM, args, env_dict=envs) as remote_server:
         yield remote_server
 


### PR DESCRIPTION

## Purpose
Update SageMaker test server to explicitly enable sagemaker stateful sessions management.

## Test Plan
Rerun relevant SageMaker tests.

```bash
pytest tests/entrypoints/openai/sagemaker/test_sagemaker_stateful_sessions.py
```

## Test Result
```bash
pytest tests/entrypoints/sagemaker/test_sagemaker_stateful_sessions.py

/usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
===================================================================== test session starts ======================================================================
platform linux -- Python 3.12.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /vllm-workspace
configfile: pyproject.toml
plugins: anyio-4.6.2.post1, buildkite-test-collector-0.1.9, hydra-core-1.3.2, hypothesis-6.131.0, asyncio-0.24.0, cov-6.3.0, forked-1.6.0, mock-3.14.0, rerunfailures-14.0, shard-0.1.2, subtests-0.14.1, timeout-2.3.1, schemathesis-3.39.15
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 5 items                                                                                                                                              
Running 5 items in this shard

tests/entrypoints/sagemaker/test_sagemaker_stateful_sessions.py .....                                                                                    [100%]

======================================================================= warnings summary =======================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
  /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 5 passed, 3 warnings in 32.64s ================================================================

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

