### PR TITLE
Supress verbose logs from model_hosting_container_standards

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib
 import inspect
 import json
+import logging
 import multiprocessing
 import multiprocessing.forkserver as forkserver
 import os
@@ -2019,6 +2020,9 @@ async def run_server(args, **uvicorn_kwargs) -> None:
 
     # Add process-specific prefix to stdout and stderr.
     decorate_logs("APIServer")
+
+    # Suppress verbose logs from model_hosting_container_standards
+    logging.getLogger("model_hosting_container_standards").setLevel(logging.ERROR)
 
     listen_address, sock = setup_server(args)
     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Suppress verbose INFO logs from `model_hosting_container_standards` during vLLM server startup. Sets the logger level to ERROR to reduce noise in the console output while preserving important error messages.

## Test Plan

## Test Result

Here is the difference in the server startup logs for a simple model on M1 CPU backend

```diff
vllm serve trl-internal-testing/tiny-random-LlamaForCausalLM --enforce-eager --load-format dummy
INFO 11-18 12:00:47 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 11-18 12:00:48 [scheduler.py:216] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=55209) INFO 11-18 12:00:48 [api_server.py:1978] vLLM API server version 0.11.1rc7.dev141+g25ba77c22
(APIServer pid=55209) INFO 11-18 12:00:48 [utils.py:253] non-default args: {'model_tag': 'trl-internal-testing/tiny-random-LlamaForCausalLM', 'model': 'trl-internal-testing/tiny-random-LlamaForCausalLM', 'enforce_eager': True, 'load_format': 'dummy'}
(APIServer pid=55209) INFO 11-18 12:00:49 [model.py:631] Resolved architecture: LlamaForCausalLM
(APIServer pid=55209) INFO 11-18 12:00:49 [model.py:1968] Downcasting torch.float32 to torch.float16.
(APIServer pid=55209) INFO 11-18 12:00:49 [model.py:1745] Using max model len 2048
(APIServer pid=55209) WARNING 11-18 12:00:49 [cpu.py:155] Environment variable VLLM_CPU_KVCACHE_SPACE (GiB) for CPU backend is not set, using 4 by default.
(APIServer pid=55209) INFO 11-18 12:00:49 [arg_utils.py:1376] Chunked prefill is not supported for ARM and POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
(APIServer pid=55209) INFO 11-18 12:00:49 [arg_utils.py:1382] Prefix caching is not supported for ARM and POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
(APIServer pid=55209) You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
(APIServer pid=55209) WARNING 11-18 12:00:49 [cpu.py:390] Pin memory is not supported on CPU.
INFO 11-18 12:00:52 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [core.py:93] Initializing a V1 LLM engine (v0.11.1rc7.dev141+g25ba77c22) with config: model='trl-internal-testing/tiny-random-LlamaForCausalLM', speculative_config=None, tokenizer='trl-internal-testing/tiny-random-LlamaForCausalLM', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=2048, download_dir=None, load_format=dummy, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=True, kv_cache_dtype=auto, device_config=cpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=trl-internal-testing/tiny-random-LlamaForCausalLM, enable_prefix_caching=False, enable_chunked_prefill=False, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': None, 'compile_mm_encoder': False, 'use_inductor': None, 'compile_sizes': None, 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'local_cache_dir': None}
(EngineCore_DP0 pid=55221) WARNING 11-18 12:00:54 [cpu.py:390] Pin memory is not supported on CPU.
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [cpu_worker.py:94] Warning: NUMA is not enabled in this build. `init_cpu_threads_env` has no effect to setup thread affinity.
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [parallel_state.py:1208] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.195.153.53:65477 backend=gloo
[W1118 12:00:54.654239000 ProcessGroupGloo.cpp:547] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [parallel_state.py:1394] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [cpu_model_runner.py:55] Starting to load model trl-internal-testing/tiny-random-LlamaForCausalLM...
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [kv_cache_utils.py:1229] GPU KV cache size: 33,554,432 tokens
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [kv_cache_utils.py:1234] Maximum concurrency for 2,048 tokens per request: 16384.00x
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [cpu_model_runner.py:65] Warming up model for the compilation...
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [cpu_model_runner.py:75] Warming up done.
(EngineCore_DP0 pid=55221) INFO 11-18 12:00:54 [core.py:250] init engine (profile, create kv cache, warmup model) took 0.18 seconds
(EngineCore_DP0 pid=55221) You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
(EngineCore_DP0 pid=55221) WARNING 11-18 12:00:55 [cpu.py:155] Environment variable VLLM_CPU_KVCACHE_SPACE (GiB) for CPU backend is not set, using 4 by default.
- (APIServer pid=55342) [INFO] model_hosting_container_standards - decorators.py:76: [PING] Framework handler registered: ping
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO decorators.py:76: [PING] Framework handler registered: ping
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:90: [INJECT_ADAPTER_ID] Transform decorator applied to: invocations
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO base_factory.py:90: [INJECT_ADAPTER_ID] Transform decorator applied to: invocations
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:115: [INJECT_ADAPTER_ID] Registered transform handler for invocations
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO base_factory.py:115: [INJECT_ADAPTER_ID] Registered transform handler for invocations
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:90: [STATEFUL_SESSION_MANAGER] Transform decorator applied to: decorated_func
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO base_factory.py:90: [STATEFUL_SESSION_MANAGER] Transform decorator applied to: decorated_func
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.transforms.base_factory - base_factory.py:115: [STATEFUL_SESSION_MANAGER] Registered transform handler for decorated_func
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO base_factory.py:115: [STATEFUL_SESSION_MANAGER] Registered transform handler for decorated_func
- (APIServer pid=55342) [INFO] model_hosting_container_standards - decorators.py:76: [INVOKE] Framework handler registered: decorated_func
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO decorators.py:76: [INVOKE] Framework handler registered: decorated_func
- (APIServer pid=55342) [INFO] model_hosting_container_standards - __init__.py:156: Starting SageMaker bootstrap process
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO __init__.py:156: Starting SageMaker bootstrap process
- (APIServer pid=55342) [INFO] model_hosting_container_standards - registry.py:109: [REGISTRY] Middleware resolution and registration complete
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO registry.py:109: [REGISTRY] Middleware resolution and registration complete
- (APIServer pid=55342) [INFO] model_hosting_container_standards - core.py:100: [MIDDLEWARE_LOADER] Middleware stack rebuilt successfully
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO core.py:100: [MIDDLEWARE_LOADER] Middleware stack rebuilt successfully
- (APIServer pid=55342) [INFO] model_hosting_container_standards - core.py:102: [MIDDLEWARE_LOADER] Processed 3 middlewares
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO core.py:102: [MIDDLEWARE_LOADER] Processed 3 middlewares
- (APIServer pid=55342) [WARNING] model_hosting_container_standards.common.custom_code_ref_resolver.function_loader - function_loader.py:73: Failed to load function from spec 'model:custom_sagemaker_invocation_handler': HandlerFileNotFoundError: File '/opt/ml/model/model.py' not found in search paths: ['/opt/ml/model/']
- (APIServer pid=55342) [2025-11-18 12:02:10] WARNING function_loader.py:73: Failed to load function from spec 'model:custom_sagemaker_invocation_handler': HandlerFileNotFoundError: File '/opt/ml/model/model.py' not found in search paths: ['/opt/ml/model/']
- (APIServer pid=55342) [WARNING] model_hosting_container_standards.common.custom_code_ref_resolver.function_loader - function_loader.py:73: Failed to load function from spec 'model:custom_sagemaker_ping_handler': HandlerFileNotFoundError: File '/opt/ml/model/model.py' not found in search paths: ['/opt/ml/model/']
- (APIServer pid=55342) [2025-11-18 12:02:10] WARNING function_loader.py:73: Failed to load function from spec 'model:custom_sagemaker_ping_handler': HandlerFileNotFoundError: File '/opt/ml/model/model.py' not found in search paths: ['/opt/ml/model/']
- (APIServer pid=55342) [INFO] model_hosting_container_standards.sagemaker.sagemaker_router - sagemaker_router.py:93: Creating SageMaker router with unified route resolver
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO sagemaker_router.py:93: Creating SageMaker router with unified route resolver
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:172: Creating router with prefix='', tags=['sagemaker']
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO routing.py:172: Creating router with prefix='', tags=['sagemaker']
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:110: Mounting 2 handlers to router
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO routing.py:110: Mounting 2 handlers to router
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:184: Router created with 0 routes
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO routing.py:184: Router created with 0 routes
- (APIServer pid=55342) [INFO] model_hosting_container_standards.sagemaker.sagemaker_router - sagemaker_router.py:101: SageMaker router created successfully with 0 routes
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO sagemaker_router.py:101: SageMaker router created successfully with 0 routes
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:287: Including router with conflict detection
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO routing.py:287: Including router with conflict detection
- (APIServer pid=55342) [INFO] model_hosting_container_standards.common.fastapi.routing - routing.py:305: Successfully included router with 0 routes
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO routing.py:305: Successfully included router with 0 routes
- (APIServer pid=55342) [INFO] model_hosting_container_standards - __init__.py:168: SageMaker bootstrap completed successfully
- (APIServer pid=55342) [2025-11-18 12:02:10] INFO __init__.py:168: SageMaker bootstrap completed successfully
(APIServer pid=55209) INFO 11-18 12:00:55 [api_server.py:1726] Supported tasks: ['generate']
(APIServer pid=55209) INFO 11-18 12:00:55 [api_server.py:2057] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:38] Available routes are:
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /docs, Methods: HEAD, GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:55 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=55209) INFO 11-18 12:00:56 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=55209) INFO:     Started server process [55209]
(APIServer pid=55209) INFO:     Waiting for application startup.
(APIServer pid=55209) INFO:     Application startup complete.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

