### PR TITLE
[tiny] Remove unsupported TRITON_MLA backend from batch invariance

### DIFF
--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -805,10 +805,11 @@ def override_envs_for_invariance():
         "FLASH_ATTN",  # best supported backend
         "FLASHINFER",
         "FLASH_ATTN_MLA",
-        "FLASHINFER_MLA",
         # Not yet supported MLA backends
         # "FLASHMLA",
         # "FLEX_ATTENTION", # IMA issue even if we disable batch invariance
+        # "FLASHINFER_MLA", https://github.com/vllm-project/vllm/pull/28967
+        # "TRITON_MLA",
     ]
     if curr_attn_backend not in supported_backends:
         warning = (

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -805,11 +805,10 @@ def override_envs_for_invariance():
         "FLASH_ATTN",  # best supported backend
         "FLASHINFER",
         "FLASH_ATTN_MLA",
-        "TRITON_MLA",
+        "FLASHINFER_MLA",
         # Not yet supported MLA backends
         # "FLASHMLA",
         # "FLEX_ATTENTION", # IMA issue even if we disable batch invariance
-        # "FLASHINFER_MLA", https://github.com/vllm-project/vllm/pull/28967
     ]
     if curr_attn_backend not in supported_backends:
         warning = (


### PR DESCRIPTION
TRITON_MLA is not well tested enough and not actually supported (but was incorrectly listed in the batch invariance supported backends and test parametrizations).

TRITON_MLA has two codepaths for prefill and decode that have not been unified. only the decode path shows batch-invariance, but the property that generated tokens have bitwise identical logprobs to prefilled does not hold.


This removes it from:
- override_envs_for_invariance() supported_backends list
- test_v1_generation_is_deterministic_across_batch_sizes_with_needle
- test_logprobs_bitwise_batch_invariance_bs1_vs_bsN
- test_simple_generation
- test_logprobs_without_batch_invariance_should_fail

## Test Plan

all listed tests

## Test Result

pass
