### PR TITLE
[Bugfix]: nccl connnector memory leak

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -306,9 +306,7 @@ class P2pNcclEngine:
         return True
 
     def pop_recv_store_after_recv(self, tensor_id: str) -> None:
-        if (
-            self.send_type == "PUT" or self.send_type == "PUT_ASYNC"
-        ) and tensor_id in self.recv_store:
+        if self.send_type == "PUT" or self.send_type == "PUT_ASYNC":
             with self.recv_store_cv:
                 tensor = self.recv_store.pop(tensor_id, None)
             if isinstance(tensor, tuple):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -305,6 +305,17 @@ class P2pNcclEngine:
             )
         return True
 
+    def pop_recv_store_after_recv(self, tensor_id: str) -> None:
+        if (
+            self.send_type == "PUT" or self.send_type == "PUT_ASYNC"
+        ) and tensor_id in self.recv_store:
+            with self.recv_store_cv:
+                tensor = self.recv_store.pop(tensor_id, None)
+            if isinstance(tensor, tuple):
+                addr, _, _ = tensor
+                self.pool.free(addr)
+        return
+
     def recv_tensor(
         self,
         tensor_id: str,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR addresses two issues:

1. In the current implementation of `recv_tensor` in the nccl connector/engine, `self.buffer_size` is restored, but the corresponding tensor is released in `get_finished`, with the decoding step in between. This can potentially lead to GPU memory leaks. For example, during this period, the decode instance continues to receive KV cache. When `self.buffer_size` is used to check for available GPU memory, it may incorrectly assume that there is free memory, potentially leading to out-of-memory errors.

2. The scheduler currently allows None when generating `new_block_ids` in `CachedRequestData`, but the nccl connector does not support this. This can cause errors in chunked prefill scenarios.
<img width="746" height="84" alt="image" src="https://github.com/user-attachments/assets/6f479c54-0d8b-489e-9b82-271c990e2b72" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

