### PR TITLE
[Bugfix] Add explicit cuBLAS linking to _C extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -858,6 +858,15 @@ if (VLLM_GPU_LANG STREQUAL "HIP")
 endif()
 
 message(STATUS "Enabling C extension.")
+
+# Link cuBLAS for CUDA builds (required for kernels, e.g. GPTQ kernels in q_gemm.cu)
+if(VLLM_GPU_LANG STREQUAL "CUDA")
+  find_package(CUDAToolkit REQUIRED)
+  set(VLLM_C_LIBRARIES CUDA::cublas)
+else()
+  set(VLLM_C_LIBRARIES)
+endif()
+
 define_extension_target(
   _C
   DESTINATION vllm
@@ -865,6 +874,7 @@ define_extension_target(
   SOURCES ${VLLM_EXT_SRC}
   COMPILE_FLAGS ${VLLM_GPU_FLAGS}
   ARCHITECTURES ${VLLM_GPU_ARCHES}
+  LIBRARIES ${VLLM_C_LIBRARIES}
   INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
   INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
   USE_SABI 3


### PR DESCRIPTION
## Purpose
Fix undefined symbol errors when importing vLLM on systems with strict ELF symbol scoping.

The `_C` extension directly calls cuBLAS functions (`cublasHgemm`, `cublasGemmEx`, etc.) in `csrc/quantization/gptq/q_gemm.cu` but wasn't explicitly linking against `libcublas`. 

## Solution

Add `CUDA::cublas` to the `_C` extension's `LIBRARIES` using CMake's `CUDAToolkit` package. This properly adds `libcublas.so.12` to the NEEDED entries.

## Test Plan

### Reproduce the bug in official wheels:
```bash
# Download and inspect official wheel
pip download vllm --no-deps
unzip -j vllm*.whl "vllm/_C.abi3.so" -d /tmp/

# Check for undefined cuBLAS symbols
nm -D /tmp/_C.abi3.so | grep "U cublas"
# Shows: U cublasGemmEx, U cublasGetMathMode, U cublasHgemm

# Check if libcublas is in NEEDED
readelf -d /tmp/_C.abi3.so | grep NEEDED | grep cublas
# Empty - libcublas.so.12 is missing

# Test import (on strict systems)
pip install vllm
python -c "import vllm._C"
# ImportError: undefined symbol: cublasGemmEx
```

### Verify the fix:
```
uv pip install -e . --no-cache-dir # Build with fix

# Verify libcublas is now in NEEDED
readelf -d vllm/_C.abi3.so | grep NEEDED | grep cublas
# Shows: libcublas.so.12

# Test import
python -c "import vllm._C; print('SUCCESS')"

# Test CLI
vllm --help # Works 
```

## Test Result

###   Before Fix - Official Wheel
```
# Undefined symbols found:
$ nm -D /tmp/_C.abi3.so | grep "U cublas"
                   U cublasGemmEx
                   U cublasGetMathMode
                   U cublasHgemm

# Missing from NEEDED:
$ readelf -d /tmp/_C.abi3.so | grep NEEDED | grep cublas
# (empty - libcublas.so.12 not listed)
# Import fails:
$ python -c "import vllm._C"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: /path/to/vllm/_C.abi3.so: undefined symbol: cublasGemmEx
```

###  After Fix - Source Build
```
# libcublas now in NEEDED:
  $ readelf -d vllm/_C.abi3.so | grep NEEDED
   0x0000000000000001 (NEEDED)             Shared library: [libcublas.so.12]  ← Added!
   0x0000000000000001 (NEEDED)             Shared library: [libtorch.so]
   0x0000000000000001 (NEEDED)             Shared library: [libcudart.so.12]
   0x0000000000000001 (NEEDED)             Shared library: [libcuda.so.1]
   0x0000000000000001 (NEEDED)             Shared library: [libtorch_cpu.so]
   0x0000000000000001 (NEEDED)             Shared library: [libtorch_cuda.so]
   ... (remaining libraries)

# Import succeeds:
$ python -c "import vllm._C"
# no error

$ vllm --help # Works
```

## Environment Tested
 - glibc 2.34
  - Python 3.12.12
  - CUDA 12.8
  - with strict ELF symbol scoping (RTLD_LOCAL)

