### PR TITLE
fix(network): prevent port allocation race condition

### DIFF
--- a/tests/distributed/test_kv_transfer_port_allocation.py
+++ b/tests/distributed/test_kv_transfer_port_allocation.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for KV transfer port allocation race condition fix (issue #28636)."""
+
+import socket
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import zmq
+
+
+@pytest.mark.skip_global_cleanup
+class TestP2pNcclEnginePortAllocation:
+    """Test suite for P2pNcclEngine port allocation with socket holding."""
+
+    def test_socket_holding_import(self):
+        """Test that we can import the socket holding function."""
+        from vllm.utils.network_utils import get_and_hold_open_port
+
+        assert get_and_hold_open_port is not None
+
+    def test_socket_holding_prevents_port_reuse(self):
+        """Test that the held socket prevents other processes from using the port.
+
+        This is the core test for the race condition fix from issue #28636.
+        """
+        from vllm.utils.network_utils import get_and_hold_open_port
+
+        # Allocate a port with socket holding
+        sock1, port1 = get_and_hold_open_port()
+        try:
+            # Try to bind another socket to the same port - should fail
+            s2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            with pytest.raises(OSError) as exc_info:
+                s2.bind(("", port1))
+            s2.close()
+            # EADDRINUSE: 48 on macOS, 98 on Linux
+            assert exc_info.value.errno in (48, 98)
+        finally:
+            sock1.close()
+
+    def test_concurrent_port_allocation(self):
+        """Test that concurrent get_and_hold_open_port calls allocate unique ports."""
+        from vllm.utils.network_utils import get_and_hold_open_port
+
+        num_allocations = 10
+
+        def allocate_port():
+            return get_and_hold_open_port()
+
+        with ThreadPoolExecutor(max_workers=num_allocations) as executor:
+            futures = [executor.submit(allocate_port) for _ in range(num_allocations)]
+            results = [f.result() for f in futures]
+
+        try:
+            ports = [port for _, port in results]
+            # All ports should be unique
+            assert len(set(ports)) == num_allocations
+        finally:
+            # Clean up sockets
+            for sock, _ in results:
+                sock.close()
+
+    def test_multiple_zmq_sockets_use_unique_ports(self):
+        """Test that multiple ZMQ sockets get unique ports via socket holding.
+
+        This simulates the P2pNcclEngine pattern without requiring full instantiation.
+        """
+        from vllm.utils.network_utils import get_and_hold_open_port
+
+        # Simulate two P2pNcclEngine instances (prefill and decode servers)
+        contexts = []
+        sockets = []
+        held_sockets = []
+        ports = []
+
+        try:
+            for i in range(2):
+                # Allocate port with socket holding (what P2pNcclEngine now does)
+                held_socket, port = get_and_hold_open_port()
+                held_sockets.append(held_socket)
+                ports.append(port)
+
+                # Bind ZMQ socket to the allocated port
+                ctx = zmq.Context()
+                zmq_socket = ctx.socket(zmq.ROUTER)
+                zmq_socket.bind(f"tcp://127.0.0.1:{port}")
+                contexts.append(ctx)
+                sockets.append(zmq_socket)
+
+                # Close held socket after ZMQ binds (as per our fix)
+                held_socket.close()
+
+            # Both ZMQ sockets should have different ports
+            assert ports[0] != ports[1], (
+                f"ZMQ sockets should have unique ports, but both got: "
+                f"{ports[0]} and {ports[1]}"
+            )
+
+        finally:
+            # Clean up
+            for sock in sockets:
+                sock.close()
+            for ctx in contexts:
+                ctx.term()
+            for held_sock in held_sockets:
+                if not held_sock._closed:
+                    held_sock.close()
+
+    def test_zmq_port_conflict_scenario(self):
+        """Simulate the exact scenario from issue #28636.
+
+        Two ZMQ sockets trying to bind to the same port should fail.
+        """
+        from vllm.utils.network_utils import get_and_hold_open_port
+
+        # Simulate prefill server allocating a port
+        prefill_held_socket, prefill_port = get_and_hold_open_port()
+
+        try:
+            # Create ZMQ context and socket for "prefill server"
+            prefill_ctx = zmq.Context()
+            prefill_zmq_socket = prefill_ctx.socket(zmq.ROUTER)
+            prefill_zmq_socket.bind(f"tcp://127.0.0.1:{prefill_port}")
+
+            # Close the held socket after ZMQ binds (as per our fix)
+            prefill_held_socket.close()
+
+            # Now simulate decode server trying to allocate its own port
+            # It should get a DIFFERENT port
+            decode_held_socket, decode_port = get_and_hold_open_port()
+
+            try:
+                # The decode server should get a different port
+                assert decode_port != prefill_port, (
+                    f"Decode server got same port as prefill server: {decode_port}"
+                )
+
+                # Decode server can successfully bind
+                decode_ctx = zmq.Context()
+                decode_zmq_socket = decode_ctx.socket(zmq.ROUTER)
+                decode_zmq_socket.bind(f"tcp://127.0.0.1:{decode_port}")
+
+                # Close the decode held socket
+                decode_held_socket.close()
+
+                # Both servers should be running on different ports
+                assert prefill_port != decode_port
+
+                # Clean up
+                decode_zmq_socket.close()
+                decode_ctx.term()
+
+            finally:
+                if not decode_held_socket._closed:
+                    decode_held_socket.close()
+
+            # Clean up
+            prefill_zmq_socket.close()
+            prefill_ctx.term()
+
+        finally:
+            if not prefill_held_socket._closed:
+                prefill_held_socket.close()

--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import socket
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import zmq
 
 from vllm.utils.network_utils import (
+    get_and_hold_open_port,
     get_open_port,
     get_tcp_uri,
     join_host_port,
@@ -14,6 +16,7 @@ from vllm.utils.network_utils import (
     split_host_port,
     split_zmq_path,
 )
+from vllm.v1.utils import get_engine_client_zmq_addr_with_socket
 
 
 def test_get_open_port(monkeypatch: pytest.MonkeyPatch):
@@ -124,3 +127,181 @@ def test_split_host_port():
 def test_join_host_port():
     assert join_host_port("127.0.0.1", 5555) == "127.0.0.1:5555"
     assert join_host_port("::1", 5555) == "[::1]:5555"
+
+
+# Tests for socket holding functionality (issue #28498)
+
+
+def test_get_and_hold_open_port_basic():
+    """Test that get_and_hold_open_port returns a valid socket and port."""
+    sock, port = get_and_hold_open_port()
+    try:
+        # Verify socket is a valid socket object
+        assert isinstance(sock, socket.socket)
+        # Verify port is a positive integer
+        assert isinstance(port, int)
+        assert port > 0
+        # Verify socket is bound to the port
+        assert sock.getsockname()[1] == port
+    finally:
+        sock.close()
+
+
+def test_get_and_hold_open_port_prevents_reuse():
+    """Test that the held socket prevents other processes from using the port.
+
+    This is the core test for the race condition fix from issue #28498.
+    """
+    sock1, port1 = get_and_hold_open_port()
+    try:
+        # Try to bind another socket to the same port - should fail
+        s2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        with pytest.raises(OSError) as exc_info:
+            s2.bind(("", port1))
+        s2.close()
+        assert exc_info.value.errno in (48, 98)  # EADDRINUSE: 48 on macOS, 98 on Linux
+    finally:
+        sock1.close()
+
+    # After closing sock1, the port should be available again
+    # (though OS may have delay in releasing)
+    # Note: We don't test rebinding immediately due to TIME_WAIT state
+
+
+def test_get_and_hold_open_port_with_dp_master_port(monkeypatch: pytest.MonkeyPatch):
+    """Test that get_and_hold_open_port avoids DP master port range."""
+    with monkeypatch.context() as m:
+        # Set DP master port to a high value to avoid conflicts
+        m.setenv("VLLM_DP_MASTER_PORT", "50000")
+
+        # Get multiple ports
+        socks_and_ports = [get_and_hold_open_port() for _ in range(5)]
+        try:
+            # Verify none of the ports are in the reserved range [50000, 50010)
+            for sock, port in socks_and_ports:
+                assert port not in range(50000, 50010), (
+                    f"Port {port} should not be in DP master port "
+                    f"reserved range [50000, 50010)"
+                )
+        finally:
+            for sock, _ in socks_and_ports:
+                sock.close()
+
+
+def test_get_and_hold_open_port_ipv4():
+    """Test that get_and_hold_open_port returns IPv4 socket with SO_REUSEADDR."""
+    sock, port = get_and_hold_open_port()
+    try:
+        # Verify socket family is AF_INET (IPv4)
+        assert sock.family == socket.AF_INET
+        # Verify SO_REUSEADDR is set
+        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) == 1
+    finally:
+        sock.close()
+
+
+def test_get_and_hold_open_port_multiple_sockets():
+    """Test that we can hold multiple ports simultaneously."""
+    num_sockets = 5
+    socks_and_ports = [get_and_hold_open_port() for _ in range(num_sockets)]
+    try:
+        # Verify all ports are unique
+        ports = [port for _, port in socks_and_ports]
+        assert len(set(ports)) == num_sockets, "All ports should be unique"
+
+        # Verify all sockets are alive and bound
+        for sock, port in socks_and_ports:
+            assert sock.getsockname()[1] == port
+    finally:
+        for sock, _ in socks_and_ports:
+            sock.close()
+
+
+def test_get_and_hold_open_port_concurrent():
+    """Test that get_and_hold_open_port works correctly under concurrent access.
+
+    This test validates the fix for the race condition reported in issue #28498.
+    """
+    num_threads = 10
+    results = []
+
+    def allocate_port():
+        sock, port = get_and_hold_open_port()
+        return (sock, port)
+
+    # Allocate ports concurrently from multiple threads
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(allocate_port) for _ in range(num_threads)]
+        results = [f.result() for f in futures]
+
+    try:
+        # Verify all ports are unique
+        ports = [port for _, port in results]
+        assert len(set(ports)) == num_threads, (
+            "All ports should be unique even under concurrent allocation"
+        )
+
+        # Verify no EADDRINUSE errors occurred (implicitly checked by futures)
+    finally:
+        for sock, _ in results:
+            sock.close()
+
+
+def test_socket_holding_prevents_zmq_conflict():
+    """Test that a held socket prevents ZMQ from binding to the same port."""
+    # Get a held socket
+    sock, port = get_and_hold_open_port()
+    try:
+        # Try to create a ZMQ socket on the same port - should fail
+        ctx = zmq.Context()
+        zmq_sock = ctx.socket(zmq.REP)
+        with pytest.raises(zmq.error.ZMQError) as exc_info:
+            zmq_sock.bind(f"tcp://127.0.0.1:{port}")
+        # ZMQError wraps EADDRINUSE
+        assert "Address already in use" in str(exc_info.value).lower()
+        zmq_sock.close()
+        ctx.term()
+    finally:
+        sock.close()
+
+
+def test_get_engine_client_zmq_addr_with_socket_tcp():
+    """Test get_engine_client_zmq_addr_with_socket for TCP addresses."""
+    address, held_socket = get_engine_client_zmq_addr_with_socket(
+        local_only=False, host="127.0.0.1", port=0
+    )
+    try:
+        # Verify address format
+        assert address.startswith("tcp://127.0.0.1:")
+        # Verify socket is returned for auto-assigned port
+        assert held_socket is not None
+        assert isinstance(held_socket, socket.socket)
+        # Extract port from address and verify it matches socket
+        port = int(address.split(":")[-1])
+        assert held_socket.getsockname()[1] == port
+    finally:
+        if held_socket:
+            held_socket.close()
+
+
+def test_get_engine_client_zmq_addr_with_socket_ipc():
+    """Test get_engine_client_zmq_addr_with_socket for IPC addresses."""
+    address, held_socket = get_engine_client_zmq_addr_with_socket(
+        local_only=True, host="127.0.0.1"
+    )
+    # Verify address format for IPC
+    assert address.startswith("ipc://")
+    # Verify no socket is returned for IPC (no port allocation needed)
+    assert held_socket is None
+
+
+def test_get_engine_client_zmq_addr_with_socket_explicit_port():
+    """Test get_engine_client_zmq_addr_with_socket with explicit port."""
+    explicit_port = 12345
+    address, held_socket = get_engine_client_zmq_addr_with_socket(
+        local_only=False, host="127.0.0.1", port=explicit_port
+    )
+    # Verify address uses the explicit port
+    assert address == f"tcp://127.0.0.1:{explicit_port}"
+    # Verify no socket is returned for explicit port (no holding needed)
+    assert held_socket is None


### PR DESCRIPTION
## Purpose

This patch fixes #28498 where multiple processes could attempt to bind to the same port, causing EADDRINUSE errors during startup.

## Test Plan

Add new unit tests to cover the new methods.

## Test Result

```
> pytest tests/utils_/test_network_utils.py -k "hold_open_port" -v

============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /root/vllm/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /root/vllm
configfile: pyproject.toml
plugins: anyio-4.11.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 24 items / 18 deselected / 6 selected

tests/utils_/test_network_utils.py::test_get_and_hold_open_port_basic PASSED                                                                                                                                                           [ 16%]
tests/utils_/test_network_utils.py::test_get_and_hold_open_port_prevents_reuse PASSED                                                                                                                                                  [ 33%]
tests/utils_/test_network_utils.py::test_get_and_hold_open_port_with_dp_master_port PASSED                                                                                                                                             [ 50%]
tests/utils_/test_network_utils.py::test_get_and_hold_open_port_ipv4 PASSED                                                                                                                                                            [ 66%]
tests/utils_/test_network_utils.py::test_get_and_hold_open_port_multiple_sockets PASSED                                                                                                                                                [ 83%]
tests/utils_/test_network_utils.py::test_get_and_hold_open_port_concurrent PASSED                                                                                                                                                      [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

