### PR TITLE
[Model][QwenVL] Simplify cos/sin rotary embedding indexing 

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -797,13 +797,8 @@ class Glm4vVisionTransformer(nn.Module):
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
 
-        cos_h = cos[pos_ids[:, 0]]  # (num_tokens, rotary_dim // 2)
-        cos_w = cos[pos_ids[:, 1]]
-        sin_h = sin[pos_ids[:, 0]]
-        sin_w = sin[pos_ids[:, 1]]
-
-        cos_combined = torch.cat([cos_h, cos_w], dim=-1)
-        sin_combined = torch.cat([sin_h, sin_w], dim=-1)
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
         return cos_combined, sin_combined, pos_ids
 
     def compute_attn_mask_seqlen(

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -738,13 +738,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_size)
 
-        cos_h = cos[pos_ids[:, 0]]  # (num_tokens, rotary_dim // 2)
-        cos_w = cos[pos_ids[:, 1]]
-        sin_h = sin[pos_ids[:, 0]]
-        sin_w = sin[pos_ids[:, 1]]
-
-        cos_combined = torch.cat([cos_h, cos_w], dim=-1)
-        sin_combined = torch.cat([sin_h, sin_w], dim=-1)
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
 
         cos_combined = cos_combined.reshape(
             cos_combined.shape[0] // self.spatial_merge_unit,

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -724,13 +724,8 @@ class Qwen2VisionTransformer(nn.Module):
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
 
-        cos_h = cos[pos_ids[:, 0]]  # (num_tokens, rotary_dim // 2)
-        cos_w = cos[pos_ids[:, 1]]
-        sin_h = sin[pos_ids[:, 0]]
-        sin_w = sin[pos_ids[:, 1]]
-
-        cos_combined = torch.cat([cos_h, cos_w], dim=-1)
-        sin_combined = torch.cat([sin_h, sin_w], dim=-1)
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
         return cos_combined, sin_combined
 
     def compute_attn_mask_seqlen(

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -428,13 +428,8 @@ class Qwen3Omni_VisionTransformer(nn.Module):
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
 
-        cos_h = cos[pos_ids[:, 0]]  # (num_tokens, rotary_dim // 2)
-        cos_w = cos[pos_ids[:, 1]]
-        sin_h = sin[pos_ids[:, 0]]
-        sin_w = sin[pos_ids[:, 1]]
-
-        cos_combined = torch.cat([cos_h, cos_w], dim=-1)
-        sin_combined = torch.cat([sin_h, sin_w], dim=-1)
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
 
         return cos_combined, sin_combined
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -464,13 +464,8 @@ class Qwen3_VisionTransformer(nn.Module):
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
 
-        cos_h = cos[pos_ids[:, 0]]  # (num_tokens, rotary_dim // 2)
-        cos_w = cos[pos_ids[:, 1]]
-        sin_h = sin[pos_ids[:, 0]]
-        sin_w = sin[pos_ids[:, 1]]
-
-        cos_combined = torch.cat([cos_h, cos_w], dim=-1)
-        sin_combined = torch.cat([sin_h, sin_w], dim=-1)
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
 
         return cos_combined, sin_combined
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -459,7 +459,7 @@ class Qwen3_VisionTransformer(nn.Module):
             else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
             for t, h, w in grid_thw
         ]
-        pos_ids = torch.cat(pos_ids, dim=0)
+        pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=True)
 
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
@@ -561,12 +561,6 @@ class Qwen3_VisionTransformer(nn.Module):
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw_list)
         hidden_states = hidden_states + pos_embeds
         rotary_pos_emb_cos, rotary_pos_emb_sin = self.rot_pos_emb(grid_thw_list)
-        rotary_pos_emb_cos = rotary_pos_emb_cos.to(
-            hidden_states.device, non_blocking=True
-        )
-        rotary_pos_emb_sin = rotary_pos_emb_sin.to(
-            hidden_states.device, non_blocking=True
-        )
 
         cu_seqlens = torch.repeat_interleave(
             grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]


### PR DESCRIPTION
## Purpose

This is a small followup from #28798 which simplifies the indexing logic. /cc @gcanlin @Isotr0py

For Qwen3VL #28798 slightly changed behaviour where `get_cos_sin()` now already returns a GPU tensor. This introduces synchronous CPU to GPU copies of `pos_ids` when using it to index. cc1f0c5e07fd361852fec7cad272c8b746c36d61 Fixes it by moving the indices onto the GPU in a non-blocking way.

**Before:**
<img width="922" height="377" alt="Screenshot 2025-11-18 at 19 46 53" src="https://github.com/user-attachments/assets/1efe9aec-fbcc-441d-82ae-58affa1bf616" />
**After:**
<img width="951" height="396" alt="Screenshot 2025-11-18 at 19 47 13" src="https://github.com/user-attachments/assets/479a9f1d-c18b-4e4a-86bd-9290bea885fa" />

## Test Plan

```
VLLM_WORKER_MULTIPROC_METHOD=spawn lm_eval --model vllm-vlm --model_args "pretrained=Qwen/Qwen3-VL-30B-A3B-Instruct-FP8,max_model_len=10000" --tasks chartqa --batch_size auto --apply_chat_template
```

## Test Result

**Before:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8752 | ±   | 0.0066 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6448 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8656 | ±   | 0.0068 |

**After:**

| Tasks   | Version | Filter | n-shot | Metric            |     |  Value |     | Stderr |
| ------- | ------: | ------ | -----: | ----------------- | --- | -----: | --- | -----: |
| chartqa |       0 | none   |      0 | anywhere_accuracy | ↑   | 0.8760 | ±   | 0.0066 |
|         |         | none   |      0 | exact_match       | ↑   | 0.6388 | ±   | 0.0096 |
|         |         | none   |      0 | relaxed_accuracy  | ↑   | 0.8656 | ±   | 0.0068 |

