### PR TITLE
[CI] Fix broken pipeline

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -926,7 +926,7 @@ steps:
     - pytest -v -s tests/kernels/moe/test_ocp_mx_moe.py
     - pytest -v -s tests/kernels/moe/test_flashinfer.py
 
-- label: Blackwell Fusion & Compile Tests # 30 min
+- label: Blackwell Fusion and Compile Tests # 30 min
   timeout_in_minutes: 40
   working_dir: "/vllm-workspace/"
   gpu: b200


### PR DESCRIPTION
Build broken by https://github.com/vllm-project/vllm/pull/27126 due to `&` in buildkite pipeline step name.

Not sure why this wasn't hit in the CI which ran on the PR. 