### PR TITLE
[Feature][Benchmark] add --link-vars can filter when serve_param equal bench_param

### DIFF
--- a/vllm/benchmarks/sweep/serve.py
+++ b/vllm/benchmarks/sweep/serve.py
@@ -227,15 +227,13 @@ def run_combs(
             else contextlib.nullcontext()
         ) as server:
             for bench_comb in bench_params:
-                filter = True
-                for serve_key, bench_key in links:
-                    if serve_key not in serve_comb or bench_key not in bench_comb:
-                        filter = False
-                        break
-                    if serve_comb[serve_key] != bench_comb[bench_key]:
-                        filter = False
-                        break
-                if not filter:
+                should_run = all(
+                    serve_key in serve_comb
+                    and bench_key in bench_comb
+                    and serve_comb[serve_key] == bench_comb[bench_key]
+                    for serve_key, bench_key in links
+                )
+                if not should_run:
                     continue
                 base_path = _get_comb_base_path(output_dir, serve_comb, bench_comb)
 
@@ -401,6 +399,7 @@ class SweepServeArgs:
 
         return parser
 
+    @staticmethod
     def parse_link_vars(s: str) -> list[tuple[str, str]]:
         if not s:
             return []

--- a/vllm/benchmarks/sweep/serve.py
+++ b/vllm/benchmarks/sweep/serve.py
@@ -211,6 +211,7 @@ def run_combs(
     output_dir: Path,
     num_runs: int,
     dry_run: bool,
+    links: list[tuple[str, str]],
 ):
     all_data = list[dict[str, object]]()
     for serve_comb in serve_params:
@@ -226,6 +227,16 @@ def run_combs(
             else contextlib.nullcontext()
         ) as server:
             for bench_comb in bench_params:
+                filter = True
+                for serve_key, bench_key in links:
+                    if serve_key not in serve_comb or bench_key not in bench_comb:
+                        filter = False
+                        break
+                    if serve_comb[serve_key] != bench_comb[bench_key]:
+                        filter = False
+                        break
+                if not filter:
+                    continue
                 base_path = _get_comb_base_path(output_dir, serve_comb, bench_comb)
 
                 comb_data = run_comb(
@@ -262,6 +273,7 @@ class SweepServeArgs:
     num_runs: int
     dry_run: bool
     resume: str | None
+    link_vars: list[tuple[str, str]] | None
 
     parser_name: ClassVar[str] = "serve"
     parser_help: ClassVar[str] = "Run vLLM server benchmark under multiple settings."
@@ -285,7 +297,7 @@ class SweepServeArgs:
         else:
             # i.e.: run bench_cmd without any modification
             bench_params = ParameterSweep.from_records([{}])
-
+        link_vars = cls.parse_link_vars(args.link_vars)
         num_runs = args.num_runs
         if num_runs < 1:
             raise ValueError("`num_runs` should be at least 1.")
@@ -301,6 +313,7 @@ class SweepServeArgs:
             num_runs=num_runs,
             dry_run=args.dry_run,
             resume=args.resume,
+            link_vars=link_vars,
         )
 
     @classmethod
@@ -376,7 +389,26 @@ class SweepServeArgs:
             "parameter combinations for which there are still no output files.",
         )
 
+        parser.add_argument(
+            "--link-vars",
+            type=str,
+            default="",
+            help=(
+                "Comma-separated list of linked variables between serve and bench, "
+                "e.g. max_num_seqs=max_concurrency,max_model_len=random_input_len"
+            ),
+        )
+
         return parser
+
+    def parse_link_vars(s: str) -> list[tuple[str, str]]:
+        if not s:
+            return []
+        pairs = []
+        for item in s.split(","):
+            a, b = item.split("=")
+            pairs.append((a.strip(), b.strip()))
+        return pairs
 
 
 def run_main(args: SweepServeArgs):
@@ -397,6 +429,7 @@ def run_main(args: SweepServeArgs):
             output_dir=output_dir,
             num_runs=args.num_runs,
             dry_run=args.dry_run,
+            links=args.link_vars,
         )
     except BaseException as exc:
         raise RuntimeError(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

FIX: https://github.com/vllm-project/vllm/issues/28548

When users can set the `--link-vars` parameter to filter out unwanted combinations that appear in the Cartesian product. 

e.g:

- serve_param.json
```
[
    {
      "max_num_seqs": 5
    },
    {
      "max_num_seqs": 10
    }
]
```

- bench_param.json

```
[
    {
        "max_concurrency": 5
    },
    {
        "max_concurrency": 10
    }
]
```

Prior to this PR, sweep would run all four combinations of conditions (5,5)(5,10)(10,5)(10,10); however, (5,10) and (10,5) might be combinations that you want to filter out.



## Test Plan

Running this dry-run command to view print benchmark command. can found it filter (5,10) and (10,5).

```
$ python3 -m vllm.benchmarks.sweep.serve \
    --serve-cmd 'vllm serve Qwen/Qwen3-0.6B' \
    --bench-cmd 'vllm bench serve --model Qwen/Qwen3-0.6B --backend vllm --endpoint /v1/completions --dataset-name sharegpt --dataset-path target/lrf/benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json' \
    --serve-params target/lrf/benchmarks/serve_params.json \
    --bench-params target/lrf/benchmarks/bench_params.json \
    --link-vars max_num_seqs=max_concurrency \
    -o target/lrf/benchmarks/results \
    --num-runs 1 \
    --dry-run
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

