### PR TITLE
build: align CUDA 12.1 xformers wheel pin

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,6 +9,7 @@ torch==2.9.0
 torchaudio==2.9.0
 # These must be updated alongside torch
 torchvision==0.24.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-xformers==0.0.33.post1; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
+# Build from https://github.com/facebookresearch/xformers/releases/tag/v0.0.32.post1
+xformers==0.0.33+5d4b92a5.d20251106; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.9
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.5.2


### PR DESCRIPTION
## Summary
- bump the `xformers` requirement on CUDA 12.1 builds to the internally built `0.0.33+5d4b92a5.d20251106` wheel
- add a comment pointing to the upstream release tag we use for the build

This isolates the build-only change that was previously bundled inside #28241.

## Testing
- not run (dependency pin update only)