### PR TITLE
[Model] [Config] Correctly identify granite-4.0-micro as non-hybrid model

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1619,6 +1619,13 @@ class ModelConfig:
 
     @property
     def is_hybrid(self) -> bool:
+        # Handle granite-4.0-micro case which uses hybrid config but does not
+        # actually contain any non-attention layers.
+        layer_types = getattr(self.hf_config, "layer_types", None)
+        if layer_types is not None and all(
+            layer == "attention" for layer in layer_types
+        ):
+            return False
         return self._model_info.is_hybrid
 
     @property


### PR DESCRIPTION
## Purpose

The model `ibm-granite/granite-4.0-micro` uses the `GraniteMoeHybrid` config, but actually is not a hybrid model in that all of the layers are attention. This is encoded in the config using the `layer_types` field. 

Right now on main, we don't check layer_types when deciding if a model is hybrid or not. Thus, for this model we are (a) disabling prefix caching by default and (b) inflating the attention block size unncessarily. 

This PR adds a simple check of the `layer_types` field before deciding if a model is hybrid or not. 

## Test Plan

```
vllm serve ibm-granite/granite-4.0-micro
```

## Test Result

After this change, we no longer see prefix caching being disabled and the attention block size being inflated. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

