### PR TITLE
[Bugfix] Fix FPS value type for Qwen2.5-Omni video processing

### DIFF
--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -1536,7 +1536,7 @@ def run_qwen2_5_omni(questions: list[str], modality: str):
         mm_processor_kwargs={
             "min_pixels": 28 * 28,
             "max_pixels": 1280 * 28 * 28,
-            "fps": [1],
+            "fps": 1,
         },
         limit_mm_per_prompt={modality: 1},
     )


### PR DESCRIPTION
## Purpose
Fixes `TypeError: unsupported operand type(s) for /: 'int' and 'list'` when initializing Qwen2.5-Omni models with video inputs.

Below is the error log:
```bash
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855] EngineCore failed to start.
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855] Traceback (most recent call last):
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855]   File "/mnt/disk4/fanlilin/upstream/vllm/vllm/multimodal/processing.py", line 1066, in call_hf_processor
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855]     output = hf_processor(**data, **allowed_kwargs, return_tensors="pt")
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py", line 187, in __call__
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855]     second_per_grid_ts = [self.video_processor.temporal_patch_size / fps] * len(video_grid_thw)
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855]                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
(EngineCore_DP0 pid=125763) ERROR 11-13 00:55:03 [core.py:855] TypeError: unsupported operand type(s) for /: 'int' and 'list'
```

The Qwen2.5-Omni processor expects `fps` to be a scalar value (int/float), , but the dummy video input was passing it as a list `[1]`. This causes a type error during encoder cache profiling when the processor tries to compute `temporal_patch_size / fps`.  (see [code](https://github.com/huggingface/transformers/blob/ffb35fe14283d61cd5434a32d04d07993e66477a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py#L174)).


## Test Plan
```bash
VLLM_WORKER_MULTIPROC_METHOD=spawn python examples/offline_inference/vision_language.py -m qwen2_5_omni --modality video --seed 42 --num-prompts 1
```
## Test Result
```bash
--------------------------------------------------
Well, it's funny because you've got this little baby wearing glasses and reading a book. It's just so cute and unexpected. I mean, babies usually don't look like they're reading. It's like they're trying to act all grown - up. And the way they're holding the book and looking at
--------------------------------------------------
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

