### PR TITLE
[refactor] CTMoEMethods to use QuantizationArgs

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -767,8 +767,10 @@ class CompressedTensorsConfig(QuantizationConfig):
                 targets=self.target_scheme_map.keys(),
                 fused_mapping=self.packed_modules_mapping,
             )
-
-            return self.target_scheme_map[matched_target]
+            scheme_dict = self.target_scheme_map[matched_target]
+            if scheme_dict.get("format") is None:
+                scheme_dict["format"] = self.quant_format
+            return scheme_dict
 
         return None
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1452,6 +1452,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         )
         self.quant_type = WNA16_SUPPORTED_TYPES_MAP[self.num_bits]
         self.use_marlin = True
+        self.marlin_input_dtype = get_marlin_input_dtype(layer_name)
 
     def create_weights(
         self,


### PR DESCRIPTION
The various CTMoeMethods currently accept hte entire QuantizationConfig, uses sketchy logic (will only match Linear, not layer names) to pick a single scheme_dict and then from there extract the necessary QuantizationArgs. Since get_moe_method already gets the relevent QuantizationArgs, can just pass those directly.

No functional changes otherwise.

depends on [28870](https://github.com/vllm-project/vllm/pull/28870)

## Test Plan
CI

## Test Result
CI