### PR TITLE
[BugFix] Fix FA3 IMA with FULL_AND_PIECEWISE and cascade attention (default)

### DIFF
--- a/tests/kernels/attention/test_cascade_flash_attn.py
+++ b/tests/kernels/attention/test_cascade_flash_attn.py
@@ -170,6 +170,7 @@ def test_cascade(
         logits_soft_cap=soft_cap if soft_cap is not None else 0,
         block_table=block_tables,
         common_prefix_len=common_prefix_len,
+        max_num_splits=0,  # no max
         fa_version=fa_version,
     )
 


### PR DESCRIPTION
Fix a subtle bug where the `get_scheduler_metadata` doesn't match the `flash_attn_varlen_func` in cascade attention; when full cudagraphs is enabled we force `num_splits` to `VLLM_FLASH_ATTN_MAX_NUM_SPLITS_FOR_CUDA_GRAPH` to make sure the `get_scheduler_metadata` always matches what the cudagraph was captured with. In the case of cascade attention this information is not piped into `cascade_attention`; this PR makes sure they match.