### PR TITLE
[CPU][Bugfix] Fix Apple Silicon M1 compilation failure

### DIFF
--- a/csrc/cpu/cpu_attn_impl.hpp
+++ b/csrc/cpu/cpu_attn_impl.hpp
@@ -741,9 +741,15 @@ class AttentionScheduler {
 
   static int64_t get_available_l2_size() {
     static int64_t size = []() {
+#if defined(__APPLE__)
+      // macOS doesn't have _SC_LEVEL2_CACHE_SIZE, use a reasonable default
+      // M1/M2/M3 typically have 128KB-256KB L2 per core
+      return 128 * 1024 >> 1;  // use 50% of 128KB
+#else
       long l2_cache_size = sysconf(_SC_LEVEL2_CACHE_SIZE);
       TORCH_CHECK_NE(l2_cache_size, -1);
       return l2_cache_size >> 1;  // use 50% of L2 cache
+#endif
     }();
     return size;
   }
@@ -816,10 +822,12 @@ struct VecTypeTrait<float> {
   using vec_t = vec_op::FP32Vec16;
 };
 
+#ifdef ARM_BF16_SUPPORT
 template <>
 struct VecTypeTrait<c10::BFloat16> {
   using vec_t = vec_op::BF16Vec16;
 };
+#endif
 
 #if !defined(__powerpc__)
 template <>
@@ -1588,9 +1596,17 @@ class AttentionMainLoop {
 
               if (use_sink) {
                 alignas(64) float s_aux_fp32[16];
+#ifdef ARM_BF16_SUPPORT
                 vec_op::BF16Vec16 vec_bf16(curr_s_aux);
                 vec_op::FP32Vec16 vec_fp32(vec_bf16);
                 vec_fp32.save(s_aux_fp32);
+#else
+                // Fallback for systems without BF16 support
+                // Convert BFloat16 to float manually
+                for (int i = 0; i < 16; ++i) {
+                  s_aux_fp32[i] = static_cast<float>(curr_s_aux[i]);
+                }
+#endif
 
                 float* __restrict__ curr_sum_buffer = sum_buffer;
                 float* __restrict__ curr_max_buffer = max_buffer;

--- a/csrc/cpu/cpu_attn_impl.hpp
+++ b/csrc/cpu/cpu_attn_impl.hpp
@@ -832,20 +832,9 @@ struct VecTypeTrait<float> {
   using vec_t = vec_op::FP32Vec16;
 };
 
-// BF16 support varies by platform:
-// - x86: always available
-// - ARM: only available with ARMv8.6-A BF16 extension (e.g., Apple M2+, AWS
-// Graviton3+)
-// - PowerPC/others: not available
-#if defined(__aarch64__)
-  #ifdef ARM_BF16_SUPPORT
-template <>
-struct VecTypeTrait<c10::BFloat16> {
-  using vec_t = vec_op::BF16Vec16;
-};
-  #endif
+// ARM only supports BF16 with ARMv8.6-A extension
+#if (defined(__aarch64__) && !defined(ARM_BF16_SUPPORT))
 #else
-// Non-ARM platforms (x86, etc.) have BF16Vec16 available
 template <>
 struct VecTypeTrait<c10::BFloat16> {
   using vec_t = vec_op::BF16Vec16;


### PR DESCRIPTION
## Purpose

The CPU attention backend refactor introduced unconditional use of BF16Vec16, which is only available on ARM platforms with native BF16 support (ARMv8.6-A extension). M1 chips and other older ARM processors lack this hardware capability.

Additionally, macOS doesn't support `_SC_LEVEL2_CACHE_SIZE` sysconf, causing L2 cache detection to fail.

Errors found:
- `error: no type named 'BF16Vec16' in namespace 'vec_op'` in `cpu_attn_impl.hpp:821`
- `error: use of undeclared identifier '_SC_LEVEL2_CACHE_SIZE'` in `cpu_attn_impl.hpp:744`

cc @bigPYJ1151 @fadara01

## Test Plan

Build on M1 Mac: `uv pip install -e .`

## Test Result

Build succeeds, vLLM imports successfully on M1.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

