### PR TITLE
[CI] Fix macos smoke test uv cache issue

### DIFF
--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            requirements/**/*.txt
+            pyproject.toml
           python-version: '3.12'
 
       - name: Install dependencies

--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: |


### PR DESCRIPTION

## Purpose

Fix failing uv setup for the workflow
https://github.com/vllm-project/vllm/actions/runs/19371140277/job/55427141839
```
Run astral-sh/setup-uv@v4
Downloading uv from "https://github.com/astral-sh/uv/releases/download/0.9.9/uv-aarch64-apple-darwin.tar.gz" ...
/usr/bin/tar xz -C /Users/runner/work/_temp/0ef0727d-06a8-40a7-8657-50ceeca9ded7 -f /Users/runner/work/_temp/a6dd913b-41be-4b7d-a755-3351a978d6b9
Added /Users/runner/hostedtoolcache/uv/0.9.9/aarch64 to the path
Added /Users/runner/.local/bin to the path
Set UV_PYTHON to 3.12
Set UV_CACHE_DIR to /Users/runner/work/_temp/setup-uv-cache
Successfully installed uv version 0.9.9
Searching files using cache dependency glob: **/uv.lock
No matches found for glob
Error: No file matched to [**/uv.lock], make sure you have checked out the target repository
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

