### PR TITLE
Fix: Correctly filter special tokens in benchmark_prefix_caching

### DIFF
--- a/benchmarks/benchmark_prefix_caching.py
+++ b/benchmarks/benchmark_prefix_caching.py
@@ -69,7 +69,7 @@ def sample_tokens(tokenizer: PreTrainedTokenizerBase, length: int) -> list[int]:
 
     # Remove the special tokens.
     return random.choices(
-        [v for k, v in vocab.items() if k not in all_special_ids],
+        [v for v in vocab.values() if v not in all_special_ids],
         k=length,
     )
 


### PR DESCRIPTION

## Purpose
Fixes a bug in `benchmarks/benchmark_prefix_caching.py` where the `sample_tokens` function failed to filter special tokens.

The original code was incorrectly comparing token strings (`k`) with a set of special token IDs (`all_special_ids`). This PR fixes the logic to correctly compare the token ID (`v`) and simplifies the list comprehension by using `vocab.values()` instead of `vocab.items()`, as the token string key is not used.

## Test Plan
This is a self-contained logic fix within a benchmark script. The test plan is to ensure the script still runs successfully after the change.

I ran the benchmark script locally to confirm that it executes without any new errors.

## Test Result

The script runs successfully. The `sample_tokens` function now correctly filters all special token IDs from the sampling pool, as the original code intended.
