### PR TITLE
Use FLASHINFER MLA backend when testing fp8_kv_scale_compile

### DIFF
--- a/tests/compile/test_full_graph.py
+++ b/tests/compile/test_full_graph.py
@@ -10,6 +10,7 @@ import torch
 
 from tests.quantization.utils import is_quant_method_supported
 from vllm import LLM, SamplingParams
+from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.config import CompilationConfig, CompilationMode, CUDAGraphMode, PassConfig
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
@@ -189,7 +190,7 @@ def test_custom_compile_config(
         ("Qwen/Qwen2-0.5B", None),  # Standard attention model
         (
             "deepseek-ai/DeepSeek-V2-Lite",
-            "FLASHINFER_MLA",
+            AttentionBackendEnum.FLASHINFER_MLA,
         ),  # MLA (Multi-head Latent Attention) model
     ],
 )
@@ -197,10 +198,10 @@ def test_fp8_kv_scale_compile(
     monkeypatch: pytest.MonkeyPatch,
     compilation_mode: int,
     model: str,
-    backend: str | None,
+    backend: AttentionBackendEnum | None,
 ):
     if backend:
-        monkeypatch.setenv("VLLM_ATTENTION_BACKEND", backend)
+        monkeypatch.setenv("VLLM_ATTENTION_BACKEND", backend.name)
 
     model_kwargs = {
         "quantization": "fp8",

--- a/tests/compile/test_full_graph.py
+++ b/tests/compile/test_full_graph.py
@@ -184,13 +184,24 @@ def test_custom_compile_config(
     [CompilationMode.NONE, CompilationMode.VLLM_COMPILE],
 )
 @pytest.mark.parametrize(
-    "model",
+    "model, backend",
     [
-        "Qwen/Qwen2-0.5B",  # Standard attention model
-        "deepseek-ai/DeepSeek-V2-Lite",  # MLA (Multi-head Latent Attention) model
+        ("Qwen/Qwen2-0.5B", None),  # Standard attention model
+        (
+            "deepseek-ai/DeepSeek-V2-Lite",
+            "FLASHINFER_MLA",
+        ),  # MLA (Multi-head Latent Attention) model
     ],
 )
-def test_fp8_kv_scale_compile(compilation_mode: int, model: str):
+def test_fp8_kv_scale_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    compilation_mode: int,
+    model: str,
+    backend: str | None,
+):
+    if backend:
+        monkeypatch.setenv("VLLM_ATTENTION_BACKEND", backend)
+
     model_kwargs = {
         "quantization": "fp8",
         "kv_cache_dtype": "fp8_e4m3",


### PR DESCRIPTION
Fixes #28468

Current Blackwell Fusion E2E Tests uses CUTLASS MLA backend causing IMA.
