### PR TITLE
[ROCm][Quantization] add apply_vllm_mapper in quark config for models like gpt-oss

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -90,8 +90,10 @@ class QuarkConfig(QuantizationConfig):
             elif isinstance(v, dict):
                 quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply_dict(v)
             else:
-                if v is not None:
-                    quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply(v)
+                if isinstance(v, str):
+                    mapped_v_list = hf_to_vllm_mapper.apply_list([v])
+                    if mapped_v_list:
+                        quant_config_with_hf_to_vllm_mapper[k] = mapped_v_list[0]
                 else:
                     quant_config_with_hf_to_vllm_mapper[k] = v
 

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -79,9 +79,6 @@ class QuarkConfig(QuantizationConfig):
         :param hf_to_vllm_mapper: maps from hf model structure (the assumed
             structure of the qconfig) to vllm model structure
         """
-        # TODO (@kylesayrs): add implementations for all subclasses
-        # from vllm.debug import ForkedPdb; ForkedPdb().set_trace()
-        # import copy
         quant_config_with_hf_to_vllm_mapper = {}
 
         for k, v in self.quant_config.items():


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Need to call https://github.com/vllm-project/vllm/blob/c9fe6abe7c0b03d552420edd63c6c678ed683dea/vllm/model_executor/models/gpt_oss.py#L656 to build a map, such as `self_attn` to `attn` in `gpt-oss` model.

Here's a snapshot of the `quant_config`  with this `apply_vllm_mapper`:
<img width="1862" height="79" alt="image" src="https://github.com/user-attachments/assets/0c303fe1-bdd8-432f-bdbc-b0d61e9ed820" />

## Test Plan
Test model: amd/gpt-oss-20b-customized-attention-quantization

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

