### PR TITLE
[Fix] improve aspect ratio in dummy image generation and add common  VLM tests for PaddleOCR-VL

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -97,14 +97,12 @@ VLM_TEST_SETTINGS = {
         multi_image_prompt=(
             "Image-1: <|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>\n"
             "Image-2: <|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>\n"
-            "请分别描述这两张图片。"
+            "Describe these two images separately."
         ),
         max_model_len=8192,
         max_num_seqs=2,
         auto_cls=AutoModelForCausalLM,
         image_size_factors=[(), (0.25,)],
-        vllm_runner_kwargs={"gpu_memory_utilization": 0.5},
-        marks=[pytest.mark.core_model],
     ),
     #### Core tests to always run in the CI
     "llava": VLMTestInfo(

--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -104,10 +104,6 @@ VLM_TEST_SETTINGS = {
         auto_cls=AutoModelForCausalLM,
         image_size_factors=[(), (0.25,)],
         vllm_runner_kwargs={"gpu_memory_utilization": 0.5},
-        # Use strict comparator; normalize outputs to (ids, text)
-        vllm_output_post_proc=lambda vllm_output, model: vllm_output[:2],
-        hf_output_post_proc=lambda hf_output, model: hf_output[:2],
-        comparator=check_outputs_equal,
         marks=[pytest.mark.core_model],
     ),
     #### Core tests to always run in the CI

--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -87,23 +87,6 @@ COMMON_BROADCAST_SETTINGS = {
 # this is a good idea for checking your command first, since tests are slow.
 
 VLM_TEST_SETTINGS = {
-    "paddleocr_vl": VLMTestInfo(
-        models=["PaddlePaddle/PaddleOCR-VL"],
-        test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"USER: {img_prompt}\nASSISTANT:",
-        img_idx_to_prompt=lambda idx: (
-            "<|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>"
-        ),
-        multi_image_prompt=(
-            "Image-1: <|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>\n"
-            "Image-2: <|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>\n"
-            "Describe these two images separately."
-        ),
-        max_model_len=8192,
-        max_num_seqs=2,
-        auto_cls=AutoModelForCausalLM,
-        image_size_factors=[(), (0.25,)],
-    ),
     #### Core tests to always run in the CI
     "llava": VLMTestInfo(
         models=["llava-hf/llava-1.5-7b-hf"],
@@ -708,6 +691,23 @@ VLM_TEST_SETTINGS = {
         num_logprobs=10,
         patch_hf_runner=model_utils.ovis2_5_patch_hf_runner,
         hf_model_kwargs={"revision": "refs/pr/5"},
+    ),
+    "paddleocr_vl": VLMTestInfo(
+        models=["PaddlePaddle/PaddleOCR-VL"],
+        test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
+        prompt_formatter=lambda img_prompt: f"USER: {img_prompt}\nASSISTANT:",
+        img_idx_to_prompt=lambda idx: (
+            "<|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>"
+        ),
+        multi_image_prompt=(
+            "Image-1: <|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>\n"
+            "Image-2: <|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>\n"
+            "Describe these two images separately."
+        ),
+        max_model_len=8192,
+        max_num_seqs=2,
+        auto_cls=AutoModelForCausalLM,
+        image_size_factors=[(), (0.25,)],
     ),
     "phi3v": VLMTestInfo(
         models=["microsoft/Phi-3.5-vision-instruct"],

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -233,7 +233,7 @@ class PaddleOCRVLProcessingInfo(BaseProcessingInfo):
         # to create a dummy image with a reasonable aspect ratio.
         h_patches = int(math.sqrt(max_num_tokens))
         while max_num_tokens % h_patches != 0:
-            h_patches -= 1
+            max_num_tokens -= 1
         w_patches = max_num_tokens // h_patches
         return ImageSize(height=h_patches * factor, width=w_patches * factor)
 

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -232,8 +232,7 @@ class PaddleOCRVLProcessingInfo(BaseProcessingInfo):
         # Find factors of max_num_tokens close to its square root
         # to create a dummy image with a reasonable aspect ratio.
         h_patches = int(math.sqrt(max_num_tokens))
-        while max_num_tokens % h_patches != 0:
-            max_num_tokens -= 1
+        max_num_tokens -= max_num_tokens % h_patches
         w_patches = max_num_tokens // h_patches
         return ImageSize(height=h_patches * factor, width=w_patches * factor)
 


### PR DESCRIPTION
## Purpose

This PR fixes an aspect ratio issue in PaddleOCR-VL's dummy image generation and adds the model to the common VLM test suite.

**Problem**: The original implementation decremented `h_patches` to find factors, which could lead to skewed aspect ratios in some cases. The fix decrements  `max_num_tokens` instead, ensuring more balanced width-height ratios that better represent image with a reasonable aspect ratio.

## Test Plan

Tested with:
  pytest -s -v tests/models/multimodal/generation/test_common.py -k paddleocr_vl

## Test Result
Both single-image and multi-image tests pass successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

