### PR TITLE
[Hardware][PowerPC] Fix fp16 compilation error for Power in cpu attention backend and bump oneDNN version

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -219,7 +219,7 @@ if ((AVX512_FOUND AND NOT AVX512_DISABLED) OR (ASIMD_FOUND AND NOT APPLE_SILICON
                 SUBBUILD_DIR "${FETCHCONTENT_BASE_DIR}/arm_compute-subbuild"
                 SOURCE_DIR   "${FETCHCONTENT_BASE_DIR}/arm_compute-src"
                 GIT_REPOSITORY https://github.com/ARM-software/ComputeLibrary.git
-                GIT_TAG        v52.2.0
+                GIT_TAG        v52.6.0
                 GIT_SHALLOW    TRUE
                 GIT_PROGRESS   TRUE
             )

--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -272,7 +272,7 @@ if ((AVX512_FOUND AND NOT AVX512_DISABLED) OR (ASIMD_FOUND AND NOT APPLE_SILICON
         FetchContent_Declare(
             oneDNN
             GIT_REPOSITORY https://github.com/oneapi-src/oneDNN.git
-            GIT_TAG v3.9
+            GIT_TAG v3.10
             GIT_PROGRESS TRUE
             GIT_SHALLOW TRUE
         )

--- a/csrc/cpu/cpu_attn_impl.hpp
+++ b/csrc/cpu/cpu_attn_impl.hpp
@@ -821,10 +821,12 @@ struct VecTypeTrait<c10::BFloat16> {
   using vec_t = vec_op::BF16Vec16;
 };
 
+#if !defined(__powerpc__)
 template <>
 struct VecTypeTrait<c10::Half> {
   using vec_t = vec_op::FP16Vec16;
 };
+#endif
 
 template <typename T>
 void print_logits(const char* name, T* ptr, int32_t row, int32_t col,


### PR DESCRIPTION
# Purpose

Fix Power compilation failure: PR [#27954](https://github.com/vllm-project/vllm/pull/27954)
 refactored the attention backend for CPU, but the build fails on Power due to the use of fp16, which is not supported on this architecture. This PR addresses that issue (also mentioned in my review on the original PR).

Update oneDNN to v3.10: The oneDNN PR [uxlfoundation/oneDNN#4002](https://github.com/uxlfoundation/oneDNN/pull/4002)
 — included in v3.10 — fixes a compilation failure on Power9 systems. Bumping the version here resolves that issue as well.

cc: @bigPYJ1151
