### PR TITLE
[CPU][IBM Z] Fix BF16 support and vectorize math operations for s390x

### DIFF
--- a/csrc/cpu/cpu_attn_impl.hpp
+++ b/csrc/cpu/cpu_attn_impl.hpp
@@ -847,7 +847,7 @@ struct VecTypeTrait<c10::BFloat16> {
 };
 #endif
 
-#if !defined(__powerpc__)
+#if !defined(__powerpc__) && !defined(__s390x__)
 template <>
 struct VecTypeTrait<c10::Half> {
   using vec_t = vec_op::FP16Vec16;


### PR DESCRIPTION

## Purpose
This PR fixes BF16 (bfloat16) support issue by fixing the byte ordering and adds comprehensive vectorized mathematical operations for IBM Z s390x architecture using VXE.
### Key Issues Addressed:
1. **BF16 Byte Ordering Bug**: Fixed incorrect byte ordering in BF16↔FP32 conversions that caused model inference failures on big-endian s390x architecture
2. **Missing Vectorization**: Replaced slow scalar fallbacks (`std::exp`, `std::tanh`, `std::erf`) with optimized vector implementations
3. **FMA Operations**: Implemented fused multiply-add intrinsics using IBM Z vector instructions for better performance
4. **Numerical Accuracy**: Improved BF16 rounding from simple truncation to round-to-nearest-even (RNE)

## Test Plan
Deploy vLLM service and check the inferencing output
## Test Result
```
[root@b314lp81 vllm]# docker run --rm -p 9000:9000 --name vllm-optimized  --entrypoint python    quay.io/r3hankhan/vllm:bf16    -m vllm.entrypoints.openai.api_server   --model ibm-granite/granite-3.3-8b-instruct   --host 0.0.0.0   --port 9000   --dtype bfloat16   --max-model-len 2048 
INFO 11-18 06:34:51 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 11-18 06:34:53 [scheduler.py:216] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=1) INFO 11-18 06:34:53 [api_server.py:1977] vLLM API server version 0.1.dev11386+g16451b2ba.d20251118
(APIServer pid=1) INFO 11-18 06:34:53 [utils.py:253] non-default args: {'host': '0.0.0.0', 'port': 9000, 'model': 'ibm-granite/granite-3.3-8b-instruct', 'dtype': 'bfloat16', 'max_model_len': 2048}
(APIServer pid=1) INFO 11-18 06:35:06 [model.py:631] Resolved architecture: GraniteForCausalLM
(APIServer pid=1) INFO 11-18 06:35:06 [model.py:1745] Using max model len 2048
(APIServer pid=1) WARNING 11-18 06:35:06 [cpu.py:155] Environment variable VLLM_CPU_KVCACHE_SPACE (GiB) for CPU backend is not set, using 4 by default.
(APIServer pid=1) INFO 11-18 06:35:06 [arg_utils.py:1376] Chunked prefill is not supported for ARM and POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
(APIServer pid=1) INFO 11-18 06:35:06 [arg_utils.py:1382] Prefix caching is not supported for ARM and POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
(APIServer pid=1) WARNING 11-18 06:35:07 [cpu.py:390] Pin memory is not supported on CPU.
INFO 11-18 06:35:14 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
(EngineCore_DP0 pid=24) INFO 11-18 06:35:15 [core.py:93] Initializing a V1 LLM engine (v0.1.dev11386+g16451b2ba.d20251118) with config: model='ibm-granite/granite-3.3-8b-instruct', speculative_config=None, tokenizer='ibm-granite/granite-3.3-8b-instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=ibm-granite/granite-3.3-8b-instruct, enable_prefix_caching=False, enable_chunked_prefill=False, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.DYNAMO_TRACE_ONCE: 2>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': None, 'compile_mm_encoder': False, 'use_inductor': None, 'compile_sizes': None, 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'dce': True, 'size_asserts': False, 'nan_asserts': False, 'epilogue_fusion': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'local_cache_dir': None}
(EngineCore_DP0 pid=24) WARNING 11-18 06:35:18 [cpu.py:390] Pin memory is not supported on CPU.
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:188] auto thread-binding list (id, physical core): [(0, 0), (1, 0), (2, 1), (3, 1), (8, 4), (9, 4), (10, 5), (11, 5), (16, 8), (17, 8), (18, 9), (19, 9), (24, 12), (25, 12), (26, 13), (27, 13), (32, 16), (33, 16), (34, 17), (35, 17), (40, 20), (41, 20), (42, 21), (43, 21), (48, 24), (49, 24)]
get_mempolicy: Operation not permitted
[W1118 06:35:19.957288234 utils.cpp:67] Warning: numa_migrate_pages failed. errno: 1 (function init_cpu_threads_env)
set_mempolicy: Operation not permitted
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] OMP threads binding of Process 24:
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 24, core 0
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 35, core 1
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 36, core 2
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 37, core 3
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 38, core 8
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 39, core 9
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 40, core 10
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 41, core 11
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 42, core 16
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 43, core 17
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 44, core 18
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 45, core 19
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 46, core 24
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 47, core 25
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 48, core 26
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 49, core 27
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 50, core 32
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 51, core 33
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 52, core 34
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 53, core 35
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 54, core 40
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 55, core 41
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 56, core 42
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 57, core 43
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 58, core 48
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 	OMP tid: 59, core 49
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_worker.py:94] 
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [parallel_state.py:1208] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.2:51829 backend=gloo
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [parallel_state.py:1394] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=24) INFO 11-18 06:35:19 [cpu_model_runner.py:55] Starting to load model ibm-granite/granite-3.3-8b-instruct...
(EngineCore_DP0 pid=24) INFO 11-18 06:40:24 [weight_utils.py:441] Time spent downloading weights for ibm-granite/granite-3.3-8b-instruct: 305.037842 seconds
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:02,  1.02it/s]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:04<00:04,  2.41s/it]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:07<00:02,  2.60s/it]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:10<00:00,  2.73s/it]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:10<00:00,  2.54s/it]
(EngineCore_DP0 pid=24) 
(EngineCore_DP0 pid=24) INFO 11-18 06:40:35 [default_loader.py:314] Loading weights took 10.15 seconds
(EngineCore_DP0 pid=24) INFO 11-18 06:40:35 [kv_cache_utils.py:1229] GPU KV cache size: 26,112 tokens
(EngineCore_DP0 pid=24) INFO 11-18 06:40:35 [kv_cache_utils.py:1234] Maximum concurrency for 2,048 tokens per request: 12.75x
(EngineCore_DP0 pid=24) INFO 11-18 06:40:35 [cpu_model_runner.py:65] Warming up model for the compilation...
(EngineCore_DP0 pid=24) INFO 11-18 06:43:59 [cpu_model_runner.py:75] Warming up done.
(EngineCore_DP0 pid=24) INFO 11-18 06:43:59 [core.py:249] init engine (profile, create kv cache, warmup model) took 204.83 seconds
(EngineCore_DP0 pid=24) WARNING 11-18 06:44:00 [cpu.py:155] Environment variable VLLM_CPU_KVCACHE_SPACE (GiB) for CPU backend is not set, using 4 by default.
(APIServer pid=1) [INFO] model_hosting_container_standards - decorators.py:76: [PING] Framework handler registered: ping
(APIServer pid=1) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:90: [INJECT_ADAPTER_ID] Transform decorator applied to: invocations
(APIServer pid=1) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:115: [INJECT_ADAPTER_ID] Registered transform handler for invocations
(APIServer pid=1) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:90: [STATEFUL_SESSION_MANAGER] Transform decorator applied to: decorated_func
(APIServer pid=1) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:115: [STATEFUL_SESSION_MANAGER] Registered transform handler for decorated_func
(APIServer pid=1) [INFO] model_hosting_container_standards - decorators.py:76: [INVOKE] Framework handler registered: decorated_func
(APIServer pid=1) [INFO] model_hosting_container_standards - __init__.py:156: Starting SageMaker bootstrap process
(APIServer pid=1) [INFO] model_hosting_container_standards - registry.py:109: [REGISTRY] Middleware resolution and registration complete
(APIServer pid=1) [INFO] model_hosting_container_standards - core.py:100: [MIDDLEWARE_LOADER] Middleware stack rebuilt successfully
(APIServer pid=1) [INFO] model_hosting_container_standards - core.py:102: [MIDDLEWARE_LOADER] Processed 3 middlewares
(APIServer pid=1) [WARNING] model_hosting_container_standards.common.custom_code_ref_resolver.function_loader - function_loader.py:73: Failed to load function from spec 'model:custom_sagemaker_invocation_handler': HandlerFileNotFoundError: File '/opt/ml/model/model.py' not found in search paths: ['/opt/ml/model/']
(APIServer pid=1) [WARNING] model_hosting_container_standards.common.custom_code_ref_resolver.function_loader - function_loader.py:73: Failed to load function from spec 'model:custom_sagemaker_ping_handler': HandlerFileNotFoundError: File '/opt/ml/model/model.py' not found in search paths: ['/opt/ml/model/']
(APIServer pid=1) [INFO] model_hosting_container_standards.sagemaker.sagemaker_router - sagemaker_router.py:93: Creating SageMaker router with unified route resolver
(APIServer pid=1) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:172: Creating router with prefix='', tags=['sagemaker']
(APIServer pid=1) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:110: Mounting 2 handlers to router
(APIServer pid=1) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:184: Router created with 0 routes
(APIServer pid=1) [INFO] model_hosting_container_standards.sagemaker.sagemaker_router - sagemaker_router.py:101: SageMaker router created successfully with 0 routes
(APIServer pid=1) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:287: Including router with conflict detection
(APIServer pid=1) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:305: Successfully included router with 0 routes
(APIServer pid=1) [INFO] model_hosting_container_standards - __init__.py:168: SageMaker bootstrap completed successfully
(APIServer pid=1) INFO 11-18 06:44:01 [api_server.py:1725] Supported tasks: ['generate']
(APIServer pid=1) INFO 11-18 06:44:01 [api_server.py:2052] Starting vLLM API server 0 on http://0.0.0.0:9000
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:38] Available routes are:
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /docs, Methods: HEAD, GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=1) INFO 11-18 06:44:01 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=1) INFO:     Started server process [1]
(APIServer pid=1) INFO:     Waiting for application startup.
(APIServer pid=1) INFO:     Application startup complete.
(APIServer pid=1) INFO 11-18 06:44:41 [loggers.py:236] Engine 000: Avg prompt throughput: 1.9 tokens/s, Avg generation throughput: 0.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:44:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:45:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:45:11 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:45:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:45:31 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:45:41 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:45:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:46:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:46:11 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:46:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:46:31 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:46:41 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:46:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:47:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:47:11 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:47:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:47:31 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:47:41 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:47:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:48:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:48:11 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 11-18 06:48:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO:     172.17.0.1:34264 - "POST /v1/completions HTTP/1.1" 200 OK
```
```
[root@b314lp81 ~]# curl http://localhost:9000/v1/completions -H "Content-Type: application/json" -d '{ "model": "ibm-granite/granite-3.3-8b-instruct", "prompt": "Tell me a creative story about how artificial intelligence changed the world for the better...", "max_tokens": 150 }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1234  100  1057    0   177      4      0  0:04:24  0:04:12  0:00:12   299
{
  "id": "cmpl-e65e31c8bc7041f0be92629c7ef4b68e",
  "object": "text_completion",
  "created": 1763449137,
  "model": "ibm-granite/granite-3.3-8b-instruct",
  "choices": [
    {
      "index": 0,
      "text": " one of its major impacts on society is the advancement of the global healthcare system.\"\n\nTitle: The Symphony of Healing: AI's Orchestration in Global Healthcare\n\nIn the year 2050, the world had witnessed a transformative shift in the realm of healthcare, orchestrated by the harmonious melody of Artificial Intelligence (AI). This evolution was not a silent revolution, but a symphony of advancements that resonated across nations, healing the sick and mitigating global health crises.\n\nThe tale began with the AI-driven diagnostic tools that became the new stethoscopes of the",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null,
      "prompt_logprobs": null,
      "prompt_token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 19,
    "total_tokens": 169,
    "completion_tokens": 150,
    "prompt_tokens_details": null
  },
  "kv_transfer_params": null
}
---
```
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

