### PR TITLE
[Bug] Fix Batch Invariant MLA test

### DIFF
--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -16,6 +16,9 @@ BACKENDS: list[str] = [
     "FLASHINFER",
 ]
 
+if current_platform.is_cuda() and current_platform.is_device_capability(90):
+    BACKENDS.append("FLASH_ATTN_MLA")
+
 DEFAULT_MODEL = "Qwen/Qwen3-1.7B"
 MLA_MODEL = "deepseek-ai/DeepSeek-V2-Lite-Chat"
 
@@ -26,11 +29,6 @@ def resolve_model_name(backend: str) -> str:
     if backend.endswith("MLA") and model == DEFAULT_MODEL:
         return MLA_MODEL
     return model
-
-
-capability = current_platform.get_device_capability()  # type: ignore[attr-defined]
-if capability is not None and capability.major == 9:
-    BACKENDS.append("FLASH_ATTN_MLA")
 
 
 @skip_unsupported

--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -452,6 +452,9 @@ def test_logprobs_without_batch_invariance_should_fail(
     The test will PASS if we detect differences (proving batch invariance matters).
     The test will FAIL if everything matches (suggesting batch invariance isn't needed).
     """
+    from vllm.model_executor.layers.batch_invariant import vllm_is_batch_invariant
+
+    vllm_is_batch_invariant.cache_clear()
     monkeypatch.setenv("VLLM_ATTENTION_BACKEND", backend)
 
     # CRITICAL: Disable batch invariance for this test
@@ -460,6 +463,8 @@ def test_logprobs_without_batch_invariance_should_fail(
     seed = int(os.getenv("VLLM_TEST_SEED", "12345"))
     random.seed(seed)
     model_name = os.getenv("VLLM_TEST_MODEL", "Qwen/Qwen3-1.7B")
+    if backend.endswith("MLA") and model_name == "Qwen/Qwen3-1.7B":
+        model_name = "deepseek-ai/DeepSeek-V2-Lite-Chat"
     tp_size = int(os.getenv("VLLM_TEST_TP_SIZE", "1"))
 
     print(f"\n{'=' * 80}")

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -803,6 +803,7 @@ def override_envs_for_invariance():
         "FLASH_ATTN",  # best supported backend
         "FLASHINFER",
         "FLASH_ATTN_MLA",
+        "TRITON_MLA",
         # Not yet supported MLA backends
         # "FLASHMLA",
         # "FLEX_ATTENTION", # IMA issue even if we disable batch invariance

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -803,11 +803,10 @@ def override_envs_for_invariance():
         "FLASH_ATTN",  # best supported backend
         "FLASHINFER",
         "FLASH_ATTN_MLA",
-        "FLASHINFER_MLA",
-        "TRITON_MLA",
         # Not yet supported MLA backends
         # "FLASHMLA",
         # "FLEX_ATTENTION", # IMA issue even if we disable batch invariance
+        # "FLASHINFER_MLA",
     ]
     if curr_attn_backend not in supported_backends:
         warning = (

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -807,7 +807,7 @@ def override_envs_for_invariance():
         # Not yet supported MLA backends
         # "FLASHMLA",
         # "FLEX_ATTENTION", # IMA issue even if we disable batch invariance
-        # "FLASHINFER_MLA",
+        # "FLASHINFER_MLA", https://github.com/vllm-project/vllm/pull/28967
     ]
     if curr_attn_backend not in supported_backends:
         warning = (


### PR DESCRIPTION
## Purpose

Fix Batch Invariant MLA test

TritonMLA will be removed in this PR: https://github.com/vllm-project/vllm/pull/28832

After Flashinfer's update, we found that batch invariant support of FlashinferMLA is broken, having issue https://github.com/flashinfer-ai/flashinfer/issues/2107 here, we don't want to use a for loop which will be very slow, so just ban the FlashinferMLA for a while. Update: even if using a for loop, still may cause some diff in logprob.

There is a bug in test

```bash
(EngineCore_DP0 pid=1348542)   File "/home/wentao/vllm-source/vllm/model_executor/models/qwen2.py", line 339, in <lambda>
(EngineCore_DP0 pid=1348542)     lambda prefix: decoder_layer_type(
(EngineCore_DP0 pid=1348542)                    ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1348542)   File "/home/wentao/vllm-source/vllm/model_executor/models/qwen3.py", line 185, in __init__
(EngineCore_DP0 pid=1348542)     self.self_attn = Qwen3Attention(
(EngineCore_DP0 pid=1348542)                      ^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1348542)   File "/home/wentao/vllm-source/vllm/model_executor/models/qwen3.py", line 120, in __init__
(EngineCore_DP0 pid=1348542)     self.attn = Attention(
(EngineCore_DP0 pid=1348542)                 ^^^^^^^^^^
(EngineCore_DP0 pid=1348542)   File "/home/wentao/vllm-source/vllm/attention/layer.py", line 287, in __init__
(EngineCore_DP0 pid=1348542)     self.attn_backend = get_attn_backend(
(EngineCore_DP0 pid=1348542)                         ^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1348542)   File "/home/wentao/vllm-source/vllm/attention/selector.py", line 90, in get_attn_backend
(EngineCore_DP0 pid=1348542)     return _cached_get_attn_backend(
(EngineCore_DP0 pid=1348542)            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1348542)   File "/home/wentao/vllm-source/vllm/attention/selector.py", line 168, in _cached_get_attn_backend
(EngineCore_DP0 pid=1348542)     attention_cls = current_platform.get_attn_backend_cls(
(EngineCore_DP0 pid=1348542)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1348542)   File "/home/wentao/vllm-source/vllm/platforms/cuda.py", line 372, in get_attn_backend_cls
(EngineCore_DP0 pid=1348542)     raise ValueError(
(EngineCore_DP0 pid=1348542) ValueError: Selected backend AttentionBackendEnum.FLASH_ATTN_MLA is not valid for this configuration. Reason: ['head_size not supported', 'non-MLA not supported']
```

This PR fixes that as well.

## Test

Now everything green
