### PR TITLE
[Bugfix] Fix incorrect use of hidden_states for shared_experts due to do_naive_dispatch_combine

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1749,14 +1749,16 @@ class FusedMoE(CustomOp):
 
         with sp_ctx:
             if do_naive_dispatch_combine:
-                hidden_states, router_logits = get_ep_group().dispatch(
+                hidden_states_combined, router_logits = get_ep_group().dispatch(
                     hidden_states, router_logits, self.is_sequence_parallel
                 )
 
             # Matrix multiply.
             final_hidden_states = self.quant_method.apply(
                 layer=self,
-                x=hidden_states,
+                x=hidden_states_combined
+                if do_naive_dispatch_combine
+                else hidden_states,
                 router_logits=router_logits,
                 top_k=self.top_k,
                 renormalize=self.renormalize,


### PR DESCRIPTION
This PR fixes an issue created by https://github.com/vllm-project/vllm/pull/28406 when running:

```
export VLLM_ATTENTION_BACKEND=FLASHINFER_MLA
export VLLM_FLASHINFER_MOE_BACKEND=latency
export VLLM_USE_FLASHINFER_MOE_FP8=1
export VLLM_USE_FLASHINFER_MOE_FP4=1
vllm serve --model nvidia/DeepSeek-R1-0528-FP4 --kv-cache-dtype fp8 --tensor-parallel-size 1 --pipeline-parallel-size 1 --data-parallel-size 4 --enable-expert-parallel
```

Thanks @hjjq for finding this issue and pinpointing the problematic commit.

The fix is simple: we just need to ensure that the shared_experts get the original hidden_states and not the combined one due to the DP+EP execution.

