### PR TITLE
[ROCm][FP4 Preshuffle Gemm] Refine the FP4 preshuffled gemm and integrate the triton FP4 preshuffled gemm

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -446,7 +446,7 @@ class rocm_aiter_ops:
     _MHA_ENABLED = envs.VLLM_ROCM_USE_AITER_MHA
     _TRITON_UNIFIED_ATTN_ENABLED = envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
     _FP8BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP8BMM
-    _FP4_GEMM_DYNAMIC_QUANT_ASM = envs.VLLM_ROCM_USE_AITER_FP4_ASM_GEMM
+    _FP4_PRESHUFFLED_GEMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP4_PRESHUFFLED_GEMM
     _TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
     _MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
     _TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
@@ -517,8 +517,8 @@ class rocm_aiter_ops:
 
     @classmethod
     @if_aiter_supported
-    def is_asm_fp4_gemm_dynamic_quant_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._FP4_GEMM_DYNAMIC_QUANT_ASM
+    def is_fp4_preshuffled_gemm_enabled(cls) -> bool:
+        return cls._AITER_ENABLED and cls._FP4_PRESHUFFLED_GEMM_ENABLED
 
     @classmethod
     @if_aiter_supported

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -108,7 +108,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
-    VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
+    VLLM_ROCM_USE_AITER_FP4_PRESHUFFLED_GEMM: bool = False
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
     VLLM_ROCM_USE_AITER_FP8BMM: bool = True
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
@@ -927,10 +927,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER_MHA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MHA", "True").lower() in ("true", "1")
     ),
-    # Whether to use aiter fp4 gemm asm.
+    # Whether to use aiter fp4 preshuffled gemm.
     # By default is disabled.
-    "VLLM_ROCM_USE_AITER_FP4_ASM_GEMM": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_FP4_ASM_GEMM", "False").lower() in ("true", "1")
+    "VLLM_ROCM_USE_AITER_FP4_PRESHUFFLED_GEMM": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_FP4_PRESHUFFLED_GEMM", "False").lower()
+        in ("true", "1")
     ),
     # Whether to use aiter rope.
     # By default is disabled.
@@ -1602,7 +1603,7 @@ def compute_hash() -> str:
         "VLLM_ROCM_USE_AITER_RMSNORM",
         "VLLM_ROCM_USE_AITER_MLA",
         "VLLM_ROCM_USE_AITER_MHA",
-        "VLLM_ROCM_USE_AITER_FP4_ASM_GEMM",
+        "VLLM_ROCM_USE_AITER_FP4_PRESHUFFLED_GEMM",
         "VLLM_ROCM_USE_AITER_TRITON_ROPE",
         "VLLM_ROCM_USE_AITER_FP8BMM",
         "VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION",


### PR DESCRIPTION
Integrate the triton FP4 preshuffled gemm kernel and deprecate the env flag **VLLM_ROCM_USE_AITER_FP4_ASM_GEMM**.
For now, we use **VLLM_ROCM_USE_AITER_FP4_PRESHUFFLED_GEMM** to control if using preshuffled gemm kernel or not. 

- When using the fp4 preshuffled gemm kernel, the triton kernel or the asm kernel will be dispatched according to the shape
- When not using the fp4 preshuffled gemm kernel, the triton kernel will be used by default

<img width="779" height="168" alt="image" src="https://github.com/user-attachments/assets/706e8169-1475-40c7-8d94-b577d3e0ac6c" />