### PR TITLE
[ROCm][Qwen3-32B] Fix AITER MHA accuracy issue cause by #25763

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -729,7 +729,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                     cu_seqlens_k=attn_metadata.prefill_metadata.query_start_loc,
                     max_seqlen_q=attn_metadata.prefill_metadata.max_query_len,
                     max_seqlen_k=attn_metadata.prefill_metadata.max_seq_len,
-                    min_seqlen_q=attn_metadata.prefill_metadata.min_query_len,
+                    min_seqlen_q=1,
                     dropout_p=0.0,
                     softmax_scale=self.scale,
                     causal=True,
@@ -759,7 +759,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                     cu_seqlens_q=attn_metadata.extend_metadata.query_start_loc,
                     max_seqlen_q=attn_metadata.extend_metadata.max_query_len,
                     max_seqlen_k=attn_metadata.extend_metadata.max_seq_len,
-                    min_seqlen_q=attn_metadata.extend_metadata.min_query_len,
+                    min_seqlen_q=1,
                     block_table=attn_metadata.block_table[
                         num_decodes : num_decodes + num_extends
                     ],


### PR DESCRIPTION
## Purpose
This PR aim to fix Qwen3-32B accuracy issue w/ AITER MHA reported by https://github.com/vllm-project/vllm/issues/28598 by passing correct `min_seqlen_q` value in `aiter.flash_attn_varlen_func` in pure prefill and extend phase. 

After further investigation, I found https://github.com/vllm-project/vllm/pull/25763 introduced this issue during refactor of AITER MHA backend w/ default AITER version `9716b1b8`: https://github.com/vllm-project/vllm/blob/3eb0c2673e128714073f7e3fd105cf962a4c8c16/docker/Dockerfile.rocm_base#L10


Before the refactor, `min_seq_len=1` was passed to `aiter.flash_attn_varlen_func` in prefill phase.
https://github.com/vllm-project/vllm/blob/2918c1b49c88c29783c86f78d2c4221cb9622379/vllm/v1/attention/backends/rocm_aiter_fa.py#L184-L198

https://github.com/vllm-project/vllm/pull/25763 split into pure prefill/extends/decode phase, the min_seq_len set by `attn_metadata.prefill_metadata.min_query_len` and `attn_metadata.extend_metadata.min_query_len` in following line: 
https://github.com/vllm-project/vllm/blob/dc937175d496a801f175b5dcce6a8157506bae52/vllm/v1/attention/backends/rocm_aiter_fa.py#L756

https://github.com/vllm-project/vllm/blob/dc937175d496a801f175b5dcce6a8157506bae52/vllm/v1/attention/backends/rocm_aiter_fa.py#L786

If wrong `min_seq_len` value pass to `aiter.flash_attn_varlen_func`, it will trigger following pre-condition check in ck `fmha_fwd_pagedkv_kernel` to return without kernel execution, hence cause the accuracy issue: https://github.com/ROCm/composable_kernel/blob/9f33b7cfd3df3fcfd540f7633b0abd7019935761/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp#L1175-L1181

## Test Plan
Accuracy test: lm-eval with gsm8k on MI308X
Base docker image: rocm/vllm-dev/nightly_main_20251113
```
#!/bin/bash
rm -rf /root/.cache/vllm/
echo "Qwen/Qwen3-32B"
export VLLM_RPC_TIMEOUT=1800000
export SAFETENSORS_FAST_GPU=1
export MODEL_PATH=Qwen/Qwen3-32B

VLLM_ROCM_USE_AITER=1 \
vllm serve $MODEL_PATH \
-tp 2 \
--trust-remote-code \
--disable-log-requests
```

lm_eval command

```
#!/bin/bash
lm_eval \
--model local-completions \
--tasks gsm8k \
--model_args model=Qwen/Qwen3-32B,base_url=http://127.0.0.1:8000/v1/completions \
--batch_size 100
```
## Test Result
**AITER MHA before fix:** 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4769|±  |0.0138|
|     |       |strict-match    |     5|exact_match|↑  |0.5428|±  |0.0137|

**AITER MHA after fix:** 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6293|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7210|±  |0.0124|

**Triton Unified Attention (default)**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6300|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7392|±  |0.0124|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

