### PR TITLE
Fix KV sharing fast prefill with cudagraph enabled

### DIFF
--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -1019,11 +1019,6 @@ def create_fast_prefill_custom_backend(
                     for _field in fields(metadata.__class__):
                         setattr(self, _field.name, getattr(metadata, _field.name))
 
-                    # Set additional fields that will be used in model code
-                    assert (
-                        common_attn_metadata.logits_indices_padded is not None
-                        and common_attn_metadata.num_logits_indices is not None
-                    )
                     self.logits_indices_padded = (
                         common_attn_metadata.logits_indices_padded
                     )

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -965,12 +965,6 @@ def reshape_attn_output_for_spec_decode(attn_output: torch.Tensor) -> torch.Tens
     return attn_output.view(total_tokens, attn_output.shape[2], attn_output.shape[3])
 
 
-KV_SHARING_FAST_PREFILL_METADATA_FIELDS = [
-    ("logits_indices_padded", torch.Tensor | None, None),
-    ("num_logits_indices", int, 0),
-]
-
-
 def subclass_attention_metadata(
     name_prefix: str,
     metadata_cls: Any,
@@ -986,8 +980,8 @@ def subclass_attention_metadata(
 
 @runtime_checkable
 class KVSharingFastPrefillMetadata(Protocol):
-    logits_indices_padded: torch.Tensor
-    num_logits_indices: int
+    logits_indices_padded: torch.Tensor | None = None
+    num_logits_indices: int | None = None
 
 
 def create_fast_prefill_custom_backend(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1314,7 +1314,7 @@ class GPUModelRunner(
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
         """
         logits_indices_padded = None
-        num_logits_indices = 0
+        num_logits_indices = None
         if logits_indices is not None:
             num_logits_indices = logits_indices.size(0)
             if self.cache_config.kv_sharing_fast_prefill:


### PR DESCRIPTION
## Purpose

`--kv-sharing-fast-prefill` works if using `--enforce-eager` but not without:

```
File "/vllm/vllm/v1/attention/backends/utils.py", line 1005, in __init__
   common_attn_metadata.logits_indices_padded is not None
AssertionError
```

This is because we now build attention metadata for cudagraph capture during dummy runs but this doesn't have logits information. 

As a fix, we can just skip this assertion which will set `logits_indices_padded` and `num_logits` to `None`. Currently this optimization is only supported for Gemma3n, which has logic to skip necessary parts in the model:

https://github.com/vllm-project/vllm/blob/91864b79b36e5a7799f90c1c350e663d484bcfee/vllm/model_executor/models/gemma3n.py#L920-L925

https://github.com/vllm-project/vllm/blob/91864b79b36e5a7799f90c1c350e663d484bcfee/vllm/model_executor/models/gemma3n.py#L953-L958

Also re-enables test in CI that was being skipped before

## Test Plan
serve Gemma3n with fast prefill enabled
```
vllm serve google/gemma-3n-E2B-it -tp 1 --kv-sharing-fast-prefill
```

run chartqa eval:
```
lm_eval --model local-chat-completions --tasks chartqa --model_args model=google/gemma-3n-E2B-it,base_url=http://localhost:8000/v1/chat/completions --apply_chat_template --limit 100
```

Run e2e test
```
pytest tests/v1/e2e/test_kv_sharing_fast_prefill.py
```

## Test Result

expected eval without `--kv-sharing-fast-prefill`
```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value|   |Stderr|
|-------|------:|------|-----:|-----------------|---|----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  | 0.63|±  |0.0485|
|       |       |none  |     0|exact_match      |↑  | 0.47|±  |0.0502|
|       |       |none  |     0|relaxed_accuracy |↑  | 0.62|±  |0.0488|
```

eval with `--kv-sharing-fast-prefill`
```
| Tasks |Version|Filter|n-shot|     Metric      |   |Value|   |Stderr|
|-------|------:|------|-----:|-----------------|---|----:|---|-----:|
|chartqa|      0|none  |     0|anywhere_accuracy|↑  | 0.63|±  |0.0485|
|       |       |none  |     0|exact_match      |↑  | 0.47|±  |0.0502|
|       |       |none  |     0|relaxed_accuracy |↑  | 0.62|±  |0.0488|
```

Test passes:
```
tests/v1/e2e/test_kv_sharing_fast_prefill.py::test_kv_sharing_fast_prefill[True-False] PASSED                                                                                                            [ 25%]
tests/v1/e2e/test_kv_sharing_fast_prefill.py::test_kv_sharing_fast_prefill[True-True] PASSED                                                                                                             [ 50%]
tests/v1/e2e/test_kv_sharing_fast_prefill.py::test_kv_sharing_fast_prefill[False-False] PASSED                                                                                                           [ 75%]
tests/v1/e2e/test_kv_sharing_fast_prefill.py::test_kv_sharing_fast_prefill[False-True] PASSED                                                                                                            [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

