### PR TITLE
[Model][Perf] Apply rotary positional embeddings for vision inplace

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -37,6 +37,7 @@ def apply_rotary_emb_torch(
     cos: torch.Tensor,
     sin: torch.Tensor,
     is_neox_style: bool,
+    inplace: bool = False,
 ) -> torch.Tensor:
     cos = cos.unsqueeze(-2).to(x.dtype)
     sin = sin.unsqueeze(-2).to(x.dtype)
@@ -47,6 +48,10 @@ def apply_rotary_emb_torch(
         x2 = x[..., 1::2]
     o1 = x1 * cos - x2 * sin
     o2 = x2 * cos + x1 * sin
+    if inplace:
+        x1.copy_(o1)
+        x2.copy_(o2)
+        return x
     if is_neox_style:
         return torch.cat((o1, o2), dim=-1)
     else:

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -357,9 +357,9 @@ class Glm4vVisionAttention(nn.Module):
         q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous() for x in (q, k, v))
         if rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
             # [2 * b, s, heads, head_dim]
-            qk_concat = torch.cat([q, k], dim=0)
+            qk_rotated = torch.cat([q, k], dim=0)
             qk_rotated = apply_rotary_pos_emb_vision(
-                qk_concat, rotary_pos_emb_cos, rotary_pos_emb_sin
+                qk_rotated, rotary_pos_emb_cos, rotary_pos_emb_sin, inplace=True
             )
             q, k = torch.chunk(qk_rotated, 2, dim=0)
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -383,11 +383,11 @@ class Qwen2_5_VisionAttention(nn.Module):
         if rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
             qk, v = qkv[:, :, :2], qkv[:, :, 2]
 
-            qk_reshaped = einops.rearrange(
+            qk_rotated = einops.rearrange(
                 qk, "b s two head head_dim -> (two b) s head head_dim", two=2
             )
             qk_rotated = apply_rotary_pos_emb_vision(
-                qk_reshaped, cos=rotary_pos_emb_cos, sin=rotary_pos_emb_sin
+                qk_rotated, cos=rotary_pos_emb_cos, sin=rotary_pos_emb_sin, inplace=True
             )
             qk_rotated = qk_rotated.view(
                 2,


### PR DESCRIPTION
## Purpose

The flash attention triton kernel used for applying rotary positional embeddings for vision supports inplace updates. This PR makes use of this ability in the Qwen style VL models which speeds up the `rotary_kernel` by ~20% as measured by the torch profiler. I also updated the torch fallback kernel to support in-place updates and have verified that accuracy is still correct. This PR also updates other models to re-use the implementation from Qwen2VL.

## Benchmark

Overall this results in a **3%** end-to-end throughput improvement when tested on a single L40s GPU

```
vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --limit-mm-per-prompt.video 0 --max-model-len 60000

vllm bench serve --backend openai-chat --model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --endpoint /v1/chat/completions --dataset-name hf --dataset-path lmarena-ai/VisionArena-Chat --hf-split train --num-prompts 1000
```

**Before:**
```
============ Serving Benchmark Result ============
Successful requests:                     998
Failed requests:                         2
Benchmark duration (s):                  119.22
Total input tokens:                      94126
Total generated tokens:                  120322
Request throughput (req/s):              8.37
Output token throughput (tok/s):         1009.28
Peak output token throughput (tok/s):    1922.00
Peak concurrent requests:                998.00
Total Token throughput (tok/s):          1798.83
---------------Time to First Token----------------
Mean TTFT (ms):                          51709.01
Median TTFT (ms):                        48599.71
P99 TTFT (ms):                           111995.99
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          102.01
Median TPOT (ms):                        100.81
P99 TPOT (ms):                           194.09
---------------Inter-token Latency----------------
Mean ITL (ms):                           109.08
Median ITL (ms):                         66.28
P99 ITL (ms):                            475.24
==================================================
```

**After:**

```
============ Serving Benchmark Result ============
Successful requests:                     998
Failed requests:                         2
Benchmark duration (s):                  115.94
Total input tokens:                      94285
Total generated tokens:                  120557
Request throughput (req/s):              8.61
Output token throughput (tok/s):         1039.82
Peak output token throughput (tok/s):    1921.00
Peak concurrent requests:                998.00
Total Token throughput (tok/s):          1853.04
---------------Time to First Token----------------
Mean TTFT (ms):                          50970.23
Median TTFT (ms):                        48455.82
P99 TTFT (ms):                           107744.76
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          106.30
Median TPOT (ms):                        104.92
P99 TPOT (ms):                           186.64
---------------Inter-token Latency----------------
Mean ITL (ms):                           112.89
Median ITL (ms):                         70.19
P99 ITL (ms):                            422.97
==================================================
```

## Accuracy

```
VLLM_WORKER_MULTIPROC_METHOD=spawn lm_eval --model vllm-vlm --model_args "pretrained=Qwen/Qwen3-VL-30B-A3B-Instruct-FP8,max_model_len=10000" --tasks chartqa --batch_size auto --apply_chat_template
```

**Before:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8752 | ±   | 0.0066 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6380 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8636 | ±   | 0.0069 |

**After:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8728 | ±   | 0.0067 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6380 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8636 | ±   | 0.0069 |
