### PR TITLE
[XPU] add sym params to IPEXConfig

### DIFF
--- a/vllm/model_executor/layers/quantization/ipex_quant.py
+++ b/vllm/model_executor/layers/quantization/ipex_quant.py
@@ -192,6 +192,7 @@ class IPEXGPTQLinearMethod(GPTQLinearMethod):
         # The float activation will be quantized (dynamic, per-token) to INT8.
         act_quant_mode = ipex.quantization.WoqActQuantMode.PER_BATCH_IC_BLOCK
 
+        assert isinstance(self.quant_config, IPEXConfig)
         qconfig = ipex.quantization.get_weight_only_quant_qconfig_mapping(
             weight_dtype=weight_dtype,
             lowp_mode=lowp_mode,
@@ -263,6 +264,7 @@ class IPEXAWQLinearMethod(AWQLinearMethod):
         # The float activation will be quantized (dynamic, per-token) to INT8.
         act_quant_mode = ipex.quantization.WoqActQuantMode.PER_BATCH
 
+        assert isinstance(self.quant_config, IPEXConfig)
         qconfig = ipex.quantization.get_weight_only_quant_qconfig_mapping(
             weight_dtype=weight_dtype,
             lowp_mode=lowp_mode,


### PR DESCRIPTION
This PR adds a sym parameter to the configuration function for IPEX WeightOnlyQuantizedLinear.
The parameter allows explicit control over whether symmetric or asymmetric quantization is used.

To support run GPTQ model with asym quant.
Command: python examples/offline_inference/basic/generate.py --enforce-eager --model  dj271/meta-llama-Llama-3.1-8B-Instruct-gptq-4bit-asym  --max-model-len 1024 --max-num-batched-tokens 2048 --dtype float16 --temperature 0 -tp 2

Before:
<img width="2328" height="365" alt="image" src="https://github.com/user-attachments/assets/925cbfed-aea6-471d-a509-80e9dee09c91" />

After:
<img width="2317" height="359" alt="image" src="https://github.com/user-attachments/assets/9ccf4058-025a-4ccb-9923-3bbe1a694381" />
