### PR TITLE
[CI/Build] Fix crash due to removed VLLM_USE_V1 attribute in EPD

### DIFF
--- a/vllm/distributed/ec_transfer/ec_transfer_state.py
+++ b/vllm/distributed/ec_transfer/ec_transfer_state.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import TYPE_CHECKING
 
-from vllm import envs
 from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorBase,
     ECConnectorRole,
@@ -38,9 +37,6 @@ def ensure_ec_transfer_initialized(vllm_config: "VllmConfig") -> None:
         vllm_config.ec_transfer_config.is_ec_transfer_instance
         and _EC_CONNECTOR_AGENT is None
     ):
-        if envs.VLLM_USE_V1:
-            _EC_CONNECTOR_AGENT = ECConnectorFactory.create_connector(
-                config=vllm_config, role=ECConnectorRole.WORKER
-            )
-        else:
-            raise ValueError("V0 is no longer supported")
+        _EC_CONNECTOR_AGENT = ECConnectorFactory.create_connector(
+            config=vllm_config, role=ECConnectorRole.WORKER
+        )


### PR DESCRIPTION
## Purpose

Fix the CI fail due to removed VLLM_USE_V1 attribute in EPD

@ywang96  @DarkLight1337  

<img width="1482" height="350" alt="image" src="https://github.com/user-attachments/assets/cd43bd34-39b4-4c87-8ea6-c69f9e191aa6" />
