### PR TITLE
fix fused_recurrent_gated_delta_rule_fwd returns incorrect final_state shape when inplace_final_state=False #28632  

### DIFF
--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -199,7 +199,7 @@ def fused_recurrent_gated_delta_rule_fwd(
     if inplace_final_state:
         final_state = initial_state
     else:
-        final_state = q.new_empty(T, HV, K, V, dtype=initial_state.dtype)
+        final_state = initial_state.new_empty((initial_state.shape[0], HV, K, V))
 
     stride_init_state_token = initial_state.stride(0)
     stride_final_state_token = final_state.stride(0)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
fix #28632
Fix fused_recurrent_gated_delta_rule_fwd final_state shape when inplace_final_state is False
## Test Plan
(.venv) root@7c9ceb5fe719:~/vllm# cat  repro_fused_delta_rule.py
import torch
from vllm.model_executor.layers.fla.ops.fused_recurrent import (
    fused_recurrent_gated_delta_rule,
)

torch.cuda.set_device(0)

B, T, H, K, V = 2, 4, 2, 16, 8
HV = 2  
dtype = torch.float16

q = torch.randn(B, T, H, K, dtype=dtype, device="cuda")
k = torch.randn(B, T, H, K, dtype=dtype, device="cuda")
v = torch.randn(B, T, HV, V, dtype=dtype, device="cuda")
g = torch.randn(B, T, HV, dtype=dtype, device="cuda")
beta = torch.randn(B, T, HV, dtype=dtype, device="cuda")

 
initial_state = torch.randn(B, HV, K, V, dtype=dtype, device="cuda")

o, final_state = fused_recurrent_gated_delta_rule(
    q=q,
    k=k,
    v=v,
    g=g,
    beta=beta,
    scale=1.0,
    initial_state=initial_state,
    inplace_final_state=False,
)

print("initial_state.shape =", initial_state.shape)
print("final_state.shape   =", final_state.shape)
(.venv) root@7c9ceb5fe719:~/vllm#
## Test Result
main branch:
(.venv) root@7c9ceb5fe719:~/vllm#  python repro_fused_delta_rule.py
initial_state.shape = torch.Size([2, 2, 16, 8])
final_state.shape   = torch.Size([4, 2, 16, 8] 

this branch:
(.venv) root@7c9ceb5fe719:~/vllm#  python repro_fused_delta_rule.py
initial_state.shape = torch.Size([2, 2, 16, 8])
final_state.shape   = torch.Size([2, 2, 16, 8])
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

