### PR TITLE
[Bugfix] [ROCm] [AITER]: Fix aiter block quant not compatible with torch compile dynamo

### DIFF
--- a/tests/rocm/aiter/test_grouped_quant.py
+++ b/tests/rocm/aiter/test_grouped_quant.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# This is a test for the AITER group_fp8_quant op.
+# It tests if the AITER op is
+# 1. correctly defined the relationship between
+#    implementation and fake function
+# 2. can be used with torch.compile
+# 3. can be used with CUDA graphs
+# This file will be skipped if AITER is not installed
+# and the platform is not ROCm.
+
+import importlib.util
+
+import pytest
+import torch
+
+# this import statement is needed to ensure the ops are registered
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.platforms import current_platform
+
+# Check if aiter package is installed
+aiter_available = importlib.util.find_spec("aiter") is not None
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_rocm() and aiter_available),
+    reason="AITER ops are only available on ROCm with aiter package installed",
+)
+
+
+def test_rocm_aiter_group_fp8_quant_fake_implementation():
+    """Test that the fake implementation is correctly
+    defined for torch.ops.vllm.rocm_aiter_group_fp8_quant."""
+    # Create test tensors
+    M = 128
+    N = 4096
+    group_size = 128
+
+    input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+
+    # Verify the op's fake implementation using torch.library.opcheck
+    # This checks that the fake function returns tensors with correct shapes and dtypes
+    torch.library.opcheck(
+        torch.ops.vllm.rocm_aiter_group_fp8_quant,
+        (input_tensor, group_size),
+        test_utils=("test_faketensor",),
+    )
+
+
+def test_rocm_aiter_group_fp8_quant_torch_compile_with_cudagraph():
+    """Test that rocm_aiter_ops.group_fp8_quant
+    with group size 128 can be used with
+    torch.compile in cudagraph mode."""
+    # Create test tensors
+    M = 128
+    N = 4096
+    group_size = 128
+
+    input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+
+    # Define a function that uses the op
+    def group_fp8_quant_fn(x):
+        return rocm_aiter_ops.group_fp8_quant(x, group_size)
+
+    # Compile with cudagraph mode
+    compiled_fn = torch.compile(
+        group_fp8_quant_fn,
+        fullgraph=True,
+        backend="inductor",
+        mode="reduce-overhead",
+        dynamic=False,
+    )
+
+    # Run eager mode
+    x_fp8_eager, scales_eager = group_fp8_quant_fn(input_tensor)
+
+    # Run compiled version (first run will trigger compilation)
+    x_fp8_compiled, scales_compiled = compiled_fn(input_tensor)
+
+    # Verify shapes match
+    assert x_fp8_compiled.shape == x_fp8_eager.shape
+    assert scales_compiled.shape == scales_eager.shape
+
+    # Verify expected shapes
+    assert x_fp8_compiled.shape == (M, N)
+    expected_scale_cols = (N + group_size - 1) // group_size
+    assert scales_compiled.shape == (M, expected_scale_cols)
+
+    # Verify results match
+    assert torch.allclose(
+        x_fp8_compiled.to(torch.float32),
+        x_fp8_eager.to(torch.float32),
+        rtol=1e-2,
+        atol=1e-2,
+    )
+    assert torch.allclose(scales_compiled, scales_eager, rtol=1e-3, atol=1e-3)
+
+    # Test with different input (reusing compiled graph)
+    input_tensor_2 = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+    x_fp8_eager_2, scales_eager_2 = group_fp8_quant_fn(input_tensor_2)
+    x_fp8_compiled_2, scales_compiled_2 = compiled_fn(input_tensor_2)
+
+    # Verify second run also produces correct results
+    assert torch.allclose(
+        x_fp8_compiled_2.to(torch.float32),
+        x_fp8_eager_2.to(torch.float32),
+        rtol=1e-2,
+        atol=1e-2,
+    )
+    assert torch.allclose(scales_compiled_2, scales_eager_2, rtol=1e-3, atol=1e-3)
+
+
+def test_rocm_aiter_group_fp8_quant_different_shapes():
+    """Test rocm_aiter_ops.group_fp8_quant with different input shapes."""
+    group_size = 128
+
+    test_shapes = [
+        (64, 2048),
+        (256, 8192),
+        (32, 1024),
+        (512, 4096),
+    ]
+
+    for M, N in test_shapes:
+        input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+
+        x_fp8, scales = rocm_aiter_ops.group_fp8_quant(input_tensor, group_size)
+
+        # Verify shapes
+        assert x_fp8.shape == (M, N)
+        expected_scale_cols = (N + group_size - 1) // group_size
+        assert scales.shape == (M, expected_scale_cols)
+
+        # Verify dtypes
+        from aiter import dtypes
+
+        assert x_fp8.dtype == dtypes.fp8
+        assert scales.dtype == torch.float32

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -342,7 +342,7 @@ class W8A8BlockFp8LinearOp:
             )
         # MI300 uses tuned AITER ASM/C++ kernel
         else:
-            q_input, input_scale = rocm_aiter_ops.per_1x128_fp8_quant(input_2d)
+            q_input, input_scale = rocm_aiter_ops.group_fp8_quant(input_2d)
 
         return gemm_a8w8_blockscale_op(
             q_input,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

For the AITER version (`9716b1b8`) in the `Dockerfile.rocm_base`, the AITER's block quant operator is not compatible with torch compile.

Trace:
```
File "/app/rocmvllm/remove_device_info/vllm/model_executor/layers/linear.py", line 565, in forward
  output_parallel = self.quant_method.apply(self, input_, bias)
File "/app/rocmvllm/remove_device_info/vllm/model_executor/layers/quantization/fp8.py", line 669, in apply
  return self.w8a8_block_fp8_linear.apply(
File "/app/rocmvllm/remove_device_info/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 296, in apply
  output = self.w8a8_blockscale_op(input_2d, weight, weight_scale)
File "/app/rocmvllm/remove_device_info/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 355, in _run_aiter
  q_input, input_scale = aiter_per1x128_quant(
File "/usr/local/lib/python3.12/dist-packages/aiter/ops/quant.py", line 236, in per_group_quant_hip
  dynamic_per_token_scaled_quant(
File "/usr/local/lib/python3.12/dist-packages/aiter/jit/core.py", line 628, in wrapper
  func.arg_checked = check_args()
File "/usr/local/lib/python3.12/dist-packages/aiter/jit/core.py", line 578, in check_args
  doc_str = re.sub(r"<(.*?)\:.*?>", r"\g<1>", doc_str)
File "/usr/lib/python3.12/re/__init__.py", line 186, in sub
  return _compile(pattern, flags).sub(repl, string, count)
File "/usr/lib/python3.12/re/__init__.py", line 307, in _compile
  p = _compiler.compile(pattern, flags)
File "/usr/lib/python3.12/re/_compiler.py", line 750, in compile
  p = _parser.parse(p, flags)
File "/usr/lib/python3.12/re/_parser.py", line 979, in parse
  p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
File "/usr/lib/python3.12/re/_parser.py", line 460, in _parse_sub
  itemsappend(_parse(source, state, verbose, nested + 1,
File "/usr/lib/python3.12/re/_parser.py", line 867, in _parse
  state.closegroup(group, p)
File "/usr/lib/python3.12/re/_parser.py", line 99, in closegroup
  self.groupwidths[gid] = p.getwidth()
File "/usr/lib/python3.12/re/_parser.py", line 204, in getwidth
  if av[1] == MAXREPEAT and j:
File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/polyfills/__init__.py", line 361, in cmp_eq
  result = a.__eq__(b)
```
Solution: register the op with `direct_register_custom_op`

The change in API name is to align with this PR https://github.com/vllm-project/vllm/pull/25693

## Test Plan

Add unit test `tests/rocm/aiter/test_grouped_quant.py` to check if the 
1. correctly defined the relationship between
    implementation and fake function
2. can be used with torch.compile
3. can be used with CUDA graphs

Evaluate end to end model accuracy.

## Test Result

1. `tests/rocm/aiter/test_grouped_quant.py` test passed

2. Lmeval score of DeepSeek-R1

```
local-completions (model=/app/local_models/deepseek-ai__DeepSeek-R1,base_url=http://127.0.0.1:8000/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.953|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.953|±  |0.0058|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

