### PR TITLE
[Build] Add OpenAI triton_kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # vllm-flash-attn built from source
 vllm/vllm_flash_attn/*
 
+# OpenAI triton kernels copied from source
+vllm/third_party/triton_kernels/*
+
 # triton jit
 .triton
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1034,6 +1034,7 @@ endif()
 if (VLLM_GPU_LANG STREQUAL "CUDA")
     include(cmake/external_projects/flashmla.cmake)
     include(cmake/external_projects/qutlass.cmake)
+    include(cmake/external_projects/triton_kernels.cmake)
 
     # vllm-flash-attn should be last as it overwrites some CMake functions
     include(cmake/external_projects/vllm_flash_attn.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1030,11 +1030,15 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
     WITH_SOABI)
 endif()
 
+# For CUDA and HIP builds also build the triton_kernels external package.
+if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
+    include(cmake/external_projects/triton_kernels.cmake)
+endif()
+
 # For CUDA we also build and ship some external projects.
 if (VLLM_GPU_LANG STREQUAL "CUDA")
     include(cmake/external_projects/flashmla.cmake)
     include(cmake/external_projects/qutlass.cmake)
-    include(cmake/external_projects/triton_kernels.cmake)
 
     # vllm-flash-attn should be last as it overwrites some CMake functions
     include(cmake/external_projects/vllm_flash_attn.cmake)

--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -32,7 +32,7 @@ if (NOT triton_kernels_SOURCE_DIR)
 endif()
 
 if (DEFINED ENV{TRITON_KERNELS_SRC_DIR})
-  set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}")
+  set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}/")
 else()
   set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}/python/triton_kernels/triton_kernels/")
 endif()

--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -19,16 +19,17 @@ else()
           GIT_REPOSITORY https://github.com/triton-lang/triton.git
           GIT_TAG ${DEFAULT_TRITON_KERNELS_TAG}
           GIT_PROGRESS TRUE
+          SOURCE_SUBDIR python/triton_kernels/triton_kernels
   )
 endif()
 
 # Fetch content 
-FetchContent_Populate(triton_kernels)
+FetchContent_MakeAvailable(triton_kernels)
 
 if (NOT triton_kernels_SOURCE_DIR)
   message (FATAL_ERROR "[triton_kernels] Cannot resolve triton_kernels_SOURCE_DIR")
 endif()
-  
+
 if (TRITON_KERNELS_SRC_DIR)
   # When passed in explicitly we expect TRITON_KERNELS_SRC_DIR to point to the python directory directly.
   set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}")
@@ -36,6 +37,8 @@ else()
   # Triton kernels lives in the python directory
   set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}/python/triton_kernels/triton_kernels/")
 endif()
+
+message (STATUS "[triton_kernels] triton_kernels is available at ${TRITON_KERNELS_PYTHON_DIR}")
 
 add_custom_target(triton_kernels)
 

--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -2,17 +2,18 @@
 
 set(DEFAULT_TRITON_KERNELS_TAG "v3.5.0")
 
-# Set TRITON_KERNELS_SRC_DIR for use with local development with vLLM.
+# Set TRITON_KERNELS_SRC_DIR for use with local development with vLLM. We expect TRITON_KERNELS_SRC_DIR to
+# be directly set to the triton_kernels python directory. 
 if (DEFINED ENV{TRITON_KERNELS_SRC_DIR})
-  set(TRITON_KERNELS_SRC_DIR $ENV{TRITON_KERNELS_SRC_DIR})
-endif()
-
-if(TRITON_KERNELS_SRC_DIR)
+  message(STATUS "[triton_kernels] Fetch from $ENV{TRITON_KERNELS_SRC_DIR}")
   FetchContent_Declare(
           triton_kernels
-          SOURCE_DIR ${TRITON_KERNELS_SRC_DIR}
+          SOURCE_DIR $ENV{TRITON_KERNELS_SRC_DIR}
   )
+
 else()
+  set(TRITON_GIT "https://github.com/triton-lang/triton.git")
+  message (STATUS "[triton_kernels] Fetch from ${TRITON_GIT}:${DEFAULT_TRITON_KERNELS_TAG}")
   FetchContent_Declare(
           triton_kernels
           # TODO (varun) : Fetch just the triton_kernels directory from Triton
@@ -30,11 +31,9 @@ if (NOT triton_kernels_SOURCE_DIR)
   message (FATAL_ERROR "[triton_kernels] Cannot resolve triton_kernels_SOURCE_DIR")
 endif()
 
-if (TRITON_KERNELS_SRC_DIR)
-  # When passed in explicitly we expect TRITON_KERNELS_SRC_DIR to point to the python directory directly.
+if (DEFINED ENV{TRITON_KERNELS_SRC_DIR})
   set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}")
 else()
-  # Triton kernels lives in the python directory
   set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}/python/triton_kernels/triton_kernels/")
 endif()
 

--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -1,0 +1,48 @@
+# Install OpenAI triton_kernels from https://github.com/triton-lang/triton/tree/main/python/triton_kernels
+
+set(DEFAULT_TRITON_KERNELS_TAG "v3.5.0")
+
+# Set TRITON_KERNELS_SRC_DIR for use with local development with vLLM.
+if (DEFINED ENV{TRITON_KERNELS_SRC_DIR})
+  set(TRITON_KERNELS_SRC_DIR $ENV{TRITON_KERNELS_SRC_DIR})
+endif()
+
+if(TRITON_KERNELS_SRC_DIR)
+  FetchContent_Declare(
+          triton_kernels
+          SOURCE_DIR ${TRITON_KERNELS_SRC_DIR}
+  )
+else()
+  FetchContent_Declare(
+          triton_kernels
+          # TODO (varun) : Fetch just the triton_kernels directory from Triton
+          GIT_REPOSITORY https://github.com/triton-lang/triton.git
+          GIT_TAG ${DEFAULT_TRITON_KERNELS_TAG}
+          GIT_PROGRESS TRUE
+  )
+endif()
+
+# Fetch content 
+FetchContent_Populate(triton_kernels)
+
+if (NOT triton_kernels_SOURCE_DIR)
+  message (FATAL_ERROR "[triton_kernels] Cannot resolve triton_kernels_SOURCE_DIR")
+endif()
+  
+if (TRITON_KERNELS_SRC_DIR)
+  # When passed in explicitly we expect TRITON_KERNELS_SRC_DIR to point to the python directory directly.
+  set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}")
+else()
+  # Triton kernels lives in the python directory
+  set(TRITON_KERNELS_PYTHON_DIR "${triton_kernels_SOURCE_DIR}/python/triton_kernels/triton_kernels/")
+endif()
+
+add_custom_target(triton_kernels)
+
+## Copy .py files to install directory.
+install(DIRECTORY
+        ${TRITON_KERNELS_PYTHON_DIR}
+        DESTINATION 
+        vllm/third_party/
+        COMPONENT triton_kernels
+        FILES_MATCHING PATTERN "*.py")

--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -42,10 +42,13 @@ message (STATUS "[triton_kernels] triton_kernels is available at ${TRITON_KERNEL
 
 add_custom_target(triton_kernels)
 
+# Ensure the vllm/third_party directory exists before installation
+install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/vllm/third_party/triton_kernels\")")
+
 ## Copy .py files to install directory.
 install(DIRECTORY
         ${TRITON_KERNELS_PYTHON_DIR}
         DESTINATION 
-        vllm/third_party/
+        vllm/third_party/triton_kernels/
         COMPONENT triton_kernels
         FILES_MATCHING PATTERN "*.py")

--- a/setup.py
+++ b/setup.py
@@ -647,14 +647,14 @@ ext_modules = []
 if _is_cuda() or _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._moe_C"))
     ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
+    # Optional since this doesn't get built (produce an .so file). This is just
+    # copying the relevant .py files from the source repository.
+    ext_modules.append(CMakeExtension(name="vllm.triton_kernels", optional=True))
 
 if _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
 
 if _is_cuda():
-    # Optional since this doesn't get built (produce an .so file). This is just
-    # copying the relevant .py files from the source repository.
-    ext_modules.append(CMakeExtension(name="vllm.triton_kernels", optional=True))
     ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
     if envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.3"):
         # FA3 requires CUDA 12.3 or later

--- a/setup.py
+++ b/setup.py
@@ -299,17 +299,19 @@ class cmake_build_ext(build_ext):
             os.makedirs(os.path.dirname(dst_file), exist_ok=True)
             self.copy_file(file, dst_file)
 
-        # copy vllm/third_party/triton_kernels/**/*.py from self.build_lib to
-        # current directory so that they can be included in the editable build
-        print(
-            f"Copying {self.build_lib}/vllm/third_party/triton_kernels "
-            "to vllm/third_party/triton_kernels"
-        )
-        shutil.copytree(
-            f"{self.build_lib}/vllm/third_party/triton_kernels",
-            "vllm/third_party/triton_kernels",
-            dirs_exist_ok=True,
-        )
+        if _is_cuda():
+            # copy vllm/third_party/triton_kernels/**/*.py from self.build_lib
+            # to current directory so that they can be included in the editable
+            # build
+            print(
+                f"Copying {self.build_lib}/vllm/third_party/triton_kernels "
+                "to vllm/third_party/triton_kernels"
+            )
+            shutil.copytree(
+                f"{self.build_lib}/vllm/third_party/triton_kernels",
+                "vllm/third_party/triton_kernels",
+                dirs_exist_ok=True,
+            )
 
 
 class precompiled_build_ext(build_ext):

--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ class cmake_build_ext(build_ext):
             os.makedirs(os.path.dirname(dst_file), exist_ok=True)
             self.copy_file(file, dst_file)
 
-        if _is_cuda():
+        if _is_cuda() or _is_hip():
             # copy vllm/third_party/triton_kernels/**/*.py from self.build_lib
             # to current directory so that they can be included in the editable
             # build

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -8,6 +8,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import triton
+from vllm.utils.import_utils import has_triton_kernels
 from vllm.utils.torch_utils import direct_register_custom_op, is_torch_equal_or_newer
 
 logger = init_logger(__name__)
@@ -15,6 +16,7 @@ logger = init_logger(__name__)
 
 def _swizzle_mxfp4(quant_tensor, scale, num_warps):
     """weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel"""
+    assert has_triton_kernels()
     import triton_kernels.matmul_ogs_details.opt_flags as opt_flags
     from triton_kernels.numerics import InFlexData
     from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -68,14 +68,24 @@ def import_pynvml():
 
 @cache
 def import_triton_kernels():
-    import vllm.third_party.triton_kernels as triton_kernels
-
-    logger.info_once(
-        "Loading module triton_kernels from vllm.third_party.triton_kernels",
-        scope="local",
-    )
-    sys.modules["triton_kernels"] = triton_kernels
-    return triton_kernels
+    """
+    For convenience, prioritize triton_kernels that is available in
+    `site-packages`. Use `vllm.third_party.triton_kernels` as a fall-back.
+    """
+    if _has_module("triton_kernels"):
+        import triton_kernels
+        logger.info_once(f"Loading module triton_kernels from {triton_kernels.__file__}.", scope="local")
+    elif _has_module("vllm.third_party.triton_kernels"):
+        import vllm.third_party.triton_kernels as triton_kernels
+        logger.info_once(
+            "Loading module triton_kernels from vllm.third_party.triton_kernels",
+            scope="local",
+        )
+        sys.modules["triton_kernels"] = triton_kernels
+    else:
+        logger.info_once("triton_kernels unavailable in this build. "
+            "Please consider installing triton_kernels from "
+            "https://github.com/triton-lang/triton/tree/main/python/triton_kernels")
 
 
 def import_from_path(module_name: str, file_path: str | os.PathLike):
@@ -413,7 +423,7 @@ def has_deep_gemm() -> bool:
 
 def has_triton_kernels() -> bool:
     """Whether the optional `triton_kernels` package is available."""
-    is_available = _has_module("vllm.third_party.triton_kernels")
+    is_available = _has_module("triton_kernels") or _has_module("vllm.third_party.triton_kernels")
     if is_available:
         import_triton_kernels()
     return is_available

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -62,6 +62,14 @@ def import_pynvml():
     return pynvml
 
 
+@cache
+def import_triton_kernels():
+    import vllm.third_party.triton_kernels as triton_kernels
+
+    sys.modules["triton_kernels"] = triton_kernels
+    return triton_kernels
+
+
 def import_from_path(module_name: str, file_path: str | os.PathLike):
     """
     Import a Python file according to its file path.
@@ -397,7 +405,10 @@ def has_deep_gemm() -> bool:
 
 def has_triton_kernels() -> bool:
     """Whether the optional `triton_kernels` package is available."""
-    return _has_module("triton_kernels")
+    is_available = _has_module("vllm.third_party.triton_kernels")
+    if is_available:
+        import_triton_kernels()
+    return is_available
 
 
 def has_tilelang() -> bool:

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -75,15 +75,15 @@ def import_triton_kernels():
     if _has_module("triton_kernels"):
         import triton_kernels
 
-        logger.info_once(
+        logger.debug_once(
             f"Loading module triton_kernels from {triton_kernels.__file__}.",
             scope="local",
         )
     elif _has_module("vllm.third_party.triton_kernels"):
         import vllm.third_party.triton_kernels as triton_kernels
 
-        logger.info_once(
-            "Loading module triton_kernels from vllm.third_party.triton_kernels",
+        logger.debug_once(
+            f"Loading module triton_kernels from {triton_kernels.__file__}.",
             scope="local",
         )
         sys.modules["triton_kernels"] = triton_kernels

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -74,18 +74,25 @@ def import_triton_kernels():
     """
     if _has_module("triton_kernels"):
         import triton_kernels
-        logger.info_once(f"Loading module triton_kernels from {triton_kernels.__file__}.", scope="local")
+
+        logger.info_once(
+            f"Loading module triton_kernels from {triton_kernels.__file__}.",
+            scope="local",
+        )
     elif _has_module("vllm.third_party.triton_kernels"):
         import vllm.third_party.triton_kernels as triton_kernels
+
         logger.info_once(
             "Loading module triton_kernels from vllm.third_party.triton_kernels",
             scope="local",
         )
         sys.modules["triton_kernels"] = triton_kernels
     else:
-        logger.info_once("triton_kernels unavailable in this build. "
+        logger.info_once(
+            "triton_kernels unavailable in this build. "
             "Please consider installing triton_kernels from "
-            "https://github.com/triton-lang/triton/tree/main/python/triton_kernels")
+            "https://github.com/triton-lang/triton/tree/main/python/triton_kernels"
+        )
 
 
 def import_from_path(module_name: str, file_path: str | os.PathLike):
@@ -423,7 +430,9 @@ def has_deep_gemm() -> bool:
 
 def has_triton_kernels() -> bool:
     """Whether the optional `triton_kernels` package is available."""
-    is_available = _has_module("triton_kernels") or _has_module("vllm.third_party.triton_kernels")
+    is_available = _has_module("triton_kernels") or _has_module(
+        "vllm.third_party.triton_kernels"
+    )
     if is_available:
         import_triton_kernels()
     return is_available

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -18,6 +18,10 @@ from typing import Any
 import regex as re
 from typing_extensions import Never
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 
 # TODO: This function can be removed if transformer_modules classes are
 # serialized by value when communicating between processes
@@ -66,6 +70,10 @@ def import_pynvml():
 def import_triton_kernels():
     import vllm.third_party.triton_kernels as triton_kernels
 
+    logger.info_once(
+        "Loading module triton_kernels from vllm.third_party.triton_kernels",
+        scope="local",
+    )
     sys.modules["triton_kernels"] = triton_kernels
     return triton_kernels
 


### PR DESCRIPTION
## Purpose
This PR adds https://github.com/triton-lang/triton/tree/main/python/triton_kernels to vLLM. 
We can't install this package via pip. Please take a look at https://github.com/vllm-project/vllm/pull/27659 . As a result, this PR, injects the `triton_kernels` package directly into vLLM during build time, similar to the approach we take with `vllm_flash_attn`. Concretely, we just copy the entire `triton_kernels` folder in `<triton-root>/python/triton_kernels/triton_kernels` to `vllm/third_party/triton_kernels`during build time and add the module to the `sys.module["triton_kernel"]` during run-time. 

Fixes : https://github.com/vllm-project/vllm/issues/27672

## Test Plan
local-build testing on H100 : `python3 setup.py build_ext --inplace` / `uv pip install -vvv -e . --no-build-isolation`
package-build testing on H100 : `TORCH_CUDA_ARCH_LIST="9.0" python3 setup.py bdist_wheel --dist-dir=dist`

gpt-oss serve command: `vllm serve openai/gpt-oss-20b --tensor-parallel-size 2  --no-enable-prefix-caching  --port 9010 `
gpt-oss eval command : ` OPENAI_API_KEY=empty python -m gpt_oss.evals --model openai/gpt-oss-20b --eval gpqa --n-threads 128 --reasoning-effort low --base-url http://localhost:9010/v1 `

## Test Result
`local-build` : The build correctly copies `triton_kernels` into `vllm/third_party/triton_kernels`
`package-build` : The wheel when installed has `triton_kernels` in `<site-packages>/vllm/third_party/triton_kernels`
Both `local_build` and `package-build` obtains expected eval score of about `0.57`.

Need to perform further testing with CI wheels. 

Thanks @zyongye  @daniel-fahey for the insights. 
