### PR TITLE
[ROCm] [Bugfix] Fix `fused_qknorm_rope_kernel` rocm compatibility

### DIFF
--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -175,7 +175,6 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "float epsilon) -> ()");
   ops.impl("fused_add_rms_norm", torch::kCUDA, &fused_add_rms_norm);
 
-#ifndef USE_ROCM
   // Function for fused QK Norm and RoPE
   ops.def(
       "fused_qk_norm_rope(Tensor! qkv, int num_heads_q, "
@@ -183,7 +182,6 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor q_weight, Tensor k_weight, Tensor cos_sin_cache, "
       "bool is_neox, Tensor position_ids) -> ()");
   ops.impl("fused_qk_norm_rope", torch::kCUDA, &fused_qk_norm_rope);
-#endif
 
   // Apply repetition penalties to logits in-place
   ops.def(

--- a/csrc/type_convert.cuh
+++ b/csrc/type_convert.cuh
@@ -67,9 +67,9 @@ struct _typeConvert<c10::Half> {
   }
 };
 
-  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800) || defined(USE_ROCM)
 // CUDA_ARCH < 800 does not have BF16 support
-// TODO: Add in ROCm support once public headers handle bf16 maturely
+// ROCm 7.0+ supports bfloat16
 template <>
 struct _typeConvert<c10::BFloat16> {
   static constexpr bool exists = true;
@@ -89,7 +89,8 @@ struct _typeConvert<c10::BFloat16> {
     return __float22bfloat162_rn(x);
   }
 };
-  #endif  // defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  #endif  // (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800) ||
+          // defined(USE_ROCM)
 #endif    // defined(USE_ROCM) || (defined(CUDA_VERSION) && (CUDA_VERSION >=
           // 12000))
 

--- a/tests/compile/test_qk_norm_rope_fusion.py
+++ b/tests/compile/test_qk_norm_rope_fusion.py
@@ -113,7 +113,7 @@ class QKNormRoPETestModel(torch.nn.Module):
 @pytest.mark.parametrize("enable_rope_custom_op", [True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.skipif(
-    not current_platform.is_cuda(),
+    not current_platform.is_cuda_alike(),
     reason="Only test on cuda platform",
 )
 def test_qk_norm_rope_fusion(

--- a/tests/compile/test_qk_norm_rope_fusion.py
+++ b/tests/compile/test_qk_norm_rope_fusion.py
@@ -114,7 +114,7 @@ class QKNormRoPETestModel(torch.nn.Module):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
-    reason="Only test on cuda platform",
+    reason="Only test on cuda and rocm platform",
 )
 def test_qk_norm_rope_fusion(
     eps, is_neox, enable_rms_norm_custom_op, enable_rope_custom_op, dtype

--- a/tests/kernels/core/test_fused_qk_norm_rope.py
+++ b/tests/kernels/core/test_fused_qk_norm_rope.py
@@ -45,7 +45,7 @@ def _apply_qk_norm_rope(
 
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
-    reason="fused_qk_norm_rope custom op requires cuda platform",
+    reason="fused_qk_norm_rope custom op requires cuda and rocm platform",
 )
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/kernels/core/test_fused_qk_norm_rope.py
+++ b/tests/kernels/core/test_fused_qk_norm_rope.py
@@ -44,7 +44,7 @@ def _apply_qk_norm_rope(
 
 
 @pytest.mark.skipif(
-    not current_platform.is_cuda(),
+    not current_platform.is_cuda_alike(),
     reason="fused_qk_norm_rope custom op requires cuda platform",
 )
 @pytest.mark.parametrize("device", CUDA_DEVICES)

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -184,10 +184,10 @@ class PassConfig:
                     "Fusion enabled but reshape elimination disabled. "
                     "Allreduce + rms norm + quant (fp8) fusion might not work"
                 )
-        if self.enable_qk_norm_rope_fusion and not current_platform.is_cuda():
+        if self.enable_qk_norm_rope_fusion and not current_platform.is_cuda_alike():
             logger.warning_once(
                 "QK Norm + RoPE fusion enabled but the current platform is not "
-                "CUDA. The fusion will be disabled."
+                "CUDA or ROCm. The fusion will be disabled."
             )
             self.enable_qk_norm_rope_fusion = False
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Bugfix for issue https://github.com/vllm-project/vllm/issues/28501 .

This PR https://github.com/vllm-project/vllm/pull/27165 introduced `fused_qknorm_rope_kernel` kernel. Since it is not compiled on ROCm, and the import statement is not handled well, it is throwing import error

```
EngineCore_DP0 pid=1115)   File "/app/rocmvllm/fix-fastsafetensors/vllm/compilation/decorators.py", line 293, in __init__                         
(EngineCore_DP0 pid=1115)     TorchCompileWrapperWithCustomDispatcher.__init__(                                                                    
(EngineCore_DP0 pid=1115)   File "/app/rocmvllm/fix-fastsafetensors/vllm/compilation/wrapper.py", line 42, in __init__                             
(EngineCore_DP0 pid=1115)     backend = vllm_config.compilation_config.init_backend(vllm_config)                                                   
(EngineCore_DP0 pid=1115)               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                   
(EngineCore_DP0 pid=1115)   File "/app/rocmvllm/fix-fastsafetensors/vllm/config/compilation.py", line 770, in init_backend                         
(EngineCore_DP0 pid=1115)     from vllm.compilation.backends import VllmBackend                                                                    
(EngineCore_DP0 pid=1115)   File "/app/rocmvllm/fix-fastsafetensors/vllm/compilation/backends.py", line 40, in <module>                            
(EngineCore_DP0 pid=1115)     from .pass_manager import PostGradPassManager                                                                        
(EngineCore_DP0 pid=1115)   File "/app/rocmvllm/fix-fastsafetensors/vllm/compilation/pass_manager.py", line 20, in <module>                        
(EngineCore_DP0 pid=1115)     from .qk_norm_rope_fusion import QKNormRoPEFusionPass                                                                
(EngineCore_DP0 pid=1115)   File "/app/rocmvllm/fix-fastsafetensors/vllm/compilation/qk_norm_rope_fusion.py", line 24, in <module>                 
(EngineCore_DP0 pid=1115)     FUSED_QK_ROPE_OP = torch.ops._C.fused_qk_norm_rope.default                                                           
(EngineCore_DP0 pid=1115)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                   
(EngineCore_DP0 pid=1115)   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1364, in __getattr__                                
(EngineCore_DP0 pid=1115)     raise AttributeError(                                                                                                
(EngineCore_DP0 pid=1115) AttributeError: '_OpNamespace' '_C' object has no attribute 'fused_qk_norm_rope'  
```

The proposed bugfix is to fix the compatibility and compile the ops for ROCm. Currently is validated and supported on MI300X.

The details of the fixes:
1. Enable compilation for ROCm platform
2. Support 64-bit warp masks (vs 32-bit on CUDA) for `__shfl_xor_sync`
3. Enable BFloat16 support for ROCm 7.0+

This fix is compatible for ROCm7 and above only.

## Test Plan

Pass all of the unit tests that are related to this ops:
1. `tests/kernels/core/test_fused_qk_norm_rope.py`
2. `tests/compile/test_qk_norm_rope_fusion.py`

Command for the fusion pass.

```bash
#!/bin/bash
rm -rf /root/.cache/vllm/
echo "Qwen/Qwen3-30B-A3B-FP8"
export VLLM_RPC_TIMEOUT=1800000
export SAFETENSORS_FAST_GPU=1
export MODEL_PATH=Qwen/Qwen3-30B-A3B-FP8
vllm serve $MODEL_PATH \
-tp 2 \
--trust-remote-code \
--disable-log-requests \
--compilation-config '{"pass_config": {"enable_qk_norm_rope_fusion": 1, "enable_noop": true}, "custom_ops": ["+rms_norm", "+rotary_embedding"]}'
```

Op replacement log:

`[1;36m(Worker_TP1 pid=135636)^[[0;0m DEBUG 11-12 01:36:15 [compilation/qk_norm_rope_fusion.py:235] Fused QK Norm+RoPE on 1 sites`

## Test Result

All tests passed:
1. `tests/kernels/core/test_fused_qk_norm_rope.py`  8/8 tests passed
2. `tests/compile/test_qk_norm_rope_fusion.py` 16/16 tests passed


### Quality Metrics (GSM8K)

| Metric | Without Fusion Pass | With Fusion Pass |
|--------|---------------------|------------------|
| Flexible-extract exact_match | 0.8340 ± 0.0102 | 0.8279 ± 0.0104 |
| Strict-match exact_match | 0.8886 ± 0.0087 | 0.8863 ± 0.0087 |

### Performance Metrics

| Metric | Without Fusion Pass | With Fusion Pass | Change |
|--------|---------------------|------------------|---------|
| Benchmark duration (s) | 38.87 | 38.60 | -0.27s |
| Request throughput (req/s) | 0.82 | 0.83 | +0.01 |
| Output token throughput (tok/s) | 843.04 | 848.90 | +5.86 |
| Peak output token throughput (tok/s) | 896.00 | 904.00 | +8.00 |
| Total token throughput (tok/s) | 1686.09 | 1697.81 | +11.72 |
| **Latency Metrics** |
| Mean TTFT (ms) | 324.17 | 336.16 | +11.99 |
| Median TTFT (ms) | 356.31 | 360.60 | +4.29 |
| P99 TTFT (ms) | 390.08 | 388.64 | -1.44 |
| Mean TPOT (ms) | 9.16 | 9.09 | -0.07 |
| Median TPOT (ms) | 9.11 | 9.04 | -0.07 |
| P99 TPOT (ms) | 9.41 | 9.36 | -0.05 |
| Mean ITL (ms) | 9.19 | 9.11 | -0.08 |
| Median ITL (ms) | 9.09 | 9.00 | -0.09 |
| P99 ITL (ms) | 9.40 | 9.38 | -0.02 |


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

