### PR TITLE
[BugFix] Fix `AssertionError: DCP not support reorder_batch_threshold > 1 now.` 

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -628,16 +628,6 @@ class GPUModelRunner(
             return
 
         if self.reorder_batch_threshold is not None:
-            # NOTE(lucas): currently no backend supports the custom masking
-            #  required for DCP with q_len > 1, so we assert here. Remove this
-            #  assert once the custom mask is support is added to FA3.
-            if (
-                self.dcp_world_size > 1
-                and envs.VLLM_ATTENTION_BACKEND != "FLASH_ATTN_MLA"
-            ):
-                assert self.reorder_batch_threshold == 1, (
-                    "DCP not support reorder_batch_threshold > 1 now."
-                )
             reorder_batch_to_split_decodes_and_prefills(
                 self.input_batch,
                 scheduler_output,


### PR DESCRIPTION
Fix `AssertionError: DCP not support reorder_batch_threshold > 1 now.` caused by https://github.com/vllm-project/vllm/pull/27363

Simply removing the assert; this assert has resulted in more false positives than true positives causing unnecessary thrash. The GPU model runner should not be responsible for tracking support of attention backends and ensuring they are advertising correct reorder batch thresholds; this would be better enforced via something like: https://github.com/vllm-project/vllm/pull/28750