### PR TITLE
fix tool-call-parser for Qwen3-Coder model

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -343,14 +343,14 @@ Supported models:
 
 Flags: `--tool-call-parser glm45`
 
-### Qwen3-Coder Models (`qwen3_xml`)
+### Qwen3-Coder Models (`qwen3_coder`)
 
 Supported models:
 
-* `Qwen/Qwen3-480B-A35B-Instruct`
+* `Qwen/Qwen3-Coder-480B-A35B-Instruct`
 * `Qwen/Qwen3-Coder-30B-A3B-Instruct`
 
-Flags: `--tool-call-parser qwen3_xml`
+Flags: `--tool-call-parser qwen3_coder`
 
 ### Olmo 3 Models (`olmo3`)
 


### PR DESCRIPTION
You will get *IndexError: list index out of range* if you use qwen3_xml

The right parser should be *qwen3_coder*, refer to: https://docs.vllm.ai/projects/recipes/en/latest/Qwen/Qwen3-Coder-480B-A35B.html

## Purpose

fix wrong content in the docs.


<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
