### PR TITLE
[BugFix] Fix `mm_encoder_attn_backend` arg type checking

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -57,7 +57,7 @@ steps:
   - pytest -v -s -m 'not cpu_test' multimodal
   - pytest -v -s utils_
 
-- label: Async Engine, Inputs, Utils, Worker Test (CPU) # 4 mins
+- label: Async Engine, Inputs, Utils, Worker, Config Test (CPU) # 4 mins
   timeout_in_minutes: 10
   source_file_dependencies:
   - vllm/
@@ -66,6 +66,7 @@ steps:
   - tests/multimodal
   - tests/standalone_tests/lazy_imports.py
   - tests/transformers_utils
+  - tests/config
   no_gpu: true
   commands:
   - python3 standalone_tests/lazy_imports.py
@@ -73,6 +74,7 @@ steps:
   - pytest -v -s test_outputs.py
   - pytest -v -s -m 'cpu_test' multimodal
   - pytest -v -s transformers_utils
+  - pytest -v -s config
 
 - label: Python-only Installation Test # 10min
   timeout_in_minutes: 20

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -170,6 +170,9 @@ class MultiModalConfig:
     def _validate_mm_encoder_attn_backend(
         cls, value: str | AttentionBackendEnum | None
     ) -> AttentionBackendEnum | None:
+        # We need to import the real type here (deferred to avoid circular import).
+        from vllm.attention.backends.registry import AttentionBackendEnum
+
         if value is None or isinstance(value, AttentionBackendEnum):
             return value
 


### PR DESCRIPTION
Currently, use of `--mm-encoder-attn-backend` fails with the following error:

```
self = typing.Any, obj = 'FLASH_ATTN'

    def __instancecheck__(self, obj):
        if self is Any:
>           raise TypeError("typing.Any cannot be used with isinstance()")
E           TypeError: typing.Any cannot be used with isinstance()

../../../.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/typing.py:530: TypeError
```

There is a [test](https://github.com/vllm-project/vllm/blob/main/tests/config/test_multimodal_config.py) for this but the `config` tests aren't referenced in `test-pipeline.yaml` and so weren't actually running in the CI!

cc @ywang96 