### PR TITLE
Fixed gpt-oss _load_weights_other() parameter position bug

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -641,8 +641,8 @@ class GptOssModel(nn.Module):
             )
         else:
             return self._load_weights_other(
-                ep_rank_end,
                 ep_rank_start,
+                ep_rank_end,
                 heads_per_rank,
                 head_start,
                 weights,


### PR DESCRIPTION
Summary:
Signed-off-by: Dezhan Tu dezhantu@gmail.com

For `_load_weights_other()`, `ep_rank_start` and `ep_rank_end` positions are wrongly placed, leading to the failure of loading expert data in expert parallelim. This diff fixed this bug.

Test Plan:
```
from vllm import LLM
llm = LLM("openai/gpt-oss-120b", tensor_parallel_size=2, enable_expert_parallel)
output = llm.generate("Hi, vLLM is a")
```

Reviewed By: helunwencser, jackm321

Differential Revision: D87021773


