### PR TITLE
Update xformers to 0.0.32.post2 instead of dev commit

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,7 +9,6 @@ torch==2.9.0
 torchaudio==2.9.0
 # These must be updated alongside torch
 torchvision==0.24.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-# Build from https://github.com/facebookresearch/xformers/releases/tag/v0.0.32.post1
-xformers==0.0.33+5d4b92a5.d20251029; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
+xformers==0.0.32.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.5.2


### PR DESCRIPTION

## Purpose

We were installing a non-released version of xformers for CUDA:
0.0.33+5d4b92a5.d20251029

5d4b92a5 is actually the commit for 0.0.32.post2 tag, so this PR just
replace the version so it's cleaner and we now consumed a stable tag
(which by the way is the latest).
