### PR TITLE
Use narrow over indexing in `hadacore_transform` to prep for ABI stable

### DIFF
--- a/csrc/quantization/hadamard/hadacore/hadamard_transform_cuda.cu
+++ b/csrc/quantization/hadamard/hadacore/hadamard_transform_cuda.cu
@@ -802,7 +802,7 @@ torch::Tensor hadacore_transform(torch::Tensor& x, bool inplace) {
     });
 
     if (numel % 256 != 0) {
-        out = out.index({torch::indexing::Slice(0, numel / had_size)});
+        out = out.narrow(0, 0, numel / had_size);
     }
 
     if (inplace && out.data_ptr() != x.data_ptr()) {


### PR DESCRIPTION
## Purpose

Instead of using indexing, use `narrow`, which is supported by ABI stable in the `hadacore_transform` kernel. They compute the same slice. Contributes to #26946.

## Test Plan
` pytest tests/kernels/quantization/test_hadacore.py `

## Test Result
```
(vllm) [janeyx@devgpu007.eag6 /data/users/janeyx/local/vllm (python-meta-kernels)]$ pytest tests/kernels/quantization/test_hadacore.py 
======================= test session starts ========================
platform linux -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /data/users/janeyx/local/vllm
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 20 items                                                 

tests/kernels/quantization/test_hadacore.py ................ [ 80%]
....                                                         [100%]

========================= warnings summary =========================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================== 20 passed, 2 warnings in 5.94s ==================
<sys>:0: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
(vllm) [janeyx@devgpu007.eag6 /data/users/janeyx/local/vllm (python-meta-kernels)]$
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

