### PR TITLE
[Model][QwenVL] Optimize `Qwen2_5_VisionAttention` q,k preparation

### DIFF
--- a/vllm/model_executor/models/dots_ocr.py
+++ b/vllm/model_executor/models/dots_ocr.py
@@ -39,8 +39,8 @@ from vllm.model_executor.models.interfaces import (
 )
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.qwen2 import Qwen2ForCausalLM
-from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VisionAttention
 from vllm.model_executor.models.qwen2_vl import (
+    Qwen2VisionAttention,
     Qwen2VLDummyInputsBuilder,
     Qwen2VLMultiModalProcessor,
     Qwen2VLProcessingInfo,
@@ -328,7 +328,7 @@ class DotsVisionAttention(nn.Module):
         # [S, C] -> [S, B=1, C]
         x = hidden_states.unsqueeze(1)
         x, _ = self.qkv(x)
-        q, k, v = Qwen2_5_VisionAttention.split_qkv(self, x)
+        q, k, v = Qwen2VisionAttention.split_qkv(self, x)
         bs = q.shape[1]
         # [S,B,H,D] -> [B,S,H,D]
         q = q.permute(1, 0, 2, 3).contiguous()


### PR DESCRIPTION
## Purpose

This is a follow up on #28271 and #24511 and further optimizes the query/key splitting. It prevents the need to concatenate the queries and keys again before applying the rotary embeddings. Instead everything is handled with fast rearrange and slicing which don't require GPU ops.

<img width="1162" height="100" alt="Screenshot 2025-11-15 at 01 34 28" src="https://github.com/user-attachments/assets/f5389c34-6a84-46f3-a217-d4a4f9af6e10" />


## Test Plan

```
VLLM_WORKER_MULTIPROC_METHOD=spawn lm_eval --model vllm-vlm --model_args "pretrained=Qwen/Qwen3-VL-30B-A3B-Instruct-FP8,max_model_len=10000" --tasks chartqa --batch_size auto --apply_chat_template
```

## Test Result

**Before:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8784 | ±   | 0.0065 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6392 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8652 | ±   | 0.0068 |

**After:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8740 | ±   | 0.0066 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6416 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8656 | ±   | 0.0068 |
