### PR TITLE
[Benchmark] Fix client seed synchronization in multi-turn benchmark

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -541,8 +541,11 @@ async def client_main(
         f"{Color.CYAN}Started client {client_id}: max_num_requests={args.max_num_requests}, max_active_conversations={args.max_active_conversations}{Color.RESET}"  # noqa: E501
     )
 
-    random.seed(args.seed)
-    np.random.seed(args.seed)
+    # Set unique seed per client (each client runs in its own process)
+    # Add 1 to ensure no client uses the same seed as the main process
+    client_seed = args.seed + client_id + 1
+    random.seed(client_seed)
+    np.random.seed(client_seed)
 
     # Active conversations
     active_convs: ConversationsMap = {}
@@ -1456,6 +1459,7 @@ async def main() -> None:
             f"Invalid --warmup-percentage={args.warmup_percentage}"
         ) from None
 
+    # Set global seeds for main process
     random.seed(args.seed)
     np.random.seed(args.seed)
 


### PR DESCRIPTION
## Problem

All clients in multi-turn benchmark use the same seed value, causing them to generate identical random sequences. This leads to synchronized behavior where all clients sleep for the same duration and make requests at the same time, defeating the purpose of Poisson-distributed request timing.

## Evidence

Real logs showing the synchronization issue:
```
10-11-2025 23:43:34 [INFO] - Client 60 will use conversation ID CONV_ID_60 (active conversations 1)
10-11-2025 23:43:34 [INFO] - Client 61 will use conversation ID CONV_ID_61 (active conversations 1)
10-11-2025 23:43:34 [INFO] - Client 62 will use conversation ID CONV_ID_62 (active conversations 1)
10-11-2025 23:43:34 [INFO] - Client 63 will use conversation ID CONV_ID_63 (active conversations 1)
10-11-2025 23:43:44 [INFO] - Sleeping for 0.796 seconds...
10-11-2025 23:43:44 [INFO] - Sleeping for 0.796 seconds...
10-11-2025 23:43:44 [INFO] - Sleeping for 0.796 seconds...
10-11-2025 23:43:54 [INFO] - Sleeping for 0.796 seconds...
```

All clients sleep for exactly 0.796 seconds because they use the same random seed.

## Solution

Add `client_id` to the seed value to ensure each client has a unique but reproducible random sequence:

```python
# Before
random.seed(args.seed)
np.random.seed(args.seed)

# After
client_seed = args.seed + client_id + 1
random.seed(client_seed)
np.random.seed(client_seed)
```

## Impact

- Each client now generates different random intervals
- Request timing is properly distributed according to Poisson process
- Benchmark results will be more realistic
- Results remain reproducible with the same seed and client configuration