### PR TITLE
[XPU]Fix crash due to removed VLLM_USE_V1 attribute

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -65,7 +65,6 @@ class XPUPlatform(Platform):
 
         if use_sparse:
             raise NotImplementedError("Sparse Attention is not supported on XPU.")
-        use_v1 = envs.VLLM_USE_V1
         if not use_v1:
             raise ValueError("XPU backend only supports V1.")
         if selected_backend == AttentionBackendEnum.TRITON_ATTN:
@@ -115,7 +114,9 @@ class XPUPlatform(Platform):
     @classmethod
     def get_vit_attn_backend(
         cls, head_size: int, dtype: torch.dtype
-    ) -> AttentionBackendEnum:
+    ) -> "AttentionBackendEnum":
+        from vllm.attention.backends.registry import AttentionBackendEnum
+
         return AttentionBackendEnum.FLASH_ATTN
 
     @classmethod


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

1. Fix crash due to removed VLLM_USE_V1 attribute 
2.  Fix AttentionBackendEnum.FLASH_ATTN fails because **AttentionBackendEnum** is None.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

