### PR TITLE
[ROCm] Update MXFP4 Triton tensor unwrapping after #28816

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -755,8 +755,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             self.w13_weight = w13_weight
             self.w2_weight = w2_weight
-            layer.w13_weight = Parameter(w13_weight.storage.data, requires_grad=False)
-            layer.w2_weight = Parameter(w2_weight.storage.data, requires_grad=False)
+            layer.w13_weight = Parameter(
+                w13_weight.storage
+                if isinstance(w13_weight.storage, torch.Tensor)
+                else w13_weight.storage.data,
+                requires_grad=False,
+            )
+            layer.w2_weight = Parameter(
+                w2_weight.storage
+                if isinstance(w2_weight.storage, torch.Tensor)
+                else w2_weight.storage.data,
+                requires_grad=False,
+            )
         else:
             raise ValueError(f"Unsupported backend: {self.mxfp4_backend}")
 


### PR DESCRIPTION
## Purpose
  The .data property in newer Triton (https://github.com/triton-lang/triton/pull/7598) is defined as:
```
  @property
  def data(self):
      t = self.storage
      return t.data if isinstance(t, Storage) else t
```

This PR patches the logic in https://github.com/vllm-project/vllm/pull/28816/files to have better alignment with the wrapping in Triton

## Test Plan
AMD: https://buildkite.com/vllm/amd-ci/builds/1073
Nvidia:
```
OPENAI_API_KEY=empty wp python -m gpt_oss.evals --model openai/gpt-oss-20b --eval gpqa --n-threads 200 --reasoning-effort low
Running with args Namespace(model='openai/gpt-oss-20b', reasoning_effort='low', sampler='responses', base_url='http://localhost:8000/v1', eval='gpqa', temperature=1.0, n_threads=200, debug=False, examples=None)

Running the following evals: {'gpqa': <gpt_oss.evals.gpqa_eval.GPQAEval object at 0x7f8a48b5e090>}
Running evals for the following models: {'openai/gpt-oss-20b-low': <gpt_oss.evals.responses_sampler.ResponsesSampler object at 0x7f8a4bd6e9c0>}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1584/1584 [02:41<00:00,  9.83it/s]
Writing report to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20251117_144320.html
{'chars': np.float64(54.249368686868685), 'chars:std': np.float64(210.95170724600803), 'score': np.float64(0.5637626262626263), 'score:std': np.float64(0.49591766200861676)}
Writing results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20251117_144320.json
Writing all results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20251117_144320_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'openai__gpt-oss-20b-low_temp1.0_20251117_144320', 'metric': 0.5637626262626263}]
```