### PR TITLE
[config] Expose `get_total_num_hidden_layers()` in ModelConfig

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1367,11 +1367,7 @@ class ModelConfig:
         # Coerce to 0 if explicitly set to None
         return num_experts or 0
 
-    def get_layers_start_end_indices(
-        self, parallel_config: ParallelConfig
-    ) -> tuple[int, int]:
-        from vllm.distributed.utils import get_pp_indices
-
+    def get_total_num_hidden_layers(self) -> int:
         if (
             self.hf_text_config.model_type == "deepseek_mtp"
             or self.hf_config.model_type == "mimo_mtp"
@@ -1391,6 +1387,15 @@ class ModelConfig:
             total_num_hidden_layers = getattr(
                 self.hf_text_config, "num_hidden_layers", 0
             )
+        return total_num_hidden_layers
+
+    def get_layers_start_end_indices(
+        self, parallel_config: ParallelConfig
+    ) -> tuple[int, int]:
+        from vllm.distributed.utils import get_pp_indices
+
+        total_num_hidden_layers = self.get_total_num_hidden_layers()
+
         # the layout order is: DP x PP x TP
         pp_rank = (
             parallel_config.rank // parallel_config.tensor_parallel_size


### PR DESCRIPTION
This PR introduces `get_total_num_hidden_layers()` as a standalone helper in `ModelConfig`. 
The logic previously lived inside `get_layers_start_end_indices()`.

**Motivation:**
Expose the model’s total hidden-layer count through a clean, reusable API.
