### PR TITLE
[Bugfix] Fix SM100 gpt-oss regression due to faulty attn sink support

### DIFF
--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -34,12 +34,13 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
     "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/",  # noqa: E501
 )
 
+
 @functools.cache
 def has_flashinfer_cubin() -> bool:
     """Return `True` if flashinfer-cubin package is available."""
     if envs.VLLM_HAS_FLASHINFER_CUBIN:
         return True
-    if importlib.util.find_spec("flashinfer-cubin") is not None:
+    if importlib.util.find_spec("flashinfer_cubin") is not None:
         return True
     logger.debug_once("flashinfer-cubin package was not found")
     return False

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -34,10 +34,20 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
     "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/",  # noqa: E501
 )
 
+@functools.cache
+def has_flashinfer_cubin() -> bool:
+    """Return `True` if flashinfer-cubin package is available."""
+    if envs.VLLM_HAS_FLASHINFER_CUBIN:
+        return True
+    if importlib.util.find_spec("flashinfer-cubin") is not None:
+        return True
+    logger.debug_once("flashinfer-cubin package was not found")
+    return False
+
 
 @functools.cache
 def has_flashinfer() -> bool:
-    """Return `True` if FlashInfer is available."""
+    """Return `True` if flashinfer-python package is available."""
     # Use find_spec to check if the module exists without importing it
     # This avoids potential CUDA initialization side effects
     if importlib.util.find_spec("flashinfer") is None:
@@ -45,7 +55,7 @@ def has_flashinfer() -> bool:
         return False
     # When not using flashinfer cubin,
     # Also check if nvcc is available since it's required to JIT compile flashinfer
-    if not envs.VLLM_HAS_FLASHINFER_CUBIN and shutil.which("nvcc") is None:
+    if not has_flashinfer_cubin() and shutil.which("nvcc") is None:
         logger.debug_once(
             "FlashInfer unavailable since nvcc was not found "
             "and not using pre-downloaded cubins"
@@ -183,9 +193,8 @@ def has_nvidia_artifactory() -> bool:
     This checks connectivity to the kernel inference library artifactory
     which is required for downloading certain cubin kernels like TRTLLM FHMA.
     """
-    # Since FLASHINFER_CUBIN_DIR defines the pre-downloaded cubins path, when
-    # it's true, we could assume the cubins are available.
-    if envs.VLLM_HAS_FLASHINFER_CUBIN:
+    # If we have pre-downloaded cubins, we can assume the cubins are available.
+    if has_flashinfer_cubin():
         return True
 
     try:

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -218,9 +218,13 @@ def has_nvidia_artifactory() -> bool:
 @functools.cache
 def supports_trtllm_attention() -> bool:
     """
-    TRTLLM attention is supported if the platform is SM100 and
-    NVIDIA artifactory is accessible
+    TRTLLM attention is supported if the platform is SM100,
+    NVIDIA artifactory is accessible, and batch-invariant mode is not enabled.
     """
+    # Batch-invariant mode disables TRTLLM attention
+    if vllm_is_batch_invariant():
+        return False
+
     # Requires SM100 and NVIDIA artifactory to be accessible to download cubins
     return current_platform.is_device_capability(100) and has_nvidia_artifactory()
 
@@ -239,9 +243,6 @@ def force_use_trtllm_attention() -> bool | None:
     return `True` if TRTLLM attention is forced to be used,
     return `False` if TRTLLM attention is forced to be not used.
     """
-    if vllm_is_batch_invariant():
-        logger.info_once("VLLM_USE_TRTLLM_ATTENTION is disabled for batch-invariant")
-        return False
     return _force_use_trtllm_attention(envs.VLLM_USE_TRTLLM_ATTENTION)
 
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -231,8 +231,16 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_sink(cls) -> bool:
         """FlashInfer supports sinks when TRTLLM attention is available (SM100)."""
-        from vllm.utils.flashinfer import supports_trtllm_attention
+        from vllm.utils.flashinfer import (
+            force_use_trtllm_attention,
+            supports_trtllm_attention,
+        )
 
+        # Respect explicit disable flag (e.g., VLLM_USE_TRTLLM_ATTENTION=0)
+        if force_use_trtllm_attention() is False:
+            return False
+
+        # Check if TRTLLM is supported on this platform
         return supports_trtllm_attention()
 
     @classmethod

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -229,6 +229,13 @@ class FlashInferBackend(AttentionBackend):
         )
 
     @classmethod
+    def supports_sink(cls) -> bool:
+        """FlashInfer supports sinks when TRTLLM attention is available (SM100)."""
+        from vllm.utils.flashinfer import supports_trtllm_attention
+
+        return supports_trtllm_attention()
+
+    @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
         from vllm.platforms import current_platform
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix regression introduced by https://github.com/vllm-project/vllm/pull/24794 where gpt-oss on Blackwell shows triton as the only valid attention backend

```
vllm serve openai/gpt-oss-20b --load-format dummy
...
(EngineCore_DP0 pid=210162) INFO 11-12 10:18:02 [cuda.py:408] Valid backends: ['TRITON_ATTN']
(EngineCore_DP0 pid=210162) INFO 11-12 10:18:02 [cuda.py:417] Using TRITON_ATTN backend.
```

FlashInfer can support attention sinks through the TRTLLM backend

## Test Plan

## Test Result

```
vllm serve openai/gpt-oss-20b
python tests/evals/gsm8k/gsm8k_eval.py

# Main
Accuracy: 0.299
Invalid responses: 0.167
Total latency: 38.394 s
Questions per second: 34.354
Total output tokens: 310429
Output tokens per second: 8085.264

# PR
Accuracy: 0.310
Invalid responses: 0.162
Total latency: 36.881 s
Questions per second: 35.764
Total output tokens: 304071
Output tokens per second: 8244.621
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

