### PR TITLE
cake modification

### DIFF
--- a/CAKE_MODIFICATION.md
+++ b/CAKE_MODIFICATION.md
@@ -1,0 +1,10 @@
+1. currently, scheduler check kv_cache, yes -> load, no -> start runnning prefill, need a way to indicate I have a cache hit but I just don't want to use it. (Adding new states)
+	1. decode > no cache hit >  local cache hit > external cache hit 
+	2. In current design, having external cache hit already makes it less favorable then the one without hitting external kv cache. But no priority given to decode.
+2. need a way to load in backward, in `start_load_kv`
+	1. currently assuming loading from the start with `allocated_ids` starting from the token_id where kv_cache hits. need to adopt to backward loading.
+3. need to allocate blocks (speculatively) after each load complete.
+	1. In current design, all blocks are allocated once for all for the loaded kv caches from lmcache right
+	2. We want to allocate blocks on the go so that we can make sure we balance the one loaded and the one computed (`num_computed_blocks`) for both `waiting` and `running` requests
+	3. each requests should remember its current state of the backward loading (ie. how many in the external cache hit has been loaded)
+	4. also while waiting/running, `num_computed_tokens` can also increment

--- a/CAKE_MODIFICATION.md
+++ b/CAKE_MODIFICATION.md
@@ -1,9 +1,12 @@
 1. currently, scheduler check kv_cache, yes -> load, no -> start runnning prefill, need a way to indicate I have a cache hit but I just don't want to use it. (Adding new states)
+	1. add states to indicate bidirectional loading decision in both running and waiting 
+3. need to ensure the priority of requests.
 	1. decode > no cache hit >  local cache hit > external cache hit 
 	2. In current design, having external cache hit already makes it less favorable then the one without hitting external kv cache. But no priority given to decode.
-2. need a way to load in backward, in `start_load_kv`
+4. need a way to load in backward, in `start_load_kv`
 	1. currently assuming loading from the start with `allocated_ids` starting from the token_id where kv_cache hits. need to adopt to backward loading.
-3. need to allocate blocks (speculatively) after each load complete.
+ 	2. Only need to change the calling of lmcache api from vllm. The lookup in lmcache is flexible enough 
+5. need to allocate blocks (speculatively) after each load complete.
 	1. In current design, all blocks are allocated once for all for the loaded kv caches from lmcache right
 	2. We want to allocate blocks on the go so that we can make sure we balance the one loaded and the one computed (`num_computed_blocks`) for both `waiting` and `running` requests
 	3. each requests should remember its current state of the backward loading (ie. how many in the external cache hit has been loaded)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -68,6 +68,11 @@ class LoadSpec:
     lmcache_cached_tokens: int
     # Whether the scheduler allow us to load the tokens
     can_load: bool
+    #TODO (cake): backward loading
+    # can_load_backward: bool
+    # lmchache_backward_loading_tokens: int <- num of tokens to load from end in this step
+
+
 
 
 @dataclass
@@ -357,6 +362,7 @@ class ReqMeta:
 
         block_ids = torch.tensor(tracker.allocated_block_ids, dtype=torch.long)
         block_offsets = torch.arange(0, block_size, dtype=torch.long)
+        # TODO (cake): Add backward loading slot mapping
         slot_mapping = (
             block_offsets.reshape((1, block_size))
             + block_ids.reshape((num_blocks, 1)) * block_size
@@ -827,6 +833,7 @@ class LMCacheConnectorV1Impl:
             self._stats_monitor.update_interval_vllm_hit_tokens(
                 request.load_spec.vllm_cached_tokens
             )
+            # TODO (cake): Add backward loading mask
             token_mask = torch.ones(len(tokens), dtype=torch.bool)
             masked_token_count = (
                 request.load_spec.vllm_cached_tokens
@@ -836,6 +843,7 @@ class LMCacheConnectorV1Impl:
             token_mask[:masked_token_count] = False
 
             lmcache_cached_tokens = request.load_spec.lmcache_cached_tokens
+            #TODO (cake): Add backward loading
             if self.use_layerwise:
                 sync = idx == last_idx
                 # NOTE(Jiayi): Perform blending before layerwise prefix caching

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -96,6 +96,9 @@ class Request:
         self.num_output_placeholders = 0  # Used in async scheduling.
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
+        #TODO (cake): 
+        # self.num_external_load_tokens (how many tokens are loaded from external KV cache)
+        # self.num_external_computed_tokens (longest cache hit length from external KV cache)
         self.cache_salt: str | None = cache_salt
 
         # Multi-modal related
@@ -211,6 +214,8 @@ class RequestStatus(enum.IntEnum):
     WAITING = enum.auto()
     WAITING_FOR_FSM = enum.auto()
     WAITING_FOR_REMOTE_KVS = enum.auto()
+    #TODO (cake): WAITING_FOR_BACKWARD_KVS: waiting but can be fired if fit
+    #TODO (cake): RUNNING_WITH_PARALLEL_IO: running but can be paused if fit
     RUNNING = enum.auto()
     PREEMPTED = enum.auto()
     # Note: anything after PREEMPTED will be considered


### PR DESCRIPTION
*cake modification rationale*
1. currently, scheduler check kv_cache, yes -> load, no -> start runnning prefill, need a way to indicate I have a cache hit but I just don't want to use it. (Adding new states)
    1. add states to indicate bidirectional loading decision in both running and waiting
2. need to ensure the priority of requests.
    1. decode > no cache hit > local cache hit > external cache hit
    2. In current design, having external cache hit already makes it less favorable then the one without hitting external kv cache. But no priority given to decode.
    3. before adding into running queue, should be filtered by priority queue
3. need modification to load in backward, in `start_load_kv`
    1. currently assuming loading from the start with `allocated_ids` starting from the token_id where kv_cache hits. need to adopt to backward loading.
    2. Only need to change the calling of lmcache api from vllm. The lookup in lmcache is flexible enough
4. need to allocate blocks (speculatively) after each load complete.
    1. In current design, all blocks are allocated once for all for the loaded kv caches from lmcache right
    2. We want to allocate blocks on the go so that we can make sure we balance the one loaded and the one computed (`num_computed_blocks`) for both `waiting` and `running` requests
    3. each requests should remember its current state of the backward loading (ie. how many in the external cache hit has been loaded)
    4. also while waiting/running, `num_computed_tokens` can also increment