### PR TITLE
[Core] Extending I/O Plugins

### DIFF
--- a/tests/plugins/prithvi_io_processor_plugin/prithvi_io_processor/prithvi_processor.py
+++ b/tests/plugins/prithvi_io_processor_plugin/prithvi_io_processor/prithvi_processor.py
@@ -248,7 +248,9 @@ class PrithviMultimodalDataProcessor(IOProcessor):
         self.requests_cache: dict[str, dict[str, Any]] = {}
         self.indices = DEFAULT_INPUT_INDICES
 
-    def parse_request(self, request: Any) -> IOProcessorInput:
+    def parse_request(
+        self, request: Any, has_preprocess_partial: bool = False
+    ) -> IOProcessorInput:
         if type(request) is dict:
             image_prompt = ImagePrompt(**request)
             return image_prompt

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -383,8 +383,9 @@ class LLM:
         prompts = self.io_processor.pre_process(
             prompt=validated_prompt,
             params=params,
-            llm_instance=self,
             lora_request=lora_request,
+            llm_engine=self.llm_engine,
+            processor=self.processor,
         )
 
         # reset the lora request unless it's one the user explicitly gave,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -415,12 +415,12 @@ class LLM:
             validated_params = []
             for param in as_iter(params):
                 validated_params.append(
-                    self.io_processor.validate_or_generate_params(param)
+                    self.io_processor.validate_or_generate_params(params=param)
                 )
             params = validated_params
         else:
             assert not isinstance(params, Sequence)
-            params = self.io_processor.validate_or_generate_params(params)
+            params = self.io_processor.validate_or_generate_params(params=params)
         return params
 
     @deprecated("`set_tokenizer` is deprecated and will be removed in v0.13.")

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -292,7 +292,6 @@ class OpenAIServingChat(OpenAIServing):
                         max_tokens, self.default_sampling_params
                     )
 
-                # TODO - align pooling behavior, since this was not previously passed
                 sampling_params = request.to_sampling_params(
                     max_tokens,
                     self.model_config.logits_processor_pattern,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1193,9 +1193,9 @@ class OpenAIServing:
             preprocess_partial is not None,
         )
 
-        # HACK - depending on the plugin, validated_prompt may actually be
-        # a request still since it's cleaner to call async preprocessors
-        # from the async method
+        # NOTE - depending on the plugin, the validated input may actually
+        # be a request still since it's cleaner to call async preprocessors
+        # from the async method than the parsing.
         engine_prompts = await self.io_processor.pre_process_async(
             prompt=validated_req_or_prompt,
             request_id=request_id,

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -114,6 +114,7 @@ class OpenAIServingPooling(OpenAIServing):
                 renderer=renderer,
             )
 
+            pooling_params = request.to_pooling_params()
             if (
                 self.io_processor is not None
                 and self.io_processor.plugin_type != IOProcessorPluginType.OUTPUT_ONLY
@@ -126,10 +127,12 @@ class OpenAIServingPooling(OpenAIServing):
                     self.engine_client,
                     self.processor,
                 )
-                pooling_params = self.io_processor.validate_or_generate_params()
+                pooling_params = self.io_processor.validate_or_generate_params(
+                    request,
+                    pooling_params,
+                )
             else:
                 engine_prompts = await preprocess_partial(request)
-                pooling_params = request.to_pooling_params()
 
         except (ValueError, TypeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")

--- a/vllm/plugins/io_processors/interface.py
+++ b/vllm/plugins/io_processors/interface.py
@@ -62,7 +62,11 @@ class IOProcessor(ABC, Generic[IOProcessorInput, IOProcessorOutput]):
         return self.post_process(collected_output, request_id, **kwargs)
 
     @abstractmethod
-    def parse_request(self, request: Any) -> IOProcessorInput:
+    def parse_request(
+        self,
+        request: Any,
+        has_preprocess_partial: bool = False,
+    ) -> IOProcessorInput:
         raise NotImplementedError
 
     def validate_or_generate_params(
@@ -75,3 +79,7 @@ class IOProcessor(ABC, Generic[IOProcessorInput, IOProcessorOutput]):
         self, plugin_output: IOProcessorOutput
     ) -> IOProcessorResponse:
         raise NotImplementedError
+
+    def get_modified_lora_request(self, engine_prompts, lora_request):
+        # FIXME - clean this up, unify sync/async
+        return lora_request

--- a/vllm/plugins/io_processors/interface.py
+++ b/vllm/plugins/io_processors/interface.py
@@ -110,5 +110,4 @@ class IOProcessor(ABC, Generic[IOProcessorInput, IOProcessorOutput]):
         )
 
     def get_modified_lora_request(self, engine_prompts, lora_request):
-        # FIXME - clean this up, unify sync/async
         return lora_request

--- a/vllm/plugins/io_processors/interface.py
+++ b/vllm/plugins/io_processors/interface.py
@@ -94,7 +94,9 @@ class IOProcessor(ABC, Generic[IOProcessorInput, IOProcessorOutput]):
         )
 
     def validate_or_generate_params(
-        self, params: SamplingParams | PoolingParams | None = None
+        self,
+        request=None,
+        params: SamplingParams | PoolingParams | None = None,
     ) -> SamplingParams | PoolingParams:
         return params or PoolingParams()
 

--- a/vllm/plugins/io_processors/interface.py
+++ b/vllm/plugins/io_processors/interface.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import AsyncGenerator, Sequence
+from enum import Enum
 from typing import Any, Generic, TypeVar
 
 from vllm.config import VllmConfig
@@ -16,18 +17,31 @@ IOProcessorInput = TypeVar("IOProcessorInput")
 IOProcessorOutput = TypeVar("IOProcessorOutput")
 
 
+class IOProcessorPluginType(Enum):
+    INPUT_OUTPUT = 1
+    INPUT_ONLY = 2
+    OUTPUT_ONLY = 3
+
+
 class IOProcessor(ABC, Generic[IOProcessorInput, IOProcessorOutput]):
+    plugin_type = IOProcessorPluginType.INPUT_OUTPUT
+
     def __init__(self, vllm_config: VllmConfig):
         self.vllm_config = vllm_config
 
-    @abstractmethod
     def pre_process(
         self,
         prompt: IOProcessorInput,
         request_id: str | None = None,
         **kwargs,
     ) -> PromptType | Sequence[PromptType]:
-        raise NotImplementedError
+        if self.plugin_type != IOProcessorPluginType.OUTPUT_ONLY:
+            raise NotImplementedError(
+                ".pre_process() is not implemented for this IO plugin"
+            )
+        raise AssertionError(
+            ".pre_process should not be invoked for output only plugins"
+        )
 
     async def pre_process_async(
         self,
@@ -37,14 +51,19 @@ class IOProcessor(ABC, Generic[IOProcessorInput, IOProcessorOutput]):
     ) -> PromptType | Sequence[PromptType]:
         return self.pre_process(prompt, request_id, **kwargs)
 
-    @abstractmethod
     def post_process(
         self,
         model_output: Sequence[PoolingRequestOutput],
         request_id: str | None = None,
         **kwargs,
     ) -> IOProcessorOutput:
-        raise NotImplementedError
+        if self.plugin_type != IOProcessorPluginType.INPUT_ONLY:
+            raise NotImplementedError(
+                ".post_process() is not implemented for this IO plugin"
+            )
+        raise AssertionError(
+            ".post_process() should not be invoked for input only plugins"
+        )
 
     async def post_process_async(
         self,
@@ -61,24 +80,34 @@ class IOProcessor(ABC, Generic[IOProcessorInput, IOProcessorOutput]):
         collected_output = [output[1] for output in sorted_output]
         return self.post_process(collected_output, request_id, **kwargs)
 
-    @abstractmethod
     def parse_request(
         self,
         request: Any,
         has_preprocess_partial: bool = False,
     ) -> IOProcessorInput:
-        raise NotImplementedError
+        if self.plugin_type != IOProcessorPluginType.OUTPUT_ONLY:
+            raise NotImplementedError(
+                ".parse_request() is not implemented for this IO plugin"
+            )
+        raise AssertionError(
+            ".parse_request() should not be invoked for output only plugins"
+        )
 
     def validate_or_generate_params(
         self, params: SamplingParams | PoolingParams | None = None
     ) -> SamplingParams | PoolingParams:
         return params or PoolingParams()
 
-    @abstractmethod
     def output_to_response(
         self, plugin_output: IOProcessorOutput
     ) -> IOProcessorResponse:
-        raise NotImplementedError
+        if self.plugin_type != IOProcessorPluginType.INPUT_ONLY:
+            raise NotImplementedError(
+                ".output_to_response() is not implemented for this IO plugin"
+            )
+        raise AssertionError(
+            ".output_to_response() should not be invoked for input only plugins"
+        )
 
     def get_modified_lora_request(self, engine_prompts, lora_request):
         # FIXME - clean this up, unify sync/async


### PR DESCRIPTION
## Purpose
This PR reworks and expands the input/output plugins, which currently are largely used for pooling / embedding models, e.g., [Prithvi-EO-2.0-300M-TL-Sen1Floods11](https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11) to allow custom processing options to do tasks like semantic segmentation using a more integrated interface with vLLM.

This PR addresses [this](https://github.com/vllm-project/vllm/issues/26157) issue, which aims to extend I/O plugin capabilities to `.generate` and extend the interface so that we can write a plugin to simplify the experience of using granite speech models, which need to call vLLM twice to act as an integrated voice model with the underlying granite LLM, since this is accomplished by intermediate transcription (e.g., audio with `what is 2+2?` -(first call to vllm, which also uses a lora)> `"what is 2+2"` -(second call to vllm, which doesn't use a lora)> `4`). To accomplish this with a minimally invasive change to existing I/O plugins, this PR approaches this with the following objectives:

- I/O plugins should work with `.generate`
- It needs the ability to access more things from the plugin itself, specifically 
     - The plugin needs to be able to submit things to the vLLM engine/client the request
     - The plugin should be able to update the LoRA to be used after the input part of the plugin is used, when the result is used for generation by vLLM
- We should have a clear pattern for wrapping preprocessing capabilities in online serving endpoints that can be invoked from the plugin if needed, since this is what people will often need to do to make their plugins work well with different async endpoints if they want to invoke the client multiple times in one vLLM call
- Plugins should be extended to allow for `input only` & `output only` plugins for convenience (but be input + output by default)
- It should pass what it needs to in order to make plugins flexible and as easy to write and well-patterned as possible against public APIs (as opposed to passing something like the whole LLM entrypoint class, which will likely tempt people with this type of use case to write plugins using internal methods like `LLM._validate_and_add_requests` etc).
- It should be as nonabrasive to existing plugins as possible

### Overview 
Quick summary of state:
- Works for .generate & chat completions
- preprocess is given access to the `lora request`, `engine` / `engine client`, and `processor` so that users can directly submit and await requests to the engine as needed.
    - For preprocessing logic that may be complex for different serving endpoints, e.g., chat templating, the preprocessing logic is wrapped into a method that is passed as a function `partial`, which should have a unified signature across different endpoints. This allows users to be able to call vLLM's preprocessing directly in a way that makes sense, while also ensuring that we have a clear path to enabling it for other endpoints.
    - ^ this is also useful for plugin flexibility, because in some cases like geospatial, we want the plugin to its own preprocessing and skip everything it normally does, but in others like granite speech, we essentially want to the normal preprocessing + extra things.

A full plugin for granite speech can be found [here](https://github.com/alex-jw-brooks/granite_speech_io_processor_plugin) that works for both synchronous generate + async chat completions (still under development and cleaning it up, but most of the hackery is in this plugin, since I tried to keep the vLLM changes as clean as possible for review).

### Changes in Behavior
TODO - there are a few important things to be aware of and caveats for existing plugins, so I will be sure to add an explicit list of default behaviors & how to rectify them.

For the most part, this may require small changes, but should be minimally invasive (geospatial test is currently passing locally with a change to one func signature, which we can also make backwards compatible if we like)

## Test Plan
I will add a test with granite speech's plugin as an example for generate. Geospatial plugin tests should also pass!

## Test Result
Geospatial tests currently pass, granite speech example in the plugin works, but is not added to vLLM tests yet since the plugin is still in a brittle state.

Will revise this and move it out of draft once I have updated docs and solidified potential changes to stuff like output interfaces for the plugin, but opening it in case anyone has thoughts!

CC @DarkLight1337 @njhill @NickLucche @christian-pinto @lastras @gsaon