### PR TITLE
[Core] Free KV cache GPU memory on engine shutdown

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -800,6 +800,31 @@ def get_physical_device_indices(devices):
 
 
 @_nvml()
+def check_gpu_memory_usage(devices: list[int]) -> dict[int, tuple[float, float]]:
+    # Use nvml instead of pytorch to reduce measurement error from torch cuda
+    # context.
+    usage_by_device: dict[int, tuple[float, float]] = {}
+    for device in devices:
+        if current_platform.is_rocm():
+            dev_handle = amdsmi_get_processor_handles()[device]
+            mem_info = amdsmi_get_gpu_vram_usage(dev_handle)
+            gb_used = mem_info["vram_used"] / 2**10
+            gb_total = mem_info["vram_total"] / 2**10
+        else:
+            dev_handle = nvmlDeviceGetHandleByIndex(device)
+            mem_info = nvmlDeviceGetMemoryInfo(dev_handle)
+            gb_used = mem_info.used / 2**30
+            gb_total = mem_info.total / 2**30
+        usage_by_device[device] = (gb_used, gb_total)
+
+    print("gpu memory used/total (GiB): ", end="")
+    for device, (gb_used, gb_total) in usage_by_device.items():
+        print(f"{device}={gb_used:.02f}/{gb_total:.02f}; ", end="")
+    print("")
+
+    return usage_by_device
+
+
 def wait_for_gpu_memory_to_clear(
     *,
     devices: list[int],
@@ -808,31 +833,10 @@ def wait_for_gpu_memory_to_clear(
     timeout_s: float = 120,
 ) -> None:
     assert threshold_bytes is not None or threshold_ratio is not None
-    # Use nvml instead of pytorch to reduce measurement error from torch cuda
-    # context.
     devices = get_physical_device_indices(devices)
     start_time = time.time()
     while True:
-        output: dict[int, str] = {}
-        output_raw: dict[int, tuple[float, float]] = {}
-        for device in devices:
-            if current_platform.is_rocm():
-                dev_handle = amdsmi_get_processor_handles()[device]
-                mem_info = amdsmi_get_gpu_vram_usage(dev_handle)
-                gb_used = mem_info["vram_used"] / 2**10
-                gb_total = mem_info["vram_total"] / 2**10
-            else:
-                dev_handle = nvmlDeviceGetHandleByIndex(device)
-                mem_info = nvmlDeviceGetMemoryInfo(dev_handle)
-                gb_used = mem_info.used / 2**30
-                gb_total = mem_info.total / 2**30
-            output_raw[device] = (gb_used, gb_total)
-            output[device] = f"{gb_used:.02f}/{gb_total:.02f}"
-
-        print("gpu memory used/total (GiB): ", end="")
-        for k, v in output.items():
-            print(f"{k}={v}; ", end="")
-        print("")
+        usage_by_device = check_gpu_memory_usage(devices)
 
         if threshold_bytes is not None:
             is_free = lambda used, total: used <= threshold_bytes / 2**30
@@ -842,7 +846,7 @@ def wait_for_gpu_memory_to_clear(
             threshold = f"{threshold_ratio:.2f}"
 
         dur_s = time.time() - start_time
-        if all(is_free(used, total) for used, total in output_raw.values()):
+        if all(is_free(used, total) for used, total in usage_by_device.values()):
             print(
                 f"Done waiting for free GPU memory on devices {devices=} "
                 f"({threshold=}) {dur_s=:.02f}"

--- a/tests/v1/shutdown/test_delete.py
+++ b/tests/v1/shutdown/test_delete.py
@@ -19,7 +19,6 @@ MODELS = ["hmellor/tiny-random-LlamaForCausalLM"]
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(SHUTDOWN_TEST_TIMEOUT_SEC)
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tensor_parallel_size", [2, 1])
 @pytest.mark.parametrize("send_one_request", [False, True])
@@ -62,10 +61,10 @@ async def test_async_llm_delete(
     wait_for_gpu_memory_to_clear(
         devices=devices,
         threshold_bytes=SHUTDOWN_TEST_THRESHOLD_BYTES,
+        timeout_s=SHUTDOWN_TEST_TIMEOUT_SEC,
     )
 
 
-@pytest.mark.timeout(SHUTDOWN_TEST_TIMEOUT_SEC)
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tensor_parallel_size", [2, 1])
 @pytest.mark.parametrize("enable_multiprocessing", [True])
@@ -111,4 +110,5 @@ def test_llm_delete(
         wait_for_gpu_memory_to_clear(
             devices=devices,
             threshold_bytes=SHUTDOWN_TEST_THRESHOLD_BYTES,
+            timeout_s=SHUTDOWN_TEST_TIMEOUT_SEC,
         )

--- a/tests/v1/shutdown/test_delete.py
+++ b/tests/v1/shutdown/test_delete.py
@@ -4,7 +4,11 @@
 
 import pytest
 
-from tests.utils import check_gpu_memory_usage, wait_for_gpu_memory_to_clear
+from tests.utils import (
+    check_gpu_memory_usage,
+    create_new_process_for_each_test,
+    wait_for_gpu_memory_to_clear,
+)
 from tests.v1.shutdown.utils import (
     SHUTDOWN_TEST_THRESHOLD_BYTES,
     SHUTDOWN_TEST_TIMEOUT_SEC,
@@ -65,15 +69,38 @@ async def test_async_llm_delete(
     )
 
 
+def _test_llm_delete(
+    model: str,
+    tensor_parallel_size: int,
+    send_one_request: bool,
+) -> None:
+    devices = list(range(tensor_parallel_size))
+    check_gpu_memory_usage(devices)
+
+    # Instantiate LLM; make request to complete any deferred
+    # initialization; then delete instance
+    llm = LLM(
+        model=model, enforce_eager=True, tensor_parallel_size=tensor_parallel_size
+    )
+    if send_one_request:
+        llm.generate("Hello my name is", sampling_params=SamplingParams(max_tokens=1))
+    del llm
+
+    # Confirm all the processes are cleaned up.
+    wait_for_gpu_memory_to_clear(
+        devices=devices,
+        threshold_bytes=SHUTDOWN_TEST_THRESHOLD_BYTES,
+        timeout_s=SHUTDOWN_TEST_TIMEOUT_SEC,
+    )
+
+
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tensor_parallel_size", [2, 1])
-@pytest.mark.parametrize("enable_multiprocessing", [False, True])
 @pytest.mark.parametrize("send_one_request", [False, True])
 def test_llm_delete(
     monkeypatch,
     model: str,
     tensor_parallel_size: int,
-    enable_multiprocessing: bool,
     send_one_request: bool,
 ) -> None:
     """Test that LLM frees GPU memory upon deletion.
@@ -81,35 +108,36 @@ def test_llm_delete(
     Args:
       model: model under test
       tensor_parallel_size: degree of tensor parallelism
-      enable_multiprocessing: enable workers in separate process(es)
       send_one_request: send one request to engine before deleting
     """
     if cuda_device_count_stateless() < tensor_parallel_size:
         pytest.skip(reason="Not enough CUDA devices")
-    if not enable_multiprocessing:  # TODO: remove this skip
-        pytest.skip(reason="Skip multiprocessing=False - must run test in subprocess")
 
-    devices = list(range(tensor_parallel_size))
-    check_gpu_memory_usage(devices)
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "1")
 
-    with monkeypatch.context() as m:
-        MP_VALUE = "1" if enable_multiprocessing else "0"
-        m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", MP_VALUE)
+    _test_llm_delete(model, tensor_parallel_size, send_one_request)
 
-        # Instantiate LLM; make request to complete any deferred
-        # initialization; then delete instance
-        llm = LLM(
-            model=model, enforce_eager=True, tensor_parallel_size=tensor_parallel_size
-        )
-        if send_one_request:
-            llm.generate(
-                "Hello my name is", sampling_params=SamplingParams(max_tokens=1)
-            )
-        del llm
 
-        # Confirm all the processes are cleaned up.
-        wait_for_gpu_memory_to_clear(
-            devices=devices,
-            threshold_bytes=SHUTDOWN_TEST_THRESHOLD_BYTES,
-            timeout_s=SHUTDOWN_TEST_TIMEOUT_SEC,
-        )
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("tensor_parallel_size", [2, 1])
+@pytest.mark.parametrize("send_one_request", [False, True])
+@create_new_process_for_each_test()  # Avoid initing CUDA in this process with TP=1
+def test_llm_delete_without_multiprocessing(
+    monkeypatch,
+    model: str,
+    tensor_parallel_size: int,
+    send_one_request: bool,
+) -> None:
+    """Test that LLM frees GPU memory upon deletion, without multiprocessing.
+
+    Args:
+      model: model under test
+      tensor_parallel_size: degree of tensor parallelism
+      send_one_request: send one request to engine before deleting
+    """
+    if cuda_device_count_stateless() < tensor_parallel_size:
+        pytest.skip(reason="Not enough CUDA devices")
+
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+    _test_llm_delete(model, tensor_parallel_size, send_one_request)

--- a/tests/v1/shutdown/test_delete.py
+++ b/tests/v1/shutdown/test_delete.py
@@ -86,6 +86,8 @@ def test_llm_delete(
     """
     if cuda_device_count_stateless() < tensor_parallel_size:
         pytest.skip(reason="Not enough CUDA devices")
+    if not enable_multiprocessing:  # TODO: remove this skip
+        pytest.skip(reason="Skip multiprocessing=False - must run test in subprocess")
 
     devices = list(range(tensor_parallel_size))
     check_gpu_memory_usage(devices)

--- a/tests/v1/shutdown/test_delete.py
+++ b/tests/v1/shutdown/test_delete.py
@@ -67,7 +67,7 @@ async def test_async_llm_delete(
 
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tensor_parallel_size", [2, 1])
-@pytest.mark.parametrize("enable_multiprocessing", [True])
+@pytest.mark.parametrize("enable_multiprocessing", [False, True])
 @pytest.mark.parametrize("send_one_request", [False, True])
 def test_llm_delete(
     monkeypatch,
@@ -77,7 +77,6 @@ def test_llm_delete(
     send_one_request: bool,
 ) -> None:
     """Test that LLM frees GPU memory upon deletion.
-    TODO(andy) - LLM without multiprocessing.
 
     Args:
       model: model under test

--- a/tests/v1/shutdown/test_startup_error.py
+++ b/tests/v1/shutdown/test_startup_error.py
@@ -4,7 +4,10 @@
 
 import pytest
 
-from tests.utils import check_gpu_memory_usage, wait_for_gpu_memory_to_clear
+from tests.utils import (
+    check_gpu_memory_usage,
+    wait_for_gpu_memory_to_clear,
+)
 from tests.v1.shutdown.utils import (
     SHUTDOWN_TEST_THRESHOLD_BYTES,
     SHUTDOWN_TEST_TIMEOUT_SEC,
@@ -65,16 +68,42 @@ def test_async_llm_startup_error(
     )
 
 
+def _test_llm_startup_error(
+    monkeypatch,
+    model: str,
+    tensor_parallel_size: int,
+    failing_method: str,
+    expected_exception_str: str,
+) -> None:
+    devices = list(range(tensor_parallel_size))
+    check_gpu_memory_usage(devices)
+
+    # Monkeypatch an error in the model.
+    assert_mp_fork_context()
+    monkeypatch.setattr(LlamaForCausalLM, failing_method, evil_method)
+
+    with pytest.raises(Exception, match=expected_exception_str):
+        _ = LLM(
+            model=model,
+            enforce_eager=True,
+            tensor_parallel_size=tensor_parallel_size,
+        )
+
+    # Confirm all the processes are cleaned up.
+    wait_for_gpu_memory_to_clear(
+        devices=devices,
+        threshold_bytes=SHUTDOWN_TEST_THRESHOLD_BYTES,
+    )
+
+
 @pytest.mark.timeout(SHUTDOWN_TEST_TIMEOUT_SEC)
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tensor_parallel_size", [2, 1])
-@pytest.mark.parametrize("enable_multiprocessing", [False, True])
 @pytest.mark.parametrize("failing_method", ["forward", "load_weights"])
 def test_llm_startup_error(
     monkeypatch,
     model: str,
     tensor_parallel_size: int,
-    enable_multiprocessing: bool,
     failing_method: str,
 ) -> None:
     """Test that LLM propagates an __init__ error and frees memory.
@@ -86,34 +115,38 @@ def test_llm_startup_error(
         pytest.skip(reason="Only test JackFram/llama-68m")
     if cuda_device_count_stateless() < tensor_parallel_size:
         pytest.skip(reason="Not enough CUDA devices")
-    if not enable_multiprocessing:  # TODO: remove this skip
-        pytest.skip(reason="Skip multiprocessing=False - must run test in subprocess")
 
-    devices = list(range(tensor_parallel_size))
-    check_gpu_memory_usage(devices)
+    _test_llm_startup_error(
+        monkeypatch,
+        model,
+        tensor_parallel_size,
+        failing_method,
+        "initialization failed",
+    )
 
-    with monkeypatch.context() as m:
-        MP_VALUE = "1" if enable_multiprocessing else "0"
-        m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", MP_VALUE)
 
-        # Monkeypatch an error in the model.
-        assert_mp_fork_context()
-        monkeypatch.setattr(LlamaForCausalLM, failing_method, evil_method)
+@pytest.mark.timeout(SHUTDOWN_TEST_TIMEOUT_SEC)
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("tensor_parallel_size", [2, 1])
+@pytest.mark.parametrize("failing_method", ["forward", "load_weights"])
+def test_llm_startup_error_without_multiprocessing(
+    monkeypatch,
+    model: str,
+    tensor_parallel_size: int,
+    failing_method: str,
+) -> None:
+    """Test that LLM propagates an __init__ error, but without multiprocessing."""
+    # Skip non-Llama models since we monkeypatch LlamaForCausalLM specifically.
+    # If MODELS list grows, each architecture needs its own test variant.
+    if model != "JackFram/llama-68m":
+        pytest.skip(reason="Only test JackFram/llama-68m")
+    if cuda_device_count_stateless() < tensor_parallel_size:
+        pytest.skip(reason="Not enough CUDA devices")
 
-        with pytest.raises(
-            Exception,
-            match="initialization failed"
-            if enable_multiprocessing
-            else "Simulated Error in startup!",
-        ):
-            _ = LLM(
-                model=model,
-                enforce_eager=True,
-                tensor_parallel_size=tensor_parallel_size,
-            )
-
-        # Confirm all the processes are cleaned up.
-        wait_for_gpu_memory_to_clear(
-            devices=devices,
-            threshold_bytes=SHUTDOWN_TEST_THRESHOLD_BYTES,
-        )
+    _test_llm_startup_error(
+        monkeypatch,
+        model,
+        tensor_parallel_size,
+        failing_method,
+        "Simulated Error in startup!",
+    )

--- a/tests/v1/shutdown/test_startup_error.py
+++ b/tests/v1/shutdown/test_startup_error.py
@@ -8,6 +8,7 @@ from tests.utils import check_gpu_memory_usage, wait_for_gpu_memory_to_clear
 from tests.v1.shutdown.utils import (
     SHUTDOWN_TEST_THRESHOLD_BYTES,
     SHUTDOWN_TEST_TIMEOUT_SEC,
+    assert_mp_fork_context,
 )
 from vllm import LLM
 from vllm.distributed import get_tensor_model_parallel_rank
@@ -46,6 +47,7 @@ def test_async_llm_startup_error(
     check_gpu_memory_usage(devices)
 
     # Monkeypatch an error in the model.
+    assert_mp_fork_context()
     monkeypatch.setattr(LlamaForCausalLM, failing_method, evil_method)
 
     engine_args = AsyncEngineArgs(
@@ -66,7 +68,7 @@ def test_async_llm_startup_error(
 @pytest.mark.timeout(SHUTDOWN_TEST_TIMEOUT_SEC)
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tensor_parallel_size", [2, 1])
-@pytest.mark.parametrize("enable_multiprocessing", [True])
+@pytest.mark.parametrize("enable_multiprocessing", [False, True])
 @pytest.mark.parametrize("failing_method", ["forward", "load_weights"])
 def test_llm_startup_error(
     monkeypatch,
@@ -77,7 +79,6 @@ def test_llm_startup_error(
 ) -> None:
     """Test that LLM propagates an __init__ error and frees memory.
     Test profiling (forward()) and load weights failures.
-    TODO(andy) - LLM without multiprocessing.
     """
     # Skip non-Llama models since we monkeypatch LlamaForCausalLM specifically.
     # If MODELS list grows, each architecture needs its own test variant.
@@ -85,6 +86,8 @@ def test_llm_startup_error(
         pytest.skip(reason="Only test JackFram/llama-68m")
     if cuda_device_count_stateless() < tensor_parallel_size:
         pytest.skip(reason="Not enough CUDA devices")
+    if not enable_multiprocessing:  # TODO: remove this skip
+        pytest.skip(reason="Skip multiprocessing=False - must run test in subprocess")
 
     devices = list(range(tensor_parallel_size))
     check_gpu_memory_usage(devices)
@@ -94,6 +97,7 @@ def test_llm_startup_error(
         m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", MP_VALUE)
 
         # Monkeypatch an error in the model.
+        assert_mp_fork_context()
         monkeypatch.setattr(LlamaForCausalLM, failing_method, evil_method)
 
         with pytest.raises(

--- a/tests/v1/shutdown/utils.py
+++ b/tests/v1/shutdown/utils.py
@@ -4,3 +4,19 @@
 
 SHUTDOWN_TEST_TIMEOUT_SEC = 120
 SHUTDOWN_TEST_THRESHOLD_BYTES = 2 * 2**30
+
+
+def assert_mp_fork_context():
+    """If we want a monkeypatch to apply to a child process, we need to ensure
+    we are using the 'fork' method rather than 'spawn'. Without this assert,
+    tests might fail unpredictably, and you would need to know to check for:
+
+    > We must use the `spawn` multiprocessing start method. Overriding
+    > VLLM_WORKER_MULTIPROC_METHOD to 'spawn'.
+    > Reasons: CUDA is initialized
+    """
+    import vllm.envs as envs
+    from vllm.utils.system_utils import get_mp_context
+
+    _ = get_mp_context()
+    assert envs.VLLM_WORKER_MULTIPROC_METHOD == "fork"

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -409,6 +409,8 @@ class LLMEngine:
         return self.collective_rpc("apply_model", args=(func,))
 
     def __del__(self):
+        self.engine_core.shutdown()
+
         dp_group = getattr(self, "dp_group", None)
         if dp_group is not None and not self.external_launcher_dp:
             stateless_destroy_torch_distributed_process_group(dp_group)

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -18,7 +18,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheSpec,
 )
-from vllm.v1.worker.utils import bind_kv_cache
+from vllm.v1.worker.utils import bind_kv_cache, unbind_kv_cache
 
 
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
@@ -138,6 +138,13 @@ def init_kv_cache(
     kv_cache_raw_tensors = _allocate_kv_cache(kv_cache_config, device)
     kv_caches = _reshape_kv_cache(kv_cache_config, kv_cache_raw_tensors, attn_backends)
     bind_kv_cache(kv_caches, forward_context, runner_kv_caches)
+
+
+def free_kv_cache(
+    forward_context: dict[str, Any],
+    kv_caches: list[torch.Tensor],
+) -> None:
+    unbind_kv_cache(forward_context, kv_caches)
 
 
 def build_attn_metadata(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -170,6 +170,7 @@ from .utils import (
     add_kv_sharing_layers_to_kv_cache_groups,
     bind_kv_cache,
     sanity_check_mm_encoder_outputs,
+    unbind_kv_cache,
 )
 
 if TYPE_CHECKING:
@@ -5465,6 +5466,11 @@ class GPUModelRunner(
             else:
                 kv_transfer_group.register_kv_caches(kv_caches)
             kv_transfer_group.set_host_xfer_buffer_ops(copy_kv_blocks)
+
+    def free_kv_cache(self) -> None:
+        if not self.kv_caches:
+            return
+        unbind_kv_cache(self.compilation_config.static_forward_context, self.kv_caches)
 
     def may_add_encoder_only_layers_to_kv_cache_config(self) -> None:
         """

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -17,6 +17,7 @@ import vllm.envs as envs
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.config.compilation import CompilationMode
 from vllm.distributed import (
+    cleanup_dist_env_and_memory,
     ensure_model_parallel_initialized,
     init_distributed_environment,
     set_custom_all_reduce,
@@ -841,7 +842,6 @@ class Worker(WorkerBase):
     ) -> None:
         from vllm.config import set_current_vllm_config
         from vllm.distributed.parallel_state import (
-            cleanup_dist_env_and_memory,
             get_ep_group,
         )
 
@@ -907,8 +907,10 @@ class Worker(WorkerBase):
     def shutdown(self) -> None:
         if runner := getattr(self, "model_runner", None):
             runner.ensure_kv_transfer_shutdown()
+            runner.free_kv_cache()
         if self.profiler is not None:
             self.profiler.shutdown()
+        cleanup_dist_env_and_memory()
 
 
 def init_worker_distributed_environment(


### PR DESCRIPTION
Related to #24885

Addresses the `enable_multiprocessing=False` TODO in `tests/v1/shutdown/test_delete.py::test_llm_delete`

The trickiest part is the single-process case ("inproc" engine and "uniproc" executor") where we can't rely on shutting down child processes to release GPU memory. To address that, we:

1. Call `engine_core.shutdown()` from `LLMEngine.__del__()`
2. Free KV cache GPU memory in `GPUWorker.shutdown()`

Other changes include:

1. Avoid pytest timeout when waiting for GPU cleanup - use the `wait_for_gpu_memory_to_clear()` timeout parameter to get a nice `Memory of devices not free` error
2. Print memory usage at start of shutdown tests
3. `assert_mp_fork_context()` added to avoid `We must use the 'spawn' multiprocessing start method....` silently breaking the `evil_forward()` monkey patch
4. Move the `TP=1` `enable_multiprocessing=False` tests into a forked subprocess, to avoid initializing CUDA in the parent process
5. Leave `test_forward_error::test_llm_model_error_without_multiprocessing` disabled in the `enable_multiprocessing=False` case - it is still broken