### PR TITLE
[Bugfix] Fix spec decode memory regression after #28549

### DIFF
--- a/vllm/model_executor/models/deepseek_eagle.py
+++ b/vllm/model_executor/models/deepseek_eagle.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
-from vllm.distributed.parallel_state import get_pp_group
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -172,10 +171,6 @@ class DeepseekV2Model(nn.Module):
                     )
                     break
                 else:
-                    # if PP disabled then draft will share embed with target
-                    if get_pp_group().world_size == 1 and "embed_tokens." in name:
-                        continue
-
                     # Skip loading extra bias for GPTQ models.
                     if name.endswith(".bias") and name not in params_dict:
                         continue

--- a/vllm/model_executor/models/llama4_eagle.py
+++ b/vllm/model_executor/models/llama4_eagle.py
@@ -23,7 +23,6 @@ import torch.nn as nn
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
-from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -127,17 +126,11 @@ class LlamaModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # if PP disabled then draft will share embed with target
-                if get_pp_group().world_size == 1 and "embed_tokens." in name:
-                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
         for name in params_dict:
-            # if PP disabled then draft will share embed with target
-            if get_pp_group().world_size == 1 and "embed_tokens." in name:
-                continue
             assert name in loaded_params, f"{name} is not loaded!"
         return loaded_params
 

--- a/vllm/model_executor/models/llama_eagle.py
+++ b/vllm/model_executor/models/llama_eagle.py
@@ -9,7 +9,6 @@ from transformers import LlamaConfig
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
-from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
@@ -126,10 +125,6 @@ class LlamaModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # if PP disabled then draft will share embed with target
-                if get_pp_group().world_size == 1 and "embed_tokens." in name:
-                    continue
-
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1017,8 +1017,8 @@ class EagleProposer:
                     isinstance(target_embed_tokens.weight, torch.Tensor)
                     and isinstance(self.model.model.embed_tokens.weight, torch.Tensor)
                     and torch.allclose(
-                        target_embed_tokens.weight,
-                        self.model.model.embed_tokens.weight,
+                        target_embed_tokens.weight.cpu(),
+                        self.model.model.embed_tokens.weight.cpu(),
                         rtol=1e-5,
                         atol=1e-7,
                     )

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1016,8 +1016,11 @@ class EagleProposer:
                 elif (
                     isinstance(target_embed_tokens.weight, torch.Tensor)
                     and isinstance(self.model.model.embed_tokens.weight, torch.Tensor)
-                    and torch.equal(
-                        target_embed_tokens.weight, self.model.model.embed_tokens.weight
+                    and torch.allclose(
+                        target_embed_tokens.weight,
+                        self.model.model.embed_tokens.weight,
+                        rtol=1e-5,
+                        atol=1e-7,
                     )
                 ):
                     share_embeddings = True


### PR DESCRIPTION
# Purpose
  
Fixes memory regression in EAGLE speculative decoding that causes OOM on L4 GPUs (24GB). The bug was introduced in #28549 and has two parts:
  1. Skip logic prevents loading embed_tokens weights in `if get_pp_group().world_size == 1 and "embed_tokens." in name:`, which will leave weights uninitialized, and we will keep an extra copy in memory
  2. Comparison uses `torch.equal()` instead of `torch.allclose(`) for floating-point: We observed a difference by ~3e-8 due to floating-point rounding.

# Test plan
```
 python3 offline_inference/spec_decode.py \
    --test --method eagle --num_spec_tokens 3 \
    --dataset-name hf --dataset-path philschmid/mt-bench \
    --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 \
    --tp 1 --enable-chunked-prefill --max-model-len 2048
```

Before:
```
...
(EngineCore_DP0 pid=1111593) INFO 11-16 11:59:24 [eagle.py:1030] Detected EAGLE model with distinct embed_tokens weights. Keeping separate embedding weights from the target model.
(EngineCore_DP0 pid=1111593) INFO 11-16 11:59:24 [eagle.py:1058] Detected EAGLE model without its own lm_head in the checkpoint. Sharing target model lm_head weights with the draft model.
(EngineCore_DP0 pid=1728506) INFO 11-16 15:38:36 [gpu_model_runner.py:3126] Model loading took 16.4366 GiB memory and 4.773771 seconds
...
```

After:
```
...
(EngineCore_DP0 pid=2229630) INFO 11-16 15:45:14 [eagle.py:1027] Detected EAGLE model with embed_tokens identical to the target model. Sharing target model embedding weights with the draft model.
(EngineCore_DP0 pid=2229630) INFO 11-16 15:45:14 [eagle.py:1061] Detected EAGLE model without its own lm_head in the checkpoint. Sharing target model lm_head weights with the draft model.
(EngineCore_DP0 pid=2229630) INFO 11-16 15:45:14 [gpu_model_runner.py:3126] Model loading took 15.4581 GiB memory and 5.090968 seconds
...
```



