### PR TITLE
Use official xformers-0.0.33 built for PT 2.9

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,7 +9,6 @@ torch==2.9.0
 torchaudio==2.9.0
 # These must be updated alongside torch
 torchvision==0.24.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-# Build from https://github.com/facebookresearch/xformers/releases/tag/v0.0.32.post1
-xformers==0.0.33+5d4b92a5.d20251029; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
+xformers==0.0.33; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.5.2


### PR DESCRIPTION
## Purpose

`xformers-0.0.33` has been released today for PyTorch 2.9 https://pypi.org/project/xformers/#history, and we can finally switch to that version instead of the custom one we build on PyTorch

FIX https://github.com/vllm-project/vllm/issues/27880 https://github.com/vllm-project/vllm/issues/27851
## Test Plan

CI

cc @simon-mo @ywang96 @ProExpertProg 
