### PR TITLE
[ROCm] Validate quantization consistency for AITER shared experts fusion

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -112,7 +112,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
     VLLM_ROCM_USE_AITER_FP8BMM: bool = True
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
-    VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = True
+    VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
@@ -948,9 +948,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         in ("true", "1")
     ),
     # Whether to use aiter fusion shared experts ops.
-    # By default is enabled.
+    # By default is disabled.
     "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS", "True").lower()
+        os.getenv("VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS", "False").lower()
         in ("true", "1")
     ),
     # Whether to use aiter triton kernels for gemm ops.

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -38,6 +38,28 @@ class ActivationMethod(IntEnum):
 aiter_topK_meta_data = None
 
 
+def validate_quantization_for_aiter_fusion_shared_experts(
+    quant_config,
+    shared_experts_layer_name: str,
+    experts_layer_name: str,
+) -> None:
+    """Validate quantization consistency for AITER shared experts fusion."""
+    if quant_config is None:
+        return
+
+    is_consistent, error_msg = quant_config.check_layer_quantization_consistency(
+        layer_name_1=shared_experts_layer_name,
+        layer_name_2=experts_layer_name,
+    )
+
+    assert is_consistent, (
+        f"AITER_FUSION_SHARED_EXPERTS requires matching quantization "
+        f"for shared_experts and experts.\n"
+        f"{error_msg}\n"
+        f"Set VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0 to disable."
+    )
+
+
 @lru_cache(maxsize=1)
 def init_aiter_topK_meta_data(
     n_routed_experts: int,

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -168,3 +168,21 @@ class QuantizationConfig(ABC):
         Interface to update values after config initialization.
         """
         pass
+
+    def check_layer_quantization_consistency(
+        self, layer_name_1: str, layer_name_2: str
+    ) -> tuple[bool, str]:
+        """
+        Check if two layers have consistent quantization configurations.
+
+        Used for operations that require fusing layers with matching quantization,
+        such as shared experts fusion in MoE models.
+
+        Default implementation assumes consistency. Subclasses should override
+        this method to provide specific validation logic.
+
+        :param layer_name_1: First layer name
+        :param layer_name_2: Second layer name
+        :return: (is_consistent, error_message) tuple
+        """
+        return True, ""

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -53,6 +53,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.transform.linear
     get_linear_transform_schemes,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    check_quantization_consistency,
     find_matched_target,
     is_activation_quantization_format,
     should_ignore_layer,
@@ -160,6 +161,18 @@ class CompressedTensorsConfig(QuantizationConfig):
         if isinstance(layer, FusedMoE):
             return CompressedTensorsMoEMethod.get_moe_method(self, layer)
         return None
+
+    def check_layer_quantization_consistency(
+        self, layer_name_1: str, layer_name_2: str
+    ) -> tuple[bool, str]:
+        """
+        Check if two layers have consistent quantization configurations.
+
+        :param layer_name_1: First layer name
+        :param layer_name_2: Second layer name
+        :return: (is_consistent, error_message) tuple
+        """
+        return check_quantization_consistency(self, layer_name_1, layer_name_2)
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "CompressedTensorsConfig":

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -292,7 +292,27 @@ class DeepseekV2MoE(nn.Module):
         )
 
         self.is_rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
-        if config.n_shared_experts is None or self.is_rocm_aiter_moe_enabled:
+        self.is_fusion_moe_shared_experts_enabled = (
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        )
+
+        # Validate quantization consistency for AITER shared experts fusion
+        if (
+            self.is_fusion_moe_shared_experts_enabled
+            and config.n_shared_experts is not None
+            and quant_config is not None
+        ):
+            from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+                validate_quantization_for_aiter_fusion_shared_experts,
+            )
+
+            validate_quantization_for_aiter_fusion_shared_experts(
+                quant_config=quant_config,
+                shared_experts_layer_name=f"{prefix}.shared_experts.gate_up_proj",
+                experts_layer_name=f"{prefix}.experts.w13",
+            )
+
+        if config.n_shared_experts is None or self.is_fusion_moe_shared_experts_enabled:
             self.shared_experts = None
         else:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
@@ -332,7 +352,7 @@ class DeepseekV2MoE(nn.Module):
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
             n_shared_experts=config.n_shared_experts
-            if rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+            if self.is_fusion_moe_shared_experts_enabled
             else None,
         )
 


### PR DESCRIPTION
## Purpose

Fix quantization mismatch issue for AITER shared experts fusion. When `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS` is enabled, shared_experts and routed experts must use identical quantization configs. For example, Kimi v2 Think model uses bf16 for shared_experts but w4a16 for routed experts, causing fusion failures.

Changes:
- Set `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS` default to False (was True)
- Add quantization consistency validation when fusion is enabled

## Test Plan

Test with Kimi v2 Think model with mixed quantization (bf16 shared_experts + w4a16 routed experts).

## Test Result

With `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`, validation correctly detects mismatch and provides clear error message.