### PR TITLE
Fix where we load CUDA only kernel when running on AMD hardware

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -92,11 +92,13 @@ void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
 void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
                         torch::Tensor& weight, double epsilon);
 
+#ifndef USE_ROCM
 void fused_qk_norm_rope(torch::Tensor& qkv, int64_t num_heads_q,
                         int64_t num_heads_k, int64_t num_heads_v,
                         int64_t head_dim, double eps, torch::Tensor& q_weight,
                         torch::Tensor& k_weight, torch::Tensor& cos_sin_cache,
                         bool is_neox, torch::Tensor& position_ids);
+#endif
 
 void apply_repetition_penalties_(torch::Tensor& logits,
                                  const torch::Tensor& prompt_mask,

--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -133,7 +133,10 @@ class FixFunctionalizationPass(VllmInductorPass):
                     ),
                 )
             # Defunctionalize fused_qk_norm_rope to remove higher-order wrapper.
-            elif at_target == torch.ops._C.fused_qk_norm_rope.default:
+            elif (
+                current_platform.is_cuda()
+                and at_target == torch.ops._C.fused_qk_norm_rope.default
+            ):
                 mutated_args = {1: "qkv"}
                 args = (
                     "qkv",

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -17,9 +17,9 @@ if current_platform.is_cuda_alike():
     from .activation_quant_fusion import ActivationQuantFusionPass
     from .fusion import RMSNormQuantFusionPass
     from .fusion_attn import AttnFusionPass
-    from .qk_norm_rope_fusion import QKNormRoPEFusionPass
 
 if current_platform.is_cuda():
+    from .qk_norm_rope_fusion import QKNormRoPEFusionPass
     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
 
 from .fix_functionalization import FixFunctionalizationPass


### PR DESCRIPTION
Summary:
#27165 introduced an issue where when we run on AMD hardware, we would try to load `FUSED_QK_ROPE_OP = torch.ops._C.fused_qk_norm_rope.default`, which is CUDA only, and get error:

```
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639] WorkerProc failed to start.
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639] WorkerProc failed to start.
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639] Traceback (most recent call last):
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639] Traceback (most recent call last):
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/executor/multiproc_executor.py", line 613, in worker_main
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/executor/multiproc_executor.py", line 613, in worker_main
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     worker = WorkerProc(*args, **kwargs)
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     worker = WorkerProc(*args, **kwargs)
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/executor/multiproc_executor.py", line 468, in __init__
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/executor/multiproc_executor.py", line 468, in __init__
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.worker.load_model()
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.worker.load_model()
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/worker/gpu_worker.py", line 266, in load_model
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/worker/gpu_worker.py", line 266, in load_model
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.model_runner.load_model(eep_scale_up=eep_scale_up)
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.model_runner.load_model(eep_scale_up=eep_scale_up)
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/worker/gpu_model_runner.py", line 3033, in load_model
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/v1/worker/gpu_model_runner.py", line 3033, in load_model
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.model = model_loader.load_model(
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.model = model_loader.load_model(
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/model_executor/model_loader/base_loader.py", line 49, in load_model
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/model_executor/model_loader/base_loader.py", line 49, in load_model
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     model = initialize_model(
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/model_executor/model_loader/utils.py", line 55, in initialize_model
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     model = initialize_model(
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     return model_class(vllm_config=vllm_config, prefix=prefix)
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/model_executor/model_loader/utils.py", line 55, in initialize_model
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/model_executor/models/deepseek_v2.py", line 1349, in __init__
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     return model_class(vllm_config=vllm_config, prefix=prefix)
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.model = DeepseekV2Model(
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/model_executor/models/deepseek_v2.py", line 1349, in __init__
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/decorators.py", line 293, in __init__
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     self.model = DeepseekV2Model(
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     TorchCompileWrapperWithCustomDispatcher.__init__(
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/wrapper.py", line 42, in __init__
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/decorators.py", line 293, in __init__
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     backend = vllm_config.compilation_config.init_backend(vllm_config)
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     TorchCompileWrapperWithCustomDispatcher.__init__(
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/config/compilation.py", line 770, in init_backend
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     from vllm.compilation.backends import VllmBackend
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/wrapper.py", line 42, in __init__
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/backends.py", line 40, in <module>
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     backend = vllm_config.compilation_config.init_backend(vllm_config)
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     from .pass_manager import PostGradPassManager
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/pass_manager.py", line 20, in <module>
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/config/compilation.py", line 770, in init_backend
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     from .qk_norm_rope_fusion import QKNormRoPEFusionPass
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     from vllm.compilation.backends import VllmBackend
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/qk_norm_rope_fusion.py", line 24, in <module>
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/backends.py", line 40, in <module>
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     FUSED_QK_ROPE_OP = torch.ops._C.fused_qk_norm_rope.default
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     from .pass_manager import PostGradPassManager
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/torch/_ops.py", line 1361, in __getattr__
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/pass_manager.py", line 20, in <module>
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     raise AttributeError(
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     from .qk_norm_rope_fusion import QKNormRoPEFusionPass
[1;36m(Worker_TP5 pid=4058)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639] AttributeError: '_OpNamespace' '_C' object has no attribute 'fused_qk_norm_rope'
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/vllm/compilation/qk_norm_rope_fusion.py", line 24, in <module>
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     FUSED_QK_ROPE_OP = torch.ops._C.fused_qk_norm_rope.default
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]   File "/dev/shm/uid-99/83e08bb2-seed-nspid4026555323_cgpid2465342-ns-4026555243/torch/_ops.py", line 1361, in __getattr__
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639]     raise AttributeError(
[1;36m(Worker_TP6 pid=4059)[0;0m ERROR 11-11 18:07:51 [multiproc_executor.py:639] AttributeError: '_OpNamespace' '_C' object has no attribute 'fused_qk_norm_rope'
```

We should only import `QKNormRoPEFusionPass` when `is_cuda`, instead of `is_cuda_alike`, which include ROCM.

Test Plan:
Patch the change and able to start vllm on AMD properly (deepseek)
```
Ran 500/500 requests in 144.51s
Success rate:        100.00%
QPS:                 3.46
Avg latency:         4.489s
Avg TTFT (client):   161.38ms
P50 TTFT (client):   143.11ms
P99 TTFT (client):   266.50ms
Avg TTIT (client):   28.85ms
P50 TTIT (client):   28.94ms
P99 TTIT (client):   29.38ms
Avg TTFT (server):   224.00ms
Avg TTIT (server):   28.62ms
Avg prefill len:     3293.05 tokens
P50 prefill len:     3293.00 tokens
P99 prefill len:     3335.00 tokens
Avg decode len:      150.00 tokens
P50 decode len:      150.00 tokens
P99 decode len:      150.00 tokens
Peak TPGS: 66.375
```

```
[2025-11-12 16:54:55,483] [rank 0] [INFO] Evaluation results on task gsm8k.8_shot.1_gen: em: 0.960576 | f1: 0.960576 | em_maj1@1: 0.960576 | f1_maj1@1: 0.960576
```

Differential Revision: D86838348


