### PR TITLE
Reduce validation to a warning

### DIFF
--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -68,25 +68,6 @@ class StructuredOutputsConfig:
 
     @model_validator(mode="after")
     def _validate_structured_output_config(self) -> Self:
-        # Import here to avoid circular import
-        from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
-
-        if self.reasoning_parser_plugin and len(self.reasoning_parser_plugin) > 3:
-            ReasoningParserManager.import_reasoning_parser(self.reasoning_parser_plugin)
-
-        valid_reasoning_parsers = ReasoningParserManager.list_registered()
-        if (
-            self.reasoning_parser != ""
-            and self.reasoning_parser not in valid_reasoning_parsers
-        ):
-            logger.warning(
-                "Reasoning parser %s not found among built-in parsers or "
-                "reasoning_parser_plugin argument. Assuming it will be "
-                "registered to the ReasoningParserManager programmatically "
-                "before use.",
-                self.reasoning_parser,
-            )
-
         if self.disable_any_whitespace and self.backend not in ("xgrammar", "guidance"):
             raise ValueError(
                 "disable_any_whitespace is only supported for "

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -8,11 +8,14 @@ from pydantic.dataclasses import dataclass
 from typing_extensions import Self
 
 from vllm.config.utils import config
+from vllm.logger import init_logger
 from vllm.utils.hashing import safe_hash
 
 StructuredOutputsBackend = Literal[
     "auto", "xgrammar", "guidance", "outlines", "lm-format-enforcer"
 ]
+
+logger = init_logger(__name__)
 
 
 @config
@@ -76,9 +79,11 @@ class StructuredOutputsConfig:
             self.reasoning_parser != ""
             and self.reasoning_parser not in valid_reasoning_parsers
         ):
-            raise ValueError(
-                f"invalid reasoning parser: {self.reasoning_parser} "
-                f"(chose from {{ {','.join(valid_reasoning_parsers)} }})"
+            logger.warning(
+                "Reasoning parser %s not defined in reasoning_parser_plugin "
+                "argument. Assuming it is registered to the "
+                "ReasoningParserManager programmatically.",
+                self.reasoning_parser,
             )
 
         if self.disable_any_whitespace and self.backend not in ("xgrammar", "guidance"):

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -8,14 +8,11 @@ from pydantic.dataclasses import dataclass
 from typing_extensions import Self
 
 from vllm.config.utils import config
-from vllm.logger import init_logger
 from vllm.utils.hashing import safe_hash
 
 StructuredOutputsBackend = Literal[
     "auto", "xgrammar", "guidance", "outlines", "lm-format-enforcer"
 ]
-
-logger = init_logger(__name__)
 
 
 @config

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -80,9 +80,10 @@ class StructuredOutputsConfig:
             and self.reasoning_parser not in valid_reasoning_parsers
         ):
             logger.warning(
-                "Reasoning parser %s not defined in reasoning_parser_plugin "
-                "argument. Assuming it is registered to the "
-                "ReasoningParserManager programmatically.",
+                "Reasoning parser %s not found among built-in parsers or "
+                "reasoning_parser_plugin argument. Assuming it will be "
+                "registered to the ReasoningParserManager programmatically "
+                "before use.",
                 self.reasoning_parser,
             )
 

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -162,7 +162,7 @@ class ReasoningParserManager:
 
         registered = ", ".join(cls.list_registered())
         raise KeyError(
-            f"Reasoning parser '{name}' not found.\nAvailable parsers: {registered}"
+            f"Reasoning parser '{name}' not found. Available parsers: {registered}"
         )
 
     @classmethod

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -160,7 +160,7 @@ class ReasoningParserManager:
         if name in cls.lazy_parsers:
             return cls._load_lazy_parser(name)
 
-        registered = ", ".join(ReasoningParserManager.list_registered())
+        registered = ", ".join(cls.list_registered())
         raise KeyError(
             f"Reasoning parser '{name}' not found.\nAvailable parsers: {registered}"
         )

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -160,7 +160,10 @@ class ReasoningParserManager:
         if name in cls.lazy_parsers:
             return cls._load_lazy_parser(name)
 
-        raise KeyError(f"Reasoning parser '{name}' not found.")
+        registered = ", ".join(ReasoningParserManager.list_registered())
+        raise KeyError(
+            f"Reasoning parser '{name}' not found.\nAvailable parsers: {registered}"
+        )
 
     @classmethod
     def list_registered(cls) -> list[str]:


### PR DESCRIPTION
## Purpose
Fix for issue introduced in [28075](https://github.com/vllm-project/vllm/pull/28075) 

The reasoning parser validation introduced on the structured_outputs_config argument is done very early and does not allow for other programmatic methods for registering reasoning parsers.

By only allowing registration of external reasoning parsers via `reasoning-parser-plugin` it would require bundling of extra python files when deploying vLLM, which is not an ideal experience. 

## Test Plan
External registration of plugins with ReasoningParserManager 

## Test Result
External registration of plugins with ReasoningParserManager works like before