### PR TITLE
Fix Llama4 Pipeline Parallelism

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -10,6 +10,6 @@ torchaudio==2.9.0
 # These must be updated alongside torch
 torchvision==0.24.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # Build from https://github.com/facebookresearch/xformers/releases/tag/v0.0.32.post1
-xformers==0.0.33+5d4b92a5.d20251029; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
+# xformers==0.0.33+5d4b92a5.d20251029; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.5.2

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -10,6 +10,6 @@ torchaudio==2.9.0
 # These must be updated alongside torch
 torchvision==0.24.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # Build from https://github.com/facebookresearch/xformers/releases/tag/v0.0.32.post1
-# xformers==0.0.33+5d4b92a5.d20251029; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
+xformers==0.0.33+5d4b92a5.d20251029; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.5.2

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -738,8 +738,9 @@ class Llama4ForCausalLM(LlamaForCausalLM, MixtureOfExperts):
         self.moe_layers = []
         example_moe = None
         for layer in self.model.layers:
-            assert isinstance(layer, Llama4DecoderLayer)
-            if isinstance(layer.feed_forward, Llama4MoE):
+            if isinstance(layer, Llama4DecoderLayer) and isinstance(
+                layer.feed_forward, Llama4MoE
+            ):
                 # Pick last one layer since the first ones may be dense layers.
                 example_moe = layer.feed_forward
                 self.moe_layers.append(layer.feed_forward.experts)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix Llama4 Pipeline Parallelism Assert Error

## Test Plan

from vllm import LLM
llm = LLM("meta-llama/Llama-4-Scout-17B-16E-Instruct", pipeline_parallel_size=4)
output= llm.generate("Hi, vLLM is a")

## Test Result
The llama4 model can be loaded successfully, and generate correct response. 

## details
When enabling PP for Llama4 model, each rank has a few `PPMissingLayer()`. The line `assert isinstance(layer, Llama4DecoderLayer)` raises assert error when encountering `PPMissingLayer()`. This PR fixed this bug by using if condition to check the layer is Llama4DecoderLayer.
