### PR TITLE
[Frontend] Allow parsed tool arguments

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1437,7 +1437,7 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
             for item in message["tool_calls"]:
                 # if arguments is None or empty string, set to {}
                 if content := item["function"].get("arguments"):
-                    if isinstance(content, str):
+                    if not isinstance(content, (dict, list)):
                         item["function"]["arguments"] = json.loads(content)
                 else:
                     item["function"]["arguments"] = {}

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1437,7 +1437,8 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
             for item in message["tool_calls"]:
                 # if arguments is None or empty string, set to {}
                 if content := item["function"].get("arguments"):
-                    item["function"]["arguments"] = json.loads(content)
+                    if isinstance(content, str):
+                        item["function"]["arguments"] = json.loads(content)
                 else:
                     item["function"]["arguments"] = {}
 


### PR DESCRIPTION
## Purpose

While working with tool calling, I noticed that vLLM **assumes all arguments are strings, even though they’re often already parsed**. As a result, users must serialize arguments to strings before passing them to vLLM, only for vLLM to immediately parse them again.

## Test Plan

```python
from vllm import LLM

llm = LLM(model="Qwen/Qwen3-0.6B")

def multiply(a: int, b: int) -> int:
    """
    Multiplies two integers.

    Args:
        a: The first integer.
        b: The second integer.

    Returns:
        The product of the two integers.
    """
    return a * b


messages = [
    [
        {"role": "user", "content": "Multiply 75 and 50.",},
        {"role": "assistant", "content": "", "tool_calls": [{"type": "function", "function": {"name": "multiply", "arguments": {"a": 75, "b": 50}}, "result": 3750}]},
        {"role": "tool", "name": "multiply", "content": "3750"},
    ],
]

print(llm.chat(messages=messages, tools=[multiply]))
```

## Test Result

### Before

```
Traceback (most recent call last):
  File "/fsx/qgallouedec/trl/aaaaa.py", line 27, in <module>
    llm.chat(messages=messages, tools=[multiply])
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/vllm/entrypoints/llm.py", line 873, in chat
    prompts = self.preprocess_chat(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/vllm/entrypoints/llm.py", line 766, in preprocess_chat
    conversation, mm_data, mm_uuids = parse_chat_messages(
                                      ^^^^^^^^^^^^^^^^^^^^
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1400, in parse_chat_messages
    _postprocess_messages(conversation)
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1368, in _postprocess_messages
    item["function"]["arguments"] = json.loads(
                                    ^^^^^^^^^^^
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not dict
ERROR 11-16 23:48:38 [core_client.py:564] Engine core proc EngineCore_DP0 died unexpectedly, shutting down client.
```

### After

```
[RequestOutput(request_id=0, prompt=None, prompt_token_ids=[151644, 8948, 198, 2, 13852, 271, 2610, 1231, 1618, 825, 476, 803, 5746, 311, 7789, 448, 279, 1196, 3239, 382, 2610, 525, 3897, 448, 729, 32628, 2878, 366, 15918, 1472, 15918, 29, 11874, 9492, 510, 27, 15918, 397, 4913, 1313, 788, 330, 1688, 497, 330, 1688, 788, 5212, 606, 788, 330, 64648, 497, 330, 4684, 788, 330, 20358, 7202, 1378, 25780, 10465, 330, 13786, 788, 5212, 1313, 788, 330, 1700, 497, 330, 13193, 788, 5212, 64, 788, 5212, 1313, 788, 330, 11662, 497, 330, 4684, 788, 330, 785, 1156, 7546, 1189, 2137, 330, 65, 788, 5212, 1313, 788, 330, 11662, 497, 330, 4684, 788, 330, 785, 2086, 7546, 1189, 38154, 330, 6279, 788, 4383, 64, 497, 330, 65, 1341, 2137, 330, 689, 788, 5212, 1313, 788, 330, 11662, 497, 330, 4684, 788, 330, 785, 1985, 315, 279, 1378, 25780, 1189, 3417, 532, 522, 15918, 1339, 2461, 1817, 729, 1618, 11, 470, 264, 2951, 1633, 448, 729, 829, 323, 5977, 2878, 220, 151657, 151658, 11874, 9492, 510, 151657, 198, 4913, 606, 788, 366, 1688, 11494, 8066, 330, 16370, 788, 366, 2116, 56080, 40432, 31296, 151658, 151645, 198, 151644, 872, 198, 95155, 220, 22, 20, 323, 220, 20, 15, 13, 151645, 198, 151644, 77091, 198, 151657, 198, 4913, 606, 788, 330, 64648, 497, 330, 16370, 788, 5212, 64, 788, 220, 22, 20, 11, 330, 65, 788, 220, 20, 15, 11248, 151658, 151645, 198, 151644, 872, 198, 151665, 198, 18, 22, 20, 15, 198, 151666, 151645, 198, 151644, 77091, 198], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text='<think>\nOkay, the user asked to multiply 75 and 50', token_ids=[151667, 198, 32313, 11, 279, 1196, 4588, 311, 30270, 220, 22, 20, 323, 220, 20, 15], cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

