### PR TITLE
[BugFix] Fix misprint introduced by modular_kernel refactoring.

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1060,7 +1060,7 @@ class FusedMoEModularKernel(torch.nn.Module):
                 global_num_experts=global_num_experts,
                 expert_map=expert_map,
                 a1q_scale=_slice_scales(a1q_scale, s, e),
-                a2_scale=_slice_scales(self.fused_experts.a2_scale, e, e),
+                a2_scale=_slice_scales(self.fused_experts.a2_scale, s, e),
                 workspace13=workspace13,
                 workspace2=workspace2,
                 expert_tokens_meta=c_expert_tokens_meta,


### PR DESCRIPTION
This bug was introduced during modular_kernel refactoring in #24812. 

Correct code before the refactoring:
https://github.com/vllm-project/vllm/blame/f08919b7d17f6adf4eea26ca410c4a3de41a71da/vllm/model_executor/layers/fused_moe/modular_kernel.py#L833
