### PR TITLE
[Bugfix] Fix FusedMoEModularKernel for triton backend

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -34,8 +34,6 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
             "disable_expert_map",
             not self.fused_experts.supports_expert_map(),
         )
-        self.w13_weight = getattr(old_quant_method, "w13_weight", None)
-        self.w2_weight = getattr(old_quant_method, "w2_weight", None)
         self.old_quant_method = old_quant_method
         logger.debug("Swapping out %s", self.old_quant_method.__class__.__name__)
 
@@ -146,8 +144,8 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
 
         result = self.fused_experts(
             hidden_states=x,
-            w1=layer.w13_weight if self.w13_weight is None else self.w13_weight,
-            w2=layer.w2_weight if self.w2_weight is None else self.w2_weight,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             inplace=self.allow_inplace,

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -39,6 +39,7 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
         self.w2_weight = None
         if self.moe_quant_config.use_mxfp4_w4a16:
             from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4Backend
+
             if old_quant_method.mxfp4_backend == Mxfp4Backend.TRITON:
                 self.w13_weight = old_quant_method.w13_weight
                 self.w2_weight = old_quant_method.w2_weight
@@ -151,8 +152,8 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
 
         result = self.fused_experts(
             hidden_states=x,
-            w1=self.w13_weight or layer.w13_weight,
-            w2=self.w2_weight or layer.w2_weight,
+            w1=layer.w13_weight if self.w13_weight is None else self.w13_weight,
+            w2=layer.w2_weight if self.w2_weight is None else self.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             inplace=self.allow_inplace,

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -34,15 +34,9 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
             "disable_expert_map",
             not self.fused_experts.supports_expert_map(),
         )
+        self.w13_weight = getattr(old_quant_method, "w13_weight", None)
+        self.w2_weight = getattr(old_quant_method, "w2_weight", None)
         self.old_quant_method = old_quant_method
-        self.w13_weight = None
-        self.w2_weight = None
-        if self.moe_quant_config.use_mxfp4_w4a16:
-            from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4Backend
-
-            if old_quant_method.mxfp4_backend == Mxfp4Backend.TRITON:
-                self.w13_weight = old_quant_method.w13_weight
-                self.w2_weight = old_quant_method.w2_weight
         logger.debug("Swapping out %s", self.old_quant_method.__class__.__name__)
 
     @staticmethod

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -755,8 +755,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             self.w13_weight = w13_weight
             self.w2_weight = w2_weight
-            layer.w13_weight = Parameter(w13_weight.storage.data, requires_grad=False)
-            layer.w2_weight = Parameter(w2_weight.storage.data, requires_grad=False)
+            del layer.w13_weight
+            del layer.w2_weight
+            layer.w13_weight = w13_weight
+            layer.w2_weight = w2_weight
         else:
             raise ValueError(f"Unsupported backend: {self.mxfp4_backend}")
 
@@ -1065,8 +1067,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             return triton_kernel_moe_forward(
                 hidden_states=x,
-                w1=self.w13_weight,
-                w2=self.w2_weight,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
                 gating_output=router_logits,
                 topk=top_k,
                 renormalize=renormalize,


### PR DESCRIPTION
## Purpose

This PR fix the AssertionError for FusedMoEModularKernel for fp4 triton backend (see stacktrace below).
* In mxfp4.py, after [_swizzle_mxfp4](https://github.com/vllm-project/vllm/blob/5bb1da5190b54aefb08478c6b1170f97722b8bdb/vllm/model_executor/layers/quantization/mxfp4.py#L742), `w13_weight` has become `triton_kernels.tensor.Tensor` type, and shape is changed.
  * For example, if running on hopper, swizzling changed the shape from [E, N, K] to [E, N // 4, K * 4], see [here](https://github.com/triton-lang/triton/blob/v3.5.1/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py#L171-L172). `w13_weight.storage.data` has the new shape [E, N // 4, K * 4], while the original shape is kept in `w13_weight.shape` attribute.
* In mxfp4.py, it passes `self.w13_weight` and `self.w2_weight` to `triton_kernel_moe_forward`, see [here](https://github.com/vllm-project/vllm/blob/5bb1da5190b54aefb08478c6b1170f97722b8bdb/vllm/model_executor/layers/quantization/mxfp4.py#L1068-L1069). But in FusedMoEModularMethod, it still passes `layer.w13_weight` and `layer.w2_weight`, causing shape mismatch.

stacktrace:
```
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/gpt_oss.py", line 236, in forward
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     output = self.mlp(hidden_states)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]              ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/gpt_oss.py", line 189, in forward
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     x = self.experts(hidden_states=x, router_logits=g)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/custom_op.py", line 46, in forward
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return self._forward_method(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 1538, in forward_cuda
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return self.forward_native(hidden_states, router_logits)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 1506, in forward_native
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     fused_output = torch.ops.vllm.moe_forward(
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1255, in __call__
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return self._op(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 1893, in moe_forward
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return self.forward_impl(hidden_states, router_logits)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 1757, in forward_impl
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     final_hidden_states = self.quant_method.apply(
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]                           ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py", line 145, in apply
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     result = self.fused_experts(
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]              ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1199, in forward
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     fused_out = self._fused_experts(
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]                 ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1052, in _fused_experts
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     self.fused_experts.apply(
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py", line 300, in apply
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     experts_output = triton_kernel_fused_experts(
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py", line 134, in triton_kernel_fused_experts
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]     assert hidden_states.shape[-1] == w1.shape[-2]
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1697) ERROR 11-17 22:30:44 [core.py:855] AssertionError
```
## Test Plan

Install triton_kernels:

```
pip install "git+https://github.com/triton-lang/triton.git@0a2e3a391cbb9e13d29bf12a2a0005e358102d74#subdirectory=python/triton_kernels"
```
serve:
```
VLLM_ALL2ALL_BACKEND="deepep_high_throughput"  vllm serve openai/gpt-oss-20b --tensor-parallel-size 1 --data-parallel-size 2 --enable-expert-parallel --no-enable-prefix-caching
```

AssertionError fixed.

## Eval

```
OPENAI_API_KEY=empty python3 -m gpt_oss.evals --model openai/gpt-oss-20b --eval gpqa --n-threads 200 --reasoning-effort low
```

Result:

```
Writing report to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20251118_143302.html
{'chars': np.float64(62.395833333333336), 'chars:std': np.float64(226.83497373844654), 'score': np.float64(0.5637626262626263), 'score:std': np.float64(0.49591766200861676)}
Writing results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20251118_143302.json
Writing all results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20251118_143302_allresults.json
[{'eval_name': 'gpqa', 'model_name': '__opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20251118_143302', 'metric': 0.5637626262626263}]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

cc @varun-sundar-rabindranath 
