### PR TITLE
[Attention][Bugfix] Fix FA sink support

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -119,6 +119,12 @@ class FlashAttentionBackend(AttentionBackend):
         return kv_cache_dtype in ["auto"]
 
     @classmethod
+    def supports_sink(cls) -> bool:
+        if not is_flash_attn_varlen_func_available():
+            return False
+        return flash_attn_supports_sinks()
+
+    @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
         return capability >= DeviceCapability(8, 0)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#24794 didn't mark FlashAttention as supporting sink, so GPT-OSS ends up selecting TRITON_ATTN, causing failure. This PR fixes the issue.

## Test Plan
```
python examples/offline_inference/spec_decode.py \
  --method "eagle3" \
  --tp 1 \
  --print-output \
  --model-dir openai/gpt-oss-20b" \
  --eagle-dir "RedHatAI/gpt-oss-20b-speculator.eagle3" \
  --dataset_name "hf" \
  --dataset_path "philschmid/mt-bench" \
  --num-spec-tokens 3
```

## Test Result
Previously failed, now works

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
