### PR TITLE
[TPU] Support GCS path in VLLM_TORCH_PROFILER_DIR

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -829,9 +829,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Note that it must be an absolute path.
     "VLLM_TORCH_PROFILER_DIR": lambda: (
         None
-        if os.getenv("VLLM_TORCH_PROFILER_DIR", None) is None
-        else os.path.abspath(
-            os.path.expanduser(os.getenv("VLLM_TORCH_PROFILER_DIR", "."))
+        if (val := os.getenv("VLLM_TORCH_PROFILER_DIR")) is None
+        else (
+            val
+            if val.startswith("gs://") and val[5:] and val[5] != "/"
+            else os.path.abspath(os.path.expanduser(val))
         )
     ),
     # Enable torch profiler to record shapes if set


### PR DESCRIPTION
## Purpose
Allow vllm to take in GCS path as profiler output.

Today, when setting `VLLM_TORCH_PROFILER_DIR` to a GCS path like "gs://abc", `/home/$user/` will be added to the path making it a local absolute path.  See [issue](https://github.com/vllm-project/tpu-inference/issues/1034) and the profile will be written locally to a path like "/home/cuiq_google_com/vllm-cuiq/gs://abc", which is not expected. 

With the fix, the Jax profiler can write profiler directly to GCS(Google Cloud Storage). 

## Test Plan
#### Manual

on TPU machine: 
1. set VLLM_TORCH_PROFILER_DIR="cuiq_profile" and run `vllm bench serve --profile`, profile is written to /home/cuiq_google_com/vllm-cuiq/cuiq_profile

2. set VLLM_TORCH_PROFILER_DIR="gs://vllm-cb-storage2/cuiq/test2" and run `vllm bench serve --profile`, profile is written to gs://vllm-cb-storage2/cuiq/test2

3.  set VLLM_TORCH_PROFILER_DIR="gs:/" and run `vllm bench serve --profile`, profile is written to gs://vllm-cb-storage2/cuiq/test2 , profile is written to local path `/home/cuiq_google_com/vllm-cuiq/gs:`

4. not set VLLM_TORCH_PROFILER_DIRand run `vllm bench serve --profile`,  `"POST /start_profile HTTP/1.1" 404 Not Found`

#### CIT
https://buildkite.com/vllm/ci/builds/38543

