### PR TITLE
[ROCm][Bugfix] Revert removing setuptools version restriction

### DIFF
--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -9,7 +9,7 @@ torchaudio==2.9.0
 triton==3.5.0
 cmake>=3.26.1,<4
 packaging>=24.2
-setuptools>=77.0.3,<81.0.0
+setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 wheel
 jinja2>=3.1.6

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -10,7 +10,7 @@ peft
 pytest-asyncio
 tensorizer==2.10.1
 packaging>=24.2
-setuptools>=77.0.3,<81.0.0
+setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 runai-model-streamer[s3,gcs]==0.15.0
 conch-triton-kernels==1.2.1


### PR DESCRIPTION
Reverting #28337 on ROCm specific files until a proper solution is found. Other platforms might suffer from a similar issue

The underlying issue mentioned in #17320 is still not fixed properly.
To elaborate, setuptools>=80 will replace `python setup.py develop` with `pip install -e .`, which creates an isolateb build environment and pulls build dependencies from pyprojec.toml. In particulat it would try to install torch==2.9.0, which is a CUDA version of torch package by default, so the ROCm build would fail.
The only possible way to build currently is with bdist_wheel, which doesn't allow creating a development environment