### PR TITLE
[Bugfix] Fix host and port join for ipv6 in bench serve

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -49,6 +49,7 @@ from vllm.benchmarks.lib.ready_checker import wait_for_endpoint
 from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
 from vllm.transformers_utils.tokenizer import get_tokenizer
 from vllm.utils.gc_utils import freeze_gc_heap
+from vllm.utils.network_utils import join_host_port
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
 
@@ -1333,8 +1334,9 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         api_url = f"{args.base_url}{args.endpoint}"
         base_url = f"{args.base_url}"
     else:
-        api_url = f"http://{args.host}:{args.port}{args.endpoint}"
-        base_url = f"http://{args.host}:{args.port}"
+        host_port = join_host_port(args.host, args.port)
+        api_url = f"http://{host_port}{args.endpoint}"
+        base_url = f"http://{host_port}"
 
     # Headers
     headers = None


### PR DESCRIPTION
## Purpose

Fix IPv6 address formatting in the benchmark client (`vllm bench serve`).

Previously, when using `--host ::` or other IPv6 addresses, the benchmark client would construct invalid URLs like `http://:::8000/v1/completions`, causing `aiohttp` to fail with
  `ValueError: Invalid URL: port can't be converted to integer`.
This PR fixes the issue by using the existing `join_host_port()` utility from `vllm.utils.network_utils`, which properly wraps IPv6 addresses in brackets per RFC 3986 (e.g.,
  `http://[::]:8000/v1/completions`).


  ## Test Plan

**Manual testing with different host formats:**

  ```bash
  # Test IPv4 (should work as before)
  vllm bench serve --host 127.0.0.1 --port 8000 --model <model> --num-prompts 10

  # Test IPv6 wildcard (previously broken, now works)
  vllm bench serve --host :: --port 8000 --model <model> --num-prompts 10

  # Test IPv6 loopback (previously broken, now works)
  vllm bench serve --host ::1 --port 8000 --model <model> --num-prompts 10

  # Test hostname (should work as before)
  vllm bench serve --host localhost --port 8000 --model <model> --num-prompts 10

  Test Result

  Before fix:
  $ vllm bench serve --host :: --port 8000 --model deepseek-ai/DeepSeek-R1-0528 ...
  Traceback (most recent call last):
    ...
    File "/home/scottzh/oss/.venv/lib/python3.12/site-packages/yarl/_parse.py", line 134, in split_netloc
      port = int(port_str)
             ^^^^^^^^^^^^^
  ValueError: invalid literal for int() with base 10: '::8000'
  ...
  aiohttp.client_exceptions.InvalidUrlClientError: http://:::8000/v1/completions

  After fix:
  $ vllm bench serve --host :: --port 8000 --model deepseek-ai/DeepSeek-R1-0528 ...
  Using base_url: http://[::]:8000
  Using api_url: http://[::]:8000/v1/completions
  Starting initial single prompt test run...
  [benchmark proceeds successfully]