### PR TITLE
[BugFix][ROCm] Fix `get_cu_count` missing variable error

### DIFF
--- a/vllm/utils/platform_utils.py
+++ b/vllm/utils/platform_utils.py
@@ -24,7 +24,7 @@ def xpu_is_initialized() -> bool:
     return torch.xpu.is_initialized()
 
 
-def get_cu_count(cls, device_id: int = 0) -> int:
+def get_cu_count(device_id: int = 0) -> int:
     """Returns the total number of compute units (CU) on single GPU."""
     return torch.cuda.get_device_properties(device_id).multi_processor_count
 


### PR DESCRIPTION

## Purpose
Got error message when PR https://github.com/vllm-project/vllm/pull/27005 merged

```
ting down executor.
(EngineCore_DP0 pid=2001222) Process EngineCore_DP0:
(EngineCore_DP0 pid=2001222) Traceback (most recent call last):
(EngineCore_DP0 pid=2001222)   File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=2001222)     self.run()
(EngineCore_DP0 pid=2001222)   File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=2001222)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/engine/core.py", line 859, in run_engine_core
(EngineCore_DP0 pid=2001222)     raise e
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/engine/core.py", line 846, in run_engine_core
(EngineCore_DP0 pid=2001222)     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/engine/core.py", line 619, in __init__
(EngineCore_DP0 pid=2001222)     super().__init__(
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/engine/core.py", line 110, in __init__
(EngineCore_DP0 pid=2001222)     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/engine/core.py", line 244, in _initialize_kv_caches
(EngineCore_DP0 pid=2001222)     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/executor/abstract.py", line 116, in initialize_from_config
(EngineCore_DP0 pid=2001222)     self.collective_rpc("compile_or_warm_up_model")
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/executor/multiproc_executor.py", line 307, in collective_rpc
(EngineCore_DP0 pid=2001222)     return aggregate(get_response())
(EngineCore_DP0 pid=2001222)   File "/home/ygan/vllm/vllm/v1/executor/multiproc_executor.py", line 290, in get_response
(EngineCore_DP0 pid=2001222)     raise RuntimeError(
(EngineCore_DP0 pid=2001222) RuntimeError: Worker failed with error 'get_cu_count() missing 1 required positional argument: 'cls'', please check the stack trace above for the root cause
```
The `get_cu_count` calling missing class variable, this PR remove that class variable to make sure the functionality on ROCm platform.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

