### PR TITLE
Fix type error when assign a trition kernel tensor to a torch.nn.Parameter

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -92,11 +92,13 @@ void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
 void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
                         torch::Tensor& weight, double epsilon);
 
+#ifndef USE_ROCM
 void fused_qk_norm_rope(torch::Tensor& qkv, int64_t num_heads_q,
                         int64_t num_heads_k, int64_t num_heads_v,
                         int64_t head_dim, double eps, torch::Tensor& q_weight,
                         torch::Tensor& k_weight, torch::Tensor& cos_sin_cache,
                         bool is_neox, torch::Tensor& position_ids);
+#endif
 
 void apply_repetition_penalties_(torch::Tensor& logits,
                                  const torch::Tensor& prompt_mask,

--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -133,7 +133,10 @@ class FixFunctionalizationPass(VllmInductorPass):
                     ),
                 )
             # Defunctionalize fused_qk_norm_rope to remove higher-order wrapper.
-            elif at_target == torch.ops._C.fused_qk_norm_rope.default:
+            elif (
+                current_platform.is_cuda()
+                and at_target == torch.ops._C.fused_qk_norm_rope.default
+            ):
                 mutated_args = {1: "qkv"}
                 args = (
                     "qkv",

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -17,9 +17,9 @@ if current_platform.is_cuda_alike():
     from .activation_quant_fusion import ActivationQuantFusionPass
     from .fusion import RMSNormQuantFusionPass
     from .fusion_attn import AttnFusionPass
-    from .qk_norm_rope_fusion import QKNormRoPEFusionPass
 
 if current_platform.is_cuda():
+    from .qk_norm_rope_fusion import QKNormRoPEFusionPass
     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
 
 from .fix_functionalization import FixFunctionalizationPass

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -755,8 +755,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             self.w13_weight = w13_weight
             self.w2_weight = w2_weight
-            layer.w13_weight = w13_weight
-            layer.w2_weight = w2_weight
+            layer.w13_weight =  Parameter(w13_weight.data, requires_grad=False)
+            layer.w2_weight = Parameter(w2_weight.data, requires_grad=False)
         else:
             raise ValueError(f"Unsupported backend: {self.mxfp4_backend}")
 


### PR DESCRIPTION
Summary:
#28064 introduced a bug where we assign triton kernel tensor to a torch parameter, and get error like:

```
[1;36m(Worker_TP0 pid=3673)[0;0m INFO 11-11 18:42:41 [default_loader.py:314] Loading weights took 2.74 seconds
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639] WorkerProc failed to start.
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639] Traceback (most recent call last):
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/vllm/v1/executor/multiproc_executor.py", line 613, in worker_main
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     worker = WorkerProc(*args, **kwargs)
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/vllm/v1/executor/multiproc_executor.py", line 468, in __init__
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     self.worker.load_model()
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/vllm/v1/worker/gpu_worker.py", line 266, in load_model
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     self.model_runner.load_model(eep_scale_up=eep_scale_up)
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/vllm/v1/worker/gpu_model_runner.py", line 3033, in load_model
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     self.model = model_loader.load_model(
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/vllm/model_executor/model_loader/base_loader.py", line 56, in load_model
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     process_weights_after_loading(model, model_config, target_device)
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/vllm/model_executor/model_loader/utils.py", line 107, in process_weights_after_loading
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     quant_method.process_weights_after_loading(module)
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/vllm/model_executor/layers/quantization/mxfp4.py", line 757, in process_weights_after_loading
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     layer.w13_weight = w13_weight
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]   File "/packages/smart.inference_platform_sp.llm_predictor_gpu_vllm_triton.persistent/service-inplace#link-tree/torch/nn/modules/module.py", line 2000, in __setattr__
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639]     raise TypeError(
[1;36m(Worker_TP1 pid=3674)[0;0m ERROR 11-11 18:42:42 [multiproc_executor.py:639] TypeError: cannot assign 'triton_kernels.tensor.Tensor' as parameter 'w13_weight' (torch.nn.Parameter or None expected)
```

Test Plan:
Run on vLLM again and able to start vLLM.


```
Ran 100/100 requests in 29.18s
Success rate:        100.00%
==Throughput (tps WIP)==
QPS:                 3.43
Input Tokens:
  Avg:               6893.63
  P50:               6900.00
  P99:               6943.00
  Input TPS:         23624.57
Cached Tokens:'
  Avg:               48.16
  P50:               48.00
  P99:               64.00
  Cached TPS:        165.05
  KV Cache Hit Rate: 0.70%
Total Tokens:
  Avg:               7087.93
  P50:               7084.00
  P99:               7243.00
  Total TPS:         24290.44
Reasoning Tokens:
  Avg:               105.78
  P50:               92.00
  P99:               298.00
  Reasoning TPS:     362.51
Output Tokens:
  Avg:               194.30
  P50:               185.00
  P99:               185.00
  Output TPS:        665.87
==Latency==
Client E2E latency:
  Avg:               10694.13ms
  P50:               10412.56ms
  P99:               19748.06ms
Avg latency: 10694.13ms; p90: 17125.17ms; p99: 19748.06ms TTFT p50: 10412.56ms; p99: 19748.06ms TTIT p50: 0.00ms; p99: 0.00ms Throughput: 3.43qps Prompt tokens: total 689363, avg 6893.63 Completion tokens: total 19430, avg 194.30 Total tokens: total 708793, avg 7087.93 Completion tokens latency: 0.00ms Completion tokens per sec: 665.87 Total tokens per sec: 24290.44
Peak TPGS: 101.75
```

```
Task: aime25_gpt_oss
exact_match: 0.7833333333333333
exact_match_stderr: 0.026648354940098685
```

Differential Revision: D86838536


