### PR TITLE
[XPU][QWEN] support qwen3-30b-a3b gptq int4 and tp=1,2

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -604,6 +604,7 @@ class FusedMoE(CustomOp):
         # need full intermediate size pre-sharding for WNA16 act order
         if self.quant_method.__class__.__name__ in (
             "GPTQMarlinMoEMethod",
+            "XPUGPTQMarlinMoEMethod",
             "CompressedTensorsWNA16MarlinMoEMethod",
             "CompressedTensorsWNA16MoEMethod",
         ):

--- a/vllm/model_executor/layers/quantization/auto_round.py
+++ b/vllm/model_executor/layers/quantization/auto_round.py
@@ -419,12 +419,22 @@ class AutoRoundConfig(QuantizationConfig):
         if isinstance(layer, (LinearBase, ParallelLMHead)):
             if "awq" in self.packing_format:
                 config = IPEXConfig(
-                    method="awq", weight_bits=weight_bits, group_size=group_size
+                    method="awq",
+                    weight_bits=weight_bits,
+                    group_size=group_size,
+                    is_qweight_sym=sym,
+                    dynamic={},
+                    full_config={},
                 )
                 return IPEXAWQLinearMethod(config)
             elif "gptq" in self.packing_format:
                 config = IPEXConfig(
-                    method="gptq", weight_bits=weight_bits, group_size=group_size
+                    method="gptq",
+                    weight_bits=weight_bits,
+                    group_size=group_size,
+                    is_qweight_sym=sym,
+                    dynamic={},
+                    full_config={},
                 )
                 return IPEXGPTQLinearMethod(config)
             else:

--- a/vllm/model_executor/layers/quantization/ipex_quant.py
+++ b/vllm/model_executor/layers/quantization/ipex_quant.py
@@ -207,7 +207,6 @@ class IPEXConfig(QuantizationConfig):
                 return get_linear_quant_method(
                     self, layer, prefix, IPEXGPTQLinearMethod
                 )
-                # return IPEXGPTQLinearMethod(self)
         if isinstance(layer, FusedMoE) and self.method == "gptq":
             return XPUGPTQMarlinMoEMethod(self, layer.moe_config)
         return None

--- a/vllm/model_executor/layers/quantization/ipex_quant.py
+++ b/vllm/model_executor/layers/quantization/ipex_quant.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from packaging import version
@@ -20,7 +20,6 @@ from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.linear import (
     LinearBase,
-    LinearMethodBase,
     UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import (
@@ -196,9 +195,7 @@ class IPEXConfig(QuantizationConfig):
 
         return None
 
-    def get_quant_method(
-        self, layer: torch.nn.Module, prefix: str
-    ) -> Optional["LinearMethodBase"]:
+    def get_quant_method(self, layer: torch.nn.Module, prefix: str):
         if isinstance(layer, LinearBase):
             if self.method == "awq":
                 if is_layer_skipped(

--- a/vllm/model_executor/layers/quantization/utils/gptq_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/gptq_utils.py
@@ -18,9 +18,11 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 if TYPE_CHECKING:
     from ..gptq import GPTQConfig
     from ..gptq_marlin import GPTQMarlinConfig
+    from ..ipex_quant import IPEXConfig
 else:
     GPTQConfig = object
     GPTQMarlinConfig = object
+    IPEXConfig = object
 
 
 # Match dynamic rules with module name (prefix) and override quantize
@@ -126,7 +128,7 @@ def is_layer_gptq_quantized(
 
 
 def get_linear_quant_method(
-    config: GPTQConfig | GPTQMarlinConfig,
+    config: GPTQConfig | GPTQMarlinConfig | IPEXConfig,
     layer: torch.nn.Module,
     prefix: str,
     linear_method_cls: type,

--- a/vllm/model_executor/layers/quantization/utils/gptq_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/gptq_utils.py
@@ -27,7 +27,7 @@ else:
 
 # Match dynamic rules with module name (prefix) and override quantize
 # config if module (prefix) matches a rule
-def override_config(config: GPTQConfig | GPTQMarlinConfig, prefix: str):
+def override_config(config: GPTQConfig | GPTQMarlinConfig | IPEXConfig, prefix: str):
     weight_bits = get_dynamic_override(config, prefix, "bits", config.weight_bits)
     if isinstance(weight_bits, int):
         config.weight_bits = weight_bits
@@ -62,7 +62,7 @@ def override_config(config: GPTQConfig | GPTQMarlinConfig, prefix: str):
 
 
 def get_dynamic_override(
-    config: GPTQConfig | GPTQMarlinConfig,
+    config: GPTQConfig | GPTQMarlinConfig | IPEXConfig,
     layer_name: str,
     key: str | None = None,
     default_value: int | bool | None = None,

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -64,6 +64,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.sequence import IntermediateTensors
+from vllm.utils.math_utils import cdiv
 
 from .interfaces import MixtureOfExperts, SupportsEagle3, SupportsLoRA, SupportsPP
 from .utils import (
@@ -510,7 +511,76 @@ class Qwen3MoeModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
+
+        quantization_config = getattr(self.config, "quantization_config", None)
+        is_gptq_or_awq = False
+        if quantization_config is not None:
+            quant_method = quantization_config.get("quant_method", "").lower()
+            if quant_method in ("gptq", "awq"):
+                is_gptq_or_awq = True
+                tp_size = get_tensor_model_parallel_world_size()
+                bits = quantization_config.get("bits", 4)
+                moe_intermediate_size = self.config.moe_intermediate_size
+                group_size = quantization_config.get("group_size", 128)
+
+                moe_intermediate_size_group = moe_intermediate_size // group_size
+                per_rank_moe_intermediate_size_group = cdiv(
+                    moe_intermediate_size_group, tp_size
+                )
+                per_rank_moe_intermediate_size = (
+                    per_rank_moe_intermediate_size_group * group_size
+                )
+                moe_intermediate_size_padded = per_rank_moe_intermediate_size * tp_size
+                grouped_moe_intermediate_size_padded = (
+                    moe_intermediate_size_padded // group_size
+                )
+
         for name, loaded_weight in weights:
+            if quantization_config is not None and is_gptq_or_awq:
+                if ".down_proj.g_idx" in name:
+                    pad_size = moe_intermediate_size_padded - loaded_weight.shape[0]
+                    loaded_weight = torch.nn.functional.pad(
+                        loaded_weight, (0, pad_size), value=0
+                    )
+                elif ".down_proj.qweight" in name:
+                    packed_factor = loaded_weight.element_size() * 8 // bits
+                    packed_moe_intermediate_size_padded = (
+                        moe_intermediate_size_padded // packed_factor
+                    )
+                    pad_size = (
+                        packed_moe_intermediate_size_padded - loaded_weight.shape[0]
+                    )
+                    loaded_weight = torch.nn.functional.pad(
+                        loaded_weight, (0, 0, 0, pad_size), value=0
+                    )
+                elif ".down_proj.scales" in name or ".down_proj.qzeros" in name:
+                    pad_size = (
+                        grouped_moe_intermediate_size_padded - loaded_weight.shape[0]
+                    )
+                    loaded_weight = torch.nn.functional.pad(
+                        loaded_weight, (0, 0, 0, pad_size), value=0
+                    )
+                elif (
+                    ".gate_proj.qweight" in name
+                    or ".gate_proj.scales" in name
+                    or ".up_proj.qweight" in name
+                    or ".up_proj.scales" in name
+                ):
+                    pad_size = moe_intermediate_size_padded - loaded_weight.shape[1]
+                    loaded_weight = torch.nn.functional.pad(
+                        loaded_weight, (0, pad_size), value=0
+                    )
+                elif ".gate_proj.qzeros" in name or ".up_proj.qzeros" in name:
+                    packed_factor = loaded_weight.element_size() * 8 // bits
+                    packed_moe_intermediate_size_padded = (
+                        moe_intermediate_size_padded // packed_factor
+                    )
+                    pad_size = (
+                        packed_moe_intermediate_size_padded - loaded_weight.shape[1]
+                    )
+                    loaded_weight = torch.nn.functional.pad(
+                        loaded_weight, (0, pad_size), value=0
+                    )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:


### PR DESCRIPTION
1. Add XPUGPTQMarlinMoEMethod
2. Add moe weights padding to qwen_moe.py. Because moe_intermediate_size of qwen3-30b-a3b is 768 and group_size is 128 ===> moe_intermediate_size // group_size = 6, so qwen3-30b-a3b gptq int4 cannot run with tp=4 or 8. Padding is needed.

Lm_eval CMD:
```
python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3-30B-A3B-GPTQ-Int4 --dtype=float16  --enforce-eager --port 8123 --host 0.0.0.0 --trust-remote-code --gpu-memory-util=0.9 --no-enable-prefix-caching --max-num-batched-tokens=4096  --disable-log-requests  --max-model-len=8192 --block-size 64 -tp=4 
lm_eval --model local-chat-completions --tasks gsm8k --num_fewshot 1 --batch_size 1 --model_args "model=Qwen/Qwen3-30B-A3B-GPTQ-Int4,base_url=http://localhost:8123/v1/chat/completions,max_gen_toks=4096,num_concurrent=32" --apply_chat_template  --output_path ./lm_eval_output --log_samples --limit 100
```
Lm_eval results on XPU as below:
<img width="531" height="94" alt="image" src="https://github.com/user-attachments/assets/29c3713f-2ea9-4454-ae95-cae288d44219" />

