### PR TITLE
[Bugfix] Eliminate tuple inputs to submodules in graph partitioning

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -443,6 +443,7 @@ steps:
     - vllm/
     - tests/compile
   commands:
+    - pytest -v -s compile/test_graph_partition.py
     - pytest -v -s compile/test_config.py
     - pytest -v -s compile/test_pass_manager.py
     - pytest -v -s compile/test_fusion.py

--- a/tests/compile/test_graph_partition.py
+++ b/tests/compile/test_graph_partition.py
@@ -17,6 +17,7 @@ def test_getitem_moved_to_producer_subgraph():
 
     class TupleOutputModule(torch.nn.Module):
         """Tuple producer."""
+
         def forward(
             self, x: torch.Tensor, y: torch.Tensor
         ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -82,6 +83,7 @@ def test_no_tuple_inputs_with_multiple_consumers():
 
     class TupleOutputModule(torch.nn.Module):
         """Tuple producer."""
+
         def forward(
             self, x: torch.Tensor, y: torch.Tensor
         ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -91,6 +93,7 @@ def test_no_tuple_inputs_with_multiple_consumers():
 
     class MultiConsumerModel(torch.nn.Module):
         """Tuple (multi-)consumer."""
+
         def __init__(self):
             super().__init__()
             self.submod = TupleOutputModule()

--- a/tests/compile/test_graph_partition.py
+++ b/tests/compile/test_graph_partition.py
@@ -5,6 +5,7 @@ import operator
 
 import pytest
 import torch
+from torch.fx.experimental.proxy_tensor import make_fx
 
 from vllm.compilation.backends import split_graph
 
@@ -15,38 +16,29 @@ def test_getitem_moved_to_producer_subgraph():
     preventing tuple inputs to submodules.
     """
 
-    class TupleOutputModule(torch.nn.Module):
-        """Tuple producer."""
+    def model_fn(x: torch.Tensor) -> torch.Tensor:
+        # torch.split returns a tuple, creating real getitem operations
+        # Should become first submodule that produces tuple
+        chunks = torch.split(x, x.shape[0] // 2, dim=0)
 
-        def forward(
-            self, x: torch.Tensor, y: torch.Tensor
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            a = x + 1
-            b = y + 2
-            return a, b
+        # Following ops should become second submodule that consumes tuple
+        result_0 = torch.relu(chunks[0])
+        result_1 = torch.relu(chunks[1])
+        return torch.cat([result_0, result_1], dim=0)
 
-    class ConsumeTupleElementsModule(torch.nn.Module):
-        """Tuple consumer."""
+    x = torch.randn(4, 3)
+    gm = make_fx(model_fn)(x)
 
-        def __init__(self):
-            super().__init__()
-            self.submod = TupleOutputModule()
+    has_getitem = any(
+        node.op == "call_function" and node.target == operator.getitem
+        for node in gm.graph.nodes
+    )
+    assert has_getitem, "Test setup failed: graph should contain getitem operations"
 
-        def forward(
-            self, x: torch.Tensor, y: torch.Tensor
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            t = self.submod(x, y)
-            a = torch.nn.functional.relu(t[0])
-            b = torch.nn.functional.relu(t[1])
-            return a, b
-
-    model = ConsumeTupleElementsModule()
-    gm = torch.fx.symbolic_trace(model)
-
-    split_ops = [torch.ops.aten.relu.default]
+    # Split on tuple producer aten::split
+    split_ops = ["aten::split.Tensor"]
     split_gm, split_items = split_graph(gm, split_ops)
-
-    assert len(split_items) > 0, "Graph should be split into submodules"
+    assert len(split_items) == 2, "Graph should be split into 2 submodules"
 
     for split_item in split_items:
         submodule = split_item.graph
@@ -66,51 +58,49 @@ def test_getitem_moved_to_producer_subgraph():
             "This means tuple inputs were not properly eliminated."
         )
 
-    x = torch.randn(2, 3)
-    y = torch.randn(2, 3)
-    output_original = gm(x, y)
-    output_split = split_gm(x, y)
+    new_x = torch.randn(4, 3)
+    output_original = gm(new_x)
+    output_split = split_gm(new_x)
 
-    assert torch.allclose(output_original[0], output_split[0]), "First output mismatch"
-    assert torch.allclose(output_original[1], output_split[1]), "Second output mismatch"
+    assert torch.allclose(output_original, output_split), "Output mismatch"
 
 
 def test_no_tuple_inputs_with_multiple_consumers():
     """
-    Test that when a tuple is consumed by multiple submodules,
+    Test that when a tuple is consumed by multiple split operations,
     getitem operations are properly moved to avoid tuple inputs.
     """
 
-    class TupleOutputModule(torch.nn.Module):
-        """Tuple producer."""
+    def model_fn(x: torch.Tensor) -> torch.Tensor:
+        # torch.split returns a tuple, creating real getitem operations
+        # Should become first submodule that produces tuple
+        chunks = torch.split(x, x.shape[0] // 2, dim=0)
 
-        def forward(
-            self, x: torch.Tensor, y: torch.Tensor
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            a = x + 1
-            b = y + 2
-            return a, b
+        # These should become second submodule consuming tuple
+        result_1 = torch.relu(chunks[0])
+        result_2 = torch.relu(chunks[1])
 
-    class MultiConsumerModel(torch.nn.Module):
-        """Tuple (multi-)consumer."""
+        # Artificial graph splitting point to create another
+        # independent submodule that consumes tuple later
+        # This would become the third submodule
+        result_1 = torch.sigmoid(result_1)
 
-        def __init__(self):
-            super().__init__()
-            self.submod = TupleOutputModule()
+        # Fourth submodule that consumes tuple
+        result = torch.cat([chunks[0], chunks[1], result_1, result_2])
+        return result
 
-        def forward(self, x: torch.Tensor) -> torch.Tensor:
-            t = self.submod(x + 1, x + 2)
-            r1 = torch.nn.functional.sigmoid(t[0])
-            r2 = torch.nn.functional.tanh(t[1])
-            # Add relu so the last subgraph has real computation
-            r2_relu = torch.nn.functional.relu(r2)
-            return r1 + r2_relu
+    x = torch.randn(4, 3)
+    gm = make_fx(model_fn)(x)
 
-    model = MultiConsumerModel()
-    gm = torch.fx.symbolic_trace(model)
+    has_getitem = any(
+        node.op == "call_function" and node.target == operator.getitem
+        for node in gm.graph.nodes
+    )
+    assert has_getitem, "Test setup failed: graph should contain getitem operations"
 
-    split_ops = [torch.ops.aten.sigmoid.default, torch.ops.aten.tanh.default]
+    split_ops = ["aten::split.Tensor", "aten::sigmoid"]
     split_gm, split_items = split_graph(gm, split_ops)
+    assert len(split_items) == 4, "Graph should be split into 4 submodules"
 
     for split_item in split_items:
         submodule = split_item.graph
@@ -127,8 +117,8 @@ def test_no_tuple_inputs_with_multiple_consumers():
                     "a tuple input"
                 )
 
-    x = torch.randn(2, 3)
-    output_original = gm(x)
-    output_split = split_gm(x)
+    new_x = torch.randn(4, 3)
+    output_original = gm(new_x)
+    output_split = split_gm(new_x)
 
     assert torch.allclose(output_original, output_split), "Output mismatch after split"

--- a/tests/compile/test_graph_partition.py
+++ b/tests/compile/test_graph_partition.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import operator
+
+import pytest
+import torch
+
+from vllm.compilation.backends import split_graph
+
+
+def test_getitem_moved_to_producer_subgraph():
+    """
+    Test that getitem operations are moved to the same subgraph as their input,
+    preventing tuple inputs to submodules.
+    """
+
+    class TupleOutputModule(torch.nn.Module):
+        """Tuple producer."""
+        def forward(
+            self, x: torch.Tensor, y: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            a = x + 1
+            b = y + 2
+            return a, b
+
+    class ConsumeTupleElementsModule(torch.nn.Module):
+        """Tuple consumer."""
+
+        def __init__(self):
+            super().__init__()
+            self.submod = TupleOutputModule()
+
+        def forward(
+            self, x: torch.Tensor, y: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            t = self.submod(x, y)
+            a = torch.nn.functional.relu(t[0])
+            b = torch.nn.functional.relu(t[1])
+            return a, b
+
+    model = ConsumeTupleElementsModule()
+    gm = torch.fx.symbolic_trace(model)
+
+    split_ops = [torch.ops.aten.relu.default]
+    split_gm, split_items = split_graph(gm, split_ops)
+
+    assert len(split_items) > 0, "Graph should be split into submodules"
+
+    for split_item in split_items:
+        submodule = split_item.graph
+
+        getitem_on_placeholder = []
+        for node in submodule.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target == operator.getitem
+                and node.args[0].op == "placeholder"
+            ):
+                getitem_on_placeholder.append(node)
+
+        assert len(getitem_on_placeholder) == 0, (
+            f"Submodule {split_item.submod_name} has getitem operations on "
+            f"placeholder nodes: {[n.name for n in getitem_on_placeholder]}. "
+            "This means tuple inputs were not properly eliminated."
+        )
+
+    x = torch.randn(2, 3)
+    y = torch.randn(2, 3)
+    output_original = gm(x, y)
+    output_split = split_gm(x, y)
+
+    assert torch.allclose(output_original[0], output_split[0]), "First output mismatch"
+    assert torch.allclose(output_original[1], output_split[1]), "Second output mismatch"
+
+
+def test_no_tuple_inputs_with_multiple_consumers():
+    """
+    Test that when a tuple is consumed by multiple submodules,
+    getitem operations are properly moved to avoid tuple inputs.
+    """
+
+    class TupleOutputModule(torch.nn.Module):
+        """Tuple producer."""
+        def forward(
+            self, x: torch.Tensor, y: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            a = x + 1
+            b = y + 2
+            return a, b
+
+    class MultiConsumerModel(torch.nn.Module):
+        """Tuple (multi-)consumer."""
+        def __init__(self):
+            super().__init__()
+            self.submod = TupleOutputModule()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            t = self.submod(x + 1, x + 2)
+            r1 = torch.nn.functional.sigmoid(t[0])
+            r2 = torch.nn.functional.tanh(t[1])
+            # Add relu so the last subgraph has real computation
+            r2_relu = torch.nn.functional.relu(r2)
+            return r1 + r2_relu
+
+    model = MultiConsumerModel()
+    gm = torch.fx.symbolic_trace(model)
+
+    split_ops = [torch.ops.aten.sigmoid.default, torch.ops.aten.tanh.default]
+    split_gm, split_items = split_graph(gm, split_ops)
+
+    for split_item in split_items:
+        submodule = split_item.graph
+
+        for node in submodule.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target == operator.getitem
+                and node.args[0].op == "placeholder"
+            ):
+                pytest.fail(
+                    f"Submodule {split_item.submod_name} has getitem on "
+                    f"placeholder {node.args[0].name}, indicating it receives "
+                    "a tuple input"
+                )
+
+    x = torch.randn(2, 3)
+    output_original = gm(x)
+    output_split = split_gm(x)
+
+    assert torch.allclose(output_original, output_split), "Output mismatch after split"

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -317,10 +317,7 @@ def split_graph(
         # Check if this is a getitem operation on a node from an earlier subgraph.
         # If so, assign it to the same subgraph as its input to avoid passing entire
         # tuple as input to submodules, which is against AoTAutograd input requirement.
-        if (
-            node.op == "call_function"
-            and node.target == operator.getitem
-        ):
+        if node.op == "call_function" and node.target == operator.getitem:
             # Assign this getitem to the same subgraph as its input
             input_node = node.args[0]
             if input_node in node_to_subgraph_id:

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -321,9 +321,10 @@ def split_graph(
         if node.op == "call_function" and node.target == operator.getitem:
             # Assign this getitem to the same subgraph as its input
             input_node = node.args[0]
-            assert input_node in node_to_subgraph_id
-            node_to_subgraph_id[node] = node_to_subgraph_id[input_node]
-            continue
+            if input_node.op != "placeholder":
+                assert input_node in node_to_subgraph_id
+                node_to_subgraph_id[node] = node_to_subgraph_id[input_node]
+                continue
 
         if should_split(node, splitting_ops):
             subgraph_id += 1

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -316,7 +316,8 @@ def split_graph(
 
         # Check if this is a getitem operation on a node from an earlier subgraph.
         # If so, assign it to the same subgraph as its input to avoid passing entire
-        # tuple as input to submodules, which is against AoTAutograd input requirement.
+        # tuple as input to submodules, which is against standalone_compile and
+        # AoTAutograd input requirement.
         if node.op == "call_function" and node.target == operator.getitem:
             # Assign this getitem to the same subgraph as its input
             input_node = node.args[0]

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -321,9 +321,9 @@ def split_graph(
         if node.op == "call_function" and node.target == operator.getitem:
             # Assign this getitem to the same subgraph as its input
             input_node = node.args[0]
-            if input_node in node_to_subgraph_id:
-                node_to_subgraph_id[node] = node_to_subgraph_id[input_node]
-                continue
+            assert input_node in node_to_subgraph_id
+            node_to_subgraph_id[node] = node_to_subgraph_id[input_node]
+            continue
 
         if should_split(node, splitting_ops):
             subgraph_id += 1

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -4,6 +4,7 @@
 import ast
 import dataclasses
 import hashlib
+import operator
 import os
 import pprint
 import time
@@ -312,6 +313,19 @@ def split_graph(
     for node in graph.graph.nodes:
         if node.op in ("output", "placeholder"):
             continue
+
+        # Check if this is a getitem operation on a node from an earlier subgraph.
+        # If so, assign it to the same subgraph as its input to avoid passing entire
+        # tuple as input to submodules, which is against AoTAutograd input requirement.
+        if (
+            node.op == "call_function"
+            and node.target == operator.getitem
+        ):
+            # Assign this getitem to the same subgraph as its input
+            input_node = node.args[0]
+            if input_node in node_to_subgraph_id:
+                node_to_subgraph_id[node] = node_to_subgraph_id[input_node]
+                continue
 
         if should_split(node, splitting_ops):
             subgraph_id += 1

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -308,8 +308,8 @@ def split_graph(
 ) -> tuple[fx.GraphModule, list[SplitItem]]:
     # split graph by ops
     subgraph_id = 0
-    node_to_subgraph_id = {}
-    split_op_graphs = []
+    node_to_subgraph_id: dict[fx.Node, int] = {}
+    split_op_graphs: list[int] = []
     for node in graph.graph.nodes:
         if node.op in ("output", "placeholder"):
             continue


### PR DESCRIPTION
Move `getitem` operations to the same subgraph as their input to prevent submodules from receiving tuple arguments. 

This is to fix issues like [#24915](https://github.com/vllm-project/vllm/issues/24915) where `split_graph` partitioned graph at a node that produces a tuple, which is then passed to subsequent submodules as input. This unfortunately does not conform to the calling convention of AoT Autograd modules, which requires flattened arguments.

Signed-off-by: Yanan Cao <gmagogsfm@gmail.com>