### PR TITLE
Fix: API server wait timeout on slow storage nodes

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -519,7 +519,7 @@ class MPClient(EngineCoreClient):
             identities = set(self.core_engines)
             sync_input_socket = zmq.Socket.shadow(self.input_socket)
             while identities:
-                if not sync_input_socket.poll(timeout=600_000):
+                if not sync_input_socket.poll(timeout=1_200_000):
                     raise TimeoutError(
                         "Timed out waiting for engines to send"
                         "initial message on input socket."


### PR DESCRIPTION
## Purpose

I'm running benchmarking on a Slurm cluster with the worst possible storage config -- almost no local disk and large data (i.e., model weights) must be stored in an NFS.

When loading models with hundreds of billions of parameters, this actually hits the API server wait timeout of 10 minutes. So I was wondering if we can increase the timeout to 20 minutes.

I did consider making this configurable but I think it'll be rare for anyone to have to change this any further. Let me know if you want this to be an env var.

cc. @njhill 