### PR TITLE
[Bugfix] [ROCm] Fix `get_cu_count` resolution

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -18,6 +18,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
+from vllm.utils.platform_utils import get_cu_count
 from vllm.v1.attention.backends.utils import (
     AttentionCGSupport,
     AttentionMetadataBuilder,
@@ -38,7 +39,7 @@ if current_platform.is_rocm():
         return min(65536 // x.element_size(), triton.next_power_of_2(head_dim))
 
     def num_programs(total_tokens):
-        return min(total_tokens, current_platform.get_cu_count())
+        return min(total_tokens, get_cu_count())
 
     @triton.jit
     def cp_mha_gather_cache_kernel(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`get_cu_count()` has been moved into platforms.utils

## Test Plan

Ensure model using the AITER FA backend runs without issue.

## Test Result

Command:
```bash
#!/bin/bash
rm -rf /root/.cache/vllm/

echo "Qwen/Qwen3-30B-A3B"
export VLLM_RPC_TIMEOUT=1800000
export SAFETENSORS_FAST_GPU=1
export MODEL_PATH=Qwen/Qwen3-30B-A3B

VLLM_ROCM_USE_AITER=1 \
vllm serve $MODEL_PATH \
-tp 2 \
--trust-remote-code \
--disable-log-requests
```

Qwen/Qwen3-30B-A3B
```
[2025-11-13 06:43:21] INFO evaluation_tracker.py:280: Output path not provided, skipping saving results aggregated
local-completions (model=Qwen/Qwen3-30B-A3B,base_url=http://127.0.0.1:8000/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8006|±  |0.0110|
|     |       |strict-match    |     5|exact_match|↑  |0.8931|±  |0.0085|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

