### PR TITLE
[amd] enable kimi k2 fp8 kv on amd mi300

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -634,11 +634,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "NO_COLOR": lambda: os.getenv("NO_COLOR", "0") != "0",
     # If set, vllm will log stats at this interval in seconds
     # If not set, vllm will log stats every 10 seconds.
-    "VLLM_LOG_STATS_INTERVAL": lambda: (
-        val
-        if (val := float(os.getenv("VLLM_LOG_STATS_INTERVAL", "10."))) > 0.0
-        else 10.0
-    ),
+    "VLLM_LOG_STATS_INTERVAL": lambda: val
+    if (val := float(os.getenv("VLLM_LOG_STATS_INTERVAL", "10."))) > 0.0
+    else 10.0,
     # Trace function calls
     # If set to 1, vllm will trace function calls
     # Useful for debugging
@@ -664,30 +662,28 @@ environment_variables: dict[str, Callable[[], Any]] = {
         ),
     ),
     # If set, vllm will use flashinfer sampler
-    "VLLM_USE_FLASHINFER_SAMPLER": lambda: (
-        bool(int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"]))
-        if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ
-        else None
-    ),
+    "VLLM_USE_FLASHINFER_SAMPLER": lambda: bool(
+        int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"])
+    )
+    if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ
+    else None,
     # Pipeline stage partition strategy
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),
     # (CPU backend only) CPU key-value cache space.
     # default is None and will be set as 4 GB
-    "VLLM_CPU_KVCACHE_SPACE": lambda: (
-        int(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0"))
-        if "VLLM_CPU_KVCACHE_SPACE" in os.environ
-        else None
-    ),
+    "VLLM_CPU_KVCACHE_SPACE": lambda: int(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0"))
+    if "VLLM_CPU_KVCACHE_SPACE" in os.environ
+    else None,
     # (CPU backend only) CPU core ids bound by OpenMP threads, e.g., "0-31",
     # "0,1,2", "0-31,33". CPU cores of different ranks are separated by '|'.
     "VLLM_CPU_OMP_THREADS_BIND": lambda: os.getenv("VLLM_CPU_OMP_THREADS_BIND", "auto"),
     # (CPU backend only) CPU cores not used by OMP threads .
     # Those CPU cores will not be used by OMP threads of a rank.
-    "VLLM_CPU_NUM_OF_RESERVED_CPU": lambda: (
-        int(os.getenv("VLLM_CPU_NUM_OF_RESERVED_CPU", "0"))
-        if "VLLM_CPU_NUM_OF_RESERVED_CPU" in os.environ
-        else None
-    ),
+    "VLLM_CPU_NUM_OF_RESERVED_CPU": lambda: int(
+        os.getenv("VLLM_CPU_NUM_OF_RESERVED_CPU", "0")
+    )
+    if "VLLM_CPU_NUM_OF_RESERVED_CPU" in os.environ
+    else None,
     # (CPU backend only) whether to use SGL kernels, optimized for small batch.
     "VLLM_CPU_SGL_KERNEL": lambda: bool(int(os.getenv("VLLM_CPU_SGL_KERNEL", "0"))),
     # If the env var is set, Ray Compiled Graph uses the specified
@@ -834,11 +830,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # a list of plugin names to load, separated by commas.
     # if this is not set, it means all plugins will be loaded
     # if this is set to an empty string, no plugins will be loaded
-    "VLLM_PLUGINS": lambda: (
-        None
-        if "VLLM_PLUGINS" not in os.environ
-        else os.environ["VLLM_PLUGINS"].split(",")
-    ),
+    "VLLM_PLUGINS": lambda: None
+    if "VLLM_PLUGINS" not in os.environ
+    else os.environ["VLLM_PLUGINS"].split(","),
     # a local directory to look in for unrecognized LoRA adapters.
     # only works if plugins are enabled and
     # VLLM_ALLOW_RUNTIME_LORA_UPDATING is enabled.
@@ -918,11 +912,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # and performance comparisons. Currently only affects MPLinearKernel
     # selection
     # (kernels: MacheteLinearKernel, MarlinLinearKernel, ExllamaLinearKernel)
-    "VLLM_DISABLED_KERNELS": lambda: (
-        []
-        if "VLLM_DISABLED_KERNELS" not in os.environ
-        else os.environ["VLLM_DISABLED_KERNELS"].split(",")
-    ),
+    "VLLM_DISABLED_KERNELS": lambda: []
+    if "VLLM_DISABLED_KERNELS" not in os.environ
+    else os.environ["VLLM_DISABLED_KERNELS"].split(","),
     # Disable pynccl (using torch.distributed instead)
     "VLLM_DISABLE_PYNCCL": lambda: (
         os.getenv("VLLM_DISABLE_PYNCCL", "False").lower() in ("true", "1")
@@ -1149,11 +1141,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     == "1",
     # Gap between padding buckets for the forward pass. So we have
     # 8, we will run forward pass with [16, 24, 32, ...].
-    "VLLM_TPU_BUCKET_PADDING_GAP": lambda: (
-        int(os.environ["VLLM_TPU_BUCKET_PADDING_GAP"])
-        if "VLLM_TPU_BUCKET_PADDING_GAP" in os.environ
-        else 0
-    ),
+    "VLLM_TPU_BUCKET_PADDING_GAP": lambda: int(
+        os.environ["VLLM_TPU_BUCKET_PADDING_GAP"]
+    )
+    if "VLLM_TPU_BUCKET_PADDING_GAP" in os.environ
+    else 0,
     "VLLM_TPU_MOST_MODEL_LEN": lambda: maybe_convert_int(
         os.environ.get("VLLM_TPU_MOST_MODEL_LEN", None)
     ),

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -153,7 +153,9 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
         assert attn_metadata.decode is not None
 
         if self.kv_cache_dtype.startswith("fp8") and (
-            layer._q_scale != 1.0 or layer._k_scale != 1.0 or layer._v_scale != 1.0
+            layer._q_scale.item() != 1.0
+            or layer._k_scale.item() != 1.0
+            or layer._v_scale.item() != 1.0
         ):
             raise NotImplementedError(
                 """

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -29,10 +29,7 @@ logger = init_logger(__name__)
 
 
 class TritonMLABackend(MLACommonBackend):
-    supported_dtypes: ClassVar[list[torch.dtype]] = [
-        torch.float16,
-        torch.bfloat16,
-    ]
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
     supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto"]
 
     @staticmethod
@@ -158,11 +155,7 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             or layer._v_scale.item() != 1.0
         ):
             raise NotImplementedError(
-                """
-                FP8 Triton MLA with q,k,v scales
-                {layer._q_scale},{layer._k_scale},{layer._v_scale}
-                not yet supported. Only values of 1.0 supported.
-            """
+                "FP8 Triton MLA with q,k,v scales != 1.0 not yet supported.",
             )
 
         if type(q) is tuple:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
ROCM_AITER_MLA is not directly usable with Kimi K2 Instruct in TP8 setup, giving "Aiter MLA only supports 16 or 128 number of heads" error. TRITON_MLA does not currently work with fp8 kv cache, giving "TritonMLA V1 with FP8 KV cache not yet supported" error.

This PR
- introduces VLLM_ROCM_USE_AITER_MLA_PREFILL, to use aiter_MLA for triton_MLA prefill
- introduces VLLM_FORCE_NUM_KV_SPLITS to force the number of KV splits for trition MLA decode. For K2 and MI300, we will set this to 9 based on empirical testing.
- relaxes fp8 kv cache assertions, allowing for fp8 kv cache if scales are 1.0 on every layer while using bf16 
- casts intermediate products in triton decode attention to bf16 to prevent accuracy regressions

## Test
Internal tests of kimi k2 on MI300 result in on-par accuracy during evals, with kv cache quant enabled.
Additionally:

Kimi-K2-Instruct:
```
SAFETENSORS_FAST_GPU=1 \
VLLM_GPU_MEMORY_UTILIZATION=0.95 \
VLLM_USE_V1=1 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_MHA=0 \
VLLM_ROCM_USE_AITER_MLA=0 \
VLLM_ROCM_USE_AITER_MLA_PREFILL=1 \
VLLM_ROCM_USE_AITER_LINEAR=0 \
VLLM_ROCM_USE_AITER_MOE=0 \
VLLM_ROCM_USE_AITER_RMSNORM=0 \
VLLM_ROCM_USE_AITER_FP8BMM=1 \
VLLM_FORCE_NUM_KV_SPLITS=9 \
python -m vllm.entrypoints.openai.api_server \
  --port 22234 \
  --served-model-name kimi-k2 \
  --model /data/local/models/Kimi-K2-Instruct \
  --trust-remote-code \
  --max-model-len 100K \
  --max-num-seqs 256 \
  --tensor-parallel-size 8 \
  --kv-cache-dtype fp8 2>&1 | tee /tmp/bradleyhd/vllm.log

(APIServer pid=2696308) INFO:     Started server process [2696308]
(APIServer pid=2696308) INFO:     Waiting for application startup.
(APIServer pid=2696308) INFO:     Application startup complete.

lm_eval --model local-completions --model_args "model=kimi-k2,base_url=http://0.0.0.0:22234/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=256" --tasks gsm8k --num_fewshot 8 2>&1 | tee /tmp/bradleyhd/eval.log

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9545|±  |0.0057|
|     |       |strict-match    |     8|exact_match|↑  |0.9553|±  |0.0057|
```

Also works on Kimi-K2-Thinking with VLLM_ROCM_USE_AITER_FP8BMM=1
```
DEBUG_CLR_GRAPH_PACKET_CAPTURE=0 \
SAFETENSORS_FAST_GPU=1 \
VLLM_GPU_MEMORY_UTILIZATION=0.95 \
VLLM_MLA_DISABLE=0 \
VLLM_ROCM_USE_AITER_LINEAR=0 \
VLLM_ROCM_USE_AITER_MHA=0 \
VLLM_ROCM_USE_AITER_MLA=0 \
VLLM_ROCM_USE_AITER_MOE=0 \
VLLM_ROCM_USE_AITER_RMSNORM=0 \
VLLM_ROCM_USE_AITER=1 \
VLLM_TRUST_REMOTE_CODE=1 \
VLLM_USE_V1=1 \
VLLM_MM_ENCODER_ATTN_BACKEND=TORCH_SDPA \
VLLM_ROCM_USE_AITER_FP8BMM=1 \
VLLM_ROCM_FP8_PADDING=1 \
VLLM_ROCM_USE_AITER_MLA_PREFILL=1 \
VLLM_FORCE_NUM_KV_SPLITS=9 \
python -m vllm.entrypoints.openai.api_server \
  --port 22234 \
  --served-model-name kimi-k2 \
  --model /data/local/models/Kimi-K2-Thinking \
  --trust-remote-code \
  --max-model-len 100K \
  --max-num-seqs 256 \
  --tensor-parallel-size 8 \
  --kv-cache-dtype fp8 \
  2>&1 | tee /tmp/bradleyhd/vllm.log

lm_eval --model local-completions --model_args "model=kimi-k2,base_url=http://0.0.0.0:22234/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=256" --tasks gsm8k --num_fewshot 8 2>&1 | tee /tmp/bradleyhd/eval.log

  local-completions (model=kimi-k2,base_url=http://0.0.0.0:22234/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=256), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9409|±  |0.0065|
|     |       |strict-match    |     8|exact_match|↑  |0.9409|±  |0.0065|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

