### PR TITLE
Fix IntermediateTensors initialization and add type hints

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -60,12 +60,13 @@ class IntermediateTensors:
     tensors: dict[str, torch.Tensor]
     kv_connector_output: KVConnectorOutput | None
 
-    def __init__(self, tensors: dict[str, torch.Tensor]) -> None:
+    def __init__(self, tensors: dict[str, torch.Tensor], kv_connector_output: KVConnectorOutput | None = None) -> None:
         # manually define this function, so that
         # Dynamo knows `IntermediateTensors()` comes from this file.
         # Otherwise, dataclass will generate this function by evaluating
         # a string, and we will lose the information about the source file.
         self.tensors = tensors
+        self.kv_connector_output = kv_connector_output
 
     def __getitem__(self, key: str | slice):
         if isinstance(key, str):

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -60,7 +60,7 @@ class IntermediateTensors:
     tensors: dict[str, torch.Tensor]
     kv_connector_output: KVConnectorOutput | None
 
-    def __init__(self, tensors):
+    def __init__(self, tensors: dict[str, torch.Tensor]) -> None:
         # manually define this function, so that
         # Dynamo knows `IntermediateTensors()` comes from this file.
         # Otherwise, dataclass will generate this function by evaluating

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -60,7 +60,11 @@ class IntermediateTensors:
     tensors: dict[str, torch.Tensor]
     kv_connector_output: KVConnectorOutput | None
 
-    def __init__(self, tensors: dict[str, torch.Tensor], kv_connector_output: KVConnectorOutput | None = None) -> None:
+    def __init__(
+        self,
+        tensors: dict[str, torch.Tensor],
+        kv_connector_output: KVConnectorOutput | None = None,
+    ) -> None:
         # manually define this function, so that
         # Dynamo knows `IntermediateTensors()` comes from this file.
         # Otherwise, dataclass will generate this function by evaluating


### PR DESCRIPTION
## Purpose

Add missing type hints and fix field initialization bug in `IntermediateTensors.__init__` method in `vllm/sequence.py`.

**Changes:**
1. Added type hint for `tensors` parameter: `dict[str, torch.Tensor]`
2. Added type hint for `kv_connector_output` parameter with default value `None`
3. Fixed bug where `kv_connector_output` field was not initialized in custom `__init__`, which could cause `AttributeError` at runtime

## Changes

- **File:** `vllm/sequence.py:63-68`
- **Added:** Type hints for both `tensors` and `kv_connector_output` parameters
- **Added:** Return type annotation `-> None`
- **Fixed:** Proper initialization of `kv_connector_output` field in method body

## Benefits

- Improves type safety and IDE autocomplete support
- Makes parameter types explicit and consistent with class definition
- Fixes potential runtime bug where `kv_connector_output` could be accessed before initialization
- Helps static type checkers catch potential bugs

## Test Plan

```bash
# Verify Python syntax is valid
python -m py_compile vllm/sequence.py

# Verify the class can be instantiated correctly
python -c "from vllm.sequence import IntermediateTensors; import torch; obj = IntermediateTensors({}); print(obj.kv_connector_output)"
```

## Test Result
✅ File compiles successfully with correct type annotations. ✅ Class instantiates properly with all fields initialized. ✅ kv_connector_output defaults to None when not provided.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>