### PR TITLE
Relax Transformers modeling backend MoE experts check

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -79,7 +79,9 @@ To make your model compatible with the Transformers modeling backend, it needs:
         1. Add `is_causal = False` to `MyAttention`.
     - If your model is mixture-of-experts (MoE):
         1. Your sparse MoE block must have an attribute called `experts`.
-        2. The class of `experts` (`MyExperts`) must inherit from `nn.ModuleList`.
+        2. The class of `experts` (`MyExperts`) must either:
+            - Inherit from `nn.ModuleList` (naive).
+            - Or contain all 3D parameters (packed).
         3. `MyExperts.forward` must accept `hidden_states`, `top_k_index`, `top_k_weights`.
 2. `MyAttention` must use `ALL_ATTENTION_FUNCTIONS` to call attention.
 3. `MyModel` must contain `_supports_attention_backend = True`.

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -81,7 +81,7 @@ To make your model compatible with the Transformers modeling backend, it needs:
         1. Your sparse MoE block must have an attribute called `experts`.
         2. The class of `experts` (`MyExperts`) must either:
             - Inherit from `nn.ModuleList` (naive).
-            - Or contain all 3D parameters (packed).
+            - Or contain all 3D `nn.Parameters` (packed).
         3. `MyExperts.forward` must accept `hidden_states`, `top_k_index`, `top_k_weights`.
 2. `MyAttention` must use `ALL_ATTENTION_FUNCTIONS` to call attention.
 3. `MyModel` must contain `_supports_attention_backend = True`.

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -256,7 +256,13 @@ class MoEMixin(MixtureOfExperts):
         def _recursive_replace(module: nn.Module, prefix: str):
             for child_name, child_module in module.named_children():
                 qual_name = maybe_prefix(prefix, child_name)
-                if child_name == "experts" and isinstance(child_module, nn.ModuleList):
+                # Naive implementations will have experts as ModuleList
+                is_modulelist = isinstance(child_module, nn.ModuleList)
+                # Packed implementations will have experts as 3D tensors of shapes like:
+                # gate_up_proj = (num_experts, 2 * intermediate_size, hidden_size)
+                # down_proj = (num_experts, intermediate_size, hidden_size)
+                is_3d = all(p.ndim == 3 for p in child_module.parameters())
+                if child_name == "experts" and (is_modulelist or is_3d):
                     # Alias for readability
                     mlp = module
                     experts = child_module

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -262,7 +262,7 @@ class MoEMixin(MixtureOfExperts):
                 # gate_up_proj = (num_experts, 2 * intermediate_size, hidden_size)
                 # down_proj = (num_experts, intermediate_size, hidden_size)
                 params = list(child_module.parameters())
-                is_3d = bool(params) and all(p.ndim == 3 for p in params)
+                is_3d = len(params) > 0 and all(p.ndim == 3 for p in params)
                 if child_name == "experts" and (is_modulelist or is_3d):
                     # Alias for readability
                     mlp = module

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -261,7 +261,8 @@ class MoEMixin(MixtureOfExperts):
                 # Packed implementations will have experts as 3D tensors of shapes like:
                 # gate_up_proj = (num_experts, 2 * intermediate_size, hidden_size)
                 # down_proj = (num_experts, intermediate_size, hidden_size)
-                is_3d = all(p.ndim == 3 for p in child_module.parameters())
+                params = list(child_module.parameters())
+                is_3d = bool(params) and all(p.ndim == 3 for p in params)
                 if child_name == "experts" and (is_modulelist or is_3d):
                     # Alias for readability
                     mlp = module


### PR DESCRIPTION
The experts module could now also be a 3D tensor.

Note that there are other issues on Transformers main which currently break Transformers modeling backend MoE support. These are being worked on separately.