### PR TITLE
[torch.compile] Try using Dynamo-native padding

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -149,7 +149,12 @@ def _padded_cutlass2(
 ) -> torch.Tensor:
     pad_multiple = 4
 
-    padding = -qx.shape[0] % pad_multiple
+    # TODO(torch==2.10): torch semantics broken for PythonMod in 2.9:
+    #  so x<=0 -> x % y <= 0 (not actually python mod semantics).
+    #  https://github.com/pytorch/pytorch/issues/169602
+    #  We increment the padded dim to avoid a negative.
+    # padding = -qx.shape[0] % pad_multiple
+    padding = (qx.shape[0] * pad_multiple - qx.shape[0]) % pad_multiple
     # print(f"{padding=}")
     padded_qx = torch.nn.functional.pad(qx, (0, 0, 0, padding))
     assert len(x_scale.size()) == 2


### PR DESCRIPTION
## Purpose

Reapply padding from #24666, which caused bug #25623. Currently fails with different error due to torch==2.9 (works with torch==2.8):

```
VLLM_USE_DEEP_GEMM=0 vllm serve Qwen/Qwen3-30B-A3B-FP8 --trust-remote-code
```

**UPDATE**: this now works!!

## Test Plan

## Test Result