### PR TITLE
[BugFix] Fix glm4_moe_mtp load weights bug

### DIFF
--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -256,13 +256,12 @@ class Glm4MoeMTP(nn.Module, SupportsPP, Glm4MixtureOfExperts):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
-        spec_layer = self.model.mtp_start_layer_idx
         for name, loaded_weight in weights:
             if name == "lm_head.weight":
-                name = f"model.layers.{spec_layer}.shard_head.head.weight"
+                spec_layer = self.model.mtp_start_layer_idx
+                name = f"model.layers.{spec_layer}.shared_head.head.weight"
             elif name == "model.embed_tokens.weight":
-                # This name is same with local model, rewriting is not needed.
-                pass
+                spec_layer = self.model.mtp_start_layer_idx
             else:
                 spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
                 if spec_layer is None:


### PR DESCRIPTION
## Purpose
As [comment in issue#25993](https://github.com/vllm-project/vllm/issues/25993#issuecomment-3538549917),[PR#27597](https://github.com/vllm-project/vllm/pull/27597) introduced bugs causing GLM-4.5/GLM-4.6 serving with mtp error because:
1. spec_layer is overwritten by later None assignment in "else" branch; 
2. mapped shard_head typo which should be shared_head;
This PR fixes them
## Test Plan
This PR has been tested with the following command.
```
vllm serve GLM-4.6/GLM-4.5
--speculative-config '{"method":"mtp","num_speculative_tokens":1}'
--tensor-parallel-size 8
```

## Test Result
After applying the fix,  servinng GLM-4.5/GLM-4.6 with MTP works really fine. 