### PR TITLE
[NIXL] Fix blocksize=128 after hetero block size PR

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1185,6 +1185,8 @@ class NixlConnectorWorker:
                         self.block_size // kernel_block_size
                     )
                     self.block_size = kernel_block_size
+                    self.kv_topo.block_size = self.block_size
+                    self._block_size[self.engine_id] = self.block_size
 
                 seen_base_addresses.append(base_addr)
                 curr_tensor_size_bytes = cache.numel() * cache.element_size()


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

quick fix when block_size=128, need to update physical_block_size to self.kv_topo

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

