### PR TITLE
[TPU] Fix import error in tpu launch

### DIFF
--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -9,20 +9,25 @@ from tpu_info import device
 
 from vllm.inputs import ProcessorInputs, PromptType
 from vllm.logger import init_logger
-from vllm.sampling_params import SamplingParams, SamplingType
 
 from .interface import Platform, PlatformEnum
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from vllm.attention.backends.registry import AttentionBackendEnum
     from vllm.config import VllmConfig
     from vllm.config.cache import BlockSize
     from vllm.pooling_params import PoolingParams
+    from vllm.sampling_params import SamplingParams
+
+    ParamsType: TypeAlias = SamplingParams | PoolingParams
 else:
     BlockSize = None
     VllmConfig = None
     PoolingParams = None
     AttentionBackendEnum = None
+    ParamsType = None
 
 logger = init_logger(__name__)
 
@@ -203,10 +208,12 @@ class TpuPlatform(Platform):
     def validate_request(
         cls,
         prompt: PromptType,
-        params: SamplingParams | PoolingParams,
+        params: ParamsType,
         processed_inputs: ProcessorInputs,
     ) -> None:
         """Raises if this request is unsupported on this platform"""
+        from vllm.sampling_params import SamplingParams, SamplingType
+
         if (
             isinstance(params, SamplingParams)
             and params.sampling_type == SamplingType.RANDOM_SEED


### PR DESCRIPTION
## Purpose
Fix import error by lazy import.

link to question: https://vllm-dev.slack.com/archives/C07QP347J4D/p1763150204944199

from  https://github.com/vllm-project/vllm/pull/24261, starting vllm on TPU started to have error: 

```
Traceback (most recent call last):
  File "/usr/local/bin/vllm", line 5, in <module>
    from vllm.entrypoints.cli.main import main
  File "/workspace/vllm/vllm/entrypoints/cli/__init__.py", line 3, in <module>
    from vllm.entrypoints.cli.benchmark.latency import BenchmarkLatencySubcommand
  File "/workspace/vllm/vllm/entrypoints/cli/benchmark/latency.py", line 5, in <module>
    from vllm.benchmarks.latency import add_cli_args, main
  File "/workspace/vllm/vllm/benchmarks/latency.py", line 17, in <module>
    from vllm.engine.arg_utils import EngineArgs
  File "/workspace/vllm/vllm/engine/arg_utils.py", line 35, in <module>
    from vllm.attention.backends.registry import AttentionBackendEnum
  File "/workspace/vllm/vllm/attention/__init__.py", line 4, in <module>
    from vllm.attention.backends.abstract import (
  File "/workspace/vllm/vllm/attention/backends/abstract.py", line 9, in <module>
    from vllm.model_executor.layers.linear import ColumnParallelLinear
  File "/workspace/vllm/vllm/model_executor/__init__.py", line 4, in <module>
    from vllm.model_executor.parameter import BasevLLMParameter, PackedvLLMParameter
  File "/workspace/vllm/vllm/model_executor/parameter.py", line 11, in <module>
    from vllm.distributed import (
  File "/workspace/vllm/vllm/distributed/__init__.py", line 4, in <module>
    from .communication_op import *
  File "/workspace/vllm/vllm/distributed/communication_op.py", line 9, in <module>
    from .parallel_state import get_tp_group
  File "/workspace/vllm/vllm/distributed/parallel_state.py", line 250, in <module>
    direct_register_custom_op(
  File "/workspace/vllm/vllm/utils/torch_utils.py", line 640, in direct_register_custom_op
    from vllm.platforms import current_platform
  File "/workspace/vllm/vllm/platforms/__init__.py", line 257, in __getattr__
    _current_platform = resolve_obj_by_qualname(platform_cls_qualname)()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/vllm/vllm/utils/import_utils.py", line 89, in resolve_obj_by_qualname
    module = importlib.import_module(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/vllm/vllm/platforms/tpu.py", line 12, in <module>
    from vllm.sampling_params import SamplingParams, SamplingType
  File "/workspace/vllm/vllm/sampling_params.py", line 18, in <module>
    from vllm.v1.serial_utils import PydanticMsgspecMixin
  File "/workspace/vllm/vllm/v1/serial_utils.py", line 24, in <module>
    from vllm.multimodal.inputs import (
  File "/workspace/vllm/vllm/multimodal/__init__.py", line 15, in <module>
    from .registry import MultiModalRegistry
  File "/workspace/vllm/vllm/multimodal/registry.py", line 9, in <module>
    from vllm.config.multimodal import BaseDummyOptions
  File "/workspace/vllm/vllm/config/__init__.py", line 5, in <module>
    from vllm.config.compilation import (
  File "/workspace/vllm/vllm/config/compilation.py", line 19, in <module>
    from vllm.platforms import current_platform
ImportError: cannot import name 'current_platform' from 'vllm.platforms' (/workspace/vllm/vllm/platforms/__init__.py). Did you mean: '_current_platform'?
```


## Test Plan
Manual verification 
1. tpu-inference hash `df7c0d39`
2. apply this change on vllm hash `6f1e7f722`
3. command below and start vllm
```
TPU_BACKEND_TYPE=jax vllm serve \
  --seed 42 \
  --model Qwen/Qwen2.5-1.5B-Instruct \
  --download_dir /mnt/disks/persist \
  --max-num-batched-tokens 2048 \
  --max-num-seqs 128  \
  --no-enable-prefix-caching \
  --disable-log-requests \
  --tensor-parallel-size 1
```

