### PR TITLE
Update xformers to 0.0.33.post1

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,6 +9,6 @@ torch==2.9.0
 torchaudio==2.9.0
 # These must be updated alongside torch
 torchvision==0.24.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-xformers==0.0.33; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
+xformers==0.0.33.post1; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.5.2


### PR DESCRIPTION
## Purpose

@youkaichao pointed out that `0.0.33` was still linked with CUDA 13.0.  

## Test Plan

`uv pip install xformers==0.0.33.post1` and confirms the `ldd` output this time

```
# 0.0.33.post1
ldd /home/huydo/.conda/envs/debug/lib/python3.12/site-packages/xformers/_C.so
        linux-vdso.so.1 (0x00007ffdab9e2000)
        libc10.so => not found
        libtorch.so => not found
        libtorch_cpu.so => not found
        libcudart.so.12 => /usr/local/cuda-12.9/lib64/libcudart.so.12 (0x00007fa6b0a00000) <== Rightly link with cudart.so.12. now
        libc10_cuda.so => not found
        libtorch_cuda.so => not found
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fa6b0600000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fa6b0d25000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fa6b2022000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fa6b201d000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fa6b0200000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fa6b2051000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007fa6b2016000)
        librt.so.1 => /lib64/librt.so.1 (0x00007fa6b2011000)
```

cc @ywang96 @simon-mo 
