### PR TITLE
[CI] Bug: Fix ci entrypoint pooling

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -579,6 +579,7 @@ class Processor:
             prompt_len == max_prompt_len
             and prompt_type == "decoder"
             and not model_config.is_multimodal_model
+            and self.model_config.runner_type != "pooling"
         ):
             suggestion = (
                 "Make sure that `max_model_len` is no smaller than the "


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/28683, issue introduced by https://github.com/vllm-project/vllm/pull/27099

https://buildkite.com/vllm/ci/builds/38880#019a7ea5-298f-4d57-8eee-8d43a70f490e

```bash
[2025-11-13T19:58:41Z]     def get_score(self, query, corpus):
[2025-11-13T19:58:41Z]         response = requests.post(
[2025-11-13T19:58:41Z]             self.url,
[2025-11-13T19:58:41Z]             json={
[2025-11-13T19:58:41Z]                 "model": self.model_name,
[2025-11-13T19:58:41Z]                 "text_1": query,
[2025-11-13T19:58:41Z]                 "text_2": corpus,
[2025-11-13T19:58:41Z]                 "truncate_prompt_tokens": -1,
[2025-11-13T19:58:41Z]             },
[2025-11-13T19:58:41Z]         ).json()
[2025-11-13T19:58:41Z] >       return response["data"][0]["score"]
[2025-11-13T19:58:41Z] E       KeyError: 'data'
[2025-11-13T19:58:41Z]
[2025-11-13T19:58:41Z] models/language/pooling_mteb_test/mteb_utils.py:131: KeyError
```

Pooling tasks don't generate tokens

## Test 

```bash
(yewentao256) [yewentao256@nma-h200-isolated-0-preserve correctness]$ pytest test_mteb_score.py 
=================================================== test session starts ====================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/yewentao256/vllm-source
configfile: pyproject.toml
plugins: anyio-4.11.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 2 items                                                                                                          

test_mteb_score.py ..                                                                                                [100%]
======================================= 2 passed, 7154 warnings in 83.95s (0:01:23)
```