### PR TITLE
Rewrite C++ meta funcs to Python

### DIFF
--- a/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
@@ -247,22 +247,6 @@ torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,
   return out;
 }
 
-torch::Tensor awq_marlin_repack_meta(torch::Tensor& b_q_weight,
-                                     c10::SymInt size_k, c10::SymInt size_n,
-                                     int64_t num_bits) {
-  int const pack_factor = 32 / num_bits;
-  auto options = torch::TensorOptions()
-                     .dtype(b_q_weight.dtype())
-                     .device(b_q_weight.device());
-  return torch::empty_symint(
-      {size_k / marlin::tile_size, size_n * marlin::tile_size / pack_factor},
-      options);
-}
-
 TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
   m.impl("awq_marlin_repack", &awq_marlin_repack);
-}
-
-TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, Meta, m) {
-  m.impl("awq_marlin_repack", &awq_marlin_repack_meta);
 }

--- a/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
@@ -321,22 +321,6 @@ torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
   return out;
 }
 
-torch::Tensor gptq_marlin_repack_meta(torch::Tensor& b_q_weight,
-                                      torch::Tensor& perm, c10::SymInt size_k,
-                                      c10::SymInt size_n, int64_t num_bits) {
-  int const pack_factor = 32 / num_bits;
-  auto options = torch::TensorOptions()
-                     .dtype(b_q_weight.dtype())
-                     .device(b_q_weight.device());
-  return torch::empty_symint(
-      {size_k / marlin::tile_size, size_n * marlin::tile_size / pack_factor},
-      options);
-}
-
 TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
   m.impl("gptq_marlin_repack", &gptq_marlin_repack);
-}
-
-TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, Meta, m) {
-  m.impl("gptq_marlin_repack", &gptq_marlin_repack_meta);
 }

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1184,10 +1184,10 @@ if hasattr(torch.ops._C, "gptq_marlin_repack"):
         size_n: torch.SymInt,
         num_bits: int,
     ) -> torch.Tensor:
-        pack_factor = 32 / num_bits
+        pack_factor = 32 // num_bits
         marlin_tile_size = 16
         return torch.empty(
-            (size_k / marlin_tile_size, size_n * marlin_tile_size / pack_factor),
+            (size_k // marlin_tile_size, size_n * marlin_tile_size // pack_factor),
             dtype=b_q_weight.dtype,
             device=b_q_weight.device,
         )
@@ -1209,10 +1209,10 @@ if hasattr(torch.ops._C, "awq_marlin_repack"):
         size_n: torch.SymInt,
         num_bits: int,
     ) -> torch.Tensor:
-        pack_factor = 32 / num_bits
+        pack_factor = 32 // num_bits
         marlin_tile_size = 16
         return torch.empty(
-            (size_k / marlin_tile_size, size_n * marlin_tile_size / pack_factor),
+            (size_k // marlin_tile_size, size_n * marlin_tile_size // pack_factor),
             dtype=b_q_weight.dtype,
             device=b_q_weight.device,
         )

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1174,11 +1174,48 @@ def gptq_marlin_repack(
     return torch.ops._C.gptq_marlin_repack(b_q_weight, perm, size_k, size_n, num_bits)
 
 
-# gptq_marlin
+if hasattr(torch.ops._C, "gptq_marlin_repack"):
+
+    @register_fake("_C::gptq_marlin_repack")
+    def _gptq_marlin_repack_fake(
+        b_q_weight: torch.Tensor,
+        perm: torch.Tensor,
+        size_k: torch.SymInt,
+        size_n: torch.SymInt,
+        num_bits: int,
+    ) -> torch.Tensor:
+        pack_factor = 32 / num_bits
+        marlin_tile_size = 16
+        return torch.empty(
+            (size_k / marlin_tile_size, size_n * marlin_tile_size / pack_factor),
+            dtype=b_q_weight.dtype,
+            device=b_q_weight.device,
+        )
+
+
+# awq_marlin
 def awq_marlin_repack(
     b_q_weight: torch.Tensor, size_k: int, size_n: int, num_bits: int
 ) -> torch.Tensor:
     return torch.ops._C.awq_marlin_repack(b_q_weight, size_k, size_n, num_bits)
+
+
+if hasattr(torch.ops._C, "awq_marlin_repack"):
+
+    @register_fake("_C::awq_marlin_repack")
+    def _awq_marlin_repack_fake(
+        b_q_weight: torch.Tensor,
+        size_k: torch.SymInt,
+        size_n: torch.SymInt,
+        num_bits: int,
+    ) -> torch.Tensor:
+        pack_factor = 32 / num_bits
+        marlin_tile_size = 16
+        return torch.empty(
+            (size_k / marlin_tile_size, size_n * marlin_tile_size / pack_factor),
+            dtype=b_q_weight.dtype,
+            device=b_q_weight.device,
+        )
 
 
 def gptq_marlin_moe_repack(


### PR DESCRIPTION

## Purpose
Migrate remaining C++ meta functions to Python. The main impetus for this is to enable vLLM cuda wheel to be libtorch ABI stable soon, see https://github.com/vllm-project/vllm/issues/26946, which doesn't have plans to support stable SymInt today. Moreover, the rest of the meta functions are already in Python, so this makes the library more consistent.

This PR does assume marlin_tile_size is 16, so when updating that, it is important to update the python there too.

## Test Plan
pytest ./tests/kernels/quantization/test_marlin_gemm.py -k test_gptq_marlin_repack
pytest ./tests/kernels/quantization/test_marlin_gemm.py -k test_awq_marlin_repack -v

## Test Result

<details>

```
(vllm) [janeyx@devgpu007.eag6 /data/users/janeyx/local/vllm (python-meta-kernels)]$ pytest ./tests/kernels/quantization/test_marlin_gemm.py -k test_gptq_marlin_repack
======================= test session starts ========================
platform linux -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /data/users/janeyx/local/vllm
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 3387 items / 3259 deselected / 128 selected              

tests/kernels/quantization/test_marlin_gemm.py ............. [ 10%]
............................................................ [ 57%]
.......................................................      [100%]

========================= warnings summary =========================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======== 128 passed, 3259 deselected, 2 warnings in 56.99s =========
^[[A<sys>:0: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
^[[A(vllm) [janeyx@devgpu007.eag6 /data/users/janeyx/local/vllm (python-meta-kernelspytest ./tests/kernels/quantization/test_marlin_gemm.py -k test_awq_marlin_repack -v
======================= test session starts ========================
platform linux -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0 -- /data/users/janeyx/local/vllm/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /data/users/janeyx/local/vllm
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 3387 items / 3355 deselected / 32 selected               

tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0--1-quant_type0-64-128] PASSED [  3%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0--1-quant_type0-256-128] PASSED [  6%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0-32-quant_type0-64-128] PASSED [  9%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0-32-quant_type0-256-128] PASSED [ 12%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0-64-quant_type0-64-128] PASSED [ 15%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0-64-quant_type0-256-128] PASSED [ 18%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0-128-quant_type0-64-128] PASSED [ 21%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors0-128-quant_type0-256-128] PASSED [ 25%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1--1-quant_type0-64-128] PASSED [ 28%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1--1-quant_type0-256-128] PASSED [ 31%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1-32-quant_type0-64-128] PASSED [ 34%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1-32-quant_type0-256-128] PASSED [ 37%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1-64-quant_type0-64-128] PASSED [ 40%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1-64-quant_type0-256-128] PASSED [ 43%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1-128-quant_type0-64-128] PASSED [ 46%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors1-128-quant_type0-256-128] PASSED [ 50%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2--1-quant_type0-64-128] PASSED [ 53%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2--1-quant_type0-256-128] PASSED [ 56%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2-32-quant_type0-64-128] PASSED [ 59%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2-32-quant_type0-256-128] PASSED [ 62%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2-64-quant_type0-64-128] PASSED [ 65%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2-64-quant_type0-256-128] PASSED [ 68%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2-128-quant_type0-64-128] PASSED [ 71%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors2-128-quant_type0-256-128] PASSED [ 75%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3--1-quant_type0-64-128] PASSED [ 78%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3--1-quant_type0-256-128] PASSED [ 81%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3-32-quant_type0-64-128] PASSED [ 84%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3-32-quant_type0-256-128] PASSED [ 87%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3-64-quant_type0-64-128] PASSED [ 90%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3-64-quant_type0-256-128] PASSED [ 93%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3-128-quant_type0-64-128] PASSED [ 96%]
tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack[mnk_factors3-128-quant_type0-256-128] PASSED [100%]

========================= warnings summary =========================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========= 32 passed, 3355 deselected, 2 warnings in 11.61s =========
<sys>:0: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

