### PR TITLE
[Bugfix][Perf] Revert applying HF processor on text-only inputs for multimodal models 

### DIFF
--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -129,8 +129,9 @@ def test_preprocessor_text_no_mm_inputs(model_id, prompt):
 )
 @pytest.mark.skip(
     reason=(
-        "Applying huggingface processor on text inputs results in ",
-        "significant performance regression for multimodal models. See https://github.com/vllm-project/vllm/issues/26320",
+        "Applying huggingface processor on text inputs results in "
+        "significant performance regression for multimodal models. "
+        "See https://github.com/vllm-project/vllm/issues/26320"
     )
 )
 def test_preprocessor_always_mm_code_path(model_id, prompt):

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -89,34 +89,6 @@ def test_zip_enc_dec_prompts(mm_processor_kwargs, expected_mm_kwargs):
 @pytest.mark.parametrize(
     "model_id",
     [
-        "facebook/opt-125m",
-    ],
-)
-@pytest.mark.parametrize(
-    "prompt",
-    [
-        {
-            "prompt": "",
-            "multi_modal_data": {"dummy": []},
-        },
-        {
-            "prompt_token_ids": [],
-            "multi_modal_data": {"dummy": []},
-        },
-    ],
-)
-def test_preprocessor_text_no_mm_inputs(model_id, prompt):
-    model_config = ModelConfig(model=model_id)
-    tokenizer = init_tokenizer_from_configs(model_config)
-    input_preprocessor = InputPreprocessor(model_config, tokenizer)
-
-    with pytest.raises(ValueError, match="does not support multimodal inputs"):
-        input_preprocessor.preprocess(prompt)
-
-
-@pytest.mark.parametrize(
-    "model_id",
-    [
         "facebook/chameleon-7b",
     ],
 )

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -127,6 +127,12 @@ def test_preprocessor_text_no_mm_inputs(model_id, prompt):
         {"prompt_token_ids": []},
     ],
 )
+@pytest.mark.skip(
+    reason=(
+        "Applying huggingface processor on text inputs results in ",
+        "significant performance regression for multimodal models. See https://github.com/vllm-project/vllm/issues/26320",
+    )
+)
 def test_preprocessor_always_mm_code_path(model_id, prompt):
     model_config = ModelConfig(model=model_id)
     tokenizer = init_tokenizer_from_configs(model_config)

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -348,18 +348,15 @@ class InputPreprocessor:
         )
 
         inputs: TokenInputs | MultiModalInputs
-        if self.model_config.is_multimodal_model:
+        if multi_modal_data := parsed_content.get("multi_modal_data"):
             inputs = self._process_multimodal(
                 prompt_token_ids,
-                parsed_content.get("multi_modal_data") or {},
+                multi_modal_data,
                 parsed_content.get("mm_processor_kwargs") or {},
                 tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=mm_uuids,
             )
         else:
-            if parsed_content.get("multi_modal_data"):
-                raise ValueError("This model does not support multimodal inputs")
-
             inputs = token_inputs(prompt_token_ids)
 
         if cache_salt := parsed_content.get("cache_salt"):
@@ -377,18 +374,15 @@ class InputPreprocessor:
         prompt_text = parsed_content["prompt"]
 
         inputs: TokenInputs | MultiModalInputs
-        if self.model_config.is_multimodal_model:
+        if multi_modal_data := parsed_content.get("multi_modal_data"):
             inputs = self._process_multimodal(
                 prompt_text,
-                parsed_content.get("multi_modal_data") or {},
+                multi_modal_data,
                 parsed_content.get("mm_processor_kwargs") or {},
                 tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=mm_uuids,
             )
         else:
-            if parsed_content.get("multi_modal_data"):
-                raise ValueError("This model does not support multimodal inputs")
-
             prompt_token_ids = self._tokenize_prompt(
                 prompt_text,
                 tokenization_kwargs=tokenization_kwargs,


### PR DESCRIPTION
## Purpose
https://github.com/vllm-project/vllm/pull/26240 caused a significant perf regression for text-only inference of multimodal models, discovered by https://github.com/vllm-project/vllm/issues/26320. 

After some investigation, it turned out that calling huggingface processor on text-only inputs is not equivalent to calling the corresponding tokenizer for most multimodal models, therefore it was decided to revert this change (even though this means models [here](https://github.com/ywang96/vllm/blob/d4acf518d09515560e1082a80b8a4d6550e20d9b/tests/models/multimodal/processing/test_common.py#L94-L99) will not have the exact behavior as HF when it comes to text only).

FIXES #26320

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

