### PR TITLE
[ROCm] Bump up the version of amd-smi to 6.4.3

### DIFF
--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -13,5 +13,5 @@ setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 wheel
 jinja2>=3.1.6
-amdsmi==6.2.4
+amdsmi==6.4.3
 timm>=1.0.17


### PR DESCRIPTION
## Purpose
This PR upgrades the version of amd-smi to 6.4.3 to match up with the version of rocm used with torch 2.9. 

## Test Plan

Without this update, I get the following on an MI300X machine running ROCm 6.4. I don't see this error after updating and amd-smi seems to work as expected.

```
(test-venv) sage ~/g/vllm (sage/amd-smi-version-bump)> amd-smi
Traceback (most recent call last):
  File "/usr/bin/amd-smi", line 44, in <module>
    from amdsmi_commands import AMDSMICommands
  File "/opt/rocm-6.4.3/libexec/amdsmi_cli/amdsmi_commands.py", line 33, in <module>
    from amdsmi_helpers import AMDSMIHelpers
  File "/opt/rocm-6.4.3/libexec/amdsmi_cli/amdsmi_helpers.py", line 37, in <module>
    from amdsmi_init import *
  File "/opt/rocm-6.4.3/libexec/amdsmi_cli/amdsmi_init.py", line 35, in <module>
    from amdsmi import amdsmi_interface
  File "/mnt/nvme3n1p1/sage/git/nm-vllm/test-venv/lib/python3.12/site-packages/amdsmi/__init__.py", line 26, in <module>
    from .amdsmi_interface import amdsmi_init
  File "/mnt/nvme3n1p1/sage/git/nm-vllm/test-venv/lib/python3.12/site-packages/amdsmi/amdsmi_interface.py", line 28, in <module>
    from . import amdsmi_wrapper
  File "/mnt/nvme3n1p1/sage/git/nm-vllm/test-venv/lib/python3.12/site-packages/amdsmi/amdsmi_wrapper.py", line 2178, in <module>
    amdsmi_reset_gpu_compute_partition = _libraries['libamd_smi.so'].amdsmi_reset_gpu_compute_partition
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme3n1p1/sage/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/ctypes/__init__.py", line 392, in __getattr__
    func = self.__getitem__(name)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme3n1p1/sage/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/ctypes/__init__.py", line 397, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: /opt/rocm/lib/libamd_smi.so: undefined symbol: amdsmi_reset_gpu_compute_partition. Did you mean: 'amdsmi_set_gpu_compute_partition'?
```
