### PR TITLE
[Bugfix] Fix GPT-OSS on AMD after #28603

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1108,7 +1108,7 @@ steps:
   - vllm/v1/attention/backends/flashinfer.py
   commands:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
-    - pytest -s -v tests/evals/gpt_oss/test_gpqa_correctness.py --model openai/gpt-oss-20b --metric 0.58
+    - VLLM_ROCM_USE_AITER_MHA=0 VLLM_ROCM_USE_AITER=1 VLLM_USE_AITER_UNIFIED_ATTENTION=1 pytest -s -v tests/evals/gpt_oss/test_gpqa_correctness.py --model openai/gpt-oss-20b --metric 0.58
 
 - label: Blackwell Quantized MoE Test
   timeout_in_minutes: 60

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1068,7 +1068,7 @@ steps:
     # this runner has 2 GPUs available even though num_gpus=2 is not set
     - pytest -v -s tests/compile/test_fusion_all_reduce.py
     # Limit to Inductor partition, no custom ops, and allreduce & attn fusion to reduce running time
-    # Wrap with quotes to escape yaml 
+    # Wrap with quotes to escape yaml
     - "pytest -v -s tests/compile/test_fusions_e2e.py::test_tp2_attn_quant_allreduce_rmsnorm -k 'True and Llama-3.1 and -quant_fp8 and -rms_norm'"
 
 - label: Blackwell Fusion E2E Tests # 30 min
@@ -1098,7 +1098,8 @@ steps:
 - label: Blackwell GPT-OSS Eval
   timeout_in_minutes: 60
   working_dir: "/vllm-workspace/"
-  gpu: b200
+  agent_pool: mi325_1
+  mirror_hardwares: [amdproduction]
   optional: true # run on nightlies
   source_file_dependencies:
   - tests/evals/gpt_oss

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1095,7 +1095,7 @@ steps:
     # test_fp8_kv_scale_compile requires FlashAttention (not supported on default L4/L40)
     - pytest -v -s tests/compile/test_full_graph.py::test_fp8_kv_scale_compile
 
-- label: Blackwell GPT-OSS Eval
+- label: ROCm GPT-OSS Eval
   timeout_in_minutes: 60
   working_dir: "/vllm-workspace/"
   agent_pool: mi325_1

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -755,8 +755,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             self.w13_weight = w13_weight
             self.w2_weight = w2_weight
-            layer.w13_weight = Parameter(w13_weight.data, requires_grad=False)
-            layer.w2_weight = Parameter(w2_weight.data, requires_grad=False)
+            layer.w13_weight = Parameter(w13_weight.storage.data, requires_grad=False)
+            layer.w2_weight = Parameter(w13_weight.storage.data, requires_grad=False)
         else:
             raise ValueError(f"Unsupported backend: {self.mxfp4_backend}")
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -756,7 +756,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.w13_weight = w13_weight
             self.w2_weight = w2_weight
             layer.w13_weight = Parameter(w13_weight.storage.data, requires_grad=False)
-            layer.w2_weight = Parameter(w13_weight.storage.data, requires_grad=False)
+            layer.w2_weight = Parameter(w2_weight.storage.data, requires_grad=False)
         else:
             raise ValueError(f"Unsupported backend: {self.mxfp4_backend}")
 


### PR DESCRIPTION
## Purpose
In https://github.com/vllm-project/vllm/pull/28603, the fix was applied to Nvidia but it's not compatible with AMD since it's using an older version of Triton([code](https://github.com/ROCm/triton/blob/57c693b627fe058878ade4163a0a8df95d9fefa1/python/triton_kernels/triton_kernels/tensor.py#L92)), where `weight.data` is not yet added as a property. 

Error([example](https://buildkite.com/vllm/amd-ci/builds/1069#019a8bed-88a9-4466-8f91-6259fbd64bef)):
```

2025-11-16 09:43:07 UTC | (EngineCore_DP0 pid=890)     quant_method.process_weights_after_loading(module)
-- | --
  | 2025-11-16 09:43:07 UTC | (EngineCore_DP0 pid=890)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/mxfp4.py", line 758, in process_weights_after_loading
  | 2025-11-16 09:43:07 UTC | (EngineCore_DP0 pid=890)     layer.w13_weight = Parameter(w13_weight.data, requires_grad=False)
  | 2025-11-16 09:43:07 UTC | (EngineCore_DP0 pid=890)                                  ^^^^^^^^^^^^^^^
  | 2025-11-16 09:43:07 UTC | (EngineCore_DP0 pid=890) AttributeError: 'Tensor' object has no attribute 'data'

```

Therefore, using an [older expression](https://github.com/triton-lang/triton/blob/07dc8626bfa1de35fcdf45c5352f0f8246983cd5/python/triton_kernels/triton_kernels/tensor.py#L109-L110)  with `weight.storage.data` should resolve the problem.

## Test Plan
CI: https://buildkite.com/vllm/amd-ci/builds/1072

Nvidia:
```
OPENAI_API_KEY=empty wp python -m gpt_oss.evals --model openai/gpt-oss-20b --eval gpqa --n-threads 200 --reasoning-effort low
Running with args Namespace(model='openai/gpt-oss-20b', reasoning_effort='low', sampler='responses', base_url='http://localhost:8000/v1', eval='gpqa', temperature=1.0, n_threads=200, debug=False, examples=None)

Running the following evals: {'gpqa': <gpt_oss.evals.gpqa_eval.GPQAEval object at 0x7fd3ea955910>}
Running evals for the following models: {'openai/gpt-oss-20b-low': <gpt_oss.evals.responses_sampler.ResponsesSampler object at 0x7fd3eb3acc80>}
 38%|████████████████████████████████████████████▍                                                                        | 601/1584 [00:51<01:10, 13.94it/s]Bad Request Error Error code: 400 - {'error': {'message': "'container'", 'type': 'BadRequestError', 'param': None, 'code': 400}}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1584/1584 [02:18<00:00, 11.47it/s]
Writing report to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20251116_163344.html
{'chars': np.float64(51.62941919191919), 'chars:std': np.float64(211.89582481470717), 'score': np.float64(0.5738636363636364), 'score:std': np.float64(0.49451406777071627)}
Writing results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20251116_163344.json
Writing all results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20251116_163344_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'openai__gpt-oss-20b-low_temp1.0_20251116_163344', 'metric': 0.5738636363636364}]
```
