### PR TITLE
[Bugfix][Nixl] Fix kernel physical<>logical block_size issue 

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -985,8 +985,10 @@ def test_hybrid_block_table_initialization():
     req_index = 0
     block_table.append_row(kvcache_manager_blocks, req_index)
     # Get expected kernel blocks from the implementation for verification.
-    expected_kernel_blocks = block_table._map_to_kernel_blocks(
-        np.array(kvcache_manager_blocks)
+    expected_kernel_blocks = block_table.map_to_kernel_blocks(
+        np.array(kvcache_manager_blocks),
+        block_table.blocks_per_kv_block,
+        block_table._kernel_block_arange,
     )
     # Verify block table state
     assert block_table.num_blocks_per_row[req_index] == len(expected_kernel_blocks)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -49,6 +49,7 @@ from vllm.platforms import current_platform
 from vllm.utils.network_utils import make_zmq_path, make_zmq_socket
 from vllm.v1.attention.backends.utils import get_kv_cache_layout
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.worker.block_table import BlockTable
 
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionMetadata
@@ -1703,6 +1704,12 @@ class NixlConnectorWorker:
         We check for these trnxs to complete in each step().
         """
         for req_id, meta in metadata.reqs_to_recv.items():
+            meta.local_block_ids = self._logical_to_kernel_block_ids(
+                meta.local_block_ids
+            )
+            meta.remote_block_ids = self._logical_to_kernel_block_ids(
+                meta.remote_block_ids
+            )
             remote_engine_id = meta.remote_engine_id
             logger.debug(
                 "start_load_kv for request %s from remote engine %s. "
@@ -1768,8 +1775,6 @@ class NixlConnectorWorker:
         dst_engine_id: str,
         request_id: str,
     ):
-        local_block_ids = self._logical_to_kernel_block_ids(local_block_ids)
-        remote_block_ids = self._logical_to_kernel_block_ids(remote_block_ids)
         # NOTE(rob): having the staging blocks be on the READER side is
         # not going to work well (since we will have to call rearrange tensors).
         # after we detect the txn is complete (which means we cannot make the
@@ -1895,7 +1900,7 @@ class NixlConnectorWorker:
             self._failed_recv_reqs.add(request_id)
 
     def _get_block_descs_ids(
-        self, engine_id: str, block_ids: np.ndarray, layer_idx: int | None = None
+        self, engine_id: str, block_ids: list[int], layer_idx: int | None = None
     ) -> np.ndarray:
         """
         Get the descs ids for a set of block ids.
@@ -1921,27 +1926,26 @@ class NixlConnectorWorker:
 
         # Compute the desc ids for each block.
         region_ids = region_ids[:, None]
-        block_ids = block_ids[None, :]
+        block_ids = np.array(block_ids)[None, :]
         descs_ids = region_ids * num_blocks + block_ids
         return descs_ids.flatten()
 
-    def _logical_to_kernel_block_ids(self, block_ids: list[int]) -> np.ndarray:
+    def _logical_to_kernel_block_ids(self, block_ids: list[int]) -> list[int]:
         """
         Convert logical block ids to kernel physical block ids.
         This is required when the logical block size (the one set by the user)
         does not match the one required by the attn backend.
         """
-        block_ids_np = np.array(block_ids)
         if self._physical_blocks_per_logical_kv_block == 1:
-            return block_ids_np
+            # Noop when physical and logical block sizes are the same
+            return block_ids
+        block_ids_np = np.array(block_ids)
         block_arange = np.arange(0, self._physical_blocks_per_logical_kv_block).reshape(
             1, -1
         )
-        kernel_block_ids = (
-            block_ids_np.reshape(-1, 1) * self._physical_blocks_per_logical_kv_block
-            + block_arange
-        )
-        return kernel_block_ids.reshape(-1)
+        return BlockTable.map_to_kernel_blocks(
+            block_ids_np, self._physical_blocks_per_logical_kv_block, block_arange
+        ).tolist()
 
     def get_backend_aware_kv_block_len(self, layer_idx: int):
         """


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/28661.
PD deployments with block_size=128  *on FA* (as well as FI) are currently broken on main.

This is pretty bad because 128 is the suggested `block_size` as it maximizes the xfer window. 
This is due to the changes introduced in https://github.com/vllm-project/vllm/pull/24486/, which adjust `block_size`at runtime based on Backend constraints.
This update value is not picked by NixlConnector and it ends up using the one defined by the user (to be precise, the updated value it's not stored anywhere).

Example
```
kv_cache.shape=torch.Size([3636, ->64, 8, 128])
nixl_worker.block_size = ->128
```


Furthermore, `kv_cache_manager.get_block_ids()` returns manager (logical) block IDs, but the connector (particularly nixl_connector) needs kernel-space block IDs.
Currently there's not a clean accessible way to map from logical->physical block_ids from anywhere in code. Also it is not clear in terms of Connector *interface contract*, whether blocks supplied by the Scheduler should be logical or already physical.
For the sake of getting this bug fixed, I have implemented the mapping logic within the connector worker. 

Bug was spotted after https://github.com/vllm-project/vllm/pull/27753/ landed, as it changed the default FA backend to not support 128 anymore.


## Test with

Same procedure as described on issue https://github.com/vllm-project/vllm/issues/28661:

```
bash tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
...
(EngineCore_DP0 pid=74640) INFO 11-13 17:19:11 [distributed/.../v1/nixl_connector.py:1142] User-specified logical block size (128) does not match physical kernel block size (64). Using the latter.
...
(APIServer pid=497251) INFO:     Application shutdown complete.
+ echo 'All tests completed!'
All tests completed!
++ jobs -pr
+ kill 498809
```



cc @heheda12345 @njhill @robertgshaw2-redhat
